### PR TITLE
fix(feishu): prevent self-loop and report file send failures

### DIFF
--- a/src/copaw/agents/tools/send_file.py
+++ b/src/copaw/agents/tools/send_file.py
@@ -83,21 +83,18 @@ async def send_file_to_user(
             return ToolResponse(
                 content=[
                     ImageBlock(type="image", source=source),
-                    TextBlock(type="text", text="已成功发送文件"),
                 ],
             )
         if as_type == "audio":
             return ToolResponse(
                 content=[
                     AudioBlock(type="audio", source=source),
-                    TextBlock(type="text", text="已成功发送文件"),
                 ],
             )
         if as_type == "video":
             return ToolResponse(
                 content=[
                     VideoBlock(type="video", source=source),
-                    TextBlock(type="text", text="已成功发送文件"),
                 ],
             )
 
@@ -108,7 +105,6 @@ async def send_file_to_user(
                     source=source,
                     filename=os.path.basename(file_path),
                 ),
-                TextBlock(type="text", text="已成功发送文件"),
             ],
         )
 

--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -19,6 +19,7 @@ import logging
 import mimetypes
 import threading
 import time
+import uuid
 from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -965,18 +966,22 @@ class FeishuChannel(BaseChannel):
         path_or_url: str,
     ) -> Tuple[Optional[str], str]:
         """Upload file to Feishu and return (file_key, reason)."""
-        token = await self._get_tenant_access_token()
+        token: Optional[str] = None
+        temp_download_path: Optional[Path] = None
         path = Path(path_or_url)
         if not path.exists():
             if path_or_url.startswith(("http://", "https://")):
                 data = await self._fetch_bytes_from_url(path_or_url)
                 if not data:
                     return (None, "file_fetch_failed")
-                path = self._media_dir / "upload_temp"
+                path = self._media_dir / f"upload_temp_{uuid.uuid4().hex}"
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(data)
+                temp_download_path = path
             else:
                 return (None, "file_not_found")
+        if not path.is_file():
+            return (None, "file_not_found")
         size = path.stat().st_size
         if size > FEISHU_FILE_MAX_BYTES:
             logger.warning("feishu file too large size=%s", size)
@@ -1008,6 +1013,9 @@ class FeishuChannel(BaseChannel):
             content_type=mime,
         )
         try:
+            token = await self._get_tenant_access_token()
+            if not token:
+                return (None, "token_fetch_failed")
             async with self._http.post(
                 url,
                 headers={"Authorization": f"Bearer {token}"},
@@ -1036,7 +1044,19 @@ class FeishuChannel(BaseChannel):
                 return (fk, "")
         except Exception:
             logger.exception("feishu _upload_file failed")
+            if not token:
+                return (None, "token_fetch_failed")
             return (None, "file_upload_exception")
+        finally:
+            if temp_download_path and temp_download_path.exists():
+                try:
+                    temp_download_path.unlink()
+                except Exception:
+                    logger.debug(
+                        "feishu _upload_file cleanup temp file failed: %s",
+                        temp_download_path,
+                        exc_info=True,
+                    )
 
     async def _fetch_bytes_from_url(self, url: str) -> Optional[bytes]:
         """Download binary from URL. Supports http(s):// and file://."""
@@ -1215,7 +1235,7 @@ class FeishuChannel(BaseChannel):
     async def _part_to_file_path_or_url(
         self,
         part: OutgoingContentPart,
-    ) -> Optional[str]:
+    ) -> Tuple[Optional[str], str]:
         """Resolve part to local path or URL for file upload."""
         url = (
             getattr(part, "file_url", None)
@@ -1246,28 +1266,29 @@ class FeishuChannel(BaseChannel):
                     "feishu _part_to_file_path_or_url base64 decode: %s",
                     e,
                 )
-                return None
+                return (None, "file_decode_failed")
             self._media_dir.mkdir(parents=True, exist_ok=True)
             path = self._media_dir / f"upload_{id(part)}_{filename}"
             path.write_bytes(data)
-            return str(path)
+            return (str(path), "")
         if url:
             if url.startswith("file://"):
                 local_path = file_url_to_local_path(url)
                 if local_path:
                     path = Path(local_path)
                     if path.exists():
-                        return str(path)
+                        return (str(path), "")
+                    return (None, "file_not_found")
             else:
                 path = Path(url)
                 if path.exists():
-                    return url
+                    return (url, "")
                 if url.startswith(("http://", "https://")):
-                    return url
+                    return (url, "")
         logger.info(
             "feishu _send_file: part has no file_url/url/base64",
         )
-        return None
+        return (None, "file_no_source")
 
     async def _send_file(
         self,
@@ -1280,12 +1301,14 @@ class FeishuChannel(BaseChannel):
             "feishu _send_file: part type=%s",
             getattr(part, "type", None),
         )
-        path_or_url = await self._part_to_file_path_or_url(part)
+        path_or_url, resolve_reason = await self._part_to_file_path_or_url(
+            part,
+        )
         if not path_or_url:
             logger.info(
                 "feishu _send_file: no path/url/base64, skip",
             )
-            return (False, "file_not_found")
+            return (False, resolve_reason or "file_no_source")
         file_key, reason = await self._upload_file(path_or_url)
         if not file_key:
             logger.info(
@@ -1322,8 +1345,14 @@ class FeishuChannel(BaseChannel):
             )
         if reason == "file_not_found":
             return "文件发送失败：源文件不存在或已被删除。"
+        if reason == "file_no_source":
+            return "文件发送失败：未找到可发送的文件地址或数据。"
+        if reason == "file_decode_failed":
+            return "文件发送失败：文件内容解析失败，请检查编码或数据格式。"
         if reason == "file_fetch_failed":
             return "文件发送失败：文件下载失败，请检查文件链接是否可访问。"
+        if reason == "token_fetch_failed":
+            return "文件发送失败：飞书鉴权失败，请检查应用配置后重试。"
         if reason == "file_message_failed":
             return "文件发送失败：上传成功但消息发送失败，请稍后重试。"
         return "文件发送失败：请稍后重试。"

--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -14,15 +14,19 @@ from __future__ import annotations
 
 import base64
 import asyncio
+import ipaddress
 import json
 import logging
 import mimetypes
+import os
+import socket
 import threading
 import time
 import uuid
 from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -112,6 +116,10 @@ class FeishuChannel(BaseChannel):
         self.encrypt_key = encrypt_key or ""
         self.verification_token = verification_token or ""
         self._media_dir = Path(media_dir).expanduser()
+        allowed_dirs = os.getenv("FEISHU_ALLOWED_FILE_DIRS", "")
+        self._allowed_local_file_roots = self._build_allowed_local_file_roots(
+            allowed_dirs,
+        )
 
         self._client: Any = None
         self._ws_client: Any = None
@@ -139,8 +147,6 @@ class FeishuChannel(BaseChannel):
         process: ProcessHandler,
         on_reply_sent: OnReplySent = None,
     ) -> "FeishuChannel":
-        import os
-
         return cls(
             process=process,
             enabled=os.getenv("FEISHU_CHANNEL_ENABLED", "0") == "1",
@@ -190,6 +196,80 @@ class FeishuChannel(BaseChannel):
         if chat_id:
             return short_session_id_from_full_id(chat_id)
         return f"{self.channel}:{sender_id}"
+
+    def _build_allowed_local_file_roots(
+        self,
+        allowed_dirs: str,
+    ) -> Tuple[Path, ...]:
+        roots: List[Path] = [Path.cwd(), self._media_dir]
+        if allowed_dirs:
+            for raw_dir in allowed_dirs.split(os.pathsep):
+                if raw_dir.strip():
+                    roots.append(Path(raw_dir.strip()).expanduser())
+        unique_roots: List[Path] = []
+        seen: set[str] = set()
+        for root in roots:
+            try:
+                resolved = root.resolve(strict=False)
+            except OSError:
+                continue
+            marker = str(resolved)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            unique_roots.append(resolved)
+        return tuple(unique_roots)
+
+    def _is_local_file_allowed(
+        self,
+        path: Path,
+    ) -> bool:
+        try:
+            resolved = path.expanduser().resolve(strict=False)
+        except OSError:
+            return False
+        for root in self._allowed_local_file_roots:
+            if resolved == root:
+                return True
+            try:
+                if resolved.is_relative_to(root):
+                    return True
+            except AttributeError:
+                if str(resolved).startswith(str(root) + os.sep):
+                    return True
+        return False
+
+    def _is_remote_url_allowed(
+        self,
+        url: str,
+    ) -> bool:
+        parsed = urlparse((url or "").strip())
+        if parsed.scheme not in ("http", "https"):
+            return False
+        host = (parsed.hostname or "").strip().lower()
+        if not host or host == "localhost" or host.endswith(".local"):
+            return False
+        try:
+            addresses = socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            return False
+        for item in addresses:
+            ip_text = item[4][0]
+            try:
+                ip_obj = ipaddress.ip_address(ip_text)
+            except ValueError:
+                continue
+            blocked = (
+                ip_obj.is_private,
+                ip_obj.is_loopback,
+                ip_obj.is_link_local,
+                ip_obj.is_reserved,
+                ip_obj.is_multicast,
+                ip_obj.is_unspecified,
+            )
+            if any(blocked):
+                return False
+        return True
 
     def build_agent_request_from_native(
         self,
@@ -974,12 +1054,21 @@ class FeishuChannel(BaseChannel):
                 data = await self._fetch_bytes_from_url(path_or_url)
                 if not data:
                     return (None, "file_fetch_failed")
-                path = self._media_dir / f"upload_temp_{uuid.uuid4().hex}"
+                ext = Path(path_or_url).suffix
+                safe_ext = (
+                    ext if (ext and "/" not in ext and "\\" not in ext) else ""
+                )
+                path = (
+                    self._media_dir
+                    / f"upload_temp_{uuid.uuid4().hex}{safe_ext}"
+                )
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(data)
                 temp_download_path = path
             else:
                 return (None, "file_not_found")
+        if not self._is_local_file_allowed(path):
+            return (None, "file_not_allowed")
         if not path.is_file():
             return (None, "file_not_found")
         size = path.stat().st_size
@@ -1059,12 +1148,21 @@ class FeishuChannel(BaseChannel):
                     )
 
     async def _fetch_bytes_from_url(self, url: str) -> Optional[bytes]:
-        """Download binary from URL. Supports http(s):// and file://."""
+        """Download binary from HTTP(S) URL with SSRF guard."""
         try:
-            path = file_url_to_local_path(url)
-            if path is not None:
-                return await asyncio.to_thread(Path(path).read_bytes)
-            if url.strip().lower().startswith("file:"):
+            url = (url or "").strip()
+            parsed = urlparse(url)
+            if parsed.scheme not in ("http", "https"):
+                return None
+            allowed = await asyncio.to_thread(
+                self._is_remote_url_allowed,
+                url,
+            )
+            if not allowed:
+                logger.warning(
+                    "feishu _fetch_bytes_from_url blocked unsafe url: %s",
+                    url[:120],
+                )
                 return None
             async with self._http.get(url) as resp:
                 if resp.status >= 400:
@@ -1178,11 +1276,30 @@ class FeishuChannel(BaseChannel):
                 "feishu _send_image: part has no image_url/base64",
             )
             return (None, filename)
-        if url.startswith(("http://", "https://", "file://")):
+        if url.startswith(("http://", "https://")):
             data = await self._fetch_bytes_from_url(url)
             return (data, filename)
+        if url.startswith("file://"):
+            local_path = file_url_to_local_path(url)
+            if local_path:
+                path = Path(local_path)
+                if (
+                    path.exists()
+                    and path.is_file()
+                    and self._is_local_file_allowed(path)
+                ):
+                    return (path.read_bytes(), filename)
+                logger.info(
+                    "feishu _send_image: blocked local file url=%s",
+                    url[:120],
+                )
+            return (None, filename)
         path = Path(url)
-        if path.exists():
+        if (
+            path.exists()
+            and path.is_file()
+            and self._is_local_file_allowed(path)
+        ):
             return (path.read_bytes(), filename)
         logger.info(
             "feishu _send_image: path not found url=%s",
@@ -1244,7 +1361,19 @@ class FeishuChannel(BaseChannel):
             or ""
         )
         url = (url or "").strip() if isinstance(url, str) else ""
-        filename = getattr(part, "filename", None) or "file.bin"
+        filename = (
+            Path(
+                str(getattr(part, "filename", None) or "file.bin"),
+            )
+            .name.replace("\x00", "")
+            .strip()
+        )
+        if not filename:
+            filename = "file.bin"
+        if len(filename) > 120:
+            suffix = Path(filename).suffix
+            stem = Path(filename).stem[:100]
+            filename = f"{stem}{suffix}" if suffix else stem
         b64 = None
         if (
             isinstance(url, str)
@@ -1268,20 +1397,30 @@ class FeishuChannel(BaseChannel):
                 )
                 return (None, "file_decode_failed")
             self._media_dir.mkdir(parents=True, exist_ok=True)
-            path = self._media_dir / f"upload_{id(part)}_{filename}"
-            path.write_bytes(data)
+            path = self._media_dir / f"upload_{uuid.uuid4().hex}_{filename}"
+            try:
+                path.write_bytes(data)
+            except OSError:
+                logger.exception(
+                    "feishu _part_to_file_path_or_url temp write failed",
+                )
+                return (None, "file_write_failed")
             return (str(path), "")
         if url:
             if url.startswith("file://"):
                 local_path = file_url_to_local_path(url)
                 if local_path:
                     path = Path(local_path)
-                    if path.exists():
+                    if path.exists() and path.is_file():
+                        if not self._is_local_file_allowed(path):
+                            return (None, "file_not_allowed")
                         return (str(path), "")
                     return (None, "file_not_found")
             else:
                 path = Path(url)
-                if path.exists():
+                if path.exists() and path.is_file():
+                    if not self._is_local_file_allowed(path):
+                        return (None, "file_not_allowed")
                     return (url, "")
                 if url.startswith(("http://", "https://")):
                     return (url, "")
@@ -1345,6 +1484,12 @@ class FeishuChannel(BaseChannel):
             )
         if reason == "file_not_found":
             return "文件发送失败：源文件不存在或已被删除。"
+        if reason == "file_not_allowed":
+            return (
+                "文件发送失败：本地文件路径不在允许目录中。"
+                "请将文件放到工作目录或 FEISHU_MEDIA_DIR，"
+                "或配置 FEISHU_ALLOWED_FILE_DIRS。"
+            )
         if reason == "file_no_source":
             return "文件发送失败：未找到可发送的文件地址或数据。"
         if reason == "file_decode_failed":
@@ -1355,6 +1500,12 @@ class FeishuChannel(BaseChannel):
             return "文件发送失败：飞书鉴权失败，请检查应用配置后重试。"
         if reason == "file_message_failed":
             return "文件发送失败：上传成功但消息发送失败，请稍后重试。"
+        if reason in ("file_upload_http_error", "file_upload_api_error"):
+            return "文件发送失败：上传接口返回错误，请稍后重试。"
+        if reason == "file_upload_exception":
+            return "文件发送失败：上传过程异常，请稍后重试。"
+        if reason == "file_write_failed":
+            return "文件发送失败：临时文件写入失败，请检查磁盘权限。"
         return "文件发送失败：请稍后重试。"
 
     async def _get_receive_for_send(

--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -490,7 +490,10 @@ class FeishuChannel(BaseChannel):
                 self._processed_message_ids.popitem(last=False)
 
             sender_type = getattr(sender, "sender_type", "") or ""
-            if sender_type == "bot":
+            sender_type = str(sender_type).strip().lower()
+            # Feishu may mark bot-originated events as "app" instead of "bot".
+            # Skip both to avoid reply-to-self loops.
+            if sender_type in ("bot", "app"):
                 return
 
             sender_id_obj = getattr(sender, "sender_id", None)
@@ -957,24 +960,27 @@ class FeishuChannel(BaseChannel):
             logger.exception("feishu _upload_image_sync failed")
             return None
 
-    async def _upload_file(self, path_or_url: str) -> Optional[str]:
-        """Upload file to Feishu; return file_key. path_or_url can be path."""
+    async def _upload_file(
+        self,
+        path_or_url: str,
+    ) -> Tuple[Optional[str], str]:
+        """Upload file to Feishu and return (file_key, reason)."""
         token = await self._get_tenant_access_token()
         path = Path(path_or_url)
         if not path.exists():
             if path_or_url.startswith(("http://", "https://")):
                 data = await self._fetch_bytes_from_url(path_or_url)
                 if not data:
-                    return None
+                    return (None, "file_fetch_failed")
                 path = self._media_dir / "upload_temp"
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(data)
             else:
-                return None
+                return (None, "file_not_found")
         size = path.stat().st_size
         if size > FEISHU_FILE_MAX_BYTES:
             logger.warning("feishu file too large size=%s", size)
-            return None
+            return (None, "file_too_large")
         ext = path.suffix.lower().lstrip(".")
         file_type = "stream"
         if ext in (
@@ -1014,23 +1020,23 @@ class FeishuChannel(BaseChannel):
                         resp.status,
                         data,
                     )
-                    return None
+                    return (None, "file_upload_http_error")
                 if data.get("code") != 0:
                     logger.info(
                         "feishu _upload_file api code=%s msg=%s",
                         data.get("code"),
                         data.get("msg"),
                     )
-                    return None
+                    return (None, "file_upload_api_error")
                 fk = (data.get("data") or {}).get("file_key")
                 logger.info(
                     "feishu _upload_file ok: file_key=%s",
                     fk[:24] if fk else "None",
                 )
-                return fk
+                return (fk, "")
         except Exception:
             logger.exception("feishu _upload_file failed")
-            return None
+            return (None, "file_upload_exception")
 
     async def _fetch_bytes_from_url(self, url: str) -> Optional[bytes]:
         """Download binary from URL. Supports http(s):// and file://."""
@@ -1268,8 +1274,8 @@ class FeishuChannel(BaseChannel):
         receive_id_type: str,
         receive_id: str,
         part: OutgoingContentPart,
-    ) -> bool:
-        """Upload file and send file message (msg_type=file, file_key)."""
+    ) -> Tuple[bool, str]:
+        """Upload file and send file message; return (ok, reason)."""
         logger.info(
             "feishu _send_file: part type=%s",
             getattr(part, "type", None),
@@ -1279,20 +1285,20 @@ class FeishuChannel(BaseChannel):
             logger.info(
                 "feishu _send_file: no path/url/base64, skip",
             )
-            return False
-        file_key = await self._upload_file(path_or_url)
+            return (False, "file_not_found")
+        file_key, reason = await self._upload_file(path_or_url)
         if not file_key:
             logger.info(
                 "feishu _send_file: upload failed, no file_key",
             )
-            return False
+            return (False, reason or "file_upload_failed")
         logger.info(
             "feishu _send_file: upload ok file_key=%s",
             file_key[:24] if file_key else "",
         )
         content = json.dumps({"file_key": file_key}, ensure_ascii=False)
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
+        ok = await loop.run_in_executor(
             None,
             lambda: self._send_message_sync(
                 receive_id_type,
@@ -1301,6 +1307,26 @@ class FeishuChannel(BaseChannel):
                 content,
             ),
         )
+        if not ok:
+            return (False, "file_message_failed")
+        return (True, "")
+
+    def _file_send_failure_hint(self, reason: str) -> str:
+        """Return user-visible hint when file upload/send fails."""
+        if reason == "file_too_large":
+            limit_mb = FEISHU_FILE_MAX_BYTES // (1024 * 1024)
+            return (
+                "文件发送失败：飞书限制单文件大小，"
+                f"当前渠道上限约 {limit_mb}MB。"
+                "请压缩后重试，或改为发送下载链接。"
+            )
+        if reason == "file_not_found":
+            return "文件发送失败：源文件不存在或已被删除。"
+        if reason == "file_fetch_failed":
+            return "文件发送失败：文件下载失败，请检查文件链接是否可访问。"
+        if reason == "file_message_failed":
+            return "文件发送失败：上传成功但消息发送失败，请稍后重试。"
+        return "文件发送失败：请稍后重试。"
 
     async def _get_receive_for_send(
         self,
@@ -1448,16 +1474,27 @@ class FeishuChannel(BaseChannel):
                 ContentType.VIDEO,
                 ContentType.AUDIO,
             ):
-                ok = await self._send_file(
+                ok, reason = await self._send_file(
                     receive_id_type,
                     receive_id,
                     part,
                 )
                 logger.info(
-                    "feishu send_content_parts: file sent ok=%s type=%s",
+                    "feishu send_content_parts: file sent ok=%s type=%s "
+                    "reason=%s",
                     ok,
                     pt,
+                    reason or "",
                 )
+                if not ok:
+                    hint = self._file_send_failure_hint(reason)
+                    await self._send_text(
+                        receive_id_type,
+                        receive_id,
+                        hint,
+                    )
+                    # stop sending following media parts to avoid repeated spam
+                    break
 
     async def send(
         self,

--- a/src/copaw/app/channels/feishu/channel.py
+++ b/src/copaw/app/channels/feishu/channel.py
@@ -90,6 +90,19 @@ class FeishuChannel(BaseChannel):
     """
 
     channel = "feishu"
+    REASON_FILE_FETCH_FAILED = "file_fetch_failed"
+    REASON_FILE_NOT_FOUND = "file_not_found"
+    REASON_FILE_NOT_ALLOWED = "file_not_allowed"
+    REASON_FILE_TOO_LARGE = "file_too_large"
+    REASON_TOKEN_FETCH_FAILED = "token_fetch_failed"
+    REASON_FILE_UPLOAD_HTTP_ERROR = "file_upload_http_error"
+    REASON_FILE_UPLOAD_API_ERROR = "file_upload_api_error"
+    REASON_FILE_UPLOAD_EXCEPTION = "file_upload_exception"
+    REASON_FILE_DECODE_FAILED = "file_decode_failed"
+    REASON_FILE_WRITE_FAILED = "file_write_failed"
+    REASON_FILE_NO_SOURCE = "file_no_source"
+    REASON_FILE_UPLOAD_FAILED = "file_upload_failed"
+    REASON_FILE_MESSAGE_FAILED = "file_message_failed"
 
     def __init__(
         self,
@@ -1053,7 +1066,7 @@ class FeishuChannel(BaseChannel):
             if path_or_url.startswith(("http://", "https://")):
                 data = await self._fetch_bytes_from_url(path_or_url)
                 if not data:
-                    return (None, "file_fetch_failed")
+                    return (None, self.REASON_FILE_FETCH_FAILED)
                 ext = Path(path_or_url).suffix
                 safe_ext = (
                     ext if (ext and "/" not in ext and "\\" not in ext) else ""
@@ -1066,15 +1079,15 @@ class FeishuChannel(BaseChannel):
                 path.write_bytes(data)
                 temp_download_path = path
             else:
-                return (None, "file_not_found")
+                return (None, self.REASON_FILE_NOT_FOUND)
         if not self._is_local_file_allowed(path):
-            return (None, "file_not_allowed")
+            return (None, self.REASON_FILE_NOT_ALLOWED)
         if not path.is_file():
-            return (None, "file_not_found")
+            return (None, self.REASON_FILE_NOT_FOUND)
         size = path.stat().st_size
         if size > FEISHU_FILE_MAX_BYTES:
             logger.warning("feishu file too large size=%s", size)
-            return (None, "file_too_large")
+            return (None, self.REASON_FILE_TOO_LARGE)
         ext = path.suffix.lower().lstrip(".")
         file_type = "stream"
         if ext in (
@@ -1104,7 +1117,7 @@ class FeishuChannel(BaseChannel):
         try:
             token = await self._get_tenant_access_token()
             if not token:
-                return (None, "token_fetch_failed")
+                return (None, self.REASON_TOKEN_FETCH_FAILED)
             async with self._http.post(
                 url,
                 headers={"Authorization": f"Bearer {token}"},
@@ -1117,14 +1130,14 @@ class FeishuChannel(BaseChannel):
                         resp.status,
                         data,
                     )
-                    return (None, "file_upload_http_error")
+                    return (None, self.REASON_FILE_UPLOAD_HTTP_ERROR)
                 if data.get("code") != 0:
                     logger.info(
                         "feishu _upload_file api code=%s msg=%s",
                         data.get("code"),
                         data.get("msg"),
                     )
-                    return (None, "file_upload_api_error")
+                    return (None, self.REASON_FILE_UPLOAD_API_ERROR)
                 fk = (data.get("data") or {}).get("file_key")
                 logger.info(
                     "feishu _upload_file ok: file_key=%s",
@@ -1134,8 +1147,8 @@ class FeishuChannel(BaseChannel):
         except Exception:
             logger.exception("feishu _upload_file failed")
             if not token:
-                return (None, "token_fetch_failed")
-            return (None, "file_upload_exception")
+                return (None, self.REASON_TOKEN_FETCH_FAILED)
+            return (None, self.REASON_FILE_UPLOAD_EXCEPTION)
         finally:
             if temp_download_path and temp_download_path.exists():
                 try:
@@ -1395,7 +1408,7 @@ class FeishuChannel(BaseChannel):
                     "feishu _part_to_file_path_or_url base64 decode: %s",
                     e,
                 )
-                return (None, "file_decode_failed")
+                return (None, self.REASON_FILE_DECODE_FAILED)
             self._media_dir.mkdir(parents=True, exist_ok=True)
             path = self._media_dir / f"upload_{uuid.uuid4().hex}_{filename}"
             try:
@@ -1404,7 +1417,7 @@ class FeishuChannel(BaseChannel):
                 logger.exception(
                     "feishu _part_to_file_path_or_url temp write failed",
                 )
-                return (None, "file_write_failed")
+                return (None, self.REASON_FILE_WRITE_FAILED)
             return (str(path), "")
         if url:
             if url.startswith("file://"):
@@ -1413,21 +1426,21 @@ class FeishuChannel(BaseChannel):
                     path = Path(local_path)
                     if path.exists() and path.is_file():
                         if not self._is_local_file_allowed(path):
-                            return (None, "file_not_allowed")
+                            return (None, self.REASON_FILE_NOT_ALLOWED)
                         return (str(path), "")
-                    return (None, "file_not_found")
+                    return (None, self.REASON_FILE_NOT_FOUND)
             else:
                 path = Path(url)
                 if path.exists() and path.is_file():
                     if not self._is_local_file_allowed(path):
-                        return (None, "file_not_allowed")
+                        return (None, self.REASON_FILE_NOT_ALLOWED)
                     return (url, "")
                 if url.startswith(("http://", "https://")):
                     return (url, "")
         logger.info(
             "feishu _send_file: part has no file_url/url/base64",
         )
-        return (None, "file_no_source")
+        return (None, self.REASON_FILE_NO_SOURCE)
 
     async def _send_file(
         self,
@@ -1447,13 +1460,13 @@ class FeishuChannel(BaseChannel):
             logger.info(
                 "feishu _send_file: no path/url/base64, skip",
             )
-            return (False, resolve_reason or "file_no_source")
+            return (False, resolve_reason or self.REASON_FILE_NO_SOURCE)
         file_key, reason = await self._upload_file(path_or_url)
         if not file_key:
             logger.info(
                 "feishu _send_file: upload failed, no file_key",
             )
-            return (False, reason or "file_upload_failed")
+            return (False, reason or self.REASON_FILE_UPLOAD_FAILED)
         logger.info(
             "feishu _send_file: upload ok file_key=%s",
             file_key[:24] if file_key else "",
@@ -1470,41 +1483,44 @@ class FeishuChannel(BaseChannel):
             ),
         )
         if not ok:
-            return (False, "file_message_failed")
+            return (False, self.REASON_FILE_MESSAGE_FAILED)
         return (True, "")
 
     def _file_send_failure_hint(self, reason: str) -> str:
         """Return user-visible hint when file upload/send fails."""
-        if reason == "file_too_large":
+        if reason == self.REASON_FILE_TOO_LARGE:
             limit_mb = FEISHU_FILE_MAX_BYTES // (1024 * 1024)
             return (
                 "文件发送失败：飞书限制单文件大小，"
                 f"当前渠道上限约 {limit_mb}MB。"
                 "请压缩后重试，或改为发送下载链接。"
             )
-        if reason == "file_not_found":
+        if reason == self.REASON_FILE_NOT_FOUND:
             return "文件发送失败：源文件不存在或已被删除。"
-        if reason == "file_not_allowed":
+        if reason == self.REASON_FILE_NOT_ALLOWED:
             return (
                 "文件发送失败：本地文件路径不在允许目录中。"
                 "请将文件放到工作目录或 FEISHU_MEDIA_DIR，"
                 "或配置 FEISHU_ALLOWED_FILE_DIRS。"
             )
-        if reason == "file_no_source":
+        if reason == self.REASON_FILE_NO_SOURCE:
             return "文件发送失败：未找到可发送的文件地址或数据。"
-        if reason == "file_decode_failed":
+        if reason == self.REASON_FILE_DECODE_FAILED:
             return "文件发送失败：文件内容解析失败，请检查编码或数据格式。"
-        if reason == "file_fetch_failed":
+        if reason == self.REASON_FILE_FETCH_FAILED:
             return "文件发送失败：文件下载失败，请检查文件链接是否可访问。"
-        if reason == "token_fetch_failed":
+        if reason == self.REASON_TOKEN_FETCH_FAILED:
             return "文件发送失败：飞书鉴权失败，请检查应用配置后重试。"
-        if reason == "file_message_failed":
+        if reason == self.REASON_FILE_MESSAGE_FAILED:
             return "文件发送失败：上传成功但消息发送失败，请稍后重试。"
-        if reason in ("file_upload_http_error", "file_upload_api_error"):
+        if reason in (
+            self.REASON_FILE_UPLOAD_HTTP_ERROR,
+            self.REASON_FILE_UPLOAD_API_ERROR,
+        ):
             return "文件发送失败：上传接口返回错误，请稍后重试。"
-        if reason == "file_upload_exception":
+        if reason == self.REASON_FILE_UPLOAD_EXCEPTION:
             return "文件发送失败：上传过程异常，请稍后重试。"
-        if reason == "file_write_failed":
+        if reason == self.REASON_FILE_WRITE_FAILED:
             return "文件发送失败：临时文件写入失败，请检查磁盘权限。"
         return "文件发送失败：请稍后重试。"
 

--- a/tests/test_feishu_file_send_guard.py
+++ b/tests/test_feishu_file_send_guard.py
@@ -6,6 +6,7 @@ import pytest
 
 from copaw.app.channels.base import ContentType
 from copaw.app.channels.feishu.channel import FeishuChannel
+from copaw.app.channels.feishu.constants import FEISHU_FILE_MAX_BYTES
 
 
 async def _empty_process(_request):
@@ -95,4 +96,26 @@ async def test_send_content_parts_stop_after_file_failure() -> None:
 
     assert len(send_file_calls) == 1
     assert len(send_text_calls) == 1
-    assert "30MB" in send_text_calls[0]
+    expected_limit_mb = FEISHU_FILE_MAX_BYTES // (1024 * 1024)
+    assert f"{expected_limit_mb}MB" in send_text_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_part_to_file_path_or_url_base64_decode_failed() -> None:
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+    part = SimpleNamespace(
+        type=ContentType.FILE,
+        data="data:application/octet-stream;base64,not-base64-@@@",
+        filename="broken.bin",
+    )
+
+    path_or_url, reason = await channel._part_to_file_path_or_url(part)
+
+    assert path_or_url is None
+    assert reason == "file_decode_failed"

--- a/tests/test_feishu_file_send_guard.py
+++ b/tests/test_feishu_file_send_guard.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from types import SimpleNamespace
 
 import pytest
@@ -8,8 +9,7 @@ from copaw.app.channels.feishu.channel import FeishuChannel
 
 
 async def _empty_process(_request):
-    if False:  # pragma: no cover
-        yield None
+    return None
 
 
 def _build_text_event(message_id: str, sender_type: str) -> SimpleNamespace:
@@ -45,7 +45,7 @@ async def test_on_message_skip_app_sender() -> None:
 
     await channel._on_message(_build_text_event("m-app", "app"))
 
-    assert enqueued == []
+    assert not enqueued
 
 
 @pytest.mark.asyncio

--- a/tests/test_feishu_file_send_guard.py
+++ b/tests/test_feishu_file_send_guard.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -119,3 +120,98 @@ async def test_part_to_file_path_or_url_base64_decode_failed() -> None:
 
     assert path_or_url is None
     assert reason == "file_decode_failed"
+
+
+@pytest.mark.asyncio
+async def test_part_to_file_path_or_url_write_failed(monkeypatch) -> None:
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+    part = SimpleNamespace(
+        type=ContentType.FILE,
+        data="data:application/octet-stream;base64,YQ==",
+        filename="ok.bin",
+    )
+
+    def _raise_oserror(*args, **kwargs):
+        del args
+        del kwargs
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_bytes", _raise_oserror)
+
+    path_or_url, reason = await channel._part_to_file_path_or_url(part)
+
+    assert path_or_url is None
+    assert reason == "file_write_failed"
+
+
+@pytest.mark.asyncio
+async def test_part_to_file_path_or_url_block_disallowed_local_file(
+    tmp_path,
+) -> None:
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+    p = tmp_path / "secret.bin"
+    p.write_bytes(b"secret")
+    part = SimpleNamespace(
+        type=ContentType.FILE,
+        file_url=p.as_uri(),
+        filename="secret.bin",
+    )
+
+    path_or_url, reason = await channel._part_to_file_path_or_url(part)
+
+    assert path_or_url is None
+    assert reason == "file_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_part_to_file_path_or_url_allow_env_dir(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("FEISHU_ALLOWED_FILE_DIRS", str(tmp_path))
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+    p = tmp_path / "allowed.bin"
+    p.write_bytes(b"ok")
+    part = SimpleNamespace(
+        type=ContentType.FILE,
+        file_url=p.as_uri(),
+        filename="allowed.bin",
+    )
+
+    path_or_url, reason = await channel._part_to_file_path_or_url(part)
+
+    assert path_or_url == str(p)
+    assert reason == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_bytes_from_url_block_loopback() -> None:
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+
+    data = await channel._fetch_bytes_from_url("http://127.0.0.1/internal")
+
+    assert data is None

--- a/tests/test_feishu_file_send_guard.py
+++ b/tests/test_feishu_file_send_guard.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+
+from copaw.app.channels.base import ContentType
+from copaw.app.channels.feishu.channel import FeishuChannel
+
+
+async def _empty_process(_request):
+    if False:  # pragma: no cover
+        yield None
+
+
+def _build_text_event(message_id: str, sender_type: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            message=SimpleNamespace(
+                message_id=message_id,
+                chat_id="oc_test_chat",
+                chat_type="group",
+                message_type="text",
+                content='{"text":"hello"}',
+            ),
+            sender=SimpleNamespace(
+                sender_type=sender_type,
+                sender_id=SimpleNamespace(open_id="ou_test_sender"),
+                name="tester",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_message_skip_app_sender() -> None:
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+    enqueued: list[dict] = []
+    channel._enqueue = enqueued.append
+
+    await channel._on_message(_build_text_event("m-app", "app"))
+
+    assert enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_send_content_parts_stop_after_file_failure() -> None:
+    channel = FeishuChannel(
+        process=_empty_process,
+        enabled=True,
+        app_id="app_id",
+        app_secret="app_secret",
+        bot_prefix="[BOT] ",
+    )
+
+    send_file_calls: list[tuple[str, str]] = []
+    send_text_calls: list[str] = []
+
+    async def fake_send_file(receive_id_type, receive_id, part):
+        send_file_calls.append((receive_id_type, receive_id))
+        del part
+        return (False, "file_too_large")
+
+    async def fake_send_text(receive_id_type, receive_id, body):
+        send_text_calls.append(body)
+        del receive_id_type
+        del receive_id
+        return True
+
+    channel._send_file = fake_send_file  # type: ignore[method-assign]
+    channel._send_text = fake_send_text  # type: ignore[method-assign]
+
+    parts = [
+        SimpleNamespace(
+            type=ContentType.FILE,
+            file_url="file:///tmp/a.bin",
+            filename="a.bin",
+        ),
+        SimpleNamespace(
+            type=ContentType.FILE,
+            file_url="file:///tmp/b.bin",
+            filename="b.bin",
+        ),
+    ]
+    await channel.send_content_parts(
+        "feishu:sw:demo",
+        parts,
+        {"feishu_receive_id_type": "chat_id", "feishu_receive_id": "oc_demo"},
+    )
+
+    assert len(send_file_calls) == 1
+    assert len(send_text_calls) == 1
+    assert "30MB" in send_text_calls[0]

--- a/tests/test_send_file_tool.py
+++ b/tests/test_send_file_tool.py
@@ -12,10 +12,35 @@ async def test_send_file_to_user_not_emit_fake_success_text(tmp_path) -> None:
     response = await send_file_to_user(str(file_path))
 
     assert response.content
+    assert len(response.content) == 1
+    first = response.content[0]
+    first_type = (
+        first.get("type")
+        if isinstance(first, dict)
+        else getattr(first, "type", None)
+    )
+    assert first_type == "file"
     assert all(
         not (
-            getattr(block, "type", None) == "text"
-            and getattr(block, "text", "") == "已成功发送文件"
+            (
+                block.get("type")
+                if isinstance(block, dict)
+                else getattr(block, "type", None)
+            )
+            == "text"
+            and (
+                (
+                    block.get("text", "")
+                    if isinstance(block, dict)
+                    else getattr(block, "text", "")
+                )
+                == "已成功发送文件"
+                or (
+                    block.get("text", "")
+                    if isinstance(block, dict)
+                    else getattr(block, "text", "")
+                ).startswith("Error:")
+            )
         )
         for block in response.content
     )

--- a/tests/test_send_file_tool.py
+++ b/tests/test_send_file_tool.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from copaw.agents.tools.send_file import send_file_to_user
+
+
+@pytest.mark.asyncio
+async def test_send_file_to_user_not_emit_fake_success_text(tmp_path) -> None:
+    file_path = tmp_path / "sample.bin"
+    file_path.write_bytes(b"copaw")
+
+    response = await send_file_to_user(str(file_path))
+
+    assert response.content
+    assert all(
+        not (
+            getattr(block, "type", None) == "text"
+            and getattr(block, "text", "") == "已成功发送文件"
+        )
+        for block in response.content
+    )


### PR DESCRIPTION
## Summary

This PR hardens Feishu file sending for large-file failure scenarios and self-message loops.

## Root Cause

1. Feishu channel only ignored `sender_type == "bot"`, but some bot-originated callbacks arrive as `sender_type == "app"`, which can be re-processed and trigger reply loops.
2. File upload failure was flattened to `ok=False` without explicit user-facing failure feedback.
3. `send_file_to_user` always appended a success text (`已成功发送文件`) for binary/media blocks, even though channel delivery could still fail.

## Changes

- Feishu inbound guard:
  - ignore both `sender_type in {"bot", "app"}` to avoid self-trigger loops.
- Feishu file send pipeline:
  - `_upload_file` now returns `(file_key, reason)`.
  - `_send_file` now returns `(ok, reason)`.
  - on file/media send failure, send a clear failure hint to user and stop sending following media parts in the same batch (fail-fast to prevent spam).
- Tool layer:
  - remove hardcoded success text from `send_file_to_user` for image/audio/video/file blocks.

## Validation

Executed locally:

```bash
PYTHONPATH=src pytest -q
```

Result: `7 passed`.

## Notes

- Feishu IM upload endpoint currently used here is `/open-apis/im/v1/files`, which is single-file upload in this integration path.
- This PR focuses on production-safe failure handling and loop prevention; it does not introduce cross-endpoint chunked upload migration.

Related to #472


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant success text after sending media so only the media block is returned.
  * Strengthened file-safety: local directory whitelisting, remote URL safety checks (rejecting loopback/private addresses), filename sanitization, clearer localized failure hints, and halting subsequent media sends after a file failure to avoid spam.
  * Normalized sender types to avoid reply loops from bot/app origins.

* **Tests**
  * Added tests for sender filtering, file-safety guards, halting media sends on failure, and ensuring no fake success text is emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->