### PR TITLE
fix(dingtalk): fail cron job when proactive send cannot deliver

### DIFF
--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -1052,6 +1052,12 @@ class DingTalkChannel(BaseChannel):
         elif prefix and not body and not media_parts:
             body = prefix
         m = meta or {}
+        is_reply_context = (
+            m.get("reply_loop") is not None
+            or m.get("reply_future") is not None
+            or bool(m.get("conversation_id"))
+        )
+        is_proactive_send = not is_reply_context
         session_webhook = await self._get_session_webhook_for_send(
             to_handle,
             meta,
@@ -1067,11 +1073,17 @@ class DingTalkChannel(BaseChannel):
         if session_webhook and (body.strip() or media_parts):
             if body.strip():
                 logger.info("dingtalk send_content_parts: sending text body")
-                await self._send_via_session_webhook(
+                text_ok = await self._send_via_session_webhook(
                     session_webhook,
                     body.strip(),
                     bot_prefix="",
                 )
+                if is_proactive_send and not text_ok:
+                    raise RuntimeError(
+                        "DingTalk proactive send failed: "
+                        "text sendBySession failed "
+                        f"(to_handle={to_handle})",
+                    )
             for i, part in enumerate(media_parts):
                 logger.info(
                     "dingtalk send_content_parts: "
@@ -1089,9 +1101,21 @@ class DingTalkChannel(BaseChannel):
                     i + 1,
                     ok,
                 )
+                if is_proactive_send and not ok:
+                    raise RuntimeError(
+                        "DingTalk proactive send failed: "
+                        "media sendBySession failed "
+                        f"(to_handle={to_handle}, index={i + 1})",
+                    )
             if m.get("reply_loop") is not None and m.get("reply_future"):
                 self._reply_sync(m, SENT_VIA_WEBHOOK)
             return
+        if is_proactive_send and (body.strip() or media_parts):
+            raise RuntimeError(
+                "DingTalk proactive send failed: no sessionWebhook found "
+                f"(to_handle={to_handle}); user must chat first and "
+                "sessionWebhook may expire.",
+            )
         if not body and media_parts:
             for p in media_parts:
                 if getattr(p, "type", None) == ContentType.IMAGE and getattr(

--- a/src/copaw/app/channels/dingtalk/channel.py
+++ b/src/copaw/app/channels/dingtalk/channel.py
@@ -679,17 +679,18 @@ class DingTalkChannel(BaseChannel):
     ) -> Optional[str]:
         """Resolve session_webhook for sending. Prefer current request's
         webhook (meta); only use store for proactive send (e.g. cron).
-        When this is a reply to a user message (meta has reply_future or
-        conversation_id) and meta has no session_webhook, do not fall back
-        to store so we never use a stale/expired webhook.
+        When this is a reply to a user message (reply_loop, reply_future, or
+        conversation_id present in meta) and meta has no session_webhook, do
+        not fall back to store so we never use a stale/expired webhook.
         """
+        short_handle = self._sanitize_to_handle(to_handle)
         m = meta or {}
         webhook = m.get("session_webhook") or m.get("sessionWebhook")
         if webhook:
             logger.info(
                 "dingtalk _get_session_webhook_for_send: to_handle=%s "
                 "source=meta session_from_url=%s",
-                to_handle[:40] if to_handle else "",
+                short_handle,
                 session_param_from_webhook_url(webhook),
             )
             return webhook
@@ -699,17 +700,17 @@ class DingTalkChannel(BaseChannel):
             logger.info(
                 "dingtalk _get_session_webhook_for_send: to_handle=%s "
                 "source=route session_from_url=%s",
-                to_handle[:40] if to_handle else "",
+                short_handle,
                 session_param_from_webhook_url(webhook),
             )
             return webhook
         # Current-request context but no webhook in meta: do not use store
         # (could be expired after long idle).
-        if m.get("reply_future") is not None or m.get("conversation_id"):
+        if self._is_reply_context(m):
             logger.info(
                 "dingtalk _get_session_webhook_for_send: to_handle=%s "
                 "current request has no session_webhook, skip store",
-                to_handle[:40] if to_handle else "",
+                short_handle,
             )
             return None
         key = route.get("webhook_key")
@@ -719,15 +720,35 @@ class DingTalkChannel(BaseChannel):
                 logger.info(
                     "dingtalk _get_session_webhook_for_send: to_handle=%s "
                     "source=store webhook_key=%s",
-                    to_handle[:40] if to_handle else "",
+                    short_handle,
                     key,
                 )
             return webhook
         logger.info(
             "dingtalk _get_session_webhook_for_send: to_handle=%s source=none",
-            to_handle[:40] if to_handle else "",
+            short_handle,
         )
         return None
+
+    def _is_reply_context(self, meta: Optional[Dict[str, Any]]) -> bool:
+        """True when meta indicates request-reply context from user message."""
+        m = meta or {}
+        return (
+            m.get("reply_loop") is not None
+            or m.get("reply_future") is not None
+            or bool(m.get("conversation_id"))
+        )
+
+    def _sanitize_to_handle(self, to_handle: str) -> str:
+        """Mask possible secret tokens in handles before logging/errors."""
+        s = (to_handle or "").strip()
+        if not s:
+            return ""
+        if s.startswith("http://") or s.startswith("https://"):
+            parsed = urlparse(s)
+            safe = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+            return safe[:40] + "..." if len(safe) > 40 else safe
+        return s[:40] + "..." if len(s) > 40 else s
 
     def _map_upload_type(self, part: OutgoingContentPart) -> Optional[str]:
         """
@@ -1016,8 +1037,9 @@ class DingTalkChannel(BaseChannel):
         parts: List[OutgoingContentPart],
         meta: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Build one body from parts. If meta has reply_future (reply path),
-        deliver via _reply_sync; otherwise proactive send via send().
+        """Build one body from parts. If reply context metadata is present
+        (`reply_loop`, `reply_future`, or `conversation_id`), deliver via
+        _reply_sync; otherwise proactive send via send().
         When session_webhook is available, sends text then image/file
         messages (upload media first for image/file).
         """
@@ -1052,11 +1074,8 @@ class DingTalkChannel(BaseChannel):
         elif prefix and not body and not media_parts:
             body = prefix
         m = meta or {}
-        is_reply_context = (
-            m.get("reply_loop") is not None
-            or m.get("reply_future") is not None
-            or bool(m.get("conversation_id"))
-        )
+        safe_handle = self._sanitize_to_handle(to_handle)
+        is_reply_context = self._is_reply_context(m)
         is_proactive_send = not is_reply_context
         session_webhook = await self._get_session_webhook_for_send(
             to_handle,
@@ -1082,7 +1101,7 @@ class DingTalkChannel(BaseChannel):
                     raise RuntimeError(
                         "DingTalk proactive send failed: "
                         "text sendBySession failed "
-                        f"(to_handle={to_handle})",
+                        f"(to_handle={safe_handle})",
                     )
             for i, part in enumerate(media_parts):
                 logger.info(
@@ -1105,7 +1124,7 @@ class DingTalkChannel(BaseChannel):
                     raise RuntimeError(
                         "DingTalk proactive send failed: "
                         "media sendBySession failed "
-                        f"(to_handle={to_handle}, index={i + 1})",
+                        f"(to_handle={safe_handle}, index={i + 1})",
                     )
             if m.get("reply_loop") is not None and m.get("reply_future"):
                 self._reply_sync(m, SENT_VIA_WEBHOOK)
@@ -1113,7 +1132,7 @@ class DingTalkChannel(BaseChannel):
         if is_proactive_send and (body.strip() or media_parts):
             raise RuntimeError(
                 "DingTalk proactive send failed: no sessionWebhook found "
-                f"(to_handle={to_handle}); user must chat first and "
+                f"(to_handle={safe_handle}); user must chat first and "
                 "sessionWebhook may expire.",
             )
         if not body and media_parts:

--- a/tests/channels/test_dingtalk_cron_send_fail_visibility.py
+++ b/tests/channels/test_dingtalk_cron_send_fail_visibility.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from agentscope_runtime.engine.schemas.agent_schemas import (
+    ContentType,
+    TextContent,
+)
+
+from copaw.app.channels.dingtalk.channel import DingTalkChannel
+
+
+async def _dummy_process(_request):
+    if False:  # pragma: no cover
+        yield None
+
+
+def _build_channel() -> DingTalkChannel:
+    return DingTalkChannel(
+        process=_dummy_process,
+        enabled=True,
+        client_id="",
+        client_secret="",
+        bot_prefix="[BOT] ",
+    )
+
+
+@pytest.mark.asyncio
+async def test_proactive_send_raises_when_no_session_webhook() -> None:
+    ch = _build_channel()
+    ch._get_session_webhook_for_send = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="no sessionWebhook found"):
+        await ch.send_content_parts(
+            "dingtalk:sw:missing",
+            [TextContent(type=ContentType.TEXT, text="hello")],
+            {"session_id": "missing", "user_id": "u1"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_proactive_send_raises_when_webhook_api_fails() -> None:
+    ch = _build_channel()
+    ch._get_session_webhook_for_send = AsyncMock(  # type: ignore[attr-defined]
+        return_value="https://oapi.dingtalk.com/robot/sendBySession?session=x",
+    )
+    ch._send_via_session_webhook = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="text sendBySession failed"):
+        await ch.send_content_parts(
+            "dingtalk:sw:exists",
+            [TextContent(type=ContentType.TEXT, text="hello")],
+            {"session_id": "exists", "user_id": "u2"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_reply_context_without_webhook_does_not_raise() -> None:
+    ch = _build_channel()
+    ch._get_session_webhook_for_send = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str] = loop.create_future()
+    await ch.send_content_parts(
+        "dingtalk:sw:reply",
+        [TextContent(type=ContentType.TEXT, text="hello")],
+        {"reply_loop": loop, "reply_future": future},
+    )
+    await asyncio.sleep(0)
+
+    assert future.done()
+    assert future.result() == "hello"

--- a/tests/channels/test_dingtalk_cron_send_fail_visibility.py
+++ b/tests/channels/test_dingtalk_cron_send_fail_visibility.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
 
 import pytest
 from agentscope_runtime.engine.schemas.agent_schemas import (
@@ -15,12 +14,33 @@ from copaw.app.channels.dingtalk.channel import DingTalkChannel
 
 
 async def _dummy_process(_request):
-    if False:  # pragma: no cover
-        yield None
+    return None
 
 
-def _build_channel() -> DingTalkChannel:
-    return DingTalkChannel(
+class _TestDingTalkChannel(DingTalkChannel):
+    async def _get_session_webhook_for_send(
+        self,
+        to_handle,
+        meta,
+    ):  # noqa: ANN001
+        del to_handle
+        del meta
+        return getattr(self, "test_webhook", None)
+
+    async def _send_via_session_webhook(  # noqa: ANN001
+        self,
+        session_webhook,
+        body,
+        bot_prefix="",
+    ):
+        del session_webhook
+        del body
+        del bot_prefix
+        return bool(getattr(self, "test_send_ok", True))
+
+
+def _build_channel() -> _TestDingTalkChannel:
+    return _TestDingTalkChannel(
         process=_dummy_process,
         enabled=True,
         client_id="",
@@ -32,7 +52,7 @@ def _build_channel() -> DingTalkChannel:
 @pytest.mark.asyncio
 async def test_proactive_send_raises_when_no_session_webhook() -> None:
     ch = _build_channel()
-    ch._get_session_webhook_for_send = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+    ch.test_webhook = None
 
     with pytest.raises(RuntimeError, match="no sessionWebhook found"):
         await ch.send_content_parts(
@@ -45,10 +65,8 @@ async def test_proactive_send_raises_when_no_session_webhook() -> None:
 @pytest.mark.asyncio
 async def test_proactive_send_raises_when_webhook_api_fails() -> None:
     ch = _build_channel()
-    ch._get_session_webhook_for_send = AsyncMock(  # type: ignore[attr-defined]
-        return_value="https://oapi.dingtalk.com/robot/sendBySession?session=x",
-    )
-    ch._send_via_session_webhook = AsyncMock(return_value=False)  # type: ignore[attr-defined]
+    ch.test_webhook = "https://oapi.dingtalk.com/robot/sendBySession?session=x"
+    ch.test_send_ok = False
 
     with pytest.raises(RuntimeError, match="text sendBySession failed"):
         await ch.send_content_parts(
@@ -61,7 +79,7 @@ async def test_proactive_send_raises_when_webhook_api_fails() -> None:
 @pytest.mark.asyncio
 async def test_reply_context_without_webhook_does_not_raise() -> None:
     ch = _build_channel()
-    ch._get_session_webhook_for_send = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+    ch.test_webhook = None
 
     loop = asyncio.get_running_loop()
     future: asyncio.Future[str] = loop.create_future()
@@ -70,7 +88,5 @@ async def test_reply_context_without_webhook_does_not_raise() -> None:
         [TextContent(type=ContentType.TEXT, text="hello")],
         {"reply_loop": loop, "reply_future": future},
     )
-    await asyncio.sleep(0)
-
-    assert future.done()
-    assert future.result() == "hello"
+    out = await asyncio.wait_for(future, timeout=1.0)
+    assert out == "hello"


### PR DESCRIPTION
## Summary
- make DingTalk proactive cron sends fail fast when `sessionWebhook` is missing
- make proactive sends fail when `sendBySession` returns API failure
- keep reply-context behavior unchanged (no new exception for normal reply path)
- add regression tests for proactive-failure and reply-context behavior

## Why
Cron jobs to DingTalk could be marked `success` even when no message was delivered (missing/expired webhook). This hides delivery failures from users.

## Validation
- `PYTHONPATH=/Users/nowcoder/.codex/worktrees/4340/CoPaw/src python3 -m pytest -q tests/channels/test_dingtalk_cron_send_fail_visibility.py tests/channels/test_qq_url_sanitize.py`
- local manual verification:
  - invalid DingTalk session id => cron state `error`
  - stored but expired sessionWebhook (`errcode=300001`) => cron state `error`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of reply vs. proactive sends and safer logging by masking sensitive handles.
  * Added clearer errors for proactive send failures when session webhooks are missing or fail.
  * Extra per-part delivery checks so individual media/text component failures are surfaced and handled.

* **Tests**
  * Added tests covering proactive send error cases and reply behavior when no session webhook is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->