### PR TITLE
fix: Handle missing local media files during memory compaction

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -41,6 +41,9 @@ def _file_url_to_path(url: str) -> str:
     return s
 
 
+import urllib.parse
+import os
+
 def _monkey_patch(func):
     """A monkey patch wrapper for agentscope <= 1.0.16dev"""
 
@@ -61,7 +64,23 @@ def _monkey_patch(func):
                     ):
                         url = block["source"]["url"]
                         if url.startswith("file://"):
-                            block["source"]["url"] = _file_url_to_path(url)
+                            url = _file_url_to_path(url)
+                            block["source"]["url"] = url
+
+                        # Prevent crash when the local file is deleted
+                        parsed_url = urllib.parse.urlparse(url)
+                        if parsed_url.scheme == "" and not os.path.exists(url):
+                            logger.warning(
+                                "Local %s file not found during formatting, replacing with placeholder: %s",
+                                block["type"],
+                                url,
+                            )
+                            # Overwrite block type to avoid sending missing media to LLM API
+                            typ = block.get("type", "media")
+                            block.clear()
+                            block["type"] = "text"
+                            block["text"] = f"[Missing {typ} file: {url}]"
+
         return await func(self, msgs, **kwargs)
 
     return wrapper


### PR DESCRIPTION
This PR handles a `TypeError` that occurs at `agentscope.formatter._openai_formatter._to_openai_image_url` during memory compaction in CoPaw when a local image file (e.g., from Telegram) is deleted.

Previously, `_to_openai_image_url` would try to process a non-existent local file URL (e.g. `file://...`), leading to an invalid image format error.

This monkey patch checks for the existence of local media files (`audio`, `image`, `video`) and replaces the block with a text placeholder if the file is missing, preventing CoPaw from crashing during memory compaction.