### PR TITLE
fix(channels): prevent empty qq text blocks from reaching anthropic

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -283,20 +283,20 @@ def _strip_empty_text_blocks(
             sanitized.append(message)
             continue
 
-        filtered = []
-        for block in content:
-            if (
+        filtered = [
+            block
+            for block in content
+            if not (
                 isinstance(block, dict)
                 and block.get("type") == "text"
                 and not str(block.get("text") or "").strip()
-            ):
-                continue
-            filtered.append(block)
+            )
+        ]
 
         if not filtered and not message.get("tool_calls"):
             continue
 
-        if filtered != content:
+        if len(filtered) != len(content):
             message = {**message, "content": filtered}
         sanitized.append(message)
     return sanitized

--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -179,6 +179,7 @@ def _create_file_block_support_formatter(
                         if reasoning:
                             out_msg["reasoning_content"] = reasoning
 
+            messages = _strip_empty_text_blocks(messages)
             return _strip_top_level_message_name(messages)
 
         @staticmethod
@@ -269,6 +270,36 @@ def _strip_top_level_message_name(
     for message in messages:
         message.pop("name", None)
     return messages
+
+
+def _strip_empty_text_blocks(
+    messages: list[dict],
+) -> list[dict]:
+    """Remove empty top-level text blocks before provider invocation."""
+    sanitized: list[dict] = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            sanitized.append(message)
+            continue
+
+        filtered = []
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and not str(block.get("text") or "").strip()
+            ):
+                continue
+            filtered.append(block)
+
+        if not filtered and not message.get("tool_calls"):
+            continue
+
+        if filtered != content:
+            message = {**message, "content": filtered}
+        sanitized.append(message)
+    return sanitized
 
 
 def create_model_and_formatter() -> Tuple[ChatModelBase, FormatterBase]:

--- a/src/copaw/app/channels/base.py
+++ b/src/copaw/app/channels/base.py
@@ -226,6 +226,23 @@ class BaseChannel(ABC):
                 return True
         return False
 
+    def _normalize_content_parts(
+        self,
+        content_parts: List[Any],
+    ) -> List[Any]:
+        """Drop semantically empty content blocks before downstream use."""
+        normalized: List[Any] = []
+        for part in content_parts or []:
+            typ = getattr(part, "type", None)
+            if typ == ContentType.TEXT:
+                if not (getattr(part, "text", None) or "").strip():
+                    continue
+            elif typ == ContentType.REFUSAL:
+                if not (getattr(part, "refusal", None) or "").strip():
+                    continue
+            normalized.append(part)
+        return normalized
+
     def _apply_no_text_debounce(
         self,
         session_id: str,
@@ -235,18 +252,21 @@ class BaseChannel(ABC):
         Debounce: if content has no text, buffer and return (False, []).
         If has text, return (True, merged) with any buffered content prepended.
         """
-        if not self._content_has_text(content_parts):
+        normalized = self._normalize_content_parts(content_parts)
+        if not normalized:
+            return (False, [])
+        if not self._content_has_text(normalized):
             self._pending_content_by_session.setdefault(
                 session_id,
                 [],
-            ).extend(content_parts)
+            ).extend(normalized)
             logger.debug(
                 "channel debounce: no text, buffered session_id=%s",
                 session_id[:24] if session_id else "",
             )
             return (False, [])
         pending = self._pending_content_by_session.pop(session_id, [])
-        merged = pending + list(content_parts)
+        merged = pending + list(normalized)
         return (True, merged)
 
     def _check_allowlist(
@@ -328,10 +348,7 @@ class BaseChannel(ABC):
             Role,
         )
 
-        if not content_parts:
-            content_parts = [
-                TextContent(type=ContentType.TEXT, text=""),
-            ]
+        content_parts = self._normalize_content_parts(content_parts)
         msg = Message(
             type=MessageType.MESSAGE,
             role=Role.USER,

--- a/src/copaw/app/channels/qq/channel.py
+++ b/src/copaw/app/channels/qq/channel.py
@@ -122,6 +122,18 @@ def _should_plaintext_fallback_from_markdown(exc: Exception) -> bool:
     )
 
 
+def _qq_text_content_parts(text: str) -> list[TextContent]:
+    """Build QQ text parts without introducing empty text placeholders."""
+    if not text:
+        return []
+    return [
+        TextContent(
+            type=ContentType.TEXT,
+            text=text,
+        ),
+    ]
+
+
 def _get_api_base() -> str:
     """API root address (e.g. sandbox: https://sandbox.api.sgroup.qq.com)"""
     return os.getenv("QQ_API_BASE", DEFAULT_API_BASE).rstrip("/")
@@ -1021,12 +1033,7 @@ class QQChannel(BaseChannel):
                             native = {
                                 "channel_id": "qq",
                                 "sender_id": sender,
-                                "content_parts": [
-                                    TextContent(
-                                        type=ContentType.TEXT,
-                                        text=text,
-                                    ),
-                                ],
+                                "content_parts": _qq_text_content_parts(text),
                                 "meta": meta,
                             }
                             request = self.build_agent_request_from_native(
@@ -1073,12 +1080,7 @@ class QQChannel(BaseChannel):
                             native = {
                                 "channel_id": "qq",
                                 "sender_id": sender,
-                                "content_parts": [
-                                    TextContent(
-                                        type=ContentType.TEXT,
-                                        text=text,
-                                    ),
-                                ],
+                                "content_parts": _qq_text_content_parts(text),
                                 "meta": meta,
                             }
                             request = self.build_agent_request_from_native(
@@ -1125,12 +1127,7 @@ class QQChannel(BaseChannel):
                             native = {
                                 "channel_id": "qq",
                                 "sender_id": sender,
-                                "content_parts": [
-                                    TextContent(
-                                        type=ContentType.TEXT,
-                                        text=text,
-                                    ),
-                                ],
+                                "content_parts": _qq_text_content_parts(text),
                                 "meta": meta,
                             }
                             request = self.build_agent_request_from_native(
@@ -1174,12 +1171,7 @@ class QQChannel(BaseChannel):
                             native = {
                                 "channel_id": "qq",
                                 "sender_id": sender,
-                                "content_parts": [
-                                    TextContent(
-                                        type=ContentType.TEXT,
-                                        text=text,
-                                    ),
-                                ],
+                                "content_parts": _qq_text_content_parts(text),
                                 "meta": meta,
                             }
                             request = self.build_agent_request_from_native(

--- a/tests/channels/test_qq_empty_text_normalization.py
+++ b/tests/channels/test_qq_empty_text_normalization.py
@@ -11,9 +11,9 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
 from copaw.app.channels.qq.channel import QQChannel
 
 
-async def _dummy_process(request):
-    if False:
-        yield request
+async def _dummy_process(_request):  # pragma: no cover
+    return  # noqa: B901
+    yield  # pylint: disable=unreachable
 
 
 def _make_channel() -> QQChannel:
@@ -25,7 +25,7 @@ def _make_channel() -> QQChannel:
     )
 
 
-def test_build_agent_request_from_user_content_drops_empty_text() -> None:
+def test_build_agent_request_from_user_content_drops_empty_text():
     channel = _make_channel()
 
     request = channel.build_agent_request_from_user_content(
@@ -34,7 +34,10 @@ def test_build_agent_request_from_user_content_drops_empty_text() -> None:
         session_id="qq:user-1",
         content_parts=[
             TextContent(type=ContentType.TEXT, text=""),
-            ImageContent(type=ContentType.IMAGE, image_url="/tmp/demo.png"),
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url="/tmp/demo.png",
+            ),
         ],
     )
 
@@ -43,17 +46,24 @@ def test_build_agent_request_from_user_content_drops_empty_text() -> None:
     ]
 
 
-def test_build_agent_request_from_native_keeps_media_without_empty_text() -> None:
+def test_build_agent_request_from_native_keeps_media():
     channel = _make_channel()
-    channel._parse_qq_attachments = lambda attachments: [  # type: ignore[attr-defined]
-        ImageContent(type=ContentType.IMAGE, image_url="/tmp/demo.png"),
-    ]
+    channel._parse_qq_attachments = (  # pylint: disable=protected-access
+        lambda _attachments: [
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url="/tmp/demo.png",
+            ),
+        ]
+    )
 
     request = channel.build_agent_request_from_native(
         {
             "channel_id": "qq",
             "sender_id": "user-1",
-            "content_parts": [TextContent(type=ContentType.TEXT, text="")],
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text=""),
+            ],
             "meta": {
                 "attachments": [
                     {
@@ -71,10 +81,10 @@ def test_build_agent_request_from_native_keeps_media_without_empty_text() -> Non
     ]
 
 
-async def test_consume_one_merges_image_then_text_without_blank_prefix() -> None:
+async def test_consume_one_merges_image_then_text():
     captured: list[list[str]] = []
 
-    async def fake_process(request):
+    async def fake_process(request):  # pragma: no cover
         captured.append(
             [
                 getattr(part, "text", None)
@@ -83,8 +93,8 @@ async def test_consume_one_merges_image_then_text_without_blank_prefix() -> None
                 for part in request.input[0].content
             ],
         )
-        if False:
-            yield request
+        return  # noqa: B901
+        yield  # pylint: disable=unreachable
 
     channel = QQChannel(
         process=fake_process,
@@ -99,18 +109,23 @@ async def test_consume_one_merges_image_then_text_without_blank_prefix() -> None
         session_id="qq:user-1",
         content_parts=[
             TextContent(type=ContentType.TEXT, text=""),
-            ImageContent(type=ContentType.IMAGE, image_url="/tmp/demo.png"),
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url="/tmp/demo.png",
+            ),
         ],
     )
     text_request = channel.build_agent_request_from_user_content(
         channel_id="qq",
         sender_id="user-1",
         session_id="qq:user-1",
-        content_parts=[TextContent(type=ContentType.TEXT, text="后续文字")],
+        content_parts=[
+            TextContent(type=ContentType.TEXT, text="后续文字"),
+        ],
     )
 
     await channel.consume_one(image_request)
-    assert captured == []
+    assert not captured
 
     await channel.consume_one(text_request)
 

--- a/tests/channels/test_qq_empty_text_normalization.py
+++ b/tests/channels/test_qq_empty_text_normalization.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from agentscope_runtime.engine.schemas.agent_schemas import (
+    ContentType,
+    ImageContent,
+    TextContent,
+)
+
+from copaw.app.channels.qq.channel import QQChannel
+
+
+async def _dummy_process(request):
+    if False:
+        yield request
+
+
+def _make_channel() -> QQChannel:
+    return QQChannel(
+        process=_dummy_process,
+        enabled=False,
+        app_id="app-id",
+        client_secret="secret",
+    )
+
+
+def test_build_agent_request_from_user_content_drops_empty_text() -> None:
+    channel = _make_channel()
+
+    request = channel.build_agent_request_from_user_content(
+        channel_id="qq",
+        sender_id="user-1",
+        session_id="qq:user-1",
+        content_parts=[
+            TextContent(type=ContentType.TEXT, text=""),
+            ImageContent(type=ContentType.IMAGE, image_url="/tmp/demo.png"),
+        ],
+    )
+
+    assert [part.type for part in request.input[0].content] == [
+        ContentType.IMAGE,
+    ]
+
+
+def test_build_agent_request_from_native_keeps_media_without_empty_text() -> None:
+    channel = _make_channel()
+    channel._parse_qq_attachments = lambda attachments: [  # type: ignore[attr-defined]
+        ImageContent(type=ContentType.IMAGE, image_url="/tmp/demo.png"),
+    ]
+
+    request = channel.build_agent_request_from_native(
+        {
+            "channel_id": "qq",
+            "sender_id": "user-1",
+            "content_parts": [TextContent(type=ContentType.TEXT, text="")],
+            "meta": {
+                "attachments": [
+                    {
+                        "filename": "demo.png",
+                        "url": "https://example.com/demo.png",
+                        "content_type": "image/png",
+                    },
+                ],
+            },
+        },
+    )
+
+    assert [part.type for part in request.input[0].content] == [
+        ContentType.IMAGE,
+    ]
+
+
+async def test_consume_one_merges_image_then_text_without_blank_prefix() -> None:
+    captured: list[list[str]] = []
+
+    async def fake_process(request):
+        captured.append(
+            [
+                getattr(part, "text", None)
+                if part.type == ContentType.TEXT
+                else getattr(part, "image_url", None)
+                for part in request.input[0].content
+            ],
+        )
+        if False:
+            yield request
+
+    channel = QQChannel(
+        process=fake_process,
+        enabled=False,
+        app_id="app-id",
+        client_secret="secret",
+    )
+
+    image_request = channel.build_agent_request_from_user_content(
+        channel_id="qq",
+        sender_id="user-1",
+        session_id="qq:user-1",
+        content_parts=[
+            TextContent(type=ContentType.TEXT, text=""),
+            ImageContent(type=ContentType.IMAGE, image_url="/tmp/demo.png"),
+        ],
+    )
+    text_request = channel.build_agent_request_from_user_content(
+        channel_id="qq",
+        sender_id="user-1",
+        session_id="qq:user-1",
+        content_parts=[TextContent(type=ContentType.TEXT, text="后续文字")],
+    )
+
+    await channel.consume_one(image_request)
+    assert captured == []
+
+    await channel.consume_one(text_request)
+
+    assert captured == [["/tmp/demo.png", "后续文字"]]

--- a/tests/test_model_factory_empty_text_blocks.py
+++ b/tests/test_model_factory_empty_text_blocks.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+from agentscope.formatter import AnthropicChatFormatter
+from agentscope.message import Msg
+
+from copaw.agents.model_factory import _create_file_block_support_formatter
+
+
+async def test_formatter_wrapper_strips_empty_text_blocks() -> None:
+    formatter_cls = _create_file_block_support_formatter(
+        AnthropicChatFormatter,
+    )
+    formatter = formatter_cls()
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[
+            {"type": "text", "text": ""},
+            {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/demo.png",
+                },
+            },
+            {"type": "text", "text": "后续文字"},
+        ],
+    )
+
+    messages = await formatter.format([msg])
+
+    assert messages == [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "url",
+                        "url": "https://example.com/demo.png",
+                    },
+                },
+                {"type": "text", "text": "后续文字"},
+            ],
+        },
+    ]


### PR DESCRIPTION
## Summary
- normalize inbound content parts so empty text/refusal blocks are removed before request construction and debounce merging
- stop QQ event handlers from creating empty text placeholders for attachment-only messages
- add a formatter-level guard to strip empty top-level text blocks before provider invocation
- add regression coverage for QQ image-only / image-then-text flows and formatter sanitization

## Validation
- `PYTHONPATH=src pre-commit run --all-files`
- `pytest tests/channels/test_qq_empty_text_normalization.py tests/test_model_factory_empty_text_blocks.py tests/channels/test_qq_url_sanitize.py`

Closes #1133
