### PR TITLE
fix(memory): normalize check_context results in compaction hook

### DIFF
--- a/src/copaw/agents/hooks/memory_compaction.py
+++ b/src/copaw/agents/hooks/memory_compaction.py
@@ -6,6 +6,7 @@ when the context window approaches its limit, preserving recent messages
 and the system prompt.
 """
 import logging
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from agentscope.agent._react_agent import _MemoryMark, ReActAgent
@@ -22,6 +23,42 @@ if TYPE_CHECKING:
     from reme.memory.file_based import ReMeInMemoryMemory
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_check_context_result(
+    result: Any,
+) -> tuple[list[Any], bool]:
+    """Normalize check_context results across dependency versions.
+
+    CoPaw only needs two fields from ``check_context``:
+    ``messages_to_compact`` and ``is_valid``. Upstream implementations may
+    evolve from a plain 3-tuple to a richer tuple, mapping, or typed object.
+    This adapter keeps the hook stable as long as those two semantics remain
+    available.
+    """
+    if isinstance(result, Mapping):
+        try:
+            return result["messages_to_compact"], bool(result["is_valid"])
+        except KeyError as exc:
+            raise ValueError(
+                "check_context result mapping is missing required keys: "
+                "'messages_to_compact' and/or 'is_valid'",
+            ) from exc
+
+    if hasattr(result, "messages_to_compact") and hasattr(result, "is_valid"):
+        return result.messages_to_compact, bool(result.is_valid)
+
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes)):
+        if len(result) < 3:
+            raise ValueError(
+                "check_context result must contain at least 3 items, "
+                f"got {len(result)}",
+            )
+        return result[0], bool(result[2])
+
+    raise TypeError(
+        "Unsupported check_context result type: " f"{type(result).__name__}",
+    )
 
 
 class MemoryCompactionHook:
@@ -104,15 +141,14 @@ class MemoryCompactionHook:
             memory_compact_reserve = (
                 config.agents.running.memory_compact_reserve
             )
-            (
-                messages_to_compact,
-                _,
-                is_valid,
-            ) = await self.memory_manager.check_context(
+            check_context_result = await self.memory_manager.check_context(
                 messages=messages,
                 memory_compact_threshold=left_compact_threshold,
                 memory_compact_reserve=memory_compact_reserve,
                 token_counter=token_counter,
+            )
+            messages_to_compact, is_valid = _normalize_check_context_result(
+                check_context_result,
             )
 
             if not messages_to_compact:

--- a/tests/test_memory_compaction_hook.py
+++ b/tests/test_memory_compaction_hook.py
@@ -12,7 +12,6 @@ from copaw.agents.hooks.memory_compaction import MemoryCompactionHook
 class FakeMsg:
     id: str
     role: str
-    token_count: int
     content: str = "x"
 
 
@@ -24,16 +23,15 @@ class FakeMemory:
     ) -> None:
         self._messages = messages
         self._compressed_summary = compressed_summary
-        self.updated_summary = None
+        self.updated_summary: str | None = None
         self.marked_ids: list[str] = []
 
     async def get_memory(
         self,
-        exclude_mark: str | None = None,
         prepend_summary: bool = False,
         **_kwargs,
     ) -> list[FakeMsg]:
-        del exclude_mark, prepend_summary
+        del prepend_summary
         return self._messages
 
     def get_compressed_summary(self) -> str:
@@ -53,10 +51,29 @@ class FakeMemory:
         return len(msg_ids)
 
 
+class FakeCheckContextResult:
+    def __init__(
+        self,
+        messages_to_compact: list[FakeMsg],
+        is_valid: bool,
+    ) -> None:
+        self.messages_to_compact = messages_to_compact
+        self.is_valid = is_valid
+
+
 class FakeMemoryManager:
-    def __init__(self) -> None:
+    def __init__(self, check_context_result: Any) -> None:
+        self.check_context_result = check_context_result
+        self.token_counter = object()
         self.summary_task_messages: list[list[FakeMsg]] = []
         self.compact_calls: list[dict[str, Any]] = []
+        self.tool_result_compact_calls: list[list[FakeMsg]] = []
+
+    async def check_context(self, **_kwargs) -> Any:
+        return self.check_context_result
+
+    async def compact_tool_result(self, messages: list[FakeMsg]) -> None:
+        self.tool_result_compact_calls.append(list(messages))
 
     def add_async_summary_task(self, messages: list[FakeMsg]) -> None:
         self.summary_task_messages.append(list(messages))
@@ -75,138 +92,166 @@ class FakeMemoryManager:
         return "compacted-summary"
 
 
-class FakeFormatter:
-    def __init__(self) -> None:
-        self.calls = 0
-
-    async def format(self, msgs: list[FakeMsg]) -> list[dict[str, Any]]:
-        self.calls += 1
-        return [
-            {
-                "role": msg.role,
-                "content": str(getattr(msg, "content", "")),
-                "_test_token_count": int(
-                    getattr(msg, "token_count", 0)
-                    or max(len(str(getattr(msg, "content", ""))) // 4, 1),
-                ),
-            }
-            for msg in msgs
-        ]
-
-
 def _make_agent(messages: list[FakeMsg], summary: str = "") -> Any:
-    memory = FakeMemory(messages=messages, compressed_summary=summary)
-    formatter = FakeFormatter()
     return SimpleNamespace(
-        memory=memory,
-        formatter=formatter,
+        memory=FakeMemory(messages=messages, compressed_summary=summary),
+        sys_prompt="system-prompt",
     )
 
 
-async def _fake_safe_count_message_tokens(
-    messages: list[dict[str, Any]],
-) -> int:
-    return sum(int(msg.get("_test_token_count", 0)) for msg in messages)
-
-
-def _fake_safe_count_str_tokens(text: str) -> int:
-    return len(text) // 4 if text else 0
-
-
-async def test_compaction_triggers_on_total_context_budget(
-    monkeypatch,
-) -> None:
-    monkeypatch.setattr(
-        "copaw.agents.hooks.memory_compaction.safe_count_message_tokens",
-        _fake_safe_count_message_tokens,
-    )
-    monkeypatch.setattr(
-        "copaw.agents.hooks.memory_compaction.safe_count_str_tokens",
-        _fake_safe_count_str_tokens,
-    )
-    monkeypatch.setattr(
-        "copaw.agents.hooks.memory_compaction.load_config",
-        lambda: SimpleNamespace(
-            agents=SimpleNamespace(
-                running=SimpleNamespace(memory_compact_threshold=950),
+def _make_config(
+    *,
+    memory_compact_threshold: int = 100,
+    enable_tool_result_compact: bool = False,
+    tool_result_compact_keep_n: int = 0,
+    memory_compact_reserve: int = 10,
+) -> Any:
+    return SimpleNamespace(
+        agents=SimpleNamespace(
+            running=SimpleNamespace(
+                memory_compact_threshold=memory_compact_threshold,
+                enable_tool_result_compact=enable_tool_result_compact,
+                tool_result_compact_keep_n=tool_result_compact_keep_n,
+                memory_compact_reserve=memory_compact_reserve,
             ),
         ),
     )
+
+
+def _make_config_loader(config: Any):
+    def _loader() -> Any:
+        return config
+
+    return _loader
+
+
+def _zero_token_count(_text: str) -> int:
+    return 0
+
+
+async def test_compaction_succeeds_with_three_item_result(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
-        "copaw.agents.hooks.memory_compaction.MEMORY_COMPACT_KEEP_RECENT",
-        1,
+        "copaw.agents.hooks.memory_compaction.load_config",
+        _make_config_loader(_make_config()),
+    )
+    monkeypatch.setattr(
+        "copaw.agents.hooks.memory_compaction.safe_count_str_tokens",
+        _zero_token_count,
     )
 
-    memory_manager = FakeMemoryManager()
-    hook = MemoryCompactionHook(
-        memory_manager=memory_manager,
-    )
-
-    # message_tokens = 950 (at threshold),
-    # so no compaction by message-only count
-    # summary_tokens > 0 for non-empty wrapped summary
-    # total = message_tokens + summary_tokens > threshold => should compact.
     messages = [
-        FakeMsg(id="sys", role="system", token_count=250),
-        FakeMsg(id="old-1", role="user", token_count=250),
-        FakeMsg(id="old-2", role="assistant", token_count=250),
-        FakeMsg(id="recent", role="user", token_count=200),
+        FakeMsg(id="old-1", role="user"),
+        FakeMsg(id="old-2", role="assistant"),
+        FakeMsg(id="recent", role="user"),
     ]
+    memory_manager = FakeMemoryManager(
+        check_context_result=(messages[:2], messages[2:], True),
+    )
+    hook = MemoryCompactionHook(memory_manager=memory_manager)
     agent = _make_agent(messages=messages, summary="existing-summary")
 
     await hook(agent=agent, kwargs={})
 
     assert memory_manager.compact_calls
-    assert memory_manager.summary_task_messages
+    assert memory_manager.summary_task_messages == [messages[:2]]
     assert agent.memory.updated_summary == "compacted-summary"
     assert agent.memory.marked_ids == ["old-1", "old-2"]
-    assert agent.formatter.calls == 1
 
 
-async def test_compaction_not_triggered_when_total_under_threshold(
+async def test_compaction_succeeds_with_extended_tuple_result(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
-        "copaw.agents.hooks.memory_compaction.safe_count_message_tokens",
-        _fake_safe_count_message_tokens,
+        "copaw.agents.hooks.memory_compaction.load_config",
+        _make_config_loader(_make_config()),
     )
     monkeypatch.setattr(
         "copaw.agents.hooks.memory_compaction.safe_count_str_tokens",
-        _fake_safe_count_str_tokens,
+        _zero_token_count,
     )
+
+    messages = [
+        FakeMsg(id="old-1", role="user"),
+        FakeMsg(id="recent", role="assistant"),
+    ]
+    memory_manager = FakeMemoryManager(
+        check_context_result=(messages[:1], messages[1:], True, {"extra": 1}),
+    )
+    hook = MemoryCompactionHook(memory_manager=memory_manager)
+    agent = _make_agent(messages=messages)
+
+    await hook(agent=agent, kwargs={})
+
+    assert memory_manager.compact_calls
+    assert memory_manager.summary_task_messages == [messages[:1]]
+    assert agent.memory.marked_ids == ["old-1"]
+
+
+async def test_compaction_succeeds_with_object_result(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         "copaw.agents.hooks.memory_compaction.load_config",
-        lambda: SimpleNamespace(
-            agents=SimpleNamespace(
-                running=SimpleNamespace(memory_compact_threshold=950),
+        _make_config_loader(_make_config()),
+    )
+    monkeypatch.setattr(
+        "copaw.agents.hooks.memory_compaction.safe_count_str_tokens",
+        _zero_token_count,
+    )
+
+    messages = [
+        FakeMsg(id="old-1", role="user"),
+        FakeMsg(id="recent", role="assistant"),
+    ]
+    memory_manager = FakeMemoryManager(
+        check_context_result=FakeCheckContextResult(
+            messages_to_compact=messages[:1],
+            is_valid=True,
+        ),
+    )
+    hook = MemoryCompactionHook(memory_manager=memory_manager)
+    agent = _make_agent(messages=messages)
+
+    await hook(agent=agent, kwargs={})
+
+    assert memory_manager.compact_calls
+    assert agent.memory.updated_summary == "compacted-summary"
+    assert agent.memory.marked_ids == ["old-1"]
+
+
+async def test_no_compaction_when_check_context_returns_empty_messages(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "copaw.agents.hooks.memory_compaction.load_config",
+        _make_config_loader(
+            _make_config(
+                enable_tool_result_compact=True,
+                tool_result_compact_keep_n=1,
             ),
         ),
     )
     monkeypatch.setattr(
-        "copaw.agents.hooks.memory_compaction.MEMORY_COMPACT_KEEP_RECENT",
-        1,
+        "copaw.agents.hooks.memory_compaction.safe_count_str_tokens",
+        _zero_token_count,
     )
 
-    memory_manager = FakeMemoryManager()
-    hook = MemoryCompactionHook(
-        memory_manager=memory_manager,
-    )
-
-    # message_tokens = 800
-    # summary_tokens ~= wrapped-summary-length//4
-    # total stays below threshold => should not compact.
     messages = [
-        FakeMsg(id="sys", role="system", token_count=200),
-        FakeMsg(id="old-1", role="user", token_count=200),
-        FakeMsg(id="old-2", role="assistant", token_count=200),
-        FakeMsg(id="recent", role="user", token_count=200),
+        FakeMsg(id="old-1", role="user"),
+        FakeMsg(id="recent", role="assistant"),
     ]
-    agent = _make_agent(messages=messages, summary="existing-summary")
+    memory_manager = FakeMemoryManager(
+        check_context_result={"messages_to_compact": [], "is_valid": True},
+    )
+    hook = MemoryCompactionHook(memory_manager=memory_manager)
+    agent = _make_agent(messages=messages)
 
     await hook(agent=agent, kwargs={})
 
+    assert memory_manager.tool_result_compact_calls == [messages[:-1]]
     assert not memory_manager.compact_calls
     assert not memory_manager.summary_task_messages
     assert agent.memory.updated_summary is None
     assert agent.memory.marked_ids == []
-    assert agent.formatter.calls == 1


### PR DESCRIPTION
## Description

Fixes the `memory_compaction` hook crashing with `ValueError: too many values to unpack (expected 3)` when `check_context()` returns a shape richer than the original 3-tuple contract.

**Related Issue:** Closes #1139

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- Added a compatibility adapter in the hook so CoPaw only depends on `messages_to_compact` and `is_valid`, instead of assuming `check_context()` always returns exactly three positional values.
- Rewrote the hook tests to cover:
  - standard 3-item tuple results
  - extended tuple results
  - object-style results
  - empty compaction results with tool-result compaction enabled

## Local Verification Evidence

```bash
PYTHONPATH=src pre-commit run --all-files
# Passed

PYTHONPATH=src pytest -q
# 121 passed in 6.47s
```

## Additional Notes

- The root cause was a brittle dependency boundary in `MemoryCompactionHook`, not a behavior change introduced directly by the `0.0.6.post1` source diff.
- The new tests are designed to keep future `check_context()` return-shape drift from silently regressing this path again.
