### PR TITLE
fix(cron): default schedules to local timezone

### DIFF
--- a/src/copaw/app/_app.py
+++ b/src/copaw/app/_app.py
@@ -29,6 +29,7 @@ from .mcp import MCPClientManager, MCPConfigWatcher  # MCP hot-reload support
 from .runner.repo.json_repo import JsonChatRepository
 from .crons.repo.json_repo import JsonJobRepository
 from .crons.manager import CronManager
+from .crons.timezone_utils import get_default_timezone
 from .runner.manager import ChatManager
 from .routers import router as api_router
 from .routers.voice import voice_router
@@ -94,7 +95,7 @@ async def lifespan(
         repo=repo,
         runner=runner,
         channel_manager=channel_manager,
-        timezone="UTC",
+        timezone=get_default_timezone(),
     )
     await cron_manager.start()
 
@@ -336,7 +337,7 @@ async def lifespan(
             repo=job_repo,
             runner=runner,
             channel_manager=new_channel_manager,
-            timezone="UTC",
+            timezone=get_default_timezone(),
         )
         try:
             await new_cron_manager.start()

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -18,6 +18,7 @@ from .executor import CronExecutor
 from .heartbeat import parse_heartbeat_every, run_heartbeat_once
 from .models import CronJobSpec, CronJobState
 from .repo.base import BaseJobRepository
+from .timezone_utils import get_default_timezone
 
 HEARTBEAT_JOB_ID = "_heartbeat"
 
@@ -36,12 +37,13 @@ class CronManager:
         repo: BaseJobRepository,
         runner: Any,
         channel_manager: Any,
-        timezone: str = "UTC",
+        timezone: str | None = None,
     ):
         self._repo = repo
         self._runner = runner
         self._channel_manager = channel_manager
-        self._scheduler = AsyncIOScheduler(timezone=timezone)
+        resolved_timezone = timezone or get_default_timezone()
+        self._scheduler = AsyncIOScheduler(timezone=resolved_timezone)
         self._executor = CronExecutor(
             runner=runner,
             channel_manager=channel_manager,

--- a/src/copaw/app/crons/models.py
+++ b/src/copaw/app/crons/models.py
@@ -13,12 +13,13 @@ from pydantic import (
 )
 
 from ..channels.schema import DEFAULT_CHANNEL
+from .timezone_utils import get_default_timezone
 
 
 class ScheduleSpec(BaseModel):
     type: Literal["cron"] = "cron"
     cron: str = Field(...)
-    timezone: str = "UTC"
+    timezone: str = Field(default_factory=get_default_timezone)
 
     @field_validator("cron")
     @classmethod

--- a/src/copaw/app/crons/timezone_utils.py
+++ b/src/copaw/app/crons/timezone_utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+DEFAULT_TIMEZONE = "UTC"
+
+
+def get_default_timezone() -> str:
+    """Return the configured or detected local timezone name."""
+    configured = os.environ.get("COPAW_TIMEZONE", "").strip()
+    if configured:
+        return configured
+
+    try:
+        import tzlocal  # type: ignore
+
+        get_name = getattr(tzlocal, "get_localzone_name", None)
+        if callable(get_name):
+            detected = get_name()
+            if isinstance(detected, str) and detected.strip():
+                return detected.strip()
+
+        get_zone = getattr(tzlocal, "get_localzone", None)
+        if callable(get_zone):
+            zone = get_zone()
+            for attr in ("key", "zone"):
+                detected = getattr(zone, attr, None)
+                if isinstance(detected, str) and detected.strip():
+                    return detected.strip()
+            detected = str(zone).strip()
+            if detected and detected.lower() != "local":
+                return detected
+    except Exception:
+        pass
+
+    try:
+        local_tz = datetime.now().astimezone().tzinfo
+        if local_tz is not None:
+            for attr in ("key", "zone"):
+                detected = getattr(local_tz, attr, None)
+                if isinstance(detected, str) and detected.strip():
+                    return detected.strip()
+    except Exception:
+        pass
+
+    return DEFAULT_TIMEZONE

--- a/src/copaw/cli/cron_cmd.py
+++ b/src/copaw/cli/cron_cmd.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import click
 
+from ..app.crons.timezone_utils import get_default_timezone
 from .http import client, print_json
 from ..app.channels.schema import DEFAULT_CHANNEL
 
@@ -102,12 +103,12 @@ def _build_spec_from_cli(
     target_user: str,
     target_session: str,
     text: Optional[str],
-    timezone: str,
+    timezone: Optional[str],
     enabled: bool,
     mode: str,
 ) -> dict:
     """Build CronJobSpec JSON payload from CLI args (no id)."""
-    schedule = {"type": "cron", "cron": cron, "timezone": timezone}
+    schedule = {"type": "cron", "cron": cron, "timezone": timezone or get_default_timezone()}
     dispatch = {
         "type": "channel",
         "channel": channel,
@@ -237,7 +238,7 @@ def _build_spec_from_cli(
 )
 @click.option(
     "--timezone",
-    default="UTC",
+    default=None,
     help="Timezone for the cron schedule (e.g. UTC, America/New_York).",
 )
 @click.option(
@@ -270,7 +271,7 @@ def create_job(
     target_user: Optional[str],
     target_session: Optional[str],
     text: Optional[str],
-    timezone: str,
+    timezone: Optional[str],
     enabled: bool,
     mode: str,
     base_url: Optional[str],

--- a/tests/unit/app/test_cron_timezone.py
+++ b/tests/unit/app/test_cron_timezone.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+MODULE_NAME = "copaw.app.crons.timezone_utils"
+
+
+def _reload_timezone_utils(monkeypatch, env_value: str | None, tzlocal_module):
+    monkeypatch.delenv("COPAW_TIMEZONE", raising=False)
+    if env_value is not None:
+        monkeypatch.setenv("COPAW_TIMEZONE", env_value)
+
+    sys.modules.pop(MODULE_NAME, None)
+    if tzlocal_module is None:
+        sys.modules.pop("tzlocal", None)
+    else:
+        sys.modules["tzlocal"] = tzlocal_module
+
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_get_default_timezone_prefers_env(monkeypatch) -> None:
+    module = _reload_timezone_utils(
+        monkeypatch,
+        env_value="Asia/Shanghai",
+        tzlocal_module=types.SimpleNamespace(
+            get_localzone_name=lambda: "America/New_York",
+        ),
+    )
+
+    assert module.get_default_timezone() == "Asia/Shanghai"
+
+
+def test_get_default_timezone_uses_tzlocal_name(monkeypatch) -> None:
+    module = _reload_timezone_utils(
+        monkeypatch,
+        env_value=None,
+        tzlocal_module=types.SimpleNamespace(
+            get_localzone_name=lambda: "Asia/Shanghai",
+        ),
+    )
+
+    assert module.get_default_timezone() == "Asia/Shanghai"
+
+
+def test_get_default_timezone_uses_tzlocal_zone_key(monkeypatch) -> None:
+    module = _reload_timezone_utils(
+        monkeypatch,
+        env_value=None,
+        tzlocal_module=types.SimpleNamespace(
+            get_localzone_name=lambda: "",
+            get_localzone=lambda: types.SimpleNamespace(key="Europe/Berlin"),
+        ),
+    )
+
+    assert module.get_default_timezone() == "Europe/Berlin"
+
+
+def test_get_default_timezone_falls_back_to_utc(monkeypatch) -> None:
+    module = _reload_timezone_utils(
+        monkeypatch,
+        env_value=None,
+        tzlocal_module=types.SimpleNamespace(
+            get_localzone_name=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        ),
+    )
+
+    assert module.get_default_timezone() == module.DEFAULT_TIMEZONE
+
+
+def test_schedule_spec_defaults_to_detected_timezone(monkeypatch) -> None:
+    _reload_timezone_utils(
+        monkeypatch,
+        env_value="Asia/Shanghai",
+        tzlocal_module=None,
+    )
+    sys.modules.pop("copaw.app.crons.models", None)
+    from copaw.app.crons.models import ScheduleSpec
+
+    spec = ScheduleSpec(cron="0 10 * * *")
+
+    assert spec.timezone == "Asia/Shanghai"
+
+
+def test_schedule_spec_keeps_explicit_timezone(monkeypatch) -> None:
+    _reload_timezone_utils(
+        monkeypatch,
+        env_value="Asia/Shanghai",
+        tzlocal_module=None,
+    )
+    sys.modules.pop("copaw.app.crons.models", None)
+    from copaw.app.crons.models import ScheduleSpec
+
+    spec = ScheduleSpec(cron="0 10 * * *", timezone="UTC")
+
+    assert spec.timezone == "UTC"
+
+
+def test_build_spec_from_cli_uses_detected_timezone(monkeypatch) -> None:
+    _reload_timezone_utils(
+        monkeypatch,
+        env_value="Asia/Shanghai",
+        tzlocal_module=None,
+    )
+    sys.modules.pop("copaw.cli.cron_cmd", None)
+    from copaw.cli.cron_cmd import _build_spec_from_cli
+
+    spec = _build_spec_from_cli(
+        task_type="text",
+        name="daily check",
+        cron="0 10 * * *",
+        channel="console",
+        target_user="u1",
+        target_session="s1",
+        text="hello",
+        timezone=None,
+        enabled=True,
+        mode="final",
+    )
+
+    assert spec["schedule"]["timezone"] == "Asia/Shanghai"
+
+
+def test_get_default_timezone_uses_datetime_zone_key(monkeypatch) -> None:
+    module = _reload_timezone_utils(
+        monkeypatch,
+        env_value=None,
+        tzlocal_module=None,
+    )
+
+    class _FakeDateTime:
+        @staticmethod
+        def now():
+            return types.SimpleNamespace(
+                astimezone=lambda: types.SimpleNamespace(
+                    tzinfo=types.SimpleNamespace(key="America/Los_Angeles"),
+                ),
+            )
+
+    monkeypatch.setattr(module, "datetime", _FakeDateTime)
+
+    assert module.get_default_timezone() == "America/Los_Angeles"
+
+
+def test_build_spec_from_cli_keeps_explicit_timezone(monkeypatch) -> None:
+    _reload_timezone_utils(
+        monkeypatch,
+        env_value="Asia/Shanghai",
+        tzlocal_module=None,
+    )
+    sys.modules.pop("copaw.cli.cron_cmd", None)
+    from copaw.cli.cron_cmd import _build_spec_from_cli
+
+    spec = _build_spec_from_cli(
+        task_type="text",
+        name="daily check",
+        cron="0 10 * * *",
+        channel="console",
+        target_user="u1",
+        target_session="s1",
+        text="hello",
+        timezone="UTC",
+        enabled=True,
+        mode="final",
+    )
+
+    assert spec["schedule"]["timezone"] == "UTC"


### PR DESCRIPTION
## Summary
- default cron schedules to `COPAW_TIMEZONE` or the detected local timezone instead of hardcoding `UTC`
- apply the same timezone resolution to app startup, service restart, API-backed schedule defaults, and CLI cron creation
- add regression tests for env override, tzlocal detection, datetime fallback, schedule defaults, and CLI payload generation

## Why this fix
`CronManager` was initialized with `timezone="UTC"`, `ScheduleSpec.timezone` defaulted to `UTC`, and `copaw cron create` also defaulted to `UTC`. That meant cron jobs created without an explicit timezone were persisted and executed in UTC even when the machine or `COPAW_TIMEZONE` was set to a local timezone, which matches the bug report in #1387.

This patch centralizes timezone resolution in one helper, prefers `COPAW_TIMEZONE`, falls back to detected local timezone, and only uses `UTC` as the final fallback.

## Validation
- `PYTHONPATH=src python -m pytest tests/unit/app/test_cron_timezone.py -q` -> `9 passed`
- `PYTHONPATH=src python -c "from pathlib import Path; files = [Path('src/copaw/app/crons/timezone_utils.py'), Path('src/copaw/app/crons/models.py'), Path('src/copaw/app/crons/manager.py'), Path('src/copaw/app/_app.py'), Path('src/copaw/cli/cron_cmd.py'), Path('tests/unit/app/test_cron_timezone.py')]; [compile(p.read_text(encoding='utf-8'), str(p), 'exec') for p in files]; print('ok')"` -> `ok`

Closes #1387