### PR TITLE
fix(cron): isolate invalid persisted schedules

### DIFF
--- a/src/copaw/app/crons/api.py
+++ b/src/copaw/app/crons/api.py
@@ -41,7 +41,10 @@ async def create_job(
     # server generates id; ignore client-provided spec.id
     job_id = str(uuid.uuid4())
     created = spec.model_copy(update={"id": job_id})
-    await mgr.create_or_replace_job(created)
+    try:
+        await mgr.create_or_replace_job(created)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return created
 
 
@@ -53,7 +56,10 @@ async def replace_job(
 ):
     if spec.id != job_id:
         raise HTTPException(status_code=400, detail="job_id mismatch")
-    await mgr.create_or_replace_job(spec)
+    try:
+        await mgr.create_or_replace_job(spec)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return spec
 
 

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -60,7 +60,17 @@ class CronManager:
 
             self._scheduler.start()
             for job in jobs_file.jobs:
-                await self._register_or_update(job)
+                try:
+                    await self._register_or_update(job)
+                except Exception as e:  # pylint: disable=broad-except
+                    self._mark_job_error(job.id, e)
+                    logger.warning(
+                        "cron startup: skipping invalid persisted job "
+                        "job_id=%s name=%s error=%s",
+                        job.id,
+                        job.name,
+                        repr(e),
+                    )
 
             # Heartbeat: one interval job when enabled in config
             hb = get_heartbeat_config()
@@ -97,9 +107,10 @@ class CronManager:
 
     async def create_or_replace_job(self, spec: CronJobSpec) -> None:
         async with self._lock:
+            trigger = self._build_trigger(spec)
             await self._repo.upsert_job(spec)
             if self._started:
-                await self._register_or_update(spec)
+                await self._register_or_update(spec, trigger=trigger)
 
     async def delete_job(self, job_id: str) -> bool:
         async with self._lock:
@@ -193,13 +204,25 @@ class CronManager:
 
     # ----- internal -----
 
-    async def _register_or_update(self, spec: CronJobSpec) -> None:
+    def _mark_job_error(self, job_id: str, error: Exception) -> None:
+        st = self._states.get(job_id, CronJobState())
+        st.next_run_at = None
+        st.last_status = "error"
+        st.last_error = repr(error)
+        self._states[job_id] = st
+
+    async def _register_or_update(
+        self,
+        spec: CronJobSpec,
+        *,
+        trigger: CronTrigger | None = None,
+    ) -> None:
         # per-job concurrency semaphore
         self._rt[spec.id] = _Runtime(
             sem=asyncio.Semaphore(spec.runtime.max_concurrency),
         )
 
-        trigger = self._build_trigger(spec)
+        trigger = trigger or self._build_trigger(spec)
 
         # replace existing
         if self._scheduler.get_job(spec.id):

--- a/src/copaw/app/crons/manager.py
+++ b/src/copaw/app/crons/manager.py
@@ -63,14 +63,7 @@ class CronManager:
                 try:
                     await self._register_or_update(job)
                 except Exception as e:  # pylint: disable=broad-except
-                    self._mark_job_error(job.id, e)
-                    logger.warning(
-                        "cron startup: skipping invalid persisted job "
-                        "job_id=%s name=%s error=%s",
-                        job.id,
-                        job.name,
-                        repr(e),
-                    )
+                    self._mark_job_invalid(job, e)
 
             # Heartbeat: one interval job when enabled in config
             hb = get_heartbeat_config()
@@ -204,12 +197,20 @@ class CronManager:
 
     # ----- internal -----
 
-    def _mark_job_error(self, job_id: str, error: Exception) -> None:
-        st = self._states.get(job_id, CronJobState())
+    def _mark_job_invalid(self, spec: CronJobSpec, exc: Exception) -> None:
+        """Record an invalid persisted job without aborting startup."""
+        self._rt.pop(spec.id, None)
+        st = self._states.get(spec.id, CronJobState())
         st.next_run_at = None
         st.last_status = "error"
-        st.last_error = repr(error)
-        self._states[job_id] = st
+        st.last_error = str(exc)
+        self._states[spec.id] = st
+        logger.warning(
+            "cron startup: skipping invalid persisted job job_id=%s name=%s error=%s",
+            spec.id,
+            spec.name,
+            repr(exc),
+        )
 
     async def _register_or_update(
         self,

--- a/tests/unit/app/test_cron_manager_validation.py
+++ b/tests/unit/app/test_cron_manager_validation.py
@@ -1,0 +1,373 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+
+from copaw.app.crons.models import CronJobSpec, JobsFile
+
+
+MANAGER_MODULE = "copaw.app.crons.manager"
+API_MODULE = "copaw.app.crons.api"
+
+
+class InMemoryJobRepository:
+    def __init__(self, jobs: list[CronJobSpec] | None = None) -> None:
+        self.jobs = list(jobs or [])
+        self.upsert_calls = 0
+        self.save_calls = 0
+
+    async def load(self) -> JobsFile:
+        return JobsFile(jobs=list(self.jobs))
+
+    async def save(self, jobs_file: JobsFile) -> None:
+        self.save_calls += 1
+        self.jobs = list(jobs_file.jobs)
+
+    async def list_jobs(self) -> list[CronJobSpec]:
+        return list(self.jobs)
+
+    async def get_job(self, job_id: str) -> CronJobSpec | None:
+        for job in self.jobs:
+            if job.id == job_id:
+                return job
+        return None
+
+    async def upsert_job(self, spec: CronJobSpec) -> None:
+        self.upsert_calls += 1
+        for index, job in enumerate(self.jobs):
+            if job.id == spec.id:
+                self.jobs[index] = spec
+                break
+        else:
+            self.jobs.append(spec)
+
+    async def delete_job(self, job_id: str) -> bool:
+        before = len(self.jobs)
+        self.jobs = [job for job in self.jobs if job.id != job_id]
+        return len(self.jobs) != before
+
+
+class FakeCronTrigger:
+    def __init__(self, **kwargs) -> None:
+        hour = kwargs.get("hour")
+        if hour == "*/30":
+            raise ValueError(
+                "Error validating expression '*/30': the step value (30) is higher than the total range of the expression (23)",
+            )
+        self.kwargs = kwargs
+
+
+class FakeIntervalTrigger:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+
+class FakeSchedulerJob:
+    def __init__(self, trigger) -> None:
+        self.trigger = trigger
+        self.next_run_time = "fake-next-run"
+        self.paused = False
+
+
+class FakeAsyncIOScheduler:
+    def __init__(self, timezone: str = "UTC") -> None:
+        self.timezone = timezone
+        self.jobs: dict[str, FakeSchedulerJob] = {}
+        self.started = False
+        self.shutdown_called = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def shutdown(self, wait: bool = False) -> None:
+        self.shutdown_called = True
+
+    def add_job(
+        self,
+        func,
+        trigger=None,
+        id: str | None = None,
+        args=None,
+        misfire_grace_time=None,
+        replace_existing: bool = False,
+    ) -> None:
+        if id is None:
+            raise ValueError("job id required")
+        self.jobs[id] = FakeSchedulerJob(trigger)
+
+    def get_job(self, job_id: str):
+        return self.jobs.get(job_id)
+
+    def remove_job(self, job_id: str) -> None:
+        self.jobs.pop(job_id, None)
+
+    def pause_job(self, job_id: str) -> None:
+        self.jobs[job_id].paused = True
+
+    def resume_job(self, job_id: str) -> None:
+        self.jobs[job_id].paused = False
+
+
+def _install_manager_stubs() -> None:
+    config_module = types.ModuleType("copaw.config")
+    config_module.get_heartbeat_config = lambda: types.SimpleNamespace(enabled=False, every="6h")
+    sys.modules["copaw.config"] = config_module
+
+    console_push_store = types.ModuleType("copaw.app.console_push_store")
+
+    async def _append(session_id: str, text: str) -> None:
+        return None
+
+    console_push_store.append = _append
+    sys.modules["copaw.app.console_push_store"] = console_push_store
+
+    executor_module = types.ModuleType("copaw.app.crons.executor")
+
+    class _CronExecutor:
+        def __init__(self, runner, channel_manager) -> None:
+            self.runner = runner
+            self.channel_manager = channel_manager
+
+        async def execute(self, job) -> None:
+            return None
+
+    executor_module.CronExecutor = _CronExecutor
+    sys.modules["copaw.app.crons.executor"] = executor_module
+
+    heartbeat_module = types.ModuleType("copaw.app.crons.heartbeat")
+    heartbeat_module.parse_heartbeat_every = lambda every: 60
+
+    async def _run_heartbeat_once(runner, channel_manager) -> None:
+        return None
+
+    heartbeat_module.run_heartbeat_once = _run_heartbeat_once
+    sys.modules["copaw.app.crons.heartbeat"] = heartbeat_module
+
+    apscheduler_module = types.ModuleType("apscheduler")
+    sys.modules["apscheduler"] = apscheduler_module
+
+    schedulers_module = types.ModuleType("apscheduler.schedulers")
+    sys.modules["apscheduler.schedulers"] = schedulers_module
+
+    schedulers_asyncio_module = types.ModuleType("apscheduler.schedulers.asyncio")
+    schedulers_asyncio_module.AsyncIOScheduler = FakeAsyncIOScheduler
+    sys.modules["apscheduler.schedulers.asyncio"] = schedulers_asyncio_module
+
+    triggers_module = types.ModuleType("apscheduler.triggers")
+    sys.modules["apscheduler.triggers"] = triggers_module
+
+    triggers_cron_module = types.ModuleType("apscheduler.triggers.cron")
+    triggers_cron_module.CronTrigger = FakeCronTrigger
+    sys.modules["apscheduler.triggers.cron"] = triggers_cron_module
+
+    triggers_interval_module = types.ModuleType("apscheduler.triggers.interval")
+    triggers_interval_module.IntervalTrigger = FakeIntervalTrigger
+    sys.modules["apscheduler.triggers.interval"] = triggers_interval_module
+
+
+def _load_manager_module():
+    _install_manager_stubs()
+    sys.modules.pop(MANAGER_MODULE, None)
+    return importlib.import_module(MANAGER_MODULE)
+
+
+def _install_fastapi_stub() -> None:
+    fastapi_module = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str) -> None:
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class APIRouter:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def _decorator(self, *args, **kwargs):
+            def wrapper(fn):
+                return fn
+
+            return wrapper
+
+        get = post = put = delete = _decorator
+
+    def Depends(fn):
+        return fn
+
+    class Request:
+        pass
+
+    fastapi_module.APIRouter = APIRouter
+    fastapi_module.Depends = Depends
+    fastapi_module.HTTPException = HTTPException
+    fastapi_module.Request = Request
+    sys.modules["fastapi"] = fastapi_module
+
+
+def _load_api_module():
+    _install_manager_stubs()
+    _install_fastapi_stub()
+    sys.modules.pop(MANAGER_MODULE, None)
+    sys.modules.pop(API_MODULE, None)
+    return importlib.import_module(API_MODULE)
+
+
+def _make_job(job_id: str, cron: str) -> CronJobSpec:
+    return CronJobSpec.model_validate(
+        {
+            "id": job_id,
+            "name": f"job-{job_id}",
+            "enabled": True,
+            "schedule": {
+                "type": "cron",
+                "cron": cron,
+                "timezone": "UTC",
+            },
+            "task_type": "text",
+            "text": "hello",
+            "dispatch": {
+                "type": "channel",
+                "channel": "console",
+                "target": {
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                },
+                "mode": "final",
+                "meta": {},
+            },
+            "runtime": {
+                "max_concurrency": 1,
+                "timeout_seconds": 120,
+                "misfire_grace_seconds": 60,
+            },
+            "meta": {},
+        },
+    )
+
+
+def test_start_skips_invalid_persisted_job_and_keeps_valid_jobs() -> None:
+    manager_module = _load_manager_module()
+    repo = InMemoryJobRepository(
+        jobs=[
+            _make_job("bad", "0 */30 8-18 * 1-5"),
+            _make_job("good", "0 9 * * 1-5"),
+        ],
+    )
+    manager = manager_module.CronManager(
+        repo=repo,
+        runner=object(),
+        channel_manager=object(),
+    )
+
+    asyncio.run(manager.start())
+
+    bad_state = manager.get_state("bad")
+    good_state = manager.get_state("good")
+
+    assert manager._started is True
+    assert bad_state.last_status == "error"
+    assert "step value (30)" in (bad_state.last_error or "")
+    assert bad_state.next_run_at is None
+    assert "bad" not in manager._scheduler.jobs
+    assert "bad" not in manager._rt
+    assert "good" in manager._scheduler.jobs
+    assert good_state.next_run_at == "fake-next-run"
+
+
+def test_create_or_replace_job_rejects_invalid_schedule_before_persisting() -> None:
+    manager_module = _load_manager_module()
+    repo = InMemoryJobRepository()
+    manager = manager_module.CronManager(
+        repo=repo,
+        runner=object(),
+        channel_manager=object(),
+    )
+
+    try:
+        asyncio.run(
+            manager.create_or_replace_job(
+                _make_job("bad", "0 */30 8-18 * 1-5"),
+            ),
+        )
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected invalid cron schedule to raise ValueError")
+
+    assert "step value (30)" in message
+    assert repo.upsert_calls == 0
+    assert repo.jobs == []
+
+
+def test_create_or_replace_job_persists_and_registers_valid_schedule() -> None:
+    manager_module = _load_manager_module()
+    repo = InMemoryJobRepository()
+    manager = manager_module.CronManager(
+        repo=repo,
+        runner=object(),
+        channel_manager=object(),
+    )
+    asyncio.run(manager.start())
+
+    spec = _make_job("good", "0 9 * * 1-5")
+    asyncio.run(manager.create_or_replace_job(spec))
+
+    assert repo.upsert_calls == 1
+    assert repo.jobs[0].id == "good"
+    assert "good" in manager._scheduler.jobs
+    assert manager.get_state("good").next_run_at == "fake-next-run"
+
+
+def test_create_job_returns_http_400_for_invalid_schedule() -> None:
+    api_module = _load_api_module()
+    http_exception_type = sys.modules["fastapi"].HTTPException
+
+    class FailingManager:
+        async def create_or_replace_job(self, spec) -> None:
+            raise ValueError("invalid cron")
+
+    try:
+        asyncio.run(
+            api_module.create_job(
+                spec=_make_job("ignored", "0 9 * * 1-5"),
+                mgr=FailingManager(),
+            ),
+        )
+    except http_exception_type as exc:
+        error = exc
+    else:
+        raise AssertionError("Expected create_job to translate ValueError into HTTPException")
+
+    assert error.status_code == 400
+    assert error.detail == "invalid cron"
+
+
+def test_replace_job_returns_http_400_for_invalid_schedule() -> None:
+    api_module = _load_api_module()
+    http_exception_type = sys.modules["fastapi"].HTTPException
+
+    class FailingManager:
+        async def create_or_replace_job(self, spec) -> None:
+            raise ValueError("invalid cron")
+
+    spec = _make_job("job-1", "0 9 * * 1-5")
+    try:
+        asyncio.run(
+            api_module.replace_job(
+                job_id="job-1",
+                spec=spec,
+                mgr=FailingManager(),
+            ),
+        )
+    except http_exception_type as exc:
+        error = exc
+    else:
+        raise AssertionError("Expected replace_job to translate ValueError into HTTPException")
+
+    assert error.status_code == 400
+    assert error.detail == "invalid cron"

--- a/tests/unit/app/test_cron_startup_validation.py
+++ b/tests/unit/app/test_cron_startup_validation.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import datetime
+import pytest
+
+from copaw.app.crons.models import CronJobSpec, JobsFile
+from copaw.app.crons.repo.base import BaseJobRepository
+
+
+class InMemoryJobRepository(BaseJobRepository):
+    def __init__(self, jobs: list[CronJobSpec] | None = None):
+        self._jobs_file = JobsFile(version=1, jobs=list(jobs or []))
+
+    async def load(self) -> JobsFile:
+        return self._jobs_file.model_copy(deep=True)
+
+    async def save(self, jobs_file: JobsFile) -> None:
+        self._jobs_file = jobs_file.model_copy(deep=True)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _make_job(job_id: str, cron: str) -> CronJobSpec:
+    return CronJobSpec.model_validate(
+        {
+            "id": job_id,
+            "name": f"job-{job_id}",
+            "enabled": True,
+            "schedule": {
+                "type": "cron",
+                "cron": cron,
+                "timezone": "UTC",
+            },
+            "task_type": "text",
+            "text": "hello",
+            "dispatch": {
+                "type": "channel",
+                "channel": "console",
+                "target": {
+                    "user_id": "user-1",
+                    "session_id": "session-1",
+                },
+                "mode": "final",
+                "meta": {},
+            },
+        },
+    )
+
+
+def _install_apscheduler_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    apscheduler_module = types.ModuleType("apscheduler")
+    schedulers_module = types.ModuleType("apscheduler.schedulers")
+    asyncio_module = types.ModuleType("apscheduler.schedulers.asyncio")
+    triggers_module = types.ModuleType("apscheduler.triggers")
+    cron_module = types.ModuleType("apscheduler.triggers.cron")
+    interval_module = types.ModuleType("apscheduler.triggers.interval")
+
+    class _ScheduledJob:
+        def __init__(self, job_id: str):
+            self.id = job_id
+            self.next_run_time = datetime.utcnow()
+
+    class AsyncIOScheduler:
+        def __init__(self, timezone: str):
+            self.timezone = timezone
+            self._jobs: dict[str, _ScheduledJob] = {}
+
+        def start(self) -> None:
+            return None
+
+        def shutdown(self, wait: bool = False) -> None:
+            return None
+
+        def add_job(
+            self,
+            func,
+            trigger,
+            *,
+            id: str,
+            replace_existing: bool = False,
+            args=None,
+            misfire_grace_time=None,
+        ) -> None:
+            self._jobs[id] = _ScheduledJob(id)
+
+        def get_job(self, job_id: str):
+            return self._jobs.get(job_id)
+
+        def remove_job(self, job_id: str) -> None:
+            self._jobs.pop(job_id, None)
+
+        def pause_job(self, job_id: str) -> None:
+            if job_id in self._jobs:
+                self._jobs[job_id].next_run_time = None
+
+        def resume_job(self, job_id: str) -> None:
+            if job_id in self._jobs:
+                self._jobs[job_id].next_run_time = datetime.utcnow()
+
+    class CronTrigger:
+        def __init__(
+            self,
+            *,
+            minute: str,
+            hour: str,
+            day: str,
+            month: str,
+            day_of_week: str,
+            timezone: str,
+        ):
+            self.minute = minute
+            self.hour = hour
+            self.day = day
+            self.month = month
+            self.day_of_week = day_of_week
+            self.timezone = timezone
+            self._validate_step(minute, 59)
+            self._validate_step(hour, 23)
+            self._validate_step(day, 31)
+            self._validate_step(month, 12)
+            self._validate_step(day_of_week, 6)
+
+        @staticmethod
+        def _validate_step(expr: str, total_range: int) -> None:
+            if expr.startswith("*/"):
+                step = int(expr[2:])
+                if step > total_range:
+                    raise ValueError(
+                        "Error validating expression "
+                        f"'{expr}': the step value ({step}) is higher than "
+                        f"the total range of the expression ({total_range})",
+                    )
+
+    class IntervalTrigger:
+        def __init__(self, *, seconds: int):
+            self.seconds = seconds
+
+    asyncio_module.AsyncIOScheduler = AsyncIOScheduler
+    cron_module.CronTrigger = CronTrigger
+    interval_module.IntervalTrigger = IntervalTrigger
+
+    monkeypatch.setitem(sys.modules, "apscheduler", apscheduler_module)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers", schedulers_module)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers.asyncio", asyncio_module)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers", triggers_module)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers.cron", cron_module)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers.interval", interval_module)
+
+
+def _load_manager_module(monkeypatch: pytest.MonkeyPatch):
+    _install_apscheduler_stub(monkeypatch)
+    sys.modules.pop("copaw.app.crons.manager", None)
+    return importlib.import_module("copaw.app.crons.manager")
+
+
+def _make_manager(manager_module, repo: BaseJobRepository):
+    return manager_module.CronManager(
+        repo=repo,
+        runner=object(),
+        channel_manager=object(),
+        timezone="UTC",
+    )
+
+
+def _load_cron_api_module(monkeypatch: pytest.MonkeyPatch):
+    _install_apscheduler_stub(monkeypatch)
+    fastapi_stub = types.ModuleType("fastapi")
+
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class APIRouter:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        def get(self, *args, **kwargs):
+            return self._decorator()
+
+        def post(self, *args, **kwargs):
+            return self._decorator()
+
+        def put(self, *args, **kwargs):
+            return self._decorator()
+
+        def delete(self, *args, **kwargs):
+            return self._decorator()
+
+        @staticmethod
+        def _decorator():
+            def wrapper(func):
+                return func
+
+            return wrapper
+
+    def Depends(dependency):
+        return dependency
+
+    class Request:  # pragma: no cover - only for import compatibility
+        pass
+
+    fastapi_stub.APIRouter = APIRouter
+    fastapi_stub.Depends = Depends
+    fastapi_stub.HTTPException = HTTPException
+    fastapi_stub.Request = Request
+
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_stub)
+    sys.modules.pop("copaw.app.crons.manager", None)
+    sys.modules.pop("copaw.app.crons.api", None)
+    return importlib.import_module("copaw.app.crons.api")
+
+
+@pytest.mark.anyio
+async def test_start_skips_invalid_persisted_job_and_marks_state_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid = _make_job("valid", "0 8 * * 1-5")
+    invalid = _make_job("invalid", "0 */30 8-18 * 1-5")
+    repo = InMemoryJobRepository([valid, invalid])
+    manager_module = _load_manager_module(monkeypatch)
+    manager = _make_manager(manager_module, repo)
+
+    try:
+        await manager.start()
+
+        assert manager._scheduler.get_job(valid.id) is not None
+        assert manager._scheduler.get_job(invalid.id) is None
+
+        state = manager.get_state(invalid.id)
+        assert state.last_status == "error"
+        assert state.next_run_at is None
+        assert "step value" in (state.last_error or "")
+    finally:
+        await manager.stop()
+
+
+@pytest.mark.anyio
+async def test_create_or_replace_job_rejects_invalid_cron_without_persisting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = InMemoryJobRepository()
+    manager_module = _load_manager_module(monkeypatch)
+    manager = _make_manager(manager_module, repo)
+
+    with pytest.raises(ValueError, match="step value"):
+        await manager.create_or_replace_job(_make_job("bad", "0 */30 8-18 * 1-5"))
+
+    assert await repo.list_jobs() == []
+
+
+@pytest.mark.anyio
+async def test_create_job_returns_400_for_invalid_semantic_cron(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_module = _load_cron_api_module(monkeypatch)
+    manager = _make_manager(api_module, InMemoryJobRepository())
+    spec = _make_job("client-id", "0 */30 8-18 * 1-5")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await api_module.create_job(spec, mgr=manager)
+
+    assert exc.value.status_code == 400
+    assert "step value" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_replace_job_returns_400_for_invalid_semantic_cron(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_module = _load_cron_api_module(monkeypatch)
+    manager = _make_manager(api_module, InMemoryJobRepository())
+    spec = _make_job("job-1", "0 */30 8-18 * 1-5")
+
+    with pytest.raises(api_module.HTTPException) as exc:
+        await api_module.replace_job("job-1", spec, mgr=manager)
+
+    assert exc.value.status_code == 400
+    assert "step value" in exc.value.detail


### PR DESCRIPTION
## Summary
- skip invalid persisted cron jobs during startup instead of aborting the whole app
- mark skipped jobs with an `error` runtime state so they remain visible for recovery
- validate cron schedules before persisting create/replace requests and return clear 400 errors from the API
- expand regression coverage for startup isolation, write-path validation, and API error translation

## Why this fix
CoPaw currently accepts cron expressions that pass the basic 5-field parser but fail APScheduler's semantic validation. If such a job is already persisted, startup fails while replaying jobs and the whole service becomes unavailable.

This patch isolates startup failures to the offending job and adds write-path validation so invalid schedules are rejected before they can be stored.

Closes #1443.

## Validation
- `PYTHONPATH=src python -m pytest tests/unit/app/test_cron_startup_validation.py tests/unit/app/test_cron_manager_validation.py -q`
- Result: `9 passed`
- `PYTHONPATH=src python -c "from pathlib import Path; files = [Path('src/copaw/app/crons/manager.py'), Path('src/copaw/app/crons/api.py'), Path('tests/unit/app/test_cron_manager_validation.py')]; [compile(p.read_text(encoding='utf-8'), str(p), 'exec') for p in files]; print('ok')"`
- Result: `ok`
- Note: the test files use lightweight stubs for `apscheduler` and `fastapi` because those runtime dependencies are not installed in this local environment; the assertions are focused on CoPaw's startup isolation and API error-mapping logic.