### PR TITLE
fix(skills): add cancel import skill choice

### DIFF
--- a/console/src/api/modules/skill.ts
+++ b/console/src/api/modules/skill.ts
@@ -48,12 +48,15 @@ export const skillApi = {
       `/skills/hub/search?q=${encodeURIComponent(query)}&limit=${limit}`,
     ),
 
-  installHubSkill: (payload: {
-    bundle_url: string;
-    version?: string;
-    enable?: boolean;
-    overwrite?: boolean;
-  }) =>
+  installHubSkill: (
+    payload: {
+      bundle_url: string;
+      version?: string;
+      enable?: boolean;
+      overwrite?: boolean;
+    },
+    options?: { signal?: AbortSignal },
+  ) =>
     request<{
       installed: boolean;
       name: string;
@@ -62,7 +65,62 @@ export const skillApi = {
     }>("/skills/hub/install", {
       method: "POST",
       body: JSON.stringify(payload),
+      signal: options?.signal,
     }),
+
+  startHubSkillInstall: (payload: {
+    bundle_url: string;
+    version?: string;
+    enable?: boolean;
+    overwrite?: boolean;
+  }) =>
+    request<{
+      task_id: string;
+      bundle_url: string;
+      version: string;
+      enable: boolean;
+      overwrite: boolean;
+      status: "pending" | "importing" | "completed" | "failed" | "cancelled";
+      error: string | null;
+      result: {
+        installed: boolean;
+        name: string;
+        enabled: boolean;
+        source_url: string;
+      } | null;
+      created_at: number;
+      updated_at: number;
+    }>("/skills/hub/install/start", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+
+  getHubSkillInstallStatus: (taskId: string) =>
+    request<{
+      task_id: string;
+      bundle_url: string;
+      version: string;
+      enable: boolean;
+      overwrite: boolean;
+      status: "pending" | "importing" | "completed" | "failed" | "cancelled";
+      error: string | null;
+      result: {
+        installed: boolean;
+        name: string;
+        enabled: boolean;
+        source_url: string;
+      } | null;
+      created_at: number;
+      updated_at: number;
+    }>(`/skills/hub/install/status/${encodeURIComponent(taskId)}`),
+
+  cancelHubSkillInstall: (taskId: string) =>
+    request<{ task_id: string; status: string }>(
+      `/skills/hub/install/cancel/${encodeURIComponent(taskId)}`,
+      {
+        method: "POST",
+      },
+    ),
 
   // Stream optimize skill with SSE (supports abort via signal)
   streamOptimizeSkill: async function (

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -178,7 +178,10 @@
     "stopOptimize": "Stop",
     "optimizeSuccess": "Skill optimized successfully",
     "optimizeFailed": "Failed to optimize skill",
-    "noContentToOptimize": "No content to optimize"
+    "noContentToOptimize": "No content to optimize",
+    "cancelImport": "Cancel Import",
+    "importCancelled": "Skill import cancelled",
+    "importTimeout": "Skill import timed out. Please retry or check your network."
   },
   "mcp": {
     "title": "MCP Clients",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -134,7 +134,10 @@
     "frontmatterDescriptionRequired": "スキルに必須フィールド「description」がありません",
     "editNotSupported": "編集操作はバックエンドAPIでサポートされていません",
     "editNote": "注意: バックエンドAPIはスキルの編集をサポートしていません。表示または有効/無効の切り替えのみ可能です。",
-    "create": "作成"
+    "create": "作成",
+    "cancelImport": "インポートを中止",
+    "importCancelled": "スキルのインポートを中止しました",
+    "importTimeout": "スキルのインポートがタイムアウトしました。再試行するかネットワークを確認してください。"
   },
   "mcp": {
     "title": "MCPクライアント",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -139,7 +139,10 @@
     "stopOptimize": "Стоп",
     "optimizeSuccess": "Навык успешно оптимизирован",
     "optimizeFailed": "Не удалось оптимизировать навык",
-    "noContentToOptimize": "Нет содержимого для оптимизации"
+    "noContentToOptimize": "Нет содержимого для оптимизации",
+    "cancelImport": "Отменить импорт",
+    "importCancelled": "Импорт навыка отменён",
+    "importTimeout": "Время ожидания импорта навыка истекло. Повторите попытку или проверьте сеть."
   },
   "mcp": {
     "title": "MCP-клиенты",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -144,7 +144,10 @@
     "stopOptimize": "停止",
     "optimizeSuccess": "技能优化成功",
     "optimizeFailed": "技能优化失败",
-    "noContentToOptimize": "没有可优化的内容"
+    "noContentToOptimize": "没有可优化的内容",
+    "cancelImport": "取消导入",
+    "importCancelled": "已取消技能导入",
+    "importTimeout": "技能导入超时，请重试或检查网络。"
   },
   "mcp": {
     "title": "MCP 客户端",

--- a/console/src/pages/Agent/Skills/index.tsx
+++ b/console/src/pages/Agent/Skills/index.tsx
@@ -13,6 +13,7 @@ function SkillsPage() {
     skills,
     loading,
     importing,
+    cancelImport,
     createSkill,
     importFromHub,
     toggleEnabled,
@@ -149,11 +150,10 @@ function SkillsPage() {
         footer={
           <div style={{ textAlign: "right" }}>
             <Button
-              onClick={closeImportModal}
+              onClick={importing ? cancelImport : closeImportModal}
               style={{ marginRight: 8 }}
-              disabled={importing}
             >
-              {t("common.cancel")}
+              {t(importing ? "skills.cancelImport" : "common.cancel")}
             </Button>
             <Button
               type="primary"

--- a/console/src/pages/Agent/Skills/useSkills.ts
+++ b/console/src/pages/Agent/Skills/useSkills.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { message, Modal } from "@agentscope-ai/design";
 import React from "react";
 import api from "../../../api";
@@ -29,6 +29,8 @@ export function useSkills() {
   const [skills, setSkills] = useState<SkillSpec[]>([]);
   const [loading, setLoading] = useState(false);
   const [importing, setImporting] = useState(false);
+  const importTaskIdRef = useRef<string | null>(null);
+  const importCancelReasonRef = useRef<"manual" | "timeout" | null>(null);
 
   const showScanErrorModal = useCallback(
     (scanError: SecurityScanErrorResponse) => {
@@ -241,25 +243,67 @@ export function useSkills() {
       );
       return false;
     }
+    const timeoutMs = 90_000;
+    const pollMs = 1_000;
+    const startedAt = Date.now();
     try {
       setImporting(true);
+      importCancelReasonRef.current = null;
       const payload = { bundle_url: text, enable: true, overwrite: false };
-      const result = await api.installHubSkill(payload);
-      if (result?.installed) {
-        message.success(`Imported skill: ${result.name}`);
-        await fetchSkills();
-        if (result.name) await checkScanWarnings(result.name);
-        return true;
+      const task = await api.startHubSkillInstall(payload);
+      importTaskIdRef.current = task.task_id;
+
+      while (importTaskIdRef.current) {
+        const status = await api.getHubSkillInstallStatus(task.task_id);
+
+        if (status.status === "completed" && status.result?.installed) {
+          message.success(`Imported skill: ${status.result.name}`);
+          await fetchSkills();
+          if (status.result.name) await checkScanWarnings(status.result.name);
+          return true;
+        }
+
+        if (status.status === "failed") {
+          throw new Error(status.error || "Import failed");
+        }
+
+        if (status.status === "cancelled") {
+          message.warning(
+            t(
+              importCancelReasonRef.current === "timeout"
+                ? "skills.importTimeout"
+                : "skills.importCancelled",
+            ),
+          );
+          return false;
+        }
+
+        if (Date.now() - startedAt >= timeoutMs) {
+          importCancelReasonRef.current = "timeout";
+          await api.cancelHubSkillInstall(task.task_id);
+        }
+
+        await new Promise((resolve) => window.setTimeout(resolve, pollMs));
       }
-      message.error("Import failed");
+
       return false;
     } catch (error) {
       handleError(error, "Import failed");
       return false;
     } finally {
+      importTaskIdRef.current = null;
+      importCancelReasonRef.current = null;
       setImporting(false);
     }
   };
+
+  const cancelImport = useCallback(() => {
+    if (!importing) return;
+    importCancelReasonRef.current = "manual";
+    const taskId = importTaskIdRef.current;
+    if (!taskId) return;
+    void api.cancelHubSkillInstall(taskId);
+  }, [importing]);
 
   const toggleEnabled = async (skill: SkillSpec) => {
     try {
@@ -324,6 +368,7 @@ export function useSkills() {
     skills,
     loading,
     importing,
+    cancelImport,
     createSkill,
     importFromHub,
     toggleEnabled,

--- a/src/copaw/agents/skills_hub.py
+++ b/src/copaw/agents/skills_hub.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import time
+import contextvars
 import base64
 import io
 import zipfile
@@ -16,6 +17,7 @@ from typing import Any
 from urllib.parse import quote, urlencode, urlparse, unquote
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from contextlib import contextmanager
 
 import frontmatter
 import yaml
@@ -23,6 +25,10 @@ import yaml
 from .skills_manager import SkillService
 
 logger = logging.getLogger(__name__)
+
+_cancel_checker_ctx: contextvars.ContextVar[
+    Any | None
+] = contextvars.ContextVar("skills_hub_cancel_checker", default=None)
 
 
 @dataclass
@@ -39,6 +45,10 @@ class HubInstallResult:
     name: str
     enabled: bool
     source_url: str
+
+
+class SkillImportCancelled(RuntimeError):
+    """Raised when a skill import task is cancelled by user."""
 
 
 RETRYABLE_HTTP_STATUS = {
@@ -93,6 +103,29 @@ def _compute_backoff_seconds(attempt: int) -> float:
     base = _hub_http_backoff_base()
     cap = _hub_http_backoff_cap()
     return min(cap, base * (2 ** max(0, attempt - 1)))
+
+
+def _ensure_not_cancelled() -> None:
+    checker = _cancel_checker_ctx.get()
+    if checker is None:
+        return
+    try:
+        if bool(checker()):
+            raise SkillImportCancelled("Skill import cancelled by user")
+    except SkillImportCancelled:
+        raise
+    except Exception:
+        # Ignore checker failures and continue.
+        return
+
+
+@contextmanager
+def _with_cancel_checker(checker: Any | None):
+    token = _cancel_checker_ctx.set(checker)
+    try:
+        yield
+    finally:
+        _cancel_checker_ctx.reset(token)
 
 
 def _hub_base_url() -> str:
@@ -153,6 +186,7 @@ def _read_response_bytes(
     full_url: str,
     max_bytes: int | None = None,
 ) -> bytes:
+    _ensure_not_cancelled()
     if max_bytes is not None and max_bytes <= 0:
         raise ValueError("max_bytes must be greater than 0")
 
@@ -176,6 +210,7 @@ def _read_response_bytes(
 
     body = bytearray()
     while True:
+        _ensure_not_cancelled()
         chunk = resp.read(HTTP_READ_CHUNK_BYTES)
         if not chunk:
             return bytes(body)
@@ -194,6 +229,7 @@ def _http_fetch(
     accept: str = "application/json",
     max_bytes: int | None = None,
 ) -> bytes:
+    _ensure_not_cancelled()
     full_url = url
     if params:
         full_url = f"{url}?{urlencode(params)}"
@@ -204,6 +240,7 @@ def _http_fetch(
     attempts = retries + 1
     last_error: Exception | None = None
     for attempt in range(1, attempts + 1):
+        _ensure_not_cancelled()
         try:
             with urlopen(req, timeout=timeout) as resp:
                 return _read_response_bytes(
@@ -240,6 +277,7 @@ def _http_fetch(
                     attempts,
                     delay,
                 )
+                _ensure_not_cancelled()
                 time.sleep(delay)
                 continue
             raise
@@ -256,6 +294,7 @@ def _http_fetch(
                     delay,
                     e,
                 )
+                _ensure_not_cancelled()
                 time.sleep(delay)
                 continue
             raise
@@ -963,10 +1002,12 @@ def _github_collect_tree_files(
     pending = [root] if root else [""]
     visited = 0
     while pending:
+        _ensure_not_cancelled()
         current_dir = pending.pop()
         target_dir = current_dir or ""
         entries = _github_get_dir_entries(owner, repo, target_dir, ref)
         for entry in entries:
+            _ensure_not_cancelled()
             entry_type = str(entry.get("type") or "")
             entry_path = str(entry.get("path") or "")
             if not entry_path:
@@ -1493,41 +1534,48 @@ def install_skill_from_hub(
     version: str = "",
     enable: bool = True,
     overwrite: bool = False,
+    cancel_checker: Any | None = None,
 ) -> HubInstallResult:
     if not bundle_url or not _is_http_url(bundle_url):
         raise ValueError("bundle_url must be a valid http(s) URL")
-    data, source_url = _resolve_bundle_from_url(bundle_url, version)
+    with _with_cancel_checker(cancel_checker):
+        _ensure_not_cancelled()
+        data, source_url = _resolve_bundle_from_url(bundle_url, version)
 
-    name, content, references, scripts, extra_files = _normalize_bundle(data)
-    if not name:
-        fallback = urlparse(bundle_url).path.strip("/").split("/")[-1]
-        name = _safe_fallback_name(fallback)
-    # Sanitize: "Excel / XLSX" etc. must not be used as dir name
-    name = _sanitize_skill_dir_name(name)
-
-    skill_service = SkillService(workspace_dir)
-    created = skill_service.create_skill(
-        name=name,
-        content=content,
-        overwrite=overwrite,
-        references=references,
-        scripts=scripts,
-        extra_files=extra_files,
-    )
-    if not created:
-        raise RuntimeError(
-            f"Failed to create skill '{name}'. "
-            "Try overwrite=true if it already exists.",
+        name, content, references, scripts, extra_files = _normalize_bundle(
+            data,
         )
+        if not name:
+            fallback = urlparse(bundle_url).path.strip("/").split("/")[-1]
+            name = _safe_fallback_name(fallback)
+        # Sanitize: "Excel / XLSX" etc. must not be used as dir name
+        name = _sanitize_skill_dir_name(name)
 
-    enabled = False
-    if enable:
-        enabled = skill_service.enable_skill(name, force=True)
-        if not enabled:
-            logger.warning("Skill '%s' imported but enable failed", name)
+        _ensure_not_cancelled()
+        skill_service = SkillService(workspace_dir)
+        created = skill_service.create_skill(
+            name=name,
+            content=content,
+            overwrite=overwrite,
+            references=references,
+            scripts=scripts,
+            extra_files=extra_files,
+        )
+        if not created:
+            raise RuntimeError(
+                f"Failed to create skill '{name}'. "
+                "Try overwrite=true if it already exists.",
+            )
 
-    return HubInstallResult(
-        name=name,
-        enabled=enabled,
-        source_url=source_url,
-    )
+        _ensure_not_cancelled()
+        enabled = False
+        if enable:
+            enabled = skill_service.enable_skill(name, force=True)
+            if not enabled:
+                logger.warning("Skill '%s' imported but enable failed", name)
+
+        return HubInstallResult(
+            name=name,
+            enabled=enabled,
+            source_url=source_url,
+        )

--- a/src/copaw/app/routers/skills.py
+++ b/src/copaw/app/routers/skills.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
+import asyncio
 import logging
+import threading
+import time
+import uuid
+from enum import Enum
 from typing import Any
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
@@ -10,6 +15,7 @@ from ...agents.skills_manager import (
     SkillInfo,
 )
 from ...agents.skills_hub import (
+    SkillImportCancelled,
     search_hub_skills,
     install_skill_from_hub,
 )
@@ -81,6 +87,33 @@ class HubInstallRequest(BaseModel):
         default=False,
         description="Overwrite existing customized skill",
     )
+
+
+class HubInstallTaskStatus(str, Enum):
+    PENDING = "pending"
+    IMPORTING = "importing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class HubInstallTask(BaseModel):
+    task_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    bundle_url: str
+    version: str = ""
+    enable: bool = True
+    overwrite: bool = False
+    status: HubInstallTaskStatus = HubInstallTaskStatus.PENDING
+    error: str | None = None
+    result: dict[str, Any] | None = None
+    created_at: float = Field(default_factory=time.time)
+    updated_at: float = Field(default_factory=time.time)
+
+
+_hub_install_tasks: dict[str, HubInstallTask] = {}
+_hub_install_runtime_tasks: dict[str, asyncio.Task] = {}
+_hub_install_cancel_events: dict[str, threading.Event] = {}
+_hub_install_lock = asyncio.Lock()
 
 
 router = APIRouter(prefix="/skills", tags=["skills"])
@@ -188,6 +221,137 @@ def _github_token_hint(bundle_url: str) -> str:
     return ""
 
 
+async def _hub_task_set_status(
+    task_id: str,
+    status: HubInstallTaskStatus,
+    *,
+    error: str | None = None,
+    result: dict[str, Any] | None = None,
+) -> None:
+    async with _hub_install_lock:
+        task = _hub_install_tasks.get(task_id)
+        if task is None:
+            return
+        task.status = status
+        task.updated_at = time.time()
+        if error is not None:
+            task.error = error
+        if result is not None:
+            task.result = result
+
+
+async def _hub_task_get(task_id: str) -> HubInstallTask | None:
+    async with _hub_install_lock:
+        return _hub_install_tasks.get(task_id)
+
+
+async def _hub_task_register_runtime(task_id: str, task: asyncio.Task) -> None:
+    async with _hub_install_lock:
+        _hub_install_runtime_tasks[task_id] = task
+
+
+async def _hub_task_pop_runtime(task_id: str) -> asyncio.Task | None:
+    async with _hub_install_lock:
+        return _hub_install_runtime_tasks.pop(task_id, None)
+
+
+def _cleanup_imported_skill(workspace_dir: Path, skill_name: str) -> None:
+    """Best-effort cleanup for cancelled skill imports."""
+    if not skill_name:
+        return
+    try:
+        skill_service = SkillService(workspace_dir)
+        skill_service.disable_skill(skill_name)
+        skill_service.delete_skill(skill_name)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(
+            "Cleanup after cancelled import failed for '%s': %s",
+            skill_name,
+            e,
+        )
+
+
+async def _run_hub_install_task(
+    *,
+    task_id: str,
+    workspace_dir: Path,
+    body: HubInstallRequest,
+    cancel_event: threading.Event,
+) -> None:
+    await _hub_task_set_status(task_id, HubInstallTaskStatus.IMPORTING)
+    result_payload: dict[str, Any] | None = None
+    imported_skill_name: str | None = None
+    try:
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            None,
+            lambda: install_skill_from_hub(
+                workspace_dir=workspace_dir,
+                bundle_url=body.bundle_url,
+                version=body.version,
+                enable=body.enable,
+                overwrite=body.overwrite,
+                cancel_checker=cancel_event.is_set,
+            ),
+        )
+        result_payload = {
+            "installed": True,
+            "name": result.name,
+            "enabled": result.enabled,
+            "source_url": result.source_url,
+        }
+        imported_skill_name = result.name
+        if cancel_event.is_set():
+            _cleanup_imported_skill(workspace_dir, result.name)
+            await _hub_task_set_status(
+                task_id,
+                HubInstallTaskStatus.CANCELLED,
+                result={
+                    "installed": False,
+                    "name": result.name,
+                    "enabled": False,
+                    "source_url": result.source_url,
+                },
+            )
+            return
+        await _hub_task_set_status(
+            task_id,
+            HubInstallTaskStatus.COMPLETED,
+            result=result_payload,
+        )
+    except SkillImportCancelled:
+        if imported_skill_name:
+            _cleanup_imported_skill(workspace_dir, imported_skill_name)
+        await _hub_task_set_status(task_id, HubInstallTaskStatus.CANCELLED)
+    except SkillScanError as e:
+        await _hub_task_set_status(
+            task_id,
+            HubInstallTaskStatus.FAILED,
+            error=str(e),
+        )
+    except ValueError as e:
+        await _hub_task_set_status(
+            task_id,
+            HubInstallTaskStatus.FAILED,
+            error=str(e),
+        )
+    except RuntimeError as e:
+        await _hub_task_set_status(
+            task_id,
+            HubInstallTaskStatus.FAILED,
+            error=str(e) + _github_token_hint(body.bundle_url),
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        await _hub_task_set_status(
+            task_id,
+            HubInstallTaskStatus.FAILED,
+            error=f"Skill hub import failed: {e}"
+            + _github_token_hint(body.bundle_url),
+        )
+    finally:
+        await _hub_task_pop_runtime(task_id)
+
+
 @router.post("/hub/install")
 async def install_from_hub(
     request_body: HubInstallRequest,
@@ -235,6 +399,70 @@ async def install_from_hub(
         "enabled": result.enabled,
         "source_url": result.source_url,
     }
+
+
+@router.post("/hub/install/start", response_model=HubInstallTask)
+async def start_install_from_hub(
+    request_body: HubInstallRequest,
+    request: Request,
+) -> HubInstallTask:
+    from ..agent_context import get_agent_for_request
+
+    workspace = await get_agent_for_request(request)
+    workspace_dir = Path(workspace.workspace_dir)
+    task = HubInstallTask(
+        bundle_url=request_body.bundle_url,
+        version=request_body.version,
+        enable=request_body.enable,
+        overwrite=request_body.overwrite,
+    )
+    cancel_event = threading.Event()
+    async with _hub_install_lock:
+        _hub_install_tasks[task.task_id] = task
+        _hub_install_cancel_events[task.task_id] = cancel_event
+
+    runtime_task = asyncio.create_task(
+        _run_hub_install_task(
+            task_id=task.task_id,
+            workspace_dir=workspace_dir,
+            body=request_body,
+            cancel_event=cancel_event,
+        ),
+        name=f"skill-hub-install-{task.task_id}",
+    )
+    await _hub_task_register_runtime(task.task_id, runtime_task)
+    return task
+
+
+@router.get("/hub/install/status/{task_id}", response_model=HubInstallTask)
+async def get_hub_install_status(task_id: str) -> HubInstallTask:
+    task = await _hub_task_get(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="install task not found")
+    return task
+
+
+@router.post("/hub/install/cancel/{task_id}")
+async def cancel_hub_install(task_id: str) -> dict[str, Any]:
+    async with _hub_install_lock:
+        task = _hub_install_tasks.get(task_id)
+        if task is None:
+            raise HTTPException(
+                status_code=404,
+                detail="install task not found",
+            )
+        if task.status in (
+            HubInstallTaskStatus.COMPLETED,
+            HubInstallTaskStatus.FAILED,
+            HubInstallTaskStatus.CANCELLED,
+        ):
+            return {"task_id": task_id, "status": task.status.value}
+        cancel_event = _hub_install_cancel_events.get(task_id)
+        if cancel_event is not None:
+            cancel_event.set()
+        task.status = HubInstallTaskStatus.CANCELLED
+        task.updated_at = time.time()
+    return {"task_id": task_id, "status": "cancelled"}
 
 
 @router.post("/batch-disable")
@@ -319,7 +547,6 @@ async def disable_skill(
     """Disable skill for active agent."""
     from ..agent_context import get_agent_for_request
     import shutil
-    import asyncio
 
     workspace = await get_agent_for_request(request)
     workspace_dir = Path(workspace.workspace_dir)
@@ -403,8 +630,6 @@ async def enable_skill(
     # Hot reload config (async, non-blocking)
     # IMPORTANT: Get manager and agent_id before creating background task
     # to avoid accessing request/workspace after their lifecycle ends
-    import asyncio
-
     manager = request.app.state.multi_agent_manager
     agent_id = workspace.agent_id
 


### PR DESCRIPTION
## Description

Added a timeout reminder for skill imports and an option to cancel the import process to prevent blocking the frontend.

**Related Issue:** Fixes issue https://github.com/agentscope-ai/CoPaw/issues/1696

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy
