### PR TITLE
fix(agent): strip historical Anthropic tool-result media on replay

### DIFF
--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -10,8 +10,9 @@ Example:
 """
 
 
+from copy import deepcopy
 import logging
-from typing import List, Sequence, Tuple, Type, Any, Union, Optional
+from typing import List, Sequence, Tuple, Type, Any, Union, Optional, Literal
 
 from agentscope.formatter import FormatterBase, OpenAIChatFormatter
 from agentscope.model import ChatModelBase, OpenAIChatModel
@@ -76,6 +77,137 @@ def _get_formatter_for_chat_model(
         chat_model_class,
         OpenAIChatFormatter,
     )
+
+
+_TOOL_RESULT_MEDIA_PLACEHOLDER = (
+    "[Historical media omitted from tool result for Anthropic compatibility]"
+)
+
+
+def _is_tool_result_only_user_message(message: dict[str, Any]) -> bool:
+    """Return True when message is a user message containing only tool results.
+
+    Anthropic tool execution sends tool_result blocks as user turns. The
+    trailing suffix of such messages represents the current tool exchange and
+    must be preserved for the next model call.
+    """
+    content = message.get("content")
+    return bool(
+        message.get("role") == "user"
+        and isinstance(content, list)
+        and content
+        and all(
+            isinstance(block, dict) and block.get("type") == "tool_result"
+            for block in content
+        )
+    )
+
+
+def _strip_media_from_tool_result_content(
+    content: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Strip media blocks from a single Anthropic tool_result content list."""
+    sanitized: list[dict[str, Any]] = []
+    removed = 0
+    for block in content:
+        if (
+            isinstance(block, dict)
+            and block.get("type") in {"image", "audio", "video"}
+        ):
+            removed += 1
+            continue
+        sanitized.append(block)
+
+    if removed > 0 and not sanitized:
+        sanitized.append(
+            {
+                "type": "text",
+                "text": _TOOL_RESULT_MEDIA_PLACEHOLDER,
+            },
+        )
+
+    return sanitized, removed
+
+
+def _sanitize_anthropic_history_tool_result_media(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Strip media from historical Anthropic tool results before replay.
+
+    Keep the trailing tool_result-only suffix untouched so the current tool
+    exchange still reaches Claude with the full multimodal payload. Any older
+    tool_result messages have already served their purpose and are replayed only
+    as conversation history, where preserving raw media blocks risks provider
+    incompatibilities.
+    """
+    if not messages:
+        return messages
+
+    trailing_tool_result_start = len(messages)
+    while trailing_tool_result_start > 0 and _is_tool_result_only_user_message(
+        messages[trailing_tool_result_start - 1],
+    ):
+        trailing_tool_result_start -= 1
+
+    sanitized_messages: list[dict[str, Any]] | None = None
+
+    for message_index in range(trailing_tool_result_start):
+        message = messages[message_index]
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+
+        for block_index, block in enumerate(content):
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "tool_result"
+                and isinstance(block.get("content"), list)
+            ):
+                continue
+
+            sanitized_content, removed = _strip_media_from_tool_result_content(
+                block["content"],
+            )
+            if removed == 0:
+                continue
+
+            if sanitized_messages is None:
+                sanitized_messages = deepcopy(messages)
+
+            sanitized_messages[message_index]["content"][block_index][
+                "content"
+            ] = sanitized_content
+
+    return sanitized_messages or messages
+
+
+class _AnthropicHistoryMediaCompatModel:
+    """Anthropic wrapper that strips replay-only media from old tool results."""
+
+    def __init__(self, model: ChatModelBase) -> None:
+        self._model = model
+
+    async def __call__(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        tool_choice: Literal["auto", "none", "required"] | str | None = None,
+        structured_model: Any | None = None,
+        **generate_kwargs: Any,
+    ) -> Any:
+        sanitized_messages = _sanitize_anthropic_history_tool_result_media(
+            messages,
+        )
+        return await self._model(
+            messages=sanitized_messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            structured_model=structured_model,
+            **generate_kwargs,
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._model, name)
 
 
 # pylint: disable-next=too-many-statements
@@ -341,6 +473,9 @@ def create_model_and_formatter(
 
     # Create the formatter based on the real model class
     formatter = _create_formatter_instance(model.__class__)
+
+    if AnthropicChatModel is not None and isinstance(model, AnthropicChatModel):
+        model = _AnthropicHistoryMediaCompatModel(model)
 
     # Wrap with retry logic for transient LLM API errors
     wrapped_model = TokenRecordingModelWrapper(provider_id, model)

--- a/src/copaw/agents/model_factory.py
+++ b/src/copaw/agents/model_factory.py
@@ -80,7 +80,8 @@ def _get_formatter_for_chat_model(
 
 
 _TOOL_RESULT_MEDIA_PLACEHOLDER = (
-    "[Historical media omitted from tool result for Anthropic compatibility]"
+    "[Historical media omitted from tool result "
+    "for Anthropic compatibility]"
 )
 
 
@@ -99,7 +100,7 @@ def _is_tool_result_only_user_message(message: dict[str, Any]) -> bool:
         and all(
             isinstance(block, dict) and block.get("type") == "tool_result"
             for block in content
-        )
+        ),
     )
 
 
@@ -110,10 +111,11 @@ def _strip_media_from_tool_result_content(
     sanitized: list[dict[str, Any]] = []
     removed = 0
     for block in content:
-        if (
-            isinstance(block, dict)
-            and block.get("type") in {"image", "audio", "video"}
-        ):
+        if isinstance(block, dict) and block.get("type") in {
+            "image",
+            "audio",
+            "video",
+        }:
             removed += 1
             continue
         sanitized.append(block)
@@ -135,10 +137,10 @@ def _sanitize_anthropic_history_tool_result_media(
     """Strip media from historical Anthropic tool results before replay.
 
     Keep the trailing tool_result-only suffix untouched so the current tool
-    exchange still reaches Claude with the full multimodal payload. Any older
-    tool_result messages have already served their purpose and are replayed only
-    as conversation history, where preserving raw media blocks risks provider
-    incompatibilities.
+    exchange still reaches Claude with the full multimodal payload.
+    Any older tool_result messages have already served their purpose
+    and are replayed only as conversation history, where preserving
+    raw media blocks risks provider incompatibilities.
     """
     if not messages:
         return messages
@@ -165,14 +167,37 @@ def _sanitize_anthropic_history_tool_result_media(
             ):
                 continue
 
-            sanitized_content, removed = _strip_media_from_tool_result_content(
-                block["content"],
-            )
+            if sanitized_messages is None:
+                (
+                    sanitized_content,
+                    removed,
+                ) = _strip_media_from_tool_result_content(
+                    block["content"],
+                )
+            else:
+                copied_block = sanitized_messages[message_index]["content"][
+                    block_index
+                ]
+                (
+                    sanitized_content,
+                    removed,
+                ) = _strip_media_from_tool_result_content(
+                    copied_block["content"],
+                )
             if removed == 0:
                 continue
 
             if sanitized_messages is None:
                 sanitized_messages = deepcopy(messages)
+                copied_block = sanitized_messages[message_index]["content"][
+                    block_index
+                ]
+                (
+                    sanitized_content,
+                    removed,
+                ) = _strip_media_from_tool_result_content(
+                    copied_block["content"],
+                )
 
             sanitized_messages[message_index]["content"][block_index][
                 "content"
@@ -181,10 +206,14 @@ def _sanitize_anthropic_history_tool_result_media(
     return sanitized_messages or messages
 
 
-class _AnthropicHistoryMediaCompatModel:
-    """Anthropic wrapper that strips replay-only media from old tool results."""
+class _AnthropicHistoryMediaCompatModel(ChatModelBase):
+    """Anthropic wrapper for replay-only historical tool-result media."""
 
     def __init__(self, model: ChatModelBase) -> None:
+        super().__init__(
+            model_name=getattr(model, "model_name", "unknown"),
+            stream=getattr(model, "stream", True),
+        )
         self._model = model
 
     async def __call__(
@@ -474,7 +503,10 @@ def create_model_and_formatter(
     # Create the formatter based on the real model class
     formatter = _create_formatter_instance(model.__class__)
 
-    if AnthropicChatModel is not None and isinstance(model, AnthropicChatModel):
+    if AnthropicChatModel is not None and isinstance(
+        model,
+        AnthropicChatModel,
+    ):
         model = _AnthropicHistoryMediaCompatModel(model)
 
     # Wrap with retry logic for transient LLM API errors

--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -720,6 +720,8 @@ class CoPawAgent(ToolGuardMixin, ReActAgent):
             "vision",
             "multimodal",
             "image_url",
+            "claudecontentblocktoolresult",
+            "object has no attribute 'source'",
         ]
         return any(kw in error_str for kw in keywords)
 

--- a/src/copaw/agents/react_agent.py
+++ b/src/copaw/agents/react_agent.py
@@ -59,6 +59,31 @@ logger = logging.getLogger(__name__)
 # Valid namesake strategies for tool registration
 NamesakeStrategy = Literal["override", "skip", "raise", "rename"]
 
+_MEDIA_ERROR_KEYWORDS = [
+    "image",
+    "audio",
+    "video",
+    "vision",
+    "multimodal",
+    "image_url",
+]
+
+
+def is_bad_request_or_media_error(exc: Exception) -> bool:
+    """Return True for 400-class or known media/tool-result model errors."""
+    status = getattr(exc, "status_code", None)
+    if status == 400:
+        return True
+
+    error_str = str(exc).lower()
+    if any(keyword in error_str for keyword in _MEDIA_ERROR_KEYWORDS):
+        return True
+
+    return (
+        "claudecontentblocktoolresult" in error_str
+        and "attribute 'source'" in error_str
+    )
+
 
 class CoPawAgent(ToolGuardMixin, ReActAgent):
     """CoPaw Agent with integrated tools, skills, and memory management.
@@ -708,22 +733,7 @@ class CoPawAgent(ToolGuardMixin, ReActAgent):
         matching provides an extra safety net for providers that use
         non-standard status codes.
         """
-        status = getattr(exc, "status_code", None)
-        if status == 400:
-            return True
-
-        error_str = str(exc).lower()
-        keywords = [
-            "image",
-            "audio",
-            "video",
-            "vision",
-            "multimodal",
-            "image_url",
-            "claudecontentblocktoolresult",
-            "object has no attribute 'source'",
-        ]
-        return any(kw in error_str for kw in keywords)
+        return is_bad_request_or_media_error(exc)
 
     _MEDIA_PLACEHOLDER = (
         "[Media content removed - model does not support this media type]"

--- a/tests/unit/agents/test_anthropic_history_media.py
+++ b/tests/unit/agents/test_anthropic_history_media.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from copaw.agents.model_factory import (
     _sanitize_anthropic_history_tool_result_media,
 )
-from copaw.agents.react_agent import CoPawAgent
+from copaw.agents.react_agent import is_bad_request_or_media_error
 
 
 def _make_tool_result_message(
@@ -66,10 +66,17 @@ def test_sanitize_history_tool_results_strips_media_but_keeps_text() -> None:
     assert tool_result["content"] == [
         {"type": "text", "text": "Image loaded: a.png"},
     ]
+    tool_result["content"][0]["text"] = "mutated"
+    assert (
+        messages[2]["content"][0]["content"][1]["text"]
+        == "Image loaded: a.png"
+    )
     assert messages == original
 
 
-def test_sanitize_history_tool_results_preserves_trailing_current_suffix() -> None:
+def test_sanitize_history_tool_results_preserves_trailing_current_suffix() -> (
+    None
+):
     messages = [
         {"role": "user", "content": [{"type": "text", "text": "look"}]},
         {
@@ -129,15 +136,29 @@ def test_sanitize_history_tool_results_preserves_trailing_current_suffix() -> No
     assert trailing_result["content"][0]["source"]["url"] == "/tmp/b.png"
 
 
-def test_bad_request_detector_matches_anthropic_tool_result_source_bug() -> None:
+def test_bad_request_detector_matches_anthropic_tool_result_source_bug() -> (
+    None
+):
     class FakeAnthropicError(Exception):
         status_code = 500
 
         def __str__(self) -> str:
             return (
                 "Error code: 500 - {'error': {'code': '500', "
-                "\"message\": \"'ClaudeContentBlockToolResult' object "
+                '"message": "\'ClaudeContentBlockToolResult\' object '
                 "has no attribute 'source'\"}}"
             )
 
-    assert CoPawAgent._is_bad_request_or_media_error(FakeAnthropicError())
+    assert is_bad_request_or_media_error(FakeAnthropicError())
+
+
+def test_bad_request_detector_ignores_unrelated_source_attribute_errors() -> (
+    None
+):
+    class FakeGenericError(Exception):
+        status_code = 500
+
+        def __str__(self) -> str:
+            return "RuntimeError: object has no attribute 'source'"
+
+    assert not is_bad_request_or_media_error(FakeGenericError())

--- a/tests/unit/agents/test_anthropic_history_media.py
+++ b/tests/unit/agents/test_anthropic_history_media.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from copy import deepcopy
+
+from copaw.agents.model_factory import (
+    _sanitize_anthropic_history_tool_result_media,
+)
+from copaw.agents.react_agent import CoPawAgent
+
+
+def _make_tool_result_message(
+    tool_use_id: str,
+    *,
+    text: str = "Image loaded: a.png",
+    include_image: bool = True,
+) -> dict:
+    content: list[dict] = []
+    if include_image:
+        content.append(
+            {
+                "type": "image",
+                "source": {"type": "url", "url": "/tmp/a.png"},
+            },
+        )
+    if text:
+        content.append({"type": "text", "text": text})
+    return {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+            },
+        ],
+    }
+
+
+def test_sanitize_history_tool_results_strips_media_but_keeps_text() -> None:
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "look"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "id": "toolu_1",
+                    "type": "tool_use",
+                    "name": "view_image",
+                    "input": {"image_path": "/tmp/a.png"},
+                },
+            ],
+        },
+        _make_tool_result_message("toolu_1"),
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "I can see it."}],
+        },
+        {"role": "user", "content": [{"type": "text", "text": "继续"}]},
+    ]
+
+    original = deepcopy(messages)
+    sanitized = _sanitize_anthropic_history_tool_result_media(messages)
+
+    tool_result = sanitized[2]["content"][0]
+    assert tool_result["content"] == [
+        {"type": "text", "text": "Image loaded: a.png"},
+    ]
+    assert messages == original
+
+
+def test_sanitize_history_tool_results_preserves_trailing_current_suffix() -> None:
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "look"}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "id": "toolu_1",
+                    "type": "tool_use",
+                    "name": "view_image",
+                    "input": {"image_path": "/tmp/a.png"},
+                },
+            ],
+        },
+        _make_tool_result_message("toolu_1"),
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "I can see it."}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "id": "toolu_2",
+                    "type": "tool_use",
+                    "name": "view_image",
+                    "input": {"image_path": "/tmp/b.png"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_2",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {"type": "url", "url": "/tmp/b.png"},
+                        },
+                        {"type": "text", "text": "Image loaded: b.png"},
+                    ],
+                },
+            ],
+        },
+    ]
+
+    sanitized = _sanitize_anthropic_history_tool_result_media(messages)
+
+    historical_result = sanitized[2]["content"][0]
+    trailing_result = sanitized[-1]["content"][0]
+
+    assert historical_result["content"] == [
+        {"type": "text", "text": "Image loaded: a.png"},
+    ]
+    assert trailing_result["content"][0]["type"] == "image"
+    assert trailing_result["content"][0]["source"]["url"] == "/tmp/b.png"
+
+
+def test_bad_request_detector_matches_anthropic_tool_result_source_bug() -> None:
+    class FakeAnthropicError(Exception):
+        status_code = 500
+
+        def __str__(self) -> str:
+            return (
+                "Error code: 500 - {'error': {'code': '500', "
+                "\"message\": \"'ClaudeContentBlockToolResult' object "
+                "has no attribute 'source'\"}}"
+            )
+
+    assert CoPawAgent._is_bad_request_or_media_error(FakeAnthropicError())


### PR DESCRIPTION
## Summary

This fixes Anthropic follow-up failures after a tool returns image content, such as `view_image`.

The underlying issue is not the first tool turn itself. The problem appears on later turns, when older `tool_result` messages containing media are replayed back to Anthropic as conversation history. That replay path is brittle across Anthropic-compatible endpoints and can fail with provider-side image/tool-result errors.

This PR keeps the current multimodal tool turn intact, but strips media blocks from older Anthropic `tool_result` history before the next replay. Textual tool-result context is preserved, so Claude still keeps the useful trace of what happened without re-sending stale image payloads.

It also broadens the existing media fallback detector to catch Anthropic errors like `ClaudeContentBlockToolResult ... source`, so the strip-and-retry path can still engage if a similar upstream failure surfaces.

## What changed

- Add an Anthropic-only compatibility wrapper in `model_factory`.
- Remove `image` / `audio` / `video` blocks from historical `tool_result` payloads before replay.
- Preserve the trailing current tool-result suffix so the active multimodal turn still reaches Claude unchanged.
- Extend media error detection for Anthropic-specific tool-result failures.
- Add regression tests for the history sanitization and fallback matching.

## Why this approach

Anthropic's tool-use docs allow image content inside `tool_result`, but they define `tool_result` primarily as the immediate continuation of a tool exchange. In practice, replaying old image-bearing tool results as long-lived history is high-cost and error-prone. The fix is intentionally narrow: it only changes Anthropic history replay, not the current tool turn, not OpenAI-format providers, and not user-visible rendering.

## Test Plan

- `PYTHONPATH=src pytest -q tests/unit/agents/test_anthropic_history_media.py tests/unit/providers/test_anthropic_provider.py tests/unit/providers/test_openai_stream_toolcall_compat.py`

Closes #2076
