### PR TITLE
fix: treat 404 from models.list as successful connection check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ src/.hypothesis/
 
 # Kiro IDE
 .kiro/
+.venv2/

--- a/src/copaw/providers/anthropic_provider.py
+++ b/src/copaw/providers/anthropic_provider.py
@@ -70,6 +70,9 @@ class AnthropicProvider(Provider):
             await client.models.list()
             return True, ""
         except anthropic.NotFoundError:
+            # Anthropic-compatible providers (e.g. MiniMax) may not
+            # support /models. A 404 here means the server is reachable
+            # and responding, but API key validity is not confirmed.
             return True, ""
         except anthropic.APIError:
             return False, "Anthropic API error"

--- a/src/copaw/providers/anthropic_provider.py
+++ b/src/copaw/providers/anthropic_provider.py
@@ -69,6 +69,8 @@ class AnthropicProvider(Provider):
             client = self._client(timeout=timeout)
             await client.models.list()
             return True, ""
+        except anthropic.NotFoundError:
+            return True, ""
         except anthropic.APIError:
             return False, "Anthropic API error"
         except Exception:


### PR DESCRIPTION
Fixes #2303

Anthropic-compatible providers like MiniMax don't support the
/models endpoint and return 404. Since a 404 response means the
server is reachable and responding, this treats it as a successful
connection check instead of failing with an API error.

The 404 only means the endpoint doesn't exist, not that the provider
is unreachable. Actual inference via messages.create() works fine.