### PR TITLE
fix(agents): trim space before and after the agents workspace path

### DIFF
--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -65,12 +65,18 @@ export default function AgentsPage() {
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields();
+      const workspaceRaw = values.workspace_dir;
+      const workspace_dir =
+        typeof workspaceRaw === "string"
+          ? workspaceRaw.trim() || undefined
+          : workspaceRaw;
+      const payload = { ...values, workspace_dir };
 
       if (editingAgent) {
-        await agentsApi.updateAgent(editingAgent.id, values);
+        await agentsApi.updateAgent(editingAgent.id, payload);
         message.success(t("agent.updateSuccess"));
       } else {
-        const result = await agentsApi.createAgent(values);
+        const result = await agentsApi.createAgent(payload);
         message.success(`${t("agent.createSuccess")} (ID: ${result.id})`);
       }
 

--- a/src/copaw/app/routers/agents.py
+++ b/src/copaw/app/routers/agents.py
@@ -9,7 +9,7 @@ import shutil
 from pathlib import Path
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi import Path as PathParam
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from ..utils import schedule_agent_reload
 from ...config.config import (
@@ -57,6 +57,17 @@ class CreateAgentRequest(BaseModel):
     description: str = ""
     workspace_dir: str | None = None
     language: str = "en"
+
+    @field_validator("workspace_dir", mode="before")
+    @classmethod
+    def strip_workspace_dir(cls, value: str | None) -> str | None:
+        """Strip accidental whitespace"""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped if stripped else None
+        return value
 
 
 class MdFileInfo(BaseModel):


### PR DESCRIPTION
## Description

When creating a new agent, any leading or trailing spaces in the entered workspace path will be automatically removed during path creation.

**Related Issue:** Fixes #2305 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
