### PR TITLE
fix(skills): add version recommendation for himalaya skill

### DIFF
--- a/src/copaw/agents/skills/himalaya/SKILL.md
+++ b/src/copaw/agents/skills/himalaya/SKILL.md
@@ -4,7 +4,7 @@ description: "CLI to manage emails via IMAP/SMTP. Use `himalaya` to list, read, 
 homepage: https://github.com/pimalaya/himalaya
 metadata:
   {
-    "builtin_skill_version": "1.0",
+    "builtin_skill_version": "1.1",
     "openclaw":
       {
         "emoji": "📧",
@@ -32,7 +32,8 @@ Himalaya is a CLI email client that lets you manage emails from the terminal usi
 
 ## Prerequisites
 
-1. Himalaya CLI installed (`himalaya --version` to verify)
+1. **Himalaya CLI** - the `himalaya` binary must already be on `PATH`. Check with `himalaya --version`.
+   - **Recommended: v1.2.0 or newer.** Older releases can fail against some IMAP servers (notably QQ Mail and similar) due to UID/sequence handling; v1.2.0+ includes related fixes.
 2. A configuration file at `~/.config/himalaya/config.toml`
 3. IMAP/SMTP credentials configured (password stored securely)
 

--- a/src/copaw/agents/skills/himalaya/SKILL.md
+++ b/src/copaw/agents/skills/himalaya/SKILL.md
@@ -33,7 +33,7 @@ Himalaya is a CLI email client that lets you manage emails from the terminal usi
 ## Prerequisites
 
 1. **Himalaya CLI** - the `himalaya` binary must already be on `PATH`. Check with `himalaya --version`.
-   - **Recommended: v1.2.0 or newer.** Older releases can fail against some IMAP servers (notably QQ Mail and similar) due to UID/sequence handling; v1.2.0+ includes related fixes.
+   - **Recommended: v1.2.0 or newer.** Older releases can fail against some IMAP servers; v1.2.0+ includes related fixes.
 2. A configuration file at `~/.config/himalaya/config.toml`
 3. IMAP/SMTP credentials configured (password stored securely)
 


### PR DESCRIPTION
## Description

Himalaya had a bug with QQ Email in version 1.1.0, which was fixed in version 1.2.0. Add a recommended version note to the Himalaya skill to prevent connection issues caused by using outdated versions.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
