### PR TITLE
fix: use max_completion_tokens for GPT-5.x and o-series models

### DIFF
--- a/src/copaw/providers/openai_provider.py
+++ b/src/copaw/providers/openai_provider.py
@@ -21,6 +21,25 @@ logger = logging.getLogger(__name__)
 DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 CODING_DASHSCOPE_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
+# Models in the o1/o3/o4 and GPT-5 families reject the legacy ``max_tokens``
+# parameter and require ``max_completion_tokens`` instead.
+_MAX_COMPLETION_TOKENS_PREFIXES = ("o1", "o3", "o4", "gpt-5")
+
+
+def _max_tokens_param(model_id: str, n: int) -> dict:
+    """Return the correct max-tokens keyword argument for the given model.
+
+    Newer OpenAI reasoning and GPT-5 family models do not accept the legacy
+    ``max_tokens`` parameter and raise a 400 error if it is passed.  Use
+    ``max_completion_tokens`` for those models and ``max_tokens`` for all
+    others.
+    """
+    # Strip an optional org/namespace prefix (e.g. "openai/gpt-5" → "gpt-5")
+    name = model_id.lower().split("/")[-1]
+    if name.startswith(_MAX_COMPLETION_TOKENS_PREFIXES):
+        return {"max_completion_tokens": n}
+    return {"max_tokens": n}
+
 
 class OpenAIProvider(Provider):
     """Provider implementation for OpenAI API and compatible endpoints."""
@@ -108,7 +127,7 @@ class OpenAIProvider(Provider):
                     },
                 ],
                 timeout=timeout,
-                max_tokens=1,
+                **_max_tokens_param(model_id, 1),
                 stream=True,
             )
             # consume the stream to ensure the model is actually responsive
@@ -258,7 +277,7 @@ class OpenAIProvider(Provider):
                         ],
                     },
                 ],
-                max_tokens=200,
+                **_max_tokens_param(model_id, 200),
                 timeout=timeout,
             )
             return self._evaluate_image_response(
@@ -429,7 +448,7 @@ class OpenAIProvider(Provider):
                         ],
                     },
                 ],
-                max_tokens=200,
+                **_max_tokens_param(model_id, 200),
                 timeout=req_timeout,
             )
             return self._evaluate_video_response(

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import copaw.providers.openai_provider as openai_provider_module
-from copaw.providers.openai_provider import OpenAIProvider
+from copaw.providers.openai_provider import OpenAIProvider, _max_tokens_param
 
 
 def _make_provider(is_custom: bool = False) -> OpenAIProvider:
@@ -16,6 +16,24 @@ def _make_provider(is_custom: bool = False) -> OpenAIProvider:
         is_custom=is_custom,
         chat_model="OpenAIChatModel",
     )
+
+
+def test_max_tokens_param_legacy_models():
+    assert _max_tokens_param("gpt-4o", 10) == {"max_tokens": 10}
+    assert _max_tokens_param("gpt-4o-mini", 1) == {"max_tokens": 1}
+    assert _max_tokens_param("gpt-4-turbo", 200) == {"max_tokens": 200}
+
+
+def test_max_tokens_param_new_style_models():
+    assert _max_tokens_param("gpt-5", 1) == {"max_completion_tokens": 1}
+    assert _max_tokens_param("gpt-5.2", 200) == {"max_completion_tokens": 200}
+    assert _max_tokens_param("gpt-5-mini", 1) == {"max_completion_tokens": 1}
+    assert _max_tokens_param("o1", 1) == {"max_completion_tokens": 1}
+    assert _max_tokens_param("o1-mini", 1) == {"max_completion_tokens": 1}
+    assert _max_tokens_param("o3", 1) == {"max_completion_tokens": 1}
+    assert _max_tokens_param("o4-mini", 1) == {"max_completion_tokens": 1}
+    # Namespaced model IDs (e.g. "openai/gpt-5")
+    assert _max_tokens_param("openai/gpt-5", 1) == {"max_completion_tokens": 1}
 
 
 async def test_check_connection_success(monkeypatch) -> None:
@@ -124,6 +142,38 @@ async def test_check_model_connection_success(monkeypatch) -> None:
     assert captured[0]["timeout"] == 4
     assert captured[0]["max_tokens"] == 1
     assert captured[0]["stream"] is True
+
+
+async def test_check_model_connection_gpt5_uses_max_completion_tokens(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    captured: list[dict] = []
+
+    class FakeStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.append(kwargs)
+            return FakeStream()
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+    monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
+
+    ok, msg = await provider.check_model_connection("gpt-5.2", timeout=4)
+
+    assert ok is True
+    assert msg == ""
+    assert "max_completion_tokens" in captured[0]
+    assert "max_tokens" not in captured[0]
+    assert captured[0]["max_completion_tokens"] == 1
 
 
 async def test_check_model_connection_api_error_returns_false(


### PR DESCRIPTION
Fixes #2777

## Problem

GPT-5.x models (`gpt-5`, `gpt-5.2`, `gpt-5-mini`, `gpt-5-nano`) and OpenAI reasoning models (`o1`, `o3`, `o4-*`) do not accept the legacy `max_tokens` parameter. Passing it results in a `400 BadRequestError`:

```
BadRequestError: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", ...}}
```

This caused two visible symptoms:
1. **Connection check fails** — `check_model_connection` uses `max_tokens=1` when probing the model, causing GPT-5.x models to appear as "not connectable".
2. **Incorrect multimodal capability detection** — `_probe_image_support` and `_try_video_url` use `max_tokens=200`; the resulting 400 error caused GPT-5.x models to be wrongly flagged as not supporting images/video.

## Solution

Add a `_max_tokens_param(model_id, n)` helper that selects the correct keyword based on the model name:
- Models with names starting with `o1`, `o3`, `o4`, or `gpt-5` → `max_completion_tokens`
- All other models → `max_tokens` (legacy behavior unchanged)

Apply this helper at the three probe call sites in `openai_provider.py`.

## Testing

- Added `test_max_tokens_param_legacy_models` and `test_max_tokens_param_new_style_models` unit tests for the helper function.
- Added `test_check_model_connection_gpt5_uses_max_completion_tokens` to verify GPT-5.x models use the new parameter during connection checks.