### PR TITLE
fix(browser): fix duplicated-element ref targeting and clarify browser action docs

### DIFF
--- a/src/copaw/agents/tools/browser_control.py
+++ b/src/copaw/agents/tools/browser_control.py
@@ -131,8 +131,8 @@ def _get_workspace_state(
     return _workspace_states[workspace_id]
 
 
-# Stop the browser after this many seconds of inactivity (default 30 minutes).
-_BROWSER_IDLE_TIMEOUT = 1800.0
+# Stop the browser after this many seconds of inactivity (default 10 minutes).
+_BROWSER_IDLE_TIMEOUT = 600.0
 
 
 def _touch_activity(state: dict) -> None:

--- a/src/copaw/agents/tools/browser_control.py
+++ b/src/copaw/agents/tools/browser_control.py
@@ -412,10 +412,10 @@ def _get_locator_by_ref(
         return None
     role = info.get("role", "generic")
     name = info.get("name")
-    nth = info.get("nth", 0)
+    nth = info.get("nth")
     root = _get_root(page, frame_selector)
     locator = root.get_by_role(role, name=name or None)
-    if nth is not None and nth > 0:
+    if nth is not None:
         locator = locator.nth(nth)
     return locator
 
@@ -3034,6 +3034,14 @@ async def browser_use(  # pylint: disable=R0911,R0912
             file_upload, fill_form, install, press_key, run_code, drag, hover,
             select_option, tabs, wait_for, pdf, close, cookies_get, cookies_set,
             cookies_clear, connect_cdp, list_cdp_targets, clear_browser_cache.
+            Commonly confused actions:
+            - start: start browser only; does not open a target URL by itself.
+            - open: create/open a page and go to URL; auto-starts browser if needed.
+            - navigate: navigate an existing page_id to URL; page must already exist.
+            - close: close one page/tab only; browser stays running if other tabs remain.
+            - stop: stop/disconnect the whole browser session and clear browser state.
+            - tabs with tab_action=close: close a tab by index; similar to close but
+              selected by tab list position instead of page_id.
         url (str):
             URL to open. Required for action=open or navigate. For
             cookies_get, optional URL or JSON array of URLs to filter


### PR DESCRIPTION
## Description

This PR fixes duplicated-element ref targeting in `browser_use` and improve browser process management guidance by clarifying the different actions (like  `close` and `stop`) in the tool documentation. Additionally, the default inactivity timeout before auto-close has been reduced from 30 minutes to 10 minutes.

**Related Issue:** Fixes https://github.com/agentscope-ai/CoPaw/issues/2990, Addresses https://github.com/agentscope-ai/CoPaw/issues/2934

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open a page containing multiple elements with the same role/name.
2. Run `browser_use(action="snapshot", ...)` and identify a ref for the first duplicate element (with `nth=0`).
3. Call `browser_use(action="click", ref="...")` on that ref.
4. Verify the action targets the correct element without a Playwright strict mode violation.
5. Review the `browser_use()` docstring and confirm it clearly distinguishes `close` from `stop`.

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
