### PR TITLE
feat(installer): auto-install WebView2 Runtime during Windows setup

### DIFF
--- a/scripts/pack/desktop.nsi
+++ b/scripts/pack/desktop.nsi
@@ -9,7 +9,7 @@
 !define MUI_ICON "${UNPACKED}\icon.ico"
 !define MUI_UNICON "${UNPACKED}\icon.ico"
 
-; WebView2 Runtime detection — same GUID used by desktop_cmd.py
+; WebView2 Runtime detection — GUID kept in sync with desktop_cmd.py (#3119)
 !define WEBVIEW2_GUID "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
 !define WEBVIEW2_BOOTSTRAPPER_URL "https://go.microsoft.com/fwlink/p/?LinkId=2124703"
 
@@ -90,10 +90,14 @@ Section "-WebView2"
     DetailPrint "Installing WebView2 Runtime (this may take a moment)..."
     ExecWait '"$TEMP\MicrosoftEdgeWebview2Setup.exe" /silent /install' $0
     Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
-    ${If} $0 != 0
-      DetailPrint "WebView2 installer exited with code $0"
+    ; Verify actual installation instead of relying solely on exit code
+    Call _DetectWebView2
+    ${If} $1 == "1"
+      DetailPrint "WebView2 Runtime installed successfully (version $0)."
+    ${Else}
+      DetailPrint "WebView2 not detected after install (exit code $0)"
       MessageBox MB_YESNO|MB_ICONEXCLAMATION \
-        "WebView2 运行时安装可能未成功（退出码：$0）。$\n$\n\
+        "WebView2 运行时安装未成功。$\n$\n\
 缺少 WebView2 将导致 QwenPaw Desktop 启动后白屏，无法正常使用。$\n$\n\
 是否仍要继续安装 QwenPaw？$\n\
 （选择「否」将终止安装）" \
@@ -101,8 +105,6 @@ Section "-WebView2"
       Abort
       webview2_cont_inst:
       StrCpy $R9 "1"
-    ${Else}
-      DetailPrint "WebView2 Runtime installed successfully."
     ${EndIf}
   ${Else}
     Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
@@ -133,14 +135,17 @@ Section "QwenPaw Desktop" SEC01
   ; Debug shortcut - shows console window for troubleshooting
   CreateShortcut "$SMPROGRAMS\QwenPaw Desktop (Debug).lnk" "$INSTDIR\QwenPaw Desktop (Debug).bat" "" "$INSTDIR\icon.ico" 0
 
-  ; Remind user to install WebView2 manually if auto-install failed earlier
+  ; Remind user only if auto-install failed AND WebView2 is still missing
   ${If} $R9 == "1"
-    MessageBox MB_OK|MB_ICONINFORMATION \
-      "安装完成！$\n$\n\
+    Call _DetectWebView2
+    ${If} $1 == "0"
+      MessageBox MB_OK|MB_ICONINFORMATION \
+        "安装完成！$\n$\n\
 提醒：您的系统缺少 WebView2 运行时，QwenPaw Desktop 暂时无法正常使用。$\n$\n\
 请前往以下地址下载安装：$\n\
 https://developer.microsoft.com/zh-cn/microsoft-edge/webview2/$\n$\n\
 安装 WebView2 后即可正常使用 QwenPaw Desktop。"
+    ${EndIf}
   ${EndIf}
 SectionEnd
 

--- a/scripts/pack/desktop.nsi
+++ b/scripts/pack/desktop.nsi
@@ -3,10 +3,15 @@
 ; Usage: makensis /DQWENPAW_VERSION=1.2.3 /DOUTPUT_EXE=dist\QwenPaw-Setup-1.2.3.exe scripts\pack\desktop.nsi
 
 !include "MUI2.nsh"
+!include "LogicLib.nsh"
 !define MUI_ABORTWARNING
 ; Use custom icon from unpacked env (copied by build_win.ps1)
 !define MUI_ICON "${UNPACKED}\icon.ico"
 !define MUI_UNICON "${UNPACKED}\icon.ico"
+
+; WebView2 Runtime detection — same GUID used by desktop_cmd.py
+!define WEBVIEW2_GUID "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+!define WEBVIEW2_BOOTSTRAPPER_URL "https://go.microsoft.com/fwlink/p/?LinkId=2124703"
 
 !ifndef QWENPAW_VERSION
   !define QWENPAW_VERSION "0.0.0"
@@ -33,6 +38,88 @@ RequestExecutionLevel user
   !define UNPACKED "dist\win-unpacked"
 !endif
 
+; ---------------------------------------------------------------------------
+; WebView2 Runtime: detect via registry, download + install if missing.
+; The bootstrapper (~1.8 MB) supports per-user install — no admin needed.
+; ---------------------------------------------------------------------------
+Function _DetectWebView2
+  ; Check HKLM 64-bit registry view
+  SetRegView 64
+  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\EdgeUpdate\Clients\${WEBVIEW2_GUID}" "pv"
+  ${If} $0 != ""
+  ${AndIf} $0 != "0.0.0.0"
+    SetRegView lastused
+    StrCpy $1 "1"
+    Return
+  ${EndIf}
+
+  ; Check HKLM 32-bit registry view
+  SetRegView 32
+  ReadRegStr $0 HKLM "SOFTWARE\Microsoft\EdgeUpdate\Clients\${WEBVIEW2_GUID}" "pv"
+  ${If} $0 != ""
+  ${AndIf} $0 != "0.0.0.0"
+    SetRegView lastused
+    StrCpy $1 "1"
+    Return
+  ${EndIf}
+  SetRegView lastused
+
+  ; Check HKCU (not affected by registry redirection)
+  ReadRegStr $0 HKCU "Software\Microsoft\EdgeUpdate\Clients\${WEBVIEW2_GUID}" "pv"
+  ${If} $0 != ""
+  ${AndIf} $0 != "0.0.0.0"
+    StrCpy $1 "1"
+    Return
+  ${EndIf}
+
+  StrCpy $1 "0"
+FunctionEnd
+
+; Hidden section (runs automatically, not shown in component list)
+Section "-WebView2"
+  Call _DetectWebView2
+  ${If} $1 == "1"
+    DetailPrint "WebView2 Runtime already installed ($0), skipping."
+    Goto webview2_done
+  ${EndIf}
+
+  DetailPrint "WebView2 Runtime not found, downloading bootstrapper..."
+  NSISdl::download "${WEBVIEW2_BOOTSTRAPPER_URL}" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+  Pop $0
+  ${If} $0 == "success"
+    DetailPrint "Installing WebView2 Runtime (this may take a moment)..."
+    ExecWait '"$TEMP\MicrosoftEdgeWebview2Setup.exe" /silent /install' $0
+    Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+    ${If} $0 != 0
+      DetailPrint "WebView2 installer exited with code $0"
+      MessageBox MB_YESNO|MB_ICONEXCLAMATION \
+        "WebView2 运行时安装可能未成功（退出码：$0）。$\n$\n\
+缺少 WebView2 将导致 QwenPaw Desktop 启动后白屏，无法正常使用。$\n$\n\
+是否仍要继续安装 QwenPaw？$\n\
+（选择「否」将终止安装）" \
+        IDYES webview2_cont_inst
+      Abort
+      webview2_cont_inst:
+      StrCpy $R9 "1"
+    ${Else}
+      DetailPrint "WebView2 Runtime installed successfully."
+    ${EndIf}
+  ${Else}
+    Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION \
+      "WebView2 运行时下载失败（$0）。$\n$\n\
+缺少 WebView2 将导致 QwenPaw Desktop 启动后白屏，无法正常使用。$\n$\n\
+是否仍要继续安装 QwenPaw？$\n\
+（选择「否」将终止安装）" \
+      IDYES webview2_cont_dl
+    Abort
+    webview2_cont_dl:
+    StrCpy $R9 "1"
+  ${EndIf}
+
+  webview2_done:
+SectionEnd
+
 Section "QwenPaw Desktop" SEC01
   SetOutPath "$INSTDIR"
   File /r "${UNPACKED}\*.*"
@@ -42,9 +129,19 @@ Section "QwenPaw Desktop" SEC01
   ; Main shortcut - uses VBS to hide console window
   CreateShortcut "$SMPROGRAMS\QwenPaw Desktop.lnk" "$INSTDIR\QwenPaw Desktop.vbs" "" "$INSTDIR\icon.ico" 0
   CreateShortcut "$DESKTOP\QwenPaw Desktop.lnk" "$INSTDIR\QwenPaw Desktop.vbs" "" "$INSTDIR\icon.ico" 0
-  
+
   ; Debug shortcut - shows console window for troubleshooting
   CreateShortcut "$SMPROGRAMS\QwenPaw Desktop (Debug).lnk" "$INSTDIR\QwenPaw Desktop (Debug).bat" "" "$INSTDIR\icon.ico" 0
+
+  ; Remind user to install WebView2 manually if auto-install failed earlier
+  ${If} $R9 == "1"
+    MessageBox MB_OK|MB_ICONINFORMATION \
+      "安装完成！$\n$\n\
+提醒：您的系统缺少 WebView2 运行时，QwenPaw Desktop 暂时无法正常使用。$\n$\n\
+请前往以下地址下载安装：$\n\
+https://developer.microsoft.com/zh-cn/microsoft-edge/webview2/$\n$\n\
+安装 WebView2 后即可正常使用 QwenPaw Desktop。"
+  ${EndIf}
 SectionEnd
 
 Section "Uninstall"


### PR DESCRIPTION
## Description

Follow-up to #3119. While #3119 adds a runtime fail-fast check that turns the silent white-screen into a clear error message, this PR goes one step further by **automatically installing WebView2 Runtime during the Windows NSIS installer**, so most users never encounter the error at all.

**How it works:**

1. Before installing CoPaw files, a hidden NSIS section checks the Windows registry for WebView2 Runtime (same 3 locations + `0.0.0.0` filtering as `desktop_cmd.py`)
2. If WebView2 is already installed → skip (log "already installed, skipping")
3. If missing → download the official Microsoft Evergreen Bootstrapper (~1.8 MB) via `NSISdl::download` and run it with `/silent /install`
4. If the download fails (e.g. no network) → show a `MessageBox` directing the user to install manually

**Key design decisions:**

- **No admin required** — the bootstrapper supports per-user install, matching the existing `RequestExecutionLevel user` in the NSIS config
- **Non-blocking** — if WebView2 install fails, CoPaw installation still proceeds; the runtime check from #3119 will catch it at launch
- **Defense in depth** — installer auto-install (preventive) + runtime detection (safety net) cover all scenarios: new installs, pip installs, post-install WebView2 removal/damage

**Related Issue:** Relates to #3119

**Security Considerations:** The bootstrapper is downloaded from Microsoft's official redirect URL (`go.microsoft.com/fwlink/p/?LinkId=2124703`). No third-party sources.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. **With WebView2 present** — installer should log "WebView2 Runtime already installed, skipping" in the detail panel and proceed normally
2. **Without WebView2** — installer should download the bootstrapper, install silently, then proceed to install CoPaw files
3. **Without network** — installer should show a MessageBox with manual install instructions and continue installing CoPaw
4. **CI build** — the `desktop-release.yml` workflow uses `negrutiu/nsis-install@v2` which includes `NSISdl` plugin; `makensis` should compile successfully

Recommended test environment: Alibaba Cloud Wuying (无影云电脑) or a clean Windows VM without Edge/WebView2.

## Local Verification Evidence

```
pre-commit run --all-files
# Passed (NSIS files are not checked by pre-commit)
```

## Additional Notes

- The WebView2 GUID and registry locations are intentionally kept in sync with `src/copaw/cli/desktop_cmd.py` — both use `{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}`
- `NSISdl` is a built-in NSIS plugin, no extra dependencies needed
- The hidden section prefix (`-WebView2`) ensures it runs automatically without appearing in the component selection UI