### PR TITLE
fix(runner): truncate oversized tool_result before session persistence

### DIFF
--- a/src/copaw/app/runner/session.py
+++ b/src/copaw/app/runner/session.py
@@ -24,6 +24,115 @@ logger = logging.getLogger(__name__)
 # Characters forbidden in Windows filenames
 _UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
 
+# Maximum bytes for a single tool_result output before truncation
+_TOOL_RESULT_MAX_BYTES = 50 * 1024  # 50KB
+
+
+def _truncate_tool_result_output(
+    output: Union[str, list],
+    max_bytes: int,
+    tool_name: str = "",
+) -> Union[str, list]:
+    """Truncate a tool_result output if it exceeds max_bytes.
+
+    Args:
+        output: The tool result output (string or list of content blocks)
+        max_bytes: Maximum allowed bytes before truncation
+        tool_name: Name of the tool for the truncation notice
+
+    Returns:
+        Truncated output with a notice if truncated, original otherwise
+    """
+    if isinstance(output, str):
+        if len(output.encode("utf-8", errors="replace")) <= max_bytes:
+            return output
+        return (
+            f"[auto-truncated] Original output exceeded {max_bytes:,} bytes "
+            f"(tool: {tool_name}). "
+            f"First 2000 chars:\n{output[:2000]}\n[truncated]"
+        )
+
+    if isinstance(output, list):
+        for block in output:
+            if not isinstance(block, dict) or block.get("type") != "text":
+                continue
+            text = block.get("text", "")
+            if len(text.encode("utf-8", errors="replace")) <= max_bytes:
+                continue
+            block["text"] = (
+                f"[auto-truncated] Original output exceeded {max_bytes:,} bytes "
+                f"(tool: {tool_name}). "
+                f"First 2000 chars:\n{text[:2000]}\n[truncated]"
+            )
+    return output
+
+
+def _compact_tool_results_in_state(state_dicts: dict) -> dict:
+    """Truncate oversized tool_result outputs before persisting to disk.
+
+    This is a safety net that prevents giant tool outputs from being
+    saved to session JSON files when the compact_tool_result hook hasn't
+    had a chance to run yet (e.g., same-turn save in the finally block).
+    """
+    agent_state = state_dicts.get("agent")
+    if not agent_state or not isinstance(agent_state, dict):
+        return state_dicts
+
+    memory_state = agent_state.get("memory")
+    if not memory_state or not isinstance(memory_state, dict):
+        return state_dicts
+
+    content = memory_state.get("content")
+    if not content or not isinstance(content, list):
+        return state_dicts
+
+    truncated_count = 0
+    for item in content:
+        if not isinstance(item, list) or len(item) < 1:
+            continue
+        msg_dict = item[0]
+        if not isinstance(msg_dict, dict):
+            continue
+
+        msg_content = msg_dict.get("content")
+        if not isinstance(msg_content, list):
+            continue
+
+        for block in msg_content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "tool_result":
+                continue
+
+            output = block.get("output")
+            if not output:
+                continue
+
+            output_size = len(
+                json.dumps(output, ensure_ascii=False).encode(
+                    "utf-8",
+                    errors="replace",
+                )
+            )
+            if output_size <= _TOOL_RESULT_MAX_BYTES:
+                continue
+
+            tool_name = block.get("name", "unknown")
+            block["output"] = _truncate_tool_result_output(
+                output,
+                _TOOL_RESULT_MAX_BYTES,
+                tool_name,
+            )
+            truncated_count += 1
+
+    if truncated_count > 0:
+        logger.info(
+            "Session guard: truncated %d oversized tool_result(s) before save",
+            truncated_count,
+        )
+
+    return state_dicts
+
 
 def sanitize_filename(name: str) -> str:
     """Replace characters that are illegal in Windows filenames with ``--``.
@@ -76,11 +185,20 @@ class SafeJSONSession(SessionBase):
         user_id: str = "",
         **state_modules_mapping,
     ) -> None:
-        """Save state modules to a JSON file using async I/O."""
+        """Save state modules to a JSON file using async I/O.
+
+        Automatically truncates oversized tool_result outputs before
+        persisting to prevent session file bloat and infinite
+        compression loops.
+        """
         state_dicts = {
             name: state_module.state_dict()
             for name, state_module in state_modules_mapping.items()
         }
+
+        # Truncate oversized tool_results before writing to disk
+        state_dicts = _compact_tool_results_in_state(state_dicts)
+
         session_save_path = self._get_save_path(session_id, user_id=user_id)
         with open(
             session_save_path,

--- a/tests/test_session_tool_result_guard.py
+++ b/tests/test_session_tool_result_guard.py
@@ -1,0 +1,145 @@
+"""Tests for oversized tool_result truncation in session persistence."""
+
+import json
+import pytest
+
+from copaw.app.runner.session import (
+    _compact_tool_results_in_state,
+    _truncate_tool_result_output,
+    _TOOL_RESULT_MAX_BYTES,
+)
+
+
+class TestTruncateToolResultOutput:
+    """Tests for _truncate_tool_result_output."""
+
+    def test_small_string_not_truncated(self):
+        output = "small output"
+        result = _truncate_tool_result_output(output, 1024, "test_tool")
+        assert result == output
+
+    def test_large_string_truncated(self):
+        output = "A" * 200000
+        result = _truncate_tool_result_output(output, 1024, "test_tool")
+        assert "[auto-truncated]" in result
+        assert "test_tool" in result
+        assert len(result) < len(output)
+
+    def test_small_list_not_truncated(self):
+        output = [{"type": "text", "text": "small"}]
+        original_text = output[0]["text"]
+        _truncate_tool_result_output(output, 1024, "test_tool")
+        assert output[0]["text"] == original_text
+
+    def test_large_list_truncated(self):
+        output = [{"type": "text", "text": "B" * 200000}]
+        _truncate_tool_result_output(output, 1024, "wait_task")
+        assert "[auto-truncated]" in output[0]["text"]
+        assert "wait_task" in output[0]["text"]
+
+
+class TestCompactToolResultsInState:
+    """Tests for _compact_tool_results_in_state."""
+
+    def _make_state(self, output_text: str, tool_name: str = "test_tool"):
+        return {
+            "agent": {
+                "memory": {
+                    "content": [
+                        [
+                            {
+                                "role": "system",
+                                "content": [
+                                    {
+                                        "type": "tool_result",
+                                        "name": tool_name,
+                                        "output": [
+                                            {"type": "text", "text": output_text},
+                                        ],
+                                    },
+                                ],
+                            },
+                            [],
+                        ],
+                    ],
+                },
+            },
+        }
+
+    def test_small_output_not_modified(self):
+        state = self._make_state("small output")
+        result = _compact_tool_results_in_state(state)
+        text = result["agent"]["memory"]["content"][0][0]["content"][0]["output"][0]["text"]
+        assert text == "small output"
+
+    def test_large_output_truncated(self):
+        state = self._make_state("X" * 200000, tool_name="wait_task")
+        result = _compact_tool_results_in_state(state)
+        text = result["agent"]["memory"]["content"][0][0]["content"][0]["output"][0]["text"]
+        assert "[auto-truncated]" in text
+        assert "wait_task" in text
+        assert len(text) < 5000
+
+    def test_string_output_truncated(self):
+        state = {
+            "agent": {
+                "memory": {
+                    "content": [
+                        [
+                            {
+                                "role": "system",
+                                "content": [
+                                    {
+                                        "type": "tool_result",
+                                        "name": "execute_shell_command",
+                                        "output": "Y" * 200000,
+                                    },
+                                ],
+                            },
+                            [],
+                        ],
+                    ],
+                },
+            },
+        }
+        result = _compact_tool_results_in_state(state)
+        output = result["agent"]["memory"]["content"][0][0]["content"][0]["output"]
+        assert "[auto-truncated]" in output
+        assert "execute_shell_command" in output
+
+    def test_no_agent_key(self):
+        state = {"other": "data"}
+        result = _compact_tool_results_in_state(state)
+        assert result == state
+
+    def test_no_memory_key(self):
+        state = {"agent": {"other": "data"}}
+        result = _compact_tool_results_in_state(state)
+        assert result == state
+
+    def test_no_content_key(self):
+        state = {"agent": {"memory": {"other": "data"}}}
+        result = _compact_tool_results_in_state(state)
+        assert result == state
+
+    def test_non_tool_result_not_modified(self):
+        state = {
+            "agent": {
+                "memory": {
+                    "content": [
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    {"type": "text", "text": "Hello world"},
+                                ],
+                            },
+                            [],
+                        ],
+                    ],
+                },
+            },
+        }
+        result = _compact_tool_results_in_state(state)
+        text = result["agent"]["memory"]["content"][0][0]["content"][0]["text"]
+        assert text == "Hello world"


### PR DESCRIPTION
## Summary

When a tool returns massive output (e.g., 3+ MB of log text from `wait_task` or `execute_shell_command`), the full content is persisted to the session JSON file via `save_session_state()`, which fires in the `finally` block **before** the next turn's `compact_tool_result` pre-reasoning hook can run.

This causes an infinite compression loop that makes the agent unresponsive.

## Root Cause

The `compact_tool_result` hook runs as a `pre_reasoning` hook (start of next turn), but `save_session_state` fires at the **end** of the current turn. Giant tool outputs are saved to disk before truncation can occur.

Confirmed with real incident data (2026-04-10): 3.8MB tool_result from `wait_task` → session bloat → infinite compression → agent unresponsive.

## Fix

Add `_compact_tool_results_in_state()` in `SafeJSONSession.save_session_state()` that truncates oversized tool_result outputs (>50KB) before writing to disk.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Component(s) Affected

- [x] Core

## Testing

- Added `tests/test_session_tool_result_guard.py`
- Verified on live CoPaw: 1,800,000 char output → 2,104 chars (855x reduction)
- Normal tool results unaffected