### PR TITLE
feat(security): prevent write_file overwriting non-empty files

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1475,6 +1475,12 @@ class FileGuardConfig(BaseModel):
 
     enabled: bool = True
     sensitive_files: List[str] = Field(default_factory=list)
+    prevent_write_file_overwrite: bool = Field(
+        default=True,
+        description=(
+            "Block write_file when the target is an existing non-empty file"
+        ),
+    )
 
 
 class SkillScannerWhitelistEntry(BaseModel):

--- a/src/qwenpaw/security/tool_guard/engine.py
+++ b/src/qwenpaw/security/tool_guard/engine.py
@@ -23,7 +23,10 @@ from typing import Any
 
 from ...constant import EnvVarLoader
 from .guardians import BaseToolGuardian
-from .guardians.file_guardian import FilePathToolGuardian
+from .guardians.file_guardian import (
+    FilePathToolGuardian,
+    WriteFileOverwriteGuardian,
+)
 from .guardians.rule_guardian import RuleBasedToolGuardian
 from .guardians.shell_evasion_guardian import ShellEvasionGuardian
 from .models import ToolGuardResult
@@ -91,6 +94,13 @@ class ToolGuardEngine:
         except Exception as exc:  # pragma: no cover
             logger.warning(
                 "Failed to initialise FilePathToolGuardian: %s",
+                exc,
+            )
+        try:
+            guardians.append(WriteFileOverwriteGuardian())
+        except Exception as exc:  # pragma: no cover
+            logger.warning(
+                "Failed to initialise WriteFileOverwriteGuardian: %s",
                 exc,
             )
         try:

--- a/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
@@ -154,6 +154,18 @@ def _is_file_guard_enabled() -> bool:
         return True
 
 
+def _is_write_file_overwrite_guard_enabled() -> bool:
+    """Check ``security.file_guard.prevent_write_file_overwrite``."""
+    try:
+        from qwenpaw.config import load_config
+
+        return bool(
+            load_config().security.file_guard.prevent_write_file_overwrite,
+        )
+    except Exception:
+        return True
+
+
 def _load_sensitive_files_from_config() -> list[str]:
     """Load ``security.file_guard.sensitive_files`` from config.json.
 
@@ -303,11 +315,18 @@ class WriteFileOverwriteGuardian(BaseToolGuardian):
 
     def __init__(self) -> None:
         super().__init__(name="write_file_overwrite_guardian", always_run=True)
-        self._enabled: bool = _is_file_guard_enabled()
+        self._enabled: bool = self._is_enabled()
+
+    @staticmethod
+    def _is_enabled() -> bool:
+        return (
+            _is_file_guard_enabled()
+            and _is_write_file_overwrite_guard_enabled()
+        )
 
     def reload(self) -> None:
         """Reload enabled state from config."""
-        self._enabled = _is_file_guard_enabled()
+        self._enabled = self._is_enabled()
 
     def _make_finding(
         self,

--- a/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
@@ -362,11 +362,13 @@ class WriteFileOverwriteGuardian(BaseToolGuardian):
         tool_name: str,
         params: dict[str, Any],
     ) -> list[GuardFinding]:
-        if not self._enabled or tool_name != "write_file":
-            return []
-
         raw_value = params.get("file_path")
-        if not isinstance(raw_value, str) or not raw_value.strip():
+        if (
+            not self._enabled
+            or tool_name != "write_file"
+            or not isinstance(raw_value, str)
+            or not raw_value.strip()
+        ):
             return []
 
         abs_path = _normalize_path(_sanitize_path_candidate(raw_value))

--- a/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
@@ -298,6 +298,76 @@ def _extract_paths_from_shell_command(command: str) -> list[str]:
     return deduped
 
 
+class WriteFileOverwriteGuardian(BaseToolGuardian):
+    """Guardian that prevents write_file from overwriting non-empty files."""
+
+    def __init__(self) -> None:
+        super().__init__(name="write_file_overwrite_guardian", always_run=True)
+        self._enabled: bool = _is_file_guard_enabled()
+
+    def reload(self) -> None:
+        """Reload enabled state from config."""
+        self._enabled = _is_file_guard_enabled()
+
+    def _make_finding(
+        self,
+        raw_value: str,
+        abs_path: str,
+        size: int,
+    ) -> GuardFinding:
+        return GuardFinding(
+            id=f"GUARD-{uuid.uuid4().hex}",
+            rule_id="WRITE_FILE_OVERWRITE_NON_EMPTY",
+            category=GuardThreatCategory.SENSITIVE_FILE_ACCESS,
+            severity=GuardSeverity.HIGH,
+            title="[HIGH] write_file would overwrite a non-empty file",
+            description=(
+                "Tool 'write_file' attempted to overwrite an existing "
+                "non-empty file."
+            ),
+            tool_name="write_file",
+            param_name="file_path",
+            matched_value=raw_value,
+            matched_pattern=abs_path,
+            snippet=abs_path,
+            remediation=(
+                "Use edit_file to modify existing non-empty files. "
+                "Use write_file only for new or empty files."
+            ),
+            guardian=self.name,
+            metadata={"resolved_path": abs_path, "size": size},
+        )
+
+    def guard(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> list[GuardFinding]:
+        if not self._enabled or tool_name != "write_file":
+            return []
+
+        raw_value = params.get("file_path")
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            return []
+
+        abs_path = _normalize_path(_sanitize_path_candidate(raw_value))
+        if not abs_path:
+            return []
+
+        try:
+            path = Path(abs_path)
+            if not path.exists() or not path.is_file():
+                return []
+            size = path.stat().st_size
+        except OSError:
+            return []
+
+        if size <= 0:
+            return []
+
+        return [self._make_finding(raw_value, abs_path, size)]
+
+
 class FilePathToolGuardian(BaseToolGuardian):
     """Guardian that blocks access to configured sensitive files."""
 

--- a/tests/unit/security/test_file_guardian.py
+++ b/tests/unit/security/test_file_guardian.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.security.tool_guard.engine import ToolGuardEngine
+from qwenpaw.security.tool_guard.guardians.file_guardian import (
+    WriteFileOverwriteGuardian,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable_file_guard(monkeypatch):
+    monkeypatch.setattr(
+        "qwenpaw.security.tool_guard.guardians.file_guardian._is_file_guard_enabled",
+        lambda: True,
+    )
+
+
+def _guard(file_path: str):
+    guardian = WriteFileOverwriteGuardian()
+    return guardian.guard("write_file", {"file_path": file_path})
+
+
+def test_write_file_allows_new_file(tmp_path):
+    target = tmp_path / "new.txt"
+
+    assert _guard(str(target)) == []
+
+
+def test_write_file_allows_empty_existing_file(tmp_path):
+    target = tmp_path / "empty.txt"
+    target.write_text("", encoding="utf-8")
+
+    assert _guard(str(target)) == []
+
+
+def test_write_file_blocks_non_empty_existing_file(tmp_path):
+    target = tmp_path / "existing.txt"
+    target.write_text("content", encoding="utf-8")
+
+    findings = _guard(str(target))
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.rule_id == "WRITE_FILE_OVERWRITE_NON_EMPTY"
+    assert finding.tool_name == "write_file"
+    assert finding.param_name == "file_path"
+    assert finding.metadata["size"] == len("content")
+
+
+def test_write_file_guard_ignores_other_tools(tmp_path):
+    target = tmp_path / "existing.txt"
+    target.write_text("content", encoding="utf-8")
+    guardian = WriteFileOverwriteGuardian()
+
+    assert guardian.guard("edit_file", {"file_path": str(target)}) == []
+
+
+def test_default_engine_registers_write_file_overwrite_guardian():
+    engine = ToolGuardEngine(enabled=True)
+
+    assert "write_file_overwrite_guardian" in engine.guardian_names

--- a/tests/unit/security/test_file_guardian.py
+++ b/tests/unit/security/test_file_guardian.py
@@ -12,11 +12,13 @@ from qwenpaw.security.tool_guard.guardians.file_guardian import (
 @pytest.fixture(autouse=True)
 def _enable_file_guard(monkeypatch):
     monkeypatch.setattr(
-        "qwenpaw.security.tool_guard.guardians.file_guardian._is_file_guard_enabled",
+        "qwenpaw.security.tool_guard.guardians.file_guardian."
+        "_is_file_guard_enabled",
         lambda: True,
     )
     monkeypatch.setattr(
-        "qwenpaw.security.tool_guard.guardians.file_guardian._is_write_file_overwrite_guard_enabled",
+        "qwenpaw.security.tool_guard.guardians.file_guardian."
+        "_is_write_file_overwrite_guard_enabled",
         lambda: True,
     )
 
@@ -29,14 +31,14 @@ def _guard(file_path: str):
 def test_write_file_allows_new_file(tmp_path):
     target = tmp_path / "new.txt"
 
-    assert _guard(str(target)) == []
+    assert not _guard(str(target))
 
 
 def test_write_file_allows_empty_existing_file(tmp_path):
     target = tmp_path / "empty.txt"
     target.write_text("", encoding="utf-8")
 
-    assert _guard(str(target)) == []
+    assert not _guard(str(target))
 
 
 def test_write_file_blocks_non_empty_existing_file(tmp_path):
@@ -58,19 +60,23 @@ def test_write_file_guard_ignores_other_tools(tmp_path):
     target.write_text("content", encoding="utf-8")
     guardian = WriteFileOverwriteGuardian()
 
-    assert guardian.guard("edit_file", {"file_path": str(target)}) == []
+    assert not guardian.guard("edit_file", {"file_path": str(target)})
 
 
 def test_write_file_guard_respects_overwrite_switch(tmp_path, monkeypatch):
     target = tmp_path / "existing.txt"
     target.write_text("content", encoding="utf-8")
     monkeypatch.setattr(
-        "qwenpaw.security.tool_guard.guardians.file_guardian._is_write_file_overwrite_guard_enabled",
+        "qwenpaw.security.tool_guard.guardians.file_guardian."
+        "_is_write_file_overwrite_guard_enabled",
         lambda: False,
     )
     guardian = WriteFileOverwriteGuardian()
 
-    assert guardian.guard("write_file", {"file_path": str(target)}) == []
+    assert not guardian.guard(
+        "write_file",
+        {"file_path": str(target)},
+    )
 
 
 def test_default_engine_registers_write_file_overwrite_guardian():

--- a/tests/unit/security/test_file_guardian.py
+++ b/tests/unit/security/test_file_guardian.py
@@ -15,6 +15,10 @@ def _enable_file_guard(monkeypatch):
         "qwenpaw.security.tool_guard.guardians.file_guardian._is_file_guard_enabled",
         lambda: True,
     )
+    monkeypatch.setattr(
+        "qwenpaw.security.tool_guard.guardians.file_guardian._is_write_file_overwrite_guard_enabled",
+        lambda: True,
+    )
 
 
 def _guard(file_path: str):
@@ -55,6 +59,18 @@ def test_write_file_guard_ignores_other_tools(tmp_path):
     guardian = WriteFileOverwriteGuardian()
 
     assert guardian.guard("edit_file", {"file_path": str(target)}) == []
+
+
+def test_write_file_guard_respects_overwrite_switch(tmp_path, monkeypatch):
+    target = tmp_path / "existing.txt"
+    target.write_text("content", encoding="utf-8")
+    monkeypatch.setattr(
+        "qwenpaw.security.tool_guard.guardians.file_guardian._is_write_file_overwrite_guard_enabled",
+        lambda: False,
+    )
+    guardian = WriteFileOverwriteGuardian()
+
+    assert guardian.guard("write_file", {"file_path": str(target)}) == []
 
 
 def test_default_engine_registers_write_file_overwrite_guardian():


### PR DESCRIPTION
## Description

  This PR adds a file-state-aware tool guard for `write_file`.

  `write_file` is intended for creating new files or writing empty files, but using it on an existing non-empty file can
   silently overwrite content. This PR adds `WriteFileOverwriteGuardian`, which blocks `write_file` when the target path
   already exists as a non-empty regular file and guides the agent to use `edit_file` instead.

  New files and existing empty files are still allowed.

  The behavior is configurable through `security.file_guard.prevent_write_file_overwrite`, which defaults to `true` and
  also respects the parent `security.file_guard.enabled` switch.

  **Related Issue:** Fixes #4020

  **Security Considerations:** This change strengthens tool-call safety by preventing accidental destructive overwrites
  through `write_file`. The new guard is controlled by `security.file_guard.prevent_write_file_overwrite` and also
  respects `security.file_guard.enabled`.

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation
  - [ ] Refactoring

  ## Component(s) Affected

  - [x] Core / Backend (app, agents, config, providers, utils, local_models)
  - [ ] Console (frontend web UI)
  - [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
  - [ ] Skills
  - [ ] CLI
  - [ ] Documentation (website)
  - [x] Tests
  - [ ] CI/CD
  - [ ] Scripts / Deploy

  ## Checklist

  - [ ] I ran `pre-commit run --all-files` locally and it passes
  - [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
  - [x] I ran tests locally (`pytest` or as relevant) and they pass
  - [x] Documentation updated (if needed)
  - [x] Ready for review

  ### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

  - [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
  - [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
  - [ ] Contract test implements `create_instance()` with proper channel initialization
  - [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
  - [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

  ## Testing

  Tested the new guardian behavior with unit tests covering:

  - `write_file` allows new files.
  - `write_file` allows existing empty files.
  - `write_file` blocks existing non-empty files.
  - Other tools such as `edit_file` are not affected.
  - The new `security.file_guard.prevent_write_file_overwrite` switch disables this guard when set to `false`.
  - The default `ToolGuardEngine` registers the new guardian.

  Also ran the full `tests/unit/security` suite.

  ## Local Verification Evidence

  ```bash
  $env:PYTHONPATH='src'
  D:\.qwenpaw\venv\Scripts\python.exe -m pytest tests/unit/security/test_file_guardian.py
  # 6 passed, 2 warnings in 1.32s

  $env:PYTHONPATH='src'
  D:\.qwenpaw\venv\Scripts\python.exe -m pytest tests/unit/security
  # 23 passed, 2 warnings in 1.32s
```

  pre-commit run --all-files was not run locally.

  Warnings observed during pytest are due to the local environment not having pytest-asyncio installed, so pytest
  reports unknown asyncio config options. The tested security cases passed.

  ## Additional Notes

  This PR does not extend custom_rules or security.file_guard.sensitive_files. The new guard is a filesystem-state check
   rather than a regex rule or sensitive-path rule, so it is implemented as a separate guardian under the file guard
  system.
 