### PR TITLE
fix(crons): eliminate concurrency state leaks in CronManager 

### DIFF
--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -63,6 +63,13 @@ class CronManager:
         self._states: Dict[str, CronJobState] = {}
         self._history: Dict[str, list[CronExecutionRecord]] = {}
         self._rt: Dict[str, _Runtime] = {}
+        # Track fire-and-forget background tasks so we can cancel them
+        # during stop() and avoid the "Task was destroyed while pending"
+        # warning caused by losing the task reference.
+        self._run_tasks: set[asyncio.Task] = set()
+        # Per-job set of running tasks, used by delete_job to cancel
+        # in-flight executions and prevent state resurrection.
+        self._job_tasks: Dict[str, set[asyncio.Task]] = {}
         self._started = False
 
     async def start(self) -> None:
@@ -152,6 +159,27 @@ class CronManager:
             self._scheduler.shutdown(wait=False)
             self._started = False
 
+            # Cancel all in-flight fire-and-forget tasks to prevent them
+            # from writing into the state dicts after we have cleared them.
+            pending = [t for t in self._run_tasks if not t.done()]
+            for task in pending:
+                task.cancel()
+
+            # Wait for cancellations to settle outside the lock so that the
+            # done callbacks (which remove tasks from the tracking set) can
+            # run without deadlocking on our lock.
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        async with self._lock:
+            # Clear all per-run state to avoid leaking it to the next
+            # start() cycle (e.g. stale last_status / last_error).
+            self._states.clear()
+            self._history.clear()
+            self._rt.clear()
+            self._run_tasks.clear()
+            self._job_tasks.clear()
+
     # ----- read/state -----
 
     async def list_jobs(self) -> list[CronJobSpec]:
@@ -181,10 +209,22 @@ class CronManager:
             if self._started and self._scheduler.get_job(job_id):
                 self._scheduler.remove_job(job_id)
             self._states.pop(job_id, None)
+            self._rt.pop(job_id, None)
+            # Cancel any in-flight executions for this job so they cannot
+            # recreate runtime/state entries after deletion.
+            running = self._job_tasks.pop(job_id, set())
+            for task in running:
+                if not task.done():
+                    task.cancel()
             self._history.pop(job_id, None)
             await self._repo.delete_history(job_id)
-            self._rt.pop(job_id, None)
-            return await self._repo.delete_job(job_id)
+            deleted = await self._repo.delete_job(job_id)
+
+            # Wait outside the lock to let _task_done_cb run and remove the
+            # cancelled tasks from the tracking set.
+        if running:
+            await asyncio.gather(*running, return_exceptions=True)
+        return deleted
 
     async def pause_job(self, job_id: str) -> None:
         async with self._lock:
@@ -311,9 +351,24 @@ class CronManager:
             ),
             name=f"cron-run-{job_id}",
         )
+        self._track_job_task(job_id, task)
         task.add_done_callback(lambda t: self._task_done_cb(t, job))
 
     # ----- callbacks -----
+
+    def _track_job_task(self, job_id: str, task: asyncio.Task) -> None:
+        """Register a fire-and-forget task for lifecycle management."""
+        self._run_tasks.add(task)
+        self._job_tasks.setdefault(job_id, set()).add(task)
+
+    def _untrack_job_task(self, job_id: str, task: asyncio.Task) -> None:
+        """Remove a tracked fire-and-forget task when it completes."""
+        self._run_tasks.discard(task)
+        job_set = self._job_tasks.get(job_id)
+        if job_set is not None:
+            job_set.discard(task)
+            if not job_set:
+                self._job_tasks.pop(job_id, None)
 
     def _task_done_cb(self, task: asyncio.Task, job: CronJobSpec) -> None:
         """Suppress and log exceptions from fire-and-forget tasks.
@@ -321,6 +376,12 @@ class CronManager:
         On failure, push an error message to the console push store so
         the frontend can display it.
         """
+        # Always drop the task from the tracking sets first so that a
+        # later stop()/delete_job() does not try to cancel a completed
+        # task (which is harmless but also leaks memory until next gc).
+        assert job.id is not None
+        self._untrack_job_task(job.id, task)
+
         if task.cancelled():
             return
         exc = task.exception()
@@ -334,9 +395,13 @@ class CronManager:
             session_id = job.dispatch.target.session_id
             if session_id:
                 error_text = f"❌ Cron job [{job.name}] failed: {exc}"
-                asyncio.ensure_future(
+                push_task = asyncio.create_task(
                     push_store_append(session_id, error_text),
+                    name=f"cron-push-err-{job.id}",
                 )
+                # Track so shutdown does not lose the reference.
+                self._run_tasks.add(push_task)
+                push_task.add_done_callback(self._run_tasks.discard)
 
     # ----- internal -----
 
@@ -347,9 +412,32 @@ class CronManager:
         trigger = self._build_trigger(spec)
 
         # per-job concurrency semaphore
-        self._rt[spec.id] = _Runtime(
-            sem=asyncio.Semaphore(spec.runtime.max_concurrency),
-        )
+        # Reuse the existing semaphore if one is already in place: blindly
+        # replacing it would orphan in-flight tasks holding permits on the
+        # old semaphore and silently double the effective max_concurrency
+        # until those tasks finish. Changes to max_concurrency therefore
+        # take effect only when no task is currently waiting on the sem.
+        existing = self._rt.get(spec.id)
+        if existing is None:
+            self._rt[spec.id] = _Runtime(
+                sem=asyncio.Semaphore(spec.runtime.max_concurrency),
+            )
+        else:
+            # Keep the existing _Runtime so in-flight executions see a
+            # consistent semaphore. If the limit actually changed, log it
+            # so operators know the new value applies to future runs only.
+            current_limit = getattr(existing.sem, "_value", None)
+            if (
+                    current_limit is not None
+                    and current_limit != spec.runtime.max_concurrency
+            ):
+                logger.info(
+                    "cron job_id=%s max_concurrency change (%s -> %s) "
+                    "will apply after current runs settle",
+                    spec.id,
+                    current_limit,
+                    spec.runtime.max_concurrency,
+                )
 
         # replace existing
         if self._scheduler.get_job(spec.id):
@@ -453,15 +541,39 @@ class CronManager:
         if not job:
             return
 
-        await self._execute_once(
-            job,
-            trigger="scheduled",
-        )
-        # refresh next_run
-        aps_job = self._scheduler.get_job(job_id)
-        st = self._states.get(job_id, CronJobState())
-        st.next_run_at = aps_job.next_run_time if aps_job else None
-        self._states[job_id] = st
+        # Track the scheduled execution as well so stop()/delete_job()
+        # can cancel it and we do not leak state writes after shutdown.
+        current = asyncio.current_task()
+        if current is not None:
+            self._track_job_task(job_id, current)
+        try:
+            try:
+                await self._execute_once(
+                    job,
+                    trigger="scheduled",
+                )
+            except Exception:  # pylint: disable=broad-except
+                # _execute_once already logged and persisted error status.
+                # Swallow here so that APScheduler does not double-report
+                # and so we still refresh next_run_at below.
+                pass
+
+            # Refresh next_run_at, but only if the job still exists.
+            # Otherwise a concurrent delete_job() would get its state
+            # resurrected by this write.
+            if (
+                    job_id not in self._states
+                    and (await self._repo.get_job(job_id)) is None
+            ):
+                return
+            aps_job = self._scheduler.get_job(job_id)
+            st = self._states.get(job_id, CronJobState()).model_copy()
+            st.next_run_at = aps_job.next_run_time if aps_job else None
+            if job_id in self._states or aps_job is not None:
+                self._states[job_id] = st
+        finally:
+            if current is not None:
+                self._untrack_job_task(job_id, current)
 
     async def _heartbeat_callback(self) -> None:
         """Run one heartbeat (HEARTBEAT.md as query, optional dispatch)."""
@@ -504,14 +616,29 @@ class CronManager:
     ) -> None:
         assert job.id is not None, "Job must have an id"
         rt = self._rt.get(job.id)
-        if not rt:
-            rt = _Runtime(sem=asyncio.Semaphore(job.runtime.max_concurrency))
-            self._rt[job.id] = rt
+        if rt is None:
+            # The job is no longer managed (likely deleted while this
+            # execution was pending). Do NOT recreate the _Runtime here:
+            # that would resurrect runtime state for a deleted job, which
+            # is exactly the concurrency state leak we are fixing. Abort
+            # silently instead.
+            logger.info(
+                "cron _execute_once skipped: job_id=%s runtime missing "
+                "(job likely deleted)",
+                job.id,
+            )
+            return
 
         async with rt.sem:
-            st = self._states.get(job.id, CronJobState())
+            # Work on a *local* CronJobState so that parallel executions
+            # for the same job (max_concurrency > 1) and for different
+            # jobs do not share a mutable instance. Without this, one
+            # run's fields (e.g. last_error) leak into another run's
+            # final state.
+            st = self._states.get(job.id, CronJobState()).model_copy()
             st.last_status = "running"
-            self._states[job.id] = st
+            self._publish_state(job.id, st)
+
             execution_result: dict[str, Any] = {}
             execution_succeeded = False
             delivery_failed = False
@@ -555,76 +682,93 @@ class CronManager:
                 raise
             finally:
                 st.last_run_at = datetime.now(timezone.utc)
-                self._states[job.id] = st
-                record = CronExecutionRecord(
-                    run_at=st.last_run_at,
-                    status=st.last_status or "error",
-                    error=st.last_error,
-                    trigger=trigger,
-                )
-                records = await self._repo.append_history(
-                    job.id,
-                    record,
-                    limit=CRON_HISTORY_LIMIT,
-                )
-                self._history[job.id] = records
-                if execution_succeeded:
-                    if delivery_failed:
-                        try:
-                            await append_inbox_event(
-                                agent_id=self._agent_id,
-                                source_type="cron",
-                                source_id=job.id,
-                                event_type="cron_delivery_failed_fallback",
-                                status="error",
-                                severity="error",
-                                title=f"Cron result not delivered: {job.name}",
-                                body=(
-                                    "Task executed successfully, "
-                                    "but channel delivery failed."
-                                ),
-                                payload={
-                                    "job_id": job.id,
-                                    "job_name": job.name,
-                                    "task_type": job.task_type,
-                                    "trigger": trigger,
-                                    "run_id": execution_result.get("run_id"),
-                                    "delivery_error": execution_result.get(
-                                        "delivery_error",
+                self._publish_state(job.id, st)
+
+                # History + inbox only if the job still exists
+                if job.id in self._rt:
+                    record = CronExecutionRecord(
+                        run_at=st.last_run_at,
+                        status=st.last_status or "error",
+                        error=st.last_error,
+                        trigger=trigger,
+                    )
+                    records = await self._repo.append_history(
+                        job.id,
+                        record,
+                        limit=CRON_HISTORY_LIMIT,
+                    )
+                    self._history[job.id] = records
+
+                    if execution_succeeded:
+                        if delivery_failed:
+                            try:
+                                await append_inbox_event(
+                                    agent_id=self._agent_id,
+                                    source_type="cron",
+                                    source_id=job.id,
+                                    event_type="cron_delivery_failed_fallback",
+                                    status="error",
+                                    severity="error",
+                                    title=f"Cron result not delivered: {job.name}",
+                                    body=(
+                                        "Task executed successfully, "
+                                        "but channel delivery failed."
                                     ),
-                                },
-                            )
-                        except Exception:  # pylint: disable=broad-except
-                            logger.exception(
-                                "failed to append cron fallback event",
-                            )
-                    elif job.save_result_to_inbox:
-                        if job.task_type == "text":
-                            body = (job.text or "").strip()
-                        else:
-                            body = "Agent cron task finished successfully."
-                        try:
-                            await append_inbox_event(
-                                agent_id=self._agent_id,
-                                source_type="cron",
-                                source_id=job.id,
-                                event_type="cron_result",
-                                status="success",
-                                severity="info",
-                                title=f"Cron result: {job.name}",
-                                body=body,
-                                payload={
-                                    "job_id": job.id,
-                                    "job_name": job.name,
-                                    "task_type": job.task_type,
-                                    "trigger": trigger,
-                                    "run_id": execution_result.get("run_id"),
-                                    "save_result_to_inbox": (
-                                        job.save_result_to_inbox
-                                    ),
-                                },
-                            )
-                        except Exception:  # pylint: disable=broad-except
-                            logger.exception(
-                                "failed to append cron result inbox event",
-                            )
+                                    payload={
+                                        "job_id": job.id,
+                                        "job_name": job.name,
+                                        "task_type": job.task_type,
+                                        "trigger": trigger,
+                                        "run_id": execution_result.get("run_id"),
+                                        "delivery_error": execution_result.get(
+                                            "delivery_error",
+                                        ),
+                                    },
+                                )
+                            except Exception:  # pylint: disable=broad-except
+                                logger.exception(
+                                    "failed to append cron fallback event",
+                                )
+                        elif job.save_result_to_inbox:
+                            if job.task_type == "text":
+                                body = (job.text or "").strip()
+                            else:
+                                body = "Agent cron task finished successfully."
+                            try:
+                                await append_inbox_event(
+                                    agent_id=self._agent_id,
+                                    source_type="cron",
+                                    source_id=job.id,
+                                    event_type="cron_result",
+                                    status="success",
+                                    severity="info",
+                                    title=f"Cron result: {job.name}",
+                                    body=body,
+                                    payload={
+                                        "job_id": job.id,
+                                        "job_name": job.name,
+                                        "task_type": job.task_type,
+                                        "trigger": trigger,
+                                        "run_id": execution_result.get("run_id"),
+                                        "save_result_to_inbox": (
+                                            job.save_result_to_inbox
+                                        ),
+                                    },
+                                )
+                            except Exception:  # pylint: disable=broad-except
+                                logger.exception(
+                                    "failed to append cron result inbox event",
+                                )
+
+    def _publish_state(self, job_id: str, state: CronJobState) -> None:
+        """Publish a per-run state snapshot, avoiding resurrection."""
+        if job_id not in self._rt:
+            return
+        # Preserve next_run_at that may have been set by the scheduler
+        # callback (the execution path never owns this field).
+        existing = self._states.get(job_id)
+        if existing is not None and existing.next_run_at is not None:
+            state = state.model_copy(
+                update={"next_run_at": existing.next_run_at},
+            )
+        self._states[job_id] = state

--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -709,7 +709,10 @@ class CronManager:
                                     event_type="cron_delivery_failed_fallback",
                                     status="error",
                                     severity="error",
-                                    title=f"Cron result not delivered: {job.name}",
+                                    title=(
+                                        "Cron result not delivered: "
+                                        f"{job.name}"
+                                    ),
                                     body=(
                                         "Task executed successfully, "
                                         "but channel delivery failed."
@@ -719,7 +722,9 @@ class CronManager:
                                         "job_name": job.name,
                                         "task_type": job.task_type,
                                         "trigger": trigger,
-                                        "run_id": execution_result.get("run_id"),
+                                        "run_id": execution_result.get(
+                                            "run_id",
+                                        ),
                                         "delivery_error": execution_result.get(
                                             "delivery_error",
                                         ),
@@ -749,7 +754,9 @@ class CronManager:
                                         "job_name": job.name,
                                         "task_type": job.task_type,
                                         "trigger": trigger,
-                                        "run_id": execution_result.get("run_id"),
+                                        "run_id": execution_result.get(
+                                            "run_id",
+                                        ),
                                         "save_result_to_inbox": (
                                             job.save_result_to_inbox
                                         ),

--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -428,8 +428,8 @@ class CronManager:
             # so operators know the new value applies to future runs only.
             current_limit = getattr(existing.sem, "_value", None)
             if (
-                    current_limit is not None
-                    and current_limit != spec.runtime.max_concurrency
+                current_limit is not None
+                and current_limit != spec.runtime.max_concurrency
             ):
                 logger.info(
                     "cron job_id=%s max_concurrency change (%s -> %s) "
@@ -562,8 +562,8 @@ class CronManager:
             # Otherwise a concurrent delete_job() would get its state
             # resurrected by this write.
             if (
-                    job_id not in self._states
-                    and (await self._repo.get_job(job_id)) is None
+                job_id not in self._states
+                and (await self._repo.get_job(job_id)) is None
             ):
                 return
             aps_job = self._scheduler.get_job(job_id)


### PR DESCRIPTION
## Description

Fix multiple concurrency state-leak bugs in `CronManager` (`src/qwenpaw/app/crons/manager.py`) so that scheduled-task state can no longer bleed across parallel runs, deleted jobs, or start/stop cycles.

Symptoms before this PR:

- A failing run could leave `last_error` on a `CronJobState` that another concurrent run later marked `last_status="success"`, producing an inconsistent snapshot (`success` + non-empty `last_error`).
- `delete_job` did not cancel in-flight executions; the still-running `_execute_once` would then re-create `_Runtime` and re-publish state, resurrecting a deleted job in `_states` / `_rt`.
- `_register_or_update` unconditionally replaced the per-job semaphore. In-flight tasks released permits on the *old* sem while new tasks acquired the *new* one, silently doubling the effective `max_concurrency` until in-flight tasks finished.
- `run_job` and `_task_done_cb` created fire-and-forget tasks (via `asyncio.create_task` / `asyncio.ensure_future`) without keeping a reference, so `stop()` could not cancel them and the runtime emitted "Task was destroyed while pending" warnings on shutdown.
- `stop()` only shut down APScheduler and never cleared `_states` / `_rt`, so the next `start()` cycle inherited stale `last_status` / `last_error` from the previous session.
- `_scheduled_callback` let exceptions from `_execute_once` propagate to APScheduler, which both double-reported the error and skipped the `next_run_at` refresh.

This PR makes state writes execution-local and lifecycle-aware via a new `_publish_state()` helper, introduces task-tracking sets (`_run_tasks`, `_job_tasks`) with `_track_job_task` / `_untrack_job_task` helpers, reuses the existing semaphore on re-registration, and clears all per-run state on `stop()`.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** N/A — no auth, env, or config-handling surface is touched. The fix only affects in-process bookkeeping inside `CronManager`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) — N/A, internal fix with no public-API change
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
  ********************************Passed******************************** 

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
