### PR TITLE
fix(cli): use loopback for desktop wildcard readiness checks

### DIFF
--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -93,14 +93,22 @@ def _find_free_port(host: str = "127.0.0.1") -> int:
         return sock.getsockname()[1]
 
 
+def _connect_host_for_bind_host(host: str) -> str:
+    """Return a TCP connect target for a server bound to *host*."""
+    if host == "0.0.0.0":
+        return "127.0.0.1"
+    return host
+
+
 def _wait_for_http(host: str, port: int, timeout_sec: float = 300.0) -> bool:
     """Return True when something accepts TCP on host:port."""
+    connect_host = _connect_host_for_bind_host(host)
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.settimeout(2.0)
-                s.connect((host, port))
+                s.connect((connect_host, port))
                 return True
         except (OSError, socket.error):
             time.sleep(1)
@@ -159,7 +167,7 @@ def desktop_cmd(
     setup_logger(log_level)
 
     port = _find_free_port(host)
-    url = f"http://{host}:{port}"
+    url = f"http://{_connect_host_for_bind_host(host)}:{port}"
     click.echo(f"Starting QwenPaw app on {url} (port {port})")
     logger.info("Server subprocess starting...")
 

--- a/tests/unit/cli/test_cli_desktop.py
+++ b/tests/unit/cli/test_cli_desktop.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import socket
+
+from qwenpaw.cli.desktop_cmd import (
+    _connect_host_for_bind_host,
+    _wait_for_http,
+)
+
+
+def test_connect_host_for_bind_host_uses_loopback_for_any_addr() -> None:
+    assert _connect_host_for_bind_host("0.0.0.0") == "127.0.0.1"
+    assert _connect_host_for_bind_host("127.0.0.1") == "127.0.0.1"
+
+
+def test_wait_for_http_reaches_server_bound_to_any_addr() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("0.0.0.0", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        assert _wait_for_http("0.0.0.0", port, timeout_sec=1.0)


### PR DESCRIPTION
## Description

Fix the desktop command's readiness check when the app is bound to the wildcard IPv4 address `0.0.0.0`.

`0.0.0.0` is valid for binding a server socket, but on Windows it is not a valid TCP connect target. When `qwenpaw desktop --host 0.0.0.0` is used, the backend can be listening correctly while `_wait_for_http()` keeps retrying against an invalid address and eventually reports that the server never became ready. This PR maps that wildcard bind address to `127.0.0.1` for TCP readiness checks, and uses the same mapped host when building the local desktop URL shown to users.

**Related Issue:** Relates to #3555

**Security Considerations:** No new exposure is introduced. The server still binds to the user-provided host; only the local readiness check and displayed desktop URL use loopback for wildcard binds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

N/A - no channel changes.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Manually invoked the new desktop helper tests with `PYTHONPATH=src` using the bundled QwenPaw Python.
- Ran a Windows socket probe that binds `0.0.0.0`, then verifies `_wait_for_http(0.0.0.0, port)` returns `True`.
- Ran `git diff --check` on the changed files.

Full `pytest` was not run because the available bundled QwenPaw Python in this environment does not have `pytest` installed.

## Local Verification Evidence

```bash
$env:PYTHONPATH='src'; $env:PYTHONDONTWRITEBYTECODE='1'; python -B -
# Imported tests.unit.cli.test_cli_desktop and invoked:
# - test_connect_host_for_bind_host_uses_loopback_for_any_addr()
# - test_wait_for_http_reaches_server_bound_to_any_addr()
# manual desktop tests passed

$env:PYTHONPATH='src'; $env:PYTHONDONTWRITEBYTECODE='1'; python -B -
# Bound a socket to 0.0.0.0 and verified:
# True

git diff --check -- src/qwenpaw/cli/desktop_cmd.py tests/unit/cli/test_cli_desktop.py
# passed
```

## Additional Notes

This PR intentionally limits scope to the directly reproducible desktop readiness bug from #3555. The separate `init` prompt/provider behavior discussed in that issue is not changed here.