### PR TITLE
fix(memory): refresh index after auto memory summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.3.1.8",
+    "reme-ai==0.3.1.9",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.3.1.9",
+    "reme-ai==0.3.1.10",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -33,7 +33,7 @@ from ...constant import EnvVarLoader
 logger = logging.getLogger(__name__)
 
 _REME_STORE_VERSION = "v1"
-_EXPECTED_REME_VERSION = "0.3.1.8"
+_EXPECTED_REME_VERSION = "0.3.1.9"
 # Maximum number of tokens from query splitting
 MAX_QUERY_TOKENS = 50
 


### PR DESCRIPTION
﻿## Summary
- bump `reme-ai` from `0.3.1.8` to `0.3.1.9`
- update QwenPaw's expected ReMe version guard to match the new release
- drop the previous QwenPaw-side explicit index refresh workaround in favor of the upstream watcher lifecycle fix

## Related Issue
Fixes #4220
Refs agentscope-ai/ReMe#233

## Root Cause / Resolution
Maintainer feedback on this PR pointed to ReMe's file watcher as the better place to fix the stale memory-index timing gap. I followed up upstream in agentscope-ai/ReMe#233, which found that `BaseFileWatcher.close()` left `_stop_event` set and `start()` reused it. After a close/start cycle, the watcher could appear running while the watch loop exited immediately.

That upstream fix has been merged and released as `reme-ai==0.3.1.9`, so this PR now updates QwenPaw to consume that fix instead of carrying a QwenPaw-specific workaround.

## Tests
- `PYTHONPATH=src python -m pytest tests/unit/agents/memory/test_reme_light_memory_manager.py -q` - 24 passed
- `pre-commit run --files pyproject.toml src/qwenpaw/agents/memory/reme_light_memory_manager.py tests/unit/agents/memory/test_reme_light_memory_manager.py` - passed
- `git diff --check` - passed
