### PR TITLE
feat(security): Mac OS file path white list

### DIFF
--- a/console/src/api/modules/security.ts
+++ b/console/src/api/modules/security.ts
@@ -27,11 +27,21 @@ export interface ToolGuardConfig {
 export interface FileGuardResponse {
   enabled: boolean;
   paths: string[];
+  whitelist_enabled: boolean;
+  whitelist_read_paths: string[];
+  whitelist_write_paths: string[];
+  shell_sandbox_mode: string;
+  shell_sandbox_provider: string;
 }
 
 export interface FileGuardUpdateBody {
   enabled?: boolean;
   paths?: string[];
+  whitelist_enabled?: boolean;
+  whitelist_read_paths?: string[];
+  whitelist_write_paths?: string[];
+  shell_sandbox_mode?: string;
+  shell_sandbox_provider?: string;
 }
 
 // ── Skill Scanner types ────────────────────────────────────────────

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2056,6 +2056,9 @@
       "directory": "Directory",
       "removeConfirm": "Remove this path from the protected list?",
       "duplicate": "This path is already in the list",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "File guard settings saved",
       "saveFailed": "Failed to save file guard settings",
       "loadFailed": "Failed to load file guard settings"

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2060,6 +2060,9 @@
       "directory": "Directory",
       "removeConfirm": "Remove this path from the protected list?",
       "duplicate": "This path is already in the list",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "File guard settings saved",
       "saveFailed": "Failed to save file guard settings",
       "loadFailed": "Failed to load file guard settings"

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1695,6 +1695,9 @@
       "directory": "ディレクトリ",
       "removeConfirm": "このパスを保護リストから削除しますか？",
       "duplicate": "このパスは既にリストに存在します",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "ファイルガード設定を保存しました",
       "saveFailed": "ファイルガード設定の保存に失敗しました",
       "loadFailed": "ファイルガード設定の読み込みに失敗しました"

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1698,6 +1698,9 @@
       "directory": "ディレクトリ",
       "removeConfirm": "このパスを保護リストから削除しますか？",
       "duplicate": "このパスは既にリストに存在します",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "ファイルガード設定を保存しました",
       "saveFailed": "ファイルガード設定の保存に失敗しました",
       "loadFailed": "ファイルガード設定の読み込みに失敗しました"

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1928,6 +1928,9 @@
       "directory": "Directory",
       "removeConfirm": "Remove this path from the protected list?",
       "duplicate": "This path is already in the list",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "File guard Configuracoes saved",
       "saveFailed": "Falha ao Salvar file guard Configuracoes",
       "loadFailed": "Falha ao load file guard Configuracoes"

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1931,6 +1931,9 @@
       "directory": "Directory",
       "removeConfirm": "Remove this path from the protected list?",
       "duplicate": "This path is already in the list",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "File guard Configuracoes saved",
       "saveFailed": "Falha ao Salvar file guard Configuracoes",
       "loadFailed": "Falha ao load file guard Configuracoes"

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1710,6 +1710,9 @@
       "directory": "Директория",
       "removeConfirm": "Удалить этот путь из списка защиты?",
       "duplicate": "Этот путь уже есть в списке",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "Настройки защиты файлов сохранены",
       "saveFailed": "Не удалось сохранить настройки защиты файлов",
       "loadFailed": "Не удалось загрузить настройки защиты файлов"

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1713,6 +1713,9 @@
       "directory": "Директория",
       "removeConfirm": "Удалить этот путь из списка защиты?",
       "duplicate": "Этот путь уже есть в списке",
+      "whitelistEnableLabel": "Enable Whitelist Protection",
+      "whitelistInputPlaceholder": "Enter whitelist path (e.g. ~/projects/ or /tmp/output.txt)",
+      "whitelistEmpty": "No whitelist paths configured",
       "saveSuccess": "Настройки защиты файлов сохранены",
       "saveFailed": "Не удалось сохранить настройки защиты файлов",
       "loadFailed": "Не удалось загрузить настройки защиты файлов"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1904,6 +1904,9 @@
       "directory": "目录",
       "removeConfirm": "从保护列表中移除该路径？",
       "duplicate": "该路径已存在",
+      "whitelistEnableLabel": "启用白名单防护",
+      "whitelistInputPlaceholder": "输入白名单路径（如 ~/projects/ 或 /tmp/output.txt）",
+      "whitelistEmpty": "未配置白名单路径",
       "saveSuccess": "文件防护设置已保存",
       "saveFailed": "保存文件防护设置失败",
       "loadFailed": "加载文件防护设置失败"

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1908,6 +1908,9 @@
       "directory": "目录",
       "removeConfirm": "从保护列表中移除该路径？",
       "duplicate": "该路径已存在",
+      "whitelistEnableLabel": "启用白名单防护",
+      "whitelistInputPlaceholder": "输入白名单路径（如 ~/projects/ 或 /tmp/output.txt）",
+      "whitelistEmpty": "未配置白名单路径",
       "saveSuccess": "文件防护设置已保存",
       "saveFailed": "保存文件防护设置失败",
       "loadFailed": "加载文件防护设置失败"

--- a/console/src/pages/Settings/Security/components/FileGuardSection.tsx
+++ b/console/src/pages/Settings/Security/components/FileGuardSection.tsx
@@ -32,9 +32,12 @@ export function FileGuardSection({ onSave }: FileGuardSectionProps = {}) {
   const { t } = useTranslation();
   const [enabled, setEnabled] = useState(true);
   const [paths, setPaths] = useState<string[]>([]);
+  const [whitelistEnabled, setWhitelistEnabled] = useState(false);
+  const [whitelistPaths, setWhitelistPaths] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [newPath, setNewPath] = useState("");
+  const [newWhitelistPath, setNewWhitelistPath] = useState("");
   const { message } = useAppMessage();
 
   const fetchData = useCallback(async () => {
@@ -43,6 +46,15 @@ export function FileGuardSection({ onSave }: FileGuardSectionProps = {}) {
       const data = await api.getFileGuard();
       setEnabled(data?.enabled ?? true);
       setPaths(data?.paths ?? []);
+      setWhitelistEnabled(data?.whitelist_enabled ?? false);
+      setWhitelistPaths(
+        Array.from(
+          new Set([
+            ...(data?.whitelist_read_paths ?? []),
+            ...(data?.whitelist_write_paths ?? []),
+          ]),
+        ),
+      );
     } catch {
       message.error(t("security.fileGuard.loadFailed"));
     } finally {
@@ -83,17 +95,50 @@ export function FileGuardSection({ onSave }: FileGuardSectionProps = {}) {
     setPaths((prev) => prev.filter((p) => p !== path));
   }, []);
 
+  const handleWhitelistToggle = useCallback(
+    async (checked: boolean) => {
+      setWhitelistEnabled(checked);
+      try {
+        await api.updateFileGuard({ whitelist_enabled: checked });
+        message.success(t("security.fileGuard.saveSuccess"));
+      } catch {
+        setWhitelistEnabled(!checked);
+        message.error(t("security.fileGuard.saveFailed"));
+      }
+    },
+    [t],
+  );
+
+  const handleAddWhitelist = useCallback(() => {
+    const trimmed = newWhitelistPath.trim();
+    if (!trimmed) return;
+    if (whitelistPaths.includes(trimmed)) {
+      message.warning(t("security.fileGuard.duplicate"));
+      return;
+    }
+    setWhitelistPaths((prev) => [...prev, trimmed]);
+    setNewWhitelistPath("");
+  }, [newWhitelistPath, whitelistPaths, t]);
+
+  const handleRemoveWhitelist = useCallback((path: string) => {
+    setWhitelistPaths((prev) => prev.filter((p) => p !== path));
+  }, []);
+
   const handleSave = useCallback(async () => {
     try {
       setSaving(true);
-      await api.updateFileGuard({ paths });
+      await api.updateFileGuard({
+        paths,
+        whitelist_read_paths: whitelistPaths,
+        whitelist_write_paths: whitelistPaths,
+      });
       message.success(t("security.fileGuard.saveSuccess"));
     } catch {
       message.error(t("security.fileGuard.saveFailed"));
     } finally {
       setSaving(false);
     }
-  }, [paths, t]);
+  }, [paths, whitelistPaths, t]);
 
   const handleReset = useCallback(() => {
     fetchData();
@@ -143,6 +188,10 @@ export function FileGuardSection({ onSave }: FileGuardSectionProps = {}) {
   ];
 
   const dataSource = paths.map((path) => ({ key: path, path }));
+  const whitelistDataSource = whitelistPaths.map((path) => ({
+    key: path,
+    path,
+  }));
 
   return (
     <>
@@ -179,6 +228,50 @@ export function FileGuardSection({ onSave }: FileGuardSectionProps = {}) {
             {t("security.fileGuard.add")}
           </Button>
         </Space.Compact>
+
+        <div
+          style={{
+            borderTop: "1px solid var(--ant-color-border-secondary, #f0f0f0)",
+            marginTop: 20,
+            paddingTop: 20,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 16,
+            }}
+          >
+            <span style={{ fontWeight: 500 }}>
+              {t("security.fileGuard.whitelistEnableLabel")}
+            </span>
+            <Switch
+              checked={whitelistEnabled}
+              onChange={handleWhitelistToggle}
+            />
+          </div>
+
+          <Space.Compact style={{ width: "100%" }}>
+            <Input
+              value={newWhitelistPath}
+              onChange={(e) => setNewWhitelistPath(e.target.value)}
+              placeholder={t("security.fileGuard.whitelistInputPlaceholder")}
+              onPressEnter={handleAddWhitelist}
+              allowClear
+              disabled={!whitelistEnabled}
+            />
+            <Button
+              type="primary"
+              icon={<PlusCircleOutlined />}
+              onClick={handleAddWhitelist}
+              disabled={!newWhitelistPath.trim() || !whitelistEnabled}
+            >
+              {t("security.fileGuard.add")}
+            </Button>
+          </Space.Compact>
+        </div>
       </Card>
 
       <Card className={styles.tableCard}>
@@ -190,6 +283,41 @@ export function FileGuardSection({ onSave }: FileGuardSectionProps = {}) {
           size="middle"
           locale={{
             emptyText: t("security.fileGuard.empty"),
+          }}
+        />
+      </Card>
+
+      <Card className={styles.tableCard} style={{ marginTop: 20 }}>
+        <Table
+          columns={[
+            columns[0],
+            {
+              title: t("security.fileGuard.actions"),
+              key: "actions",
+              width: 80,
+              render: (_: unknown, record: { path: string }) => (
+                <Popconfirm
+                  title={t("security.fileGuard.removeConfirm")}
+                  onConfirm={() => handleRemoveWhitelist(record.path)}
+                  okText={t("common.delete")}
+                  cancelText={t("common.cancel")}
+                >
+                  <Button
+                    type="text"
+                    danger
+                    icon={<DeleteOutlined />}
+                    size="small"
+                  />
+                </Popconfirm>
+              ),
+            },
+          ]}
+          dataSource={whitelistDataSource}
+          loading={loading}
+          pagination={false}
+          size="middle"
+          locale={{
+            emptyText: t("security.fileGuard.whitelistEmpty"),
           }}
         />
       </Card>

--- a/src/qwenpaw/agents/tool_guard_mixin.py
+++ b/src/qwenpaw/agents/tool_guard_mixin.py
@@ -131,6 +131,59 @@ class ToolGuardMixin:
             return _normalize_tool_guard_ui_lang(raw)
         return "en"
 
+    async def _apply_tool_pre_hook(self, tool_call: dict[str, Any]) -> bool:
+        """Run file-guard pre-hook. Return True when blocked."""
+        from qwenpaw.security.file_guard import (
+            apply_file_guard_pre_hook,
+            is_file_guard_whitelist_enabled,
+        )
+
+        if not is_file_guard_whitelist_enabled():
+            return False
+
+        hook_result = apply_file_guard_pre_hook(tool_call)
+        if hook_result.warning:
+            await self._emit_pre_hook_warning(hook_result.warning)
+        if hook_result.allowed:
+            return False
+        await self._emit_pre_hook_denied(tool_call, hook_result.message)
+        return True
+
+    async def _emit_pre_hook_warning(self, warning: str) -> None:
+        """Emit a warning notice for non-blocking pre-hook fallbacks."""
+        from agentscope.message import TextBlock
+
+        msg = Msg(
+            self.name,
+            [TextBlock(type="text", text=f"⚠️ {warning}")],
+            "assistant",
+        )
+        await self.print(msg, True)
+
+    async def _emit_pre_hook_denied(
+        self,
+        tool_call: dict[str, Any],
+        message: str,
+    ) -> None:
+        """Emit a tool_result block when pre-hook blocks execution."""
+        from agentscope.message import ToolResultBlock
+
+        tool_name = str(tool_call.get("name", ""))
+        tool_res_msg = Msg(
+            "system",
+            [
+                ToolResultBlock(
+                    type="tool_result",
+                    id=tool_call["id"],
+                    name=tool_name,
+                    output=[{"type": "text", "text": message}],
+                ),
+            ],
+            "system",
+        )
+        await self.print(tool_res_msg, True)
+        await self.memory.add(tool_res_msg)
+
     # ------------------------------------------------------------------
     # _acting override
     # ------------------------------------------------------------------
@@ -153,6 +206,8 @@ class ToolGuardMixin:
         true parallelism.
         """
         ctx = getattr(self, "_request_context", None) or {}
+        if await self._apply_tool_pre_hook(tool_call):
+            return None
         # TODO: remove this
         if ctx.get("_headless_tool_guard", "true").lower() == "false":
             return await super()._acting(tool_call)  # type: ignore[misc]

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -725,11 +725,30 @@ async def get_builtin_rules() -> List[ToolGuardRuleConfig]:
 class FileGuardResponse(BaseModel):
     enabled: bool = True
     paths: List[str] = []
+    whitelist_enabled: bool = False
+    whitelist_read_paths: List[str] = []
+    whitelist_write_paths: List[str] = []
+    shell_sandbox_mode: str = "audit"
+    shell_sandbox_provider: str = "auto"
 
 
 class FileGuardUpdateBody(BaseModel):
     enabled: Optional[bool] = None
     paths: Optional[List[str]] = None
+    whitelist_enabled: Optional[bool] = None
+    whitelist_read_paths: Optional[List[str]] = None
+    whitelist_write_paths: Optional[List[str]] = None
+    shell_sandbox_mode: Optional[str] = None
+    shell_sandbox_provider: Optional[str] = None
+
+
+_ALLOWED_SHELL_SANDBOX_MODES = {"enforce", "audit"}
+_ALLOWED_SHELL_SANDBOX_PROVIDERS = {
+    "auto",
+    "macos_sandbox_exec",
+    "linux_placeholder",
+    "windows_placeholder",
+}
 
 
 @router.get(
@@ -745,7 +764,23 @@ async def get_file_guard() -> FileGuardResponse:
     )
 
     paths = ensure_file_guard_paths(fg.sensitive_files or [])
-    return FileGuardResponse(enabled=fg.enabled, paths=paths)
+    return FileGuardResponse(
+        enabled=fg.enabled,
+        paths=paths,
+        whitelist_enabled=getattr(fg, "whitelist_enabled", False),
+        whitelist_read_paths=list(
+            getattr(fg, "whitelist_read_paths", []) or [],
+        ),
+        whitelist_write_paths=list(
+            getattr(fg, "whitelist_write_paths", []) or [],
+        ),
+        shell_sandbox_mode=str(
+            getattr(fg, "shell_sandbox_mode", "audit") or "audit",
+        ),
+        shell_sandbox_provider=str(
+            getattr(fg, "shell_sandbox_provider", "auto") or "auto",
+        ),
+    )
 
 
 @router.put(
@@ -767,6 +802,33 @@ async def put_file_guard(
         )
 
         fg.sensitive_files = ensure_file_guard_paths(body.paths)
+    if body.whitelist_enabled is not None:
+        fg.whitelist_enabled = body.whitelist_enabled
+    if body.whitelist_read_paths is not None:
+        fg.whitelist_read_paths = list(body.whitelist_read_paths)
+    if body.whitelist_write_paths is not None:
+        fg.whitelist_write_paths = list(body.whitelist_write_paths)
+    if body.shell_sandbox_mode is not None:
+        if body.shell_sandbox_mode not in _ALLOWED_SHELL_SANDBOX_MODES:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Invalid shell_sandbox_mode. Allowed values: "
+                    "enforce, audit"
+                ),
+            )
+        fg.shell_sandbox_mode = body.shell_sandbox_mode
+    if body.shell_sandbox_provider is not None:
+        if body.shell_sandbox_provider not in _ALLOWED_SHELL_SANDBOX_PROVIDERS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Invalid shell_sandbox_provider. Allowed values: auto, "
+                    "macos_sandbox_exec, linux_placeholder, "
+                    "windows_placeholder"
+                ),
+            )
+        fg.shell_sandbox_provider = body.shell_sandbox_provider
 
     save_config(config)
 
@@ -778,6 +840,19 @@ async def put_file_guard(
     return FileGuardResponse(
         enabled=fg.enabled,
         paths=fg.sensitive_files,
+        whitelist_enabled=getattr(fg, "whitelist_enabled", False),
+        whitelist_read_paths=list(
+            getattr(fg, "whitelist_read_paths", []) or [],
+        ),
+        whitelist_write_paths=list(
+            getattr(fg, "whitelist_write_paths", []) or [],
+        ),
+        shell_sandbox_mode=str(
+            getattr(fg, "shell_sandbox_mode", "audit") or "audit",
+        ),
+        shell_sandbox_provider=str(
+            getattr(fg, "shell_sandbox_provider", "auto") or "auto",
+        ),
     )
 
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1673,6 +1673,43 @@ class FileGuardConfig(BaseModel):
 
     enabled: bool = True
     sensitive_files: List[str] = Field(default_factory=list)
+    whitelist_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable file path whitelist checks. "
+            "When disabled, legacy behavior is unchanged."
+        ),
+    )
+    whitelist_read_paths: List[str] = Field(
+        default_factory=list,
+        description="Whitelisted read paths for file tools and shell sandbox.",
+    )
+    whitelist_write_paths: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Whitelisted write paths for file tools and shell sandbox."
+        ),
+    )
+    shell_sandbox_mode: Literal["enforce", "audit"] = Field(
+        default="audit",
+        description=(
+            "Sandbox strategy hint. "
+            "When backend is unavailable, execution falls back to "
+            "original command with a warning."
+        ),
+    )
+    shell_sandbox_provider: Literal[
+        "auto",
+        "macos_sandbox_exec",
+        "linux_placeholder",
+        "windows_placeholder",
+    ] = Field(
+        default="auto",
+        description=(
+            "Platform sandbox backend selector. "
+            "linux/windows providers are placeholders for future support."
+        ),
+    )
 
 
 class SkillScannerWhitelistEntry(BaseModel):

--- a/src/qwenpaw/security/file_guard/__init__.py
+++ b/src/qwenpaw/security/file_guard/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""File guard whitelist and sandbox helpers."""
+
+from .whitelist import FileWhitelistPolicy, normalize_access_path
+from .pre_hook import (
+    apply_file_guard_pre_hook,
+    FileGuardPreHookResult,
+    is_file_guard_whitelist_enabled,
+)
+
+__all__ = [
+    "FileWhitelistPolicy",
+    "normalize_access_path",
+    "apply_file_guard_pre_hook",
+    "FileGuardPreHookResult",
+    "is_file_guard_whitelist_enabled",
+]

--- a/src/qwenpaw/security/file_guard/pre_hook.py
+++ b/src/qwenpaw/security/file_guard/pre_hook.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""File guard pre-hook for tool calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from ...config.context import get_current_workspace_dir
+from ...constant import WORKING_DIR
+from .shell_sandbox import prepare_sandboxed_shell_command
+from .whitelist import FileWhitelistPolicy
+
+FileAccessKind = Literal["read", "write"]
+
+_TOOL_ACCESS_PARAMS: dict[str, tuple[FileAccessKind, tuple[str, ...]]] = {
+    "read_file": ("read", ("file_path",)),
+    "write_file": ("write", ("file_path",)),
+    "edit_file": ("write", ("file_path",)),
+    "append_file": ("write", ("file_path",)),
+    "send_file_to_user": ("read", ("file_path",)),
+    "view_text_file": ("read", ("file_path", "path")),
+    "write_text_file": ("write", ("file_path", "path")),
+}
+
+
+@dataclass
+class FileGuardPreHookResult:
+    """Pre-hook result for one tool call."""
+
+    allowed: bool
+    message: str = ""
+    warning: str = ""
+
+
+def is_file_guard_whitelist_enabled() -> bool:
+    """Return whether whitelist-based pre-hook should run."""
+    return FileWhitelistPolicy.from_config().enabled
+
+
+def _working_dir_value(tool_input: dict[str, Any]) -> str:
+    raw = tool_input.get("cwd")
+    if isinstance(raw, str) and raw.strip():
+        return raw
+    wd = get_current_workspace_dir() or WORKING_DIR
+    return str(Path(wd))
+
+
+def _allow_or_reason(
+    policy: FileWhitelistPolicy,
+    path: str,
+    access: FileAccessKind,
+) -> tuple[bool, str]:
+    if policy.allows(path, access):
+        return True, ""
+    return (
+        False,
+        "Access blocked by file whitelist policy: "
+        f"{access} is not allowed for '{path}'.",
+    )
+
+
+def _check_regular_file_tools(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    policy: FileWhitelistPolicy,
+) -> FileGuardPreHookResult:
+    config = _TOOL_ACCESS_PARAMS.get(tool_name)
+    if config is None:
+        return FileGuardPreHookResult(allowed=True)
+    access_mode, params = config
+    denied: list[str] = []
+    for key in params:
+        val = tool_input.get(key)
+        if not isinstance(val, str) or not val.strip():
+            continue
+        allowed, _reason = _allow_or_reason(policy, val, access_mode)
+        if not allowed:
+            denied.append(val)
+    if not denied:
+        return FileGuardPreHookResult(allowed=True)
+    detail = "\n".join(f"- {p}" for p in denied[:10])
+    return FileGuardPreHookResult(
+        allowed=False,
+        message=(
+            "File tool call blocked by whitelist policy.\n"
+            f"Tool: {tool_name}\n"
+            f"Access: {access_mode}\n"
+            "Denied paths:\n"
+            f"{detail}"
+        ),
+    )
+
+
+def apply_file_guard_pre_hook(tool_call: dict[str, Any]) -> FileGuardPreHookResult:
+    """Apply whitelist pre-hook and mutate tool input when needed."""
+    tool_name = str(tool_call.get("name", ""))
+    tool_input = tool_call.get("input")
+    if not isinstance(tool_input, dict):
+        return FileGuardPreHookResult(allowed=True)
+
+    policy = FileWhitelistPolicy.from_config()
+
+    if tool_name == "execute_shell_command":
+        command = tool_input.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return FileGuardPreHookResult(allowed=True)
+        prepared = prepare_sandboxed_shell_command(
+            command=command,
+            working_dir=_working_dir_value(tool_input),
+        )
+        if prepared.blocked_reason:
+            return FileGuardPreHookResult(
+                allowed=False,
+                message=(
+                    "Shell sandbox preparation failed.\n"
+                    f"{prepared.blocked_reason}"
+                ),
+            )
+        tool_input["command"] = prepared.command
+        return FileGuardPreHookResult(
+            allowed=True,
+            warning=prepared.warning,
+        )
+
+    if not policy.enabled:
+        return FileGuardPreHookResult(allowed=True)
+
+    return _check_regular_file_tools(tool_name, tool_input, policy)

--- a/src/qwenpaw/security/file_guard/pre_hook.py
+++ b/src/qwenpaw/security/file_guard/pre_hook.py
@@ -94,7 +94,7 @@ def _check_regular_file_tools(
 
 
 def apply_file_guard_pre_hook(
-    tool_call: dict[str, Any]
+    tool_call: dict[str, Any],
 ) -> FileGuardPreHookResult:
     """Apply whitelist pre-hook and mutate tool input when needed."""
     tool_name = str(tool_call.get("name", ""))

--- a/src/qwenpaw/security/file_guard/pre_hook.py
+++ b/src/qwenpaw/security/file_guard/pre_hook.py
@@ -93,7 +93,9 @@ def _check_regular_file_tools(
     )
 
 
-def apply_file_guard_pre_hook(tool_call: dict[str, Any]) -> FileGuardPreHookResult:
+def apply_file_guard_pre_hook(
+    tool_call: dict[str, Any]
+) -> FileGuardPreHookResult:
     """Apply whitelist pre-hook and mutate tool input when needed."""
     tool_name = str(tool_call.get("name", ""))
     tool_input = tool_call.get("input")

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -11,6 +11,24 @@ from typing import Protocol
 
 from .whitelist import FileWhitelistPolicy, normalize_access_path
 
+_MACOS_BASELINE_READ_ROOTS: tuple[str, ...] = (
+    "/private/var/select/",
+    "/bin/",
+    "/sbin/",
+    "/usr/bin/",
+    "/usr/sbin/",
+    "/usr/lib/",
+    "/usr/libexec/",
+    "/System/",
+    "/Library/",
+    "/dev/",
+)
+_MACOS_BASELINE_WRITE_ROOTS: tuple[str, ...] = (
+    "/tmp/",
+    "/private/tmp/",
+    "/private/var/tmp/",
+)
+
 
 @dataclass
 class SandboxPreparation:
@@ -46,18 +64,47 @@ class MacOSSandboxExecProvider:
     """macOS sandbox provider using sandbox-exec profile strings."""
 
     @staticmethod
+    def _normalized_roots(paths: list[str]) -> set[str]:
+        roots: set[str] = set()
+        for path in paths:
+            normalized = normalize_access_path(path)
+            if normalized:
+                roots.add(normalized)
+        return roots
+
+    @staticmethod
     def _profile_text(policy: FileWhitelistPolicy, working_dir: str) -> str:
         read_roots, write_roots = policy.allowed_roots_for_shell()
+        read_set = MacOSSandboxExecProvider._normalized_roots(read_roots)
+        write_set = MacOSSandboxExecProvider._normalized_roots(write_roots)
+
+        read_set.update(
+            MacOSSandboxExecProvider._normalized_roots(
+                list(_MACOS_BASELINE_READ_ROOTS),
+            ),
+        )
+        write_set.update(
+            MacOSSandboxExecProvider._normalized_roots(
+                list(_MACOS_BASELINE_WRITE_ROOTS),
+            ),
+        )
+
         wd = normalize_access_path(working_dir)
         if wd:
-            read_roots = sorted(set(read_roots) | {wd})
-            write_roots = sorted(set(write_roots) | {wd})
+            read_set.add(wd)
+            write_set.add(wd)
+        read_roots = sorted(read_set)
+        write_roots = sorted(write_set)
         lines = [
             "(version 1)",
             "(deny default)",
             '(import "system.sb")',
             "(allow process*)",
             "(allow sysctl-read)",
+            # Allow metadata reads globally so basic traversal operations
+            # (`ls -la`, resolving `..`, `find` walking) keep working,
+            # while file content access is still controlled by read/write roots.
+            "(allow file-read-metadata)",
         ]
         for root in read_roots:
             lines.append(f'(allow file-read* (subpath "{root}"))')
@@ -114,7 +161,7 @@ def prepare_sandboxed_shell_command(
     mode, configured_provider = _load_shell_sandbox_config()
 
     if mode not in ("enforce", "audit"):
-        mode = "enforce"
+        mode = "audit"
 
     provider = _resolve_provider(mode, configured_provider)
     return provider.prepare(command=command, working_dir=working_dir)

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Shell sandbox abstraction for file guard pre-hook."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import shlex
+import shutil
+from typing import Protocol
+
+from .whitelist import FileWhitelistPolicy, normalize_access_path
+
+
+@dataclass
+class SandboxPreparation:
+    """Prepared command payload returned by sandbox providers."""
+
+    command: str
+    warning: str = ""
+    blocked_reason: str = ""
+
+
+class ShellSandboxProvider(Protocol):
+    """Platform-specific shell sandbox provider interface."""
+
+    def prepare(self, command: str, working_dir: str) -> SandboxPreparation:
+        """Return wrapped command or a blocking reason."""
+
+
+def _load_shell_sandbox_config() -> tuple[str, str]:
+    try:
+        from qwenpaw.config import load_config
+
+        fg = load_config().security.file_guard
+        mode = str(getattr(fg, "shell_sandbox_mode", "audit") or "audit")
+        provider = str(
+            getattr(fg, "shell_sandbox_provider", "auto") or "auto",
+        )
+        return mode, provider
+    except Exception:
+        return "audit", "auto"
+
+
+class MacOSSandboxExecProvider:
+    """macOS sandbox provider using sandbox-exec profile strings."""
+
+    @staticmethod
+    def _profile_text(policy: FileWhitelistPolicy, working_dir: str) -> str:
+        read_roots, write_roots = policy.allowed_roots_for_shell()
+        wd = normalize_access_path(working_dir)
+        if wd:
+            read_roots = sorted(set(read_roots) | {wd})
+            write_roots = sorted(set(write_roots) | {wd})
+        lines = [
+            "(version 1)",
+            "(deny default)",
+            '(import "system.sb")',
+            "(allow process*)",
+            "(allow sysctl-read)",
+        ]
+        for root in read_roots:
+            lines.append(f'(allow file-read* (subpath "{root}"))')
+        for root in write_roots:
+            lines.append(f'(allow file-write* (subpath "{root}"))')
+        return "\n".join(lines)
+
+    def prepare(self, command: str, working_dir: str) -> SandboxPreparation:
+        policy = FileWhitelistPolicy.from_config()
+        profile = self._profile_text(policy, working_dir=working_dir)
+        wrapped = (
+            f"sandbox-exec -p {shlex.quote(profile)} "
+            f"/bin/sh -c {shlex.quote(command)}"
+        )
+        return SandboxPreparation(command=wrapped)
+
+
+class UnsupportedSandboxProvider:
+    """Placeholder provider for Linux/Windows until implemented."""
+
+    def __init__(self, platform_name: str, mode: str) -> None:
+        self._platform_name = platform_name
+        _ = mode
+
+    def prepare(self, command: str, working_dir: str) -> SandboxPreparation:
+        _ = working_dir
+        msg = (
+            "Shell sandbox is configured but not implemented on "
+            f"{self._platform_name} yet."
+        )
+        return SandboxPreparation(command=command, warning=msg)
+
+
+def _resolve_provider(mode: str, configured_provider: str) -> ShellSandboxProvider:
+    if configured_provider == "macos_sandbox_exec":
+        return MacOSSandboxExecProvider()
+    if configured_provider == "linux_placeholder":
+        return UnsupportedSandboxProvider("linux", mode)
+    if configured_provider == "windows_placeholder":
+        return UnsupportedSandboxProvider("windows", mode)
+    # auto mode
+    if os.name == "posix" and shutil.which("sandbox-exec") is not None:
+        return MacOSSandboxExecProvider()
+    if os.name == "nt":
+        return UnsupportedSandboxProvider("windows", mode)
+    return UnsupportedSandboxProvider("linux", mode)
+
+
+def prepare_sandboxed_shell_command(
+    command: str,
+    working_dir: str,
+) -> SandboxPreparation:
+    """Prepare command for platform sandbox execution."""
+    mode, configured_provider = _load_shell_sandbox_config()
+
+    if mode not in ("enforce", "audit"):
+        mode = "enforce"
+
+    provider = _resolve_provider(mode, configured_provider)
+    return provider.prepare(command=command, working_dir=working_dir)

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -103,7 +103,7 @@ class MacOSSandboxExecProvider:
             "(allow sysctl-read)",
             # Allow metadata reads globally so basic traversal operations
             # (`ls -la`, resolving `..`, `find` walking) keep working,
-            # while file content access is still controlled by read/write roots.
+            # while file content access stays limited by read/write roots.
             "(allow file-read-metadata)",
         ]
         for root in read_roots:

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -139,7 +139,8 @@ class UnsupportedSandboxProvider:
 
 
 def _resolve_provider(
-    mode: str, configured_provider: str
+    mode: str,
+    configured_provider: str,
 ) -> ShellSandboxProvider:
     if configured_provider == "macos_sandbox_exec":
         return MacOSSandboxExecProvider()

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -138,7 +138,9 @@ class UnsupportedSandboxProvider:
         return SandboxPreparation(command=command, warning=msg)
 
 
-def _resolve_provider(mode: str, configured_provider: str) -> ShellSandboxProvider:
+def _resolve_provider(
+    mode: str, configured_provider: str
+) -> ShellSandboxProvider:
     if configured_provider == "macos_sandbox_exec":
         return MacOSSandboxExecProvider()
     if configured_provider == "linux_placeholder":

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -88,7 +88,8 @@ class MacOSSandboxExecProvider:
         for ch in raw:
             if ord(ch) < 0x20 or ord(ch) == 0x7F:
                 raise ValueError(
-                    "sandbox profile path contains forbidden control character",
+                    "sandbox profile path contains forbidden "
+                    "control character",
                 )
 
     @staticmethod

--- a/src/qwenpaw/security/file_guard/shell_sandbox.py
+++ b/src/qwenpaw/security/file_guard/shell_sandbox.py
@@ -73,6 +73,30 @@ class MacOSSandboxExecProvider:
         return roots
 
     @staticmethod
+    def _escape_profile_string(raw: str) -> str:
+        """Escape a string for quoted sandbox-exec profile literals."""
+        return (
+            raw.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+        )
+
+    @staticmethod
+    def _validate_profile_path(raw: str) -> None:
+        """Reject unsafe control characters for profile path literals."""
+        for ch in raw:
+            if ord(ch) < 0x20 or ord(ch) == 0x7F:
+                raise ValueError(
+                    "sandbox profile path contains forbidden control character",
+                )
+
+    @staticmethod
+    def _quoted_profile_path(raw: str) -> str:
+        MacOSSandboxExecProvider._validate_profile_path(raw)
+        return MacOSSandboxExecProvider._escape_profile_string(raw)
+
+    @staticmethod
     def _profile_text(policy: FileWhitelistPolicy, working_dir: str) -> str:
         read_roots, write_roots = policy.allowed_roots_for_shell()
         read_set = MacOSSandboxExecProvider._normalized_roots(read_roots)
@@ -107,14 +131,22 @@ class MacOSSandboxExecProvider:
             "(allow file-read-metadata)",
         ]
         for root in read_roots:
-            lines.append(f'(allow file-read* (subpath "{root}"))')
+            safe_root = MacOSSandboxExecProvider._quoted_profile_path(root)
+            lines.append(f'(allow file-read* (subpath "{safe_root}"))')
         for root in write_roots:
-            lines.append(f'(allow file-write* (subpath "{root}"))')
+            safe_root = MacOSSandboxExecProvider._quoted_profile_path(root)
+            lines.append(f'(allow file-write* (subpath "{safe_root}"))')
         return "\n".join(lines)
 
     def prepare(self, command: str, working_dir: str) -> SandboxPreparation:
         policy = FileWhitelistPolicy.from_config()
-        profile = self._profile_text(policy, working_dir=working_dir)
+        try:
+            profile = self._profile_text(policy, working_dir=working_dir)
+        except ValueError as exc:
+            return SandboxPreparation(
+                command=command,
+                blocked_reason=f"invalid sandbox profile path: {exc}",
+            )
         wrapped = (
             f"sandbox-exec -p {shlex.quote(profile)} "
             f"/bin/sh -c {shlex.quote(command)}"

--- a/src/qwenpaw/security/file_guard/whitelist.py
+++ b/src/qwenpaw/security/file_guard/whitelist.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""File-access whitelist policy helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ntpath
+import os
+import re
+from pathlib import Path
+from typing import Iterable, Literal
+
+from ...config.context import get_current_workspace_dir
+from ...constant import WORKING_DIR
+
+FileAccessKind = Literal["read", "write"]
+
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WIN_UNC_RE = re.compile(r"^\\\\[^\\/?%*:|\"<>]+[\\/][^\\/?%*:|\"<>]+")
+
+
+def _workspace_root() -> Path:
+    return Path(get_current_workspace_dir() or WORKING_DIR)
+
+
+def _is_windows_style_path(raw: str) -> bool:
+    if not raw:
+        return False
+    if _WIN_DRIVE_RE.match(raw):
+        return True
+    if _WIN_UNC_RE.match(raw):
+        return True
+    if raw.startswith((".\\", "..\\", "\\")):
+        return True
+    if "\\" in raw:
+        return True
+    return False
+
+
+def normalize_access_path(raw_path: str) -> str:
+    """Normalize a path string to canonical absolute form."""
+    if not isinstance(raw_path, str):
+        return ""
+    raw = raw_path.strip()
+    if not raw:
+        return ""
+
+    if os.name == "nt" or _is_windows_style_path(raw):
+        expanded = os.path.expanduser(raw) if raw.startswith("~") else raw
+        if not ntpath.isabs(expanded):
+            expanded = ntpath.join(str(_workspace_root()), expanded)
+        normalized = ntpath.normpath(expanded)
+        return normalized.replace("\\", "/").lower()
+
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        p = _workspace_root() / p
+    return str(p.resolve(strict=False))
+
+
+def _classify_roots(paths: Iterable[str]) -> tuple[set[str], set[str]]:
+    files: set[str] = set()
+    dirs: set[str] = set()
+    for path in paths:
+        if not path:
+            continue
+        normalized = normalize_access_path(path)
+        if not normalized:
+            continue
+        p = Path(normalized)
+        if p.is_dir() or path.endswith(("/", "\\")):
+            dirs.add(normalized.rstrip("/\\"))
+        else:
+            files.add(normalized)
+    return files, dirs
+
+
+def _path_in_roots(
+    normalized_path: str,
+    root_files: set[str],
+    root_dirs: set[str],
+) -> bool:
+    if not normalized_path:
+        return False
+    if normalized_path in root_files:
+        return True
+    for dir_path in root_dirs:
+        if not dir_path:
+            continue
+        if normalized_path == dir_path:
+            return True
+        if normalized_path.startswith(dir_path + "/"):
+            return True
+        if normalized_path.startswith(dir_path + "\\"):
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class FileWhitelistPolicy:
+    """In-memory whitelist policy resolved from config."""
+
+    enabled: bool
+    read_files: set[str]
+    read_dirs: set[str]
+    write_files: set[str]
+    write_dirs: set[str]
+
+    @classmethod
+    def from_config(cls) -> "FileWhitelistPolicy":
+        try:
+            from qwenpaw.config import load_config
+
+            fg = load_config().security.file_guard
+            enabled = bool(getattr(fg, "whitelist_enabled", False))
+            read_paths = list(getattr(fg, "whitelist_read_paths", []) or [])
+            write_paths = list(
+                getattr(fg, "whitelist_write_paths", []) or [],
+            )
+            read_files, read_dirs = _classify_roots(read_paths)
+            write_files, write_dirs = _classify_roots(write_paths)
+            return cls(
+                enabled=enabled,
+                read_files=read_files,
+                read_dirs=read_dirs,
+                write_files=write_files,
+                write_dirs=write_dirs,
+            )
+        except Exception:
+            return cls(
+                enabled=False,
+                read_files=set(),
+                read_dirs=set(),
+                write_files=set(),
+                write_dirs=set(),
+            )
+
+    def allows(self, path: str, access: FileAccessKind) -> bool:
+        """Return whether *path* is allowed for the given access kind."""
+        if not self.enabled:
+            return True
+        normalized = normalize_access_path(path)
+        if not normalized:
+            return False
+        if access == "read":
+            # Write roots also imply readable roots.
+            return _path_in_roots(
+                normalized,
+                root_files=(self.read_files | self.write_files),
+                root_dirs=(self.read_dirs | self.write_dirs),
+            )
+        return _path_in_roots(
+            normalized,
+            root_files=self.write_files,
+            root_dirs=self.write_dirs,
+        )
+
+    def allowed_roots_for_shell(self) -> tuple[list[str], list[str]]:
+        read_roots = sorted(self.read_files | self.read_dirs)
+        write_roots = sorted(self.write_files | self.write_dirs)
+        return read_roots, write_roots


### PR DESCRIPTION
## Description

This PR introduces a file whitelist-based pre-hook mechanism for tool execution, with macOS `sandbox-exec` protection for shell commands, while keeping existing tool implementations unchanged.

Key changes:
- Added a dedicated file-guard module under `src/qwenpaw/security/file_guard`:
  - whitelist policy resolution (`whitelist.py`)
  - shell sandbox abstraction + macOS provider (`shell_sandbox.py`)
  - tool-call pre-hook enforcement (`pre_hook.py`)
- Integrated pre-hook at the agent tool execution entry (`ToolGuardMixin`) so checks happen before tool execution.
- For `execute_shell_command`, pre-hook now wraps execution with `sandbox-exec` directly (no path parsing gate), using sandbox as the primary containment layer.
- For non-shell file tools, pre-hook validates relevant path parameters against whitelist rules.
- Removed whitelist checks from `tool_guard/guardians/file_guardian.py` to keep responsibilities clear (guardian remains for sensitive path guarding only).
- Added macOS baseline sandbox allowances (system/runtime paths + metadata access + temp write paths) to avoid breaking normal command behavior.
- Simplified config usage:
  - removed unused `shell_sandbox_enabled`
  - defaulted sandbox mode behavior toward non-breaking fallback (`audit`-style semantics when backend unavailable).

**Related Issue:** Relates to #(issue_number)

**Security Considerations:**  
- Strengthens shell execution containment via sandbox wrapping on macOS.  
- Uses explicit whitelist for file-access-sensitive tools in pre-hook.  
- Preserves usability via baseline runtime allowances and warning-based fallback on unsupported platforms.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

How to verify:
1. Enable whitelist in `security.file_guard` config.
2. Set `whitelist_read_paths` / `whitelist_write_paths` to a test directory.
3. Call non-shell file tools (`read_file`, `write_file`, etc.) with in-scope and out-of-scope paths; verify allow/deny behavior.
4. Call `execute_shell_command` and confirm command is sandbox-wrapped on macOS.
5. Verify normal shell usability (`ls -la`, traversal) under sandbox baseline allowances.
6. On unsupported platforms/provider placeholders, verify fallback execution with warning.

## Local Verification Evidence

```bash
pre-commit run --all-files
# (not run in this PR context)