### PR TITLE
fix(console): TokenUsage

### DIFF
--- a/console/src/pages/Settings/AgentStats/index.tsx
+++ b/console/src/pages/Settings/AgentStats/index.tsx
@@ -35,11 +35,17 @@ interface ColumnSeries {
   label: string;
 }
 
+function formatDateLabel(dateStr: string, crossesYear: boolean): string {
+  const date = dayjs(dateStr);
+  return crossesYear ? date.format("YY/MM-DD") : date.format("MM-DD");
+}
+
 function getColumnConfig(
   chartData: ChartDataItem[],
   series: ColumnSeries[],
   colors: string[],
   isDarkMode: boolean,
+  crossesYear: boolean,
   options?: {
     yAxisFormatter?: (v: number) => string;
     tooltipFormatter?: (v: number) => string;
@@ -48,7 +54,7 @@ function getColumnConfig(
   const config: Record<string, unknown> = {
     data: chartData.flatMap((d) =>
       series.map((s) => ({
-        date: d.displayDate,
+        date: d.date,
         value: d[s.key],
         category: s.label,
       })),
@@ -65,6 +71,14 @@ function getColumnConfig(
     meta: {
       color: { range: colors },
     },
+    axis: {
+      x: {
+        labelFormatter: (d: string) => formatDateLabel(d, crossesYear),
+      },
+      ...(options?.yAxisFormatter
+        ? { y: { labelFormatter: options.yAxisFormatter } }
+        : {}),
+    },
     tooltip: {
       title: "date",
       items: [
@@ -77,12 +91,6 @@ function getColumnConfig(
       ],
     },
   };
-
-  if (options?.yAxisFormatter) {
-    config.axis = {
-      y: { labelFormatter: options.yAxisFormatter },
-    };
-  }
 
   return config;
 }
@@ -132,6 +140,11 @@ function AgentStatsPage() {
     }
   };
 
+  const crossesYear = useMemo(
+    () => startDate.year() !== endDate.year(),
+    [startDate, endDate],
+  );
+
   const chartData = useMemo(() => {
     if (!data?.by_date) return [];
     return data.by_date.map((d) => ({
@@ -169,8 +182,9 @@ function AgentStatsPage() {
         ],
         ["#3b82f6", "#f97316"],
         isDarkMode,
+        crossesYear,
       ),
-    [chartData, t, isDarkMode],
+    [chartData, t, isDarkMode, crossesYear],
   );
 
   const chatColumnConfig = useMemo(
@@ -183,8 +197,9 @@ function AgentStatsPage() {
         ],
         ["#ff7f16", "#3b82f6"],
         isDarkMode,
+        crossesYear,
       ),
-    [chartData, t, isDarkMode],
+    [chartData, t, isDarkMode, crossesYear],
   );
 
   const tokenColumnConfig = useMemo(
@@ -197,12 +212,13 @@ function AgentStatsPage() {
         ],
         ["#8b5cf6", "#10b981"],
         isDarkMode,
+        crossesYear,
         {
           yAxisFormatter: formatCompact,
           tooltipFormatter: formatCompact,
         },
       ),
-    [chartData, t, isDarkMode],
+    [chartData, t, isDarkMode, crossesYear],
   );
 
   const llmToolColumnConfig = useMemo(
@@ -215,8 +231,9 @@ function AgentStatsPage() {
         ],
         ["#ec4899", "#14b8a6"],
         isDarkMode,
+        crossesYear,
       ),
-    [chartData, t, isDarkMode],
+    [chartData, t, isDarkMode, crossesYear],
   );
 
   const pieCommon = useMemo(

--- a/console/src/pages/Settings/TokenUsage/hooks/useModelTrendConfig.ts
+++ b/console/src/pages/Settings/TokenUsage/hooks/useModelTrendConfig.ts
@@ -93,7 +93,8 @@ export function useModelTrendConfig({
           tickCount,
           labelFormatter: (d: string) => {
             const date = dayjs(d);
-            return date.format("MM-DD");
+            const crossesYear = startDate.year() !== endDate.year();
+            return crossesYear ? date.format("YY/MM-DD") : date.format("MM-DD");
           },
           grid: null,
         },

--- a/console/src/pages/Settings/TokenUsage/hooks/useTokenTypeConfig.ts
+++ b/console/src/pages/Settings/TokenUsage/hooks/useTokenTypeConfig.ts
@@ -107,7 +107,8 @@ export function useTokenTypeConfig({
           tickCount,
           labelFormatter: (d: string) => {
             const date = dayjs(d);
-            return date.format("MM-DD");
+            const crossesYear = startDate.year() !== endDate.year();
+            return crossesYear ? date.format("YY/MM-DD") : date.format("MM-DD");
           },
           grid: null,
         },


### PR DESCRIPTION
## Description

Fixed: Issue with data misalignment when the message trend chart spanned multiple year dates.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
