### PR TITLE
fix(channels): graceful shutdown for WeCom WebSocket connection

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -59,9 +59,7 @@ _UPLOAD_CMD_FINISH = "aibot_upload_media_finish"
 _UPLOAD_CMDS = (_UPLOAD_CMD_INIT, _UPLOAD_CMD_CHUNK, _UPLOAD_CMD_FINISH)
 _UPLOAD_ACK_TIMEOUT = 30.0  # seconds to wait for each upload ack
 
-# Keepalive for "🤔 Thinking..." stream: refresh to avoid WeCom
-# server-side timeout; force-finish before the limit so later replies
-# can start a fresh stream_id (issue #3947).
+# Keepalive for "🤔 Thinking..." stream.
 _PROCESSING_REFRESH_INTERVAL = 20.0
 _PROCESSING_MAX_DURATION = 180.0
 _PROCESSING_TEXT = "🤔 Thinking..."
@@ -907,13 +905,8 @@ class WecomChannel(BaseChannel):
                     media_type,
                 )
                 return media_id
-            except Exception as e:
-                logger.exception(
-                    "wecom _upload_media failed path=%s error=%s",
-                    local[:60],
-                    str(e)[:100],
-                )
-
+            except Exception:
+                logger.exception("wecom _upload_media failed path=%s", local[:60])
                 return None
 
     async def _send_media_part(
@@ -1406,27 +1399,88 @@ class WecomChannel(BaseChannel):
             (self.bot_id or "")[:12],
         )
 
+    async def _graceful_shutdown(self) -> None:
+        """Close the WebSocket connection and release all resources safely.
+
+        This coroutine **must** run in the WS thread's event loop.
+        """
+        # 1. Cancel keepalive tasks to stop background refreshes.
+        for task in list(self._keepalive_tasks.values()):
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+        self._keepalive_tasks.clear()
+
+        # 2. Fail all pending upload futures so no sender hangs forever.
+        for future in list(self._upload_ack_futures.values()):
+            if not future.done():
+                future.set_exception(
+                    RuntimeError("WeCom adapter shutting down")
+                )
+        self._upload_ack_futures.clear()
+
+        # 3. Disconnect via the SDK public API.  disconnect() is
+        #    synchronous but schedules _async_disconnect() on the
+        #    current loop (which is the WS loop here).  We then
+        #    await _cleanup_ws() to ensure the socket and receive
+        #    task are fully torn down before returning.
+        if self._client:
+            self._client.disconnect()
+            ws_manager = getattr(self._client, "_ws_manager", None)
+            if ws_manager and hasattr(ws_manager, "_cleanup_ws"):
+                await ws_manager._cleanup_ws()
+
     async def stop(self) -> None:
+        """Stop the WeCom channel gracefully."""
         if not self.enabled:
             return
-        # disconnect() uses asyncio.ensure_future() internally which
-        # binds to the current loop; schedule it on _ws_loop so the
-        # ws is operated on its own loop (issue #2757).
+
+        # Schedule the shutdown coroutine in the WS event loop and wait
+        # for it to complete without blocking the caller's event loop.
         if (
-            self._client
-            and self._ws_loop is not None
+            self._ws_loop is not None
             and self._ws_loop.is_running()
         ):
             try:
-                self._ws_loop.call_soon_threadsafe(self._client.disconnect)
-            except Exception:
-                pass
-        if self._ws_loop is not None:
+                shutdown_future = asyncio.run_coroutine_threadsafe(
+                    self._graceful_shutdown(), self._ws_loop
+                )
+                await asyncio.wait_for(
+                    asyncio.wrap_future(shutdown_future),
+                    timeout=15,
+                )
+            except Exception as exc:
+                logger.warning("wecom shutdown error: %s", exc)
+        else:
+            # Fallback: the WS loop already stopped so
+            # asyncio.ensure_future inside disconnect() would not
+            # work.  Clean up synchronous state only.
+            try:
+                if self._client:
+                    ws_manager = getattr(
+                        self._client, "_ws_manager", None
+                    )
+                    if ws_manager:
+                        ws_manager._is_manual_close = True
+                        ws_manager._stop_heartbeat()
+                        ws_manager._clear_pending_messages(
+                            "WeCom adapter shutting down"
+                        )
+            except Exception as exc:
+                logger.warning("wecom shutdown error (fallback): %s", exc)
+
+        # Stop the WS event loop if it is still running.
+        if self._ws_loop is not None and self._ws_loop.is_running():
             try:
                 self._ws_loop.call_soon_threadsafe(self._ws_loop.stop)
             except Exception:
                 pass
+
+        # Wait for the background thread to finish.
         if self._ws_thread:
-            self._ws_thread.join(timeout=5)
+            self._ws_thread.join(timeout=10)
         self._client = None
         logger.info("wecom channel stopped")

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -906,7 +906,9 @@ class WecomChannel(BaseChannel):
                 )
                 return media_id
             except Exception:
-                logger.exception("wecom _upload_media failed path=%s", local[:60])
+                logger.exception(
+                    "wecom _upload_media failed path=%s", local[:60]
+                )
                 return None
 
     async def _send_media_part(
@@ -1418,7 +1420,7 @@ class WecomChannel(BaseChannel):
         for future in list(self._upload_ack_futures.values()):
             if not future.done():
                 future.set_exception(
-                    RuntimeError("WeCom adapter shutting down")
+                    RuntimeError("WeCom adapter shutting down"),
                 )
         self._upload_ack_futures.clear()
 
@@ -1440,13 +1442,11 @@ class WecomChannel(BaseChannel):
 
         # Schedule the shutdown coroutine in the WS event loop and wait
         # for it to complete without blocking the caller's event loop.
-        if (
-            self._ws_loop is not None
-            and self._ws_loop.is_running()
-        ):
+        if self._ws_loop is not None and self._ws_loop.is_running():
             try:
                 shutdown_future = asyncio.run_coroutine_threadsafe(
-                    self._graceful_shutdown(), self._ws_loop
+                    self._graceful_shutdown(),
+                    self._ws_loop,
                 )
                 await asyncio.wait_for(
                     asyncio.wrap_future(shutdown_future),
@@ -1461,13 +1461,15 @@ class WecomChannel(BaseChannel):
             try:
                 if self._client:
                     ws_manager = getattr(
-                        self._client, "_ws_manager", None
+                        self._client,
+                        "_ws_manager",
+                        None,
                     )
                     if ws_manager:
                         ws_manager._is_manual_close = True
                         ws_manager._stop_heartbeat()
                         ws_manager._clear_pending_messages(
-                            "WeCom adapter shutting down"
+                            "WeCom adapter shutting down",
                         )
             except Exception as exc:
                 logger.warning("wecom shutdown error (fallback): %s", exc)

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -907,7 +907,8 @@ class WecomChannel(BaseChannel):
                 return media_id
             except Exception:
                 logger.exception(
-                    "wecom _upload_media failed path=%s", local[:60]
+                    "wecom _upload_media failed path=%s",
+                    local[:60],
                 )
                 return None
 


### PR DESCRIPTION
## Description

Fix WeCom channel shutdown reliability by introducing a structured `_graceful_shutdown()` coroutine that runs on the WS event loop. Previously `stop()` used `call_soon_threadsafe(self._client.disconnect)` which only triggered SDK's synchronous disconnect without awaiting cleanup—keepalive tasks and pending upload futures could leak.

**Changes:**

1. **New `_graceful_shutdown()` coroutine** — executed on `_ws_loop` via `run_coroutine_threadsafe`, with three ordered steps:
   - Cancel all keepalive tasks and await their completion
   - Fail all pending upload futures with `RuntimeError("WeCom adapter shutting down")` so no sender hangs
   - Call `self._client.disconnect()` + `await ws_manager._cleanup_ws()` for full socket teardown

2. **`stop()` rewritten** — replaces `call_soon_threadsafe(disconnect)` with `run_coroutine_threadsafe(_graceful_shutdown())` + `asyncio.wait_for(…, timeout=15)`, plus a fallback path for when the WS loop has already stopped.

3. **Simplified `_upload_media` exception handler** — removes the redundant `str(e)[:100]` argument since `logger.exception()` already includes the traceback.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
  ********************************Passed******************************** 

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
