### PR TITLE
fix(session): serialize session file updates

### DIFF
--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -6,6 +6,7 @@ Windows filenames cannot contain: \\ / : * ? " < > |
 This module wraps agentscope's SessionBase so that session_id and user_id
 are sanitized before being used as filenames.
 """
+import asyncio
 import os
 import re
 import json
@@ -211,6 +212,39 @@ class SafeJSONSession(SessionBase):
                 The directory to save the session state.
         """
         self.save_dir = save_dir
+        self._path_locks: dict[str, asyncio.Lock] = {}
+
+    def _get_path_lock(self, session_save_path: str) -> asyncio.Lock:
+        """Return the per-file lock for a session JSON path."""
+        normalized_path = os.path.abspath(session_save_path)
+        lock = self._path_locks.get(normalized_path)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._path_locks[normalized_path] = lock
+        return lock
+
+    @staticmethod
+    async def _read_states_from_path(session_save_path: str) -> dict:
+        async with aiofiles.open(
+            session_save_path,
+            "r",
+            encoding="utf-8",
+            errors="surrogatepass",
+        ) as f:
+            content = await f.read()
+            return _safe_json_loads(content, session_save_path)
+
+    @staticmethod
+    async def _write_states_to_path(
+        session_save_path: str,
+        states: dict,
+    ) -> None:
+        async with aiofiles.open(
+            session_save_path,
+            "w",
+            encoding="utf-8",
+        ) as f:
+            await f.write(json.dumps(states, ensure_ascii=False))
 
     def _get_save_path(
         self,
@@ -276,21 +310,17 @@ class SafeJSONSession(SessionBase):
         **state_modules_mapping,
     ) -> None:
         """Save state modules to a JSON file using async I/O."""
-        state_dicts = {
-            name: state_module.state_dict()
-            for name, state_module in state_modules_mapping.items()
-        }
         session_save_path = self._get_save_path(
             session_id,
             user_id=user_id,
             channel=channel,
         )
-        with open(
-            session_save_path,
-            "w",
-            encoding="utf-8",
-        ) as f:
-            f.write(json.dumps(state_dicts, ensure_ascii=False))
+        async with self._get_path_lock(session_save_path):
+            state_dicts = {
+                name: state_module.state_dict()
+                for name, state_module in state_modules_mapping.items()
+            }
+            await self._write_states_to_path(session_save_path, state_dicts)
 
         logger.info(
             "Saved session state to %s successfully.",
@@ -311,38 +341,32 @@ class SafeJSONSession(SessionBase):
             user_id=user_id,
             channel=channel,
         )
-        if os.path.exists(session_save_path):
-            async with aiofiles.open(
-                session_save_path,
-                "r",
-                encoding="utf-8",
-                errors="surrogatepass",
-            ) as f:
-                content = await f.read()
-                states = _safe_json_loads(content, session_save_path)
+        async with self._get_path_lock(session_save_path):
+            if os.path.exists(session_save_path):
+                states = await self._read_states_from_path(session_save_path)
+            elif allow_not_exist:
+                logger.info(
+                    "Session file %s does not exist. "
+                    "Skip loading session state.",
+                    session_save_path,
+                )
+                return
+            else:
+                raise AgentStateError(
+                    session_id=session_id,
+                    message=(
+                        f"Failed to load session state for file "
+                        f"{session_save_path} because it does not exist"
+                    ),
+                )
 
-            for name, state_module in state_modules_mapping.items():
-                if name in states:
-                    state_module.load_state_dict(states[name])
-            logger.info(
-                "Load session state from %s successfully.",
-                session_save_path,
-            )
-
-        elif allow_not_exist:
-            logger.info(
-                "Session file %s does not exist. Skip loading session state.",
-                session_save_path,
-            )
-
-        else:
-            raise AgentStateError(
-                session_id=session_id,
-                message=(
-                    f"Failed to load session state for file "
-                    f"{session_save_path} because it does not exist"
-                ),
-            )
+        for name, state_module in state_modules_mapping.items():
+            if name in states:
+                state_module.load_state_dict(states[name])
+        logger.info(
+            "Load session state from %s successfully.",
+            session_save_path,
+        )
 
     async def update_session_state(
         self,
@@ -359,45 +383,34 @@ class SafeJSONSession(SessionBase):
             channel=channel,
         )
 
-        if os.path.exists(session_save_path):
-            async with aiofiles.open(
-                session_save_path,
-                "r",
-                encoding="utf-8",
-                errors="surrogatepass",
-            ) as f:
-                content = await f.read()
-                states = _safe_json_loads(content, session_save_path)
+        async with self._get_path_lock(session_save_path):
+            if os.path.exists(session_save_path):
+                states = await self._read_states_from_path(session_save_path)
+            else:
+                if not create_if_not_exist:
+                    raise AgentStateError(
+                        session_id=session_id,
+                        message=(
+                            f"Session file {session_save_path} does not exist"
+                        ),
+                    )
+                states = {}
 
-        else:
-            if not create_if_not_exist:
-                raise AgentStateError(
-                    session_id=session_id,
-                    message=f"Session file {session_save_path} does not exist",
+            path = key.split(".") if isinstance(key, str) else list(key)
+            if not path:
+                raise ConfigurationException(
+                    config_key="session.key",
+                    message="key path is empty",
                 )
-            states = {}
 
-        path = key.split(".") if isinstance(key, str) else list(key)
-        if not path:
-            raise ConfigurationException(
-                config_key="session.key",
-                message="key path is empty",
-            )
+            cur = states
+            for k in path[:-1]:
+                if k not in cur or not isinstance(cur[k], dict):
+                    cur[k] = {}
+                cur = cur[k]
 
-        cur = states
-        for k in path[:-1]:
-            if k not in cur or not isinstance(cur[k], dict):
-                cur[k] = {}
-            cur = cur[k]
-
-        cur[path[-1]] = value
-
-        with open(
-            session_save_path,
-            "w",
-            encoding="utf-8",
-        ) as f:
-            f.write(json.dumps(states, ensure_ascii=False))
+            cur[path[-1]] = value
+            await self._write_states_to_path(session_save_path, states)
 
         logger.info(
             "Updated session state key '%s' in %s successfully.",
@@ -436,33 +449,26 @@ class SafeJSONSession(SessionBase):
             user_id=user_id,
             channel=channel,
         )
-        if os.path.exists(session_save_path):
-            async with aiofiles.open(
-                session_save_path,
-                "r",
-                encoding="utf-8",
-                errors="surrogatepass",
-            ) as file:
-                content = await file.read()
-                states = _safe_json_loads(content, session_save_path)
+        async with self._get_path_lock(session_save_path):
+            if os.path.exists(session_save_path):
+                states = await self._read_states_from_path(session_save_path)
+            elif allow_not_exist:
+                logger.info(
+                    "Session file %s does not exist. Return empty state dict.",
+                    session_save_path,
+                )
+                return {}
+            else:
+                raise AgentStateError(
+                    session_id=session_id,
+                    message=(
+                        f"Failed to get session state for file "
+                        f"{session_save_path} because it does not exist"
+                    ),
+                )
 
-            logger.info(
-                "Get session state dict from %s successfully.",
-                session_save_path,
-            )
-            return states
-
-        if allow_not_exist:
-            logger.info(
-                "Session file %s does not exist. Return empty state dict.",
-                session_save_path,
-            )
-            return {}
-
-        raise AgentStateError(
-            session_id=session_id,
-            message=(
-                f"Failed to get session state for file {session_save_path} "
-                f"because it does not exist"
-            ),
+        logger.info(
+            "Get session state dict from %s successfully.",
+            session_save_path,
         )
+        return states

--- a/tests/unit/agents/test_session.py
+++ b/tests/unit/agents/test_session.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for SafeJSONSession JSON corruption resilience."""
 # pylint: disable=redefined-outer-name
+import asyncio
 import json
 import os
 import pathlib
@@ -162,6 +163,39 @@ async def test_update_corrupted_json(sess, tmp_session_dir):
 
 
 # ── non-existent session ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_session_state_preserves_concurrent_writes(sess):
+    """Concurrent updates to the same session file should not clobber."""
+    await sess.update_session_state(
+        "race:session",
+        key="agent.seed",
+        value=0,
+        user_id="user",
+    )
+
+    await asyncio.gather(
+        *[
+            sess.update_session_state(
+                "race:session",
+                key=f"agent.k{i}",
+                value=i,
+                user_id="user",
+            )
+            for i in range(50)
+        ],
+    )
+
+    result = await sess.get_session_state_dict(
+        "race:session",
+        user_id="user",
+    )
+    agent_state = result["agent"]
+
+    assert agent_state["seed"] == 0
+    for i in range(50):
+        assert agent_state[f"k{i}"] == i
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #4232.

## Description
Adds per-session-file `asyncio.Lock` protection inside `SafeJSONSession` so reads, writes, and read-modify-write updates for the same JSON session file cannot interleave. This prevents concurrent `update_session_state` calls from silently clobbering each other while keeping different session files independent.

I read the README and CONTRIBUTING guidelines before taking this issue, and commented on #4232 before starting the focused fix.

## Type of Change
Bug fix.

## Components Affected
Core / Backend session persistence, tests.

## Testing
```bash
PYTHONPATH=src python -m pytest tests/unit/agents/test_session.py
# 17 passed

pre-commit run --files src/qwenpaw/app/runner/session.py tests/unit/agents/test_session.py
# all hooks passed
```

Additional local note:
```bash
pre-commit run --all-files
# attempted; local Python 3.13 run fails on unrelated baseline files:
# src/qwenpaw/cli/shutdown_cmd.py mypy arg-type errors,
# plus pylint no-name-in-module on existing collections.abc imports.
```

## Checklist
- [x] Checked existing issues and open PRs
- [x] Commented on the issue before starting
- [x] Added a regression test for concurrent session updates
- [x] Ran targeted pytest
- [x] Ran pre-commit on changed files