### PR TITLE
fix(shell): preserve Unix multiline commands

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -41,11 +41,12 @@ def _kill_process_tree_win32(pid: int) -> None:
 
 
 def _collapse_newlines_outside_quotes(cmd: str) -> str:
-    r"""Collapse newlines outside quoted strings; preserve those inside.
+    r"""Normalize newlines for Unix shells without flattening commands.
 
-    Used only on Unix where sh/bash correctly handles newlines in quotes.
-    Handles backslash-newline (line continuation) by removing both chars,
-    and treats single-quoted content as fully literal per POSIX.
+    Used only on Unix where sh/bash correctly handles newlines as command
+    separators and inside quoted strings.  Handles backslash-newline (line
+    continuation) by removing both chars, and treats single-quoted content
+    as fully literal per POSIX.
     """
     result: list[str] = []
     in_single_quote = False
@@ -90,16 +91,13 @@ def _collapse_newlines_outside_quotes(cmd: str) -> str:
             i += 2
             continue
 
-        # Newlines
+        # Newlines: preserve Unix shell command-separator semantics.  The
+        # previous space collapse turned "# comment\ncmd" into one shell
+        # comment, so the command was never executed.
         if char in ("\r", "\n"):
-            if in_double_quote:
-                # Preserve newlines inside double quotes
-                result.append(char)
-            else:
-                # Collapse \r\n as a single space
-                if char == "\r" and i + 1 < length and cmd[i + 1] == "\n":
-                    i += 1
-                result.append(" ")
+            if char == "\r" and i + 1 < length and cmd[i + 1] == "\n":
+                i += 1
+            result.append("\n")
             i += 1
             continue
 
@@ -129,12 +127,12 @@ def _collapse_embedded_newlines(cmd: str) -> str:
     ``--text "Hello\nWorld"``).  On Windows, all newlines are collapsed
     to ensure the command at least executes successfully.
     """
-    if "\n" not in cmd:
+    if "\n" not in cmd and "\r" not in cmd:
         return cmd
     if sys.platform == "win32":
         # cmd.exe truncates at newlines regardless of quoting — must
         # collapse all to ensure the command executes at all.
-        return cmd.replace("\r\n", " ").replace("\n", " ")
+        return cmd.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
     return _collapse_newlines_outside_quotes(cmd)
 
 

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Tests for shell tool command preprocessing."""
+
+import sys
+
+import pytest
+
+from qwenpaw.agents.tools import shell
+from qwenpaw.agents.tools.shell import (
+    _collapse_embedded_newlines,
+    execute_shell_command,
+)
+
+
+def test_unix_preserves_comment_prefixed_multiline_command(monkeypatch):
+    monkeypatch.setattr(shell.sys, "platform", "linux")
+
+    command = "# inspect workspace\nprintf qwenpaw-ok"
+
+    assert _collapse_embedded_newlines(command) == command
+
+
+def test_unix_preserves_sequential_multiline_command(monkeypatch):
+    monkeypatch.setattr(shell.sys, "platform", "linux")
+
+    command = 'cd /tmp\nprintf "%s" "qwenpaw-ok"'
+
+    assert _collapse_embedded_newlines(command) == command
+
+
+def test_unix_normalizes_crlf_without_flattening_command_separator(
+    monkeypatch,
+):
+    monkeypatch.setattr(shell.sys, "platform", "linux")
+
+    command = "# inspect workspace\r\nprintf qwenpaw-ok"
+
+    assert (
+        _collapse_embedded_newlines(command)
+        == "# inspect workspace\nprintf qwenpaw-ok"
+    )
+
+
+def test_unix_normalizes_lone_carriage_return(monkeypatch):
+    monkeypatch.setattr(shell.sys, "platform", "linux")
+
+    command = "# inspect workspace\rprintf qwenpaw-ok"
+
+    assert (
+        _collapse_embedded_newlines(command)
+        == "# inspect workspace\nprintf qwenpaw-ok"
+    )
+
+
+def test_windows_still_collapses_newlines(monkeypatch):
+    monkeypatch.setattr(shell.sys, "platform", "win32")
+
+    command = "# inspect workspace\nprintf qwenpaw-ok"
+
+    assert (
+        _collapse_embedded_newlines(command)
+        == "# inspect workspace printf qwenpaw-ok"
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="This verifies Unix shell newline separator behavior.",
+)
+async def test_execute_shell_command_runs_comment_prefixed_multiline(tmp_path):
+    response = await execute_shell_command(
+        "# inspect workspace\nprintf qwenpaw-ok",
+        cwd=tmp_path,
+    )
+
+    assert response.content[0].text == "qwenpaw-ok"


### PR DESCRIPTION
Fixes #4244.

## Description
Preserves Unix multiline shell command semantics in `_collapse_embedded_newlines()` instead of flattening unquoted newlines into spaces. This prevents comment-prefixed commands like `# note\nprintf ...` from being collapsed into a single shell comment that exits successfully with no output.

Windows behavior remains unchanged for command execution safety: `cmd.exe` still collapses newline characters before execution.

I read the README and CONTRIBUTING guidelines before taking this issue, and commented on #4244 before starting the focused fix.

## Type of Change
Bug fix.

## Components Affected
Core shell tool, tests.

## Testing
```bash
PYTHONPATH=src python -m pytest tests/unit/agents/tools/test_shell.py -q
# 5 passed, 1 skipped

pre-commit run --files src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell.py
# all hooks passed
```

## Checklist
- [x] Checked existing issues and open PRs
- [x] Commented on the issue before starting
- [x] Added regression tests for comment-prefixed and sequential multiline commands
- [x] Ran targeted pytest
- [x] Ran pre-commit on changed files