### PR TITLE
feat(agents): add magic command `memorize` (request your like to continue or rejection to stop)

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -40,6 +40,7 @@ class ConversationCommandHandlerMixin:
             "compact",
             "new",
             "clear",
+            "memorize",
             "history",
             "compact_str",
             "summarize_status",
@@ -247,6 +248,29 @@ class CommandHandler(ConversationCommandHandlerMixin):
             "- Memory is now empty\n"
             "- Plan state cleared",
             metadata={"clear_history": True, "clear_plan": True},
+        )
+
+    async def _process_memorize(self, messages: list[Msg], _args: str = "") -> Msg:
+        """Process /memorize command."""
+        if not messages:
+            return await self._make_system_msg(
+                "📭 **No messages to compact.**\n\n"
+                "- Current memory is empty\n"
+                "- No action taken",
+            )
+        if not self._has_memory_manager():
+            return await self._make_system_msg(
+                "🚫 **Memory/Context Manager Disabled**\n\n"
+                "- Cannot start new conversation with summary\n"
+                "- Enable memory manager to use this feature",
+            )
+
+        self.memory_manager.add_summarize_task(messages=messages)
+
+        return await self._make_system_msg(
+            "**Summary Started!**\n\n"
+            "- Summary task started in background\n"
+            "- Ready to continue the conversation",
         )
 
     async def _process_compact_str(


### PR DESCRIPTION


## Description

I don't want to `clear` or `compact` the chat session, as I'd like to be able to review it later. I simply want the agent to remember the current conversation for other chat sessions to refer.

So I add a magic command `memorize`. It take notes into `memory/yyyy-MM-dd.md`, and don't clear chat.

I submit a draft first so we can see if you like the change.

If **you like, I will continue** to update the doc or other omitted details.

If you have another roadmap, feel free to close this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

For a draft, I’ve simply run a quick test with a sample conversation; everything worked perfectly.

After sent `\memorize` message, agent successfully recorded the memory file, and this chat session was not cleared.

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```
