### PR TITLE
fix(mcp): fail fast on streamable HTTP errors

### DIFF
--- a/src/qwenpaw/app/mcp/__init__.py
+++ b/src/qwenpaw/app/mcp/__init__.py
@@ -10,7 +10,10 @@ that solve the CPU leak issue caused by cross-task context manager exits.
 
 from .manager import MCPClientManager
 from .stateful_client import HttpStatefulClient, StdIOStatefulClient
+from .streamable_http_compat import apply_streamable_http_error_patch
 from .watcher import MCPConfigWatcher
+
+apply_streamable_http_error_patch()
 
 __all__ = [
     "HttpStatefulClient",

--- a/src/qwenpaw/app/mcp/streamable_http_compat.py
+++ b/src/qwenpaw/app/mcp/streamable_http_compat.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Compatibility patches for MCP streamable HTTP transport."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import mcp.client.streamable_http as _streamable_http_mod
+from mcp.shared.message import SessionMessage
+from mcp.types import (
+    ErrorData,
+    INTERNAL_ERROR,
+    JSONRPCError,
+    JSONRPCMessage,
+    JSONRPCRequest,
+    RequestId,
+)
+
+
+async def _send_status_error(
+    read_stream_writer: Any,
+    request_id: RequestId,
+    status_code: int,
+) -> None:
+    """Send an HTTP status failure as a JSON-RPC response error."""
+    await read_stream_writer.send(
+        SessionMessage(
+            JSONRPCMessage(
+                JSONRPCError(
+                    jsonrpc="2.0",
+                    id=request_id,
+                    error=ErrorData(
+                        code=INTERNAL_ERROR,
+                        message=(
+                            f"MCP streamable HTTP server returned "
+                            f"HTTP {status_code}."
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _needs_status_error_patch() -> bool:
+    """Return True when the installed MCP SDK lacks the >=400 fix."""
+    try:
+        source = inspect.getsource(
+            _streamable_http_mod.StreamableHTTPTransport._handle_post_request,
+        )
+    except (OSError, TypeError):
+        return True
+    return "response.status_code >= 400" not in source
+
+
+async def _handle_post_request_with_status_errors(
+    self: Any,
+    ctx: Any,
+) -> None:
+    """Backport MCP SDK's fail-fast handling for HTTP >=400 responses."""
+    headers = self._prepare_headers()
+    message = ctx.session_message.message
+    root = getattr(message, "root", message)
+    is_initialization = self._is_initialization_request(message)
+
+    async with ctx.client.stream(
+        "POST",
+        self.url,
+        json=message.model_dump(by_alias=True, mode="json", exclude_none=True),
+        headers=headers,
+    ) as response:
+        if response.status_code == 202:
+            _streamable_http_mod.logger.debug("Received 202 Accepted")
+            return
+
+        if response.status_code == 404:
+            if isinstance(root, JSONRPCRequest):
+                await self._send_session_terminated_error(
+                    ctx.read_stream_writer,
+                    root.id,
+                )
+            return
+
+        if response.status_code >= 400:
+            # Keep setup failures as HTTP exceptions so QwenPaw's connect
+            # path can surface OAuth/setup errors immediately. Normal request
+            # failures are returned to the waiting request as JSON-RPC errors.
+            if is_initialization:
+                response.raise_for_status()
+            if isinstance(root, JSONRPCRequest):
+                await _send_status_error(
+                    ctx.read_stream_writer,
+                    root.id,
+                    response.status_code,
+                )
+            return
+
+        response.raise_for_status()
+        if is_initialization:
+            self._maybe_extract_session_id_from_response(response)
+
+        if isinstance(root, JSONRPCRequest):
+            content_type = response.headers.get(
+                _streamable_http_mod.CONTENT_TYPE,
+                "",
+            ).lower()
+            if content_type.startswith(_streamable_http_mod.JSON):
+                await self._handle_json_response(
+                    response,
+                    ctx.read_stream_writer,
+                    is_initialization,
+                )
+            elif content_type.startswith(_streamable_http_mod.SSE):
+                await self._handle_sse_response(
+                    response,
+                    ctx,
+                    is_initialization,
+                )
+            else:
+                await self._handle_unexpected_content_type(
+                    content_type,
+                    ctx.read_stream_writer,
+                )
+
+
+def apply_streamable_http_error_patch() -> None:
+    """Patch old MCP SDK versions so HTTP errors do not hang requests."""
+    if not _needs_status_error_patch():
+        return
+    _streamable_http_mod.StreamableHTTPTransport._handle_post_request = (
+        _handle_post_request_with_status_errors
+    )

--- a/tests/unit/app/test_mcp_streamable_http_patch.py
+++ b/tests/unit/app/test_mcp_streamable_http_patch.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Tests for QwenPaw's streamable HTTP MCP compatibility patch."""
+
+import importlib
+
+import httpx
+import pytest
+
+from mcp.client.streamable_http import (
+    RequestContext,
+    StreamableHTTPTransport,
+)
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCError, JSONRPCMessage, JSONRPCRequest
+
+# Importing this package applies the streamable HTTP compatibility patch.
+importlib.import_module("qwenpaw.app.mcp")
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        self.headers: dict[str, str] = {}
+        self._request = httpx.Request("POST", "https://mcp.example.test")
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=self._request,
+                response=httpx.Response(
+                    self.status_code,
+                    request=self._request,
+                ),
+            )
+
+
+class _FakeStream:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, *_exc_info) -> None:
+        return None
+
+
+class _FakeClient:
+    def __init__(self, status_code: int) -> None:
+        self.response = _FakeResponse(status_code)
+
+    def stream(self, *_args, **_kwargs) -> _FakeStream:
+        return _FakeStream(self.response)
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.messages = []
+
+    async def send(self, message) -> None:
+        self.messages.append(message)
+
+
+def _request_context(method: str, writer: _FakeWriter) -> RequestContext:
+    message = JSONRPCMessage(
+        JSONRPCRequest(
+            jsonrpc="2.0",
+            id=1,
+            method=method,
+        ),
+    )
+    return RequestContext(
+        client=_FakeClient(401),
+        session_id=None,
+        session_message=SessionMessage(message),
+        metadata=None,
+        read_stream_writer=writer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_http_error_returns_jsonrpc_error():
+    writer = _FakeWriter()
+    transport = StreamableHTTPTransport("https://mcp.example.test")
+
+    await transport._handle_post_request(  # pylint: disable=protected-access
+        _request_context("tools/call", writer),
+    )
+
+    assert len(writer.messages) == 1
+    root = writer.messages[0].message.root
+    assert isinstance(root, JSONRPCError)
+    assert root.id == 1
+    assert root.error.code == -32603
+    assert "HTTP 401" in root.error.message
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_initialization_http_error_still_raises():
+    writer = _FakeWriter()
+    transport = StreamableHTTPTransport("https://mcp.example.test")
+
+    with pytest.raises(httpx.HTTPStatusError):
+        # pylint: disable=protected-access
+        await transport._handle_post_request(
+            _request_context("initialize", writer),
+        )
+
+    assert not writer.messages


### PR DESCRIPTION
Fixes #4227.

## Description
Adds a temporary compatibility patch for the published MCP SDK streamable HTTP client. The installed SDK only converts HTTP 404 into a JSON-RPC response error; other HTTP >=400 responses can leave the waiting MCP request blocked until read timeout.

This patch applies only when the installed MCP SDK lacks upstream's >=400 handling. Normal request failures are returned to the waiting caller as JSON-RPC errors, while initialization failures still raise HTTP status errors so QwenPaw's connect/OAuth path can fail fast.

I read the README and CONTRIBUTING guidelines before taking this issue, and commented on #4227 before starting the focused fix.

## Type of Change
Bug fix.

## Components Affected
MCP streamable HTTP client compatibility, tests.

## Testing
```bash
PYTHONPATH=src python -m pytest tests/unit/app/mcp/test_streamable_http_patch.py -q
# 2 passed

pre-commit run --files src/qwenpaw/app/mcp/__init__.py src/qwenpaw/app/mcp/streamable_http_compat.py tests/unit/app/mcp/test_streamable_http_patch.py
# all hooks passed
```

## Checklist
- [x] Checked existing issues and open PRs
- [x] Commented on the issue before starting
- [x] Added regression tests for non-404 HTTP errors and initialization errors
- [x] Ran targeted pytest
- [x] Ran pre-commit on changed files