### PR TITLE
feat(console): show context usage in chat

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -113,6 +113,69 @@
   }
 }
 
+.contextUsageIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 168px;
+  max-width: 220px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.78);
+  color: rgba(0, 0, 0, 0.72);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.contextUsageText {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.contextUsageTrack {
+  position: relative;
+  flex: 0 0 42px;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.contextUsageFill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  transition: width 160ms ease;
+}
+
+.ok {
+  background: #2da44e;
+}
+
+.warn {
+  background: #d29922;
+}
+
+.danger {
+  background: #cf222e;
+}
+
+:global(.dark-mode) {
+  .contextUsageIndicator {
+    border-color: rgba(255, 255, 255, 0.16);
+    background: rgba(31, 31, 31, 0.86);
+    color: rgba(255, 255, 255, 0.78);
+  }
+
+  .contextUsageTrack {
+    background: rgba(255, 255, 255, 0.16);
+  }
+}
+
 /* Prompt star icon - use theme color */
 :global {
   .chat-anywhere-prompt-icon,

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -86,6 +86,62 @@ interface CommandSuggestion {
   description: string;
 }
 
+interface ContextUsage {
+  total_tokens: number;
+  max_input_length: number;
+  pct: number;
+}
+
+function isContextUsage(value: unknown): value is ContextUsage {
+  if (!value || typeof value !== "object") return false;
+  const usage = value as Record<string, unknown>;
+  return (
+    typeof usage.total_tokens === "number" &&
+    typeof usage.max_input_length === "number" &&
+    typeof usage.pct === "number"
+  );
+}
+
+function formatTokenCount(value: number): string {
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1)}m`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return String(value);
+}
+
+function getUsageTone(pct: number): "ok" | "warn" | "danger" {
+  if (pct >= 70) return "danger";
+  if (pct >= 50) return "warn";
+  return "ok";
+}
+
+function ContextUsageIndicator({
+  usage,
+  label,
+}: {
+  usage: ContextUsage | null;
+  label: string;
+}) {
+  if (!usage) return null;
+
+  const pct = Math.max(0, Math.min(100, usage.pct));
+  const tone = getUsageTone(pct);
+
+  return (
+    <div className={styles.contextUsageIndicator} title={`${pct.toFixed(1)}%`}>
+      <span className={styles.contextUsageText}>
+        {label}: {formatTokenCount(usage.total_tokens)} /{" "}
+        {formatTokenCount(usage.max_input_length)}
+      </span>
+      <span className={styles.contextUsageTrack}>
+        <span
+          className={`${styles.contextUsageFill} ${styles[tone]}`}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+    </div>
+  );
+}
+
 function messageRequestsHistoryClear(message: unknown): boolean {
   if (!message || typeof message !== "object") return false;
   const metadata = (message as Record<string, unknown>).metadata;
@@ -517,6 +573,11 @@ export default function ChatPage() {
     Map<string, ApprovalMessageData>
   >(new Map());
   const [planEnabled, setPlanEnabled] = useState(false);
+  const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null);
+
+  useEffect(() => {
+    setContextUsage(null);
+  }, [chatId, selectedAgent]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1042,6 +1103,10 @@ export default function ChatPage() {
             <RuntimeLoadingBridge bridgeRef={runtimeLoadingBridgeRef} />
             <ChatHeaderTitle />
             <span style={{ flex: 1 }} />
+            <ContextUsageIndicator
+              usage={contextUsage}
+              label={t("chat.contextUsage.label", "Context")}
+            />
             <ModelSelector />
             <ChatActionGroup planEnabled={planEnabled} />
           </>
@@ -1098,6 +1163,9 @@ export default function ChatPage() {
         fetch: customFetch,
         responseParser: (chunk: string) => {
           const payload = JSON.parse(chunk) as Record<string, unknown>;
+          if (isContextUsage(payload.context_usage)) {
+            setContextUsage(payload.context_usage);
+          }
 
           if (payloadRequestsHistoryClear(payload)) {
             pendingClearHistoryRef.current = true;
@@ -1166,6 +1234,7 @@ export default function ChatPage() {
     toolRenderConfig,
     scheduleHistoryClear,
     planEnabled,
+    contextUsage,
   ]);
 
   return (

--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -26,6 +26,7 @@ from .compactor_prompts import (
     UPDATE_USER_MESSAGE_EN,
     UPDATE_USER_MESSAGE_ZH,
 )
+from .usage_store import set_context_usage
 from ..model_factory import create_model_and_formatter
 from ..tools.utils import truncate_text_output, DEFAULT_MAX_BYTES
 from ..utils import get_token_counter
@@ -773,6 +774,15 @@ class LightContextManager(BaseContextManager):
                 as_token_counter=token_counter,
             )
 
+            from ...app.agent_context import get_current_session_id
+
+            set_context_usage(
+                agent_id=self.agent_id,
+                session_id=get_current_session_id() or "",
+                total_tokens=str_token_count + ctx_total_tokens,
+                max_input_length=running_config.max_input_length,
+            )
+
             if not messages_to_compact:
                 return None
 
@@ -979,6 +989,26 @@ class LightContextManager(BaseContextManager):
         When ``auto_memory_interval`` is set (e.g., 2), this hook counts user
         messages in the memory and triggers auto memory every N queries.
         """
+        try:
+            from ...app.agent_context import get_current_session_id
+
+            agent_config = load_agent_config(self.agent_id)
+            max_input_length = agent_config.running.max_input_length
+            stats = await agent.memory.estimate_tokens(max_input_length)
+            token_counter = get_token_counter(agent_config)
+            sys_token_count = await token_counter.count(
+                messages=[],
+                text=(agent.sys_prompt or ""),
+            )
+            set_context_usage(
+                agent_id=self.agent_id,
+                session_id=get_current_session_id() or "",
+                total_tokens=stats["estimated_tokens"] + sys_token_count,
+                max_input_length=max_input_length,
+            )
+        except Exception as e:
+            logger.debug("Failed to update context usage snapshot: %s", e)
+
         try:
             memory_manager = agent.memory_manager
             if memory_manager is None:

--- a/src/qwenpaw/agents/context/usage_store.py
+++ b/src/qwenpaw/agents/context/usage_store.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""In-memory context usage snapshots for active chat streams."""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import Any, Dict, Optional, Tuple
+
+_UsageKey = Tuple[str, str]
+
+_lock = Lock()
+_usage_by_session: Dict[_UsageKey, Dict[str, Any]] = {}
+
+
+def set_context_usage(
+    *,
+    agent_id: str,
+    session_id: str,
+    total_tokens: int,
+    max_input_length: int,
+) -> None:
+    """Store the latest context usage for a running agent session."""
+    if not agent_id or not session_id:
+        return
+
+    pct = (
+        (total_tokens / max_input_length * 100)
+        if max_input_length > 0
+        else 0.0
+    )
+    snapshot = {
+        "total_tokens": int(total_tokens),
+        "max_input_length": int(max_input_length),
+        "pct": pct,
+    }
+    with _lock:
+        _usage_by_session[(agent_id, session_id)] = snapshot
+
+
+def get_context_usage(
+    *,
+    agent_id: str,
+    session_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Return a copy of the latest context usage snapshot if available."""
+    if not agent_id or not session_id:
+        return None
+
+    with _lock:
+        snapshot = _usage_by_session.get((agent_id, session_id))
+        return dict(snapshot) if snapshot else None

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -13,6 +13,7 @@ pretty-printed to the terminal.
 from __future__ import annotations
 
 import copy
+import json
 import logging
 import os
 import sys
@@ -29,6 +30,8 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
 from ....config.config import ConsoleConfig as ConsoleChannelConfig
 from ...console_push_store import append as push_store_append
 from ....constant import DEFAULT_MEDIA_DIR
+from ....agents.context.usage_store import get_context_usage
+from ...agent_context import get_current_agent_id
 from ..base import (
     BaseChannel,
     AudioContent,
@@ -329,6 +332,29 @@ class ConsoleChannel(BaseChannel):
         logger.info("Usage for session %s (cleaned up): %s", session_id, usage)
         return usage
 
+    def _attach_context_usage(
+        self,
+        data: str,
+        session_id: Optional[str],
+    ) -> str:
+        """Attach context usage to response SSE payloads."""
+        usage = get_context_usage(
+            agent_id=get_current_agent_id(),
+            session_id=session_id or "",
+        )
+        if not usage:
+            return data
+
+        try:
+            payload = json.loads(data)
+            if payload.get("object") != "response":
+                return data
+            payload["context_usage"] = usage
+            return json.dumps(payload, ensure_ascii=True, default=str)
+        except Exception:
+            logger.debug("Failed to attach context usage to SSE payload")
+            return data
+
     async def stream_one(self, payload: Any) -> AsyncGenerator[str, None]:
         """Process one payload and yield SSE-formatted events"""
         if isinstance(payload, dict) and "content_parts" in payload:
@@ -401,6 +427,8 @@ class ConsoleChannel(BaseChannel):
                         setattr(event, "usage", usage_data)
 
                 data = self._serialize_event_for_sse(event)
+                if obj == "response":
+                    data = self._attach_context_usage(data, session_id)
                 yield f"data: {data}\n\n"
 
                 if obj == "message" and status == RunStatus.Completed:

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -522,6 +522,78 @@ class TestConsoleStreaming:
 
             assert len(events) == 1
 
+    async def test_stream_one_attaches_context_usage(
+        self,
+        stream_channel,
+        monkeypatch,
+    ):
+        """Response SSE events should include latest context usage."""
+        import json
+
+        from qwenpaw.agents.context.usage_store import set_context_usage
+        from qwenpaw.app.channels.console import channel as console_module
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            ContentType,
+            TextContent,
+        )
+
+        class ResponseEvent:
+            object = "response"
+            status = "completed"
+            type = "response.completed"
+            output = []
+
+            def model_dump_json(self):
+                return json.dumps(
+                    {
+                        "object": self.object,
+                        "status": self.status,
+                        "type": self.type,
+                    },
+                )
+
+        monkeypatch.setattr(
+            console_module,
+            "get_current_agent_id",
+            lambda: "test-agent",
+        )
+        monkeypatch.setattr(
+            stream_channel,
+            "_extract_token_usage",
+            lambda _session_id: None,
+        )
+        set_context_usage(
+            agent_id="test-agent",
+            session_id="console:user123",
+            total_tokens=3200,
+            max_input_length=128000,
+        )
+
+        async def mock_process(_request):
+            yield ResponseEvent()
+
+        stream_channel._process = mock_process
+
+        payload = {
+            "sender_id": "user123",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="Hello"),
+            ],
+            "meta": {},
+        }
+
+        events = []
+        async for event in stream_channel.stream_one(payload):
+            events.append(event)
+            break
+
+        data = json.loads(events[0].removeprefix("data: ").strip())
+        assert data["context_usage"] == {
+            "total_tokens": 3200,
+            "max_input_length": 128000,
+            "pct": 2.5,
+        }
+
     async def test_stream_one_falls_back_on_surrogate_json_error(
         self,
         stream_channel,


### PR DESCRIPTION
## Summary
- expose latest context usage on console response SSE events
- update usage snapshots from light context pre-reasoning/post-reply hooks
- render a compact context usage indicator in the chat header

Relates to #4284.

## Testing
- `PYTHONPATH=src uv run pytest tests/unit/channels/test_console.py -q`
- `PYTHONPATH=src uv run pre-commit run --files src/qwenpaw/agents/context/usage_store.py src/qwenpaw/agents/context/light_context_manager.py src/qwenpaw/app/channels/console/channel.py tests/unit/channels/test_console.py`
- `npx prettier --check src/pages/Chat/index.tsx src/pages/Chat/index.module.less`
- `npx tsc -b --noEmit`
- `npm run build`

Note: local full `npm run format:check` on Windows reports existing line-ending/style warnings across many untouched console files; targeted checks for the changed files pass.