### PR TITLE
feat(mcp): support custom TLS verification

### DIFF
--- a/console/src/api/types/mcp.ts
+++ b/console/src/api/types/mcp.ts
@@ -28,6 +28,10 @@ export interface MCPClientInfo {
   url: string;
   /** HTTP headers for remote transport */
   headers: Record<string, string>;
+  /** Whether TLS certificates are verified for HTTP/SSE transport */
+  tls_verify: boolean;
+  /** Custom CA bundle path for HTTP/SSE transport */
+  ca_file: string;
   /** Command to launch the MCP server */
   command: string;
   /** Command-line arguments */
@@ -83,6 +87,10 @@ export interface MCPClientCreateRequest {
     url?: string;
     /** HTTP headers for remote transport */
     headers?: Record<string, string>;
+    /** Whether TLS certificates are verified for HTTP/SSE transport */
+    tls_verify?: boolean;
+    /** Custom CA bundle path for HTTP/SSE transport */
+    ca_file?: string;
     /** Command to launch the MCP server */
     command?: string;
     /** Command-line arguments */
@@ -116,6 +124,10 @@ export interface MCPClientUpdateRequest {
   url?: string;
   /** HTTP headers for remote transport */
   headers?: Record<string, string>;
+  /** Whether TLS certificates are verified for HTTP/SSE transport */
+  tls_verify?: boolean;
+  /** Custom CA bundle path for HTTP/SSE transport */
+  ca_file?: string;
   /** Command to launch the MCP server */
   command?: string;
   /** Command-line arguments */

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -701,7 +701,9 @@
       "description": "Description",
       "descriptionPlaceholder": "Optional description",
       "env": "Environment Variables",
-      "envPlaceholder": "KEY=VALUE (one per line)"
+      "envPlaceholder": "KEY=VALUE (one per line)",
+      "tlsVerify": "Verify TLS certificates",
+      "caFile": "Custom CA file"
     },
     "oauth": {
       "enableOAuth": "Use OAuth Authorization",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -555,7 +555,9 @@
       "description": "描述",
       "descriptionPlaceholder": "可选描述",
       "env": "环境变量",
-      "envPlaceholder": "KEY=VALUE（每行一个）"
+      "envPlaceholder": "KEY=VALUE（每行一个）",
+      "tlsVerify": "验证 TLS 证书",
+      "caFile": "自定义 CA 文件"
     },
     "oauth": {
       "enableOAuth": "使用 OAuth 授权",

--- a/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
@@ -30,6 +30,8 @@ interface MCPClientUpdate {
   transport?: "stdio" | "streamable_http" | "sse";
   url?: string;
   headers?: Record<string, string>;
+  tls_verify?: boolean;
+  ca_file?: string;
   args?: string[];
   env?: Record<string, string>;
   cwd?: string;

--- a/console/src/pages/Agent/MCP/index.tsx
+++ b/console/src/pages/Agent/MCP/index.tsx
@@ -1,5 +1,12 @@
 import { useState, useCallback } from "react";
-import { Button, Empty, Modal, Input, Select } from "@agentscope-ai/design";
+import {
+  Button,
+  Checkbox,
+  Empty,
+  Modal,
+  Input,
+  Select,
+} from "@agentscope-ai/design";
 import { Tabs } from "antd";
 import { Plus } from "lucide-react";
 import type { MCPClientInfo } from "../../../api/types";
@@ -40,6 +47,12 @@ function normalizeClientData(key: string, rawData: Record<string, unknown>) {
 
   const command =
     transport === "stdio" ? ((rawData.command ?? "") as string) : "";
+  const tlsVerify =
+    typeof rawData.tls_verify === "boolean"
+      ? rawData.tls_verify
+      : typeof rawData.tlsVerify === "boolean"
+      ? rawData.tlsVerify
+      : true;
 
   return {
     name: (rawData.name as string) || key,
@@ -49,6 +62,8 @@ function normalizeClientData(key: string, rawData: Record<string, unknown>) {
     transport,
     url: (rawData.url || rawData.baseUrl || "") as string,
     headers: (rawData.headers as Record<string, string>) || {},
+    tls_verify: tlsVerify,
+    ca_file: (rawData.ca_file || rawData.caFile || "") as string,
     command,
     args: Array.isArray(rawData.args) ? (rawData.args as string[]) : [],
     env: (rawData.env as Record<string, string>) || {},
@@ -70,6 +85,8 @@ const defaultForm = {
   args: "",
   env: "",
   cwd: "",
+  tlsVerify: true,
+  caFile: "",
 };
 
 function MCPPage() {
@@ -246,6 +263,8 @@ function MCPPage() {
       description: form.description,
       transport: form.transport,
       url: isHttp ? form.url.trim() : "",
+      tls_verify: isHttp ? form.tlsVerify : true,
+      ca_file: isHttp ? form.caFile.trim() : "",
       command: form.transport === "stdio" ? form.command.trim() : "",
       args,
       env,
@@ -422,17 +441,45 @@ function MCPPage() {
 
                   {/* URL (HTTP/SSE) or Command (stdio) */}
                   {isHttpTransport ? (
-                    <div>
-                      <label style={labelStyle}>
-                        {t("mcp.form.url")}
-                        <span style={{ color: "#c0392b" }}> *</span>
-                      </label>
-                      <Input
-                        placeholder="https://mcp.example.com/mcp"
-                        value={form.url}
-                        onChange={(e) => setField("url", e.target.value)}
-                      />
-                    </div>
+                    <>
+                      <div>
+                        <label style={labelStyle}>
+                          {t("mcp.form.url")}
+                          <span style={{ color: "#c0392b" }}> *</span>
+                        </label>
+                        <Input
+                          placeholder="https://mcp.example.com/mcp"
+                          value={form.url}
+                          onChange={(e) => setField("url", e.target.value)}
+                        />
+                      </div>
+                      <div style={rowStyle}>
+                        <div style={fieldStyle}>
+                          <label style={labelStyle}>
+                            {t("mcp.form.caFile")}
+                          </label>
+                          <Input
+                            placeholder="/path/to/ca.pem"
+                            value={form.caFile}
+                            onChange={(e) => setField("caFile", e.target.value)}
+                            disabled={!form.tlsVerify}
+                          />
+                        </div>
+                        <div style={checkboxFieldStyle}>
+                          <Checkbox
+                            checked={form.tlsVerify}
+                            onChange={(event) =>
+                              setField(
+                                "tlsVerify",
+                                Boolean(event?.target?.checked),
+                              )
+                            }
+                          >
+                            {t("mcp.form.tlsVerify")}
+                          </Checkbox>
+                        </div>
+                      </div>
+                    </>
                   ) : (
                     <>
                       <div>
@@ -501,6 +548,12 @@ const fieldStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   gap: 4,
+};
+
+const checkboxFieldStyle: React.CSSProperties = {
+  ...fieldStyle,
+  justifyContent: "flex-end",
+  paddingBottom: 4,
 };
 
 const labelStyle: React.CSSProperties = {

--- a/console/src/pages/Agent/MCP/useMCP.ts
+++ b/console/src/pages/Agent/MCP/useMCP.ts
@@ -40,6 +40,8 @@ export function useMCP() {
         transport?: "stdio" | "streamable_http" | "sse";
         url?: string;
         headers?: Record<string, string>;
+        tls_verify?: boolean;
+        ca_file?: string;
         args?: string[];
         env?: Record<string, string>;
         cwd?: string;
@@ -73,6 +75,8 @@ export function useMCP() {
         transport?: "stdio" | "streamable_http" | "sse";
         url?: string;
         headers?: Record<string, string>;
+        tls_verify?: boolean;
+        ca_file?: string;
         args?: string[];
         env?: Record<string, string>;
         cwd?: string;

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -250,6 +250,8 @@ class MCPClientManager:
             "transport": client_config.transport,
             "url": client_config.url,
             "headers": client_config.headers or None,
+            "tls_verify": client_config.tls_verify,
+            "ca_file": client_config.ca_file,
             "command": client_config.command,
             "args": list(client_config.args),
             "env": dict(client_config.env),
@@ -275,12 +277,32 @@ class MCPClientManager:
             headers,
             client_config,
         )
+        client_kwargs = MCPClientManager._build_http_client_kwargs(
+            client_config,
+        )
 
         client = HttpStatefulClient(
             name=client_config.name,
             transport=client_config.transport,
             url=client_config.url,
             headers=headers or None,
+            **client_kwargs,
         )
         setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
         return client
+
+    @staticmethod
+    def _build_http_client_kwargs(
+        client_config: "MCPClientConfig",
+    ) -> Dict[str, Any]:
+        """Build httpx kwargs for remote MCP transports."""
+        if not client_config.tls_verify:
+            return {"verify": False}
+
+        ca_file = os.path.expanduser(
+            os.path.expandvars(client_config.ca_file.strip()),
+        )
+        if ca_file:
+            return {"verify": ca_file}
+
+        return {}

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -697,13 +697,36 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
                 streamable_http_client(url=self.url, http_client=http_client),
             )
         else:
+            httpx_client_factory = None
+            if self.client_kwargs:
+                httpx_client_factory = self._build_httpx_client_factory()
+
+            kwargs: dict[str, Any] = {}
+            if httpx_client_factory is not None:
+                kwargs["httpx_client_factory"] = httpx_client_factory
+
             context = await stack.enter_async_context(
                 sse_client(
                     url=self.url,
                     headers=self.headers,
                     timeout=self.timeout,
                     sse_read_timeout=self.sse_read_timeout,
-                    **self.client_kwargs,
+                    **kwargs,
                 ),
             )
         return context[0], context[1]
+
+    def _build_httpx_client_factory(self):
+        def _factory(
+            headers: dict[str, str] | None = None,
+            timeout: httpx.Timeout | None = None,
+            auth: httpx.Auth | None = None,
+        ) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                headers=headers,
+                timeout=timeout,
+                auth=auth,
+                **self.client_kwargs,
+            )
+
+        return _factory

--- a/src/qwenpaw/app/routers/mcp.py
+++ b/src/qwenpaw/app/routers/mcp.py
@@ -45,6 +45,14 @@ class MCPClientInfo(BaseModel):
         default_factory=dict,
         description="HTTP headers for remote transport",
     )
+    tls_verify: bool = Field(
+        default=True,
+        description="Whether to verify TLS certificates for remote transport",
+    )
+    ca_file: str = Field(
+        default="",
+        description="Custom CA bundle path for remote transport",
+    )
     command: str = Field(
         default="",
         description="Command to launch the MCP server",
@@ -88,6 +96,14 @@ class MCPClientCreateRequest(BaseModel):
         default_factory=dict,
         description="HTTP headers for remote transport",
     )
+    tls_verify: bool = Field(
+        default=True,
+        description="Whether to verify TLS certificates for remote transport",
+    )
+    ca_file: str = Field(
+        default="",
+        description="Custom CA bundle path for remote transport",
+    )
     command: str = Field(
         default="",
         description="Command to launch the MCP server",
@@ -126,6 +142,14 @@ class MCPClientUpdateRequest(BaseModel):
     headers: Optional[Dict[str, str]] = Field(
         None,
         description="HTTP headers for remote transport",
+    )
+    tls_verify: Optional[bool] = Field(
+        None,
+        description="Whether to verify TLS certificates for remote transport",
+    )
+    ca_file: Optional[str] = Field(
+        None,
+        description="Custom CA bundle path for remote transport",
     )
     command: Optional[str] = Field(
         None,
@@ -233,6 +257,8 @@ def _build_client_info(key: str, client: MCPClientConfig) -> MCPClientInfo:
         transport=client.transport,
         url=client.url,
         headers=masked_headers,
+        tls_verify=client.tls_verify,
+        ca_file=client.ca_file,
         command=client.command,
         args=client.args,
         env=masked_env,
@@ -393,6 +419,8 @@ async def create_mcp_client(
         transport=client.transport,
         url=client.url,
         headers=client.headers,
+        tls_verify=client.tls_verify,
+        ca_file=client.ca_file,
         command=client.command,
         args=client.args,
         env=client.env,

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1251,6 +1251,8 @@ class MCPClientConfig(BaseModel):
     transport: Literal["stdio", "streamable_http", "sse"] = "stdio"
     url: str = ""
     headers: Dict[str, str] = Field(default_factory=dict)
+    tls_verify: bool = True
+    ca_file: str = ""
     command: str = ""
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)

--- a/tests/unit/app/test_mcp_tls_config.py
+++ b/tests/unit/app/test_mcp_tls_config.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from qwenpaw.app.mcp.manager import MCPClientManager
+from qwenpaw.app.mcp.stateful_client import HttpStatefulClient
+from qwenpaw.app.routers.mcp import _build_client_info
+from qwenpaw.config.config import MCPClientConfig
+
+
+def _remote_config(**overrides):
+    data = {
+        "name": "remote-mcp",
+        "transport": "streamable_http",
+        "url": "https://mcp.example.com/mcp",
+    }
+    data.update(overrides)
+    return MCPClientConfig.model_validate(data)
+
+
+def test_build_client_disables_tls_verification():
+    config = _remote_config(tls_verify=False)
+
+    client = MCPClientManager._build_client(config)
+
+    assert isinstance(client, HttpStatefulClient)
+    assert client.client_kwargs == {"verify": False}
+    assert client._qwenpaw_rebuild_info["tls_verify"] is False
+
+
+def test_build_client_uses_custom_ca_file(monkeypatch, tmp_path):
+    ca_file = tmp_path / "ca.pem"
+    monkeypatch.setenv("QWENPAW_TEST_CA_FILE", str(ca_file))
+    config = _remote_config(ca_file="$QWENPAW_TEST_CA_FILE")
+
+    client = MCPClientManager._build_client(config)
+
+    assert isinstance(client, HttpStatefulClient)
+    assert client.client_kwargs == {"verify": str(ca_file)}
+    assert client._qwenpaw_rebuild_info["ca_file"] == "$QWENPAW_TEST_CA_FILE"
+
+
+def test_build_client_keeps_default_tls_settings_empty():
+    config = _remote_config()
+
+    client = MCPClientManager._build_client(config)
+
+    assert isinstance(client, HttpStatefulClient)
+    assert not client.client_kwargs
+
+
+def test_build_client_info_exposes_tls_fields():
+    config = _remote_config(
+        tls_verify=False,
+        ca_file="/etc/ssl/private-ca.pem",
+    )
+
+    info = _build_client_info("remote", config)
+
+    assert info.tls_verify is False
+    assert info.ca_file == "/etc/ssl/private-ca.pem"


### PR DESCRIPTION
## Summary
- add tls_verify and ca_file to MCP client config/API responses and requests
- pass TLS verification settings through to remote MCP HTTP clients
- expose the fields in MCP JSON/form create flows and TypeScript types
- add unit coverage for TLS config propagation

Fixes #4175

## Testing
- PYTHONPATH=src uv run pytest tests/unit/app/test_mcp_tls_config.py -q
- uv run pre-commit run --files src/qwenpaw/config/config.py src/qwenpaw/app/mcp/manager.py src/qwenpaw/app/mcp/stateful_client.py src/qwenpaw/app/routers/mcp.py tests/unit/app/test_mcp_tls_config.py
- npx prettier --check console/src/pages/Agent/MCP/index.tsx console/src/pages/Agent/MCP/useMCP.ts console/src/pages/Agent/MCP/components/MCPClientCard.tsx console/src/api/types/mcp.ts console/src/locales/en.json console/src/locales/zh.json
- npx tsc -b --noEmit
- npm run build