### PR TITLE
feat(mcp): support configurable timeouts

### DIFF
--- a/console/src/api/types/mcp.ts
+++ b/console/src/api/types/mcp.ts
@@ -28,6 +28,10 @@ export interface MCPClientInfo {
   url: string;
   /** HTTP headers for remote transport */
   headers: Record<string, string>;
+  /** HTTP connect/write/pool timeout in seconds */
+  timeout: number;
+  /** SSE/read timeout in seconds */
+  sse_read_timeout: number;
   /** Command to launch the MCP server */
   command: string;
   /** Command-line arguments */
@@ -83,6 +87,10 @@ export interface MCPClientCreateRequest {
     url?: string;
     /** HTTP headers for remote transport */
     headers?: Record<string, string>;
+    /** HTTP connect/write/pool timeout in seconds */
+    timeout?: number;
+    /** SSE/read timeout in seconds */
+    sse_read_timeout?: number;
     /** Command to launch the MCP server */
     command?: string;
     /** Command-line arguments */
@@ -116,6 +124,10 @@ export interface MCPClientUpdateRequest {
   url?: string;
   /** HTTP headers for remote transport */
   headers?: Record<string, string>;
+  /** HTTP connect/write/pool timeout in seconds */
+  timeout?: number;
+  /** SSE/read timeout in seconds */
+  sse_read_timeout?: number;
   /** Command to launch the MCP server */
   command?: string;
   /** Command-line arguments */

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -701,7 +701,11 @@
       "description": "Description",
       "descriptionPlaceholder": "Optional description",
       "env": "Environment Variables",
-      "envPlaceholder": "KEY=VALUE (one per line)"
+      "envPlaceholder": "KEY=VALUE (one per line)",
+      "timeout": "HTTP timeout (seconds)",
+      "timeoutRequired": "HTTP timeout must be greater than 0",
+      "sseReadTimeout": "SSE read timeout (seconds)",
+      "sseReadTimeoutRequired": "SSE read timeout must be greater than 0"
     },
     "oauth": {
       "enableOAuth": "Use OAuth Authorization",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -555,7 +555,11 @@
       "description": "描述",
       "descriptionPlaceholder": "可选描述",
       "env": "环境变量",
-      "envPlaceholder": "KEY=VALUE（每行一个）"
+      "envPlaceholder": "KEY=VALUE（每行一个）",
+      "timeout": "HTTP 超时（秒）",
+      "timeoutRequired": "HTTP 超时必须大于 0",
+      "sseReadTimeout": "SSE 读取超时（秒）",
+      "sseReadTimeoutRequired": "SSE 读取超时必须大于 0"
     },
     "oauth": {
       "enableOAuth": "使用 OAuth 授权",

--- a/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
@@ -30,6 +30,8 @@ interface MCPClientUpdate {
   transport?: "stdio" | "streamable_http" | "sse";
   url?: string;
   headers?: Record<string, string>;
+  timeout?: number;
+  sse_read_timeout?: number;
   args?: string[];
   env?: Record<string, string>;
   cwd?: string;

--- a/console/src/pages/Agent/MCP/index.tsx
+++ b/console/src/pages/Agent/MCP/index.tsx
@@ -49,6 +49,13 @@ function normalizeClientData(key: string, rawData: Record<string, unknown>) {
     transport,
     url: (rawData.url || rawData.baseUrl || "") as string,
     headers: (rawData.headers as Record<string, string>) || {},
+    timeout: typeof rawData.timeout === "number" ? rawData.timeout : 30,
+    sse_read_timeout:
+      typeof rawData.sse_read_timeout === "number"
+        ? rawData.sse_read_timeout
+        : typeof rawData.sseReadTimeout === "number"
+        ? rawData.sseReadTimeout
+        : 300,
     command,
     args: Array.isArray(rawData.args) ? (rawData.args as string[]) : [],
     env: (rawData.env as Record<string, string>) || {},
@@ -70,6 +77,8 @@ const defaultForm = {
   args: "",
   env: "",
   cwd: "",
+  timeout: "30",
+  sseReadTimeout: "300",
 };
 
 function MCPPage() {
@@ -221,6 +230,16 @@ function MCPPage() {
       alert(t("mcp.form.commandRequired"));
       return;
     }
+    const timeout = Number(form.timeout);
+    const sseReadTimeout = Number(form.sseReadTimeout);
+    if (isHttp && (!Number.isFinite(timeout) || timeout <= 0)) {
+      alert(t("mcp.form.timeoutRequired"));
+      return;
+    }
+    if (isHttp && (!Number.isFinite(sseReadTimeout) || sseReadTimeout <= 0)) {
+      alert(t("mcp.form.sseReadTimeoutRequired"));
+      return;
+    }
 
     // Parse args: split on newlines, commas, or spaces
     const args = form.args
@@ -246,6 +265,8 @@ function MCPPage() {
       description: form.description,
       transport: form.transport,
       url: isHttp ? form.url.trim() : "",
+      timeout: isHttp ? timeout : 30,
+      sse_read_timeout: isHttp ? sseReadTimeout : 300,
       command: form.transport === "stdio" ? form.command.trim() : "",
       args,
       env,
@@ -422,17 +443,45 @@ function MCPPage() {
 
                   {/* URL (HTTP/SSE) or Command (stdio) */}
                   {isHttpTransport ? (
-                    <div>
-                      <label style={labelStyle}>
-                        {t("mcp.form.url")}
-                        <span style={{ color: "#c0392b" }}> *</span>
-                      </label>
-                      <Input
-                        placeholder="https://mcp.example.com/mcp"
-                        value={form.url}
-                        onChange={(e) => setField("url", e.target.value)}
-                      />
-                    </div>
+                    <>
+                      <div>
+                        <label style={labelStyle}>
+                          {t("mcp.form.url")}
+                          <span style={{ color: "#c0392b" }}> *</span>
+                        </label>
+                        <Input
+                          placeholder="https://mcp.example.com/mcp"
+                          value={form.url}
+                          onChange={(e) => setField("url", e.target.value)}
+                        />
+                      </div>
+                      <div style={rowStyle}>
+                        <div style={fieldStyle}>
+                          <label style={labelStyle}>
+                            {t("mcp.form.timeout")}
+                          </label>
+                          <Input
+                            placeholder="30"
+                            value={form.timeout}
+                            onChange={(e) =>
+                              setField("timeout", e.target.value)
+                            }
+                          />
+                        </div>
+                        <div style={fieldStyle}>
+                          <label style={labelStyle}>
+                            {t("mcp.form.sseReadTimeout")}
+                          </label>
+                          <Input
+                            placeholder="300"
+                            value={form.sseReadTimeout}
+                            onChange={(e) =>
+                              setField("sseReadTimeout", e.target.value)
+                            }
+                          />
+                        </div>
+                      </div>
+                    </>
                   ) : (
                     <>
                       <div>

--- a/console/src/pages/Agent/MCP/useMCP.ts
+++ b/console/src/pages/Agent/MCP/useMCP.ts
@@ -40,6 +40,8 @@ export function useMCP() {
         transport?: "stdio" | "streamable_http" | "sse";
         url?: string;
         headers?: Record<string, string>;
+        timeout?: number;
+        sse_read_timeout?: number;
         args?: string[];
         env?: Record<string, string>;
         cwd?: string;
@@ -73,6 +75,8 @@ export function useMCP() {
         transport?: "stdio" | "streamable_http" | "sse";
         url?: string;
         headers?: Record<string, string>;
+        timeout?: number;
+        sse_read_timeout?: number;
         args?: string[];
         env?: Record<string, string>;
         cwd?: string;

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -250,6 +250,8 @@ class MCPClientManager:
             "transport": client_config.transport,
             "url": client_config.url,
             "headers": client_config.headers or None,
+            "timeout": client_config.timeout,
+            "sse_read_timeout": client_config.sse_read_timeout,
             "command": client_config.command,
             "args": list(client_config.args),
             "env": dict(client_config.env),
@@ -281,6 +283,8 @@ class MCPClientManager:
             transport=client_config.transport,
             url=client_config.url,
             headers=headers or None,
+            timeout=client_config.timeout,
+            sse_read_timeout=client_config.sse_read_timeout,
         )
         setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
         return client

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -623,7 +623,7 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
             url: The URL to the MCP server
             headers: Additional headers to include in the HTTP request
             timeout: The timeout for the HTTP request in seconds
-            sse_read_timeout: The timeout for reading SSE in seconds
+            sse_read_timeout: The timeout for reading SSE events in seconds
             **client_kwargs: Additional keyword arguments for the client
 
         Raises:

--- a/src/qwenpaw/app/routers/mcp.py
+++ b/src/qwenpaw/app/routers/mcp.py
@@ -45,6 +45,14 @@ class MCPClientInfo(BaseModel):
         default_factory=dict,
         description="HTTP headers for remote transport",
     )
+    timeout: float = Field(
+        default=30.0,
+        description="HTTP connect/write/pool timeout in seconds",
+    )
+    sse_read_timeout: float = Field(
+        default=300.0,
+        description="SSE/read timeout in seconds",
+    )
     command: str = Field(
         default="",
         description="Command to launch the MCP server",
@@ -88,6 +96,14 @@ class MCPClientCreateRequest(BaseModel):
         default_factory=dict,
         description="HTTP headers for remote transport",
     )
+    timeout: float = Field(
+        default=30.0,
+        description="HTTP connect/write/pool timeout in seconds",
+    )
+    sse_read_timeout: float = Field(
+        default=300.0,
+        description="SSE/read timeout in seconds",
+    )
     command: str = Field(
         default="",
         description="Command to launch the MCP server",
@@ -126,6 +142,14 @@ class MCPClientUpdateRequest(BaseModel):
     headers: Optional[Dict[str, str]] = Field(
         None,
         description="HTTP headers for remote transport",
+    )
+    timeout: Optional[float] = Field(
+        None,
+        description="HTTP connect/write/pool timeout in seconds",
+    )
+    sse_read_timeout: Optional[float] = Field(
+        None,
+        description="SSE/read timeout in seconds",
     )
     command: Optional[str] = Field(
         None,
@@ -233,6 +257,8 @@ def _build_client_info(key: str, client: MCPClientConfig) -> MCPClientInfo:
         transport=client.transport,
         url=client.url,
         headers=masked_headers,
+        timeout=client.timeout,
+        sse_read_timeout=client.sse_read_timeout,
         command=client.command,
         args=client.args,
         env=masked_env,
@@ -393,6 +419,8 @@ async def create_mcp_client(
         transport=client.transport,
         url=client.url,
         headers=client.headers,
+        timeout=client.timeout,
+        sse_read_timeout=client.sse_read_timeout,
         command=client.command,
         args=client.args,
         env=client.env,

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1251,6 +1251,8 @@ class MCPClientConfig(BaseModel):
     transport: Literal["stdio", "streamable_http", "sse"] = "stdio"
     url: str = ""
     headers: Dict[str, str] = Field(default_factory=dict)
+    timeout: float = 30.0
+    sse_read_timeout: float = 300.0
     command: str = ""
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)
@@ -1301,6 +1303,17 @@ class MCPClientConfig(BaseModel):
     @model_validator(mode="after")
     def _validate_transport_config(self):
         """Validate required fields for each MCP transport type."""
+        if self.timeout <= 0:
+            raise ConfigurationException(
+                config_key="mcp.timeout",
+                message="MCP client timeout must be greater than 0",
+            )
+        if self.sse_read_timeout <= 0:
+            raise ConfigurationException(
+                config_key="mcp.sse_read_timeout",
+                message="MCP client SSE read timeout must be greater than 0",
+            )
+
         if self.transport == "stdio":
             if not self.command.strip():
                 raise ConfigurationException(

--- a/tests/unit/app/test_mcp_timeout_config.py
+++ b/tests/unit/app/test_mcp_timeout_config.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+
+import pytest
+from agentscope_runtime.engine.schemas.exception import (
+    ConfigurationException,
+)
+
+from qwenpaw.app.mcp.manager import MCPClientManager
+from qwenpaw.app.mcp.stateful_client import HttpStatefulClient
+from qwenpaw.app.routers.mcp import _build_client_info
+from qwenpaw.config.config import MCPClientConfig
+
+
+def _remote_config(**overrides):
+    data = {
+        "name": "remote-mcp",
+        "transport": "streamable_http",
+        "url": "https://mcp.example.com/mcp",
+    }
+    data.update(overrides)
+    return MCPClientConfig.model_validate(data)
+
+
+def test_build_client_passes_remote_timeouts():
+    config = _remote_config(timeout=1200.0, sse_read_timeout=900.0)
+
+    client = MCPClientManager._build_client(config)
+
+    assert isinstance(client, HttpStatefulClient)
+    assert client.timeout == 1200.0
+    assert client.sse_read_timeout == 900.0
+    assert client._qwenpaw_rebuild_info["timeout"] == 1200.0
+    assert client._qwenpaw_rebuild_info["sse_read_timeout"] == 900.0
+
+
+def test_build_client_uses_default_remote_timeouts():
+    config = _remote_config()
+
+    client = MCPClientManager._build_client(config)
+
+    assert isinstance(client, HttpStatefulClient)
+    assert client.timeout == 30.0
+    assert client.sse_read_timeout == 300.0
+
+
+def test_build_client_info_exposes_timeout_fields():
+    config = _remote_config(timeout=60.0, sse_read_timeout=120.0)
+
+    info = _build_client_info("remote", config)
+
+    assert info.timeout == 60.0
+    assert info.sse_read_timeout == 120.0
+
+
+@pytest.mark.parametrize("field", ["timeout", "sse_read_timeout"])
+def test_remote_timeout_fields_must_be_positive(field):
+    with pytest.raises(ConfigurationException):
+        _remote_config(**{field: 0})


### PR DESCRIPTION
## Summary
- add timeout and sse_read_timeout fields to MCP client config/API
- pass remote MCP timeout settings into HttpStatefulClient
- preserve timeout fields through JSON import, form create, and TypeScript types
- validate timeout values and cover propagation with unit tests

Fixes #3997

## Testing
- PYTHONPATH=src uv run pytest tests/unit/app/test_mcp_timeout_config.py -q
- uv run pre-commit run --files src/qwenpaw/config/config.py src/qwenpaw/app/mcp/manager.py src/qwenpaw/app/mcp/stateful_client.py src/qwenpaw/app/routers/mcp.py tests/unit/app/test_mcp_timeout_config.py
- npx prettier --check src/pages/Agent/MCP/index.tsx src/pages/Agent/MCP/useMCP.ts src/pages/Agent/MCP/components/MCPClientCard.tsx src/api/types/mcp.ts src/locales/en.json src/locales/zh.json
- npx tsc -b --noEmit
- npm run build