### PR TITLE
fix(openai): normalize reasoning content extras

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -25,6 +25,41 @@ def _clone_with_overrides(obj: Any, **overrides: Any) -> Any:
     return SimpleNamespace(**data)
 
 
+def _extract_reasoning_content(obj: Any) -> str | None:
+    """Read provider-specific reasoning content from object attrs/extras."""
+    for key in ("reasoning_content", "reasoning"):
+        value = getattr(obj, key, None)
+        if isinstance(value, str):
+            return value
+
+    model_extra = getattr(obj, "model_extra", None)
+    if isinstance(model_extra, dict):
+        for key in ("reasoning_content", "reasoning"):
+            value = model_extra.get(key)
+            if isinstance(value, str):
+                return value
+
+    return None
+
+
+def _ensure_delta_reasoning_attr(delta: Any) -> Any:
+    """Expose reasoning content as an attribute for AgentScope parsers."""
+    if _extract_reasoning_content(delta) is None:
+        return delta
+
+    if isinstance(
+        getattr(delta, "reasoning_content", None),
+        str,
+    ) or isinstance(
+        getattr(delta, "reasoning", None),
+        str,
+    ):
+        return delta
+
+    reasoning = _extract_reasoning_content(delta)
+    return _clone_with_overrides(delta, reasoning_content=reasoning)
+
+
 def _sanitize_tool_call(tool_call: Any) -> Any | None:
     """Normalize a tool call for parser safety, or drop it if unusable."""
     if not hasattr(tool_call, "index"):
@@ -89,12 +124,20 @@ def _sanitize_chunk(chunk: Any) -> Any:
             sanitized_choices.append(choice)
             continue
 
+        sanitized_delta = _ensure_delta_reasoning_attr(delta)
+        choice_changed = sanitized_delta is not delta
+
         raw_tool_calls = getattr(delta, "tool_calls", None)
         if not raw_tool_calls:
-            sanitized_choices.append(choice)
+            if choice_changed:
+                changed = True
+                sanitized_choices.append(
+                    _clone_with_overrides(choice, delta=sanitized_delta),
+                )
+            else:
+                sanitized_choices.append(choice)
             continue
 
-        choice_changed = False
         sanitized_tool_calls: list[Any] = []
         for tool_call in raw_tool_calls:
             sanitized = _sanitize_tool_call(tool_call)
@@ -106,7 +149,7 @@ def _sanitize_chunk(chunk: Any) -> Any:
         if choice_changed:
             changed = True
             sanitized_delta = _clone_with_overrides(
-                delta,
+                sanitized_delta,
                 tool_calls=sanitized_tool_calls,
             )
             sanitized_choice = _clone_with_overrides(
@@ -288,6 +331,35 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         return super()._format_tools_json_schemas(
             _sanitize_tool_schemas(schemas),
         )
+
+    def _parse_openai_completion_response(
+        self,
+        start_datetime: datetime,
+        response: Any,
+        structured_model: Type[BaseModel] | None = None,
+    ) -> ChatResponse:
+        parsed = super()._parse_openai_completion_response(
+            start_datetime=start_datetime,
+            response=response,
+            structured_model=structured_model,
+        )
+        if any(block.get("type") == "thinking" for block in parsed.content):
+            return parsed
+
+        choices = getattr(response, "choices", None) or []
+        if not choices:
+            return parsed
+
+        message = getattr(choices[0], "message", None)
+        reasoning = _extract_reasoning_content(message)
+        if not reasoning:
+            return parsed
+
+        parsed.content = [
+            {"type": "thinking", "thinking": reasoning},
+            *parsed.content,
+        ]
+        return parsed
 
     # pylint: disable=too-many-branches, too-many-statements
     async def _parse_openai_stream_response(

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -6,6 +6,10 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
+from agentscope.message import Msg
+
+from qwenpaw.app.channels.renderer import MessageRenderer, RenderStyle
+from qwenpaw.app.runner.utils import agentscope_msg_to_message
 from qwenpaw.providers.openai_chat_model_compat import (
     OpenAIChatModelCompat,
     _sanitize_tool_call,
@@ -25,6 +29,16 @@ class CompatHarnessOpenAIChatModel(OpenAIChatModelCompat):
         ):
             responses.append(response)
         return responses
+
+    def parse_completion_for_test(
+        self,
+        start_datetime: datetime,
+        response: Any,
+    ) -> Any:
+        return self._parse_openai_completion_response(
+            start_datetime,
+            response,
+        )
 
 
 class FakeAsyncStream:
@@ -58,6 +72,21 @@ def _make_chunk(tool_calls: list[Any]) -> Any:
     )
     choice = SimpleNamespace(delta=delta)
     return SimpleNamespace(usage=None, choices=[choice])
+
+
+def _render_with_thinking_filter(content: list[dict[str, Any]]) -> list[Any]:
+    runtime_messages = agentscope_msg_to_message(
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=content,
+        ),
+    )
+    renderer = MessageRenderer(RenderStyle(filter_thinking=True))
+    parts = []
+    for message in runtime_messages:
+        parts.extend(renderer.message_to_parts(message))
+    return parts
 
 
 async def test_stream_parser_skips_tool_call_without_function() -> None:
@@ -106,6 +135,72 @@ async def test_stream_parser_skips_tool_call_without_function() -> None:
     assert tool_blocks
     assert tool_blocks[-1]["name"] == "ping"
     assert tool_blocks[-1]["input"] == {"x": 1}
+
+
+def test_completion_reasoning_content_in_model_extra_is_filterable() -> None:
+    model = CompatHarnessOpenAIChatModel(
+        "dummy",
+        api_key="sk-test",
+        stream=False,
+    )
+    response = SimpleNamespace(
+        id="resp_1",
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    model_extra={
+                        "reasoning_content": "hidden reasoning",
+                    },
+                    content="visible answer",
+                    audio=None,
+                    tool_calls=None,
+                ),
+            ),
+        ],
+    )
+
+    parsed = model.parse_completion_for_test(datetime.now(), response)
+
+    assert parsed.content[0] == {
+        "type": "thinking",
+        "thinking": "hidden reasoning",
+    }
+    parts = _render_with_thinking_filter(parsed.content)
+    assert [part.text for part in parts] == ["visible answer"]
+
+
+async def test_stream_reasoning_content_in_model_extra_is_filterable() -> None:
+    model = CompatHarnessOpenAIChatModel(
+        "dummy",
+        api_key="sk-test",
+        stream=True,
+    )
+    delta = SimpleNamespace(
+        model_extra={
+            "reasoning_content": "hidden reasoning",
+        },
+        content="visible answer",
+        tool_calls=None,
+    )
+    stream = FakeAsyncStream(
+        [
+            SimpleNamespace(
+                id="resp_1",
+                usage=None,
+                choices=[SimpleNamespace(delta=delta)],
+            ),
+        ],
+    )
+
+    responses = await model.parse_stream_for_test(datetime.now(), stream)
+
+    assert responses[-1].content[0] == {
+        "type": "thinking",
+        "thinking": "hidden reasoning",
+    }
+    parts = _render_with_thinking_filter(responses[-1].content)
+    assert [part.text for part in parts] == ["visible answer"]
 
 
 def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:


### PR DESCRIPTION
## Summary
- normalize OpenAI-compatible reasoning fields from model_extra for streaming and non-streaming responses
- keep reasoning as thinking blocks so existing filter_thinking handling hides it
- add regression coverage for renderer filtering of reasoning_content outputs

Fixes #4006

## Tests
- PYTHONPATH=src uv run pytest tests/unit/providers/test_openai_stream_toolcall_compat.py -q
- uv run pre-commit run --files src/qwenpaw/providers/openai_chat_model_compat.py tests/unit/providers/test_openai_stream_toolcall_compat.py