### PR TITLE
fix(providers): annotate extra models from baseline

### DIFF
--- a/src/qwenpaw/providers/capability_baseline.py
+++ b/src/qwenpaw/providers/capability_baseline.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-statements,too-many-branches
 """Capability baseline — expected multimodal capabilities and discrepancy
 reporting for all built-in providers.
 """
@@ -96,7 +97,7 @@ class ExpectedCapabilityRegistry:
         """Register a single baseline entry."""
         self._data[(cap.provider_id, cap.model_id)] = cap
 
-    def _load_baseline(self) -> None:  # pylint: disable=too-many-statements
+    def _load_baseline(self) -> None:
         """Load baseline data for built-in providers."""
 
         # ---------------------------------------------------------------
@@ -335,16 +336,22 @@ class ExpectedCapabilityRegistry:
                     note="GLM text/code models are text-only",
                 ),
             )
-        self._register(
-            ExpectedCapability(
-                provider_id="zhipu-cn",
-                model_id="glm-5v-turbo",
-                expected_image=True,
-                expected_video=False,
-                doc_url=_zhipu_cn_doc,
-                note="GLM vision model supports image input",
-            ),
-        )
+        for mid in (
+            "glm-4v",
+            "glm-4v-flash",
+            "glm-4.6v-flash",
+            "glm-5v-turbo",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="zhipu-cn",
+                    model_id=mid,
+                    expected_image=True,
+                    expected_video=False,
+                    doc_url=_zhipu_cn_doc,
+                    note="GLM vision model supports image input",
+                ),
+            )
 
         # ---------------------------------------------------------------
         # Zhipu Coding Plan (BigModel)
@@ -361,16 +368,22 @@ class ExpectedCapabilityRegistry:
                     note="GLM text/code models are text-only",
                 ),
             )
-        self._register(
-            ExpectedCapability(
-                provider_id="zhipu-cn-codingplan",
-                model_id="glm-5v-turbo",
-                expected_image=True,
-                expected_video=False,
-                doc_url=_zhipu_cn_cp_doc,
-                note="GLM vision model supports image input",
-            ),
-        )
+        for mid in (
+            "glm-4v",
+            "glm-4v-flash",
+            "glm-4.6v-flash",
+            "glm-5v-turbo",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="zhipu-cn-codingplan",
+                    model_id=mid,
+                    expected_image=True,
+                    expected_video=False,
+                    doc_url=_zhipu_cn_cp_doc,
+                    note="GLM vision model supports image input",
+                ),
+            )
 
         # ---------------------------------------------------------------
         # Zhipu (Z.AI)
@@ -387,16 +400,22 @@ class ExpectedCapabilityRegistry:
                     note="GLM text/code models are text-only",
                 ),
             )
-        self._register(
-            ExpectedCapability(
-                provider_id="zhipu-intl",
-                model_id="glm-5v-turbo",
-                expected_image=True,
-                expected_video=False,
-                doc_url=_zhipu_intl_doc,
-                note="GLM vision model supports image input",
-            ),
-        )
+        for mid in (
+            "glm-4v",
+            "glm-4v-flash",
+            "glm-4.6v-flash",
+            "glm-5v-turbo",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="zhipu-intl",
+                    model_id=mid,
+                    expected_image=True,
+                    expected_video=False,
+                    doc_url=_zhipu_intl_doc,
+                    note="GLM vision model supports image input",
+                ),
+            )
 
         # ---------------------------------------------------------------
         # Zhipu Coding Plan (Z.AI)
@@ -413,16 +432,22 @@ class ExpectedCapabilityRegistry:
                     note="GLM text/code models are text-only",
                 ),
             )
-        self._register(
-            ExpectedCapability(
-                provider_id="zhipu-intl-codingplan",
-                model_id="glm-5v-turbo",
-                expected_image=True,
-                expected_video=False,
-                doc_url=_zhipu_intl_cp_doc,
-                note="GLM vision model supports image input",
-            ),
-        )
+        for mid in (
+            "glm-4v",
+            "glm-4v-flash",
+            "glm-4.6v-flash",
+            "glm-5v-turbo",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="zhipu-intl-codingplan",
+                    model_id=mid,
+                    expected_image=True,
+                    expected_video=False,
+                    doc_url=_zhipu_intl_cp_doc,
+                    note="GLM vision model supports image input",
+                ),
+            )
 
         # ---------------------------------------------------------------
         # 4. OpenAI

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1815,7 +1815,7 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
 
         registry = ExpectedCapabilityRegistry()
         for provider in self.builtin_providers.values():
-            for model in provider.models:
+            for model in provider.models + provider.extra_models:
                 # Already fully annotated (e.g. by a prior probe) → skip
                 if model.supports_multimodal is not None:
                     continue

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -129,6 +129,25 @@ def test_builtin_zhipu_providers_registered(isolated_secret_dir) -> None:
         ]
 
 
+def test_default_annotations_apply_to_extra_models(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider("aliyun-codingplan")
+    assert provider is not None
+    provider.extra_models = [
+        ModelInfo(id="qwen3.6-plus", name="Qwen3.6 Plus"),
+    ]
+
+    manager._apply_default_annotations()
+
+    model = provider.extra_models[0]
+    assert model.supports_multimodal is True
+    assert model.supports_image is True
+    assert model.supports_video is True
+    assert model.probe_source == "documentation"
+
+
 async def test_add_custom_provider_and_reload_from_storage(
     isolated_secret_dir,
 ) -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -148,6 +148,25 @@ def test_default_annotations_apply_to_extra_models(
     assert model.probe_source == "documentation"
 
 
+def test_zhipu_vision_extra_model_gets_multimodal_annotation(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider("zhipu-cn")
+    assert provider is not None
+    provider.extra_models = [
+        ModelInfo(id="glm-4.6v-flash", name="GLM-4.6V Flash"),
+    ]
+
+    manager._apply_default_annotations()
+
+    model = provider.extra_models[0]
+    assert model.supports_multimodal is True
+    assert model.supports_image is True
+    assert model.supports_video is False
+    assert model.probe_source == "documentation"
+
+
 async def test_add_custom_provider_and_reload_from_storage(
     isolated_secret_dir,
 ) -> None:


### PR DESCRIPTION
## Summary
- apply provider capability baseline annotations to user-added extra_models as well as built-in models
- preserve existing probed/static annotations while filling missing multimodal flags from documentation
- add Zhipu GLM vision aliases (`glm-4v`, `glm-4v-flash`, `glm-4.6v-flash`, `glm-5v-turbo`) across Zhipu providers
- add regression coverage for user-added multimodal extra models

Fixes #3166
Fixes #3259

## Tests
- PYTHONPATH=src pytest tests/unit/providers/test_provider_manager.py -q
- pre-commit run --files src/qwenpaw/providers/capability_baseline.py tests/unit/providers/test_provider_manager.py
- git diff --check