### PR TITLE
fix(console): hide built-in chat drawer toggle

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -37,6 +37,12 @@
       display: flex;
       align-items: center;
     }
+
+    /* QwenPaw provides its own chat history controls, so hide the
+       dependency's narrow-mode session drawer toggle. */
+    [class*="chat-anywhere-default-header-inner"] {
+      display: none;
+    }
   }
 
   /* Custom scrollbar */


### PR DESCRIPTION
## Summary
- Hide the built-in @agentscope-ai/chat narrow-mode session header on the QwenPaw chat page
- Keep QwenPaw's existing custom chat history controls as the single session entry point

Fixes #3328

## Review-ready note
- Scope is intentionally small: 1 LESS file, 6 added lines, no runtime logic changes.
- GitHub reports this PR as mergeable.
- All relevant checks are green: Vitest, pre-commit, console format, and website format.

## Testing
- `npx prettier --check src/pages/Chat/index.module.less`
- `npx tsc -b --noEmit`
- `git diff --check`