### PR TITLE
fix(console): show persistent model errors

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1797,6 +1797,8 @@
   },
   "chat": {
     "modelSelectTooltip": "Select model",
+    "modelErrorTitle": "Model request failed",
+    "modelErrorStatus": "Model request failed (HTTP {{status}}). Check the model configuration and try again.",
     "newChatTooltip": "New chat",
     "searchTooltip": "Search all chats",
     "chatHistoryTooltip": "Chat history",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -107,6 +107,8 @@
   },
   "chat": {
     "modelSelectTooltip": "Pilih model",
+    "modelErrorTitle": "Permintaan model gagal",
+    "modelErrorStatus": "Permintaan model gagal (HTTP {{status}}). Periksa konfigurasi model dan coba lagi.",
     "newChatTooltip": "Chat baru",
     "searchTooltip": "Cari semua chat",
     "chatHistoryTooltip": "Riwayat chat",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1487,6 +1487,8 @@
   },
   "chat": {
     "modelSelectTooltip": "モデルを選択",
+    "modelErrorTitle": "モデルリクエストが失敗しました",
+    "modelErrorStatus": "モデルリクエストが失敗しました (HTTP {{status}})。モデル設定を確認して再試行してください。",
     "newChatTooltip": "新しいチャット",
     "searchTooltip": "すべてのチャットを検索",
     "chatHistoryTooltip": "チャット履歴",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1675,6 +1675,8 @@
   },
   "chat": {
     "modelSelectTooltip": "Selecionar Modelo",
+    "modelErrorTitle": "Falha na solicitação do modelo",
+    "modelErrorStatus": "Falha na solicitação do modelo (HTTP {{status}}). Verifique a configuração do modelo e tente novamente.",
     "newChatTooltip": "Novo Chat",
     "searchTooltip": "Pesquisar Todos chats",
     "chatHistoryTooltip": "Chat history",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1502,6 +1502,8 @@
   },
   "chat": {
     "modelSelectTooltip": "Выбор модели",
+    "modelErrorTitle": "Ошибка запроса модели",
+    "modelErrorStatus": "Ошибка запроса модели (HTTP {{status}}). Проверьте конфигурацию модели и повторите попытку.",
     "newChatTooltip": "Новый чат",
     "searchTooltip": "Поиск во всех чатах",
     "chatHistoryTooltip": "История чатов",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1660,6 +1660,8 @@
   },
   "chat": {
     "modelSelectTooltip": "模型选择",
+    "modelErrorTitle": "模型请求失败",
+    "modelErrorStatus": "模型请求失败 (HTTP {{status}})，请检查模型配置后重试。",
     "newChatTooltip": "新建聊天",
     "searchTooltip": "搜索所有聊天",
     "chatHistoryTooltip": "聊天历史",

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -77,6 +77,12 @@
   }
 }
 
+.modelErrorBanner {
+  margin: 12px 16px 0;
+  position: relative;
+  z-index: 2;
+}
+
 .suggestionLabel {
   display: flex;
   align-items: flex-start;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -4,7 +4,7 @@ import {
   type IAgentScopeRuntimeWebUIRef,
 } from "@agentscope-ai/chat";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Button, Modal, Result, Tooltip } from "antd";
+import { Alert, Button, Modal, Result, Tooltip } from "antd";
 import { useAppMessage } from "../../hooks/useAppMessage";
 import { ExclamationCircleOutlined, SettingOutlined } from "@ant-design/icons";
 import { SparkCopyLine, SparkAttachmentLine } from "@agentscope-ai/icons";
@@ -32,6 +32,11 @@ import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { planApi } from "../../api/modules/plan";
+import {
+  extractErrorText,
+  payloadHasErrorSignal,
+  readErrorResponse,
+} from "./modelError";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -507,6 +512,7 @@ export default function ChatPage() {
     return match?.[1];
   }, [location.pathname]);
   const [showModelPrompt, setShowModelPrompt] = useState(false);
+  const [modelErrorBanner, setModelErrorBanner] = useState<string | null>(null);
   const { selectedAgent } = useAgentStore();
   const { toolRenderConfig } = usePlugins();
   const [refreshKey, setRefreshKey] = useState(0);
@@ -942,9 +948,21 @@ export default function ChatPage() {
         signal: data.signal,
       });
 
+      if (!response.ok) {
+        const detail = await readErrorResponse(response);
+        setModelErrorBanner(
+          detail ||
+            t("chat.modelErrorStatus", {
+              status: response.status,
+            }),
+        );
+      } else {
+        setModelErrorBanner(null);
+      }
+
       return response;
     },
-    [selectedAgent],
+    [selectedAgent, t],
   );
 
   const handleFileUpload = useCallback(
@@ -1098,6 +1116,12 @@ export default function ChatPage() {
         fetch: customFetch,
         responseParser: (chunk: string) => {
           const payload = JSON.parse(chunk) as Record<string, unknown>;
+          const errorText = payloadHasErrorSignal(payload)
+            ? extractErrorText(payload)
+            : null;
+          if (errorText) {
+            setModelErrorBanner(errorText);
+          }
 
           if (payloadRequestsHistoryClear(payload)) {
             pendingClearHistoryRef.current = true;
@@ -1178,6 +1202,22 @@ export default function ChatPage() {
       }}
     >
       <div className={styles.chatMessagesArea}>
+        {modelErrorBanner && (
+          <Alert
+            className={styles.modelErrorBanner}
+            type="error"
+            showIcon
+            closable
+            message={t("chat.modelErrorTitle")}
+            description={modelErrorBanner}
+            onClose={() => setModelErrorBanner(null)}
+            action={
+              <Button size="small" onClick={() => navigate("/models")}>
+                {t("modelConfig.configureButton")}
+              </Button>
+            }
+          />
+        )}
         <AgentScopeRuntimeWebUI
           ref={chatRef}
           key={refreshKey}

--- a/console/src/pages/Chat/modelError.test.ts
+++ b/console/src/pages/Chat/modelError.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractErrorText,
+  payloadHasErrorSignal,
+  readErrorResponse,
+} from "./modelError";
+
+describe("model error helpers", () => {
+  it("extracts error text from nested response payloads", () => {
+    expect(
+      extractErrorText({
+        detail: {
+          error: {
+            message: "Invalid API key",
+          },
+        },
+      }),
+    ).toBe("Invalid API key");
+  });
+
+  it("does not treat normal message payloads as stream errors", () => {
+    expect(
+      payloadHasErrorSignal({ object: "message", message: "normal output" }),
+    ).toBe(false);
+    expect(payloadHasErrorSignal({ status: "error" })).toBe(true);
+  });
+
+  it("reads json and text error responses", async () => {
+    await expect(
+      readErrorResponse(
+        new Response(JSON.stringify({ error: "Provider rejected request" }), {
+          status: 502,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    ).resolves.toBe("Provider rejected request");
+
+    await expect(
+      readErrorResponse(new Response("upstream unavailable", { status: 503 })),
+    ).resolves.toBe("upstream unavailable");
+  });
+});

--- a/console/src/pages/Chat/modelError.ts
+++ b/console/src/pages/Chat/modelError.ts
@@ -1,0 +1,50 @@
+export function extractErrorText(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+
+  const record = payload as Record<string, unknown>;
+  const candidates = [
+    record.detail,
+    record.message,
+    record.error,
+    record.error_message,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+    if (candidate && typeof candidate === "object") {
+      const nested = extractErrorText(candidate);
+      if (nested) return nested;
+    }
+  }
+
+  return null;
+}
+
+export function payloadHasErrorSignal(
+  payload: Record<string, unknown>,
+): boolean {
+  return (
+    "detail" in payload ||
+    "error" in payload ||
+    "error_message" in payload ||
+    payload.status === "failed" ||
+    payload.status === "error"
+  );
+}
+
+export async function readErrorResponse(
+  response: Response,
+): Promise<string | null> {
+  try {
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return extractErrorText(await response.clone().json());
+    }
+    const text = await response.clone().text();
+    return text.trim() || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- show a persistent in-chat error banner when /console/chat returns a model/provider error
- surface streamed error payloads without mistaking normal message payloads for failures
- add localized banner strings and focused helper coverage

Fixes #4090.

## Tests
- npx vitest run src/pages/Chat/modelError.test.ts
- npx prettier --check src/pages/Chat/index.tsx src/pages/Chat/index.module.less src/pages/Chat/modelError.ts src/pages/Chat/modelError.test.ts src/locales/en.json src/locales/zh.json src/locales/id.json src/locales/ja.json src/locales/ru.json src/locales/pt-BR.json
- git diff --check

Notes: npx tsc -b --noEmit is currently blocked by pre-existing missing jszip types in src/pages/Settings/PluginManager/hooks/useInstallModal.ts. Focused eslint on index.tsx also reports existing no-explicit-any/exhaustive-deps issues outside this patch; eslint passes for the new modelError helper files.