### PR TITLE
feat(console): show context usage

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1797,6 +1797,7 @@
   },
   "chat": {
     "modelSelectTooltip": "Select model",
+    "contextUsageLabel": "Context",
     "newChatTooltip": "New chat",
     "searchTooltip": "Search all chats",
     "chatHistoryTooltip": "Chat history",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -107,6 +107,7 @@
   },
   "chat": {
     "modelSelectTooltip": "Pilih model",
+    "contextUsageLabel": "Konteks",
     "newChatTooltip": "Chat baru",
     "searchTooltip": "Cari semua chat",
     "chatHistoryTooltip": "Riwayat chat",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1487,6 +1487,7 @@
   },
   "chat": {
     "modelSelectTooltip": "モデルを選択",
+    "contextUsageLabel": "コンテキスト",
     "newChatTooltip": "新しいチャット",
     "searchTooltip": "すべてのチャットを検索",
     "chatHistoryTooltip": "チャット履歴",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1675,6 +1675,7 @@
   },
   "chat": {
     "modelSelectTooltip": "Selecionar Modelo",
+    "contextUsageLabel": "Contexto",
     "newChatTooltip": "Novo Chat",
     "searchTooltip": "Pesquisar Todos chats",
     "chatHistoryTooltip": "Chat history",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1502,6 +1502,7 @@
   },
   "chat": {
     "modelSelectTooltip": "Выбор модели",
+    "contextUsageLabel": "Контекст",
     "newChatTooltip": "Новый чат",
     "searchTooltip": "Поиск во всех чатах",
     "chatHistoryTooltip": "История чатов",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1660,6 +1660,7 @@
   },
   "chat": {
     "modelSelectTooltip": "模型选择",
+    "contextUsageLabel": "上下文",
     "newChatTooltip": "新建聊天",
     "searchTooltip": "搜索所有聊天",
     "chatHistoryTooltip": "聊天历史",

--- a/console/src/pages/Chat/contextUsage.test.ts
+++ b/console/src/pages/Chat/contextUsage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  contextUsageLevel,
+  formatContextTokens,
+  parseContextUsage,
+} from "./contextUsage";
+
+describe("context usage helpers", () => {
+  it("parses structured context usage payloads", () => {
+    expect(
+      parseContextUsage({
+        context_usage: {
+          total_tokens: 3200,
+          max_input_length: 128000,
+          pct: 2.5,
+          total_messages: 7,
+        },
+      }),
+    ).toEqual({
+      totalTokens: 3200,
+      maxInputLength: 128000,
+      pct: 2.5,
+      totalMessages: 7,
+    });
+  });
+
+  it("ignores incomplete payloads", () => {
+    expect(
+      parseContextUsage({ context_usage: { total_tokens: 1 } }),
+    ).toBeNull();
+    expect(parseContextUsage({})).toBeNull();
+  });
+
+  it("formats token counts and classifies usage levels", () => {
+    expect(formatContextTokens(999)).toBe("999");
+    expect(formatContextTokens(3200)).toBe("3.2k");
+    expect(contextUsageLevel(20)).toBe("normal");
+    expect(contextUsageLevel(50)).toBe("warning");
+    expect(contextUsageLevel(70)).toBe("danger");
+  });
+});

--- a/console/src/pages/Chat/contextUsage.ts
+++ b/console/src/pages/Chat/contextUsage.ts
@@ -1,0 +1,49 @@
+export interface ContextUsage {
+  totalTokens: number;
+  maxInputLength: number;
+  pct: number;
+  totalMessages?: number;
+}
+
+export function parseContextUsage(payload: unknown): ContextUsage | null {
+  if (!payload || typeof payload !== "object") return null;
+
+  const raw = (payload as Record<string, unknown>).context_usage;
+  if (!raw || typeof raw !== "object") return null;
+
+  const record = raw as Record<string, unknown>;
+  const totalTokens = Number(record.total_tokens);
+  const maxInputLength = Number(record.max_input_length);
+  const pct = Number(record.pct);
+
+  if (
+    !Number.isFinite(totalTokens) ||
+    !Number.isFinite(maxInputLength) ||
+    !Number.isFinite(pct)
+  ) {
+    return null;
+  }
+
+  const totalMessages = Number(record.total_messages);
+  return {
+    totalTokens,
+    maxInputLength,
+    pct,
+    totalMessages: Number.isFinite(totalMessages) ? totalMessages : undefined,
+  };
+}
+
+export function formatContextTokens(value: number): string {
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`;
+  }
+  return `${Math.max(0, Math.round(value))}`;
+}
+
+export function contextUsageLevel(
+  pct: number,
+): "normal" | "warning" | "danger" {
+  if (pct >= 70) return "danger";
+  if (pct >= 50) return "warning";
+  return "normal";
+}

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -77,6 +77,65 @@
   }
 }
 
+.contextUsageBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  max-width: min(260px, 34vw);
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(31, 141, 78, 0.3);
+  background: rgba(31, 141, 78, 0.08);
+  color: #1f8d4e;
+  font-size: 12px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.contextUsageBadge[data-level="warning"] {
+  border-color: rgba(214, 137, 16, 0.35);
+  background: rgba(214, 137, 16, 0.1);
+  color: #ad6800;
+}
+
+.contextUsageBadge[data-level="danger"] {
+  border-color: rgba(207, 19, 34, 0.35);
+  background: rgba(207, 19, 34, 0.1);
+  color: #cf1322;
+}
+
+.contextUsageLabel {
+  font-weight: 600;
+}
+
+.contextUsageValue {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.contextUsageTrack {
+  flex: 0 0 42px;
+  height: 4px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.contextUsageFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: currentcolor;
+  opacity: 1;
+}
+
+:global(.dark-mode) {
+  .contextUsageTrack {
+    background: rgba(255, 255, 255, 0.18);
+  }
+}
+
 .suggestionLabel {
   display: flex;
   align-items: flex-start;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -32,6 +32,12 @@ import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { planApi } from "../../api/modules/plan";
+import {
+  contextUsageLevel,
+  formatContextTokens,
+  parseContextUsage,
+  type ContextUsage,
+} from "./contextUsage";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -131,6 +137,32 @@ function renderSuggestionLabel(command: string, description: string) {
     <div className={styles.suggestionLabel}>
       <span className={styles.suggestionCommand}>{command}</span>
       <span className={styles.suggestionDescription}>{description}</span>
+    </div>
+  );
+}
+
+function renderContextUsage(
+  usage: ContextUsage | null,
+  label: string,
+): React.ReactNode {
+  if (!usage) return null;
+
+  const pct = Math.max(0, Math.min(100, usage.pct));
+  const level = contextUsageLevel(pct);
+  const value = `${formatContextTokens(
+    usage.totalTokens,
+  )} / ${formatContextTokens(usage.maxInputLength)} (${Math.round(pct)}%)`;
+
+  return (
+    <div className={styles.contextUsageBadge} data-level={level} title={value}>
+      <span className={styles.contextUsageLabel}>{label}</span>
+      <span className={styles.contextUsageValue}>{value}</span>
+      <span className={styles.contextUsageTrack}>
+        <span
+          className={styles.contextUsageFill}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
     </div>
   );
 }
@@ -507,6 +539,7 @@ export default function ChatPage() {
     return match?.[1];
   }, [location.pathname]);
   const [showModelPrompt, setShowModelPrompt] = useState(false);
+  const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null);
   const { selectedAgent } = useAgentStore();
   const { toolRenderConfig } = usePlugins();
   const [refreshKey, setRefreshKey] = useState(0);
@@ -1042,6 +1075,7 @@ export default function ChatPage() {
             <RuntimeLoadingBridge bridgeRef={runtimeLoadingBridgeRef} />
             <ChatHeaderTitle />
             <span style={{ flex: 1 }} />
+            {renderContextUsage(contextUsage, t("chat.contextUsageLabel"))}
             <ModelSelector />
             <ChatActionGroup planEnabled={planEnabled} />
           </>
@@ -1098,6 +1132,10 @@ export default function ChatPage() {
         fetch: customFetch,
         responseParser: (chunk: string) => {
           const payload = JSON.parse(chunk) as Record<string, unknown>;
+          const nextContextUsage = parseContextUsage(payload);
+          if (nextContextUsage) {
+            setContextUsage(nextContextUsage);
+          }
 
           if (payloadRequestsHistoryClear(payload)) {
             pendingClearHistoryRef.current = true;
@@ -1166,6 +1204,7 @@ export default function ChatPage() {
     toolRenderConfig,
     scheduleHistoryClear,
     planEnabled,
+    contextUsage,
   ]);
 
   return (

--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -32,6 +32,8 @@ from ..utils import get_token_counter
 from ..utils.estimate_token_counter import EstimatedTokenCounter
 from ...config.config import load_agent_config
 from ...constant import TRUNCATION_NOTICE_MARKER
+from ...context_usage import record_context_usage
+from ...app.agent_context import get_current_session_id
 
 if TYPE_CHECKING:
     from ..react_agent import QwenPawAgent
@@ -968,6 +970,43 @@ class LightContextManager(BaseContextManager):
 
         return None
 
+    async def _record_context_usage(
+        self,
+        agent: "QwenPawAgent",
+    ) -> None:
+        session_id = get_current_session_id()
+        if not session_id:
+            return
+
+        agent_config = load_agent_config(self.agent_id)
+        running_config = agent_config.running
+        token_counter = get_token_counter(agent_config)
+        memory = agent.memory
+        messages = await memory.get_memory(prepend_summary=False)
+        summary = memory.get_compressed_summary() or ""
+        system_prompt = agent.sys_prompt or ""
+
+        sys_token_count = await token_counter.count(
+            messages=[],
+            text=system_prompt,
+        )
+        summary_token_count = await token_counter.count(
+            messages=[],
+            text=summary,
+        )
+        msg_token_count = await AsMsgHandler(token_counter).count_msgs_token(
+            messages,
+        )
+
+        record_context_usage(
+            session_id,
+            total_tokens=(
+                sys_token_count + summary_token_count + msg_token_count
+            ),
+            max_input_length=running_config.max_input_length,
+            total_messages=len(messages),
+        )
+
     async def post_reply(
         self,
         agent: "QwenPawAgent",
@@ -980,6 +1019,11 @@ class LightContextManager(BaseContextManager):
         messages in the memory and triggers auto memory every N queries.
         """
         try:
+            try:
+                await self._record_context_usage(agent)
+            except Exception as e:
+                logger.warning("context usage recording failed: %s", e)
+
             memory_manager = agent.memory_manager
             if memory_manager is None:
                 return None

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -13,6 +13,7 @@ pretty-printed to the terminal.
 from __future__ import annotations
 
 import copy
+import json
 import logging
 import os
 import sys
@@ -329,6 +330,35 @@ class ConsoleChannel(BaseChannel):
         logger.info("Usage for session %s (cleaned up): %s", session_id, usage)
         return usage
 
+    def _extract_context_usage(
+        self,
+        session_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        from ....context_usage import pop_context_usage_for_session
+
+        if not session_id:
+            return None
+
+        usage = pop_context_usage_for_session(session_id)
+        logger.info("Context usage for session %s: %s", session_id, usage)
+        return usage
+
+    @staticmethod
+    def _inject_context_usage(
+        data: str,
+        context_usage: Dict[str, Any],
+    ) -> str:
+        try:
+            payload = json.loads(data)
+        except (TypeError, json.JSONDecodeError):
+            return data
+
+        if not isinstance(payload, dict):
+            return data
+
+        payload["context_usage"] = context_usage
+        return json.dumps(payload, ensure_ascii=True, default=str)
+
     async def stream_one(self, payload: Any) -> AsyncGenerator[str, None]:
         """Process one payload and yield SSE-formatted events"""
         if isinstance(payload, dict) and "content_parts" in payload:
@@ -401,6 +431,13 @@ class ConsoleChannel(BaseChannel):
                         setattr(event, "usage", usage_data)
 
                 data = self._serialize_event_for_sse(event)
+                if obj == "response" and status == RunStatus.Completed:
+                    context_usage = self._extract_context_usage(session_id)
+                    if context_usage:
+                        data = self._inject_context_usage(
+                            data,
+                            context_usage,
+                        )
                 yield f"data: {data}\n\n"
 
                 if obj == "message" and status == RunStatus.Completed:

--- a/src/qwenpaw/context_usage.py
+++ b/src/qwenpaw/context_usage.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""In-memory context window usage snapshots keyed by session."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_usage_by_session: dict[str, dict[str, Any]] = {}
+
+
+def record_context_usage(
+    session_id: str,
+    *,
+    total_tokens: int,
+    max_input_length: int,
+    total_messages: int | None = None,
+) -> dict[str, Any] | None:
+    """Store the latest context usage snapshot for a session."""
+    if not session_id:
+        return None
+
+    safe_total = max(0, int(total_tokens or 0))
+    safe_max = max(0, int(max_input_length or 0))
+    pct = (safe_total / safe_max * 100) if safe_max > 0 else 0.0
+
+    usage: dict[str, Any] = {
+        "total_tokens": safe_total,
+        "max_input_length": safe_max,
+        "pct": pct,
+    }
+    if total_messages is not None:
+        usage["total_messages"] = max(0, int(total_messages))
+
+    _usage_by_session[session_id] = usage
+    return usage
+
+
+def pop_context_usage_for_session(
+    session_id: str,
+) -> dict[str, Any] | None:
+    """Return and remove the latest context usage snapshot for a session."""
+    if not session_id:
+        return None
+    return _usage_by_session.pop(session_id, None)
+
+
+def clear_context_usage() -> None:
+    """Clear all recorded snapshots. Intended for tests."""
+    _usage_by_session.clear()

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -582,6 +582,73 @@ class TestConsoleStreaming:
         assert "\\ud83d" not in events[0]
         assert "? broken" in events[0]
 
+    async def test_stream_one_injects_context_usage_on_completed_response(
+        self,
+        stream_channel,
+    ):
+        """Completed response SSE should include the latest context usage."""
+        import json
+
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            RunStatus,
+            TextContent,
+            ContentType,
+        )
+        from qwenpaw.context_usage import (
+            clear_context_usage,
+            record_context_usage,
+        )
+
+        clear_context_usage()
+        record_context_usage(
+            "chat-1",
+            total_tokens=3200,
+            max_input_length=128000,
+            total_messages=4,
+        )
+
+        class ResponseEvent:
+            object = "response"
+            status = RunStatus.Completed
+            type = "response.completed"
+            output = []
+
+            def model_dump_json(self):
+                return json.dumps(
+                    {
+                        "object": "response",
+                        "status": "completed",
+                        "output": [],
+                    },
+                )
+
+        mock_event = ResponseEvent()
+
+        async def mock_process(_request):
+            yield mock_event
+
+        stream_channel._process = mock_process
+
+        payload = {
+            "sender_id": "user123",
+            "content_parts": [
+                TextContent(
+                    type=ContentType.TEXT,
+                    text="Hello",
+                ),
+            ],
+            "meta": {"session_id": "chat-1"},
+        }
+
+        events = []
+        async for event in stream_channel.stream_one(payload):
+            events.append(event)
+            break
+
+        assert len(events) == 1
+        assert '"context_usage"' in events[0]
+        assert '"total_tokens": 3200' in events[0]
+
     async def test_consume_one_drain_stream(self, stream_channel):
         """consume_one should drain stream_one."""
         from unittest.mock import patch, AsyncMock

--- a/tests/unit/test_context_usage.py
+++ b/tests/unit/test_context_usage.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Tests for context usage snapshots."""
+
+from qwenpaw.context_usage import (
+    clear_context_usage,
+    pop_context_usage_for_session,
+    record_context_usage,
+)
+
+
+def test_context_usage_pop_removes_snapshot():
+    """Stored snapshots should be returned once and then cleared."""
+    clear_context_usage()
+
+    usage = record_context_usage(
+        "session-1",
+        total_tokens=3200,
+        max_input_length=128000,
+        total_messages=7,
+    )
+
+    assert usage == {
+        "total_tokens": 3200,
+        "max_input_length": 128000,
+        "pct": 2.5,
+        "total_messages": 7,
+    }
+    assert pop_context_usage_for_session("session-1") == usage
+    assert pop_context_usage_for_session("session-1") is None
+
+
+def test_context_usage_handles_zero_context_window():
+    """Invalid token counts should be normalized without division errors."""
+    clear_context_usage()
+
+    usage = record_context_usage(
+        "session-2",
+        total_tokens=-10,
+        max_input_length=0,
+    )
+
+    assert usage == {
+        "total_tokens": 0,
+        "max_input_length": 0,
+        "pct": 0.0,
+    }


### PR DESCRIPTION
## Summary
- record the latest context window usage after replies and expose it on completed console SSE response events
- render a compact context usage indicator in the chat header with normal/warning/danger levels
- add backend store/SSE coverage and frontend parsing/formatting coverage

Fixes #4284.

## Tests
- pytest tests/unit/test_context_usage.py tests/unit/channels/test_console.py -q
- npx vitest run src/pages/Chat/contextUsage.test.ts
- npx prettier --check src/pages/Chat/index.tsx src/pages/Chat/index.module.less src/pages/Chat/contextUsage.ts src/pages/Chat/contextUsage.test.ts src/locales/en.json src/locales/zh.json src/locales/id.json src/locales/ja.json src/locales/ru.json src/locales/pt-BR.json
- npx eslint src/pages/Chat/contextUsage.ts src/pages/Chat/contextUsage.test.ts
- flake8 src/qwenpaw/context_usage.py tests/unit/test_context_usage.py
- flake8 src/qwenpaw/agents/context/light_context_manager.py src/qwenpaw/app/channels/console/channel.py tests/unit/channels/test_console.py --select=F401,F821,E999
- pylint src/qwenpaw/context_usage.py tests/unit/test_context_usage.py
- git diff --check

Notes: npx tsc -b --noEmit is currently blocked by pre-existing missing jszip types in src/pages/Settings/PluginManager/hooks/useInstallModal.ts.