### PR TITLE
fix(prompt): add runtime reload guidance

### DIFF
--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -23,6 +23,24 @@ DEFAULT_SYS_PROMPT = """
 You are a helpful assistant.
 """
 
+RUNTIME_RELOAD_GUIDANCE = """
+# Runtime Config Reload Guidance
+
+When advising users after QwenPaw configuration changes, do not recommend a
+full process restart by default.
+
+- Channel and heartbeat changes are watched and normally reload automatically.
+- MCP client changes are managed by the MCP hot-reload watcher.
+- Prompt files and skill configuration are re-read on new agent
+  initialization; use `/reload-config` or `/daemon reload-config` when a
+  manual refresh is needed.
+- Cron task changes may require recreating or restarting the task; verify the
+  task status before suggesting a full service restart.
+- Reserve a full process restart for upgrades, dependency installation, static
+  frontend asset changes, daemon reload failure, or config areas without a
+  supported reload path.
+"""
+
 # Backward compatibility alias
 SYS_PROMPT = DEFAULT_SYS_PROMPT
 
@@ -37,6 +55,11 @@ class PromptConfig:
         "SOUL.md",
         "PROFILE.md",
     ]
+
+
+def build_runtime_reload_guidance() -> str:
+    """Build runtime reload guidance for the agent system prompt."""
+    return RUNTIME_RELOAD_GUIDANCE.strip()
 
 
 class PromptBuilder:
@@ -307,6 +330,7 @@ def build_system_prompt_from_working_dir(
         memory_manager=memory_manager,
     )
     prompt = builder.build()
+    prompt = prompt.rstrip() + "\n\n" + build_runtime_reload_guidance()
 
     # Add agent identity information at the beginning of the prompt
     if agent_id:
@@ -471,6 +495,7 @@ def format_multimodal_hint(model_info, _model_name: str) -> str:
 __all__ = [
     "build_system_prompt_from_working_dir",
     "build_bootstrap_guidance",
+    "build_runtime_reload_guidance",
     "build_multimodal_hint",
     "format_multimodal_hint",
     "get_active_model_supports_multimodal",

--- a/tests/unit/workspace/test_prompt.py
+++ b/tests/unit/workspace/test_prompt.py
@@ -96,3 +96,22 @@ def test_prompt_identity_format(temp_workspace):  # pylint: disable=W0621
         "This is your unique identifier in the multi-agent system.\n\n"
     )
     assert expected_header in prompt
+
+
+def test_prompt_includes_runtime_reload_guidance(
+    temp_workspace,
+):  # pylint: disable=W0621
+    """Test that agents receive config reload guidance."""
+    agents_md = temp_workspace / "AGENTS.md"
+    agents_md.write_text("You are a helpful assistant.", encoding="utf-8")
+
+    prompt = build_system_prompt_from_working_dir(
+        working_dir=temp_workspace,
+        agent_id="default",
+    )
+
+    assert "Runtime Config Reload Guidance" in prompt
+    assert "do not recommend a" in prompt
+    assert "full process restart by default" in prompt
+    assert "MCP client changes" in prompt
+    assert "`/daemon reload-config`" in prompt


### PR DESCRIPTION
## Summary
- add built-in runtime config reload guidance to the generated system prompt
- steer agents away from recommending full process restarts by default
- document when to prefer automatic reload, /reload-config, /daemon reload-config, or task-level checks

Addresses the hot-reload knowledge part of #4315.

## Tests
- PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\workspace\test_prompt.py -q
- flake8 src\qwenpaw\agents\prompt.py tests\unit\workspace\test_prompt.py --select=F401,F821,E999
- git diff --check

Note: PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\workspace -q currently cannot collect locally because questionary is not installed for CLI workspace tests.