### PR TITLE
fix(console): render user messages as markdown

### DIFF
--- a/console/src/pages/Chat/components/MarkdownRequestCard.test.tsx
+++ b/console/src/pages/Chat/components/MarkdownRequestCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { requestContentToCards } from "./MarkdownRequestCard.utils";
+
+describe("MarkdownRequestCard", () => {
+  it("keeps user text on the markdown renderer", () => {
+    const cards = requestContentToCards([
+      { type: "text", text: "**bold**\n\n- item", status: "created" },
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      code: "Text",
+      data: {
+        content: "**bold**\n\n- item",
+      },
+    });
+    expect((cards[0].data as Record<string, unknown>).raw).toBeUndefined();
+  });
+
+  it("preserves non-text request cards", () => {
+    const cards = requestContentToCards([
+      { type: "image", image_url: "/img.png", status: "created" },
+      {
+        type: "file",
+        file_url: "/doc.pdf",
+        file_name: "doc.pdf",
+        file_size: 42,
+        status: "created",
+      },
+    ]);
+
+    expect(cards).toEqual([
+      { code: "Images", data: [{ url: "/img.png" }] },
+      {
+        code: "Files",
+        data: [{ url: "/doc.pdf", name: "doc.pdf", size: 42 }],
+      },
+    ]);
+  });
+});

--- a/console/src/pages/Chat/components/MarkdownRequestCard.tsx
+++ b/console/src/pages/Chat/components/MarkdownRequestCard.tsx
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import { Bubble } from "@agentscope-ai/chat";
+import {
+  requestContentToCards,
+  type RuntimeRequest,
+} from "./MarkdownRequestCard.utils";
+
+export default function MarkdownRequestCard(props: { data: RuntimeRequest }) {
+  const cards = useMemo(
+    () => requestContentToCards(props.data.input[0]?.content || []),
+    [props.data.input],
+  );
+
+  if (!cards.length) return null;
+
+  return <Bubble role="user" cards={cards} />;
+}

--- a/console/src/pages/Chat/components/MarkdownRequestCard.utils.ts
+++ b/console/src/pages/Chat/components/MarkdownRequestCard.utils.ts
@@ -1,0 +1,87 @@
+interface RequestContentItem {
+  type: string;
+  status?: unknown;
+  text?: string;
+  image_url?: string;
+  video_url?: string;
+  video_poster?: string;
+  audio_url?: string;
+  data?: string;
+  file_url?: string;
+  file_name?: string;
+  fileName?: string;
+  file_size?: number;
+}
+
+type RequestContent = RequestContentItem[];
+
+export interface RuntimeRequest {
+  input: Array<{
+    content?: RequestContent;
+  }>;
+}
+
+interface RequestCard {
+  code: string;
+  data: unknown;
+}
+
+const CONTENT_TEXT = "text";
+const CONTENT_IMAGE = "image";
+const CONTENT_VIDEO = "video";
+const CONTENT_AUDIO = "audio";
+const CONTENT_FILE = "file";
+
+function appendGroupedCard(
+  cards: RequestCard[],
+  code: string,
+  item: Record<string, unknown>,
+) {
+  const existing = cards.find((card) => card.code === code);
+  if (existing && Array.isArray(existing.data)) {
+    existing.data.push(item);
+    return;
+  }
+
+  cards.push({ code, data: [item] });
+}
+
+export function requestContentToCards(content: RequestContent): RequestCard[] {
+  return content.reduce<RequestCard[]>((cards, item) => {
+    if (item.type === CONTENT_TEXT) {
+      cards.push({
+        code: "Text",
+        data: {
+          content: item.text,
+        },
+      });
+    }
+
+    if (item.type === CONTENT_IMAGE) {
+      appendGroupedCard(cards, "Images", { url: item.image_url });
+    }
+
+    if (item.type === CONTENT_VIDEO) {
+      appendGroupedCard(cards, "Videos", {
+        src: item.video_url,
+        poster: item.video_poster,
+      });
+    }
+
+    if (item.type === CONTENT_AUDIO) {
+      appendGroupedCard(cards, "Audios", {
+        src: item.audio_url || item.data,
+      });
+    }
+
+    if (item.type === CONTENT_FILE) {
+      appendGroupedCard(cards, "Files", {
+        url: item.file_url,
+        name: item.file_name || item.fileName,
+        size: item.file_size,
+      });
+    }
+
+    return cards;
+  }, []);
+}

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -122,9 +122,8 @@
   }
 }
 
-/* Fix #4216: Preserve newlines in user message bubbles.
- * The Raw text renderer (used when raw=true) renders \n as plain React
- * children which HTML collapses into whitespace. pre-wrap keeps them. */
+/* Preserve user-authored soft line breaks in message bubbles while allowing
+ * markdown block syntax to render normally. */
 .chatMessagesArea :global {
   [class*="bubble-end"] [class*="markdown"],
   [class*="bubble-user"] [class*="markdown"] {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -28,6 +28,7 @@ import { IconButton } from "@agentscope-ai/design";
 import ChatActionGroup from "./components/ChatActionGroup";
 import ChatHeaderTitle from "./components/ChatHeaderTitle";
 import ChatSessionInitializer from "./components/ChatSessionInitializer";
+import MarkdownRequestCard from "./components/MarkdownRequestCard";
 import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
@@ -1092,6 +1093,9 @@ export default function ChatPage() {
         multiple: true,
         hideBuiltInSessionList: true,
         api: sessionApi,
+      },
+      cards: {
+        AgentScopeRuntimeRequestCard: MarkdownRequestCard,
       },
       api: {
         ...defaultConfig.api,


### PR DESCRIPTION
## Summary
- add a console request-card override for user messages so text content goes through the markdown renderer instead of `raw: true`
- preserve image/audio/video/file request cards when rendering user bubbles
- keep user-authored soft line breaks readable and add focused conversion coverage

Fixes #2975
Also addresses #3802

## Tests
- `$env:NODE_OPTIONS='--max-old-space-size=4096'; npx vitest run src/pages/Chat/components/MarkdownRequestCard.test.tsx`
- `npx tsc -b --noEmit`
- `npx prettier --check src/pages/Chat/components/MarkdownRequestCard.tsx src/pages/Chat/components/MarkdownRequestCard.utils.ts src/pages/Chat/components/MarkdownRequestCard.test.tsx src/pages/Chat/index.tsx src/pages/Chat/index.module.less`
- `npx eslint src/pages/Chat/components/MarkdownRequestCard.tsx src/pages/Chat/components/MarkdownRequestCard.utils.ts src/pages/Chat/components/MarkdownRequestCard.test.tsx`
- `git diff --check`