### PR TITLE
feat: add session lifecycle hooks

### DIFF
--- a/src/qwenpaw/app/runner/manager.py
+++ b/src/qwenpaw/app/runner/manager.py
@@ -27,17 +27,24 @@ class ChatManager:
         self,
         *,
         repo: BaseChatRepository,
+        agent_id: Optional[str] = None,
     ):
         """Initialize chat manager.
 
         Args:
             repo: Chat spec repository for persistence
+            agent_id: Agent identifier for lifecycle hook payloads
         """
         self._repo = repo
+        self._agent_id = agent_id
         self._lock = asyncio.Lock()
         logger.debug(
             f"ChatManager created with repo path: {repo.path}",
         )
+
+    def set_agent_id(self, agent_id: Optional[str]) -> None:
+        """Update the agent identifier used for lifecycle hook payloads."""
+        self._agent_id = agent_id
 
     # ----- Read Operations -----
 
@@ -132,7 +139,8 @@ class ChatManager:
             logger.info(
                 f"Auto-registered new chat: {spec.id} -> {session_id}",
             )
-            return spec
+        await self._emit_session_event("session.create", spec)
+        return spec
 
     async def create_chat(self, spec: ChatSpec) -> ChatSpec:
         """Create a new chat.
@@ -145,7 +153,43 @@ class ChatManager:
         """
         async with self._lock:
             await self._repo.upsert_chat(spec)
-            return spec
+        await self._emit_session_event("session.create", spec)
+        return spec
+
+    async def _emit_session_event(
+        self,
+        hook_name: str,
+        spec: ChatSpec,
+    ) -> None:
+        """Emit a plugin session lifecycle event for a chat spec."""
+        try:
+            from ...plugins.registry import PluginRegistry
+            from ..agent_context import get_current_agent_id
+
+            agent_id = self._agent_id or get_current_agent_id()
+            metadata = {
+                "chat_id": spec.id,
+                "chat_name": spec.name,
+                "user_id": spec.user_id,
+                "channel": spec.channel,
+                "created_at": spec.created_at.isoformat(),
+                "updated_at": spec.updated_at.isoformat(),
+                "status": spec.status,
+                "pinned": spec.pinned,
+                "chat_meta": dict(spec.meta),
+            }
+            await PluginRegistry().emit_session_event(
+                hook_name,
+                session_id=spec.session_id,
+                agent_id=agent_id,
+                metadata=metadata,
+            )
+        except Exception as e:  # Defensive guard for plugin hook machinery.
+            logger.error(
+                f"Failed to emit session event '{hook_name}' "
+                f"for chat '{spec.id}': {e}",
+                exc_info=True,
+            )
 
     async def patch_chat(
         self,

--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -47,12 +47,13 @@ async def create_chat_service(ws: "Workspace", service):
     if service is not None:
         # Reused ChatManager - just wire to new runner
         cm = service
+        cm.set_agent_id(ws.agent_id)
         logger.info(f"Reusing ChatManager for {ws.agent_id}")
     else:
         # Create new ChatManager
         chats_path = str(ws.workspace_dir / "chats.json")
         chat_repo = JsonChatRepository(chats_path)
-        cm = ChatManager(repo=chat_repo)
+        cm = ChatManager(repo=chat_repo, agent_id=ws.agent_id)
         ws._service_manager.services["chat_manager"] = cm
         logger.info(f"ChatManager created: {chats_path}")
 

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -188,6 +188,40 @@ class PluginApi:
                 f"'{hook_name}' (priority={priority})",
             )
 
+    def register_session_hook(
+        self,
+        hook_name: str,
+        callback: Callable,
+        priority: int = 100,
+    ):
+        """Register a conversation/session lifecycle hook.
+
+        Args:
+            hook_name: Lifecycle event name, e.g. ``session.create``
+            callback: Async or sync callback to call for this event
+            priority: Execution priority (lower = earlier, default=100)
+
+        Example:
+            >>> async def on_session_create(session_id, agent_id, metadata):
+            ...     print(session_id, agent_id, metadata)
+            >>> api.register_session_hook(
+            ...     hook_name="session.create",
+            ...     callback=on_session_create,
+            ...     priority=50,
+            ... )
+        """
+        if self._registry:
+            self._registry.register_session_hook(
+                plugin_id=self.plugin_id,
+                hook_name=hook_name,
+                callback=callback,
+                priority=priority,
+            )
+            logger.info(
+                f"Plugin '{self.plugin_id}' registered session hook "
+                f"'{hook_name}' (priority={priority})",
+            )
+
     def register_http_router(
         self,
         router: Any,

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -4,7 +4,10 @@
 
 from typing import Any, Callable, Dict, List, Optional, Type
 from dataclasses import dataclass, field
+import asyncio
+import inspect
 import logging
+import time
 
 from fastapi import APIRouter
 
@@ -118,6 +121,7 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         self._providers: Dict[str, ProviderRegistration] = {}
         self._startup_hooks: List[HookRegistration] = []
         self._shutdown_hooks: List[HookRegistration] = []
+        self._session_hooks: List[HookRegistration] = []
         self._control_commands: List[ControlCommandRegistration] = []
         self._runtime_helpers = None
         self._plugin_manifests: Dict[str, Dict[str, Any]] = {}
@@ -380,6 +384,34 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
             f"'{plugin_id}' (priority={priority})",
         )
 
+    def register_session_hook(
+        self,
+        plugin_id: str,
+        hook_name: str,
+        callback: Callable,
+        priority: int = 100,
+    ):
+        """Register a conversation/session lifecycle hook.
+
+        Args:
+            plugin_id: Plugin identifier
+            hook_name: Lifecycle event name, e.g. ``session.create``
+            callback: Sync or async callback
+            priority: Priority (lower = earlier execution)
+        """
+        hook = HookRegistration(
+            plugin_id=plugin_id,
+            hook_name=hook_name,
+            callback=callback,
+            priority=priority,
+        )
+        self._session_hooks.append(hook)
+        self._session_hooks.sort(key=lambda h: h.priority)
+        logger.info(
+            f"Registered session hook '{hook_name}' from plugin "
+            f"'{plugin_id}' (priority={priority})",
+        )
+
     def get_startup_hooks(self) -> List[HookRegistration]:
         """Get all startup hooks sorted by priority.
 
@@ -395,6 +427,76 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
             List of HookRegistration
         """
         return self._shutdown_hooks.copy()
+
+    def get_session_hooks(
+        self,
+        hook_name: Optional[str] = None,
+    ) -> List[HookRegistration]:
+        """Get session lifecycle hooks sorted by priority.
+
+        Args:
+            hook_name: Optional event name filter
+
+        Returns:
+            List of HookRegistration
+        """
+        if hook_name is None:
+            return self._session_hooks.copy()
+        return [
+            hook for hook in self._session_hooks if hook.hook_name == hook_name
+        ]
+
+    async def emit_session_event(
+        self,
+        hook_name: str,
+        *,
+        session_id: str,
+        agent_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = 10.0,
+    ) -> None:
+        """Execute registered session lifecycle hooks.
+
+        Args:
+            hook_name: Lifecycle event name, e.g. ``session.create``
+            session_id: Session identifier
+            agent_id: Agent identifier
+            metadata: Additional event metadata
+            timeout: Optional timeout for async callbacks
+        """
+        event_metadata = metadata or {}
+        for hook in self.get_session_hooks(hook_name):
+            started_at = time.monotonic()
+            try:
+                logger.debug(
+                    f"Executing session hook '{hook.hook_name}' "
+                    f"from plugin '{hook.plugin_id}' "
+                    f"(priority={hook.priority})",
+                )
+                result = hook.callback(
+                    session_id=session_id,
+                    agent_id=agent_id,
+                    metadata=event_metadata,
+                )
+                if inspect.isawaitable(result):
+                    if timeout is None:
+                        await result
+                    else:
+                        await asyncio.wait_for(result, timeout=timeout)
+
+                elapsed = time.monotonic() - started_at
+                logger.debug(
+                    f"Completed session hook '{hook.hook_name}' "
+                    f"from plugin '{hook.plugin_id}' in {elapsed:.3f}s",
+                )
+            except Exception as e:
+                elapsed = time.monotonic() - started_at
+                logger.error(
+                    f"Failed to execute session hook '{hook.hook_name}' "
+                    f"from plugin '{hook.plugin_id}' after "
+                    f"{elapsed:.3f}s: {e}",
+                    exc_info=True,
+                )
 
     def register_control_command(
         self,
@@ -494,6 +596,9 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         ]
         self._shutdown_hooks = [
             h for h in self._shutdown_hooks if h.plugin_id != plugin_id
+        ]
+        self._session_hooks = [
+            h for h in self._session_hooks if h.plugin_id != plugin_id
         ]
         self._control_commands = [
             c for c in self._control_commands if c.plugin_id != plugin_id

--- a/tests/unit/plugins/test_session_hooks.py
+++ b/tests/unit/plugins/test_session_hooks.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Regression tests for plugin session lifecycle hooks."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.app.runner.manager import ChatManager
+from qwenpaw.app.runner.repo.json_repo import JsonChatRepository
+from qwenpaw.plugins.api import PluginApi
+from qwenpaw.plugins.registry import PluginRegistry
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_registry():
+    """Isolate PluginRegistry singleton state between tests."""
+    PluginRegistry._instance = None
+    yield
+    PluginRegistry._instance = None
+
+
+async def test_session_hooks_run_in_priority_order_for_sync_and_async():
+    """Session hooks should support sync/async callbacks in priority order."""
+    registry = PluginRegistry()
+    calls = []
+
+    def sync_callback(*, session_id, agent_id, metadata):
+        calls.append(("sync", session_id, agent_id, metadata["source"]))
+
+    async def async_callback(*, session_id, agent_id, metadata):
+        calls.append(("async", session_id, agent_id, metadata["source"]))
+
+    registry.register_session_hook(
+        "sync-plugin",
+        "session.create",
+        sync_callback,
+        priority=20,
+    )
+    registry.register_session_hook(
+        "async-plugin",
+        "session.create",
+        async_callback,
+        priority=10,
+    )
+
+    await registry.emit_session_event(
+        "session.create",
+        session_id="console:user-1",
+        agent_id="agent-a",
+        metadata={"source": "unit-test"},
+    )
+
+    assert calls == [
+        ("async", "console:user-1", "agent-a", "unit-test"),
+        ("sync", "console:user-1", "agent-a", "unit-test"),
+    ]
+
+
+async def test_plugin_api_registers_session_hook():
+    """PluginApi should expose session hook registration to plugins."""
+    registry = PluginRegistry()
+    api = PluginApi("session-plugin", {})
+    api.set_registry(registry)
+    calls = []
+
+    async def on_session_create(*, session_id, agent_id, metadata):
+        calls.append((session_id, agent_id, metadata["chat_id"]))
+
+    api.register_session_hook(
+        hook_name="session.create",
+        callback=on_session_create,
+        priority=50,
+    )
+
+    hooks = registry.get_session_hooks("session.create")
+    assert len(hooks) == 1
+    assert hooks[0].plugin_id == "session-plugin"
+
+    await registry.emit_session_event(
+        "session.create",
+        session_id="console:user-2",
+        agent_id="agent-b",
+        metadata={"chat_id": "chat-2"},
+    )
+
+    assert calls == [("console:user-2", "agent-b", "chat-2")]
+
+
+async def test_chat_manager_emits_session_create_once_for_new_chat(
+    tmp_path: Path,
+):
+    """Auto-registration should emit session.create only for new chats."""
+    registry = PluginRegistry()
+    calls = []
+
+    def on_session_create(**payload):
+        calls.append(payload)
+
+    registry.register_session_hook(
+        "audit-plugin",
+        "session.create",
+        on_session_create,
+        priority=100,
+    )
+    chat_manager = ChatManager(
+        repo=JsonChatRepository(tmp_path / "chats.json"),
+        agent_id="agent-c",
+    )
+
+    chat = await chat_manager.get_or_create_chat(
+        session_id="console:user-3",
+        user_id="user-3",
+        channel="console",
+        name="New Chat",
+    )
+    existing = await chat_manager.get_or_create_chat(
+        session_id="console:user-3",
+        user_id="user-3",
+        channel="console",
+        name="New Chat",
+    )
+
+    assert existing.id == chat.id
+    assert len(calls) == 1
+    assert calls[0]["session_id"] == "console:user-3"
+    assert calls[0]["agent_id"] == "agent-c"
+    assert calls[0]["metadata"]["chat_id"] == chat.id
+    assert calls[0]["metadata"]["chat_name"] == "New Chat"


### PR DESCRIPTION
## Summary
- add plugin registry and PluginApi support for session lifecycle hooks
- emit session.create when ChatManager creates a new chat session
- pass agent/session/chat metadata to hooks and cover sync/async callbacks with tests

## Tests
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\plugins\\test_session_hooks.py -q
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\app\\test_chat_updates.py -q
- flake8 src\\qwenpaw\\plugins\\api.py src\\qwenpaw\\plugins\\registry.py src\\qwenpaw\\app\\runner\\manager.py src\\qwenpaw\\app\\workspace\\service_factories.py tests\\unit\\plugins\\test_session_hooks.py
- pylint src\\qwenpaw\\plugins\\api.py src\\qwenpaw\\plugins\\registry.py src\\qwenpaw\\app\\runner\\manager.py src\\qwenpaw\\app\\workspace\\service_factories.py tests\\unit\\plugins\\test_session_hooks.py --disable=all --enable=syntax-error,undefined-variable,unused-import,mixed-line-endings
- git diff --check

Closes #4249