### PR TITLE
fix(shell): inject request context into subprocess env

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -23,6 +23,7 @@ from ...config.context import (
     get_current_shell_command_timeout,
     get_current_workspace_dir,
 )
+from .shell_context import get_shell_command_context_env
 
 
 def _kill_process_tree_win32(pid: int) -> None:
@@ -180,6 +181,21 @@ def _is_powershell(executable: str) -> bool:
 def _is_cmd(executable: str) -> bool:
     """Check if the given executable path is cmd.exe."""
     return _shell_basename(executable) in ("cmd", "cmd.exe")
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    """Build the environment passed to shell subprocesses."""
+    env = os.environ.copy()
+    env.update(get_shell_command_context_env())
+
+    # Ensure the venv Python is on PATH for subprocesses
+    python_bin_dir = str(Path(sys.executable).parent)
+    existing_path = env.get("PATH", "")
+    if existing_path:
+        env["PATH"] = python_bin_dir + os.pathsep + existing_path
+    else:
+        env["PATH"] = python_bin_dir
+    return env
 
 
 _PS_CMD_RE = re.compile(
@@ -403,14 +419,7 @@ async def execute_shell_command(
     else:
         working_dir = get_current_workspace_dir() or WORKING_DIR
 
-    # Ensure the venv Python is on PATH for subprocesses
-    env = os.environ.copy()
-    python_bin_dir = str(Path(sys.executable).parent)
-    existing_path = env.get("PATH", "")
-    if existing_path:
-        env["PATH"] = python_bin_dir + os.pathsep + existing_path
-    else:
-        env["PATH"] = python_bin_dir
+    env = _build_subprocess_env()
 
     shell_executable = (
         get_current_shell_command_executable()

--- a/src/qwenpaw/agents/tools/shell_context.py
+++ b/src/qwenpaw/agents/tools/shell_context.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Per-request shell subprocess context."""
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from typing import Mapping, Optional
+
+
+_SHELL_CONTEXT: ContextVar[dict[str, str]] = ContextVar(
+    "qwenpaw_shell_context",
+    default={},
+)
+
+_ENV_MAPPING = {
+    "user_id": "QWENPAW_USER_ID",
+    "session_id": "QWENPAW_SESSION_ID",
+    "channel": "QWENPAW_CHANNEL",
+    "room_id": "QWENPAW_ROOM_ID",
+    "event_id": "QWENPAW_EVENT_ID",
+}
+
+
+def _normalize_shell_context(
+    context: Optional[Mapping[str, object]],
+) -> dict[str, str]:
+    """Keep only non-empty context values that can be exported as env."""
+    normalized: dict[str, str] = {}
+    for key in _ENV_MAPPING:
+        value = (context or {}).get(key)
+        if value is None:
+            continue
+        text = str(value)
+        if text:
+            normalized[key] = text
+    return normalized
+
+
+def set_shell_command_context(
+    context: Optional[Mapping[str, object]],
+) -> Token[dict[str, str]]:
+    """Set the current request context for shell subprocess env injection."""
+    return _SHELL_CONTEXT.set(_normalize_shell_context(context))
+
+
+def reset_shell_command_context(token: Token[dict[str, str]]) -> None:
+    """Restore the previous shell subprocess context."""
+    _SHELL_CONTEXT.reset(token)
+
+
+def get_shell_command_context_env() -> dict[str, str]:
+    """Return QwenPaw env vars for the current shell subprocess context."""
+    context = _SHELL_CONTEXT.get()
+    return {
+        env_key: context[context_key]
+        for context_key, env_key in _ENV_MAPPING.items()
+        if context.get(context_key)
+    }

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -88,10 +88,7 @@ async def _stream_printing_messages_interruptible(
     try:
         while True:
             printing_msg = await queue.get()
-            if (
-                isinstance(printing_msg, str)
-                and printing_msg == _PRINT_END_SIGNAL
-            ):
+            if isinstance(printing_msg, str) and printing_msg == _PRINT_END_SIGNAL:
                 break
             msg, last, _ = printing_msg
             yield msg, last
@@ -116,9 +113,7 @@ class AgentRunner(Runner):
         super().__init__()
         self.framework_type = "agentscope"
         self.agent_id = agent_id  # Store agent_id for config loading
-        self.workspace_dir = (
-            workspace_dir  # Store workspace_dir for prompt building
-        )
+        self.workspace_dir = workspace_dir  # Store workspace_dir for prompt building
         self._chat_manager = None  # Store chat_manager reference
         self._mcp_manager = None  # MCP client manager for hot-reload
         self._workspace: Any = None  # Workspace instance for control commands
@@ -189,7 +184,7 @@ class AgentRunner(Runner):
             if close < 0:
                 return None
             name = rest[1:close].strip().lower()
-            user_input = rest[close + 1:].strip()
+            user_input = rest[close + 1 :].strip()
             return (name, user_input) if name else None
 
         # /name input — plain form
@@ -225,11 +220,7 @@ class AgentRunner(Runner):
 
         # Lookup by folder name
         skill = next(
-            (
-                s
-                for s in skills.values()
-                if Path(s["dir"]).name.lower() == name
-            ),
+            (s for s in skills.values() if Path(s["dir"]).name.lower() == name),
             None,
         )
         if not skill:
@@ -388,9 +379,7 @@ class AgentRunner(Runner):
             # Load agent-specific configuration
             agent_config = load_agent_config(self.agent_id)
 
-            _configured_shell = (
-                agent_config.running.shell_command_executable or None
-            )
+            _configured_shell = agent_config.running.shell_command_executable or None
             _default_shell = (
                 _configured_shell
                 or os.environ.get("SHELL")
@@ -402,9 +391,7 @@ class AgentRunner(Runner):
                 user_name=user_name,
                 channel=channel,
                 working_dir=(
-                    str(self.workspace_dir)
-                    if self.workspace_dir
-                    else str(WORKING_DIR)
+                    str(self.workspace_dir) if self.workspace_dir else str(WORKING_DIR)
                 ),
                 default_shell=_default_shell,
             )
@@ -760,18 +747,18 @@ class AgentRunner(Runner):
             from ..approvals.service import get_approval_service
 
             approval_svc = get_approval_service()
-            cancelled_count = (
-                await approval_svc.cancel_all_pending_by_root_session(
-                    root_session_id,
-                )
+            cancelled_count = await approval_svc.cancel_all_pending_by_root_session(
+                root_session_id,
             )
             if cancelled_count > 0:
                 logger.info(
                     "Auto-denied %d pending approval(s) for root session %s",
                     cancelled_count,
-                    root_session_id[:8]
-                    if len(root_session_id) >= 8
-                    else root_session_id,
+                    (
+                        root_session_id[:8]
+                        if len(root_session_id) >= 8
+                        else root_session_id
+                    ),
                 )
 
             if agent is not None:
@@ -792,9 +779,7 @@ class AgentRunner(Runner):
                 exc=converted,
                 locals_=locals(),
             )
-            path_hint = (
-                f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
-            )
+            path_hint = f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
             logger.exception(f"Error in query handler: {converted}{path_hint}")
             if debug_dump_path:
                 setattr(converted, "debug_dump_path", debug_dump_path)
@@ -809,9 +794,9 @@ class AgentRunner(Runner):
                 ):
                     converted.message += suffix
                 elif converted.args:
-                    converted.args = (
-                        f"{converted.args[0]}{suffix}",
-                    ) + converted.args[1:]
+                    converted.args = (f"{converted.args[0]}{suffix}",) + converted.args[
+                        1:
+                    ]
             raise converted from e
         finally:
             if shell_context_token is not None:
@@ -845,8 +830,7 @@ class AgentRunner(Runner):
             )
 
         session_dir = str(
-            (self.workspace_dir if self.workspace_dir else WORKING_DIR)
-            / "sessions",
+            (self.workspace_dir if self.workspace_dir else WORKING_DIR) / "sessions",
         )
         self.session = SafeJSONSession(save_dir=session_dir)
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -88,7 +88,10 @@ async def _stream_printing_messages_interruptible(
     try:
         while True:
             printing_msg = await queue.get()
-            if isinstance(printing_msg, str) and printing_msg == _PRINT_END_SIGNAL:
+            if (
+                isinstance(printing_msg, str)
+                and printing_msg == _PRINT_END_SIGNAL
+            ):
                 break
             msg, last, _ = printing_msg
             yield msg, last
@@ -113,7 +116,9 @@ class AgentRunner(Runner):
         super().__init__()
         self.framework_type = "agentscope"
         self.agent_id = agent_id  # Store agent_id for config loading
-        self.workspace_dir = workspace_dir  # Store workspace_dir for prompt building
+        self.workspace_dir = (
+            workspace_dir  # Store workspace_dir for prompt building
+        )
         self._chat_manager = None  # Store chat_manager reference
         self._mcp_manager = None  # MCP client manager for hot-reload
         self._workspace: Any = None  # Workspace instance for control commands
@@ -220,7 +225,11 @@ class AgentRunner(Runner):
 
         # Lookup by folder name
         skill = next(
-            (s for s in skills.values() if Path(s["dir"]).name.lower() == name),
+            (
+                s
+                for s in skills.values()
+                if Path(s["dir"]).name.lower() == name
+            ),
             None,
         )
         if not skill:
@@ -379,7 +388,9 @@ class AgentRunner(Runner):
             # Load agent-specific configuration
             agent_config = load_agent_config(self.agent_id)
 
-            _configured_shell = agent_config.running.shell_command_executable or None
+            _configured_shell = (
+                agent_config.running.shell_command_executable or None
+            )
             _default_shell = (
                 _configured_shell
                 or os.environ.get("SHELL")
@@ -391,7 +402,9 @@ class AgentRunner(Runner):
                 user_name=user_name,
                 channel=channel,
                 working_dir=(
-                    str(self.workspace_dir) if self.workspace_dir else str(WORKING_DIR)
+                    str(self.workspace_dir)
+                    if self.workspace_dir
+                    else str(WORKING_DIR)
                 ),
                 default_shell=_default_shell,
             )
@@ -747,8 +760,10 @@ class AgentRunner(Runner):
             from ..approvals.service import get_approval_service
 
             approval_svc = get_approval_service()
-            cancelled_count = await approval_svc.cancel_all_pending_by_root_session(
-                root_session_id,
+            cancelled_count = (
+                await approval_svc.cancel_all_pending_by_root_session(
+                    root_session_id,
+                )
             )
             if cancelled_count > 0:
                 logger.info(
@@ -779,7 +794,9 @@ class AgentRunner(Runner):
                 exc=converted,
                 locals_=locals(),
             )
-            path_hint = f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
+            path_hint = (
+                f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
+            )
             logger.exception(f"Error in query handler: {converted}{path_hint}")
             if debug_dump_path:
                 setattr(converted, "debug_dump_path", debug_dump_path)
@@ -794,9 +811,9 @@ class AgentRunner(Runner):
                 ):
                     converted.message += suffix
                 elif converted.args:
-                    converted.args = (f"{converted.args[0]}{suffix}",) + converted.args[
-                        1:
-                    ]
+                    converted.args = (
+                        f"{converted.args[0]}{suffix}",
+                    ) + converted.args[1:]
             raise converted from e
         finally:
             if shell_context_token is not None:
@@ -830,7 +847,8 @@ class AgentRunner(Runner):
             )
 
         session_dir = str(
-            (self.workspace_dir if self.workspace_dir else WORKING_DIR) / "sessions",
+            (self.workspace_dir if self.workspace_dir else WORKING_DIR)
+            / "sessions",
         )
         self.session = SafeJSONSession(save_dir=session_dir)
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -189,7 +189,7 @@ class AgentRunner(Runner):
             if close < 0:
                 return None
             name = rest[1:close].strip().lower()
-            user_input = rest[close + 1 :].strip()
+            user_input = rest[close + 1:].strip()
             return (name, user_input) if name else None
 
         # /name input — plain form
@@ -336,6 +336,10 @@ class AgentRunner(Runner):
             set_current_session_id,
             set_current_root_session_id,
         )
+        from ...agents.tools.shell_context import (
+            reset_shell_command_context,
+            set_shell_command_context,
+        )
 
         set_current_agent_id(self.agent_id)
 
@@ -345,6 +349,7 @@ class AgentRunner(Runner):
         agent = None
         chat = None
         session_state_loaded = False
+        shell_context_token = None
         try:
             session_id = request.session_id
             user_id = request.user_id
@@ -370,6 +375,15 @@ class AgentRunner(Runner):
             if not isinstance(channel_meta, dict):
                 channel_meta = {}
             user_name = channel_meta.get("user_name")
+
+            shell_context = {
+                "session_id": session_id,
+                "user_id": channel_meta.get("sender_id") or user_id,
+                "channel": channel,
+                "room_id": channel_meta.get("room_id"),
+                "event_id": channel_meta.get("event_id"),
+            }
+            shell_context_token = set_shell_command_context(shell_context)
 
             # Load agent-specific configuration
             agent_config = load_agent_config(self.agent_id)
@@ -800,6 +814,9 @@ class AgentRunner(Runner):
                     ) + converted.args[1:]
             raise converted from e
         finally:
+            if shell_context_token is not None:
+                reset_shell_command_context(shell_context_token)
+
             if agent is not None and session_state_loaded:
                 await self.session.save_session_state(
                     session_id=session_id,

--- a/tests/unit/agents/tools/test_shell_context.py
+++ b/tests/unit/agents/tools/test_shell_context.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Regression tests for per-request shell subprocess context."""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from qwenpaw.agents.tools.shell import _build_subprocess_env
+from qwenpaw.agents.tools.shell_context import (
+    get_shell_command_context_env,
+    reset_shell_command_context,
+    set_shell_command_context,
+)
+
+
+def test_shell_context_env_overrides_process_env(monkeypatch):
+    """Per-request shell context should be exported to subprocess env."""
+    monkeypatch.setenv("PATH", "base-path")
+    monkeypatch.setenv("QWENPAW_USER_ID", "process-user")
+
+    token = set_shell_command_context(
+        {
+            "user_id": "@alice:example.org",
+            "session_id": "matrix:!room",
+            "channel": "matrix",
+            "room_id": "!room",
+            "event_id": "$event",
+        },
+    )
+    try:
+        env = _build_subprocess_env()
+    finally:
+        reset_shell_command_context(token)
+
+    assert env["QWENPAW_USER_ID"] == "@alice:example.org"
+    assert env["QWENPAW_SESSION_ID"] == "matrix:!room"
+    assert env["QWENPAW_CHANNEL"] == "matrix"
+    assert env["QWENPAW_ROOM_ID"] == "!room"
+    assert env["QWENPAW_EVENT_ID"] == "$event"
+    assert env["PATH"].startswith(
+        str(Path(sys.executable).parent) + os.pathsep,
+    )
+
+
+def test_shell_context_skips_empty_optional_values():
+    """Optional room/event fields should be unset when unavailable."""
+    token = set_shell_command_context(
+        {
+            "user_id": "console-user",
+            "session_id": "console:console-user",
+            "channel": "console",
+            "room_id": "",
+            "event_id": None,
+        },
+    )
+    try:
+        env = get_shell_command_context_env()
+    finally:
+        reset_shell_command_context(token)
+
+    assert env == {
+        "QWENPAW_USER_ID": "console-user",
+        "QWENPAW_SESSION_ID": "console:console-user",
+        "QWENPAW_CHANNEL": "console",
+    }
+
+
+async def test_shell_context_is_isolated_across_concurrent_tasks():
+    """Concurrent requests must not see each other's attribution values."""
+
+    async def collect(user_id: str) -> str:
+        token = set_shell_command_context(
+            {
+                "user_id": user_id,
+                "session_id": f"console:{user_id}",
+                "channel": "console",
+            },
+        )
+        try:
+            await asyncio.sleep(0)
+            return get_shell_command_context_env()["QWENPAW_USER_ID"]
+        finally:
+            reset_shell_command_context(token)
+
+    assert await asyncio.gather(collect("user-a"), collect("user-b")) == [
+        "user-a",
+        "user-b",
+    ]
+    assert get_shell_command_context_env() == {}


### PR DESCRIPTION
## Description
This PR fixes #3825 by injecting runtime request context into shell subprocess environments. The runner now provides per-call attribution as `QWENPAW_*` env vars, so downstream skill scripts can reliably audit the originating user/session/channel without trusting LLM-spliced shell arguments.

## Type of Change
- Bug fix
- Feature enhancement

## Component(s) Affected
- Core
- Skills
- Tests

## Summary
- add a per-request shell contextvar that maps runtime attribution to `QWENPAW_*` env vars
- set shell context from `AgentRunner` using session/user/channel plus optional `room_id` and `event_id` metadata
- merge the context env into `execute_shell_command` subprocess environments while preserving the venv PATH prepend
- cover fallback, optional metadata, and concurrent context isolation with unit tests

## Testing
Local verification:
```bash
PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\tools\test_shell_context.py -q
flake8 src\qwenpaw\agents\tools\shell.py src\qwenpaw\agents\tools\shell_context.py src\qwenpaw\app\runner\runner.py tests\unit\agents\tools\test_shell_context.py
pylint src\qwenpaw\agents\tools\shell.py src\qwenpaw\agents\tools\shell_context.py src\qwenpaw\app\runner\runner.py tests\unit\agents\tools\test_shell_context.py --disable=all --enable=syntax-error,undefined-variable,unused-import,mixed-line-endings
git diff --check
```

GitHub Actions currently passing:
- Pre-commit Checks
- Unit Tests - py3.10
- Unit Tests - py3.13
- Coverage Report
- website format check
- console format check

## Checklist
- [x] Read README and contributing guidance before implementation
- [x] Added focused unit coverage
- [x] Ran relevant local tests/lint checks
- [x] Confirmed existing CI checks pass
- [x] Documentation update not required; this is runtime env behavior for shell subprocesses

Closes #3825