### PR TITLE
fix(session): preserve initial chat messages before final save

### DIFF
--- a/src/qwenpaw/app/runner/api.py
+++ b/src/qwenpaw/app/runner/api.py
@@ -19,6 +19,14 @@ from .utils import agentscope_msg_to_message
 router = APIRouter(prefix="/chats", tags=["chats"])
 
 
+def _get_initial_messages(state: dict) -> list[dict]:
+    """Return placeholder messages captured before final session save."""
+    initial_messages = state.get("_initial_messages")
+    if not isinstance(initial_messages, list):
+        return []
+    return [msg for msg in initial_messages if isinstance(msg, dict)]
+
+
 async def get_workspace(request: Request):
     """Get the workspace for the active agent."""
     from ..agent_context import get_agent_for_request
@@ -168,11 +176,15 @@ async def get_chat(
     if not state:
         return ChatHistory(messages=[], status=status)
     memory_state = state.get("agent", {}).get("memory", {})
-    memory = InMemoryMemory()
-    memory.load_state_dict(memory_state, strict=False)
+    messages = []
+    if memory_state:
+        memory = InMemoryMemory()
+        memory.load_state_dict(memory_state, strict=False)
 
-    memories = await memory.get_memory(prepend_summary=False)
-    messages = agentscope_msg_to_message(memories)
+        memories = await memory.get_memory(prepend_summary=False)
+        messages = agentscope_msg_to_message(memories)
+    if not messages:
+        messages = _get_initial_messages(state)
     return ChatHistory(messages=messages, status=status)
 
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -88,7 +88,10 @@ async def _stream_printing_messages_interruptible(
     try:
         while True:
             printing_msg = await queue.get()
-            if isinstance(printing_msg, str) and printing_msg == _PRINT_END_SIGNAL:
+            if (
+                isinstance(printing_msg, str)
+                and printing_msg == _PRINT_END_SIGNAL
+            ):
                 break
             msg, last, _ = printing_msg
             yield msg, last
@@ -113,7 +116,9 @@ class AgentRunner(Runner):
         super().__init__()
         self.framework_type = "agentscope"
         self.agent_id = agent_id  # Store agent_id for config loading
-        self.workspace_dir = workspace_dir  # Store workspace_dir for prompt building
+        self.workspace_dir = (
+            workspace_dir  # Store workspace_dir for prompt building
+        )
         self._chat_manager = None  # Store chat_manager reference
         self._mcp_manager = None  # MCP client manager for hot-reload
         self._workspace: Any = None  # Workspace instance for control commands
@@ -220,7 +225,11 @@ class AgentRunner(Runner):
 
         # Lookup by folder name
         skill = next(
-            (s for s in skills.values() if Path(s["dir"]).name.lower() == name),
+            (
+                s
+                for s in skills.values()
+                if Path(s["dir"]).name.lower() == name
+            ),
             None,
         )
         if not skill:
@@ -365,7 +374,9 @@ class AgentRunner(Runner):
             # Load agent-specific configuration
             agent_config = load_agent_config(self.agent_id)
 
-            _configured_shell = agent_config.running.shell_command_executable or None
+            _configured_shell = (
+                agent_config.running.shell_command_executable or None
+            )
             _default_shell = (
                 _configured_shell
                 or os.environ.get("SHELL")
@@ -377,7 +388,9 @@ class AgentRunner(Runner):
                 user_name=user_name,
                 channel=channel,
                 working_dir=(
-                    str(self.workspace_dir) if self.workspace_dir else str(WORKING_DIR)
+                    str(self.workspace_dir)
+                    if self.workspace_dir
+                    else str(WORKING_DIR)
                 ),
                 default_shell=_default_shell,
             )
@@ -743,8 +756,10 @@ class AgentRunner(Runner):
             from ..approvals.service import get_approval_service
 
             approval_svc = get_approval_service()
-            cancelled_count = await approval_svc.cancel_all_pending_by_root_session(
-                root_session_id,
+            cancelled_count = (
+                await approval_svc.cancel_all_pending_by_root_session(
+                    root_session_id,
+                )
             )
             if cancelled_count > 0:
                 logger.info(
@@ -775,7 +790,9 @@ class AgentRunner(Runner):
                 exc=converted,
                 locals_=locals(),
             )
-            path_hint = f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
+            path_hint = (
+                f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
+            )
             logger.exception(f"Error in query handler: {converted}{path_hint}")
             if debug_dump_path:
                 setattr(converted, "debug_dump_path", debug_dump_path)
@@ -790,9 +807,9 @@ class AgentRunner(Runner):
                 ):
                     converted.message += suffix
                 elif converted.args:
-                    converted.args = (f"{converted.args[0]}{suffix}",) + converted.args[
-                        1:
-                    ]
+                    converted.args = (
+                        f"{converted.args[0]}{suffix}",
+                    ) + converted.args[1:]
             raise converted from e
         finally:
             if agent is not None and session_state_loaded:
@@ -823,7 +840,8 @@ class AgentRunner(Runner):
             )
 
         session_dir = str(
-            (self.workspace_dir if self.workspace_dir else WORKING_DIR) / "sessions",
+            (self.workspace_dir if self.workspace_dir else WORKING_DIR)
+            / "sessions",
         )
         self.session = SafeJSONSession(save_dir=session_dir)
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -88,10 +88,7 @@ async def _stream_printing_messages_interruptible(
     try:
         while True:
             printing_msg = await queue.get()
-            if (
-                isinstance(printing_msg, str)
-                and printing_msg == _PRINT_END_SIGNAL
-            ):
+            if isinstance(printing_msg, str) and printing_msg == _PRINT_END_SIGNAL:
                 break
             msg, last, _ = printing_msg
             yield msg, last
@@ -116,9 +113,7 @@ class AgentRunner(Runner):
         super().__init__()
         self.framework_type = "agentscope"
         self.agent_id = agent_id  # Store agent_id for config loading
-        self.workspace_dir = (
-            workspace_dir  # Store workspace_dir for prompt building
-        )
+        self.workspace_dir = workspace_dir  # Store workspace_dir for prompt building
         self._chat_manager = None  # Store chat_manager reference
         self._mcp_manager = None  # MCP client manager for hot-reload
         self._workspace: Any = None  # Workspace instance for control commands
@@ -189,7 +184,7 @@ class AgentRunner(Runner):
             if close < 0:
                 return None
             name = rest[1:close].strip().lower()
-            user_input = rest[close + 1:].strip()
+            user_input = rest[close + 1 :].strip()
             return (name, user_input) if name else None
 
         # /name input — plain form
@@ -225,11 +220,7 @@ class AgentRunner(Runner):
 
         # Lookup by folder name
         skill = next(
-            (
-                s
-                for s in skills.values()
-                if Path(s["dir"]).name.lower() == name
-            ),
+            (s for s in skills.values() if Path(s["dir"]).name.lower() == name),
             None,
         )
         if not skill:
@@ -374,9 +365,7 @@ class AgentRunner(Runner):
             # Load agent-specific configuration
             agent_config = load_agent_config(self.agent_id)
 
-            _configured_shell = (
-                agent_config.running.shell_command_executable or None
-            )
+            _configured_shell = agent_config.running.shell_command_executable or None
             _default_shell = (
                 _configured_shell
                 or os.environ.get("SHELL")
@@ -388,9 +377,7 @@ class AgentRunner(Runner):
                 user_name=user_name,
                 channel=channel,
                 working_dir=(
-                    str(self.workspace_dir)
-                    if self.workspace_dir
-                    else str(WORKING_DIR)
+                    str(self.workspace_dir) if self.workspace_dir else str(WORKING_DIR)
                 ),
                 default_shell=_default_shell,
             )
@@ -756,18 +743,18 @@ class AgentRunner(Runner):
             from ..approvals.service import get_approval_service
 
             approval_svc = get_approval_service()
-            cancelled_count = (
-                await approval_svc.cancel_all_pending_by_root_session(
-                    root_session_id,
-                )
+            cancelled_count = await approval_svc.cancel_all_pending_by_root_session(
+                root_session_id,
             )
             if cancelled_count > 0:
                 logger.info(
                     "Auto-denied %d pending approval(s) for root session %s",
                     cancelled_count,
-                    root_session_id[:8]
-                    if len(root_session_id) >= 8
-                    else root_session_id,
+                    (
+                        root_session_id[:8]
+                        if len(root_session_id) >= 8
+                        else root_session_id
+                    ),
                 )
 
             if agent is not None:
@@ -788,9 +775,7 @@ class AgentRunner(Runner):
                 exc=converted,
                 locals_=locals(),
             )
-            path_hint = (
-                f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
-            )
+            path_hint = f"\n(Details:  {debug_dump_path})" if debug_dump_path else ""
             logger.exception(f"Error in query handler: {converted}{path_hint}")
             if debug_dump_path:
                 setattr(converted, "debug_dump_path", debug_dump_path)
@@ -805,9 +790,9 @@ class AgentRunner(Runner):
                 ):
                     converted.message += suffix
                 elif converted.args:
-                    converted.args = (
-                        f"{converted.args[0]}{suffix}",
-                    ) + converted.args[1:]
+                    converted.args = (f"{converted.args[0]}{suffix}",) + converted.args[
+                        1:
+                    ]
             raise converted from e
         finally:
             if agent is not None and session_state_loaded:
@@ -838,8 +823,7 @@ class AgentRunner(Runner):
             )
 
         session_dir = str(
-            (self.workspace_dir if self.workspace_dir else WORKING_DIR)
-            / "sessions",
+            (self.workspace_dir if self.workspace_dir else WORKING_DIR) / "sessions",
         )
         self.session = SafeJSONSession(save_dir=session_dir)
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -31,7 +31,7 @@ from .mission_dispatch import (
     detect_active_mission_phase,
 )
 from .session import SafeJSONSession
-from .utils import build_env_context
+from .utils import agentscope_msg_to_message, build_env_context
 from ..channels.schema import DEFAULT_CHANNEL
 from ...agents.react_agent import QwenPawAgent
 from ...exceptions import convert_model_exception
@@ -189,7 +189,7 @@ class AgentRunner(Runner):
             if close < 0:
                 return None
             name = rest[1:close].strip().lower()
-            user_input = rest[close + 1 :].strip()
+            user_input = rest[close + 1:].strip()
             return (name, user_input) if name else None
 
         # /name input — plain form
@@ -627,6 +627,16 @@ class AgentRunner(Runner):
                     user_id,
                     channel,
                     name=name,
+                )
+                initial_messages = [
+                    message.model_dump(mode="json")
+                    for message in agentscope_msg_to_message(msgs)
+                ]
+                await self.session.ensure_session_placeholder(
+                    session_id=session_id,
+                    user_id=user_id,
+                    channel=channel,
+                    initial_messages=initial_messages,
                 )
                 logger.debug(f"Runner: Got chat: {chat.id}")
             else:

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -181,7 +181,9 @@ def _rewrite_weixin_in_session_filename(name: str) -> str | None:
     if idx >= 0:
         safe_uid = stem[:idx]
         safe_sid_tail = stem[idx + len(delim) :]
-        return f"{safe_uid}_{_CANONICAL_WECHAT_SAFE_PREFIX}{safe_sid_tail}.json"
+        return (
+            f"{safe_uid}_{_CANONICAL_WECHAT_SAFE_PREFIX}{safe_sid_tail}.json"
+        )
     if stem.startswith(_LEGACY_WEIXIN_SAFE_PREFIX):
         return (
             _CANONICAL_WECHAT_SAFE_PREFIX

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -180,14 +180,12 @@ def _rewrite_weixin_in_session_filename(name: str) -> str | None:
     idx = stem.find(delim)
     if idx >= 0:
         safe_uid = stem[:idx]
-        safe_sid_tail = stem[idx + len(delim):]
-        return (
-            f"{safe_uid}_{_CANONICAL_WECHAT_SAFE_PREFIX}{safe_sid_tail}.json"
-        )
+        safe_sid_tail = stem[idx + len(delim) :]
+        return f"{safe_uid}_{_CANONICAL_WECHAT_SAFE_PREFIX}{safe_sid_tail}.json"
     if stem.startswith(_LEGACY_WEIXIN_SAFE_PREFIX):
         return (
             _CANONICAL_WECHAT_SAFE_PREFIX
-            + stem[len(_LEGACY_WEIXIN_SAFE_PREFIX):]
+            + stem[len(_LEGACY_WEIXIN_SAFE_PREFIX) :]
             + ".json"
         )
     return None

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -180,14 +180,14 @@ def _rewrite_weixin_in_session_filename(name: str) -> str | None:
     idx = stem.find(delim)
     if idx >= 0:
         safe_uid = stem[:idx]
-        safe_sid_tail = stem[idx + len(delim) :]
+        safe_sid_tail = stem[idx + len(delim):]
         return (
             f"{safe_uid}_{_CANONICAL_WECHAT_SAFE_PREFIX}{safe_sid_tail}.json"
         )
     if stem.startswith(_LEGACY_WEIXIN_SAFE_PREFIX):
         return (
             _CANONICAL_WECHAT_SAFE_PREFIX
-            + stem[len(_LEGACY_WEIXIN_SAFE_PREFIX) :]
+            + stem[len(_LEGACY_WEIXIN_SAFE_PREFIX):]
             + ".json"
         )
     return None
@@ -296,6 +296,48 @@ class SafeJSONSession(SessionBase):
             "Saved session state to %s successfully.",
             session_save_path,
         )
+
+    async def ensure_session_placeholder(
+        self,
+        session_id: str,
+        user_id: str = "",
+        channel: str = "",
+        initial_messages: list[dict] | None = None,
+    ) -> bool:
+        """Create a lightweight session file if none exists yet.
+
+        The normal final ``save_session_state`` call overwrites this
+        placeholder after the agent run completes. If the process exits before
+        that final save, the chat API can still recover the initial user
+        request instead of showing an empty orphan chat.
+        """
+        session_save_path = self._get_save_path(
+            session_id,
+            user_id=user_id,
+            channel=channel,
+        )
+        if os.path.exists(session_save_path):
+            return False
+
+        state: dict = {}
+        if initial_messages:
+            state["_initial_messages"] = initial_messages
+
+        try:
+            with open(
+                session_save_path,
+                "x",
+                encoding="utf-8",
+            ) as f:
+                f.write(json.dumps(state, ensure_ascii=False))
+        except FileExistsError:
+            return False
+
+        logger.info(
+            "Created session placeholder at %s.",
+            session_save_path,
+        )
+        return True
 
     async def load_session_state(
         self,

--- a/tests/unit/agents/test_session.py
+++ b/tests/unit/agents/test_session.py
@@ -188,6 +188,40 @@ async def test_get_nonexistent(sess):
 
 
 @pytest.mark.asyncio
+async def test_ensure_session_placeholder_preserves_initial_messages(sess):
+    """Placeholder sessions should keep the initial request recoverable."""
+    initial_messages = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+        },
+    ]
+
+    created = await sess.ensure_session_placeholder(
+        "console:alice",
+        user_id="alice",
+        channel="console",
+        initial_messages=initial_messages,
+    )
+    created_again = await sess.ensure_session_placeholder(
+        "console:alice",
+        user_id="alice",
+        channel="console",
+        initial_messages=[{"role": "assistant"}],
+    )
+
+    state = await sess.get_session_state_dict(
+        "console:alice",
+        user_id="alice",
+        channel="console",
+    )
+    assert created is True
+    assert created_again is False
+    assert state["_initial_messages"] == initial_messages
+
+
+@pytest.mark.asyncio
 async def test_load_completely_corrupted(sess, tmp_session_dir):
     """File with no valid JSON at all should not crash (returns empty)."""
     path = os.path.join(tmp_session_dir, "test--session.json")

--- a/tests/unit/app/test_chat_orphan_recovery.py
+++ b/tests/unit/app/test_chat_orphan_recovery.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for orphan chat recovery placeholders."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app.runner.api import (
+    get_chat_manager,
+    get_session,
+    get_workspace,
+    router,
+)
+from qwenpaw.app.runner.manager import ChatManager
+from qwenpaw.app.runner.models import ChatSpec
+from qwenpaw.app.runner.repo.json_repo import JsonChatRepository
+from qwenpaw.app.runner.session import SafeJSONSession
+
+
+class FakeTaskTracker:
+    """Minimal task tracker dependency for chat API tests."""
+
+    async def get_status(self, _chat_id: str) -> str:
+        return "idle"
+
+
+class FakeWorkspace:
+    """Minimal workspace dependency for chat API tests."""
+
+    task_tracker = FakeTaskTracker()
+
+
+async def test_get_chat_returns_placeholder_initial_messages(
+    tmp_path: Path,
+) -> None:
+    """A chat with only a placeholder session should not open empty."""
+    chat_manager = ChatManager(
+        repo=JsonChatRepository(tmp_path / "chats.json"),
+    )
+    session = SafeJSONSession(save_dir=str(tmp_path / "sessions"))
+    chat = await chat_manager.create_chat(
+        ChatSpec(
+            id="chat-1",
+            name="Recoverable Chat",
+            session_id="console:alice",
+            user_id="alice",
+            channel="console",
+        ),
+    )
+    await session.ensure_session_placeholder(
+        chat.session_id,
+        user_id=chat.user_id,
+        channel=chat.channel,
+        initial_messages=[
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        ],
+    )
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_chat_manager] = lambda: chat_manager
+    app.dependency_overrides[get_session] = lambda: session
+    app.dependency_overrides[get_workspace] = lambda: FakeWorkspace()
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        response = await client.get(f"/api/chats/{chat.id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "idle"
+    assert body["messages"][0]["role"] == "user"
+    assert body["messages"][0]["content"][0]["text"] == "hello"

--- a/tests/unit/app/test_chat_orphan_recovery.py
+++ b/tests/unit/app/test_chat_orphan_recovery.py
@@ -32,6 +32,11 @@ class FakeWorkspace:
     task_tracker = FakeTaskTracker()
 
 
+def get_fake_workspace() -> FakeWorkspace:
+    """Return a fake workspace dependency."""
+    return FakeWorkspace()
+
+
 async def test_get_chat_returns_placeholder_initial_messages(
     tmp_path: Path,
 ) -> None:
@@ -66,7 +71,7 @@ async def test_get_chat_returns_placeholder_initial_messages(
     app.include_router(router, prefix="/api")
     app.dependency_overrides[get_chat_manager] = lambda: chat_manager
     app.dependency_overrides[get_session] = lambda: session
-    app.dependency_overrides[get_workspace] = lambda: FakeWorkspace()
+    app.dependency_overrides[get_workspace] = get_fake_workspace
     transport = ASGITransport(app=app)
 
     async with AsyncClient(


### PR DESCRIPTION
## Summary
- create a lightweight session placeholder right after a chat is registered
- store initial request messages in the placeholder so interrupted runs do not reopen as empty orphan chats
- let the chat detail API return placeholder messages when final agent memory has not been saved yet

## Tests
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\agents\\test_session.py tests\\unit\\app\\test_chat_orphan_recovery.py -q
- flake8 src\\qwenpaw\\app\\runner\\session.py src\\qwenpaw\\app\\runner\\runner.py src\\qwenpaw\\app\\runner\\api.py tests\\unit\\agents\\test_session.py tests\\unit\\app\\test_chat_orphan_recovery.py
- pylint src\\qwenpaw\\app\\runner\\session.py src\\qwenpaw\\app\\runner\\runner.py src\\qwenpaw\\app\\runner\\api.py tests\\unit\\agents\\test_session.py tests\\unit\\app\\test_chat_orphan_recovery.py --disable=all --enable=syntax-error,undefined-variable,unused-import,mixed-line-endings
- git diff --check

Closes #4151