### PR TITLE
fix(shell): discover local command bins

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -182,6 +182,76 @@ def _is_cmd(executable: str) -> bool:
     return _shell_basename(executable) in ("cmd", "cmd.exe")
 
 
+def _has_node_executable(path: Path) -> bool:
+    """Return True when *path* contains a node executable."""
+    names = ("node.exe", "node.cmd", "node.bat", "node")
+    return any((path / name).exists() for name in names)
+
+
+def _discover_node_bin_dirs(home: Path | None = None) -> list[str]:
+    """Find existing Node.js bin directories from common user installs."""
+    try:
+        home_dir = home or Path.home()
+    except RuntimeError:
+        home_dir = None
+
+    candidates: list[Path] = []
+    if home_dir is not None:
+        candidates.append(home_dir / ".volta" / "bin")
+
+        fnm_root = home_dir / ".local" / "share" / "fnm" / "node-versions"
+        if fnm_root.exists():
+            candidates.extend(
+                sorted(
+                    fnm_root.glob("*/installation/bin"),
+                    reverse=True,
+                ),
+            )
+
+        nvm_root = home_dir / ".nvm" / "versions" / "node"
+        if nvm_root.exists():
+            candidates.extend(
+                sorted(
+                    nvm_root.glob("*/bin"),
+                    reverse=True,
+                ),
+            )
+
+    candidates.extend(
+        [
+            Path("/opt/homebrew/bin"),
+            Path("/usr/local/bin"),
+        ],
+    )
+
+    return [str(path) for path in candidates if _has_node_executable(path)]
+
+
+def _dedupe_path_entries(entries: list[str]) -> list[str]:
+    """Remove duplicate PATH entries while preserving order."""
+    seen = set()
+    deduped = []
+    for entry in entries:
+        if not entry or entry in seen:
+            continue
+        seen.add(entry)
+        deduped.append(entry)
+    return deduped
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    """Build the environment passed to shell subprocesses."""
+    env = os.environ.copy()
+    python_bin_dir = str(Path(sys.executable).parent)
+    existing_path = env.get("PATH", "")
+    path_entries = [python_bin_dir]
+    path_entries.extend(_discover_node_bin_dirs())
+    if existing_path:
+        path_entries.extend(existing_path.split(os.pathsep))
+    env["PATH"] = os.pathsep.join(_dedupe_path_entries(path_entries))
+    return env
+
+
 _PS_CMD_RE = re.compile(
     r"^(powershell(?:\.exe)?|pwsh(?:\.exe)?)"
     r"((?:\s+-(?:NoProfile|NonInteractive|NoLogo))*)"
@@ -403,14 +473,7 @@ async def execute_shell_command(
     else:
         working_dir = get_current_workspace_dir() or WORKING_DIR
 
-    # Ensure the venv Python is on PATH for subprocesses
-    env = os.environ.copy()
-    python_bin_dir = str(Path(sys.executable).parent)
-    existing_path = env.get("PATH", "")
-    if existing_path:
-        env["PATH"] = python_bin_dir + os.pathsep + existing_path
-    else:
-        env["PATH"] = python_bin_dir
+    env = _build_subprocess_env()
 
     shell_executable = (
         get_current_shell_command_executable()

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -227,6 +227,22 @@ def _discover_node_bin_dirs(home: Path | None = None) -> list[str]:
     return [str(path) for path in candidates if _has_node_executable(path)]
 
 
+def _discover_user_bin_dirs(home: Path | None = None) -> list[str]:
+    """Find existing user-level command bin directories."""
+    if home is None:
+        expanded_home = os.path.expanduser("~")
+        if expanded_home == "~":
+            return []
+        home_dir = Path(expanded_home)
+    else:
+        home_dir = home
+
+    user_local_bin = home_dir / ".local" / "bin"
+    if user_local_bin.is_dir():
+        return [str(user_local_bin)]
+    return []
+
+
 def _dedupe_path_entries(entries: list[str]) -> list[str]:
     """Remove duplicate PATH entries while preserving order."""
     seen = set()
@@ -245,6 +261,7 @@ def _build_subprocess_env() -> dict[str, str]:
     python_bin_dir = str(Path(sys.executable).parent)
     existing_path = env.get("PATH", "")
     path_entries = [python_bin_dir]
+    path_entries.extend(_discover_user_bin_dirs())
     path_entries.extend(_discover_node_bin_dirs())
     if existing_path:
         path_entries.extend(existing_path.split(os.pathsep))

--- a/tests/unit/agents/tools/test_shell_node_path.py
+++ b/tests/unit/agents/tools/test_shell_node_path.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for shell Node.js PATH discovery."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from qwenpaw.agents.tools import shell
+from qwenpaw.agents.tools.shell import (
+    _build_subprocess_env,
+    _dedupe_path_entries,
+    _discover_node_bin_dirs,
+)
+
+
+def _touch_node(bin_dir: Path) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (bin_dir / "node").write_text("", encoding="utf-8")
+
+
+def test_discover_node_bin_dirs_finds_common_user_managers(
+    tmp_path: Path,
+) -> None:
+    """Node bins from Volta, fnm, and nvm should be discoverable."""
+    volta_bin = tmp_path / ".volta" / "bin"
+    fnm_bin = (
+        tmp_path
+        / ".local"
+        / "share"
+        / "fnm"
+        / "node-versions"
+        / "v24.14.1"
+        / "installation"
+        / "bin"
+    )
+    nvm_bin = tmp_path / ".nvm" / "versions" / "node" / "v22.0.0" / "bin"
+    for bin_dir in (volta_bin, fnm_bin, nvm_bin):
+        _touch_node(bin_dir)
+
+    discovered = _discover_node_bin_dirs(home=tmp_path)
+
+    assert str(volta_bin) in discovered
+    assert str(fnm_bin) in discovered
+    assert str(nvm_bin) in discovered
+
+
+def test_build_subprocess_env_prepends_python_and_node_bins(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Subprocess PATH should include Python venv and discovered Node bins."""
+    node_bin = tmp_path / ".volta" / "bin"
+    _touch_node(node_bin)
+    monkeypatch.setenv("PATH", os.pathsep.join([str(node_bin), "base"]))
+
+    def discover_node_bin_dirs() -> list[str]:
+        return [str(node_bin)]
+
+    monkeypatch.setattr(
+        shell,
+        "_discover_node_bin_dirs",
+        discover_node_bin_dirs,
+    )
+
+    path_entries = _build_subprocess_env()["PATH"].split(os.pathsep)
+
+    assert path_entries[:3] == [
+        str(Path(sys.executable).parent),
+        str(node_bin),
+        "base",
+    ]
+    assert path_entries.count(str(node_bin)) == 1
+
+
+def test_dedupe_path_entries_preserves_order() -> None:
+    assert _dedupe_path_entries(["a", "b", "a", "", "c"]) == [
+        "a",
+        "b",
+        "c",
+    ]

--- a/tests/unit/agents/tools/test_shell_node_path.py
+++ b/tests/unit/agents/tools/test_shell_node_path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Regression tests for shell Node.js PATH discovery."""
+"""Regression tests for shell PATH discovery."""
 from __future__ import annotations
 
 import os
@@ -11,6 +11,7 @@ from qwenpaw.agents.tools.shell import (
     _build_subprocess_env,
     _dedupe_path_entries,
     _discover_node_bin_dirs,
+    _discover_user_bin_dirs,
 )
 
 
@@ -71,6 +72,40 @@ def test_build_subprocess_env_prepends_python_and_node_bins(
         "base",
     ]
     assert path_entries.count(str(node_bin)) == 1
+
+
+def test_discover_user_bin_dirs_finds_local_bin(tmp_path: Path) -> None:
+    user_bin = tmp_path / ".local" / "bin"
+    user_bin.mkdir(parents=True)
+
+    assert _discover_user_bin_dirs(home=tmp_path) == [str(user_bin)]
+
+
+def test_build_subprocess_env_prepends_user_local_bin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    user_bin = tmp_path / ".local" / "bin"
+    user_bin.mkdir(parents=True)
+    monkeypatch.setenv("PATH", "base")
+
+    def discover_user_bin_dirs() -> list[str]:
+        return [str(user_bin)]
+
+    monkeypatch.setattr(
+        shell,
+        "_discover_user_bin_dirs",
+        discover_user_bin_dirs,
+    )
+    monkeypatch.setattr(shell, "_discover_node_bin_dirs", lambda: [])
+
+    path_entries = _build_subprocess_env()["PATH"].split(os.pathsep)
+
+    assert path_entries[:3] == [
+        str(Path(sys.executable).parent),
+        str(user_bin),
+        "base",
+    ]
 
 
 def test_dedupe_path_entries_preserves_order() -> None:


### PR DESCRIPTION
## Summary
- detect existing Node.js bin directories from Volta, fnm, nvm, Homebrew, and /usr/local
- add existing `~/.local/bin` to execute_shell_command subprocess PATH for daemon/systemd users
- dedupe PATH entries while preserving existing Python venv precedence

## Tests
- `PYTHONPATH=src python -m pytest tests/unit/agents/tools/test_shell_node_path.py -q` (PowerShell: `$env:PYTHONPATH='src'; ...`)
- `pre-commit run --files src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell_node_path.py`
- `git diff --check`

Closes #3809
Closes #4365