### PR TITLE
feat(api): paginate chat list responses

### DIFF
--- a/src/qwenpaw/app/runner/api.py
+++ b/src/qwenpaw/app/runner/api.py
@@ -66,6 +66,17 @@ async def get_session(
 async def list_chats(
     user_id: Optional[str] = Query(None, description="Filter by user ID"),
     channel: Optional[str] = Query(None, description="Filter by channel"),
+    offset: Optional[int] = Query(
+        None,
+        ge=0,
+        description="Optional zero-based chat offset",
+    ),
+    limit: Optional[int] = Query(
+        None,
+        ge=1,
+        le=500,
+        description="Optional maximum number of chats to return",
+    ),
     mgr: ChatManager = Depends(get_chat_manager),
     workspace=Depends(get_workspace),
 ):
@@ -77,6 +88,10 @@ async def list_chats(
         mgr: Chat manager dependency
     """
     chats = await mgr.list_chats(user_id=user_id, channel=channel)
+    if offset is not None or limit is not None:
+        start = offset or 0
+        end = None if limit is None else start + limit
+        chats = chats[start:end]
     tracker = workspace.task_tracker
     result = []
     for spec in chats:

--- a/tests/unit/app/test_chat_list_pagination.py
+++ b/tests/unit/app/test_chat_list_pagination.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for chat list pagination."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app.runner.api import get_chat_manager, get_workspace, router
+from qwenpaw.app.runner.manager import ChatManager
+from qwenpaw.app.runner.models import ChatSpec
+from qwenpaw.app.runner.repo.json_repo import JsonChatRepository
+
+
+class FakeTaskTracker:
+    """Minimal task tracker dependency for chat API tests."""
+
+    async def get_status(self, _chat_id: str) -> str:
+        return "idle"
+
+
+class FakeWorkspace:
+    """Minimal workspace dependency for chat API tests."""
+
+    task_tracker = FakeTaskTracker()
+
+
+async def _client_with_chats(tmp_path: Path) -> AsyncClient:
+    chat_manager = ChatManager(
+        repo=JsonChatRepository(tmp_path / "chats.json"),
+    )
+    for idx in range(5):
+        await chat_manager.create_chat(
+            ChatSpec(
+                id=f"chat-{idx}",
+                name=f"Chat {idx}",
+                session_id=f"console:user-{idx}",
+                user_id=f"user-{idx}",
+                channel="console",
+            ),
+        )
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    def get_test_chat_manager() -> ChatManager:
+        return chat_manager
+
+    def get_test_workspace() -> FakeWorkspace:
+        return FakeWorkspace()
+
+    app.dependency_overrides[get_chat_manager] = get_test_chat_manager
+    app.dependency_overrides[get_workspace] = get_test_workspace
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+async def test_list_chats_supports_offset_and_limit(tmp_path: Path) -> None:
+    """GET /chats should return a requested chat window."""
+    client = await _client_with_chats(tmp_path)
+
+    async with client:
+        response = await client.get(
+            "/api/chats",
+            params={"offset": 1, "limit": 2},
+        )
+
+    assert response.status_code == 200
+    assert [chat["id"] for chat in response.json()] == ["chat-1", "chat-2"]
+
+
+async def test_list_chats_without_pagination_returns_full_list(
+    tmp_path: Path,
+) -> None:
+    """The default chat list response should remain backwards compatible."""
+    client = await _client_with_chats(tmp_path)
+
+    async with client:
+        response = await client.get("/api/chats")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 5


### PR DESCRIPTION
## Summary
- add optional offset/limit query parameters to GET /api/chats
- keep full chat-list responses as the default for backwards compatibility
- add API regression tests for paged and default chat list responses

## Tests
- PYTHONPATH=E:\\Data Yayasan\\APP Aqil\\PR\\QwenPaw\\src pytest tests\\unit\\app\\test_chat_list_pagination.py -q
- flake8 src\\qwenpaw\\app\\runner\\api.py tests\\unit\\app\\test_chat_list_pagination.py
- pylint src\\qwenpaw\\app\\runner\\api.py tests\\unit\\app\\test_chat_list_pagination.py --disable=all --enable=syntax-error,undefined-variable,unused-import,mixed-line-endings
- git diff --check

Closes #3570