### PR TITLE
fix(memory): skip automation auto memory

### DIFF
--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -39,9 +39,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_AUTOMATION_MEMORY_SKIP_SOURCES = {"cron", "heartbeat"}
+
+
 def _fmt_tokens(n: int) -> str:
     """Format token count as e.g. '82.3k' or '450'."""
     return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
+
+
+def _request_context_source(agent: Any) -> str:
+    """Return normalized source tag from an agent request context."""
+    request_context = getattr(agent, "_request_context", {}) or {}
+    if not isinstance(request_context, dict):
+        return ""
+    return str(request_context.get("source") or "").strip().lower()
+
+
+def _should_skip_automation_memory(agent: Any) -> bool:
+    """Return True when the request is non-user automation."""
+    return _request_context_source(agent) in _AUTOMATION_MEMORY_SKIP_SOURCES
 
 
 @context_registry.register("light")
@@ -920,7 +936,9 @@ class LightContextManager(BaseContextManager):
             )
             logger.info(f"Marked {updated_count} messages as compacted")
 
-            if messages_to_compact:
+            if messages_to_compact and not _should_skip_automation_memory(
+                agent,
+            ):
                 await memory_manager.summarize_when_compact(
                     messages=messages_to_compact,
                 )
@@ -987,7 +1005,7 @@ class LightContextManager(BaseContextManager):
             memory = agent.memory
             all_messages = [msg for msg, _ in memory.content]
 
-            if all_messages:
+            if all_messages and not _should_skip_automation_memory(agent):
                 await memory_manager.auto_memory(
                     all_messages=all_messages,
                 )

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -88,6 +88,13 @@ class CronExecutor:
 
         req["channel"] = target_channel
         req["user_id"] = target_user_id or "cron"
+        raw_context = req.get("request_context")
+        request_context = (
+            dict(raw_context) if isinstance(raw_context, dict) else {}
+        )
+        request_context["source"] = "cron"
+        request_context["cron_job_id"] = job.id or ""
+        req["request_context"] = request_context
 
         # Determine session_id based on share_session
         share_session = job.runtime.share_session

--- a/src/qwenpaw/app/crons/heartbeat.py
+++ b/src/qwenpaw/app/crons/heartbeat.py
@@ -216,6 +216,7 @@ async def run_heartbeat_once(
         "session_id": "main",
         "user_id": "main",
         "channel": DEFAULT_CHANNEL,
+        "request_context": {"source": "heartbeat"},
     }
 
     # Get last_dispatch from agent config if agent_id provided

--- a/tests/unit/agents/context/test_light_context_manager.py
+++ b/tests/unit/agents/context/test_light_context_manager.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for LightContextManager automation memory handling."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from agentscope.message import Msg
+
+from qwenpaw.agents.context.light_context_manager import (
+    LightContextManager,
+    _should_skip_automation_memory,
+)
+
+
+def _agent_with_source(source: str):
+    return SimpleNamespace(_request_context={"source": source})
+
+
+@pytest.mark.parametrize("source", ["cron", "heartbeat", "CRON"])
+def test_should_skip_automation_memory_for_system_sources(source):
+    assert _should_skip_automation_memory(_agent_with_source(source)) is True
+
+
+@pytest.mark.parametrize("source", ["", "console", "user"])
+def test_should_not_skip_automation_memory_for_user_sources(source):
+    assert _should_skip_automation_memory(_agent_with_source(source)) is False
+
+
+@pytest.mark.asyncio
+async def test_post_reply_skips_auto_memory_for_cron_source(tmp_path):
+    manager = LightContextManager(str(tmp_path), "default")
+    memory_manager = SimpleNamespace(auto_memory=AsyncMock())
+    memory = SimpleNamespace(
+        content=[(Msg("user", "cron task input", "user"), None)],
+    )
+    agent = SimpleNamespace(
+        memory_manager=memory_manager,
+        memory=memory,
+        _request_context={"source": "cron"},
+    )
+
+    await manager.post_reply(agent, {}, None)
+
+    memory_manager.auto_memory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_reply_keeps_auto_memory_for_user_source(tmp_path):
+    manager = LightContextManager(str(tmp_path), "default")
+    memory_manager = SimpleNamespace(auto_memory=AsyncMock())
+    user_msg = Msg("user", "normal user input", "user")
+    memory = SimpleNamespace(content=[(user_msg, None)])
+    agent = SimpleNamespace(
+        memory_manager=memory_manager,
+        memory=memory,
+        _request_context={"source": "user"},
+    )
+
+    await manager.post_reply(agent, {}, None)
+
+    memory_manager.auto_memory.assert_awaited_once_with(
+        all_messages=[user_msg],
+    )


### PR DESCRIPTION
﻿## Summary
- tag cron and heartbeat agent requests with a request_context source
- skip auto-memory and summarize-on-compact for automation-sourced requests
- add focused LightContextManager tests for automation memory skipping

## Related Issue
Fixes #3944
Refs #4333

## Root Cause / Scope
Heartbeat and cron requests currently enter the same context/memory path as user chat requests, so auto-memory and summarize-on-compact can treat automated prompts as user experience. This PR keeps the fix intentionally backend-scoped: it tags automation request sources at the cron/heartbeat entry points and skips memory summarization for those sources, while leaving normal user conversations unchanged.

## Validation
I reviewed the implementation against the contribution policy in #4333: the changed path is grounded in the existing cron/heartbeat request flow, the patch is limited to request-source tagging and memory skipping, and the regression tests cover both automation-sourced and user-sourced behavior.

## Tests
- `PYTHONPATH=src python -m pytest tests/unit/agents/context/test_light_context_manager.py tests/unit/agents/context/test_as_msg_handler.py -q` - 13 passed
- `pre-commit run --files src/qwenpaw/agents/context/light_context_manager.py src/qwenpaw/app/crons/executor.py src/qwenpaw/app/crons/heartbeat.py tests/unit/agents/context/test_light_context_manager.py` - passed
- `git diff --check` - passed
