### PR TITLE
fix(file): avoid raw spreadsheet reads

### DIFF
--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -19,6 +19,14 @@ from ...config.context import (
 )
 from ...constant import WORKING_DIR, TRUNCATION_NOTICE_MARKER
 
+_SPREADSHEET_WORKBOOK_SUFFIXES = {
+    ".ods",
+    ".xls",
+    ".xlsb",
+    ".xlsm",
+    ".xlsx",
+}
+
 
 def _resolve_file_path(file_path: str) -> str:
     """Resolve file path: use absolute path as-is,
@@ -61,6 +69,22 @@ def _get_encoding_for_file(file_path: str) -> str:
     # Default: UTF-8 without BOM (safe for all other files)
     # This includes: .sh, .yaml, .json, .py, .js, .md, etc.
     return "utf-8"
+
+
+def _spreadsheet_raw_read_error(file_path: str) -> str | None:
+    """Return a safety message when read_file targets a workbook binary."""
+    suffix = Path(file_path).suffix.lower()
+    if suffix not in _SPREADSHEET_WORKBOOK_SUFFIXES:
+        return None
+
+    return (
+        f"Error: The file {file_path} is a spreadsheet workbook ({suffix}). "
+        "Reading it as raw text can exhaust memory or return unreadable "
+        "ZIP/XML bytes. Inspect only the needed rows with a bounded "
+        "spreadsheet reader, for example a short Python script using "
+        "openpyxl/pandas in read-only mode, or export the relevant sheet "
+        "to CSV and then call read_file on that CSV."
+    )
 
 
 async def read_file(  # pylint: disable=too-many-return-statements
@@ -132,6 +156,17 @@ async def read_file(  # pylint: disable=too-many-return-statements
         )
 
     try:
+        spreadsheet_error = _spreadsheet_raw_read_error(file_path)
+        if spreadsheet_error:
+            return ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=spreadsheet_error,
+                    ),
+                ],
+            )
+
         content = await read_file_safe(file_path)
         all_lines = content.split("\n")
         total = len(all_lines)

--- a/tests/unit/agents/tools/test_file_io.py
+++ b/tests/unit/agents/tools/test_file_io.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from qwenpaw.agents.tools import file_io
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_excel_workbook_raw_read(tmp_path):
+    workbook = tmp_path / "classes.xlsx"
+    workbook.write_bytes(b"PK\x03\x04 fake xlsx zip bytes")
+
+    response = await file_io.read_file(str(workbook))
+    text = response.content[0].get("text", "")
+
+    assert text.startswith("Error:")
+    assert "spreadsheet workbook" in text
+    assert "bounded spreadsheet reader" in text
+    assert "read_file on that CSV" in text
+
+
+@pytest.mark.asyncio
+async def test_read_file_still_reads_csv(tmp_path):
+    csv_file = tmp_path / "classes.csv"
+    csv_file.write_text("label,value\ncat,1\n", encoding="utf-8")
+
+    response = await file_io.read_file(str(csv_file))
+    text = response.content[0].get("text", "")
+
+    assert "label,value" in text
+    assert "cat,1" in text


### PR DESCRIPTION
## Summary
- make `read_file` reject raw reads for Excel/workbook binary formats (`.xlsx`, `.xls`, `.xlsm`, `.xlsb`, `.ods`)
- return guidance to inspect bounded rows via a spreadsheet reader or export to CSV instead of decoding the workbook as text
- add unit coverage that workbook raw reads are rejected while CSV files still read normally

Fixes #4354

## Tests
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pytest tests\unit\agents\tools\test_file_io.py -q`
- `PYTHONPATH=E:\Data Yayasan\APP Aqil\PR\QwenPaw\src pre-commit run --files src\qwenpaw\agents\tools\file_io.py tests\unit\agents\tools\test_file_io.py`
- `git diff --check`