### PR TITLE
fix(security): guard shell file access bypasses

### DIFF
--- a/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
+++ b/src/qwenpaw/security/tool_guard/guardians/file_guardian.py
@@ -71,6 +71,37 @@ _SHELL_REDIRECT_OPERATORS = frozenset(
 _REDIRECT_OPS_BY_LEN = tuple(
     sorted(_SHELL_REDIRECT_OPERATORS, key=len, reverse=True),
 )
+_NESTED_SHELL_COMMANDS = frozenset(
+    {
+        "bash",
+        "sh",
+        "zsh",
+        "fish",
+        "cmd",
+        "cmd.exe",
+        "powershell",
+        "powershell.exe",
+        "pwsh",
+        "pwsh.exe",
+    },
+)
+_POWERSHELL_COMMAND_FLAGS = frozenset(
+    {
+        "-command",
+        "-c",
+        "/command",
+        "/c",
+    },
+)
+_INLINE_FILE_ACCESS_PATTERNS = (
+    re.compile(r"\bopen\(\s*(['\"])(?P<path>.+?)\1"),
+    re.compile(r"\bPath\(\s*(['\"])(?P<path>.+?)\1"),
+    re.compile(r"\breadFileSync\(\s*(['\"])(?P<path>.+?)\1"),
+    re.compile(r"\bwriteFileSync\(\s*(['\"])(?P<path>.+?)\1"),
+)
+_WINDOWS_PERCENT_ENV_RE = re.compile(r"%([A-Za-z_][A-Za-z0-9_]*)%")
+_POWERSHELL_ENV_RE = re.compile(r"\$env:([A-Za-z_][A-Za-z0-9_]*)")
+_MAX_NESTED_SHELL_DEPTH = 3
 
 
 def _workspace_root() -> Path:
@@ -120,6 +151,28 @@ def _canonicalize_windows_path(raw: str) -> str:
     normalized = ntpath.normpath(expanded)
     # Canonical form: forward slashes + lowercase (NTFS is case-insensitive).
     return normalized.replace("\\", "/").lower()
+
+
+def _expand_shell_path_vars(raw: str) -> str:
+    """Expand common shell path variables before path normalization.
+
+    ``os.path.expandvars`` handles POSIX ``$HOME`` / ``${HOME}`` on all
+    platforms.  File guard also needs to reason about Windows shell forms while
+    running tests or servers on POSIX, so expand ``%USERPROFILE%`` and
+    PowerShell ``$env:USERPROFILE`` explicitly.
+    """
+
+    def replace_percent(match: re.Match[str]) -> str:
+        name = match.group(1)
+        return os.environ.get(name, match.group(0))
+
+    def replace_powershell(match: re.Match[str]) -> str:
+        name = match.group(1)
+        return os.environ.get(name, match.group(0))
+
+    expanded = _WINDOWS_PERCENT_ENV_RE.sub(replace_percent, raw)
+    expanded = _POWERSHELL_ENV_RE.sub(replace_powershell, expanded)
+    return os.path.expandvars(expanded)
 
 
 def _normalize_path(raw_path: str) -> str:
@@ -243,59 +296,142 @@ def _extract_attached_redirect_path(token: str) -> str | None:
     return None
 
 
-def _extract_paths_from_shell_command(command: str) -> list[str]:
+def _shell_token_streams(command: str) -> list[list[str]]:
+    """Return token streams using POSIX and Windows-friendly shlex modes."""
+    streams: list[list[str]] = []
+    for use_posix in (os.name != "nt", os.name == "nt"):
+        try:
+            tokens = shlex.split(command, posix=use_posix)
+        except ValueError:
+            continue
+        if not use_posix:
+            tokens = [_strip_surrounding_quotes(t) for t in tokens]
+        streams.append(tokens)
+
+    # Always include the opposite mode too.  This lets POSIX hosts correctly
+    # inspect Windows paths with backslashes, and Windows hosts inspect POSIX
+    # shell snippets in tests or copied commands.
+    for use_posix in (True, False):
+        try:
+            tokens = shlex.split(command, posix=use_posix)
+        except ValueError:
+            continue
+        if not use_posix:
+            tokens = [_strip_surrounding_quotes(t) for t in tokens]
+        if tokens not in streams:
+            streams.append(tokens)
+
+    if not streams:
+        streams.append(command.split())
+    return streams
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    """Return values with stable de-duplication."""
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _looks_like_shell_c_flag(token: str) -> bool:
+    """Return True for shell flags that make the next token executable code."""
+    lowered = token.lower()
+    if lowered in _POWERSHELL_COMMAND_FLAGS:
+        return True
+    if not lowered.startswith("-"):
+        return False
+    # bash/sh/zsh accept compact combinations such as -c, -lc, -exc.
+    return "c" in lowered[1:]
+
+
+def _extract_nested_shell_commands(tokens: list[str]) -> list[str]:
+    """Extract command strings passed to nested shell interpreters."""
+    if not tokens:
+        return []
+    executable = Path(tokens[0].lower()).name
+    executable = ntpath.basename(executable)
+    if executable not in _NESTED_SHELL_COMMANDS:
+        return []
+
+    nested: list[str] = []
+    for i, token in enumerate(tokens[1:], start=1):
+        if _looks_like_shell_c_flag(_sanitize_path_candidate(token)):
+            if i + 1 < len(tokens):
+                nested.append(
+                    " ".join(
+                        _sanitize_path_candidate(part)
+                        for part in tokens[i + 1 :]
+                    ),
+                )
+            break
+    return nested
+
+
+def _extract_inline_file_access_paths(command: str) -> list[str]:
+    """Extract paths from common inline interpreter file APIs."""
+    candidates: list[str] = []
+    for pattern in _INLINE_FILE_ACCESS_PATTERNS:
+        for match in pattern.finditer(command):
+            path = match.group("path")
+            if path:
+                candidates.append(_sanitize_path_candidate(path))
+    return candidates
+
+
+def _extract_paths_from_shell_command(
+    command: str,
+    *,
+    _depth: int = 0,
+) -> list[str]:
     """Extract candidate file paths from a shell command string.
 
     On Windows, :func:`shlex.split` is invoked with ``posix=False`` so that
     backslashes in paths like ``C:\\Users\\foo`` are not interpreted as POSIX
     escape characters and dropped from the token stream.
     """
-    use_posix = os.name != "nt"
-    try:
-        tokens = shlex.split(command, posix=use_posix)
-    except ValueError:
-        # Best-effort fallback when quotes are malformed.
-        tokens = command.split()
-    if not use_posix:
-        # ``posix=False`` keeps surrounding quotes in tokens. Strip them so
-        # downstream path checks see the raw value.
-        tokens = [_strip_surrounding_quotes(t) for t in tokens]
+    candidates: list[str] = _extract_inline_file_access_paths(command)
 
-    candidates: list[str] = []
-    i = 0
-    while i < len(tokens):
-        token = _sanitize_path_candidate(tokens[i])
+    for tokens in _shell_token_streams(command):
+        if _depth < _MAX_NESTED_SHELL_DEPTH:
+            for nested_command in _extract_nested_shell_commands(tokens):
+                candidates.extend(
+                    _extract_paths_from_shell_command(
+                        nested_command,
+                        _depth=_depth + 1,
+                    ),
+                )
 
-        # Handle separated redirection operators: `cat a > out.txt`
-        if token in _SHELL_REDIRECT_OPERATORS:
-            if i + 1 < len(tokens):
-                next_token = tokens[i + 1]
-                next_token = _sanitize_path_candidate(next_token)
-                if _looks_like_path_token(next_token):
-                    candidates.append(next_token)
+        i = 0
+        while i < len(tokens):
+            token = _sanitize_path_candidate(tokens[i])
+
+            # Handle separated redirection operators: `cat a > out.txt`
+            if token in _SHELL_REDIRECT_OPERATORS:
+                if i + 1 < len(tokens):
+                    next_token = tokens[i + 1]
+                    next_token = _sanitize_path_candidate(next_token)
+                    if _looks_like_path_token(next_token):
+                        candidates.append(next_token)
+                i += 1
+                continue
+
+            # Handle attached redirection: `>out.txt`, `2>err.log`, `<in.txt`
+            attached_path = _extract_attached_redirect_path(token)
+            if attached_path is not None:
+                candidates.append(_sanitize_path_candidate(attached_path))
+                i += 1
+                continue
+
+            if _looks_like_path_token(token):
+                candidates.append(token)
             i += 1
-            continue
 
-        # Handle attached redirection: `>out.txt`, `2>err.log`, `<in.txt`
-        attached_path = _extract_attached_redirect_path(token)
-        if attached_path is not None:
-            candidates.append(_sanitize_path_candidate(attached_path))
-            i += 1
-            continue
-
-        if _looks_like_path_token(token):
-            candidates.append(token)
-        i += 1
-
-    # Stable de-duplication.
-    deduped: list[str] = []
-    seen: set[str] = set()
-    for c in candidates:
-        if c in seen:
-            continue
-        seen.add(c)
-        deduped.append(c)
-    return deduped
+    return _dedupe(candidates)
 
 
 class FilePathToolGuardian(BaseToolGuardian):
@@ -434,6 +570,7 @@ class FilePathToolGuardian(BaseToolGuardian):
     ) -> None:
         """Check a single string value against sensitive paths."""
         normalized_input = _sanitize_path_candidate(raw_value)
+        normalized_input = _expand_shell_path_vars(normalized_input)
         abs_path = _normalize_path(normalized_input)
         if self._is_sensitive(abs_path):
             findings.append(

--- a/tests/unit/security/tool_guard/test_file_guardian_shell_bypass.py
+++ b/tests/unit/security/tool_guard/test_file_guardian_shell_bypass.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.security.tool_guard.guardians import file_guardian
+from qwenpaw.security.tool_guard.guardians.file_guardian import (
+    FilePathToolGuardian,
+)
+from qwenpaw.security.tool_guard.models import GuardFinding
+
+
+@pytest.fixture(name="workspace_root")
+def _workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        file_guardian,
+        "get_current_workspace_dir",
+        lambda: str(workspace),
+    )
+    monkeypatch.setattr(file_guardian, "_is_file_guard_enabled", lambda: True)
+    monkeypatch.setattr(
+        file_guardian,
+        "_load_sensitive_files_from_config",
+        lambda: [],
+    )
+    return workspace
+
+
+def _findings_for(
+    command: str,
+    sensitive_paths: list[str],
+) -> list[GuardFinding]:
+    guardian = FilePathToolGuardian(sensitive_files=sensitive_paths)
+    return guardian.guard("execute_shell_command", {"command": command})
+
+
+def test_file_guard_blocks_direct_shell_file_access(
+    workspace_root: Path,
+) -> None:
+    sensitive_dir = workspace_root / "protected"
+    sensitive_dir.mkdir()
+    sensitive_file = sensitive_dir / "secret.txt"
+    sensitive_paths = [str(sensitive_dir) + "/"]
+
+    read_findings = _findings_for(f"cat {sensitive_file}", sensitive_paths)
+    write_findings = _findings_for(
+        f"echo hello > {sensitive_file}",
+        sensitive_paths,
+    )
+
+    assert read_findings
+    assert write_findings
+
+
+@pytest.mark.parametrize(
+    ("case_name", "command_factory", "sensitive_path_factory"),
+    [
+        (
+            "posix_env_home",
+            lambda workspace, home: "cat $HOME/.ssh/id_rsa",
+            lambda workspace, home: [str(home / ".ssh") + "/"],
+        ),
+        (
+            "nested_bash_lc",
+            lambda workspace, home: (
+                f"bash -lc 'cat {workspace / 'protected' / 'secret.txt'}'"
+            ),
+            lambda workspace, home: [
+                str(workspace / "protected") + "/",
+            ],
+        ),
+        (
+            "python_inline_open",
+            lambda workspace, home: (
+                "python -c "
+                f"\"open('{workspace / 'protected' / 'secret.txt'}').read()\""
+            ),
+            lambda workspace, home: [
+                str(workspace / "protected") + "/",
+            ],
+        ),
+        (
+            "windows_shell_path",
+            lambda workspace, home: r"type C:\Users\alice\.ssh\id_rsa",
+            lambda workspace, home: [r"C:\Users\alice\.ssh\\"],
+        ),
+        (
+            "powershell_env_userprofile",
+            lambda workspace, home: (
+                r"powershell -Command "
+                r'"Get-Content $env:USERPROFILE\.ssh\id_rsa"'
+            ),
+            lambda workspace, home: [r"C:\Users\alice\.ssh\\"],
+        ),
+        (
+            "cmd_percent_userprofile",
+            lambda workspace, home: (r"cmd /c type %USERPROFILE%\.ssh\id_rsa"),
+            lambda workspace, home: [r"C:\Users\alice\.ssh\\"],
+        ),
+    ],
+)
+def test_file_guard_blocks_shell_fallback_bypass_patterns(
+    case_name: str,
+    command_factory: Callable[[Path, Path], str],
+    sensitive_path_factory: Callable[[Path, Path], list[str]],
+    workspace_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home" / "alice"
+    (home / ".ssh").mkdir(parents=True)
+    (workspace_root / "protected").mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", r"C:\Users\alice")
+
+    command = command_factory(workspace_root, home)
+    sensitive_paths = sensitive_path_factory(workspace_root, home)
+    findings = _findings_for(command, sensitive_paths)
+
+    assert findings, f"{case_name} was not blocked: {command}"


### PR DESCRIPTION
## Description

This PR fixes a File Guard bypass where an agent could fall back from guarded file tools to `execute_shell_command` and access configured sensitive files through shell syntax.

The change improves shell command path extraction by:

- Expanding shell path variables before sensitive path matching, including POSIX `$HOME`, Windows `%USERPROFILE%`, and PowerShell `$env:USERPROFILE` forms.
- Extracting shell command paths with both POSIX and Windows-friendly tokenization so Windows backslash paths remain visible on non-Windows hosts.
- Recursively inspecting nested shell commands passed through `bash/sh/zsh/fish -c`, `cmd /c`, and PowerShell command flags.
- Detecting common inline file-access APIs such as Python `open(...)` / `Path(...)` and Node `readFileSync(...)` / `writeFileSync(...)` inside shell snippets.
- Adding regression coverage for direct shell access and representative bypass patterns.

Root cause: `execute_shell_command` file extraction only tokenized one shell layer and did not expand shell variables before normalizing path candidates. On POSIX hosts it also used POSIX `shlex` semantics only, which can strip backslashes from Windows paths.

Impact: `read_file` and `write_file` are high-frequency agent tools, so the shell fallback path must be guarded with the same sensitivity when File Guard blocks direct file access.

**Related Issue:** Fixes #2967

**Security Considerations:** This is a security hardening bug fix for File Guard. It reduces shell-command bypasses for configured sensitive files, especially on Windows paths, shell environment variables, and nested shell invocations.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The new regression tests cover:

- Direct shell reads/writes against sensitive paths.
- POSIX env var expansion via `$HOME`.
- Nested shell execution via `bash -lc`.
- Inline interpreter file access via Python `open(...)`.
- Windows shell paths such as `C:\Users\alice\.ssh\id_rsa`.
- PowerShell env var expansion via `$env:USERPROFILE`.
- `cmd /c` with `%USERPROFILE%` expansion.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed, including mypy, black, flake8, pylint, and prettier.

PYTHONPATH=src pytest tests/unit/security/tool_guard/test_file_guardian_shell_bypass.py -q
# 7 passed in 0.94s

PYTHONPATH=src pytest tests/unit/security -q
# 24 passed in 3.19s

ruff check src/qwenpaw/security/tool_guard/guardians/file_guardian.py tests/unit/security/tool_guard/test_file_guardian_shell_bypass.py
# All checks passed!
```

## Additional Notes

This PR intentionally keeps the fix scoped to known direct bypass patterns for #2967. A broader Phase 2 can introduce a dedicated `ShellFileAccessExtractor` with deeper command semantics, glob/cwd handling, and fail-closed approval for ambiguous shell constructs.
