### PR TITLE
fix(providers): parse raw think tags

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -13,7 +13,10 @@ from agentscope.model._model_response import ChatResponse
 from pydantic import BaseModel
 
 from qwenpaw.local_models.tag_parser import (
+    THINK_END,
+    THINK_START,
     parse_tool_calls_from_text,
+    text_contains_think_tag,
     text_contains_tool_call_tag,
 )
 
@@ -133,6 +136,72 @@ def _sanitize_stream_item(item: Any) -> Any:
         return _clone_with_overrides(item, chunk=sanitized_chunk)
 
     return _sanitize_chunk(item)
+
+
+def _split_thinking_tagged_text(text: str) -> list[dict[str, str]] | None:
+    """Convert raw ``<think>`` tagged text into ordered content blocks."""
+    if not text_contains_think_tag(text):
+        return None
+
+    blocks: list[dict[str, str]] = []
+    cursor = 0
+
+    while cursor < len(text):
+        start = text.find(THINK_START, cursor)
+        if start == -1:
+            remaining = text[cursor:].strip()
+            if remaining:
+                blocks.append({"type": "text", "text": remaining})
+            break
+
+        before = text[cursor:start].strip()
+        if before:
+            blocks.append({"type": "text", "text": before})
+
+        thinking_start = start + len(THINK_START)
+        end = text.find(THINK_END, thinking_start)
+        if end == -1:
+            thinking = text[thinking_start:].strip()
+            blocks.append({"type": "thinking", "thinking": thinking})
+            break
+
+        thinking = text[thinking_start:end].strip()
+        blocks.append({"type": "thinking", "thinking": thinking})
+        cursor = end + len(THINK_END)
+
+    return blocks
+
+
+def _extract_thinking_tagged_blocks(
+    content: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Split text blocks containing ``<think>`` into structured blocks."""
+    normalized: list[dict[str, Any]] = []
+    changed = False
+
+    for block in content:
+        if block.get("type") != "text":
+            normalized.append(block)
+            continue
+
+        text = block.get("text")
+        if not isinstance(text, str):
+            normalized.append(block)
+            continue
+
+        split_blocks = _split_thinking_tagged_text(text)
+        if split_blocks is None:
+            normalized.append(block)
+            continue
+
+        changed = True
+        for split_block in split_blocks:
+            if split_block["type"] == "text":
+                normalized.append({**block, "text": split_block["text"]})
+            else:
+                normalized.append(split_block)
+
+    return normalized if changed else content
 
 
 class _SanitizedStream:
@@ -333,6 +402,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                     ec = sanitized_response.extra_contents.get(tool_id)
                     if ec:
                         block["extra_content"] = ec
+
+            parsed.content = _extract_thinking_tagged_blocks(parsed.content)
 
             # Check whether the response already carries structured tool_use
             # blocks (either from the model or from extra_content above).

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -60,6 +60,16 @@ def _make_chunk(tool_calls: list[Any]) -> Any:
     return SimpleNamespace(usage=None, choices=[choice])
 
 
+def _make_text_chunk(content: str) -> Any:
+    delta = SimpleNamespace(
+        reasoning_content=None,
+        content=content,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(delta=delta)
+    return SimpleNamespace(usage=None, choices=[choice])
+
+
 async def test_stream_parser_skips_tool_call_without_function() -> None:
     model = CompatHarnessOpenAIChatModel(
         "dummy",
@@ -106,6 +116,37 @@ async def test_stream_parser_skips_tool_call_without_function() -> None:
     assert tool_blocks
     assert tool_blocks[-1]["name"] == "ping"
     assert tool_blocks[-1]["input"] == {"x": 1}
+
+
+async def test_stream_parser_splits_raw_think_tags() -> None:
+    model = CompatHarnessOpenAIChatModel(
+        "dummy",
+        api_key="sk-test",
+        stream=True,
+    )
+
+    stream = FakeAsyncStream(
+        [
+            _make_text_chunk(
+                "<think>\nI should answer briefly.\n</think>\nFinal answer.",
+            ),
+        ],
+    )
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        stream,
+    )
+
+    assert responses
+    content = responses[-1].content
+    assert {
+        "type": "thinking",
+        "thinking": "I should answer briefly.",
+    } in content
+    assert {"type": "text", "text": "Final answer."} in content
+    assert "<think>" not in str(content)
+    assert "</think>" not in str(content)
 
 
 def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:


### PR DESCRIPTION
## Summary
- Parse raw `<think>...</think>` text emitted by OpenAI-compatible providers into structured `thinking` blocks.
- Preserve normal answer text as `text` blocks, so the console can collapse reasoning instead of rendering raw tags inline.
- Keep existing tool-call extraction working after thinking-tag normalization.

Fixes #4174

## Tests
- `PYTHONPATH=src python -m pytest tests/unit/providers/test_openai_stream_toolcall_compat.py tests/unit/agents/test_cross_provider_normalization.py -q`
- `pre-commit run --files src/qwenpaw/providers/openai_chat_model_compat.py tests/unit/providers/test_openai_stream_toolcall_compat.py`
- `git diff --check c89ed13..HEAD`