### PR TITLE
Consolidate console static directory resolution

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -35,6 +35,7 @@ from ..utils.logging import (
     add_project_file_handler,
     LOG_FILE_PATH,
 )
+from ..utils.console_static import resolve_console_static_dir
 from ..utils.system_info import summarize_python_environment
 from .auth import AuthMiddleware, auto_register_from_env
 from .routers import router as api_router, create_agent_scoped_router
@@ -569,42 +570,7 @@ if CORS_ORIGINS:
     )
 
 
-_CONSOLE_STATIC_ENV = "QWENPAW_CONSOLE_STATIC_DIR"
-
-
-def _resolve_console_static_dir() -> str:
-    from ..constant import EnvVarLoader
-
-    static_dir = EnvVarLoader.get_str(_CONSOLE_STATIC_ENV)
-    if static_dir:
-        return static_dir
-    # Shipped dist lives in the package as static data
-    pkg_dir = Path(__file__).resolve().parent.parent
-    candidate = pkg_dir / "console"
-    if candidate.is_dir() and (candidate / "index.html").exists():
-        return str(candidate)
-
-    # Fallback to repo data
-    repo_dir = pkg_dir.parent.parent
-    candidate = repo_dir / "console" / "dist"
-    if candidate.is_dir() and (candidate / "index.html").exists():
-        return str(candidate)
-
-    # Fallback to cwd data
-    cwd = Path(os.getcwd())
-    for subdir in ("console/dist", "console_dist"):
-        candidate = cwd / subdir
-        if candidate.is_dir() and (candidate / "index.html").exists():
-            return str(candidate)
-
-    fallback = cwd / "console" / "dist"
-    logger.warning(
-        f"Console static directory not found. Falling back to '{fallback}'.",
-    )
-    return str(fallback)
-
-
-_CONSOLE_STATIC_DIR = _resolve_console_static_dir()
+_CONSOLE_STATIC_DIR = resolve_console_static_dir()
 _CONSOLE_INDEX = (
     Path(_CONSOLE_STATIC_DIR) / "index.html" if _CONSOLE_STATIC_DIR else None
 )

--- a/tests/unit/utils/test_console_static.py
+++ b/tests/unit/utils/test_console_static.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.utils import console_static
+
+
+def _write_index(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    index = directory / "index.html"
+    index.write_text("<!doctype html>", encoding="utf-8")
+    return directory
+
+
+@pytest.fixture(autouse=True)
+def _clear_console_static_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("QWENPAW_CONSOLE_STATIC_DIR", raising=False)
+    monkeypatch.delenv("COPAW_CONSOLE_STATIC_DIR", raising=False)
+
+
+def test_resolve_console_static_dir_prefers_qwenpaw_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    configured = tmp_path / "configured-console"
+    monkeypatch.setenv("QWENPAW_CONSOLE_STATIC_DIR", str(configured))
+
+    assert console_static.resolve_console_static_dir() == str(configured)
+
+
+def test_resolve_console_static_dir_accepts_legacy_copaw_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    configured = tmp_path / "legacy-console"
+    monkeypatch.setenv("COPAW_CONSOLE_STATIC_DIR", str(configured))
+
+    assert console_static.resolve_console_static_dir() == str(configured)
+
+
+def test_resolve_console_static_dir_prefers_packaged_console(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_dir = tmp_path / "site-packages" / "qwenpaw"
+    packaged_console = _write_index(package_dir / "console")
+    fake_module = tmp_path / "site-packages" / "qwenpaw" / "utils" / "console_static.py"
+    monkeypatch.setattr(console_static, "__file__", str(fake_module))
+    monkeypatch.chdir(tmp_path)
+
+    assert console_static.resolve_console_static_dir() == str(packaged_console)
+
+
+def test_resolve_console_static_dir_falls_back_to_repo_dist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_console = _write_index(repo_dir / "console" / "dist")
+    fake_module = repo_dir / "src" / "qwenpaw" / "utils" / "console_static.py"
+    monkeypatch.setattr(console_static, "__file__", str(fake_module))
+    monkeypatch.chdir(tmp_path)
+
+    assert console_static.resolve_console_static_dir() == str(repo_console)
+
+
+def test_resolve_console_static_dir_falls_back_to_cwd_console_dist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cwd_console = _write_index(tmp_path / "console" / "dist")
+    fake_module = (
+        tmp_path
+        / "venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "qwenpaw"
+        / "utils"
+        / "console_static.py"
+    )
+    monkeypatch.setattr(console_static, "__file__", str(fake_module))
+    monkeypatch.chdir(tmp_path)
+
+    assert console_static.resolve_console_static_dir() == str(cwd_console)
+
+
+def test_resolve_console_static_dir_returns_missing_cwd_console_dist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_module = (
+        tmp_path
+        / "venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "qwenpaw"
+        / "utils"
+        / "console_static.py"
+    )
+    monkeypatch.setattr(console_static, "__file__", str(fake_module))
+    monkeypatch.chdir(tmp_path)
+
+    assert console_static.resolve_console_static_dir() == str(
+        tmp_path / "console" / "dist",
+    )


### PR DESCRIPTION
## Summary
- Reuse the shared console static directory resolver from the FastAPI app entrypoint.
- Add unit tests covering env overrides, legacy COPAW env fallback, packaged assets, repo dist, cwd fallback, and missing fallback paths.

## Tests
- ./.venv/bin/python -m pytest tests/unit/utils/test_console_static.py tests/unit/utils/test_http.py
- ./.venv/bin/python -m py_compile src/qwenpaw/app/_app.py src/qwenpaw/utils/console_static.py tests/unit/utils/test_console_static.py

## Notes
- Attempted a wider CLI proxy test selection, but collection requires the optional acp package that is not installed in this local environment.