### PR TITLE
fix(console): render table line breaks

### DIFF
--- a/console/src/components/MarkdownCopy/MarkdownCopy.tsx
+++ b/console/src/components/MarkdownCopy/MarkdownCopy.tsx
@@ -5,7 +5,10 @@ import { XMarkdown } from "@ant-design/x-markdown";
 import { useTranslation } from "react-i18next";
 import type { CSSProperties } from "react";
 import { useAppMessage } from "../../hooks/useAppMessage";
-import { stripFrontmatter } from "../../utils/markdown";
+import {
+  normalizeMarkdownTableLineBreaks,
+  stripFrontmatter,
+} from "../../utils/markdown";
 import { mermaidComponents } from "../MermaidCodeBlock";
 import styles from "./index.module.less";
 
@@ -59,7 +62,7 @@ export function MarkdownCopy({
   const [editContent, setEditContent] = useState(content);
   const [localShowMarkdown, setLocalShowMarkdown] = useState(showMarkdown);
   const markdownContent = useMemo(
-    () => stripFrontmatter(content || ""),
+    () => normalizeMarkdownTableLineBreaks(stripFrontmatter(content || "")),
     [content],
   );
 

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -32,6 +32,7 @@ import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { planApi } from "../../api/modules/plan";
+import { normalizeMarkdownPayloadLineBreaks } from "../../utils/markdown";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -1092,14 +1093,15 @@ export default function ChatPage() {
         fetch: customFetch,
         responseParser: (chunk: string) => {
           const payload = JSON.parse(chunk) as Record<string, unknown>;
+          const normalizedPayload = normalizeMarkdownPayloadLineBreaks(payload);
 
-          if (payloadRequestsHistoryClear(payload)) {
+          if (payloadRequestsHistoryClear(normalizedPayload)) {
             pendingClearHistoryRef.current = true;
-            if (payloadCompletesResponse(payload)) {
+            if (payloadCompletesResponse(normalizedPayload)) {
               scheduleHistoryClear();
             }
           }
-          return payload as any;
+          return normalizedPayload as any;
         },
         replaceMediaURL: (url: string) => {
           return toDisplayUrl(url);

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -9,6 +9,7 @@ import api, {
   type ChatStatus,
   type Message,
 } from "../../../api";
+import { normalizeMarkdownTableLineBreaks } from "../../../utils/markdown";
 import { toDisplayUrl } from "../utils";
 
 // ---------------------------------------------------------------------------
@@ -139,9 +140,15 @@ function contentToRequestParts(
   return parts;
 }
 function normalizeOutputMessageContent(content: unknown): unknown {
-  if (typeof content === "string") return content;
+  if (typeof content === "string") {
+    return normalizeMarkdownTableLineBreaks(content);
+  }
   if (!Array.isArray(content)) return content;
-  return content as ContentItem[];
+  return (content as ContentItem[]).map((item) =>
+    item.type === "text" && typeof item.text === "string"
+      ? { ...item, text: normalizeMarkdownTableLineBreaks(item.text) }
+      : item,
+  );
 }
 
 /**

--- a/console/src/utils/markdown.test.tsx
+++ b/console/src/utils/markdown.test.tsx
@@ -1,0 +1,80 @@
+import { Marked } from "marked";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeMarkdownPayloadLineBreaks,
+  normalizeMarkdownTableLineBreaks,
+} from "./markdown";
+
+const markedLikeChatRenderer = new Marked({
+  renderer: {
+    html(token) {
+      const text = token.text || token.raw || "";
+      return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    },
+  },
+});
+
+describe("markdown helpers", () => {
+  it("normalizes br tags inside markdown table rows", () => {
+    const markdown = [
+      "| Name | Notes |",
+      "| --- | --- |",
+      "| Alpha | first<br>second<br />third |",
+    ].join("\n");
+
+    expect(normalizeMarkdownTableLineBreaks(markdown)).toContain(
+      "first&#10;second&#10;third",
+    );
+  });
+
+  it("leaves non-table br tags unchanged", () => {
+    expect(normalizeMarkdownTableLineBreaks("first<br>second")).toBe(
+      "first<br>second",
+    );
+  });
+
+  it("normalizes nested response payload text", () => {
+    const payload = {
+      object: "response",
+      output: [
+        {
+          content: [
+            {
+              type: "text",
+              text: "| A | B |\n| --- | --- |\n| x | y<br>z |",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(normalizeMarkdownPayloadLineBreaks(payload)).toEqual({
+      object: "response",
+      output: [
+        {
+          content: [
+            {
+              type: "text",
+              text: "| A | B |\n| --- | --- |\n| x | y&#10;z |",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps normalized table breaks renderable when raw html is escaped", () => {
+    const content = normalizeMarkdownTableLineBreaks(
+      "| A | B |\n| --- | --- |\n| x | y<br>z |",
+    );
+    const html = markedLikeChatRenderer.parse(content) as string;
+
+    expect(html).toContain("<td>y&#10;z</td>");
+    expect(html).not.toContain("&lt;br");
+
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    const cell = container.querySelector("tbody td:nth-child(2)");
+    expect(cell?.textContent).toBe("y\nz");
+  });
+});

--- a/console/src/utils/markdown.ts
+++ b/console/src/utils/markdown.ts
@@ -7,3 +7,138 @@
  */
 export const stripFrontmatter = (s: string): string =>
   s.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+
+const HTML_LINE_BREAK_RE = /<br\s*\/?>/gi;
+const HTML_LINE_BREAK_TEST_RE = /<br\s*\/?>/i;
+const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+
+const isTableLikeLine = (line: string): boolean => line.includes("|");
+
+/**
+ * Keep GFM table cells compatible with the chat Markdown renderer.
+ *
+ * The upstream Markdown component escapes raw HTML by default. In table cells,
+ * users commonly emit `<br>` to force a line break, but that becomes literal
+ * text. Replacing only table-row `<br>` tags with the HTML line-feed entity
+ * preserves the existing safe HTML behavior while rendering as a visual break
+ * because table cells use `white-space: pre`.
+ */
+export function normalizeMarkdownTableLineBreaks(markdown: string): string {
+  if (
+    !markdown ||
+    !HTML_LINE_BREAK_TEST_RE.test(markdown) ||
+    !markdown.includes("|")
+  ) {
+    return markdown;
+  }
+
+  const lines = markdown.split("\n");
+  let insideTable = false;
+
+  return lines
+    .map((line, index) => {
+      const isSeparator = TABLE_SEPARATOR_RE.test(line);
+      const previousIsSeparator = TABLE_SEPARATOR_RE.test(
+        lines[index - 1] || "",
+      );
+      const nextIsSeparator = TABLE_SEPARATOR_RE.test(lines[index + 1] || "");
+      const isTableLine = isTableLikeLine(line);
+
+      if (!isTableLine) {
+        insideTable = false;
+        return line;
+      }
+
+      const inTable =
+        isSeparator || previousIsSeparator || nextIsSeparator || insideTable;
+      insideTable = inTable;
+
+      return inTable ? line.replace(HTML_LINE_BREAK_RE, "&#10;") : line;
+    })
+    .join("\n");
+}
+
+function normalizeMarkdownContent(value: unknown): unknown {
+  if (typeof value === "string") {
+    return normalizeMarkdownTableLineBreaks(value);
+  }
+
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  let changed = false;
+  const normalized = value.map((item) => {
+    if (!item || typeof item !== "object") {
+      return item;
+    }
+
+    const record = item as Record<string, unknown>;
+    if (record.type !== "text" || typeof record.text !== "string") {
+      return item;
+    }
+
+    const text = normalizeMarkdownTableLineBreaks(record.text);
+    if (text === record.text) {
+      return item;
+    }
+
+    changed = true;
+    return { ...record, text };
+  });
+
+  return changed ? normalized : value;
+}
+
+export function normalizeMarkdownPayloadLineBreaks<T>(payload: T): T {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+
+  const record = payload as Record<string, unknown>;
+  let next: Record<string, unknown> | null = null;
+  const ensureNext = () => {
+    if (!next) next = { ...record };
+    return next;
+  };
+
+  if (record.type === "text" && typeof record.text === "string") {
+    const text = normalizeMarkdownTableLineBreaks(record.text);
+    if (text !== record.text) {
+      ensureNext().text = text;
+    }
+  }
+
+  if ("content" in record) {
+    const content = normalizeMarkdownContent(record.content);
+    if (content !== record.content) {
+      ensureNext().content = content;
+    }
+  }
+
+  if (Array.isArray(record.output)) {
+    let changed = false;
+    const output = record.output.map((item) => {
+      const normalized = normalizeMarkdownPayloadLineBreaks(item);
+      if (normalized !== item) changed = true;
+      return normalized;
+    });
+    if (changed) {
+      ensureNext().output = output;
+    }
+  }
+
+  if (Array.isArray(record.input)) {
+    let changed = false;
+    const input = record.input.map((item) => {
+      const normalized = normalizeMarkdownPayloadLineBreaks(item);
+      if (normalized !== item) changed = true;
+      return normalized;
+    });
+    if (changed) {
+      ensureNext().input = input;
+    }
+  }
+
+  return (next || record) as T;
+}


### PR DESCRIPTION
Fixes #2983.

## Summary
- normalize `<br>` tags inside Markdown table rows to an HTML line-feed entity before rendering
- apply the normalization to live chat stream payloads, loaded chat history, and Markdown preview content
- add regression coverage proving table cell breaks render without enabling raw HTML rendering

I read the README and CONTRIBUTING guidelines before taking this issue, and commented on #2983 before starting the focused fix.

## Tests
- `$env:NODE_OPTIONS='--max-old-space-size=4096'; npx vitest run src/utils/markdown.test.tsx`
- `npx prettier --check src/utils/markdown.ts src/utils/markdown.test.tsx src/components/MarkdownCopy/MarkdownCopy.tsx src/pages/Chat/index.tsx src/pages/Chat/sessionApi/index.ts`
- `npx tsc -b --noEmit`
- `pre-commit run --files console/src/utils/markdown.ts console/src/utils/markdown.test.tsx console/src/components/MarkdownCopy/MarkdownCopy.tsx console/src/pages/Chat/index.tsx console/src/pages/Chat/sessionApi/index.ts`
- `git diff --check`

Note: focused ESLint passes for `src/utils/markdown.ts`, `src/utils/markdown.test.tsx`, `src/components/MarkdownCopy/MarkdownCopy.tsx`, and `src/pages/Chat/sessionApi/index.ts`. `src/pages/Chat/index.tsx` still has pre-existing `no-explicit-any` and hook dependency lint findings outside this patch.