### PR TITLE
fix(audio): accept top-level audio data sources

### DIFF
--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -21,6 +21,55 @@ from .file_handling import download_file_from_base64, download_file_from_url
 logger = logging.getLogger(__name__)
 
 
+def _audio_media_type_from_block(block: dict, data: str) -> str:
+    media_type = block.get("media_type")
+    if isinstance(media_type, str) and media_type:
+        return media_type
+
+    audio_format = str(block.get("format") or "").lstrip(".")
+    if audio_format:
+        return _media_type_from_path(f"audio.{audio_format}")
+    return _media_type_from_path(data)
+
+
+def _extract_audio_data_source(block: dict):
+    data = block.get("data")
+    if not isinstance(data, str) or not data:
+        return None, None
+
+    media_type = _audio_media_type_from_block(block, data)
+    parsed = urllib.parse.urlparse(data)
+    if parsed.scheme in {"http", "https", "file"}:
+        filename = os.path.basename(parsed.path) or None
+        return {
+            "type": "url",
+            "url": data,
+            "media_type": media_type,
+        }, filename
+
+    if os.path.isfile(data):
+        local_path = Path(data).resolve()
+        return {
+            "type": "url",
+            "url": local_path.as_uri(),
+            "media_type": media_type,
+        }, local_path.name
+
+    if os.path.isabs(data):
+        local_path = Path(data)
+        return {
+            "type": "url",
+            "url": local_path.as_uri(),
+            "media_type": media_type,
+        }, local_path.name
+
+    return {
+        "type": "base64",
+        "data": data,
+        "media_type": media_type,
+    }, None
+
+
 async def _process_single_file_block(
     source: dict,
     filename: Optional[str],
@@ -72,6 +121,11 @@ def _extract_source_and_filename(block: dict, block_type: str):
         return block.get("source", {}), block.get("filename")
 
     source = block.get("source", {})
+    if block_type == "audio" and not source:
+        source, filename = _extract_audio_data_source(block)
+        if source is not None:
+            return source, filename
+
     if not isinstance(source, dict):
         return None, None
 

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -5,12 +5,18 @@ Covers:
 - is_first_user_interaction
 - prepend_to_message_content
 """
-# pylint: disable=redefined-outer-name
+# pylint: disable=protected-access
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+from agentscope.message import Msg
+
 from qwenpaw.agents.utils.message_processing import (
+    _extract_source_and_filename,
     is_first_user_interaction,
     prepend_to_message_content,
+    process_file_and_media_blocks_in_message,
 )
 
 
@@ -143,3 +149,92 @@ class TestPrependToMessageContent:
         prepend_to_message_content(msg, "guidance")
         assert len(msg.content) == 2
         assert msg.content[1]["type"] == "image"
+
+
+# ---------------------------------------------------------------------------
+# audio source extraction
+# ---------------------------------------------------------------------------
+
+
+class TestAudioDataSource:
+    def test_audio_top_level_data_local_path_becomes_file_url(self, tmp_path):
+        audio_path = tmp_path / "voice.oga"
+        audio_path.write_bytes(b"audio")
+
+        source, filename = _extract_source_and_filename(
+            {
+                "type": "audio",
+                "data": str(audio_path),
+                "format": "ogg",
+            },
+            "audio",
+        )
+
+        assert source == {
+            "type": "url",
+            "url": audio_path.resolve().as_uri(),
+            "media_type": "audio/ogg",
+        }
+        assert filename == "voice.oga"
+
+    def test_audio_top_level_data_base64_stays_base64(self):
+        source, filename = _extract_source_and_filename(
+            {
+                "type": "audio",
+                "data": "YXVkaW8=",
+                "format": "mp3",
+            },
+            "audio",
+        )
+
+        assert source == {
+            "type": "base64",
+            "data": "YXVkaW8=",
+            "media_type": "audio/mp3",
+        }
+        assert filename is None
+
+    @pytest.mark.asyncio
+    async def test_audio_top_level_data_is_transcribed(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        audio_path = tmp_path / "voice.oga"
+        audio_path.write_bytes(b"audio")
+
+        async def fake_transcribe(path):
+            assert path == str(audio_path.resolve())
+            return "hello from voice"
+
+        monkeypatch.setattr(
+            "qwenpaw.agents.utils.audio_transcription.transcribe_audio",
+            fake_transcribe,
+        )
+        monkeypatch.setattr(
+            "qwenpaw.agents.utils.message_processing.load_config",
+            lambda: SimpleNamespace(
+                agents=SimpleNamespace(audio_mode="auto", language="en"),
+            ),
+        )
+
+        msg = Msg(
+            name="user",
+            role="user",
+            content=[
+                {
+                    "type": "audio",
+                    "data": str(audio_path),
+                    "format": "ogg",
+                },
+            ],
+        )
+
+        await process_file_and_media_blocks_in_message(msg)
+
+        assert msg.content == [
+            {
+                "type": "text",
+                "text": "[Voice message]: hello from voice",
+            },
+        ]


### PR DESCRIPTION
## Summary
- accept audio blocks that use top-level `data` without a `source` dict
- map local audio paths and `file://`/HTTP(S) audio references into URL sources with media types
- keep non-path audio strings on the existing base64 path
- add regression coverage for local Telegram-style voice data and transcription flow

## Root cause
Telegram and other channels can emit `AudioContent(data=...)`. The message processing pipeline only extracted `source`, so those audio blocks were skipped and could later reach formatters as raw/invalid audio payloads.

## Notes
This is a current-main replacement for the same root contract gap discussed in #1516. The older PR #1896 is currently conflicting/failing, and this patch keeps the scope limited to source extraction plus regression tests.

## Tests
- `PYTHONPATH=src pytest tests/unit/agents/utils/test_message_processing.py -q`
- `pre-commit run --files src/qwenpaw/agents/utils/message_processing.py tests/unit/agents/utils/test_message_processing.py`
- `git diff --check`

Closes #1516