### PR TITLE
test(dingtalk): cover quoted message parsing

### DIFF
--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -3032,6 +3032,107 @@ class TestDingTalkHandlerRichContent:
 
         assert result == []
 
+    def test_process_quoted_text_message(self, rich_handler):
+        """Quoted plain text should be prepended as context."""
+        raw_data = {
+            "robotCode": "robot_123",
+            "text": {
+                "isReplyMsg": True,
+                "repliedMsg": {
+                    "msgType": "text",
+                    "content": {"text": "previous message"},
+                },
+            },
+        }
+        text_parts = []
+        content_parts = []
+
+        rich_handler._process_quoted_message(
+            raw_data,
+            text_parts,
+            content_parts,
+        )
+
+        assert text_parts == ["[quoted message: previous message]"]
+        assert not content_parts
+
+    def test_process_quoted_file_message(self, rich_handler):
+        """Quoted file messages should resolve their download code."""
+        raw_data = {
+            "robotCode": "robot_123",
+            "text": {
+                "isReplyMsg": True,
+                "repliedMsg": {
+                    "msgType": "file",
+                    "content": {
+                        "downloadCode": "file_dl",
+                        "fileName": "report.pdf",
+                    },
+                },
+            },
+        }
+        file_part = MagicMock()
+        text_parts = []
+        content_parts = []
+
+        with patch.object(
+            rich_handler,
+            "_fetch_download_url_and_content",
+            return_value=file_part,
+        ) as mock_fetch:
+            rich_handler._process_quoted_message(
+                raw_data,
+                text_parts,
+                content_parts,
+            )
+
+        mock_fetch.assert_called_once_with(
+            "file_dl",
+            "robot_123",
+            "file",
+            filename_hint="report.pdf",
+        )
+        assert not text_parts
+        assert content_parts == [file_part]
+
+    def test_process_quoted_rich_text_message(self, rich_handler):
+        """Quoted richText should preserve both text and image parts."""
+        raw_data = {
+            "robotCode": "robot_123",
+            "text": {
+                "isReplyMsg": True,
+                "repliedMsg": {
+                    "msgType": "richText",
+                    "content": {
+                        "richText": [
+                            {"msgType": "text", "content": "quoted text"},
+                            {
+                                "msgType": "picture",
+                                "downloadCode": "image_dl",
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+        image_part = MagicMock()
+        text_parts = []
+        content_parts = []
+
+        with patch.object(
+            rich_handler,
+            "_fetch_download_url_and_content",
+            return_value=image_part,
+        ):
+            rich_handler._process_quoted_message(
+                raw_data,
+                text_parts,
+                content_parts,
+            )
+
+        assert text_parts == ["[quoted message: quoted text]"]
+        assert content_parts == [image_part]
+
     def test_parse_rich_content_exception_handled(self, rich_handler):
         """Exceptions in parsing should be handled."""
         incoming = MagicMock()


### PR DESCRIPTION
## Description

Adds DingTalk regression coverage for quoted messages. The current handler already has quoted-message parsing paths; this PR locks that behavior down for quoted plain text, quoted files, and quoted richText content so future channel changes do not regress #3109.

**Related Issue:** Covers #3109

**Security Considerations:** None; test-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Tests

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Focused regression coverage only; no production behavior changes.

## Local Verification Evidence

```bash
pytest tests/unit/channels/test_dingtalk.py::TestDingTalkHandlerRichContent
# 8 passed

pytest tests/unit/channels/test_dingtalk.py
# 158 passed, 27 existing warnings

pre-commit run --files tests/unit/channels/test_dingtalk.py
# passed

git diff --check
# no whitespace errors

git diff --name-only fork/main..origin/main -- tests/unit/channels/test_dingtalk.py src/qwenpaw/app/channels/dingtalk/handler.py
# no output; target files unchanged upstream

git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'
# no output; no merge conflicts detected
```

## Additional Notes

`pre-commit run --all-files` and `scripts/check-channels.sh` were not run locally. This PR only adds unit coverage for existing DingTalk quoted-message parsing behavior.