### PR TITLE
test(envs): cover persisted env store

### DIFF
--- a/tests/unit/envs/test_store.py
+++ b/tests/unit/envs/test_store.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.envs import store
+from qwenpaw.security import secret_store
+
+
+ENV_KEYS = (
+    "QWENPAW_TEST_KEY",
+    "QWENPAW_EMPTY_KEY",
+    "QWENPAW_KEEP_KEY",
+    "QWENPAW_DROP_KEY",
+    "QWENPAW_EXISTING_KEY",
+    "QWENPAW_CRUD_KEY",
+    "QWENPAW_WORKING_DIR",
+    "QWENPAW_SECRET_DIR",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    test_key = bytes.fromhex(
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+    )
+    monkeypatch.setattr(secret_store, "_cached_master_key", test_key)
+    monkeypatch.setattr(secret_store, "_cached_fernet", None)
+    monkeypatch.setattr(secret_store, "_get_secret_dir", lambda: tmp_path)
+    monkeypatch.setattr(store, "_BOOTSTRAP_SECRET_DIR", tmp_path)
+    monkeypatch.setattr(store, "_ENVS_JSON", tmp_path / "envs.json")
+    monkeypatch.setattr(store, "_LEGACY_ENVS_JSON_CANDIDATES", ())
+    for key in ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _read_raw(path: Path) -> dict[str, str]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_save_envs_writes_encrypted_values_and_syncs_environ(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "envs.json"
+
+    store.save_envs(
+        {
+            "QWENPAW_TEST_KEY": "secret-value",
+            "QWENPAW_EMPTY_KEY": "",
+        },
+        path,
+    )
+
+    raw = _read_raw(path)
+    assert store.is_encrypted(raw["QWENPAW_TEST_KEY"])
+    assert store.decrypt(raw["QWENPAW_TEST_KEY"]) == "secret-value"
+    assert raw["QWENPAW_EMPTY_KEY"] == ""
+    assert store.load_envs(path) == {
+        "QWENPAW_TEST_KEY": "secret-value",
+        "QWENPAW_EMPTY_KEY": "",
+    }
+    assert os.environ["QWENPAW_TEST_KEY"] == "secret-value"
+    assert os.environ["QWENPAW_EMPTY_KEY"] == ""
+
+
+def test_load_envs_reencrypts_legacy_plaintext_values(tmp_path: Path) -> None:
+    path = tmp_path / "envs.json"
+    path.write_text(
+        json.dumps(
+            {
+                "QWENPAW_TEST_KEY": "legacy-plain",
+                "QWENPAW_EMPTY_KEY": "",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    assert store.load_envs(path) == {
+        "QWENPAW_TEST_KEY": "legacy-plain",
+        "QWENPAW_EMPTY_KEY": "",
+    }
+
+    raw = _read_raw(path)
+    assert store.is_encrypted(raw["QWENPAW_TEST_KEY"])
+    assert store.decrypt(raw["QWENPAW_TEST_KEY"]) == "legacy-plain"
+    assert raw["QWENPAW_EMPTY_KEY"] == ""
+
+
+def test_save_envs_removes_stale_environ_values(tmp_path: Path) -> None:
+    path = tmp_path / "envs.json"
+    store.save_envs(
+        {
+            "QWENPAW_KEEP_KEY": "old",
+            "QWENPAW_DROP_KEY": "old",
+        },
+        path,
+    )
+
+    store.save_envs({"QWENPAW_KEEP_KEY": "new"}, path)
+
+    assert os.environ["QWENPAW_KEEP_KEY"] == "new"
+    assert "QWENPAW_DROP_KEY" not in os.environ
+
+
+def test_save_envs_preserves_runtime_override_for_stale_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "envs.json"
+    store.save_envs({"QWENPAW_DROP_KEY": "persisted"}, path)
+    monkeypatch.setenv("QWENPAW_DROP_KEY", "runtime")
+
+    store.save_envs({}, path)
+
+    assert os.environ["QWENPAW_DROP_KEY"] == "runtime"
+
+
+def test_set_and_delete_env_var_use_default_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "envs.json"
+    monkeypatch.setattr(store, "_ENVS_JSON", path)
+
+    assert store.set_env_var("QWENPAW_CRUD_KEY", "created") == {
+        "QWENPAW_CRUD_KEY": "created",
+    }
+    assert store.load_envs(path) == {"QWENPAW_CRUD_KEY": "created"}
+    assert os.environ["QWENPAW_CRUD_KEY"] == "created"
+
+    assert store.delete_env_var("QWENPAW_CRUD_KEY") == {}
+    assert store.load_envs(path) == {}
+    assert "QWENPAW_CRUD_KEY" not in os.environ
+
+
+def test_load_envs_into_environ_preserves_runtime_and_protected_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "envs.json"
+    monkeypatch.setattr(store, "_ENVS_JSON", path)
+    path.write_text(
+        json.dumps(
+            {
+                "QWENPAW_TEST_KEY": store.encrypt("persisted"),
+                "QWENPAW_EXISTING_KEY": store.encrypt("persisted"),
+                "QWENPAW_SECRET_DIR": store.encrypt("secret-dir"),
+            },
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("QWENPAW_EXISTING_KEY", "runtime")
+
+    envs = store.load_envs_into_environ()
+
+    assert envs == {
+        "QWENPAW_TEST_KEY": "persisted",
+        "QWENPAW_EXISTING_KEY": "persisted",
+        "QWENPAW_SECRET_DIR": "secret-dir",
+    }
+    assert os.environ["QWENPAW_TEST_KEY"] == "persisted"
+    assert os.environ["QWENPAW_EXISTING_KEY"] == "runtime"
+    assert "QWENPAW_SECRET_DIR" not in os.environ
+
+
+def test_load_envs_returns_empty_for_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "envs.json"
+    path.write_text("{not-json", encoding="utf-8")
+
+    assert store.load_envs(path) == {}


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.envs.store` persistence behavior:

- encrypted writes to `envs.json`
- transparent plaintext migration and re-encryption
- `os.environ` synchronization for saved, updated, and removed keys
- preserving runtime overrides when a stale persisted key is removed
- `set_env_var` / `delete_env_var` CRUD helpers
- bootstrap loading that preserves existing runtime env values and excludes protected bootstrap keys
- invalid JSON fallback

**Related Issue:** Relates to #4341

**Security Considerations:** Tests only. The test fixture isolates the secret-store key and env store path under `tmp_path`, so it does not read or write real user secrets.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Tests

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/envs/test_store.py`
- `pytest tests/unit/envs`
- `pre-commit run --files tests/unit/envs/test_store.py`
- `git diff --check`
- Merge-tree conflict scan against `origin/main`

## Local Verification Evidence

```bash
pytest tests/unit/envs/test_store.py
# 7 passed

pytest tests/unit/envs
# 7 passed

pre-commit run --files tests/unit/envs/test_store.py
# check python ast, docstring, encoding pragma, private key, trailing whitespace,
# trailing commas, mypy, black, flake8, pylint all passed

git diff --check
# no output
```

## Additional Notes

This is a focused slice of the Phase 4 envs coverage request rather than the full 10-file milestone.