### PR TITLE
test(local-models): cover tag parser

### DIFF
--- a/tests/unit/local_models/test_tag_parser.py
+++ b/tests/unit/local_models/test_tag_parser.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from qwenpaw.local_models import tag_parser
+
+
+def test_extract_thinking_from_complete_tag() -> None:
+    result = tag_parser.extract_thinking_from_text(
+        "before <think>reasoning\nsteps</think> after",
+    )
+
+    assert result.thinking == "reasoning\nsteps"
+    assert result.remaining_text == "before  after"
+    assert result.has_open_tag is False
+
+
+def test_extract_thinking_from_open_streaming_tag() -> None:
+    result = tag_parser.extract_thinking_from_text(
+        "answer prefix <think>still thinking",
+    )
+
+    assert result.thinking == "still thinking"
+    assert result.remaining_text == "answer prefix"
+    assert result.has_open_tag is True
+
+
+def test_text_contains_tag_helpers() -> None:
+    assert tag_parser.text_contains_think_tag("<think>x")
+    assert not tag_parser.text_contains_think_tag("plain text")
+    assert tag_parser.text_contains_tool_call_tag("<tool_call>{}</tool_call>")
+    assert not tag_parser.text_contains_tool_call_tag("plain text")
+
+
+def test_parse_json_tool_call() -> None:
+    result = tag_parser.parse_tool_calls_from_text(
+        'before <tool_call>{"name": "read_file", '
+        '"arguments": {"path": "notes.md"}}</tool_call> after',
+    )
+
+    assert result.text_before == "before"
+    assert result.text_after == "after"
+    assert result.has_open_tag is False
+    assert len(result.tool_calls) == 1
+    call = result.tool_calls[0]
+    assert call.id.startswith("call_")
+    assert call.name == "read_file"
+    assert call.arguments == {"path": "notes.md"}
+    assert call.raw_arguments == '{"path": "notes.md"}'
+
+
+def test_parse_json_tool_call_with_arguments_string() -> None:
+    result = tag_parser.parse_tool_calls_from_text(
+        '<tool_call>{"name": "write_file", '
+        '"arguments": "{\\"path\\": \\"a.txt\\", \\"content\\": \\"ok\\"}"'
+        "}</tool_call>",
+    )
+
+    assert result.tool_calls[0].name == "write_file"
+    assert result.tool_calls[0].arguments == {
+        "path": "a.txt",
+        "content": "ok",
+    }
+
+
+def test_parse_strict_xml_tool_call() -> None:
+    result = tag_parser.parse_tool_calls_from_text(
+        "<tool_call>"
+        "<function=read_file>"
+        "<parameter=path>notes.md</parameter>"
+        "<parameter=limit>20</parameter>"
+        "</function>"
+        "</tool_call>",
+    )
+
+    call = result.tool_calls[0]
+    assert call.name == "read_file"
+    assert call.arguments == {"path": "notes.md", "limit": "20"}
+
+
+def test_parse_lenient_xml_tool_call_without_closing_parameter_tags() -> None:
+    result = tag_parser.parse_tool_calls_from_text(
+        "<tool_call>"
+        "<function=grep_search>"
+        "<parameter=pattern>TODO"
+        "<parameter=path>src"
+        "</tool_call>",
+    )
+
+    call = result.tool_calls[0]
+    assert call.name == "grep_search"
+    assert call.arguments == {"pattern": "TODO", "path": "src"}
+
+
+def test_parse_multiple_tool_calls_and_trailing_partial() -> None:
+    result = tag_parser.parse_tool_calls_from_text(
+        'intro <tool_call>{"name": "read_file", '
+        '"arguments": {"path": "a.md"}}</tool_call>'
+        ' middle <tool_call>{"name": "write_file", '
+        '"arguments": {"path": "b.md"}}</tool_call>'
+        " outro <tool_call>partial",
+    )
+
+    assert result.text_before == "intro"
+    assert result.text_after == "outro"
+    assert result.has_open_tag is True
+    assert result.partial_tool_text == "partial"
+    assert [call.name for call in result.tool_calls] == [
+        "read_file",
+        "write_file",
+    ]
+
+
+def test_parse_only_open_tool_call_tag() -> None:
+    result = tag_parser.parse_tool_calls_from_text(
+        "lead text <tool_call>partial body",
+    )
+
+    assert result.text_before == "lead text"
+    assert not result.tool_calls
+    assert result.has_open_tag is True
+    assert result.partial_tool_text == "partial body"
+
+
+def test_invalid_tool_call_is_skipped_and_logged(monkeypatch) -> None:
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        tag_parser.logger,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+
+    result = tag_parser.parse_tool_calls_from_text(
+        "before <tool_call>{not-json}</tool_call> after",
+    )
+
+    assert result.text_before == "before"
+    assert result.text_after == "after"
+    assert not result.tool_calls
+    assert any("Failed to parse tool call" in msg for msg in warnings)


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.local_models.tag_parser`:

- complete and streaming `<think>` extraction
- fast tag-detection helpers
- JSON tool-call parsing, including stringified `arguments`
- strict XML tool-call parsing
- lenient XML parsing when parameter closing tags are absent
- multiple tool calls plus trailing partial streaming tag
- invalid tool-call blocks being skipped and logged

**Related Issue:** Relates to #4342

**Security Considerations:** Tests only. No runtime parsing behavior is changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Tests

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/local_models/test_tag_parser.py`
- `pytest tests/unit/local_models`
- `pre-commit run --files tests/unit/local_models/test_tag_parser.py`
- `git diff --check`
- Merge-tree conflict scan against `origin/main`

## Local Verification Evidence

```bash
pytest tests/unit/local_models/test_tag_parser.py
# 10 passed

pytest tests/unit/local_models
# 67 passed, 1 warning

pre-commit run --files tests/unit/local_models/test_tag_parser.py
# check python ast, docstring, encoding pragma, private key, trailing whitespace,
# trailing commas, mypy, black, flake8, pylint all passed

git diff --check
# no output
```

## Additional Notes

This is another focused slice of the Phase 5 coverage request rather than the full 7-file milestone.