### PR TITLE
test(tunnel): cover cloudflare tunnel driver

### DIFF
--- a/tests/unit/tunnel/test_cloudflare.py
+++ b/tests/unit/tunnel/test_cloudflare.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from qwenpaw.tunnel import cloudflare
+
+
+class FakeBinaryManager:
+    def __init__(self, path: str = "cloudflared") -> None:
+        self.path = path
+
+    async def get_binary_path(self) -> str:
+        return self.path
+
+
+class FakeStderr:
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = list(lines)
+
+    async def readline(self) -> bytes:
+        if self._lines:
+            return self._lines.pop(0)
+        return b""
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        stderr_lines: list[bytes] | None = None,
+        pid: int = 1234,
+    ) -> None:
+        self.pid = pid
+        self.stderr = FakeStderr(stderr_lines or [])
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int | None:
+        return self.returncode
+
+
+async def test_start_launches_cloudflared_and_sets_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[Any, ...]] = []
+    process = FakeProcess(pid=9876)
+
+    async def fake_create_subprocess_exec(*args: Any, **_kwargs: Any):
+        calls.append(args)
+        return process
+
+    async def fake_wait_for_url(timeout: float) -> str:
+        assert timeout == 30
+        return "https://abc123.trycloudflare.com"
+
+    async def fake_monitor() -> None:
+        return None
+
+    monkeypatch.setattr(
+        cloudflare.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager("cf"))
+    monkeypatch.setattr(driver, "_wait_for_url", fake_wait_for_url)
+    monkeypatch.setattr(driver, "_monitor", fake_monitor)
+
+    info = await driver.start(8088)
+
+    assert calls == [("cf", "tunnel", "--url", "http://localhost:8088")]
+    assert info.public_url == "https://abc123.trycloudflare.com"
+    assert info.public_wss_url == "wss://abc123.trycloudflare.com"
+    assert info.pid == 9876
+    assert driver.get_public_url() == info.public_url
+    assert driver.get_info() == info
+    assert await driver.health_check() is True
+
+    await driver.stop()
+
+
+async def test_start_stops_process_when_url_is_not_detected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(pid=100)
+
+    async def fake_create_subprocess_exec(*_args: Any, **_kwargs: Any):
+        return process
+
+    async def fake_wait_for_url(timeout: float) -> None:
+        assert timeout == 30
+        return None
+
+    monkeypatch.setattr(
+        cloudflare.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager())
+    monkeypatch.setattr(driver, "_wait_for_url", fake_wait_for_url)
+
+    with pytest.raises(RuntimeError, match="did not produce a tunnel URL"):
+        await driver.start(8088)
+
+    assert process.terminated is True
+    assert driver.get_info() is None
+
+
+async def test_start_restarts_existing_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_process = FakeProcess(pid=1)
+    new_process = FakeProcess(pid=2)
+    processes = [new_process]
+
+    async def fake_create_subprocess_exec(*_args: Any, **_kwargs: Any):
+        return processes.pop(0)
+
+    async def fake_wait_for_url(timeout: float) -> str:
+        assert timeout == 30
+        return "https://next.trycloudflare.com"
+
+    async def fake_monitor() -> None:
+        return None
+
+    monkeypatch.setattr(
+        cloudflare.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager())
+    driver._process = old_process  # pylint: disable=protected-access
+    monkeypatch.setattr(driver, "_wait_for_url", fake_wait_for_url)
+    monkeypatch.setattr(driver, "_monitor", fake_monitor)
+
+    info = await driver.start(9000)
+
+    assert old_process.terminated is True
+    assert info.pid == 2
+    await driver.stop()
+
+
+async def test_wait_for_url_extracts_trycloudflare_url() -> None:
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager())
+    driver._process = FakeProcess(  # pylint: disable=protected-access
+        [
+            b"info: starting\n",
+            b"https://abc-123.trycloudflare.com is ready\n",
+        ],
+    )
+
+    assert (
+        await driver._wait_for_url(timeout=1)
+        == "https://abc-123.trycloudflare.com"
+    )
+
+
+async def test_wait_for_url_returns_none_without_process_or_stderr() -> None:
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager())
+
+    assert await driver._wait_for_url(timeout=0.1) is None
+
+    driver._process = FakeProcess()  # pylint: disable=protected-access
+    driver._process.stderr = None
+
+    assert await driver._wait_for_url(timeout=0.1) is None
+
+
+async def test_stop_kills_process_after_graceful_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess()
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager())
+    driver._process = process  # pylint: disable=protected-access
+
+    async def fake_wait_for(awaitable: Any, timeout: float) -> None:
+        awaitable.close()
+        assert timeout == 5
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(cloudflare.asyncio, "wait_for", fake_wait_for)
+
+    await driver.stop()
+
+    assert process.terminated is True
+    assert process.killed is True
+    assert driver.get_info() is None
+
+
+async def test_monitor_clears_info_after_process_exits() -> None:
+    process = FakeProcess()
+    process.returncode = 1
+    driver = cloudflare.CloudflareTunnelDriver(FakeBinaryManager())
+    driver._process = process  # pylint: disable=protected-access
+    driver._info = cloudflare.TunnelInfo(  # pylint: disable=protected-access
+        public_url="https://dead.trycloudflare.com",
+        public_wss_url="wss://dead.trycloudflare.com",
+        started_at=datetime.now(timezone.utc),
+        pid=process.pid,
+    )
+
+    await driver._monitor()
+
+    assert driver.get_info() is None


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.tunnel.cloudflare`: subprocess launch arguments, tunnel info URL/WSS derivation, restart behavior, missing URL cleanup, stderr URL parsing, health/info helpers, graceful-stop timeout kill fallback, and monitor cleanup after process exit.

**Related Issue:** Relates to #4342

**Security Considerations:** Test-only change. No runtime security behavior changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/tunnel/test_cloudflare.py`
- `pytest tests/unit/tunnel`
- `pre-commit run --files tests/unit/tunnel/test_cloudflare.py`
- `git diff --check`
- `git diff --name-only fork/main..origin/main -- src/qwenpaw/tunnel tests/unit/tunnel`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'`

## Local Verification Evidence

```bash
pytest tests/unit/tunnel/test_cloudflare.py
# 7 passed in 3.65s

pytest tests/unit/tunnel
# 7 passed in 5.20s

pre-commit run --files tests/unit/tunnel/test_cloudflare.py
# check python ast, encoding pragma, secrets, whitespace, trailing commas,
# mypy, black, flake8, pylint all Passed

git diff --check
# no output
```

## Additional Notes

This is a targeted Phase 5 tunnel coverage slice and does not change runtime code.