### PR TITLE
test(providers): cover model capability cache

### DIFF
--- a/tests/unit/providers/test_model_capability_cache.py
+++ b/tests/unit/providers/test_model_capability_cache.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+
+from qwenpaw.providers import model_capability_cache
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton() -> Generator[None, None, None]:
+    model_capability_cache.ModelCapabilityCache._instance = None
+    yield
+    model_capability_cache.ModelCapabilityCache._instance = None
+
+
+def test_get_instance_returns_process_singleton() -> None:
+    first = model_capability_cache.ModelCapabilityCache.get_instance()
+    second = model_capability_cache.ModelCapabilityCache.get_instance()
+
+    assert first is second
+    assert model_capability_cache.get_capability_cache() is first
+
+
+def test_learn_and_get_returns_cached_value_or_default() -> None:
+    cache = model_capability_cache.ModelCapabilityCache()
+
+    assert cache.get("openai:gpt", "rejects_media") is None
+    assert cache.get("openai:gpt", "rejects_media", False) is False
+
+    cache.learn("openai:gpt", "rejects_media", True)
+    cache.learn("openai:gpt", "needs_reasoning_content", False)
+
+    assert cache.get("openai:gpt", "rejects_media") is True
+    assert cache.get("openai:gpt", "needs_reasoning_content") is False
+    assert (
+        cache.get("anthropic:claude", "rejects_media", "missing") == "missing"
+    )
+
+
+def test_learn_updates_value_and_logs_only_when_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = model_capability_cache.ModelCapabilityCache()
+    messages: list[str] = []
+
+    def capture_info(message: str, *args: object) -> None:
+        messages.append(message % args)
+
+    monkeypatch.setattr(model_capability_cache.logger, "info", capture_info)
+
+    cache.learn("model-a", "rejects_media", True)
+    cache.learn("model-a", "rejects_media", True)
+    cache.learn("model-a", "rejects_media", False)
+
+    assert cache.get("model-a", "rejects_media") is False
+    assert messages == [
+        "Learned capability for model-a: rejects_media=True",
+        "Learned capability for model-a: rejects_media=False",
+    ]
+
+
+def test_clear_removes_single_model_or_everything() -> None:
+    cache = model_capability_cache.ModelCapabilityCache()
+    cache.learn("model-a", "rejects_media", True)
+    cache.learn("model-b", "rejects_media", True)
+
+    cache.clear("model-a")
+
+    assert cache.get("model-a", "rejects_media") is None
+    assert cache.get("model-b", "rejects_media") is True
+
+    cache.clear()
+
+    assert cache.get("model-b", "rejects_media") is None
+
+
+def test_clear_unknown_model_is_noop() -> None:
+    cache = model_capability_cache.ModelCapabilityCache()
+    cache.learn("model-a", "rejects_media", True)
+
+    cache.clear("missing")
+
+    assert cache.get("model-a", "rejects_media") is True


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.providers.model_capability_cache`: singleton access, learned capability reads/defaults, update logging on value changes only, targeted clear, full clear, and unknown-model clear no-op behavior.

**Related Issue:** Relates to #4342

**Security Considerations:** Test-only change. No runtime security behavior changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/providers/test_model_capability_cache.py`
- `pytest tests/unit/providers`
- `pre-commit run add-trailing-comma --all-files`
- `pre-commit run black --all-files`
- `pre-commit run --files tests/unit/providers/test_model_capability_cache.py`
- `git diff --check`
- `git diff --name-only fork/main..origin/main -- src/qwenpaw/providers/model_capability_cache.py tests/unit/providers/test_model_capability_cache.py`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'`

## Local Verification Evidence

```bash
pytest tests/unit/providers/test_model_capability_cache.py
# 5 passed in 10.59s

pytest tests/unit/providers
# 105 passed in 11.99s

pre-commit run --files tests/unit/providers/test_model_capability_cache.py
# check python ast, encoding pragma, secrets, whitespace, trailing commas,
# mypy, black, flake8, pylint all Passed

git diff --check
# no output
```

## Additional Notes

This is a targeted Phase 5 providers coverage slice and does not change runtime code.