### PR TITLE
test(providers): cover multimodal prober helpers

### DIFF
--- a/tests/unit/providers/test_multimodal_prober.py
+++ b/tests/unit/providers/test_multimodal_prober.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import base64
+import time
+
+import pytest
+
+from qwenpaw.providers import multimodal_prober
+
+
+@pytest.mark.parametrize(
+    ("supports_image", "supports_video", "expected"),
+    [
+        (False, False, False),
+        (True, False, True),
+        (False, True, True),
+        (True, True, True),
+    ],
+)
+def test_probe_result_supports_multimodal_reflects_media_flags(
+    supports_image: bool,
+    supports_video: bool,
+    expected: bool,
+) -> None:
+    result = multimodal_prober.ProbeResult(
+        supports_image=supports_image,
+        supports_video=supports_video,
+    )
+
+    assert result.supports_multimodal is expected
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "image input is not supported",
+        "VIDEO_URL field is invalid",
+        "vision models only",
+        "multimodal request failed",
+        "this model does not support media",
+    ],
+)
+def test_is_media_keyword_error_detects_media_failures(message: str) -> None:
+    assert multimodal_prober._is_media_keyword_error(RuntimeError(message))
+
+
+def test_is_media_keyword_error_ignores_unrelated_errors() -> None:
+    assert (
+        multimodal_prober._is_media_keyword_error(
+            RuntimeError("rate limit exceeded"),
+        )
+        is False
+    )
+
+
+def test_probe_payload_constants_are_valid_base64() -> None:
+    image = base64.b64decode(multimodal_prober._PROBE_IMAGE_B64)
+    video = base64.b64decode(multimodal_prober._PROBE_VIDEO_B64)
+
+    assert image.startswith(b"\x89PNG\r\n\x1a\n")
+    assert b"ftyp" in video[:16]
+    assert multimodal_prober._PROBE_VIDEO_URL.startswith("https://")
+
+
+def test_evaluate_image_probe_answer_accepts_red_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 12.5)
+
+    supported, message = multimodal_prober.evaluate_image_probe_answer(
+        "  Crimson  ",
+        model_id="vision-model",
+        start_time=10.0,
+    )
+
+    assert supported is True
+    assert message == "Image supported (answer='crimson')"
+
+
+def test_evaluate_image_probe_answer_accepts_red_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 20.0)
+
+    supported, message = multimodal_prober.evaluate_image_probe_answer(
+        "unknown",
+        model_id="reasoning-model",
+        start_time=15.0,
+        reasoning="The image appears red.",
+    )
+
+    assert supported is True
+    assert message == "Image supported (reasoning, answer='unknown')"
+
+
+def test_evaluate_image_probe_answer_rejects_non_red_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(time, "monotonic", lambda: 30.0)
+
+    supported, message = multimodal_prober.evaluate_image_probe_answer(
+        "blue",
+        model_id="text-model",
+        start_time=25.0,
+    )
+
+    assert supported is False
+    assert message == "Model did not recognise image (answer='blue')"


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.providers.multimodal_prober`: `ProbeResult.supports_multimodal`, media-keyword error detection, probe payload sanity, and image probe answer evaluation through answer, reasoning, and failure paths.

**Related Issue:** Relates to #4342

**Security Considerations:** Test-only change. No runtime security behavior changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/providers/test_multimodal_prober.py`
- `pytest tests/unit/providers`
- `pre-commit run add-trailing-comma --all-files`
- `pre-commit run black --all-files`
- `pre-commit run --files tests/unit/providers/test_multimodal_prober.py`
- `git diff --check`
- `git diff --name-only fork/main..origin/main -- src/qwenpaw/providers/multimodal_prober.py tests/unit/providers/test_multimodal_prober.py`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'`

## Local Verification Evidence

```bash
pytest tests/unit/providers/test_multimodal_prober.py
# 14 passed in 13.35s

pytest tests/unit/providers
# 114 passed in 11.67s

pre-commit run --files tests/unit/providers/test_multimodal_prober.py
# check python ast, encoding pragma, secrets, whitespace, trailing commas,
# mypy, black, flake8, pylint all Passed

git diff --check
# no output
```

## Additional Notes

This is a targeted Phase 5 providers coverage slice and does not change runtime code.