### PR TITLE
test(providers): cover capability baseline helpers

### DIFF
--- a/tests/unit/providers/test_capability_baseline.py
+++ b/tests/unit/providers/test_capability_baseline.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from qwenpaw.providers import capability_baseline
+
+
+def _cap(
+    expected_image: bool | None,
+    expected_video: bool | None,
+) -> capability_baseline.ExpectedCapability:
+    return capability_baseline.ExpectedCapability(
+        provider_id="provider",
+        model_id="model",
+        expected_image=expected_image,
+        expected_video=expected_video,
+    )
+
+
+def test_registry_loads_known_baseline_entries() -> None:
+    registry = capability_baseline.ExpectedCapabilityRegistry()
+
+    openai = registry.get_expected("openai", "gpt-5")
+    dashscope = registry.get_expected("dashscope", "qwen3-max")
+
+    assert openai is not None
+    assert openai.expected_image is True
+    assert openai.expected_video is True
+    assert openai.doc_url == "https://platform.openai.com/docs/models"
+
+    assert dashscope is not None
+    assert dashscope.expected_image is False
+    assert dashscope.expected_video is False
+    assert registry.get_expected("missing", "model") is None
+
+
+def test_registry_filters_models_by_provider() -> None:
+    registry = capability_baseline.ExpectedCapabilityRegistry()
+
+    kimi_models = registry.get_all_for_provider("kimi-cn")
+    model_ids = {cap.model_id for cap in kimi_models}
+
+    assert "kimi-k2.5" in model_ids
+    assert "kimi-k2-thinking" in model_ids
+    assert all(cap.provider_id == "kimi-cn" for cap in kimi_models)
+    assert registry.get_all_for_provider("missing") == []
+
+
+def test_register_overwrites_existing_model_entry() -> None:
+    registry = capability_baseline.ExpectedCapabilityRegistry()
+    custom = capability_baseline.ExpectedCapability(
+        provider_id="custom",
+        model_id="model-a",
+        expected_image=None,
+        expected_video=True,
+        doc_url="https://example.test",
+        note="custom note",
+    )
+
+    registry._register(custom)
+
+    assert registry.get_expected("custom", "model-a") == custom
+
+
+def test_compare_probe_result_reports_false_negative_and_positive() -> None:
+    logs = capability_baseline.compare_probe_result(
+        _cap(expected_image=True, expected_video=False),
+        actual_image=False,
+        actual_video=True,
+    )
+
+    assert logs == [
+        capability_baseline.DiscrepancyLog(
+            provider_id="provider",
+            model_id="model",
+            field="image",
+            expected=True,
+            actual=False,
+            discrepancy_type="false_negative",
+        ),
+        capability_baseline.DiscrepancyLog(
+            provider_id="provider",
+            model_id="model",
+            field="video",
+            expected=False,
+            actual=True,
+            discrepancy_type="false_positive",
+        ),
+    ]
+
+
+def test_compare_probe_result_skips_unknown_and_matching_fields() -> None:
+    assert not capability_baseline.compare_probe_result(
+        _cap(expected_image=None, expected_video=True),
+        actual_image=True,
+        actual_video=True,
+    )
+
+
+def test_generate_summary_counts_statuses_and_discrepancy_details() -> None:
+    ok_cap = _cap(expected_image=True, expected_video=True)
+    discrepancy_cap = _cap(expected_image=True, expected_video=False)
+    failure_cap = _cap(expected_image=False, expected_video=False)
+
+    summary = capability_baseline.generate_summary(
+        [
+            (ok_cap, True, True, "ok"),
+            (discrepancy_cap, False, True, "discrepancy"),
+            (failure_cap, False, False, "failure"),
+        ],
+    )
+
+    assert summary.total_models == 3
+    assert summary.passed == 1
+    assert summary.discrepancies == 1
+    assert summary.failures == 1
+    assert [detail.field for detail in summary.details] == ["image", "video"]


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.providers.capability_baseline`: known baseline registry lookups, provider filtering, manual registration overwrite, discrepancy classification, unknown/matching field skips, and comparison summary counts/details.

**Related Issue:** Relates to #4342

**Security Considerations:** Test-only change. No runtime security behavior changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/providers/test_capability_baseline.py`
- `pytest tests/unit/providers`
- `pre-commit run add-trailing-comma --all-files`
- `pre-commit run black --all-files`
- `pre-commit run --files tests/unit/providers/test_capability_baseline.py`
- `git diff --check`
- `git diff --name-only fork/main..origin/main -- src/qwenpaw/providers/capability_baseline.py tests/unit/providers/test_capability_baseline.py`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'`

## Local Verification Evidence

```bash
pytest tests/unit/providers/test_capability_baseline.py
# 6 passed in 10.59s

pytest tests/unit/providers
# 106 passed in 11.72s

pre-commit run --files tests/unit/providers/test_capability_baseline.py
# check python ast, encoding pragma, secrets, whitespace, trailing commas,
# mypy, black, flake8, pylint all Passed

git diff --check
# no output
```

## Additional Notes

This is a targeted Phase 5 providers coverage slice and does not change runtime code.