### PR TITLE
test(config): cover timezone detection helpers

### DIFF
--- a/tests/unit/config/test_timezone.py
+++ b/tests/unit/config/test_timezone.py
@@ -101,7 +101,9 @@ def test_detect_system_timezone_inner_falls_back_to_utc(
     monkeypatch.setattr(timezone_config, "_probe_python", lambda: None)
     monkeypatch.setattr(timezone_config, "_probe_env", lambda: "Invalid/Zone")
     monkeypatch.setattr(
-        timezone_config, "_probe_windows_registry", lambda: None
+        timezone_config,
+        "_probe_windows_registry",
+        lambda: None,
     )
     monkeypatch.setattr(timezone_config.os, "name", "nt")
 

--- a/tests/unit/config/test_timezone.py
+++ b/tests/unit/config/test_timezone.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.config import timezone as timezone_config
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Asia/Jakarta", "Asia/Jakarta"),
+        ("Asia/Calcutta", "Asia/Kolkata"),
+        ("Europe/Kiev", "Europe/Kyiv"),
+        ("PRC", "Asia/Shanghai"),
+        ("", None),
+        ("Not/AZone", None),
+    ],
+)
+def test_normalize_tz_validates_and_maps_aliases(
+    name: str,
+    expected: str | None,
+) -> None:
+    assert timezone_config.normalize_tz(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Asia/Jakarta", True),
+        ("UTC", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_iana_requires_slash(name: str | None, expected: bool) -> None:
+    assert timezone_config._is_iana(name) is expected
+
+
+def test_probe_env_returns_only_iana_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TZ", "Asia/Jakarta")
+    assert timezone_config._probe_env() == "Asia/Jakarta"
+
+    monkeypatch.setenv("TZ", "UTC")
+    assert timezone_config._probe_env() is None
+
+    monkeypatch.delenv("TZ", raising=False)
+    assert timezone_config._probe_env() is None
+
+
+def test_probe_localtime_link_extracts_zoneinfo_suffix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        timezone_config.os,
+        "readlink",
+        lambda _path: "/usr/share/zoneinfo/Asia/Jakarta",
+    )
+
+    assert timezone_config._probe_localtime_link() == "Asia/Jakarta"
+
+
+def test_probe_localtime_link_ignores_plain_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        timezone_config.os,
+        "readlink",
+        lambda _path: "/etc/localtime",
+    )
+
+    assert timezone_config._probe_localtime_link() is None
+
+
+def test_detect_system_timezone_inner_uses_first_normalized_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(timezone_config, "_probe_python", lambda: "Not/AZone")
+    monkeypatch.setattr(timezone_config, "_probe_env", lambda: "PRC")
+    monkeypatch.setattr(
+        timezone_config,
+        "_probe_windows_registry",
+        lambda: "America/New_York",
+    )
+    monkeypatch.setattr(
+        timezone_config,
+        "_probe_etc_timezone",
+        lambda: "Europe/London",
+    )
+    monkeypatch.setattr(timezone_config.os, "name", "nt")
+
+    assert timezone_config._detect_system_timezone_inner() == "Asia/Shanghai"
+
+
+def test_detect_system_timezone_inner_falls_back_to_utc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(timezone_config, "_probe_python", lambda: None)
+    monkeypatch.setattr(timezone_config, "_probe_env", lambda: "Invalid/Zone")
+    monkeypatch.setattr(
+        timezone_config, "_probe_windows_registry", lambda: None
+    )
+    monkeypatch.setattr(timezone_config.os, "name", "nt")
+
+    assert timezone_config._detect_system_timezone_inner() == "UTC"
+
+
+def test_detect_system_timezone_never_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail() -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(timezone_config, "_detect_system_timezone_inner", fail)
+
+    assert timezone_config.detect_system_timezone() == "UTC"


### PR DESCRIPTION
## Description

Adds focused unit coverage for `qwenpaw.config.timezone`: timezone normalization and legacy alias mapping, IANA-name screening, `TZ` env probing, `/etc/localtime` symlink parsing, inner detection fallback/mapping, and the public never-raise fallback.

**Related Issue:** Relates to #4341

**Security Considerations:** Test-only change. No runtime security behavior changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/config/test_timezone.py`
- `pytest tests/unit/config`
- `pre-commit run add-trailing-comma --all-files`
- `pre-commit run black --all-files`
- `pre-commit run --files tests/unit/config/test_timezone.py`
- `git diff --check`
- `git diff --name-only fork/main..origin/main -- src/qwenpaw/config/timezone.py tests/unit/config/test_timezone.py`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'`

## Local Verification Evidence

```bash
pytest tests/unit/config/test_timezone.py
# 16 passed in 8.88s

pytest tests/unit/config
# 16 passed in 5.25s

pre-commit run --files tests/unit/config/test_timezone.py
# check python ast, encoding pragma, secrets, whitespace, trailing commas,
# mypy, black, flake8, pylint all Passed

git diff --check
# no output
```

## Additional Notes

This is a targeted Phase 4 config coverage slice and does not change runtime code.