### PR TITLE
test(config): cover utils helpers

### DIFF
--- a/tests/unit/config/test_utils_helpers.py
+++ b/tests/unit/config/test_utils_helpers.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from pathlib import Path
+
+from qwenpaw.config import utils as config_utils
+
+
+def test_normalize_working_dir_bound_paths_rewrites_legacy_roots(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(config_utils, "WORKING_DIR", tmp_path)
+    legacy_abs = str(Path("~/.copaw").expanduser().resolve())
+    data = {
+        "workspace_dir": "~/.copaw/workspaces/default",
+        "nested": {
+            "media_dir": f"{legacy_abs}/media",
+            "other": "~/.copaw/keep",
+        },
+        "items": [{"workspace_dir": "~/.copaw/workspaces/child"}],
+    }
+
+    normalized = config_utils._normalize_working_dir_bound_paths(data)
+
+    assert normalized == {
+        "workspace_dir": f"{tmp_path}/workspaces/default",
+        "nested": {
+            "media_dir": f"{tmp_path}/media",
+            "other": "~/.copaw/keep",
+        },
+        "items": [{"workspace_dir": f"{tmp_path}/workspaces/child"}],
+    }
+
+
+def test_remove_nested_key_handles_dicts_and_lists() -> None:
+    data = {"agents": [{"id": "a", "bad": True}], "keep": 1}
+
+    assert config_utils._remove_nested_key(data, ["agents", 0, "bad"]) is True
+    assert data == {"agents": [{"id": "a"}], "keep": 1}
+    assert config_utils._remove_nested_key(data, ["agents", 9, "bad"]) is False
+    assert config_utils._remove_nested_key(data, ["missing"]) is False
+
+
+def test_remove_bad_field_falls_back_to_ancestor_key() -> None:
+    data = {"outer": {"inner": {"bad": True}}, "keep": 1}
+
+    assert config_utils._remove_bad_field(data, ["outer", "missing", "bad"])
+    assert data == {"keep": 1}
+
+
+def test_remove_bad_field_removes_exact_leaf_first() -> None:
+    data = {"outer": {"inner": {"bad": True, "keep": True}}}
+
+    assert config_utils._remove_bad_field(data, ["outer", "inner", "bad"])
+    assert data == {"outer": {"inner": {"keep": True}}}
+
+
+def test_linux_desktop_to_kind_and_path_maps_known_browsers() -> None:
+    assert config_utils._linux_desktop_to_kind_and_path(
+        "/usr/bin/google-chrome",
+    ) == ("chromium", "/usr/bin/google-chrome")
+    assert config_utils._linux_desktop_to_kind_and_path(
+        "/usr/bin/firefox",
+    ) == ("firefox", "/usr/bin/firefox")
+    assert config_utils._linux_desktop_to_kind_and_path(
+        "/usr/bin/microsoft-edge",
+    ) == ("chromium", "/usr/bin/microsoft-edge")
+    assert config_utils._linux_desktop_to_kind_and_path(
+        "/opt/browser/custom",
+    ) == ("chromium", "/opt/browser/custom")
+
+
+def test_working_dir_path_helpers_use_configured_root(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(config_utils, "WORKING_DIR", tmp_path)
+
+    assert config_utils.get_config_path() == tmp_path / "config.json"
+    assert config_utils.get_heartbeat_query_path() == tmp_path / "HEARTBEAT.md"
+    assert config_utils.get_jobs_path() == tmp_path / "jobs.json"
+    assert config_utils.get_chats_path() == tmp_path / "chats.json"


### PR DESCRIPTION
## Description

Adds focused unit coverage for safe helper behavior in `qwenpaw.config.utils`: legacy working-dir path rewrite, nested bad-field removal, Linux browser executable kind mapping, and WORKING_DIR-based path helpers.

**Related Issue:** Relates to #4341

**Security Considerations:** Test-only change. No runtime security behavior changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/config/test_utils_helpers.py`
- `pytest tests/unit/config`
- `pre-commit run add-trailing-comma --all-files`
- `pre-commit run black --all-files`
- `pre-commit run --files tests/unit/config/test_utils_helpers.py`
- `git diff --check`
- `git diff --name-only fork/main..origin/main -- src/qwenpaw/config/utils.py tests/unit/config/test_utils_helpers.py`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | Select-String -Pattern '<<<<<<<|CONFLICT|changed in both'`

## Local Verification Evidence

```bash
pytest tests/unit/config/test_utils_helpers.py
# 6 passed in 8.59s

pytest tests/unit/config
# 6 passed in 5.57s

pre-commit run --files tests/unit/config/test_utils_helpers.py
# check python ast, encoding pragma, secrets, whitespace, trailing commas,
# mypy, black, flake8, pylint all Passed

git diff --check
# no output
```

## Additional Notes

This is a targeted Phase 4 config coverage slice and does not change runtime code.