### PR TITLE
feat: add lightweight goal mode

### DIFF
--- a/src/qwenpaw/app/goal_dispatch.py
+++ b/src/qwenpaw/app/goal_dispatch.py
@@ -25,10 +25,14 @@ GOAL_COMMAND = "/goal"
 GOAL_STATUS_ACTIVE = "active"
 GOAL_STATUS_PAUSED = "paused"
 GOAL_STATUS_ACHIEVED = "achieved"
+DEFAULT_GOAL_MAX_TURNS = 5
 
 _GOAL_MIN_LEN = 5
 _GOAL_DONE_RE = re.compile(
     r"(?im)^\s*(goal status:\s*achieved|\[goal:\s*achieved\])\s*$",
+)
+_GOAL_PAUSED_RE = re.compile(
+    r"(?im)^\s*(goal status:\s*paused|\[goal:\s*paused\])\s*$",
 )
 _UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
 
@@ -126,18 +130,32 @@ def _format_status(state: dict[str, Any] | None, path: Path) -> str:
             "Use `/goal <objective>` to start one."
         )
 
+    max_turns = _goal_max_turns(state)
     lines = [
         "**Goal Status**",
         f"- Status: `{state.get('status', 'unknown')}`",
         f"- Objective: {state.get('objective', '')}",
-        f"- Attempts: {state.get('attempts', 0)}",
+        f"- Attempts: {state.get('attempts', 0)}/{max_turns}",
         f"- Updated: `{state.get('updated_at', '')}`",
         f"- State file: `{path}`",
     ]
     last_result = state.get("last_result")
     if last_result:
         lines.append(f"- Last result: {last_result}")
+    paused_reason = state.get("paused_reason")
+    if paused_reason:
+        lines.append(f"- Paused reason: {paused_reason}")
     return "\n".join(lines)
+
+
+def _goal_max_turns(state: dict[str, Any] | None) -> int:
+    if not state:
+        return DEFAULT_GOAL_MAX_TURNS
+    try:
+        max_turns = int(state.get("max_turns") or DEFAULT_GOAL_MAX_TURNS)
+    except (TypeError, ValueError):
+        return DEFAULT_GOAL_MAX_TURNS
+    return max(max_turns, 1)
 
 
 def _new_goal_state(
@@ -158,8 +176,10 @@ def _new_goal_state(
         "user_id": user_id,
         "channel": channel,
         "attempts": 0,
+        "max_turns": DEFAULT_GOAL_MAX_TURNS,
         "last_result": "",
         "last_response_excerpt": "",
+        "paused_reason": "",
     }
 
 
@@ -203,6 +223,10 @@ async def handle_goal_command(  # pylint: disable=too-many-return-statements
         state["status"] = (
             GOAL_STATUS_PAUSED if subcommand == "pause" else GOAL_STATUS_ACTIVE
         )
+        if subcommand == "pause":
+            state["paused_reason"] = "user-paused"
+        else:
+            state["paused_reason"] = ""
         state["updated_at"] = _utc_now()
         _write_goal(path, state)
         return _format_status(state, path)
@@ -279,6 +303,8 @@ def build_goal_refresher(
     """Build the prompt prefix injected into the normal agent turn."""
     objective = goal_info.get("objective", "")
     state_path = goal_info.get("_goal_path", "")
+    attempts = int(goal_info.get("attempts", 0) or 0)
+    max_turns = _goal_max_turns(goal_info)
     started = bool(goal_info.get("_goal_started"))
     action = (
         "The user just started this goal. Begin working on it now."
@@ -293,16 +319,54 @@ def build_goal_refresher(
         "[Goal active]\n"
         f"Objective: {objective}\n"
         f"State file: `{state_path}`\n"
+        f"Turn budget: {attempts}/{max_turns} completed\n"
         f"{action}\n\n"
         "Constraints:\n"
         "- Use the normal main-agent tools and approval flow.\n"
         "- Do not create Mission workers, PRD files, or background agents "
         "unless the user explicitly asks.\n"
         "- If the objective is fully achieved in this turn, include a final "
-        "line exactly: `Goal status: achieved`.\n\n"
+        "line exactly: `Goal status: achieved`.\n"
+        "- If you are blocked and need the user to answer or approve a "
+        "choice, include a final line exactly: `Goal status: paused`.\n\n"
         "User message:\n"
         f"{cleaned_user_text}"
     )
+
+
+def build_goal_continuation(goal_info: dict[str, Any]) -> str:
+    """Build the next automatic goal turn prompt."""
+    objective = goal_info.get("objective", "")
+    state_path = goal_info.get("_goal_path", "")
+    attempts = int(goal_info.get("attempts", 0) or 0)
+    max_turns = _goal_max_turns(goal_info)
+    last_result = goal_info.get("last_result", "") or "in_progress"
+    excerpt = (goal_info.get("last_response_excerpt", "") or "").strip()
+    previous = f"Previous response excerpt:\n{excerpt}\n\n" if excerpt else ""
+
+    return (
+        "[Goal continuation]\n"
+        f"Objective: {objective}\n"
+        f"State file: `{state_path}`\n"
+        f"Turn budget: {attempts}/{max_turns} completed\n"
+        f"Last result: {last_result}\n\n"
+        f"{previous}"
+        "Continue working toward this goal. Take the next concrete step "
+        "using the normal main-agent tools and approval flow. Do not create "
+        "Mission workers, PRD files, or background agents unless the user "
+        "explicitly asks.\n\n"
+        "If the objective is fully achieved in this turn, include a final "
+        "line exactly: `Goal status: achieved`.\n"
+        "If you are blocked and need the user to answer or approve a choice, "
+        "include a final line exactly: `Goal status: paused`."
+    )
+
+
+def should_continue_goal(goal_info: dict[str, Any] | None) -> bool:
+    """Return True when another automatic goal turn should be launched."""
+    if not goal_info:
+        return False
+    return goal_info.get("status") == GOAL_STATUS_ACTIVE
 
 
 def _msg_text(msg: Any) -> str:
@@ -332,17 +396,17 @@ def _msg_text(msg: Any) -> str:
 def update_goal_from_message(
     goal_info: dict[str, Any] | None,
     assistant_msg: Any,
-) -> None:
+) -> dict[str, Any] | None:
     """Persist a lightweight progress update from the final assistant msg."""
     if not goal_info:
-        return
+        return None
     path_value = goal_info.get("_goal_path")
     if not path_value:
-        return
+        return None
     path = Path(path_value)
     state = _read_goal(path)
     if not state:
-        return
+        return None
 
     text = _msg_text(assistant_msg).strip()
     state["attempts"] = int(state.get("attempts", 0) or 0) + 1
@@ -351,6 +415,22 @@ def update_goal_from_message(
     if _GOAL_DONE_RE.search(text):
         state["status"] = GOAL_STATUS_ACHIEVED
         state["last_result"] = "achieved"
+        state["paused_reason"] = ""
+    elif _GOAL_PAUSED_RE.search(text):
+        state["status"] = GOAL_STATUS_PAUSED
+        state["last_result"] = "paused"
+        state["paused_reason"] = "model-requested-user-input"
+    elif state["attempts"] >= _goal_max_turns(state):
+        state["status"] = GOAL_STATUS_PAUSED
+        state["last_result"] = "turn_budget_exhausted"
+        state["paused_reason"] = (
+            f"turn budget exhausted ({state['attempts']}/"
+            f"{_goal_max_turns(state)})"
+        )
     else:
         state["last_result"] = "in_progress"
+        state["paused_reason"] = ""
+    state.pop("_goal_path", None)
     _write_goal(path, state)
+    state["_goal_path"] = str(path)
+    return state

--- a/src/qwenpaw/app/goal_dispatch.py
+++ b/src/qwenpaw/app/goal_dispatch.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+"""Goal mode dispatch for lightweight, session-scoped objectives.
+
+Goal mode is intentionally smaller than Mission Mode:
+
+- it stores one active objective per channel/user/session;
+- it keeps execution on the normal main-agent path;
+- it does not create workers, PRDs, or bypass tool approvals.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agentscope.message import Msg, TextBlock
+
+logger = logging.getLogger(__name__)
+
+GOAL_COMMAND = "/goal"
+GOAL_STATUS_ACTIVE = "active"
+GOAL_STATUS_PAUSED = "paused"
+GOAL_STATUS_ACHIEVED = "achieved"
+
+_GOAL_MIN_LEN = 5
+_GOAL_DONE_RE = re.compile(
+    r"(?im)^\s*(goal status:\s*achieved|\[goal:\s*achieved\])\s*$",
+)
+_UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
+
+
+def _sanitize_filename(name: str) -> str:
+    """Replace characters that are illegal in cross-platform filenames."""
+    return _UNSAFE_FILENAME_RE.sub("--", name)
+
+
+def is_goal_command(query: str | None) -> bool:
+    """Return True if *query* starts with the goal command token."""
+    if not query or not isinstance(query, str):
+        return False
+    token = query.strip().split(None, 1)[0].lower()
+    return token == GOAL_COMMAND
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _goal_dir(workspace_dir: Path, channel: str = "") -> Path:
+    root = workspace_dir / "goals"
+    if channel:
+        root = root / _sanitize_filename(channel)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _goal_path(
+    workspace_dir: Path,
+    session_id: str,
+    user_id: str = "",
+    channel: str = "",
+) -> Path:
+    safe_sid = _sanitize_filename(session_id or "default")
+    safe_uid = _sanitize_filename(user_id) if user_id else ""
+    filename = (
+        f"{safe_uid}_{safe_sid}.json" if safe_uid else f"{safe_sid}.json"
+    )
+    return _goal_dir(workspace_dir, channel) / filename
+
+
+def _read_goal(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        logger.warning(
+            "Failed to read goal state from %s",
+            path,
+            exc_info=True,
+        )
+    return None
+
+
+def _write_goal(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    os.replace(tmp_path, path)
+
+
+def _delete_goal(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def _usage() -> str:
+    return (
+        "**Goal Mode**\n\n"
+        "Usage:\n"
+        "- `/goal <objective>` - set a lightweight standing objective\n"
+        "- `/goal status` - show the current goal\n"
+        "- `/goal pause` - pause goal injection\n"
+        "- `/goal resume` - resume a paused goal\n"
+        "- `/goal clear` - remove the current goal\n\n"
+        "Goal Mode keeps using the main agent and the normal tool "
+        "approval flow. It does not create Mission workers or PRD files."
+    )
+
+
+def _format_status(state: dict[str, Any] | None, path: Path) -> str:
+    if not state:
+        return (
+            "**Goal Status**: No goal is set for this session.\n\n"
+            "Use `/goal <objective>` to start one."
+        )
+
+    lines = [
+        "**Goal Status**",
+        f"- Status: `{state.get('status', 'unknown')}`",
+        f"- Objective: {state.get('objective', '')}",
+        f"- Attempts: {state.get('attempts', 0)}",
+        f"- Updated: `{state.get('updated_at', '')}`",
+        f"- State file: `{path}`",
+    ]
+    last_result = state.get("last_result")
+    if last_result:
+        lines.append(f"- Last result: {last_result}")
+    return "\n".join(lines)
+
+
+def _new_goal_state(
+    *,
+    objective: str,
+    session_id: str,
+    user_id: str,
+    channel: str,
+) -> dict[str, Any]:
+    now = _utc_now()
+    return {
+        "version": 1,
+        "objective": objective,
+        "status": GOAL_STATUS_ACTIVE,
+        "created_at": now,
+        "updated_at": now,
+        "session_id": session_id,
+        "user_id": user_id,
+        "channel": channel,
+        "attempts": 0,
+        "last_result": "",
+        "last_response_excerpt": "",
+    }
+
+
+async def handle_goal_command(  # pylint: disable=too-many-return-statements
+    query: str,
+    workspace_dir: Path,
+    session_id: str = "",
+    user_id: str = "",
+    channel: str = "",
+) -> str | dict[str, Any]:
+    """Process a ``/goal`` command.
+
+    Returns display text for subcommands, or a goal state dict when the
+    caller should continue through the normal agent path.
+    """
+    parts = query.strip().split(None, 1)
+    raw_arg = parts[1].strip() if len(parts) > 1 else ""
+    subcommand = raw_arg.lower()
+    path = _goal_path(workspace_dir, session_id, user_id, channel)
+
+    if not raw_arg or subcommand == "help":
+        return _usage()
+
+    if subcommand == "status":
+        return _format_status(_read_goal(path), path)
+
+    if subcommand == "clear":
+        existed = path.exists()
+        _delete_goal(path)
+        if existed:
+            return "**Goal Cleared**: Removed the current session goal."
+        return "**Goal Cleared**: No goal was set for this session."
+
+    if subcommand in {"pause", "resume"}:
+        state = _read_goal(path)
+        if not state:
+            return (
+                "**Goal Status**: No goal is set for this session.\n\n"
+                "Use `/goal <objective>` to start one."
+            )
+        state["status"] = (
+            GOAL_STATUS_PAUSED if subcommand == "pause" else GOAL_STATUS_ACTIVE
+        )
+        state["updated_at"] = _utc_now()
+        _write_goal(path, state)
+        return _format_status(state, path)
+
+    objective = raw_arg
+    if len(objective.strip()) < _GOAL_MIN_LEN:
+        return (
+            "**Goal Mode**\n\n"
+            "Please provide a more specific objective, for example:\n"
+            "`/goal Finish the retry handling patch and verify tests`"
+        )
+
+    state = _new_goal_state(
+        objective=objective,
+        session_id=session_id,
+        user_id=user_id,
+        channel=channel,
+    )
+    _write_goal(path, state)
+    state["_goal_path"] = str(path)
+    state["_goal_started"] = True
+    return state
+
+
+async def maybe_handle_goal_command(
+    query: str | None,
+    workspace_dir: Path,
+    session_id: str = "",
+    user_id: str = "",
+    channel: str = "",
+    agent_name: str = "QwenPaw",
+) -> Msg | dict[str, Any] | None:
+    """Handle ``/goal`` if the query matches."""
+    if not query or not is_goal_command(query):
+        return None
+
+    result = await handle_goal_command(
+        query=query,
+        workspace_dir=workspace_dir,
+        session_id=session_id,
+        user_id=user_id,
+        channel=channel,
+    )
+
+    if isinstance(result, str):
+        return Msg(
+            name=agent_name,
+            role="assistant",
+            content=[TextBlock(type="text", text=result)],
+        )
+
+    return result
+
+
+def detect_active_goal(
+    workspace_dir: Path,
+    session_id: str = "",
+    user_id: str = "",
+    channel: str = "",
+) -> dict[str, Any] | None:
+    """Return the active goal state for the current session, if any."""
+    path = _goal_path(workspace_dir, session_id, user_id, channel)
+    state = _read_goal(path)
+    if not state or state.get("status") != GOAL_STATUS_ACTIVE:
+        return None
+    state["_goal_path"] = str(path)
+    return state
+
+
+def build_goal_refresher(
+    goal_info: dict[str, Any],
+    user_text: str,
+) -> str:
+    """Build the prompt prefix injected into the normal agent turn."""
+    objective = goal_info.get("objective", "")
+    state_path = goal_info.get("_goal_path", "")
+    started = bool(goal_info.get("_goal_started"))
+    action = (
+        "The user just started this goal. Begin working on it now."
+        if started
+        else "A goal is active for this session. Keep making progress on it."
+    )
+    cleaned_user_text = user_text.strip()
+    if started and cleaned_user_text.lower().startswith(GOAL_COMMAND):
+        cleaned_user_text = objective
+
+    return (
+        "[Goal active]\n"
+        f"Objective: {objective}\n"
+        f"State file: `{state_path}`\n"
+        f"{action}\n\n"
+        "Constraints:\n"
+        "- Use the normal main-agent tools and approval flow.\n"
+        "- Do not create Mission workers, PRD files, or background agents "
+        "unless the user explicitly asks.\n"
+        "- If the objective is fully achieved in this turn, include a final "
+        "line exactly: `Goal status: achieved`.\n\n"
+        "User message:\n"
+        f"{cleaned_user_text}"
+    )
+
+
+def _msg_text(msg: Any) -> str:
+    if msg is None:
+        return ""
+    if hasattr(msg, "get_text_content"):
+        text = msg.get_text_content()
+        return text if isinstance(text, str) else ""
+    content = getattr(msg, "content", None)
+    if isinstance(msg, dict):
+        content = msg.get("content") or msg.get("text")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+            else:
+                text = getattr(block, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def update_goal_from_message(
+    goal_info: dict[str, Any] | None,
+    assistant_msg: Any,
+) -> None:
+    """Persist a lightweight progress update from the final assistant msg."""
+    if not goal_info:
+        return
+    path_value = goal_info.get("_goal_path")
+    if not path_value:
+        return
+    path = Path(path_value)
+    state = _read_goal(path)
+    if not state:
+        return
+
+    text = _msg_text(assistant_msg).strip()
+    state["attempts"] = int(state.get("attempts", 0) or 0) + 1
+    state["updated_at"] = _utc_now()
+    state["last_response_excerpt"] = text[:500]
+    if _GOAL_DONE_RE.search(text):
+        state["status"] = GOAL_STATUS_ACHIEVED
+        state["last_result"] = "achieved"
+    else:
+        state["last_result"] = "in_progress"
+    _write_goal(path, state)

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -31,9 +31,11 @@ from .mission_dispatch import (
     detect_active_mission_phase,
 )
 from ..goal_dispatch import (
+    build_goal_continuation,
     build_goal_refresher,
     detect_active_goal,
     maybe_handle_goal_command,
+    should_continue_goal,
     update_goal_from_message,
 )
 from .session import SafeJSONSession
@@ -110,6 +112,58 @@ async def _stream_printing_messages_interruptible(
         raise
     finally:
         await _cancel_streaming_agent_task(task)
+
+
+def _goal_user_msg(text: str) -> Msg:
+    return Msg(
+        name="user",
+        role="user",
+        content=[TextBlock(type="text", text=text)],
+    )
+
+
+async def _stream_goal_auto_continuation(
+    *,
+    agent: Any,
+    initial_msgs: list,
+    goal_info: dict[str, Any] | None,
+) -> AsyncGenerator[tuple[Msg, bool], None]:
+    """Run a bounded goal loop on the standard main-agent path."""
+    current_msgs = initial_msgs
+    active_goal_info = goal_info
+    while True:
+        final_goal_msg = None
+        async for msg, last in _stream_printing_messages_interruptible(
+            agents=[agent],
+            coroutine_task=agent(current_msgs),
+        ):
+            if active_goal_info is not None and last:
+                final_goal_msg = msg
+                continue
+            yield msg, last
+
+        if active_goal_info is None:
+            break
+
+        if final_goal_msg is None:
+            break
+
+        active_goal_info = update_goal_from_message(
+            active_goal_info,
+            final_goal_msg,
+        )
+        continue_goal = should_continue_goal(active_goal_info)
+        yield final_goal_msg, not continue_goal
+
+        if not continue_goal:
+            break
+
+        if active_goal_info is None:
+            break
+
+        current_msgs = [
+            _goal_user_msg(build_goal_continuation(active_goal_info)),
+        ]
 
 
 class AgentRunner(Runner):
@@ -798,16 +852,12 @@ class AgentRunner(Runner):
                     ):
                         yield msg, last
             else:
-                final_goal_msg = None
-                async for msg, last in _stream_printing_messages_interruptible(
-                    agents=[agent],
-                    coroutine_task=agent(msgs),
+                async for msg, last in _stream_goal_auto_continuation(
+                    agent=agent,
+                    initial_msgs=msgs,
+                    goal_info=goal_info,
                 ):
-                    if goal_info is not None and last:
-                        final_goal_msg = msg
                     yield msg, last
-                if goal_info is not None:
-                    update_goal_from_message(goal_info, final_goal_msg)
 
         except asyncio.CancelledError as exc:
             logger.info(f"query_handler: {session_id} cancelled!")

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -30,6 +30,12 @@ from .mission_dispatch import (
     maybe_handle_mission_command,
     detect_active_mission_phase,
 )
+from ..goal_dispatch import (
+    build_goal_refresher,
+    detect_active_goal,
+    maybe_handle_goal_command,
+    update_goal_from_message,
+)
 from .session import SafeJSONSession
 from .utils import build_env_context
 from ..channels.schema import DEFAULT_CHANNEL
@@ -443,6 +449,7 @@ class AgentRunner(Runner):
             # Mission Mode: /mission
             _ws = self.workspace_dir or WORKING_DIR
             mission_info: dict | None = None
+            goal_info: dict | None = None
 
             mission_result = await maybe_handle_mission_command(
                 query=query,
@@ -498,6 +505,42 @@ class AgentRunner(Runner):
                 self._rewrite_last_message_text(
                     msgs,
                     refresher + original,
+                )
+
+            # Goal Mode: lightweight session objective on the normal path.
+            if mission_info is None:
+                goal_result = await maybe_handle_goal_command(
+                    query=query,
+                    workspace_dir=_ws,
+                    session_id=session_id,
+                    user_id=user_id,
+                    channel=channel,
+                    agent_name=self.agent_name,
+                )
+                if isinstance(goal_result, Msg):
+                    yield goal_result, True
+                    return
+                if isinstance(goal_result, dict):
+                    goal_info = goal_result
+
+            # Active goal: inject a reminder into ordinary follow-ups.
+            if (
+                mission_info is None
+                and goal_info is None
+                and query
+                and not query.strip().startswith("/")
+            ):
+                goal_info = detect_active_goal(
+                    _ws,
+                    session_id=session_id,
+                    user_id=user_id,
+                    channel=channel,
+                )
+
+            if mission_info is None and goal_info is not None:
+                self._rewrite_last_message_text(
+                    msgs,
+                    build_goal_refresher(goal_info, query or ""),
                 )
 
             # --- Plan Mode ------------------------------------------
@@ -755,11 +798,16 @@ class AgentRunner(Runner):
                     ):
                         yield msg, last
             else:
+                final_goal_msg = None
                 async for msg, last in _stream_printing_messages_interruptible(
                     agents=[agent],
                     coroutine_task=agent(msgs),
                 ):
+                    if goal_info is not None and last:
+                        final_goal_msg = msg
                     yield msg, last
+                if goal_info is not None:
+                    update_goal_from_message(goal_info, final_goal_msg)
 
         except asyncio.CancelledError as exc:
             logger.info(f"query_handler: {session_id} cancelled!")

--- a/tests/unit/runner/test_goal_auto_continuation.py
+++ b/tests/unit/runner/test_goal_auto_continuation.py
@@ -34,6 +34,7 @@ async def test_goal_loop_continues_until_achieved(tmp_path, monkeypatch):
             return _assistant_msg("unused")
 
     async def fake_stream(*, agents, coroutine_task):
+        _ = agents
         await coroutine_task
         yield _assistant_msg(responses.pop(0)), True
 
@@ -62,6 +63,7 @@ async def test_goal_loop_continues_until_achieved(tmp_path, monkeypatch):
     ]
 
     streamed = []
+    # pylint: disable-next=protected-access
     async for item in runner_mod._stream_goal_auto_continuation(
         agent=agent,
         initial_msgs=initial_msgs,

--- a/tests/unit/runner/test_goal_auto_continuation.py
+++ b/tests/unit/runner/test_goal_auto_continuation.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from agentscope.message import Msg, TextBlock
+
+from qwenpaw.app.goal_dispatch import handle_goal_command
+
+
+def _assistant_msg(text: str) -> Msg:
+    return Msg(
+        name="QwenPaw",
+        role="assistant",
+        content=[TextBlock(type="text", text=text)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_goal_loop_continues_until_achieved(tmp_path, monkeypatch):
+    runner_mod = importlib.import_module("qwenpaw.app.runner.runner")
+    responses = [
+        "I made progress but still need to verify tests.",
+        "Tests pass now.\nGoal status: achieved",
+    ]
+
+    class FakeAgent:
+        def __init__(self):
+            self.calls = []
+
+        async def __call__(self, msgs):
+            self.calls.append(msgs)
+            return _assistant_msg("unused")
+
+    async def fake_stream(*, agents, coroutine_task):
+        await coroutine_task
+        yield _assistant_msg(responses.pop(0)), True
+
+    monkeypatch.setattr(
+        runner_mod,
+        "_stream_printing_messages_interruptible",
+        fake_stream,
+    )
+
+    goal = await handle_goal_command(
+        "/goal Fix the retry test",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert isinstance(goal, dict)
+
+    agent = FakeAgent()
+    initial_msgs = [
+        Msg(
+            name="user",
+            role="user",
+            content=[TextBlock(type="text", text="Fix the retry test")],
+        ),
+    ]
+
+    streamed = []
+    async for item in runner_mod._stream_goal_auto_continuation(
+        agent=agent,
+        initial_msgs=initial_msgs,
+        goal_info=goal,
+    ):
+        streamed.append(item)
+
+    assert [last for _, last in streamed] == [False, True]
+    assert len(agent.calls) == 2
+    continuation_text = agent.calls[1][0].get_text_content()
+    assert "[Goal continuation]" in continuation_text
+    assert "Objective: Fix the retry test" in continuation_text

--- a/tests/unit/runner/test_goal_dispatch.py
+++ b/tests/unit/runner/test_goal_dispatch.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from qwenpaw.app.goal_dispatch import (
+    GOAL_STATUS_ACHIEVED,
+    GOAL_STATUS_ACTIVE,
+    build_goal_refresher,
+    detect_active_goal,
+    handle_goal_command,
+    maybe_handle_goal_command,
+    update_goal_from_message,
+)
+
+
+@pytest.mark.asyncio
+async def test_goal_command_starts_session_goal(tmp_path):
+    result = await handle_goal_command(
+        "/goal Finish the retry patch and run tests",
+        workspace_dir=tmp_path,
+        session_id="chat:1",
+        user_id="user:1",
+        channel="console",
+    )
+
+    assert isinstance(result, dict)
+    assert result["objective"] == "Finish the retry patch and run tests"
+    assert result["status"] == GOAL_STATUS_ACTIVE
+
+    state_path = tmp_path / "goals" / "console" / "user--1_chat--1.json"
+    assert state_path.exists()
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    assert data["objective"] == "Finish the retry patch and run tests"
+
+
+@pytest.mark.asyncio
+async def test_goal_status_pause_resume_clear(tmp_path):
+    await handle_goal_command(
+        "/goal Prepare release notes",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+
+    paused = await handle_goal_command(
+        "/goal pause",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert "Status: `paused`" in paused
+    assert (
+        detect_active_goal(
+            tmp_path,
+            session_id="s1",
+            user_id="u1",
+            channel="console",
+        )
+        is None
+    )
+
+    resumed = await handle_goal_command(
+        "/goal resume",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert "Status: `active`" in resumed
+    assert (
+        detect_active_goal(
+            tmp_path,
+            session_id="s1",
+            user_id="u1",
+            channel="console",
+        )
+        is not None
+    )
+
+    cleared = await handle_goal_command(
+        "/goal clear",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert "Goal Cleared" in cleared
+    assert (
+        detect_active_goal(
+            tmp_path,
+            session_id="s1",
+            user_id="u1",
+            channel="console",
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_maybe_handle_goal_status_returns_assistant_msg(tmp_path):
+    msg = await maybe_handle_goal_command(
+        "/goal status",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+        agent_name="QwenPaw",
+    )
+
+    assert msg is not None
+    assert msg.role == "assistant"
+    assert "No goal is set" in msg.get_text_content()
+
+
+def test_build_goal_refresher_rewrites_initial_command():
+    refresher = build_goal_refresher(
+        {
+            "objective": "Ship the goal MVP",
+            "_goal_path": "/tmp/goal.json",
+            "_goal_started": True,
+        },
+        "/goal Ship the goal MVP",
+    )
+
+    assert "Objective: Ship the goal MVP" in refresher
+    assert "User message:\nShip the goal MVP" in refresher
+    assert "normal main-agent tools and approval flow" in refresher
+    assert "Mission workers" in refresher
+
+
+@pytest.mark.asyncio
+async def test_update_goal_from_message_marks_achieved(tmp_path):
+    goal = await handle_goal_command(
+        "/goal Document the feature",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert isinstance(goal, dict)
+
+    update_goal_from_message(
+        goal,
+        {"content": "Done.\n\nGoal status: achieved"},
+    )
+
+    state_path = tmp_path / "goals" / "console" / "u1_s1.json"
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    assert data["status"] == GOAL_STATUS_ACHIEVED
+    assert data["attempts"] == 1

--- a/tests/unit/runner/test_goal_dispatch.py
+++ b/tests/unit/runner/test_goal_dispatch.py
@@ -6,12 +6,16 @@ import json
 import pytest
 
 from qwenpaw.app.goal_dispatch import (
+    DEFAULT_GOAL_MAX_TURNS,
     GOAL_STATUS_ACHIEVED,
     GOAL_STATUS_ACTIVE,
+    GOAL_STATUS_PAUSED,
+    build_goal_continuation,
     build_goal_refresher,
     detect_active_goal,
     handle_goal_command,
     maybe_handle_goal_command,
+    should_continue_goal,
     update_goal_from_message,
 )
 
@@ -34,6 +38,7 @@ async def test_goal_command_starts_session_goal(tmp_path):
     assert state_path.exists()
     data = json.loads(state_path.read_text(encoding="utf-8"))
     assert data["objective"] == "Finish the retry patch and run tests"
+    assert data["max_turns"] == DEFAULT_GOAL_MAX_TURNS
 
 
 @pytest.mark.asyncio
@@ -131,6 +136,85 @@ def test_build_goal_refresher_rewrites_initial_command():
     assert "User message:\nShip the goal MVP" in refresher
     assert "normal main-agent tools and approval flow" in refresher
     assert "Mission workers" in refresher
+    assert "Goal status: paused" in refresher
+
+
+@pytest.mark.asyncio
+async def test_goal_in_progress_builds_auto_continuation(tmp_path):
+    goal = await handle_goal_command(
+        "/goal Document the feature",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert isinstance(goal, dict)
+
+    updated = update_goal_from_message(
+        goal,
+        {"content": "I inspected the files and still need to write docs."},
+    )
+
+    assert updated is not None
+    assert updated["status"] == GOAL_STATUS_ACTIVE
+    assert should_continue_goal(updated)
+
+    continuation = build_goal_continuation(updated)
+    assert "[Goal continuation]" in continuation
+    assert "Objective: Document the feature" in continuation
+    assert "Turn budget: 1/5 completed" in continuation
+    assert "Previous response excerpt" in continuation
+
+    state_path = tmp_path / "goals" / "console" / "u1_s1.json"
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    assert "_goal_path" not in data
+
+
+@pytest.mark.asyncio
+async def test_goal_auto_pauses_when_turn_budget_is_exhausted(tmp_path):
+    goal = await handle_goal_command(
+        "/goal Document the feature",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert isinstance(goal, dict)
+
+    updated = goal
+    for _ in range(DEFAULT_GOAL_MAX_TURNS):
+        updated = update_goal_from_message(
+            updated,
+            {"content": "Still working."},
+        )
+
+    assert updated is not None
+    assert updated["status"] == GOAL_STATUS_PAUSED
+    assert updated["last_result"] == "turn_budget_exhausted"
+    assert not should_continue_goal(updated)
+
+
+@pytest.mark.asyncio
+async def test_goal_can_pause_when_model_needs_user_input(tmp_path):
+    goal = await handle_goal_command(
+        "/goal Choose a deployment target",
+        workspace_dir=tmp_path,
+        session_id="s1",
+        user_id="u1",
+        channel="console",
+    )
+    assert isinstance(goal, dict)
+
+    paused_text = "I need you to pick staging or prod.\nGoal status: paused"
+    updated = update_goal_from_message(
+        goal,
+        {"content": paused_text},
+    )
+
+    assert updated is not None
+    assert updated["status"] == GOAL_STATUS_PAUSED
+    assert updated["last_result"] == "paused"
+    assert not should_continue_goal(updated)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Adds a lightweight `/goal` mode for session-scoped standing objectives. The MVP stores one goal per channel/user/session, supports `/goal status`, `/goal pause`, `/goal resume`, and `/goal clear`, and injects the active objective into ordinary follow-up turns.

This update also adds bounded automatic continuation: when a goal turn finishes without `Goal status: achieved` or `Goal status: paused`, QwenPaw queues another main-agent turn with a `[Goal continuation]` prompt. The loop stops when the model marks the goal achieved, when it asks to pause for user input, or when the default 5-turn budget is exhausted.

Execution stays on the normal main-agent path, so it preserves the existing tool guard and approval behavior instead of using the Mission worker/verifier pipeline.

**Related Issue:** Fixes #4442

**Security Considerations:** Goal Mode does not create worker agents, PRD loops, or background execution, and it does not bypass the normal tool approval flow. Automatic continuation is bounded by `max_turns` and remains on the same main-agent approval path. State is stored as session-scoped JSON under the workspace `goals/` directory with sanitized path components.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Covered scenarios:

- `/goal <objective>` creates a session-scoped goal JSON file and continues through the normal main-agent execution path.
- `/goal status`, `/goal pause`, `/goal resume`, and `/goal clear` manage the stored goal state.
- Paused goals are not auto-injected into ordinary follow-up messages.
- Active goals are not injected into Mission Mode or other slash commands.
- `Goal status: achieved` marks the goal achieved and stops continuation.
- `Goal status: paused` marks the goal paused and stops continuation.
- Goal turns without an achieved/paused marker automatically continue until completion or the turn budget is exhausted.
- Budget exhaustion pauses the goal with `last_result=turn_budget_exhausted`.
- The automatic continuation loop keeps using the main agent and does not create Mission workers.
- A full local service smoke test exercised FastAPI + `/api/agent/process` + `/api/console/chat` + Console channel + TaskTracker + ChatManager + runner + real DashScope/Qwen model calls + SSE streaming responses + persisted goal state.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Passed: check-ast, yaml/xml/toml/json checks, encoding pragma, detect-private-key, trailing whitespace, add-trailing-comma, mypy, black, flake8, pylint, prettier
```

```bash
ruff check src/qwenpaw/app/goal_dispatch.py src/qwenpaw/app/runner/runner.py tests/unit/runner/test_goal_dispatch.py tests/unit/runner/test_goal_auto_continuation.py
# All checks passed!
```

```bash
PYTHONPATH=src pytest tests/unit/runner -q
# 9 passed in 1.82s
```

Real local service smoke test:

```bash
PYTHONPATH=src QWENPAW_WORKING_DIR=/tmp/qwenpaw-goal-live QWENPAW_SECRET_DIR=/tmp/qwenpaw-goal-live.secret QWENPAW_BACKUP_DIR=/tmp/qwenpaw-goal-live.backups QWENPAW_AUTH_ENABLED=false NO_PROXY='*' PYTHONUNBUFFERED=1 python -m qwenpaw app --host 127.0.0.1 --port 64960 --log-level debug
```

Confirmed the effective model through the HTTP/Console path:

```text
/model -> Provider: dashscope, Model: qwen3.5-plus
```

Automatic continuation smoke scenarios with the real Qwen model:

```text
POST /api/agent/process, channel=console, session=goal-live-auto-achieved-1
Result: attempts=2/5, status=achieved, last_result=achieved
Observed session history: initial [Goal active] user turn, assistant progress, automatic [Goal continuation] user turn, assistant final `Goal status: achieved`.

POST /api/agent/process, channel=console, session=goal-live-budget-exhausted-1
Result: attempts=5/5, status=paused, last_result=turn_budget_exhausted, paused_reason="turn budget exhausted (5/5)"
Observed session history: five main-agent turns with automatic [Goal continuation] prompts between them.

POST /api/console/chat, session=goal-live-console-auto-achieved-1
Result: attempts=2/5, status=achieved, last_result=achieved
Observed Console stream completed after the automatic continuation turn.
```

## Additional Notes

This remains a constrained MVP, not a Mission Mode replacement. `/goal` now has the core continuous-execution behavior, but it still keeps a clear boundary from `/mission`: no PRD loop, no worker/verifier orchestration, no child-agent auto-approval path, and no separate judge model requirement.

### Why `goal_dispatch` lives under `qwenpaw.app`

`/goal` is integrated from `AgentRunner.query_handler` today, so runner is currently the execution consumer. The state itself is intentionally not treated as runner-private, though: it represents a session-scoped application objective (`channel` + `user_id` + `session_id`) that other app surfaces can reasonably read later.

This differs from `/mission`, which is a specialized runner execution mode with Phase 1 / Phase 2 control, PRD state, and worker/verifier orchestration. Mission state primarily exists to drive that runner-owned pipeline. Goal Mode, by contrast, keeps execution on the ordinary main-agent path and only provides lightweight objective context around normal conversation.

Keeping the MVP in `qwenpaw.app.goal_dispatch` avoids coupling pure goal state management to the heavier `qwenpaw.app.runner` package, while still letting the runner inject and update active goals. It also leaves a cleaner path for follow-up consumers such as Console status UI, `GET /api/goals/status`, chat sidebar badges, cleanup/migration tasks, or a future read-only evaluator without making them import runner internals.

### Follow-up plan after this PR

If this MVP lands, the next `/goal` work should stay incremental and keep the boundary with `/mission` clear:

1. Add docs/help text that explains when to use `/goal` vs `/mission`, including the security difference that `/goal` stays on the main-agent approval path.
2. Add a small status surface in Console so active/paused/achieved goals are visible without opening the JSON state file.
3. Add a lightweight read-only evaluator pass for ambiguous completion cases, configurable to reuse the current model by default and optionally use a separate judge model.
4. Add explicit `/goal done` and `/goal reopen` commands so users can override model self-reporting.
5. Add bounded progress notes, such as last N updates or a short checklist, without introducing Mission-style PRDs or worker agents.
6. Add channel-level smoke/contract coverage only if future work changes channel behavior; this PR only routes through the existing Console channel path.
