### PR TITLE
fix(providers): 修复 OpenAIProvider 连接测试未携带 extra_headers 的问题

### DIFF
--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -47,7 +47,14 @@ class OpenAIProvider(Provider):
     """Provider implementation for OpenAI API and compatible endpoints."""
 
     def _build_default_headers(self) -> dict:
-        return dict(self.custom_headers) if self.custom_headers else {}
+        headers: dict = {}
+        custom_headers = getattr(self, "custom_headers", None) or {}
+        extra_headers = self.generate_kwargs.get("extra_headers")
+        if custom_headers:
+            headers.update(custom_headers)
+        if extra_headers:
+            headers.update(extra_headers)
+        return headers
 
     def _client(self, timeout: float = 5) -> AsyncOpenAI:
         kwargs: dict = {


### PR DESCRIPTION
Fixes #4484

## 问题描述

当第三方大模型 API 需要自定义 HTTP 请求头（如 `token` 鉴权）时，用户在 `generate_kwargs` 中配置 `extra_headers` 后，**连接测试和模型探测会失败**，但**实际对话可以正常工作**。

原因：`_build_default_headers()` 未从 `generate_kwargs` 中读取 `extra_headers`，导致连接测试和模型探测场景缺少自定义请求头。

## 改动说明

只修改了 `_build_default_headers()` 方法（+8, -1）：

- 从 `generate_kwargs` 中读取 `extra_headers` 并合并到返回的 headers 字典
- 使用 `getattr(self, "custom_headers", None)` 兼容未定义该字段的旧版本
- `_client()` 和 `get_chat_model_instance()` 已统一调用 `_build_default_headers()`，无需额外修改

## 使用方式

在网页前端自定义供应商的设置里的进阶配置，生成参数支持自定义 `extra_headers` 请求头。

```json
{
  "extra_headers": {
    "token": "xxxxxxxxxxxx",
    "Accept": "application/json, text/event-stream",
    "scene": "customer"
  }
}