### PR TITLE
feat: support extraSystemPrompt parameter in console chat API

### DIFF
--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -74,12 +74,16 @@ def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
 
     run_key must be ChatSpec.id (chat_id) so it matches list_chats/get_chat.
     """
+    extra_system_prompt = None
     if isinstance(request_data, AgentRequest):
         channel_id = getattr(request_data, "channel", None) or "console"
         sender_id = request_data.user_id or "default"
         session_id = request_data.session_id or "default"
         content_parts = (
             list(request_data.input[0].content) if request_data.input else []
+        )
+        extra_system_prompt = getattr(
+            request_data, "extraSystemPrompt", None,
         )
     else:
         channel_id = request_data.get("channel", "console")
@@ -92,15 +96,20 @@ def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
                 content_parts.extend(list(content_part.content or []))
             elif isinstance(content_part, dict) and "content" in content_part:
                 content_parts.extend(content_part["content"] or [])
+        extra_system_prompt = request_data.get("extraSystemPrompt")
+
+    meta = {
+        "session_id": session_id,
+        "user_id": sender_id,
+    }
+    if extra_system_prompt and isinstance(extra_system_prompt, str):
+        meta["extra_system_prompt"] = extra_system_prompt
 
     native_payload = {
         "channel_id": channel_id,
         "sender_id": sender_id,
         "content_parts": content_parts,
-        "meta": {
-            "session_id": session_id,
-            "user_id": sender_id,
-        },
+        "meta": meta,
     }
     return native_payload
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -420,6 +420,7 @@ class AgentRunner(Runner):
             if not isinstance(channel_meta, dict):
                 channel_meta = {}
             user_name = channel_meta.get("user_name")
+            extra_system_prompt = channel_meta.get("extra_system_prompt")
 
             # Load agent-specific configuration
             agent_config = load_agent_config(self.agent_id)
@@ -443,6 +444,7 @@ class AgentRunner(Runner):
                     else str(WORKING_DIR)
                 ),
                 default_shell=_default_shell,
+                extra_system_prompt=extra_system_prompt,
             )
 
             # Get MCP clients from manager (hot-reloadable)

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -37,6 +37,7 @@ def build_env_context(
     working_dir: Optional[str] = None,
     add_hint: bool = True,
     default_shell: Optional[str] = None,
+    extra_system_prompt: Optional[str] = None,
 ) -> str:
     """
     Build environment context with current request context prepended.
@@ -52,6 +53,11 @@ def build_env_context(
         default_shell: Shell executable used by execute_shell_command.
             When provided, included in the context so the LLM can
             generate syntax appropriate for that shell.
+        extra_system_prompt: Optional extra system prompt text injected
+            by the caller (e.g. from the ``extraSystemPrompt`` API
+            parameter).  When provided, it is appended as a dedicated
+            ``Extra Context`` section so the agent can access per-request
+            parameters (API keys, business context, etc.).
     Returns:
         Formatted environment context string
     """
@@ -101,6 +107,14 @@ def build_env_context(
             "tool call indicates the task is complete. To continue a task, "
             "you must generate a tool call or provide useful feedback if "
             "you are blocked.\n",
+        )
+
+    if extra_system_prompt and isinstance(extra_system_prompt, str):
+        parts.append(
+            "- Extra Context:\n"
+            + "\n".join(
+                "  " + line for line in extra_system_prompt.strip().splitlines()
+            ),
         )
 
     return (

--- a/tests/unit/routers/test_console_extra_prompt.py
+++ b/tests/unit/routers/test_console_extra_prompt.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for extraSystemPrompt support in the console chat pipeline.
+
+Validates the full data-flow:
+  API request → _extract_session_and_payload → native_payload.meta
+  → ConsoleChannel.build_agent_request_from_native → request.channel_meta
+  → Runner.query_handler → build_env_context → system prompt
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from qwenpaw.app.routers.console import _extract_session_and_payload
+from qwenpaw.app.runner.utils import build_env_context
+
+
+class TestExtractSessionAndPayloadExtraSystemPrompt:
+    """_extract_session_and_payload should extract extraSystemPrompt."""
+
+    def test_dict_with_extra_system_prompt(self):
+        data = {
+            "input": [],
+            "session_id": "sess-1",
+            "user_id": "u1",
+            "channel": "console",
+            "extraSystemPrompt": "user_key=sk-abc",
+        }
+        payload = _extract_session_and_payload(data)
+        assert payload["meta"]["extra_system_prompt"] == "user_key=sk-abc"
+
+    def test_dict_without_extra_system_prompt(self):
+        data = {
+            "input": [],
+            "session_id": "sess-1",
+            "user_id": "u1",
+            "channel": "console",
+        }
+        payload = _extract_session_and_payload(data)
+        assert "extra_system_prompt" not in payload["meta"]
+
+    def test_dict_with_empty_extra_system_prompt(self):
+        data = {
+            "input": [],
+            "session_id": "sess-1",
+            "user_id": "u1",
+            "channel": "console",
+            "extraSystemPrompt": "",
+        }
+        payload = _extract_session_and_payload(data)
+        assert "extra_system_prompt" not in payload["meta"]
+
+    def test_dict_with_non_string_extra_system_prompt(self):
+        data = {
+            "input": [],
+            "session_id": "sess-1",
+            "user_id": "u1",
+            "channel": "console",
+            "extraSystemPrompt": 12345,
+        }
+        payload = _extract_session_and_payload(data)
+        assert "extra_system_prompt" not in payload["meta"]
+
+    def test_agent_request_with_extra_system_prompt(self):
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            AgentRequest,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        req = AgentRequest(
+            session_id="sess-2",
+            user_id="u2",
+            channel="console",
+            input=[
+                Message(
+                    type=MessageType.MESSAGE,
+                    role=Role.USER,
+                    content=[
+                        TextContent(type=ContentType.TEXT, text="hi"),
+                    ],
+                ),
+            ],
+        )
+        req.extraSystemPrompt = "business_id=xyz"
+        payload = _extract_session_and_payload(req)
+        assert payload["meta"]["extra_system_prompt"] == "business_id=xyz"
+
+    def test_agent_request_without_extra_system_prompt(self):
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            AgentRequest,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        req = AgentRequest(
+            session_id="sess-3",
+            user_id="u3",
+            channel="console",
+            input=[
+                Message(
+                    type=MessageType.MESSAGE,
+                    role=Role.USER,
+                    content=[
+                        TextContent(type=ContentType.TEXT, text="hi"),
+                    ],
+                ),
+            ],
+        )
+        payload = _extract_session_and_payload(req)
+        assert "extra_system_prompt" not in payload["meta"]
+
+
+class TestBuildEnvContextExtraSystemPrompt:
+    """build_env_context should inject extra_system_prompt."""
+
+    def test_with_extra_system_prompt(self):
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            extra_system_prompt="api_key=sk-test123",
+        )
+        assert "Extra Context:" in ctx
+        assert "api_key=sk-test123" in ctx
+
+    def test_without_extra_system_prompt(self):
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+        )
+        assert "Extra Context:" not in ctx
+
+    def test_multiline_extra_system_prompt(self):
+        prompt = "line one\nline two\nline three"
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            extra_system_prompt=prompt,
+        )
+        assert "line one" in ctx
+        assert "line two" in ctx
+        assert "line three" in ctx
+
+    def test_empty_extra_system_prompt_not_injected(self):
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            extra_system_prompt="",
+        )
+        assert "Extra Context:" not in ctx
+
+    def test_none_extra_system_prompt_not_injected(self):
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            extra_system_prompt=None,
+        )
+        assert "Extra Context:" not in ctx
+
+    def test_extra_context_after_important(self):
+        ctx = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            extra_system_prompt="my context",
+        )
+        important_idx = ctx.index("- Important:")
+        extra_idx = ctx.index("- Extra Context:")
+        assert extra_idx > important_idx
+
+
+class TestConsoleChannelExtraSystemPrompt:
+    """ConsoleChannel.build_agent_request_from_native should propagate
+    extra_system_prompt from meta to request.channel_meta."""
+
+    @pytest.fixture
+    def channel(self):
+        from unittest.mock import AsyncMock
+
+        from qwenpaw.app.channels.console.channel import ConsoleChannel
+
+        return ConsoleChannel(
+            process=AsyncMock(),
+            enabled=True,
+            bot_prefix="",
+        )
+
+    def test_meta_extra_system_prompt_propagated(self, channel):
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            TextContent,
+            ContentType,
+        )
+
+        payload = {
+            "channel_id": "console",
+            "sender_id": "u1",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="hi"),
+            ],
+            "meta": {
+                "session_id": "sess-x",
+                "user_id": "u1",
+                "extra_system_prompt": "my_secret=abc",
+            },
+        }
+        request = channel.build_agent_request_from_native(payload)
+        assert request.channel_meta.get("extra_system_prompt") == "my_secret=abc"
+
+    def test_meta_without_extra_system_prompt(self, channel):
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            TextContent,
+            ContentType,
+        )
+
+        payload = {
+            "channel_id": "console",
+            "sender_id": "u1",
+            "content_parts": [
+                TextContent(type=ContentType.TEXT, text="hi"),
+            ],
+            "meta": {
+                "session_id": "sess-y",
+                "user_id": "u1",
+            },
+        }
+        request = channel.build_agent_request_from_native(payload)
+        assert "extra_system_prompt" not in request.channel_meta


### PR DESCRIPTION
## Summary

Support passing an `extraSystemPrompt` string field in the `POST /api/console/chat` request body, similar to OpenClaw's `extraSystemPrompt` feature. This enables per-request context injection (API keys, business params, etc.) that the agent and its skills can access during the session.

## Usage

```json
POST /api/console/chat
{
  "input": [...],
  "session_id": "xxx",
  "user_id": "default",
  "channel": "console",
  "extraSystemPrompt": "当前用户的 API Key 是 sk-xxx，请使用该 Key 调用服务"
}
```

## Data Flow

```
API request (extraSystemPrompt)
  → _extract_session_and_payload() extracts
    → native_payload["meta"]["extra_system_prompt"]
      → ConsoleChannel.build_agent_request_from_native() → request.channel_meta
        → Runner.query_handler() extracts from channel_meta
          → build_env_context(extra_system_prompt=...)
            → Agent system prompt: "Extra Context" section in env_context
```

## Changes

| File | Change |
|------|--------|
| `src/qwenpaw/app/routers/console.py` | `_extract_session_and_payload()` extracts `extraSystemPrompt` from both `AgentRequest` and `dict`, puts into `meta["extra_system_prompt"]` |
| `src/qwenpaw/app/runner/runner.py` | `query_handler()` extracts `extra_system_prompt` from `channel_meta` and passes to `build_env_context()` |
| `src/qwenpaw/app/runner/utils.py` | `build_env_context()` new `extra_system_prompt` param, injects as `- Extra Context:` section after `- Important:` |
| `tests/unit/routers/test_console_extra_prompt.py` | 14 new tests covering the full data flow |

## Test Results

- **14 new tests**: all pass
- **1257 unit tests**: all pass (0 regressions)
- **220 contract tests**: all pass (0 regressions)

## Design Notes

- `extraSystemPrompt` is a **string field**, not persisted in session state (per-request only)
- Propagated through existing `channel_meta` dict — no `AgentRequest` schema change needed
- Only non-empty string values are injected; empty/None/non-string values are silently ignored
- The `Extra Context` section is placed after `Important` hints in the `env_context` block, following the OpenClaw convention of injecting after the cache boundary