### PR TITLE
feat(console): reload the page when a plugin is successfully installed/uninstalled

### DIFF
--- a/console/src/pages/Settings/PluginManager/hooks/useInstallModal.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useInstallModal.ts
@@ -115,6 +115,7 @@ export function useInstallModal(onSuccess: () => void) {
       setInstallOpen(false);
       setLocalSel(null);
       onSuccess();
+      setTimeout(() => window.location.reload(), 800);
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : t("pluginManager.installFailed");
@@ -139,6 +140,7 @@ export function useInstallModal(onSuccess: () => void) {
       setInstallOpen(false);
       form.resetFields();
       onSuccess();
+      setTimeout(() => window.location.reload(), 800);
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : t("pluginManager.installFailed");

--- a/console/src/pages/Settings/PluginManager/hooks/useOfficialPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useOfficialPlugins.ts
@@ -55,7 +55,7 @@ export function useOfficialPlugins({ onInstalled }: UseOfficialPluginsOptions) {
         });
         message.success(`${t("pluginManager.installSuccess")}: ${result.name}`);
         onInstalled();
-        await loadCatalog();
+        setTimeout(() => window.location.reload(), 800);
       } catch (err) {
         const msg =
           err instanceof Error ? err.message : t("pluginManager.installFailed");

--- a/console/src/pages/Settings/PluginManager/hooks/usePluginManager.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/usePluginManager.ts
@@ -33,6 +33,7 @@ export function usePluginManager() {
             await uninstallPlugin(plugin.id);
             message.success(t("pluginManager.uninstallSuccess"));
             refresh();
+            setTimeout(() => window.location.reload(), 800);
           } catch (err) {
             const msg =
               err instanceof Error


### PR DESCRIPTION
## Description

After a plugin is successfully installed/uninstalled, the frontend does not automatically reload the plugin module; users must manually refresh the page for the changes to take effect.

## Solution:
Add `setTimeout(() => window.location.reload(), 800)` to the callbacks for all successful plugin installations and uninstalls to delay page refresh (800ms ensures users see the success message), triggering a complete frontend reinitialization and reloading of the plugin UI module. The backend has already performed agent hot reloading via `_schedule_all_agents_reload` in the installation/uninstall API; after the page refreshes, the frontend will reconnect to the backend, and both ends will be refreshed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
