### PR TITLE
feat(local-models): add max_context_length to provider model info and…

### DIFF
--- a/src/qwenpaw/app/routers/local_models.py
+++ b/src/qwenpaw/app/routers/local_models.py
@@ -465,6 +465,13 @@ async def configure_local_model_settings(
     """Configure local model settings."""
     if payload.max_context_length is not None:
         await local_manager.set_max_context_length(payload.max_context_length)
+        # Sync max_input_length on the provider's model info so context
+        # compaction uses the correct threshold without a server restart.
+        provider = provider_manager.get_provider("qwenpaw-local")
+        if provider:
+            for model in provider.extra_models:
+                model.max_input_length = payload.max_context_length
+            provider_manager.update_provider("qwenpaw-local", {})
 
     if "port" in payload.model_fields_set:
         await local_manager.set_port(payload.port)

--- a/src/qwenpaw/local_models/llamacpp.py
+++ b/src/qwenpaw/local_models/llamacpp.py
@@ -241,6 +241,7 @@ class LlamaCppBackend:
         model_info = self._build_model_info(
             model_name=model_name,
             resolved_mmproj_path=resolved_mmproj_path,
+            max_context_length=max_context_length,
         )
 
         if (
@@ -494,17 +495,20 @@ class LlamaCppBackend:
     def _build_model_info(
         model_name: str,
         resolved_mmproj_path: Path | None,
+        max_context_length: int | None = None,
     ) -> ModelInfo:
         supports_multimodal = resolved_mmproj_path is not None
-        return ModelInfo(
-            id=model_name,
-            name=model_name,
-            supports_multimodal=supports_multimodal,
-            # TODO: add more detailed capability flags
-            supports_image=supports_multimodal,
-            supports_video=False,
-            probe_source="probed",
-        )
+        info_kwargs: dict = {
+            "id": model_name,
+            "name": model_name,
+            "supports_multimodal": supports_multimodal,
+            "supports_image": supports_multimodal,
+            "supports_video": False,
+            "probe_source": "probed",
+        }
+        if max_context_length is not None:
+            info_kwargs["max_input_length"] = max_context_length
+        return ModelInfo(**info_kwargs)
 
     def _finalize_download_result(
         self,

--- a/tests/unit/local_models/test_llamacpp_backend.py
+++ b/tests/unit/local_models/test_llamacpp_backend.py
@@ -919,6 +919,40 @@ async def test_setup_server_falls_back_on_windows_not_implemented(
     ]
 
 
+def test_build_model_info_sets_max_input_length_from_max_context_length() -> (
+    None
+):
+    info = LlamaCppBackend._build_model_info(
+        model_name="test-model",
+        resolved_mmproj_path=None,
+        max_context_length=65536,
+    )
+    assert info.max_input_length == 65536
+    assert info.id == "test-model"
+    assert info.supports_multimodal is False
+
+
+def test_build_model_info_uses_default_max_input_length_without_context() -> (
+    None
+):
+    info = LlamaCppBackend._build_model_info(
+        model_name="test-model",
+        resolved_mmproj_path=None,
+    )
+    assert info.max_input_length == 131072
+
+
+def test_build_model_info_sets_multimodal_flags_with_mmproj() -> None:
+    info = LlamaCppBackend._build_model_info(
+        model_name="vision-model",
+        resolved_mmproj_path=Path("/fake/mmproj.gguf"),
+        max_context_length=32768,
+    )
+    assert info.supports_multimodal is True
+    assert info.supports_image is True
+    assert info.max_input_length == 32768
+
+
 def test_resolve_model_file_returns_single_model_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1155,6 +1189,69 @@ async def test_setup_server_uses_requested_port(
             },
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_setup_server_passes_ctx_size_when_max_context_length_set(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    downloader = _build_downloader(monkeypatch)
+    model_path = tmp_path / "demo.gguf"
+    model_path.write_text("gguf")
+    start_calls: list[tuple[list[str], dict[str, object]]] = []
+
+    class _FakeAsyncStdout:
+        async def readline(self) -> bytes:
+            return b""
+
+    class _FakeStartedProcess:
+        def __init__(self) -> None:
+            self.pid = 9999
+            self.stdout = _FakeAsyncStdout()
+            self.returncode: int | None = None
+
+        async def wait(self) -> int:
+            self.returncode = 0
+            return 0
+
+        def terminate(self) -> None:
+            self.returncode = -15
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    async def fake_start_command_async(command, **kwargs):
+        start_calls.append((list(command), kwargs))
+        return _FakeStartedProcess()
+
+    async def fake_server_ready(*_args, **_kwargs) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        downloader,
+        "check_llamacpp_installation",
+        lambda: (True, ""),
+    )
+    monkeypatch.setattr(
+        downloader_module,
+        "start_command_async",
+        fake_start_command_async,
+    )
+    monkeypatch.setattr(downloader, "server_ready", fake_server_ready)
+
+    setup_result = await downloader.setup_server(
+        model_path,
+        "demo-model",
+        max_context_length=131072,
+    )
+    await asyncio.sleep(0)
+
+    assert setup_result.model_info.max_input_length == 131072
+    command_args = start_calls[0][0]
+    assert "--ctx-size" in command_args
+    ctx_size_idx = command_args.index("--ctx-size")
+    assert command_args[ctx_size_idx + 1] == "131072"
 
 
 def test_resolve_server_port_rejects_unavailable_port(

--- a/tests/unit/local_models/test_local_model_manager.py
+++ b/tests/unit/local_models/test_local_model_manager.py
@@ -77,16 +77,19 @@ class _FakeLlamaCppBackend:
                 ),
             ),
         )
+        model_info_kwargs: dict = {
+            "id": model_name,
+            "name": model_name,
+            "supports_multimodal": False,
+            "supports_image": False,
+            "supports_video": False,
+            "probe_source": "documentation",
+        }
+        if max_context_length is not None:
+            model_info_kwargs["max_input_length"] = max_context_length
         return LlamaCppServerSetupResult(
             port=8080,
-            model_info=ModelInfo(
-                id=model_name,
-                name=model_name,
-                supports_multimodal=False,
-                supports_image=False,
-                supports_video=False,
-                probe_source="documentation",
-            ),
+            model_info=ModelInfo(**model_info_kwargs),
         )
 
     async def shutdown_server(self) -> None:
@@ -216,6 +219,7 @@ async def test_local_model_manager_forwards_async_server_calls(
         supports_image=False,
         supports_video=False,
         probe_source="documentation",
+        max_input_length=131072,
     )
     assert fake_llamacpp_backend.calls == [
         ("server_ready", 7.5),

--- a/tests/unit/routers/test_local_models.py
+++ b/tests/unit/routers/test_local_models.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the local-models router endpoints."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app.routers.local_models import router
+from qwenpaw.local_models import LocalModelConfig
+from qwenpaw.providers.provider import ModelInfo
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+
+
+class _FakeLocalModelManager:
+    def __init__(self) -> None:
+        self._config = LocalModelConfig()
+        self.set_max_context_length_calls: list[int] = []
+        self.set_port_calls: list[int | None] = []
+
+    async def set_max_context_length(self, value: int) -> None:
+        self.set_max_context_length_calls.append(value)
+        self._config.max_context_length = value
+
+    async def set_port(self, value: int | None) -> None:
+        self.set_port_calls.append(value)
+        self._config.port = value
+
+    def get_config(self) -> LocalModelConfig:
+        return self._config
+
+
+class _FakeProviderManager:
+    def __init__(self, provider: Any | None = None) -> None:
+        self._provider = provider
+        self.update_provider_calls: list[tuple[str, dict]] = []
+
+    def get_provider(self, provider_id: str) -> Any | None:
+        if provider_id == "qwenpaw-local":
+            return self._provider
+        return None
+
+    def update_provider(self, provider_id: str, config: dict) -> bool:
+        self.update_provider_calls.append((provider_id, config))
+        return True
+
+
+def _make_fake_provider(
+    extra_models: list[ModelInfo] | None = None,
+) -> MagicMock:
+    provider = MagicMock()
+    provider.extra_models = extra_models if extra_models is not None else []
+    return provider
+
+
+def _setup_client(manager: _FakeLocalModelManager) -> AsyncClient:
+    fake_provider = _make_fake_provider()
+    fake_provider_manager = _FakeProviderManager(provider=fake_provider)
+    app.state.local_model_manager = manager
+    app.state.provider_manager = fake_provider_manager
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+
+# ── PUT /config ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_config_max_ctx_syncs_provider_input_len() -> None:
+    manager = _FakeLocalModelManager()
+    model = ModelInfo(
+        id="local-model",
+        name="local-model",
+        probe_source="probed",
+        max_input_length=131072,
+    )
+    fake_provider = _make_fake_provider(extra_models=[model])
+    fake_provider_manager = _FakeProviderManager(provider=fake_provider)
+    app.state.local_model_manager = manager
+    app.state.provider_manager = fake_provider_manager
+    client = AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+    async with client:
+        resp = await client.put(
+            "/api/local-models/config",
+            json={"max_context_length": 65536},
+        )
+
+    assert resp.status_code == 200
+    assert manager.set_max_context_length_calls == [65536]
+    assert model.max_input_length == 65536
+    assert ("qwenpaw-local", {}) in fake_provider_manager.update_provider_calls
+
+
+@pytest.mark.asyncio
+async def test_configure_max_context_length_noop_when_no_provider() -> None:
+    manager = _FakeLocalModelManager()
+    fake_provider_manager = _FakeProviderManager(provider=None)
+    app.state.local_model_manager = manager
+    app.state.provider_manager = fake_provider_manager
+    client = AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+    async with client:
+        resp = await client.put(
+            "/api/local-models/config",
+            json={"max_context_length": 65536},
+        )
+
+    assert resp.status_code == 200
+    assert manager.set_max_context_length_calls == [65536]
+    assert not fake_provider_manager.update_provider_calls
+
+
+@pytest.mark.asyncio
+async def test_config_max_ctx_syncs_multiple_extra_models() -> None:
+    manager = _FakeLocalModelManager()
+    models = [
+        ModelInfo(
+            id="model-a",
+            name="model-a",
+            probe_source="probed",
+            max_input_length=131072,
+        ),
+        ModelInfo(
+            id="model-b",
+            name="model-b",
+            probe_source="probed",
+            max_input_length=131072,
+        ),
+    ]
+    fake_provider = _make_fake_provider(extra_models=models)
+    fake_provider_manager = _FakeProviderManager(provider=fake_provider)
+    app.state.local_model_manager = manager
+    app.state.provider_manager = fake_provider_manager
+    client = AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+    async with client:
+        resp = await client.put(
+            "/api/local-models/config",
+            json={"max_context_length": 32768},
+        )
+
+    assert resp.status_code == 200
+    assert all(m.max_input_length == 32768 for m in models)
+
+
+@pytest.mark.asyncio
+async def test_configure_port() -> None:
+    manager = _FakeLocalModelManager()
+    client = _setup_client(manager)
+
+    async with client:
+        resp = await client.put(
+            "/api/local-models/config",
+            json={"port": 43110},
+        )
+
+    assert resp.status_code == 200
+    assert manager.set_port_calls == [43110]
+
+
+@pytest.mark.asyncio
+async def test_configure_generate_kwargs() -> None:
+    manager = _FakeLocalModelManager()
+    fake_provider = _make_fake_provider()
+    fake_provider_manager = _FakeProviderManager(provider=fake_provider)
+    app.state.local_model_manager = manager
+    app.state.provider_manager = fake_provider_manager
+    client = AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+    async with client:
+        resp = await client.put(
+            "/api/local-models/config",
+            json={"generate_kwargs": {"temperature": 0.7}},
+        )
+
+    assert resp.status_code == 200
+    assert any(
+        call[0] == "qwenpaw-local"
+        and call[1] == {"generate_kwargs": {"temperature": 0.7}}
+        for call in fake_provider_manager.update_provider_calls
+    )
+
+
+# ── GET /config ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_config() -> None:
+    manager = _FakeLocalModelManager()
+    client = _setup_client(manager)
+
+    async with client:
+        resp = await client.get("/api/local-models/config")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "max_context_length" in data
+    assert "port" in data


### PR DESCRIPTION
… llama.cpp ctx-size

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
