### PR TITLE
feta(console): persist chat input draft across page navigation

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -471,6 +471,97 @@ function useMessageHistoryNavigation(
   }, [isChatActive, isComposingRef, getUserMessagesWithText]);
 }
 
+// ---------------------------------------------------------------------------
+// Chat input draft persistence
+// ---------------------------------------------------------------------------
+
+const DRAFT_STORAGE_KEY = "qwenpaw_chat_input_draft";
+
+interface DraftState {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+function useChatInputDraft(isChatActive: () => boolean) {
+  useEffect(() => {
+    if (!isChatActive()) return;
+
+    let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const getTextarea = (): HTMLTextAreaElement | null => {
+      const sender = document.querySelector('[class*="sender"]');
+      return sender?.querySelector("textarea") as HTMLTextAreaElement | null;
+    };
+
+    const saveDraft = (textarea: HTMLTextAreaElement) => {
+      const draft: DraftState = {
+        value: textarea.value,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd,
+      };
+      if (draft.value) {
+        localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+      } else {
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
+      }
+    };
+
+    const handleInput = (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target?.tagName !== "TEXTAREA") return;
+      if (!target?.closest('[class*="sender"]')) return;
+
+      if (saveTimer) clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => {
+        saveDraft(target as HTMLTextAreaElement);
+      }, 300);
+    };
+
+    // Restore draft on mount with polling for textarea readiness
+    let restoreAttempts = 0;
+    const maxRestoreAttempts = 20;
+    const restoreInterval = setInterval(() => {
+      restoreAttempts++;
+      const textarea = getTextarea();
+      if (textarea) {
+        clearInterval(restoreInterval);
+        const raw = localStorage.getItem(DRAFT_STORAGE_KEY);
+        if (raw) {
+          try {
+            const draft: DraftState = JSON.parse(raw);
+            if (draft.value) {
+              setTextareaValue(textarea, draft.value);
+              requestAnimationFrame(() => {
+                textarea.selectionStart = draft.selectionStart;
+                textarea.selectionEnd = draft.selectionEnd;
+              });
+            }
+          } catch {
+            // Ignore malformed data
+          }
+        }
+      } else if (restoreAttempts >= maxRestoreAttempts) {
+        clearInterval(restoreInterval);
+      }
+    }, 100);
+
+    document.addEventListener("input", handleInput, true);
+
+    return () => {
+      clearInterval(restoreInterval);
+      if (saveTimer) clearTimeout(saveTimer);
+      document.removeEventListener("input", handleInput, true);
+
+      // Final save on unmount
+      const textarea = getTextarea();
+      if (textarea) {
+        saveDraft(textarea);
+      }
+    };
+  }, [isChatActive]);
+}
+
 function RuntimeLoadingBridge({
   bridgeRef,
 }: {
@@ -721,6 +812,7 @@ export default function ChatPage() {
   }, []);
 
   useMessageHistoryNavigation(chatRef, isChatActive, isComposingRef);
+  useChatInputDraft(isChatActive);
 
   // Shortcut key for voice recording (Ctrl+Shift+M or Cmd+Shift+M on Mac)
   useEffect(() => {


### PR DESCRIPTION
## Description

If you type something in the chat page and then switch to another page (such as models, skills, etc.) and then switch back to the chat page, the content in the input box will be lost.

Fixes #4520

## Solution

Add a `useChatInputDraft` hook to `console/src/pages/Chat/index.tsx` to persist input drafts via `localStorage`:

Save: Listen for the global `input` event and write the input content and cursor position to `localStorage` via a 300ms debounce.
Restore: After the component mounts, poll for the `textarea` to finish rendering, read from `localStorage` and refill the content, restoring the cursor position.
Clean up: Perform a final save when the component unmounts to ensure no data loss when switching pages; automatically clear storage when the input is empty.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
