### PR TITLE
fix(console): add dark mode support for pet import drop zone

### DIFF
--- a/plugins/bundle/qwenpaw-pet/frontend/src/index.tsx
+++ b/plugins/bundle/qwenpaw-pet/frontend/src/index.tsx
@@ -181,6 +181,22 @@ function PetControlPage() {
   const [startingDesktop, setStartingDesktop] = React.useState(false);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
 
+  const [isDark, setIsDark] = React.useState(
+    () => document.documentElement.classList.contains("dark-mode"),
+  );
+  React.useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(
+        document.documentElement.classList.contains("dark-mode"),
+      );
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
   const refresh = React.useCallback(async () => {
     setLoading(true);
     try {
@@ -556,15 +572,29 @@ function PetControlPage() {
                   }
                 },
                 style: {
-                  border: `2px dashed ${dragOver ? "#1677ff" : "#d9d9d9"}`,
+                  border: `2px dashed ${
+                    dragOver
+                      ? "#1677ff"
+                      : isDark
+                        ? "rgba(255,255,255,0.15)"
+                        : "#d9d9d9"
+                  }`,
                   borderRadius: 8,
                   padding: "32px 16px",
                   textAlign: "center" as const,
                   cursor: importing ? "not-allowed" : "pointer",
-                  background: dragOver ? "rgba(22, 119, 255, 0.06)" : "#fafafa",
+                  background: dragOver
+                    ? "rgba(22, 119, 255, 0.06)"
+                    : isDark
+                      ? "rgba(255,255,255,0.04)"
+                      : "#fafafa",
                   transition: "border-color .15s ease, background .15s ease",
                   userSelect: "none" as const,
-                  color: dragOver ? "#1677ff" : undefined,
+                  color: dragOver
+                    ? "#1677ff"
+                    : isDark
+                      ? "rgba(255,255,255,0.85)"
+                      : undefined,
                 },
               },
               // Line-art cube icon (matches the dropzone reference)

--- a/plugins/bundle/qwenpaw-pet/frontend/src/index.tsx
+++ b/plugins/bundle/qwenpaw-pet/frontend/src/index.tsx
@@ -181,14 +181,12 @@ function PetControlPage() {
   const [startingDesktop, setStartingDesktop] = React.useState(false);
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
 
-  const [isDark, setIsDark] = React.useState(
-    () => document.documentElement.classList.contains("dark-mode"),
+  const [isDark, setIsDark] = React.useState(() =>
+    document.documentElement.classList.contains("dark-mode"),
   );
   React.useEffect(() => {
     const observer = new MutationObserver(() => {
-      setIsDark(
-        document.documentElement.classList.contains("dark-mode"),
-      );
+      setIsDark(document.documentElement.classList.contains("dark-mode"));
     });
     observer.observe(document.documentElement, {
       attributes: true,
@@ -576,8 +574,8 @@ function PetControlPage() {
                     dragOver
                       ? "#1677ff"
                       : isDark
-                        ? "rgba(255,255,255,0.15)"
-                        : "#d9d9d9"
+                      ? "rgba(255,255,255,0.15)"
+                      : "#d9d9d9"
                   }`,
                   borderRadius: 8,
                   padding: "32px 16px",
@@ -586,15 +584,15 @@ function PetControlPage() {
                   background: dragOver
                     ? "rgba(22, 119, 255, 0.06)"
                     : isDark
-                      ? "rgba(255,255,255,0.04)"
-                      : "#fafafa",
+                    ? "rgba(255,255,255,0.04)"
+                    : "#fafafa",
                   transition: "border-color .15s ease, background .15s ease",
                   userSelect: "none" as const,
                   color: dragOver
                     ? "#1677ff"
                     : isDark
-                      ? "rgba(255,255,255,0.85)"
-                      : undefined,
+                    ? "rgba(255,255,255,0.85)"
+                    : undefined,
                 },
               },
               // Line-art cube icon (matches the dropzone reference)


### PR DESCRIPTION
## Description

This PR fixes the pet import modal's drop zone so that it is clearly visible in dark mode. The drop zone previously used hardcoded light-mode colors (`#fafafa` background, `#d9d9d9` border, and default dark icon/text), causing the area to appear as a blank white rectangle when the Console is in dark theme.

The fix uses the existing `isDark` state to switch color values dynamically, ensuring the drop zone border, background, and text/icon remain readable in both light and dark modes.

**Related Issue:** #4592 
**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [X] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Manual verification in browser:
1. Open QwenPaw Console in dark mode.
2. Navigate to Settings → Desktop Pet → Import pet.
3. Observe that the drop zone border, background, and icon/text are now clearly visible (light gray border + subtle background + white icon/text), instead of appearing as a blank white area.

Light mode was also verified to remain unchanged.

## Local Verification Evidence

This is a pure frontend CSS/styling change within `plugins/bundle/qwenpaw-pet/frontend/src/index.tsx`. No Python backend code was modified, so `pytest` is not applicable. CI pre-commit will validate formatting on push.

## Additional Notes