### PR TITLE
fix(DingTalk): decode percent-encoded Chinese filenames in file sending 

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -29,7 +29,7 @@ from typing import (
     Optional,
 )
 from uuid import uuid4
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import aiohttp
 import dingtalk_stream
@@ -1032,21 +1032,6 @@ class DingTalkChannel(BaseChannel):
                 url = data_attr
         url = (url or "").strip() if isinstance(url, str) else ""
 
-        # AudioContent stores URL in "data"; derive real filename/ext
-        if ptype == ContentType.AUDIO:
-            data_attr = getattr(part, "data", None)
-            if isinstance(data_attr, str) and (
-                data_attr.startswith("http") or data_attr.startswith("file:")
-            ):
-                try:
-                    path = urlparse(data_attr).path
-                    base = os.path.basename(path)
-                    if base and "." in base:
-                        filename = base
-                        ext = base.rsplit(".", 1)[-1].lower()
-                except Exception:
-                    pass
-
         # For images with public HTTP URLs, send directly via sampleImageMsg
         if upload_type == "image" and self._is_public_http_url(url):
             return await self._send_open_api_message(
@@ -1456,20 +1441,6 @@ class DingTalkChannel(BaseChannel):
             part,
             default=default_name,
         )
-        # AudioContent URL is in part.data; derive filename/ext for m4a etc.
-        if ptype == ContentType.AUDIO:
-            data_attr = getattr(part, "data", None)
-            if isinstance(data_attr, str) and (
-                data_attr.startswith("http") or data_attr.startswith("file:")
-            ):
-                try:
-                    path = urlparse(data_attr).path
-                    base = os.path.basename(path)
-                    if base and "." in base:
-                        filename = base
-                        ext = base.rsplit(".", 1)[-1].lower()
-                except Exception:
-                    pass
         if upload_type == "video" and ext not in ("mp4",):
             upload_type = "file"
         elif upload_type == "voice":
@@ -3380,17 +3351,29 @@ class DingTalkChannel(BaseChannel):
         filename = (getattr(part, "filename", None) or "").strip()
 
         if not filename:
+            # AudioContent stores its URL in "data" instead of file_url
+            data_attr = getattr(part, "data", None)
+            audio_url = (
+                data_attr
+                if isinstance(data_attr, str)
+                and (
+                    data_attr.startswith("http")
+                    or data_attr.startswith("file:")
+                )
+                else None
+            )
             url = (
                 getattr(part, "file_url", None)
                 or getattr(part, "image_url", None)
                 or getattr(part, "video_url", None)
+                or audio_url
                 or ""
             )
             url = (url or "").strip() if isinstance(url, str) else ""
             if url:
                 try:
                     path = urlparse(url).path
-                    base = os.path.basename(path)
+                    base = unquote(os.path.basename(path))
                     if base:
                         filename = base
                 except Exception:


### PR DESCRIPTION
## Description

When send_file_to_user converts a local path to a RFC 8089 file:// URL, non-ASCII characters (e.g. Chinese) are percent-encoded. The DingTalk channel extracted filenames from URL paths without decoding, causing uploaded files to have encoded names like %E7%99%BE%E4%BC%98%E8%A7%A3...png.

### Changes:

- Add urllib.parse.unquote() in _guess_filename_and_ext to decode percent-encoded filenames from URLs.
- Consolidate duplicated audio filename extraction logic (previously in _send_media_part_via_open_api and _send_media_part_via_webhook) into _guess_filename_and_ext by including part.data in the URL lookup chain with a guard to skip base64 data.

**Related Issue:** Fixes #4586 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
