### PR TITLE
feat(tool): Add headless browser warning message

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -46,8 +46,9 @@ _MAX_DIRECT_URL_DOWNLOAD_BYTES = 10 * 1024 * 1024
 _CDP_CONNECT_TIMEOUT_SECONDS = 30.0
 _HEADLESS_VERIFICATION_WARNING = (
     "Headless browser launches are more likely to trigger verification. "
-    "If verification appears, try stopping the current browser first, "
-    "then start a visible browser and operate there."
+    "If verification appears, call browser_use with action='stop' to stop "
+    "the current browser, then call browser_use with action='start' and "
+    "headed=true to open a visible browser and continue there."
 )
 
 

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 
 _MAX_DIRECT_URL_DOWNLOAD_BYTES = 10 * 1024 * 1024
 _CDP_CONNECT_TIMEOUT_SECONDS = 30.0
+_HEADLESS_VERIFICATION_WARNING = (
+    "Headless browser launches are more likely to trigger verification. "
+    "If verification appears, try stopping the current browser first, "
+    "then start a visible browser and operate there."
+)
 
 
 # Keywords used to validate executable_path — the binary filename must
@@ -1049,12 +1054,14 @@ async def _action_start(
             except Exception:
                 pass
         else:
+            result: dict[str, Any] = {
+                "ok": True,
+                "message": "Browser already running",
+            }
+            if current_headless:
+                result["headless_warning"] = _HEADLESS_VERIFICATION_WARNING
             return _tool_response(
-                json.dumps(
-                    {"ok": True, "message": "Browser already running"},
-                    ensure_ascii=False,
-                    indent=2,
-                ),
+                json.dumps(result, ensure_ascii=False, indent=2),
             )
     # Default: headless (background). Only headed=True (e.g. browser_visible skill) shows window.
     state["headless"] = not headed
@@ -1189,7 +1196,7 @@ async def _action_start(
             if not state["headless"]
             else "Browser started"
         )
-        result: dict[str, Any] = {
+        result = {
             "ok": True,
             "message": msg,
             "tip": "Enable browser-related skills in the agent config for a better experience.",
@@ -1197,6 +1204,8 @@ async def _action_start(
             "owned_browser_process": state.get("owned_browser_process", False),
             "private_mode": bool(private_mode),
         }
+        if state["headless"]:
+            result["headless_warning"] = _HEADLESS_VERIFICATION_WARNING
         if state.get("browser_pid"):
             result["browser_pid"] = state["browser_pid"]
         cdp_url = state.get("cdp_url") or (


### PR DESCRIPTION
## Description

Add a headless browser verification warning to `browser_control.py` start responses.

When `browser_use` launches or reuses a headless browser, the tool now returns a `headless_warning` field explaining that headless launches are more likely to trigger verification and suggesting that users stop the current browser, then start a visible browser if verification appears.

**Related Issue:** N/A

**Security Considerations:** No security-sensitive behavior changed. This only adds user-facing guidance to the tool response.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Ran Python syntax compilation for the changed tool file:

```bash
python3 -m py_compile src/qwenpaw/agents/tools/browser_control.py
```

## Local Verification Evidence

```bash
python3 -m py_compile src/qwenpaw/agents/tools/browser_control.py
# passed
```

## Additional Notes

This PR description intentionally excludes skill documentation changes.
