### PR TITLE
fix(gemini): map max_tokens to max_output_tokens and unmask validation errors

### DIFF
--- a/src/qwenpaw/exceptions.py
+++ b/src/qwenpaw/exceptions.py
@@ -189,6 +189,17 @@ def convert_model_exception(  # pylint: disable=too-many-return-statements
             details=details,
         )
 
+    # Pydantic ValidationError indicates a malformed request payload (wrong
+    # parameter name/type), not an auth/quota issue.  Route it to the generic
+    # model execution exception so the underlying message reaches the user
+    # instead of being masked as "Unauthorized access".
+    if type(exc).__name__ == "ValidationError" and (
+        type(exc).__module__.startswith("pydantic")
+    ):
+        model = model_name or "unknown"
+        details["model_name"] = model
+        return ModelExecutionException(model, details=details)
+
     # Extract information for model errors
     status_code = getattr(exc, "status_code", None)
     error_message = str(exc).lower()

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -138,6 +138,23 @@ class GeminiProvider(Provider):
                 f"Unknown exception when connecting to model '{model_id}'",
             )
 
+    @staticmethod
+    def _adapt_generate_kwargs_for_gemini(
+        kwargs: dict,
+    ) -> dict:
+        """Translate OpenAI-style keys to Gemini's GenerateContentConfig
+        schema.
+
+        google-genai's GenerateContentConfig forbids extra fields, so
+        ``max_tokens`` must be renamed to ``max_output_tokens``.  If both are
+        present, the explicit ``max_output_tokens`` wins.
+        """
+        adapted = dict(kwargs)
+        max_tokens = adapted.pop("max_tokens", None)
+        if max_tokens is not None and "max_output_tokens" not in adapted:
+            adapted["max_output_tokens"] = max_tokens
+        return adapted
+
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
         from agentscope.model import GeminiChatModel
 
@@ -147,12 +164,15 @@ class GeminiProvider(Provider):
             client_kwargs["http_options"] = genai_types.HttpOptions(
                 headers=headers,
             )
+        generate_kwargs = self._adapt_generate_kwargs_for_gemini(
+            self.get_effective_generate_kwargs(model_id),
+        )
         return GeminiChatModel(
             model_name=model_id,
             stream=True,
             api_key=self.api_key,
             client_kwargs=client_kwargs or None,
-            generate_kwargs=self.get_effective_generate_kwargs(model_id),
+            generate_kwargs=generate_kwargs,
         )
 
     async def probe_model_multimodal(


### PR DESCRIPTION
## Description

Gemini/Gemma calls crashed because QwenPaw forwarded `max_tokens` into `google-genai`'s `GenerateContentConfig`, which rejects unknown fields. The resulting pydantic `ValidationError` was then misclassified as `MODEL_UNAUTHORIZED_ACCESS` (the message contains the substring "forbidden" via `extra_forbidden`), hiding the real cause from users.

This change:

Adapts generate kwargs in `GeminiProvider` by renaming `max_tokens` → `max_output_tokens` before instantiating `GeminiChatModel` (preserves an explicit `max_output_tokens` if already set).
Routes pydantic `ValidationError` in `convert_model_exception` to `ModelExecutionException` so payload/schema errors surface accurately instead of being reported as auth failures.

Fixes #4605.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
