### PR TITLE
 fix(qwenpaw-pet): fix pet stuck in Done state on consecutive conversations

### DIFF
--- a/plugins/bundle/qwenpaw-pet/qwenpaw_pet_desktop/window.py
+++ b/plugins/bundle/qwenpaw-pet/qwenpaw_pet_desktop/window.py
@@ -209,11 +209,12 @@ class PetWindow(QWidget):
         ev_name = event.get("event")
         text = event.get("text")
 
-        if self._drop_stale_event(event):
+        if self._is_stale_event(event):
             return
         if self._handle_early_lifecycle(ev_name, event):
             return
 
+        self._advance_event_serial(event)
         state = state_for_event(ev_name, event.get("state"))
         self._apply_bubble_text(ev_name, text)
         self.set_state(state)
@@ -221,14 +222,18 @@ class PetWindow(QWidget):
         self._schedule_post_event_timing(ev_name, state, event)
         self.update()
 
-    def _drop_stale_event(self, event: dict[str, Any]) -> bool:
+    def _is_stale_event(self, event: dict[str, Any]) -> bool:
         serial = event.get("serial")
         if isinstance(serial, int) and serial > 0:
             if serial < self._last_event_serial:
                 self.update()
                 return True
-            self._last_event_serial = serial
         return False
+
+    def _advance_event_serial(self, event: dict[str, Any]) -> None:
+        serial = event.get("serial")
+        if isinstance(serial, int) and serial > self._last_event_serial:
+            self._last_event_serial = serial
 
     def _handle_early_lifecycle(
         self,
@@ -275,6 +280,7 @@ class PetWindow(QWidget):
             return True
 
         if self._approval_pending and ev_name == "tool.result":
+            self._advance_event_serial(event)
             state = state_for_event(ev_name, event.get("state"))
             self.set_state(state)
             self._write_state(event)
@@ -363,6 +369,7 @@ class PetWindow(QWidget):
                 return
             if self._approval_pending:
                 return
+            self._turn_complete = False
             self.set_state("idle")
 
         QTimer.singleShot(duration_ms, _revert_animation_only)


### PR DESCRIPTION
## Description

1. Fix condition where blocked events advanced the serial high-water mark, causing subsequent query.received to be dropped as "stale"
2. Clear _turn_complete flag when the post-done animation timer expires as a safety net

Root Cause:
query.received and query.running are emitted concurrently via schedule_emit_pet_event. Thread scheduling can assign query.running a higher serial. When it arrives first and gets blocked by _turn_complete, it still advanced _last_event_serial — causing the later query.received (lower serial) to be silently dropped. The pet never resets _turn_complete and stays stuck in Done.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
