### PR TITLE
fix(WeChat): replace instance-level token invalid flag with per-request meta flag

### DIFF
--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -155,9 +155,6 @@ class WeChatChannel(BaseChannel):
 
         # Cache last context_token per user for proactive sends
         self._user_context_tokens: Dict[str, str] = {}
-        # Flag: set when context_token is invalid (ret=-2) during a request,
-        # so subsequent sends in the same request are skipped silently.
-        self._context_token_invalid: bool = False
 
         # Cache typing tickets per user (24h TTL)
         self._typing_tickets: Dict[
@@ -1099,17 +1096,19 @@ class WeChatChannel(BaseChannel):
         context_token: str,
         client: Optional[ILinkClient] = None,
         api_initiated: bool = False,
+        send_meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Send text using the shared ILinkClient (or create a temp one).
 
         Args:
             api_initiated: If True, raise ChannelError on send failure.
                 Used by /api/messages/send to provide accurate error feedback.
+            send_meta: If provided, used to track context_token invalidation.
+                When ret=-2, sets send_meta["_wechat_token_invalid"] = True
+                so subsequent sends in the same request are skipped.
         """
         _client = client or self._client
         if not _client or not to_user_id or not text:
-            return
-        if self._context_token_invalid and not api_initiated:
             return
         try:
             resp = await _client.send_text(to_user_id, text, context_token)
@@ -1138,9 +1137,9 @@ class WeChatChannel(BaseChannel):
                         ),
                     )
                 # ret=-2 means context_token is invalid/consumed;
-                # mark flag so subsequent sends in this request are skipped.
-                if ret == -2:
-                    self._context_token_invalid = True
+                # mark meta so subsequent sends in this request are skipped.
+                if ret == -2 and send_meta is not None:
+                    send_meta["_wechat_token_invalid"] = True
 
     async def _send_media_file(
         self,
@@ -1157,8 +1156,6 @@ class WeChatChannel(BaseChannel):
             file_path: Local path to the media file.
             content_type: Type of media (IMAGE/FILE/VIDEO).
         """
-        if self._context_token_invalid:
-            return
         if not self._client or not to_user_id or not context_token:
             logger.warning(
                 "wechat _send_media_file: missing required parameters",
@@ -1364,6 +1361,10 @@ class WeChatChannel(BaseChannel):
         text_parts: List[str] = []
 
         for p in parts:
+            # Skip all sends once context_token is marked invalid
+            if m.get("_wechat_token_invalid"):
+                break
+
             t = getattr(p, "type", None) or (
                 p.get("type") if isinstance(p, dict) else None
             )
@@ -1430,16 +1431,19 @@ class WeChatChannel(BaseChannel):
         if prefix and body:
             body = prefix + "  " + body
 
-        if not body:
+        if not body or m.get("_wechat_token_invalid"):
             return
 
         api_send = bool(m.get("_api_send"))
         for chunk in split_text(body):
+            if m.get("_wechat_token_invalid"):
+                return
             await self._send_text_direct(
                 to_user_id,
                 chunk,
                 context_token,
                 api_initiated=api_send,
+                send_meta=m,
             )
 
     async def _on_process_completed(
@@ -1449,9 +1453,6 @@ class WeChatChannel(BaseChannel):
         send_meta: Dict[str, Any],
     ) -> None:
         """Flush merge buffer (if any) and stop typing indicator."""
-        # Reset context_token_invalid flag for the next request.
-        self._context_token_invalid = False
-
         # Flush any remaining merged messages before finishing
         if self._message_merge_enabled:
             await self._flush_merge_buffer(to_handle)
@@ -1471,9 +1472,6 @@ class WeChatChannel(BaseChannel):
         err_text: str,
     ) -> None:
         """Flush merge buffer, stop typing, and send error message."""
-        # Reset context_token_invalid flag for the next request.
-        self._context_token_invalid = False
-
         # Flush any buffered messages before sending the error
         if self._message_merge_enabled:
             await self._flush_merge_buffer(to_handle)
@@ -1505,8 +1503,16 @@ class WeChatChannel(BaseChannel):
         body = (prefix + "  " + text) if prefix and text else text
         if not body or not to_user_id:
             return
+        send_state: Dict[str, Any] = {}
         for chunk in split_text(body):
-            await self._send_text_direct(to_user_id, chunk, context_token)
+            if send_state.get("_wechat_token_invalid"):
+                return
+            await self._send_text_direct(
+                to_user_id,
+                chunk,
+                context_token,
+                send_meta=send_state,
+            )
 
     # ------------------------------------------------------------------
     # Typing Indicator

--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1147,6 +1147,7 @@ class WeChatChannel(BaseChannel):
         context_token: str,
         file_path: str,
         content_type: ContentType,
+        send_meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Send a media file (image/file/video) to WeChat.
 
@@ -1155,6 +1156,7 @@ class WeChatChannel(BaseChannel):
             context_token: Context token from inbound message.
             file_path: Local path to the media file.
             content_type: Type of media (IMAGE/FILE/VIDEO).
+            send_meta: If provided, used to track context_token invalidation.
         """
         if not self._client or not to_user_id or not context_token:
             logger.warning(
@@ -1176,22 +1178,23 @@ class WeChatChannel(BaseChannel):
                 return
 
             # Send based on content type
+            resp: Optional[Dict[str, Any]] = None
             if content_type == ContentType.IMAGE:
-                await self._client.send_image(
+                resp = await self._client.send_image(
                     to_user_id,
                     str(path_obj),
                     context_token,
                 )
             elif content_type == ContentType.FILE:
                 filename = path_obj.name
-                await self._client.send_file(
+                resp = await self._client.send_file(
                     to_user_id,
                     str(path_obj),
                     filename,
                     context_token,
                 )
             elif content_type == ContentType.VIDEO:
-                await self._client.send_video(
+                resp = await self._client.send_video(
                     to_user_id,
                     str(path_obj),
                     context_token,
@@ -1201,6 +1204,23 @@ class WeChatChannel(BaseChannel):
                     "wechat _send_media_file: unsupported content type: %s",
                     content_type,
                 )
+                return
+
+            # Check response for errors (same logic as _send_text_direct)
+            if isinstance(resp, dict):
+                ret = resp.get("ret", 0)
+                errcode = resp.get("errcode", 0)
+                if ret != 0 or errcode != 0:
+                    logger.warning(
+                        "wechat send_media rejected: "
+                        "ret=%s errcode=%s to_user_id=%s type=%s",
+                        ret,
+                        errcode,
+                        to_user_id,
+                        content_type,
+                    )
+                    if ret == -2 and send_meta is not None:
+                        send_meta["_wechat_token_invalid"] = True
         except Exception:
             logger.exception(
                 "wechat _send_media_file failed type=%s path=%s",
@@ -1389,6 +1409,7 @@ class WeChatChannel(BaseChannel):
                         context_token,
                         image_url,
                         ContentType.IMAGE,
+                        send_meta=m,
                     )
             elif t == ContentType.FILE:
                 # Send file
@@ -1401,6 +1422,7 @@ class WeChatChannel(BaseChannel):
                         context_token,
                         file_url,
                         ContentType.FILE,
+                        send_meta=m,
                     )
             elif t == ContentType.VIDEO:
                 # Send video
@@ -1413,6 +1435,7 @@ class WeChatChannel(BaseChannel):
                         context_token,
                         video_url,
                         ContentType.VIDEO,
+                        send_meta=m,
                     )
             elif t == ContentType.AUDIO:
                 # Send audio as file (WeChat has no dedicated audio send)
@@ -1425,6 +1448,7 @@ class WeChatChannel(BaseChannel):
                         context_token,
                         audio_url,
                         ContentType.FILE,
+                        send_meta=m,
                     )
 
         body = "\n".join(text_parts).strip()


### PR DESCRIPTION
## Description

Improves #4618. The previous instance-level `_context_token_invalid` flag could cause cross-request
interference — once one request's token was invalidated, all subsequent requests (including cron jobs)
were silently blocked until the flag was manually reset in lifecycle hooks.

This PR replaces it with a per-request meta-based approach (`_wechat_token_invalid` on the request's
meta dict). Since meta is scoped to each individual request, the flag naturally resets for the next
request without needing explicit cleanup.

Changes:
- Remove instance-level `_context_token_invalid` flag and its reset logic in
  `_on_process_completed` / `_on_consume_error`
- `_send_text_direct`: add `send_meta` param; on `ret=-2` set `send_meta["_wechat_token_invalid"]`
- `_send_media_file`: add `send_meta` param, capture response from send_image/send_file/send_video,
  check ret/errcode, log warning and set meta flag on `ret=-2`
- Stream path (`_send_content_parts_immediate`): check meta flag in loop to skip subsequent sends
- `send()` (proactive/cron path): use a temporary `send_state` dict for the same skip behavior
- Pass `send_meta=m` at all call sites (IMAGE, FILE, VIDEO, AUDIO, TEXT)

Confirmed via live testing: iLink API returns `{'ret': -2}` when context_token is expired/consumed.

**Related Issue:** Fixes #4612 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
