### PR TITLE
feat(console): keep sidebar collapse button visible at bottom

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -539,83 +539,85 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
         collapsed ? ` ${styles.siderCollapsed}` : ""
       }${isDark ? ` ${styles.siderDark}` : ""}`}
     >
-      {collapsed ? (
-        <nav className={styles.collapsedNav}>
-          {collapsedNavItems.map((item) => {
-            const isActive = selectedKey === item.key;
-            return (
-              <Tooltip
-                key={item.key}
-                title={item.label}
-                placement="right"
-                overlayInnerStyle={{
-                  background: "rgba(0,0,0,0.75)",
-                  color: "#fff",
-                }}
-              >
-                <button
-                  className={`${styles.collapsedNavItem} ${
-                    isActive ? styles.collapsedNavItemActive : ""
-                  }`}
-                  onClick={() => navigate(item.path)}
+      <div className={styles.sidebarScrollArea}>
+        {collapsed ? (
+          <nav className={styles.collapsedNav}>
+            {collapsedNavItems.map((item) => {
+              const isActive = selectedKey === item.key;
+              return (
+                <Tooltip
+                  key={item.key}
+                  title={item.label}
+                  placement="right"
+                  overlayInnerStyle={{
+                    background: "rgba(0,0,0,0.75)",
+                    color: "#fff",
+                  }}
                 >
-                  {item.icon}
+                  <button
+                    className={`${styles.collapsedNavItem} ${
+                      isActive ? styles.collapsedNavItemActive : ""
+                    }`}
+                    onClick={() => navigate(item.path)}
+                  >
+                    {item.icon}
+                  </button>
+                </Tooltip>
+              );
+            })}
+          </nav>
+        ) : (
+          <>
+            {/* Agent-scoped section: selector + Chat + Control + Workspace */}
+            <div className={styles.agentScopedSection}>
+              <div className={styles.agentSelectorContainer}>
+                <AgentSelector collapsed={collapsed} />
+                {/* Chat entry — sticky together with agent selector */}
+                <button
+                  className={`${styles.stickyChatButton}${
+                    selectedKey === "chat"
+                      ? ` ${styles.stickyChatButtonActive}`
+                      : ""
+                  }`}
+                  onClick={() => navigate("/chat")}
+                >
+                  <SparkChatTabFill size={16} />
+                  <span>{t("nav.chat")}</span>
                 </button>
-              </Tooltip>
-            );
-          })}
-        </nav>
-      ) : (
-        <>
-          {/* Agent-scoped section: selector + Chat + Control + Workspace */}
-          <div className={styles.agentScopedSection}>
-            <div className={styles.agentSelectorContainer}>
-              <AgentSelector collapsed={collapsed} />
-              {/* Chat entry — sticky together with agent selector */}
-              <button
-                className={`${styles.stickyChatButton}${
-                  selectedKey === "chat"
-                    ? ` ${styles.stickyChatButtonActive}`
-                    : ""
-                }`}
-                onClick={() => navigate("/chat")}
-              >
-                <SparkChatTabFill size={16} />
-                <span>{t("nav.chat")}</span>
-              </button>
+              </div>
+              <Menu
+                mode="inline"
+                selectedKeys={[selectedKey]}
+                openKeys={DEFAULT_OPEN_KEYS}
+                onClick={({ key }) => {
+                  const path = KEY_TO_PATH[String(key)];
+                  if (path) navigate(path);
+                }}
+                items={agentMenuItems}
+                theme={isDark ? "dark" : "light"}
+                className={styles.sideMenu}
+              />
             </div>
+
+            {/* Global settings section */}
             <Menu
               mode="inline"
               selectedKeys={[selectedKey]}
-              openKeys={DEFAULT_OPEN_KEYS}
+              openKeys={[
+                ...DEFAULT_OPEN_KEYS,
+                ...(pluginRoutes.length > 0 ? ["plugins-group"] : []),
+              ]}
               onClick={({ key }) => {
-                const path = KEY_TO_PATH[String(key)];
-                if (path) navigate(path);
+                const path = KEY_TO_PATH[String(key)] ?? `/${String(key)}`;
+                navigate(path);
               }}
-              items={agentMenuItems}
+              items={settingsMenuItems}
               theme={isDark ? "dark" : "light"}
               className={styles.sideMenu}
             />
-          </div>
-
-          {/* Global settings section */}
-          <Menu
-            mode="inline"
-            selectedKeys={[selectedKey]}
-            openKeys={[
-              ...DEFAULT_OPEN_KEYS,
-              ...(pluginRoutes.length > 0 ? ["plugins-group"] : []),
-            ]}
-            onClick={({ key }) => {
-              const path = KEY_TO_PATH[String(key)] ?? `/${String(key)}`;
-              navigate(path);
-            }}
-            items={settingsMenuItems}
-            theme={isDark ? "dark" : "light"}
-            className={styles.sideMenu}
-          />
-        </>
-      )}
+          </>
+        )}
+      </div>
 
       {authEnabled && !collapsed && (
         <div className={styles.authActions}>

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -25,7 +25,7 @@
 // ─── Sidebar ─────────────────────────────────────────────────────────────────
 .sider {
   background: #f9f8f4 !important;
-  overflow: auto;
+  overflow: hidden;
   height: calc(100vh - 64px);
   padding: 0 16px;
   display: flex;
@@ -52,8 +52,35 @@
   -ms-overflow-style: none;
   /* IE and Edge */
 
+  :global {
+    .qwenpaw-layout-sider-children,
+    .ant-layout-sider-children {
+      height: 100%;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+  }
+
+  .sidebarScrollArea {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
   // Agent-scoped section: selector + Chat + Control + Workspace
   .agentScopedSection {
+    flex-shrink: 0;
     background: rgba(43, 18, 0, 0.02);
     border-radius: 12px;
     border: 1px solid rgba(0, 0, 0, 0.06);
@@ -104,24 +131,8 @@
 
   // Menu takes remaining space
   .sideMenu {
-    flex: 1;
-    overflow-y: auto;
-
-    // Hide scrollbar for menu too
-    &::-webkit-scrollbar {
-      display: none;
-    }
-
-    &::-moz-scrollbar {
-      display: none;
-    }
-
-    &::-ms-scrollbar {
-      display: none;
-    }
-
-    scrollbar-width: none;
-    -ms-overflow-style: none;
+    flex-shrink: 0;
+    overflow: visible;
   }
 
   &.siderCollapsed {
@@ -352,6 +363,7 @@
 
 // ─── Auth actions (account + logout) ──────────────────────────────────────────
 .authActions {
+  flex-shrink: 0;
   padding: 12px 16px;
   border-top: 1px solid #f0f0f0;
 }


### PR DESCRIPTION
## Description

Fixes the console sidebar layout so the collapse button (`SparkMenuFoldLine` / `SparkMenuExpandLine`) stays visible and clickable at the bottom while the sidebar menu content scrolls.

This separates the scrollable sidebar menu area from the fixed bottom collapse control, matching the always-available behavior of the sticky chat entry.

**Related Issue:** N/A

**Security Considerations:** N/A. UI layout-only change; no auth, env/config, or data handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open the console frontend.
2. Ensure the sidebar has enough items to scroll.
3. Scroll/drag through the sidebar menu.
4. Verify the bottom collapse button remains visible and clickable at all times.
5. Click the collapse/expand button and verify the sidebar toggles normally in both expanded and collapsed states.

## Local Verification Evidence

```bash
npm run format:check
# Passed: TypeScript check and Prettier check completed successfully.

npm run build
# Passed: Vite production build completed successfully.
<img width="2098" height="1524" alt="微信图片_20260522154656_28_2" src="https://github.com/user-attachments/assets/eaf35821-c36a-4b6a-95e0-3267d86234a2" />
