### PR TITLE
feat(chat): add customizable slash command shortcut menu

### DIFF
--- a/console/src/api/modules/chatCommands.ts
+++ b/console/src/api/modules/chatCommands.ts
@@ -1,0 +1,24 @@
+import { request } from "../request";
+
+export interface AvailableCommand {
+  command: string;
+  display: string;
+  category: string;
+  has_args: boolean;
+}
+
+export interface ChatCommandsResponse {
+  commands: string[];
+}
+
+export const chatCommandsApi = {
+  getAvailable: () => request<AvailableCommand[]>("/chat-commands/available"),
+
+  get: () => request<ChatCommandsResponse>("/chat-commands"),
+
+  update: (commands: string[]) =>
+    request<ChatCommandsResponse>("/chat-commands", {
+      method: "PUT",
+      body: JSON.stringify({ commands }),
+    }),
+};

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1880,7 +1880,69 @@
       },
       "plan": {
         "description": "Create a structured plan to decompose the task into subtasks"
-      }
+      },
+      "category": {
+        "context": "Context",
+        "history": "History",
+        "model": "Model",
+        "session": "Session",
+        "control": "Control",
+        "daemon": "Daemon"
+      },
+      "new": {
+        "description": "Start a new conversation (keep memory)"
+      },
+      "history": {
+        "description": "View conversation history"
+      },
+      "message": {
+        "description": "View a specific message by index"
+      },
+      "compact_str": {
+        "description": "View compressed summary"
+      },
+      "summarize_status": {
+        "description": "View summary task status"
+      },
+      "dump_history": {
+        "description": "Export conversation to JSONL file"
+      },
+      "load_history": {
+        "description": "Load conversation from JSONL file"
+      },
+      "model": {
+        "description": "Model management (switch/list/reset)"
+      },
+      "proactive": {
+        "description": "Proactive message mode (set idle duration)"
+      },
+      "stop": {
+        "description": "Stop the current task"
+      },
+      "daemon_status": {
+        "description": "View daemon process status"
+      },
+      "daemon_restart": {
+        "description": "Restart the daemon process"
+      },
+      "daemon_reload_config": {
+        "description": "Reload configuration"
+      },
+      "daemon_reload_config_alt": {
+        "description": "Reload configuration"
+      },
+      "daemon_version": {
+        "description": "View version number"
+      },
+      "daemon_logs": {
+        "description": "View daemon process logs"
+      },
+      "customizeTitle": "Customize Shortcut Commands",
+      "customizeHint": "Select the magic commands to show in the / shortcut menu",
+      "resetToDefault": "Reset to Default",
+      "save": "Save",
+      "saveSuccess": "Shortcut command configuration saved",
+      "saveFailed": "Failed to save, please try again"
     },
     "attachments": {
       "tooltip": "Supports documents, images, videos, audio and more formats, single file up to {{limit}}MB",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1728,7 +1728,69 @@
       },
       "plan": {
         "description": "创建结构化计划，将任务分解为多个子任务"
-      }
+      },
+      "category": {
+        "context": "上下文",
+        "history": "历史",
+        "model": "模型",
+        "session": "会话",
+        "control": "控制",
+        "daemon": "守护"
+      },
+      "new": {
+        "description": "创建新对话（保留记忆）"
+      },
+      "history": {
+        "description": "查看对话历史"
+      },
+      "message": {
+        "description": "查看指定序号的消息内容"
+      },
+      "compact_str": {
+        "description": "查看压缩摘要"
+      },
+      "summarize_status": {
+        "description": "查看摘要任务状态"
+      },
+      "dump_history": {
+        "description": "导出对话到 JSONL 文件"
+      },
+      "load_history": {
+        "description": "从 JSONL 文件加载对话"
+      },
+      "model": {
+        "description": "模型管理（切换/列表/重置）"
+      },
+      "proactive": {
+        "description": "主动消息模式（设置空闲时长）"
+      },
+      "stop": {
+        "description": "停止当前任务"
+      },
+      "daemon_status": {
+        "description": "查看守护进程状态"
+      },
+      "daemon_restart": {
+        "description": "重启守护进程"
+      },
+      "daemon_reload_config": {
+        "description": "重载配置文件"
+      },
+      "daemon_reload_config_alt": {
+        "description": "重载配置文件"
+      },
+      "daemon_version": {
+        "description": "查看版本号"
+      },
+      "daemon_logs": {
+        "description": "查看守护进程日志"
+      },
+      "customizeTitle": "自定义快捷命令",
+      "customizeHint": "勾选你希望在输入框 / 菜单中显示的魔法命令",
+      "resetToDefault": "恢复默认",
+      "save": "保存",
+      "saveSuccess": "快捷命令配置已保存",
+      "saveFailed": "保存失败，请重试"
     },
     "attachments": {
       "tooltip": "支持文档、图片、视频、音频等多种格式，单文件不超过 {{limit}}MB",

--- a/console/src/pages/Chat/components/CommandCustomizer.tsx
+++ b/console/src/pages/Chat/components/CommandCustomizer.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Modal, Checkbox, Button, Space, Typography, message } from "antd";
 import { useTranslation } from "react-i18next";
-import { chatCommandsApi, AvailableCommand } from "../../../api/modules/chatCommands";
+import {
+  chatCommandsApi,
+  AvailableCommand,
+} from "../../../api/modules/chatCommands";
 
 interface Props {
   visible: boolean;
@@ -12,17 +15,27 @@ interface Props {
 
 const CATEGORY_I18N_KEYS: Record<string, string> = {
   context: "chat.commands.category.context",
-  history:  "chat.commands.category.history",
-  model:    "chat.commands.category.model",
-  session:  "chat.commands.category.session",
-  control:  "chat.commands.category.control",
-  daemon:   "chat.commands.category.daemon",
+  history: "chat.commands.category.history",
+  model: "chat.commands.category.model",
+  session: "chat.commands.category.session",
+  control: "chat.commands.category.control",
+  daemon: "chat.commands.category.daemon",
 };
 
-const CATEGORY_ORDER = ["context", "history", "model", "session", "control", "daemon"];
+const CATEGORY_ORDER = [
+  "context",
+  "history",
+  "model",
+  "session",
+  "control",
+  "daemon",
+];
 
 export const CommandCustomizer: React.FC<Props> = ({
-  visible, onClose, selected, onChange,
+  visible,
+  onClose,
+  selected,
+  onChange,
 }) => {
   const { t } = useTranslation();
   const [available, setAvailable] = useState<AvailableCommand[]>([]);
@@ -32,7 +45,10 @@ export const CommandCustomizer: React.FC<Props> = ({
   useEffect(() => {
     if (visible) {
       setDraft([...selected]);
-      chatCommandsApi.getAvailable().then(setAvailable).catch(() => {});
+      chatCommandsApi
+        .getAvailable()
+        .then(setAvailable)
+        .catch(() => {});
     }
   }, [visible]);
 
@@ -68,13 +84,11 @@ export const CommandCustomizer: React.FC<Props> = ({
       arr.push(cmd);
       map.set(cmd.category, arr);
     }
-    return CATEGORY_ORDER
-      .filter((cat) => map.has(cat))
-      .map((cat) => ({
-        category: cat,
-        label: t(CATEGORY_I18N_KEYS[cat], cat),
-        commands: map.get(cat)!,
-      }));
+    return CATEGORY_ORDER.filter((cat) => map.has(cat)).map((cat) => ({
+      category: cat,
+      label: t(CATEGORY_I18N_KEYS[cat], cat),
+      commands: map.get(cat)!,
+    }));
   }, [available, t]);
 
   return (
@@ -94,15 +108,22 @@ export const CommandCustomizer: React.FC<Props> = ({
       }
     >
       <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
-        {t("chat.commands.customizeHint",
-           "勾选你希望在输入框 / 菜单中显示的魔法命令")}
+        {t(
+          "chat.commands.customizeHint",
+          "勾选你希望在输入框 / 菜单中显示的魔法命令",
+        )}
       </Typography.Paragraph>
       {grouped.map(({ category, label, commands }) => (
         <div key={category} style={{ marginBottom: 12 }}>
           <Typography.Text strong>{label}</Typography.Text>
-          <div style={{
-            display: "flex", flexWrap: "wrap", gap: "8px 16px", marginTop: 4,
-          }}>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "8px 16px",
+              marginTop: 4,
+            }}
+          >
             {commands.map((cmd) => (
               <Checkbox
                 key={cmd.command}

--- a/console/src/pages/Chat/components/CommandCustomizer.tsx
+++ b/console/src/pages/Chat/components/CommandCustomizer.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Modal, Checkbox, Button, Space, Typography, message } from "antd";
+import { useTranslation } from "react-i18next";
+import { chatCommandsApi, AvailableCommand } from "../../../api/modules/chatCommands";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  selected: string[];
+  onChange: (commands: string[]) => void;
+}
+
+const CATEGORY_I18N_KEYS: Record<string, string> = {
+  context: "chat.commands.category.context",
+  history:  "chat.commands.category.history",
+  model:    "chat.commands.category.model",
+  session:  "chat.commands.category.session",
+  control:  "chat.commands.category.control",
+  daemon:   "chat.commands.category.daemon",
+};
+
+const CATEGORY_ORDER = ["context", "history", "model", "session", "control", "daemon"];
+
+export const CommandCustomizer: React.FC<Props> = ({
+  visible, onClose, selected, onChange,
+}) => {
+  const { t } = useTranslation();
+  const [available, setAvailable] = useState<AvailableCommand[]>([]);
+  const [draft, setDraft] = useState<string[]>(selected);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setDraft([...selected]);
+      chatCommandsApi.getAvailable().then(setAvailable).catch(() => {});
+    }
+  }, [visible]);
+
+  const handleToggle = (cmd: string, checked: boolean) => {
+    setDraft((prev) =>
+      checked ? [...prev, cmd] : prev.filter((c) => c !== cmd),
+    );
+  };
+
+  const handleSave = async () => {
+    setLoading(true);
+    try {
+      await chatCommandsApi.update(draft);
+      onChange(draft);
+      message.success(t("chat.commands.saveSuccess", "保存成功"));
+      onClose();
+    } catch {
+      message.error(t("chat.commands.saveFailed", "保存失败"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReset = () => {
+    setDraft(["clear", "compact", "mission", "skills"]);
+  };
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, AvailableCommand[]>();
+    for (const cmd of available) {
+      if (cmd.command === "plan") continue;
+      const arr = map.get(cmd.category) ?? [];
+      arr.push(cmd);
+      map.set(cmd.category, arr);
+    }
+    return CATEGORY_ORDER
+      .filter((cat) => map.has(cat))
+      .map((cat) => ({
+        category: cat,
+        label: t(CATEGORY_I18N_KEYS[cat], cat),
+        commands: map.get(cat)!,
+      }));
+  }, [available, t]);
+
+  return (
+    <Modal
+      open={visible}
+      title={t("chat.commands.customizeTitle", "自定义快捷命令")}
+      onCancel={onClose}
+      footer={
+        <Space>
+          <Button onClick={handleReset}>
+            {t("chat.commands.resetToDefault", "恢复默认")}
+          </Button>
+          <Button type="primary" loading={loading} onClick={handleSave}>
+            {t("chat.commands.save", "保存")}
+          </Button>
+        </Space>
+      }
+    >
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+        {t("chat.commands.customizeHint",
+           "勾选你希望在输入框 / 菜单中显示的魔法命令")}
+      </Typography.Paragraph>
+      {grouped.map(({ category, label, commands }) => (
+        <div key={category} style={{ marginBottom: 12 }}>
+          <Typography.Text strong>{label}</Typography.Text>
+          <div style={{
+            display: "flex", flexWrap: "wrap", gap: "8px 16px", marginTop: 4,
+          }}>
+            {commands.map((cmd) => (
+              <Checkbox
+                key={cmd.command}
+                checked={draft.includes(cmd.command)}
+                onChange={(e) => handleToggle(cmd.command, e.target.checked)}
+              >
+                {cmd.display}
+              </Checkbox>
+            ))}
+          </div>
+        </div>
+      ))}
+    </Modal>
+  );
+};

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -32,7 +32,10 @@ import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { planApi } from "../../api/modules/plan";
-import { chatCommandsApi, AvailableCommand } from "../../api/modules/chatCommands";
+import {
+  chatCommandsApi,
+  AvailableCommand,
+} from "../../api/modules/chatCommands";
 import { CommandCustomizer } from "./components/CommandCustomizer";
 
 interface ApprovalMessageData {
@@ -619,10 +622,15 @@ export default function ChatPage() {
   >(new Map());
   const [planEnabled, setPlanEnabled] = useState(false);
   const [chatCommands, setChatCommands] = useState<string[]>([
-    "clear", "compact", "mission", "skills",
+    "clear",
+    "compact",
+    "mission",
+    "skills",
   ]);
   const [customizerVisible, setCustomizerVisible] = useState(false);
-  const [availableCommands, setAvailableCommands] = useState<AvailableCommand[]>([]);
+  const [availableCommands, setAvailableCommands] = useState<
+    AvailableCommand[]
+  >([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -640,7 +648,9 @@ export default function ChatPage() {
       .catch(() => {});
     chatCommandsApi
       .getAvailable()
-      .then((cmds) => { if (!cancelled) setAvailableCommands(cmds); })
+      .then((cmds) => {
+        if (!cancelled) setAvailableCommands(cmds);
+      })
       .catch(() => {});
     return () => {
       cancelled = true;
@@ -1180,7 +1190,9 @@ export default function ChatPage() {
                 onTranscription={handleWhisperTranscription}
               />
             )}
-            <Tooltip title={t("chat.commands.customizeTitle", "Customize Commands")}>
+            <Tooltip
+              title={t("chat.commands.customizeTitle", "Customize Commands")}
+            >
               <IconButton
                 icon={<SettingOutlined />}
                 bordered={false}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -32,6 +32,8 @@ import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { planApi } from "../../api/modules/plan";
+import { chatCommandsApi, AvailableCommand } from "../../api/modules/chatCommands";
+import { CommandCustomizer } from "./components/CommandCustomizer";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -616,6 +618,11 @@ export default function ChatPage() {
     Map<string, ApprovalMessageData>
   >(new Map());
   const [planEnabled, setPlanEnabled] = useState(false);
+  const [chatCommands, setChatCommands] = useState<string[]>([
+    "clear", "compact", "mission", "skills",
+  ]);
+  const [customizerVisible, setCustomizerVisible] = useState(false);
+  const [availableCommands, setAvailableCommands] = useState<AvailableCommand[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -624,6 +631,16 @@ export default function ChatPage() {
       .then((cfg) => {
         if (!cancelled) setPlanEnabled(cfg.enabled);
       })
+      .catch(() => {});
+    chatCommandsApi
+      .get()
+      .then((res) => {
+        if (!cancelled && res.commands?.length) setChatCommands(res.commands);
+      })
+      .catch(() => {});
+    chatCommandsApi
+      .getAvailable()
+      .then((cmds) => { if (!cancelled) setAvailableCommands(cmds); })
       .catch(() => {});
     return () => {
       cancelled = true;
@@ -1100,33 +1117,25 @@ export default function ChatPage() {
 
   const options = useMemo(() => {
     const i18nConfig = getDefaultConfig(t);
-    const commandSuggestions: CommandSuggestion[] = [
-      {
-        command: "/clear",
-        value: "clear",
-        description: t("chat.commands.clear.description"),
-      },
-      {
-        command: "/compact",
-        value: "compact",
-        description: t("chat.commands.compact.description"),
-      },
-      {
-        command: "/mission",
-        value: "mission",
-        description: t("chat.commands.mission.description"),
-      },
-      {
-        command: "/skills",
-        value: "skills",
-        description: t("chat.commands.skills.description"),
-      },
-    ];
+    const cmdMap = new Map(availableCommands.map((c) => [c.command, c]));
+    const commandSuggestions: CommandSuggestion[] = [];
+    for (const name of chatCommands) {
+      const cmd = cmdMap.get(name);
+      if (!cmd) continue;
+      if (cmd.command === "plan") continue;
+      const rawValue = cmd.display.replace(/^\//, "");
+      const value = cmd.has_args ? `${rawValue} ` : rawValue;
+      commandSuggestions.push({
+        command: cmd.display,
+        value,
+        description: t(`chat.commands.${cmd.command}.description`, ""),
+      });
+    }
     if (planEnabled) {
       commandSuggestions.push({
         command: "/plan",
         value: "plan ",
-        description: t("chat.commands.plan.description"),
+        description: t("chat.commands.plan.description", ""),
       });
     }
 
@@ -1163,12 +1172,23 @@ export default function ChatPage() {
         ...(i18nConfig as any)?.sender,
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: !whisperEnabled,
-        prefix: whisperEnabled ? (
-          <WhisperSpeechButton
-            ref={whisperSpeechRef}
-            onTranscription={handleWhisperTranscription}
-          />
-        ) : undefined,
+        prefix: (
+          <>
+            {whisperEnabled && (
+              <WhisperSpeechButton
+                ref={whisperSpeechRef}
+                onTranscription={handleWhisperTranscription}
+              />
+            )}
+            <Tooltip title={t("chat.commands.customizeTitle", "Customize Commands")}>
+              <IconButton
+                icon={<SettingOutlined />}
+                bordered={false}
+                onClick={() => setCustomizerVisible(true)}
+              />
+            </Tooltip>
+          </>
+        ),
         attachments: {
           multiple: true,
           trigger: function (props: any) {
@@ -1273,6 +1293,8 @@ export default function ChatPage() {
     toolRenderConfig,
     scheduleHistoryClear,
     planEnabled,
+    chatCommands,
+    availableCommands,
   ]);
 
   return (
@@ -1397,6 +1419,12 @@ export default function ChatPage() {
           ]}
         />
       </Modal>
+      <CommandCustomizer
+        visible={customizerVisible}
+        onClose={() => setCustomizerVisible(false)}
+        selected={chatCommands}
+        onChange={setChatCommands}
+      />
     </div>
   );
 }

--- a/src/qwenpaw/app/routers/__init__.py
+++ b/src/qwenpaw/app/routers/__init__.py
@@ -27,12 +27,14 @@ from .settings import router as settings_router
 from .plugins import router as plugins_router
 from .frontend_plugin import router as frontend_plugin_router
 from .backup import router as backup_router
+from .chat_commands import router as chat_commands_router
 from .plan import router as plan_router
 
 router = APIRouter()
 
 router.include_router(agents_router)
 router.include_router(config_router)
+router.include_router(chat_commands_router)
 router.include_router(console_router)
 router.include_router(cron_router)
 router.include_router(local_models_router)

--- a/src/qwenpaw/app/routers/agent_scoped.py
+++ b/src/qwenpaw/app/routers/agent_scoped.py
@@ -80,6 +80,7 @@ def create_agent_scoped_router() -> APIRouter:
     from ..runner.api import router as chats_router
     from .console import router as console_router
     from .plugins import router as plugins_router
+    from .chat_commands import router as chat_commands_router
     from .plan import router as plan_router
 
     router = APIRouter(prefix="/agents/{agentId}", tags=["agent-scoped"])
@@ -102,6 +103,7 @@ def create_agent_scoped_router() -> APIRouter:
     router.include_router(skills_router)
     router.include_router(tools_router)
     router.include_router(workspace_router)
+    router.include_router(chat_commands_router)
     router.include_router(console_router)
     router.include_router(plugins_router)
     router.include_router(plan_router)

--- a/src/qwenpaw/app/routers/chat_commands.py
+++ b/src/qwenpaw/app/routers/chat_commands.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""Chat slash-command shortcut menu configuration.
+
+Endpoints
+---------
+GET  /available  全量可用魔法命令（后端定义单一真相源）
+GET  /           当前用户勾选的命令列表
+PUT  /           更新勾选列表（写入 agent.json）
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Body, Request
+from pydantic import BaseModel, Field
+
+from ...config.config import save_agent_config
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/chat-commands", tags=["chat-commands"])
+
+
+# ============================================================
+# 模型
+# ============================================================
+
+
+class AvailableCommand(BaseModel):
+    command: str  # 内部标识符，如 "clear" / "daemon_status"
+    display: str  # 用户看到的文本，如 "/clear" / "/status"
+    category: str  # context/history/model/session/control/daemon
+    has_args: bool = False  # type: ignore
+
+
+class ChatCommandsResponse(BaseModel):
+    commands: list[str] = Field(default_factory=list)
+
+
+class ChatCommandsUpdate(BaseModel):
+    commands: list[str] = Field(default_factory=list, max_length=30)
+
+
+# ============================================================
+# 全量命令清单（后端单一真相源）
+# ============================================================
+# display 字段的值必须能被后端三个命令分发路径识别：
+#   - command_handler.py  → SYSTEM_COMMANDS
+#   - control_commands/   → 注册表
+#   - daemon_commands.py  → DAEMON_SHORT_ALIASES / parse_daemon_query
+# 前端构造 CommandSuggestion.value 时直接去掉前缀 / 即可。
+
+_AVAILABLE_COMMANDS: list[AvailableCommand] = [
+    # ---- 上下文 ----
+    AvailableCommand(
+        command="compact",
+        display="/compact",
+        category="context",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="clear",
+        display="/clear",
+        category="context",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="new",
+        display="/new",
+        category="context",
+        has_args=False,
+    ),
+    # ---- 历史 ----
+    AvailableCommand(
+        command="history",
+        display="/history",
+        category="history",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="message",
+        display="/message <n>",
+        category="history",
+        has_args=True,
+    ),
+    AvailableCommand(
+        command="compact_str",
+        display="/compact_str",
+        category="history",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="summarize_status",
+        display="/summarize_status",
+        category="history",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="dump_history",
+        display="/dump_history",
+        category="history",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="load_history",
+        display="/load_history",
+        category="history",
+        has_args=False,
+    ),
+    # ---- 模型 ----
+    AvailableCommand(
+        command="model",
+        display="/model",
+        category="model",
+        has_args=True,
+    ),
+    # ---- 会话 ----
+    AvailableCommand(
+        command="mission",
+        display="/mission",
+        category="session",
+        has_args=True,
+    ),
+    AvailableCommand(
+        command="plan",
+        display="/plan",
+        category="session",
+        has_args=True,
+    ),
+    AvailableCommand(
+        command="proactive",
+        display="/proactive",
+        category="session",
+        has_args=True,
+    ),
+    AvailableCommand(
+        command="skills",
+        display="/skills",
+        category="session",
+        has_args=False,
+    ),
+    # ---- 控制 ----
+    AvailableCommand(
+        command="stop",
+        display="/stop",
+        category="control",
+        has_args=False,
+    ),
+    # ---- 守护（短别名，与 DAEMON_SHORT_ALIASES / parse_daemon_query 匹配）----
+    AvailableCommand(
+        command="daemon_status",
+        display="/status",
+        category="daemon",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="daemon_restart",
+        display="/restart",
+        category="daemon",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="daemon_reload_config",
+        display="/reload-config",
+        category="daemon",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="daemon_reload_config_alt",
+        display="/reload_config",
+        category="daemon",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="daemon_version",
+        display="/version",
+        category="daemon",
+        has_args=False,
+    ),
+    AvailableCommand(
+        command="daemon_logs",
+        display="/logs",
+        category="daemon",
+        has_args=True,
+    ),
+]
+
+
+# ============================================================
+# 辅助
+# ============================================================
+
+
+async def _get_workspace(request: Request):
+    from ..agent_context import get_agent_for_request
+
+    return await get_agent_for_request(request)
+
+
+# ============================================================
+# 端点
+# ============================================================
+
+
+@router.get(
+    "/available",
+    response_model=list[AvailableCommand],
+    summary="获取全量可用魔法命令",
+)
+async def get_available_commands() -> list[AvailableCommand]:
+    """返回全量可用命令（含分类、参数标识）。
+
+    前端用此数据生成设置面板的勾选列表。
+    i18n 描述由前端根据 ``command`` 字段自推导 key：
+        t(`chat.commands.${cmd.command}.description`)
+    """
+    return _AVAILABLE_COMMANDS
+
+
+@router.get(
+    "",
+    response_model=ChatCommandsResponse,
+    summary="获取当前快捷菜单命令配置",
+)
+async def get_chat_commands(request: Request) -> ChatCommandsResponse:
+    """返回 agent.json 中 running.chat_commands 的当前值。
+
+    若字段缺失（旧版 agent.json），利用 Pydantic default_factory 返回默认值。
+    """
+    workspace = await _get_workspace(request)
+    commands = workspace.config.running.chat_commands
+    return ChatCommandsResponse(commands=list(commands))
+
+
+@router.put(
+    "",
+    response_model=ChatCommandsResponse,
+    summary="更新快捷菜单命令配置",
+)
+async def put_chat_commands(
+    request: Request,
+    body: ChatCommandsUpdate = Body(...),
+) -> ChatCommandsResponse:
+    """更新用户在快捷菜单中显示的命令列表。
+
+    白名单过滤 + 去重，防止脏数据写入 agent.json。
+    """
+    valid_names = {cmd.command for cmd in _AVAILABLE_COMMANDS}
+
+    # 白名单过滤 + 保序去重
+    seen: set[str] = set()
+    filtered: list[str] = []
+    for c in body.commands:
+        if c in valid_names and c not in seen:
+            filtered.append(c)
+            seen.add(c)
+
+    workspace = await _get_workspace(request)
+    workspace.config.running.chat_commands = filtered
+    save_agent_config(workspace.agent_id, workspace.config)
+
+    return ChatCommandsResponse(commands=filtered)

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1005,6 +1005,20 @@ class AgentsRunningConfig(BaseModel):
         ),
     )
 
+    chat_commands: list[str] = Field(
+        default_factory=lambda: [
+            "clear",
+            "compact",
+            "mission",
+            "skills",
+            "plan",
+        ],
+        description=(
+            "Shortcut menu commands shown in chat input /-menu. "
+            "Order reflects display order."
+        ),
+    )
+
 
 class AgentsLLMRoutingConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")

--- a/tests/unit/routers/test_chat_commands.py
+++ b/tests/unit/routers/test_chat_commands.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Unit tests for the chat commands router (/chat-commands)."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from qwenpaw.app.routers.chat_commands import router
+
+
+# ---- helpers ---------------------------------------------------------
+
+
+def _mock_workspace(agent_id="test_agent", chat_commands=None):
+    """Build a mock workspace whose config has given chat_commands."""
+    ws = MagicMock()
+    ws.agent_id = agent_id
+    config = MagicMock()
+    config.running = MagicMock()
+    config.running.chat_commands = (
+        chat_commands[:]
+        if chat_commands
+        else ["clear", "compact", "mission", "skills"]
+    )
+    ws.config = config
+    return ws
+
+
+# ---- app fixture -----------------------------------------------------
+
+
+@pytest.fixture
+def app_client():
+    """Create async test client with the chat-commands router mounted.
+
+    Monkey-patches _get_workspace and save_agent_config so tests
+    don't need a real config.json or agent.json on disk.
+    """
+    app = FastAPI()
+    app.include_router(router)  # router has prefix="/chat-commands"
+
+    # Store the last PUT value so GET round-trip works
+    _stored: dict = {}
+
+    async def _fake_get_workspace(request):
+        agent_id = getattr(request.state, "agent_id", "test_agent")
+        cmds = getattr(request.state, "mock_chat_commands", None)
+        ws = _mock_workspace(agent_id, cmds)
+        # Round-trip support: if PUT was called, reflect the updated value
+        if _stored:
+            ws.config.running.chat_commands = list(
+                _stored.get("cmds", ws.config.running.chat_commands),
+            )
+        return ws
+
+    def _fake_save_agent_config(agent_id, agent_config):
+        _stored["agent_id"] = agent_id
+        _stored["cmds"] = list(agent_config.running.chat_commands)
+
+    with (
+        patch(
+            "qwenpaw.app.routers.chat_commands._get_workspace",
+            _fake_get_workspace,
+        ),
+        patch(
+            "qwenpaw.app.routers.chat_commands.save_agent_config",
+            _fake_save_agent_config,
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        yield AsyncClient(transport=transport, base_url="http://test")
+
+
+# ---- 1. GET /available -------------------------------------------------
+
+
+async def test_get_available_returns_all_21_commands(app_client):
+    async with app_client:
+        resp = await app_client.get("/chat-commands/available")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 21
+
+    by_name = {c["command"]: c for c in data}
+
+    assert by_name["daemon_status"]["display"] == "/status"
+    assert by_name["daemon_restart"]["display"] == "/restart"
+    assert by_name["daemon_logs"]["display"] == "/logs"
+    assert by_name["daemon_reload_config"]["display"] == "/reload-config"
+    assert by_name["daemon_reload_config_alt"]["display"] == "/reload_config"
+
+    assert by_name["clear"]["category"] == "context"
+    assert by_name["history"]["category"] == "history"
+    assert by_name["model"]["category"] == "model"
+    assert by_name["skills"]["category"] == "session"
+    assert by_name["stop"]["category"] == "control"
+
+    assert by_name["clear"]["has_args"] is False
+    assert by_name["message"]["has_args"] is True
+
+
+# ---- 2. GET / (defaults) -----------------------------------------------
+
+
+async def test_get_default_commands(app_client):
+    async with app_client:
+        resp = await app_client.get("/chat-commands")
+    assert resp.status_code == 200
+    assert resp.json()["commands"] == ["clear", "compact", "mission", "skills"]
+
+
+# ---- 3. PUT + GET round-trip ------------------------------------------
+
+
+async def test_put_then_get(app_client):
+    new_list = ["clear", "new", "history", "stop"]
+    async with app_client:
+        put_resp = await app_client.put(
+            "/chat-commands",
+            json={"commands": new_list},
+        )
+        get_resp = await app_client.get("/chat-commands")
+    assert put_resp.status_code == 200
+    assert put_resp.json()["commands"] == new_list
+    assert get_resp.json()["commands"] == new_list
+
+
+# ---- 4. PUT dedup -----------------------------------------------------
+
+
+async def test_put_dedup_preserves_order(app_client):
+    async with app_client:
+        put_resp = await app_client.put(
+            "/chat-commands",
+            json={"commands": ["clear", "compact", "clear", "new", "compact"]},
+        )
+    assert put_resp.status_code == 200
+    assert put_resp.json()["commands"] == ["clear", "compact", "new"]
+
+
+# ---- 5. PUT filters invalid commands -----------------------------------
+
+
+async def test_put_filters_invalid_commands(app_client):
+    async with app_client:
+        put_resp = await app_client.put(
+            "/chat-commands",
+            json={"commands": ["clear", "nonexistent", "compact", "fake_cmd"]},
+        )
+    assert put_resp.status_code == 200
+    assert put_resp.json()["commands"] == ["clear", "compact"]
+
+
+# ---- 6. Old agent.json fallback (defaults) -----------------------------
+
+
+async def test_get_empty_list_falls_back_to_default(app_client):
+    async with app_client:
+        resp = await app_client.get("/chat-commands")
+    assert resp.status_code == 200
+    assert resp.json()["commands"] == ["clear", "compact", "mission", "skills"]

--- a/website/public/docs/commands.en.md
+++ b/website/public/docs/commands.en.md
@@ -22,14 +22,14 @@ Changes take effect immediately and are persisted across sessions. By default, `
 
 > 💡 Want to see all available commands? Check them all. Prefer a minimal menu? Keep only the ones you actually use.
 
-| Category | Available shortcut commands |
-|----------|---------------------------|
-| Context | `/compact` `/new` `/clear` |
-| History | `/history` `/message <n>` `/compact_str` `/summarize_status` `/dump_history` `/load_history` |
-| Model | `/model` |
-| Session | `/mission` `/plan` `/proactive` `/skills` |
-| Control | `/stop` |
-| Daemon | `/status` `/restart` `/reload-config` `/reload_config` `/version` `/logs` |
+| Category | Available shortcut commands                                                                  |
+| -------- | -------------------------------------------------------------------------------------------- |
+| Context  | `/compact` `/new` `/clear`                                                                   |
+| History  | `/history` `/message <n>` `/compact_str` `/summarize_status` `/dump_history` `/load_history` |
+| Model    | `/model`                                                                                     |
+| Session  | `/mission` `/plan` `/proactive` `/skills`                                                    |
+| Control  | `/stop`                                                                                      |
+| Daemon   | `/status` `/restart` `/reload-config` `/reload_config` `/version` `/logs`                    |
 
 > ⚠️ `/approve` and `/deny` only appear dynamically during tool approval flows. They are not in the shortcut menu options.
 

--- a/website/public/docs/commands.en.md
+++ b/website/public/docs/commands.en.md
@@ -14,6 +14,25 @@ Commands for controlling conversation context.
 | `/new`     | ⚡ No  | 🗑️ Clear           | ✅ Background save | ✅ New conversation prompt    |
 | `/clear`   | ⚡ No  | 🗑️ Clear           | ❌ No save         | ✅ History cleared prompt     |
 
+### Customizable Shortcut Menu
+
+The slash-command shortcut menu that appears when you type `/` in the chat input can be customized. Click the gear icon inside the input area to open a settings panel where you can check which commands you want to show.
+
+Changes take effect immediately and are persisted across sessions. By default, `/clear`, `/compact`, `/mission`, and `/skills` are shown.
+
+> 💡 Want to see all available commands? Check them all. Prefer a minimal menu? Keep only the ones you actually use.
+
+| Category | Available shortcut commands |
+|----------|---------------------------|
+| Context | `/compact` `/new` `/clear` |
+| History | `/history` `/message <n>` `/compact_str` `/summarize_status` `/dump_history` `/load_history` |
+| Model | `/model` |
+| Session | `/mission` `/plan` `/proactive` `/skills` |
+| Control | `/stop` |
+| Daemon | `/status` `/restart` `/reload-config` `/reload_config` `/version` `/logs` |
+
+> ⚠️ `/approve` and `/deny` only appear dynamically during tool approval flows. They are not in the shortcut menu options.
+
 ---
 
 ### /compact - Compress Current Conversation

--- a/website/public/docs/commands.zh.md
+++ b/website/public/docs/commands.zh.md
@@ -22,14 +22,14 @@
 
 > 💡 想要显示全部可用命令？勾上所有选项就行。觉得太吵？只留你真正需要的几个。
 
-| 分类 | 可选的快捷命令 |
-|------|---------------|
-| 上下文 | `/compact` `/new` `/clear` |
-| 历史 | `/history` `/message <n>` `/compact_str` `/summarize_status` `/dump_history` `/load_history` |
-| 模型 | `/model` |
-| 会话 | `/mission` `/plan` `/proactive` `/skills` |
-| 控制 | `/stop` |
-| 守护 | `/status` `/restart` `/reload-config` `/reload_config` `/version` `/logs` |
+| 分类   | 可选的快捷命令                                                                               |
+| ------ | -------------------------------------------------------------------------------------------- |
+| 上下文 | `/compact` `/new` `/clear`                                                                   |
+| 历史   | `/history` `/message <n>` `/compact_str` `/summarize_status` `/dump_history` `/load_history` |
+| 模型   | `/model`                                                                                     |
+| 会话   | `/mission` `/plan` `/proactive` `/skills`                                                    |
+| 控制   | `/stop`                                                                                      |
+| 守护   | `/status` `/restart` `/reload-config` `/reload_config` `/version` `/logs`                    |
 
 > ⚠️ `/approve` 和 `/deny` 仅在出现工具审批时动态显示，不在快捷菜单可选列表中。
 

--- a/website/public/docs/commands.zh.md
+++ b/website/public/docs/commands.zh.md
@@ -14,6 +14,25 @@
 | `/new`     | ⚡ 否    | 🗑️ 清空       | ✅ 后台保存 | ✅ 新对话开始提示    |
 | `/clear`   | ⚡ 否    | 🗑️ 清空       | ❌ 不保存   | ✅ 历史清空提示      |
 
+### 自定义快捷菜单
+
+在控制台输入 `/` 时出现的快捷命令列表可自行定制。点击输入框内侧的齿轮图标，在弹出面板中勾选你常用的命令即可。
+
+切换后即时生效，选择会持久化保存。默认显示 `/clear`、`/compact`、`/mission`、`/skills` 四个最常用的命令。
+
+> 💡 想要显示全部可用命令？勾上所有选项就行。觉得太吵？只留你真正需要的几个。
+
+| 分类 | 可选的快捷命令 |
+|------|---------------|
+| 上下文 | `/compact` `/new` `/clear` |
+| 历史 | `/history` `/message <n>` `/compact_str` `/summarize_status` `/dump_history` `/load_history` |
+| 模型 | `/model` |
+| 会话 | `/mission` `/plan` `/proactive` `/skills` |
+| 控制 | `/stop` |
+| 守护 | `/status` `/restart` `/reload-config` `/reload_config` `/version` `/logs` |
+
+> ⚠️ `/approve` 和 `/deny` 仅在出现工具审批时动态显示，不在快捷菜单可选列表中。
+
 ---
 
 ### /compact - 压缩当前对话


### PR DESCRIPTION
## Description

The `/` shortcut menu in chat input currently hardcodes only 4–5 magic commands (`/clear`, `/compact`, `/mission`, `/skills`), but QwenPaw has 20+ built-in commands that users never discover without reading the docs.

This PR lets users **choose which built-in commands appear** in the shortcut menu via a gear-icon settings panel, with preferences persisted to `agent.json`.

Backend:
- `config.py` — added `chat_commands` field to `AgentsRunningConfig` (default: the same 4 commands)
- `chat_commands.py` (new) — `GET /available` returns catalog of 21 commands, `GET /` and `PUT /` for user selection (whitelist-filtered + deduped)
- `__init__.py` + `agent_scoped.py` — route registration

Frontend:
- `chatCommands.ts` (new) — API module
- `CommandCustomizer.tsx` (new) — settings modal with checkboxes grouped by category
- `Chat/index.tsx` — dynamic shortcut menu, gear icon in input area

Other:
- `zh.json` + `en.json` — 22 new i18n keys
- `test_chat_commands.py` (new) — 6 test cases
- `docs/commands.*.md` — "Customizable Shortcut Menu" section

Design notes:
- `/plan` is excluded from the settings panel — it auto-appears when Plan Mode is enabled
- `/approve` / `/deny` are excluded (context-sensitive, only appear during approval flows)
- PUT endpoint validates commands against a whitelist and deduplicates

**Related Issue:** Closes #4633

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (config, API, router)
- [x] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] pre-commit 全过
- [x] pytest 全过（6/6）
- [x] 文档已更新
- [x] Ready for review
