### PR TITLE
fix(DingTalk): use sender_id prefix in DM webhook store key to avoid conversation_id suffix collision

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -384,7 +384,13 @@ class DingTalkChannel(BaseChannel):
     def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
         # Key by session_id (short suffix of conversation_id) so cron can
         # use the same session_id to look up stored sessionWebhook.
-        return f"dingtalk:sw:{session_id}"
+        # For DM, prefix with user_id to avoid collision when different
+        # conversation_ids share the same suffix.
+        return (
+            f"dingtalk:sw:{user_id}_{session_id}"
+            if user_id
+            else f"dingtalk:sw:{session_id}"
+        )
 
     async def _before_consume_process(self, request: "AgentRequest") -> None:
         """Save session_webhook, send processing reaction, pre-create card."""
@@ -395,10 +401,17 @@ class DingTalkChannel(BaseChannel):
         if session_webhook:
             session_id = getattr(request, "session_id", None)
             if session_id:
-                webhook_key = self.to_handle_from_target(
-                    user_id=getattr(request, "user_id", None) or "",
-                    session_id=session_id,
-                )
+                conversation_type = meta.get("conversation_type")
+                # For DM, use user_id + suffix as key to avoid collision
+                # when different conversation_ids share the same suffix.
+                # For group, use suffix-only key (shared across users).
+                if conversation_type == "dm":
+                    webhook_key = self.to_handle_from_target(
+                        user_id=getattr(request, "user_id", None) or "",
+                        session_id=session_id,
+                    )
+                else:
+                    webhook_key = f"dingtalk:sw:{session_id}"
                 logger.info(
                     "dingtalk _before_consume_process: storing webhook "
                     "session_id=%s conversation_id=%s",
@@ -409,7 +422,7 @@ class DingTalkChannel(BaseChannel):
                     webhook_key,
                     session_webhook,
                     conversation_id=meta.get("conversation_id"),
-                    conversation_type=meta.get("conversation_type"),
+                    conversation_type=conversation_type,
                     sender_staff_id=meta.get("sender_staff_id"),
                 )
 
@@ -604,6 +617,14 @@ class DingTalkChannel(BaseChannel):
             return
         async with self._session_webhook_lock:
             raw = self._session_webhook_store.get(webhook_key)
+            # Fallback to suffix-only key
+            actual_key = webhook_key
+            if raw is None:
+                fallback_key = self._suffix_only_webhook_key(webhook_key)
+                if fallback_key:
+                    raw = self._session_webhook_store.get(fallback_key)
+                    if raw is not None:
+                        actual_key = fallback_key
             if raw is None:
                 return
             entry = raw if isinstance(raw, dict) else {"webhook": raw}
@@ -612,10 +633,10 @@ class DingTalkChannel(BaseChannel):
             logger.info(
                 "dingtalk _invalidate_session_webhook: "
                 "clearing webhook for key=%s",
-                webhook_key,
+                actual_key,
             )
             entry["webhook"] = ""
-            self._session_webhook_store[webhook_key] = entry
+            self._session_webhook_store[actual_key] = entry
             self._save_session_webhook_store_to_disk()
 
     async def _load_session_webhook(self, webhook_key: str) -> Optional[str]:
@@ -627,6 +648,26 @@ class DingTalkChannel(BaseChannel):
             return entry.get("webhook")
         return None
 
+    @staticmethod
+    def _suffix_only_webhook_key(webhook_key: str) -> Optional[str]:
+        """Extract suffix-only fallback key from a user-prefixed key.
+
+        e.g. "dingtalk:sw:user123_tru1C1k=" -> "dingtalk:sw:tru1C1k="
+        Returns None if the key has no user prefix (already suffix-only).
+        """
+        prefix = "dingtalk:sw:"
+        if not webhook_key.startswith(prefix):
+            return None
+        ident = webhook_key[len(prefix) :]
+        # If ident contains '_', it might be user_id + suffix
+        underscore_idx = ident.rfind("_")
+        if underscore_idx < 0:
+            return None  # Already suffix-only
+        suffix = ident[underscore_idx + 1 :]
+        if not suffix:
+            return None
+        return f"{prefix}{suffix}"
+
     async def _load_session_webhook_entry(
         self,
         webhook_key: str,
@@ -634,6 +675,8 @@ class DingTalkChannel(BaseChannel):
         """Load the full webhook entry dict from store (memory then disk).
 
         Returns None if not found or if the webhook is expired.
+        Falls back to suffix-only key for backward compatibility with
+        old DM entries and group chat entries.
         """
         if not webhook_key:
             return None
@@ -645,6 +688,14 @@ class DingTalkChannel(BaseChannel):
                 self._load_session_webhook_store_from_disk()
                 raw = self._session_webhook_store.get(webhook_key)
                 source = "disk"
+
+            # Fallback: try suffix-only key (old DM data / group chat)
+            if raw is None:
+                fallback_key = self._suffix_only_webhook_key(webhook_key)
+                if fallback_key:
+                    raw = self._session_webhook_store.get(fallback_key)
+                    if raw is not None:
+                        source = f"fallback({fallback_key})"
 
             if raw is not None:
                 entry = raw if isinstance(raw, dict) else {"webhook": raw}
@@ -952,6 +1003,11 @@ class DingTalkChannel(BaseChannel):
                 if raw is None:
                     self._load_session_webhook_store_from_disk()
                     raw = self._session_webhook_store.get(webhook_key)
+                # Fallback to suffix-only key
+                if raw is None:
+                    fallback_key = self._suffix_only_webhook_key(webhook_key)
+                    if fallback_key:
+                        raw = self._session_webhook_store.get(fallback_key)
                 if raw is not None:
                     webhook_entry = (
                         raw if isinstance(raw, dict) else {"webhook": raw}

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -906,13 +906,19 @@ class TestDingTalkResolveSession:
         assert result == "dingtalk:user456"
 
     def test_to_handle_from_target_formats_correctly(self, dingtalk_channel):
-        """to_handle_from_target should format handle with session_id."""
+        """to_handle_from_target should include user_id prefix for DM."""
         result = dingtalk_channel.to_handle_from_target(
             user_id="user123",
             session_id="sess_abc",
         )
+        assert result == "dingtalk:sw:user123_sess_abc"
 
-        assert result == "dingtalk:sw:sess_abc"
+        # Without user_id, falls back to suffix-only key (group chat)
+        result_no_user = dingtalk_channel.to_handle_from_target(
+            user_id="",
+            session_id="sess_abc",
+        )
+        assert result_no_user == "dingtalk:sw:sess_abc"
 
     def test_route_from_handle_sw(self, dingtalk_channel):
         """_route_from_handle should parse 'dingtalk:sw:' format."""


### PR DESCRIPTION
## Description

The last 8 characters of conversation_id were used as the webhook store key, which caused collisions when different conversation_ids shared the same suffix — leading to multiple DM conversations incorrectly sharing the same webhook entry in dingtalk_session_webhooks.json.

##Changes:

- For DM conversations, prefix the webhook store key with sender_id (e.g. dingtalk:sw:{sender_id}_{suffix})
- For group chats, keep the suffix-only key unchanged (shared across users in the same group)
- Add fallback logic in all load/invalidate paths: try the full key first, then fall back to suffix-only key for backward compatibility with old DM data and group chat entries
- Add _suffix_only_webhook_key static helper to extract the fallback key

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
