### PR TITLE
feat(QQ): add tool_guard interactive approval card with keyboard buttons

### DIFF
--- a/src/qwenpaw/app/channels/qq/cards/__init__.py
+++ b/src/qwenpaw/app/channels/qq/cards/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""QQ channel interactive card support."""

--- a/src/qwenpaw/app/channels/qq/cards/context.py
+++ b/src/qwenpaw/app/channels/qq/cards/context.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Shared helpers used by QQ card kinds.
+
+Covers extracting metadata / body text from runtime Msg objects and
+building stateless routing context for button callbacks.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Event / message extraction
+# ---------------------------------------------------------------------
+
+
+def extract_meta(event: Any) -> Optional[Dict[str, Any]]:
+    """Return the original ``Msg.metadata`` dict, unwrapping the
+    ``metadata.metadata`` nesting the runtime introduces."""
+    metadata = getattr(event, "metadata", None) or {}
+    if not isinstance(metadata, dict):
+        return None
+    inner = metadata.get("metadata")
+    meta = inner if isinstance(inner, dict) else metadata
+    return meta if isinstance(meta, dict) else None
+
+
+def extract_body_text(content: Any) -> str:
+    """Flatten ``Message.content`` into a plain string."""
+    if not content:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for item in content:
+        if hasattr(item, "text") and item.text:
+            parts.append(item.text)
+        elif isinstance(item, dict) and item.get("type") == "text":
+            parts.append(item.get("text") or "")
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------
+# Routing context
+# ---------------------------------------------------------------------
+
+
+def build_session_ctx(
+    to_handle: str,
+    send_meta: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Routing info encoded into button action.data so the inbound
+    handler can recover the original session/sender/chat."""
+    meta = send_meta or {}
+    message_type = str(meta.get("message_type") or "c2c")
+    sender_id = str(meta.get("sender_id") or "")
+    session_id = str(meta.get("session_id") or to_handle or "")
+    group_openid = str(meta.get("group_openid") or "")
+    channel_id = str(meta.get("channel_id") or "")
+    guild_id = str(meta.get("guild_id") or "")
+    message_id = str(meta.get("message_id") or "")
+
+    return {
+        "sid": session_id,
+        "sender": sender_id,
+        "mt": message_type,
+        "goid": group_openid,
+        "cid": channel_id,
+        "gid": guild_id,
+        "mid": message_id,
+    }
+
+
+__all__ = [
+    "extract_meta",
+    "extract_body_text",
+    "build_session_ctx",
+]

--- a/src/qwenpaw/app/channels/qq/cards/dispatcher.py
+++ b/src/qwenpaw/app/channels/qq/cards/dispatcher.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""QQ interactive card dispatcher (routing-only).
+
+Two lookup tables drive the dispatch:
+
+* ``_by_message_type``     — outbound: ``metadata.message_type`` → ``render``.
+* ``_by_action_data_prefix`` — inbound: ``action.data`` prefix  → ``handle``.
+
+Public entry-points (called by :class:`~..channel.QQChannel`):
+:meth:`try_send_card_for_event` and :meth:`handle_interaction_event`.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+)
+
+from . import context
+
+if TYPE_CHECKING:
+    from ..channel import QQChannel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Registry record
+# ---------------------------------------------------------------------
+
+RenderFn = Callable[
+    ["QQChannel", str, Any, Dict[str, Any], Dict[str, Any]],
+    Awaitable[bool],
+]
+
+HandleFn = Callable[["QQChannel", Dict[str, Any]], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class CardKind:
+    """Describes one kind of interactive card and its handlers."""
+
+    name: str
+    message_type: str
+    action_data_prefix: str
+    render: RenderFn
+    handle: HandleFn
+
+
+# ---------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------
+
+
+class QQCardHandler:
+    """Routing-only dispatcher for QQ interactive keyboard cards."""
+
+    def __init__(self, channel: "QQChannel") -> None:
+        self._channel = channel
+        self._by_message_type: Dict[str, CardKind] = {}
+        self._by_action_data_prefix: Dict[str, CardKind] = {}
+        self._register_kinds()
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self, kind: CardKind) -> None:
+        """Install a card kind into both lookup tables."""
+        self._by_message_type[kind.message_type] = kind
+        self._by_action_data_prefix[kind.action_data_prefix] = kind
+
+    def _register_kinds(self) -> None:
+        """Register every built-in card kind."""
+        from . import tool_guard
+
+        self.register(
+            CardKind(
+                name=tool_guard.NAME,
+                message_type=tool_guard.MESSAGE_TYPE,
+                action_data_prefix=tool_guard.ACTION_DATA_PREFIX,
+                render=tool_guard.render,
+                handle=tool_guard.handle,
+            ),
+        )
+
+    # ==================================================================
+    # Public entry-points
+    # ==================================================================
+
+    async def try_send_card_for_event(
+        self,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> bool:
+        """Render ``event`` as a keyboard card if any kind matches.
+
+        Returns ``True`` when a card was sent so the caller can skip
+        the default text rendering.
+        """
+        meta = context.extract_meta(event)
+        if meta is None:
+            return False
+        kind = self._by_message_type.get(str(meta.get("message_type") or ""))
+        if kind is None:
+            return False
+
+        try:
+            return await kind.render(
+                self._channel,
+                to_handle,
+                event,
+                send_meta,
+                meta,
+            )
+        except Exception:
+            logger.exception(
+                "qq card render failed: kind=%s",
+                kind.name,
+            )
+            return False
+
+    def handle_interaction_event(self, event_data: Dict[str, Any]) -> None:
+        """Sync entry called from the WS thread; routes by action.data
+        prefix and dispatches to the main loop."""
+        loop = self._channel._loop
+        if not loop or not loop.is_running():
+            logger.warning(
+                "qq card event: main loop not running, drop event",
+            )
+            return
+
+        kind = self._lookup_kind_for_event(event_data)
+        if kind is None:
+            return
+
+        asyncio.run_coroutine_threadsafe(
+            self._safe_handle(kind, event_data),
+            loop,
+        )
+
+    async def _safe_handle(
+        self,
+        kind: CardKind,
+        event_data: Dict[str, Any],
+    ) -> None:
+        """Wrap the registered handler with logging."""
+        try:
+            await kind.handle(self._channel, event_data)
+        except Exception:
+            logger.exception(
+                "qq card handle failed: kind=%s",
+                kind.name,
+            )
+
+    def _lookup_kind_for_event(
+        self,
+        event_data: Dict[str, Any],
+    ) -> Optional[CardKind]:
+        """Find the CardKind matching the interaction event's action data."""
+        import json as _json
+
+        # Extract button_data from various possible locations
+        data_str = ""
+        resolved = event_data.get("data", {})
+        if isinstance(resolved, dict):
+            resolved_inner = resolved.get("resolved", {})
+            if isinstance(resolved_inner, dict):
+                data_str = str(resolved_inner.get("button_data") or "")
+        if not data_str:
+            data_str = str(event_data.get("button_data") or "")
+        if not data_str:
+            return None
+
+        try:
+            ctx = _json.loads(data_str)
+        except (ValueError, TypeError):
+            return None
+
+        prefix = str(ctx.get("p") or "")
+        return self._by_action_data_prefix.get(prefix)
+
+
+__all__ = ["QQCardHandler", "CardKind"]

--- a/src/qwenpaw/app/channels/qq/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/qq/cards/tool_guard.py
@@ -84,10 +84,18 @@ def build_approval_keyboard(
     ctx = session_ctx or {}
 
     approve_data = _build_action_data(
-        APPROVE_KEY, request_id, tool_name, severity_lower, ctx,
+        APPROVE_KEY,
+        request_id,
+        tool_name,
+        severity_lower,
+        ctx,
     )
     deny_data = _build_action_data(
-        DENY_KEY, request_id, tool_name, severity_lower, ctx,
+        DENY_KEY,
+        request_id,
+        tool_name,
+        severity_lower,
+        ctx,
     )
 
     return {
@@ -106,7 +114,9 @@ def build_approval_keyboard(
                                 "type": 1,
                                 "permission": {"type": 2},
                                 "data": approve_data,
-                                "unsupport_tips": "Please use /approval approve",
+                                "unsupport_tips": (
+                                    "Please use /approval approve"
+                                ),
                             },
                         },
                         {
@@ -176,8 +186,10 @@ def parse_interaction_event(
 
     Returns None if the event is not a tool-guard button action.
     """
-    data_str = str(event_data.get("data", {}).get("resolved", {})
-                   .get("button_data") or "")
+    data_str = str(
+        event_data.get("data", {}).get("resolved", {}).get("button_data")
+        or "",
+    )
     if not data_str:
         # Try alternate path: d.data might be the button action data directly
         data_str = str(event_data.get("button_data") or "")
@@ -304,7 +316,11 @@ async def _send_keyboard_message(
     from ..channel import _api_request_async, _get_next_msg_seq
 
     path, use_msg_seq, seq_key = channel._resolve_send_path(
-        message_type, sender_id, channel_id, group_openid, guild_id=guild_id,
+        message_type,
+        sender_id,
+        channel_id,
+        group_openid,
+        guild_id=guild_id,
     )
 
     body: Dict[str, Any] = {
@@ -369,8 +385,9 @@ async def handle(
     tool_name = parsed.get("tool_name") or "tool"
     session_ctx = parsed.get("session_ctx") or {}
 
-    # Extract operator info from the interaction event
-    # group: group_member_openid, c2c: user_openid, guild: data.resolved.user_id
+    # Extract operator info from the interaction event.
+    # group: group_member_openid, c2c: user_openid,
+    # guild: data.resolved.user_id
     operator_member_openid = str(
         event_data.get("group_member_openid")
         or event_data.get("user_openid")
@@ -403,7 +420,9 @@ async def handle(
 
     # 3. Resolve operator display (openid last 6 chars; QQ API doesn't
     #    expose nicknames in group/c2c openid scenarios).
-    operator_display = operator_member_openid[-6:] if operator_member_openid else ""
+    operator_display = (
+        operator_member_openid[-6:] if operator_member_openid else ""
+    )
 
     # 4. Send resolved status message showing who approved/denied
     await _send_resolved_message(
@@ -445,11 +464,14 @@ async def _ack_interaction(
             {"code": code},
         )
         logger.debug(
-            "qq interaction ack: id=%s code=%d", interaction_id[:20], code,
+            "qq interaction ack: id=%s code=%d",
+            interaction_id[:20],
+            code,
         )
     except Exception:
         logger.exception(
-            "qq interaction ack failed: id=%s", interaction_id[:20],
+            "qq interaction ack failed: id=%s",
+            interaction_id[:20],
         )
 
 

--- a/src/qwenpaw/app/channels/qq/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/qq/cards/tool_guard.py
@@ -1,0 +1,558 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""QQ tool-guard approval card (keyboard buttons).
+
+Uses QQ's markdown + keyboard mechanism to send approval buttons.
+Inbound button clicks arrive as INTERACTION_CREATE WebSocket events.
+
+QQ API refs:
+  https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/msg-btn.html
+  https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/send.html
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from . import context
+
+if TYPE_CHECKING:
+    from ..channel import QQChannel
+
+logger = logging.getLogger(__name__)
+
+
+# =====================================================================
+# Module-level metadata (read by the dispatcher when registering)
+# =====================================================================
+
+NAME = "tool_guard_approval"
+
+# Outbound metadata.message_type that triggers this card kind.
+MESSAGE_TYPE = "tool_guard_approval"
+
+# Prefix in action.data to identify our button callbacks.
+ACTION_DATA_PREFIX = "tg_"
+
+
+# =====================================================================
+# Constants
+# =====================================================================
+
+APPROVE_KEY = "approve"
+DENY_KEY = "deny"
+
+
+# =====================================================================
+# Builders
+# =====================================================================
+
+
+def _build_action_data(
+    action: str,
+    request_id: str,
+    tool_name: str,
+    severity: str,
+    session_ctx: Dict[str, Any],
+) -> str:
+    """Encode action + context into button action.data string."""
+    payload = json.dumps(
+        {
+            "p": ACTION_DATA_PREFIX,
+            "a": action,
+            "rid": request_id,
+            "tool": tool_name,
+            "sev": severity,
+            **session_ctx,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return payload
+
+
+def build_approval_keyboard(
+    *,
+    request_id: str,
+    tool_name: str,
+    severity: str,
+    session_ctx: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the keyboard JSON for approve/deny buttons."""
+    severity_lower = (severity or "medium").lower()
+    ctx = session_ctx or {}
+
+    approve_data = _build_action_data(
+        APPROVE_KEY, request_id, tool_name, severity_lower, ctx,
+    )
+    deny_data = _build_action_data(
+        DENY_KEY, request_id, tool_name, severity_lower, ctx,
+    )
+
+    return {
+        "content": {
+            "rows": [
+                {
+                    "buttons": [
+                        {
+                            "id": f"approve_{request_id[:8]}",
+                            "render_data": {
+                                "label": "✅ Approve",
+                                "visited_label": "✅ Approved",
+                                "style": 1,
+                            },
+                            "action": {
+                                "type": 1,
+                                "permission": {"type": 2},
+                                "data": approve_data,
+                                "unsupport_tips": "Please use /approval approve",
+                            },
+                        },
+                        {
+                            "id": f"deny_{request_id[:8]}",
+                            "render_data": {
+                                "label": "🚫 Deny",
+                                "visited_label": "🚫 Denied",
+                                "style": 0,
+                            },
+                            "action": {
+                                "type": 1,
+                                "permission": {"type": 2},
+                                "data": deny_data,
+                                "unsupport_tips": "Please use /approval deny",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def build_approval_markdown(
+    tool_name: str,
+    severity: str,
+    body_text: str = "",
+) -> str:
+    """Build the markdown content for the approval message.
+
+    Includes the full tool-guard details (body_text) so users see the
+    complete risk information alongside the approve/deny buttons.
+    """
+    severity_lower = (severity or "medium").lower()
+    header = (
+        f"🛡️ **Tool Approval Required**\n"
+        f"Tool: `{tool_name}` | Severity: `{severity_lower}`"
+    )
+    if body_text:
+        return f"{header}\n\n{body_text}"
+    return header
+
+
+def build_resolved_text(
+    tool_name: str,
+    action: str,
+    operator_display: str = "",
+) -> str:
+    """Build the text message sent after a button click (shows who acted)."""
+    by_text = f" by **{operator_display}**" if operator_display else ""
+    if action == APPROVE_KEY:
+        return f"✅ **Approved**{by_text}\nTool: `{tool_name}`"
+    elif action == DENY_KEY:
+        return f"🚫 **Denied**{by_text}\nTool: `{tool_name}`"
+    return f"⌛ **Expired**\nApproval for `{tool_name}` has expired."
+
+
+# =====================================================================
+# Parser
+# =====================================================================
+
+
+def parse_interaction_event(
+    event_data: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Parse an INTERACTION_CREATE event for tool-guard button clicks.
+
+    Returns None if the event is not a tool-guard button action.
+    """
+    data_str = str(event_data.get("data", {}).get("resolved", {})
+                   .get("button_data") or "")
+    if not data_str:
+        # Try alternate path: d.data might be the button action data directly
+        data_str = str(event_data.get("button_data") or "")
+
+    if not data_str:
+        return None
+
+    try:
+        ctx = json.loads(data_str)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    # Verify this is our tool-guard button
+    if str(ctx.get("p") or "") != ACTION_DATA_PREFIX:
+        return None
+
+    action = str(ctx.get("a") or "")
+    if action not in (APPROVE_KEY, DENY_KEY):
+        return None
+
+    return {
+        "action": action,
+        "request_id": str(ctx.get("rid") or ""),
+        "tool_name": str(ctx.get("tool") or ""),
+        "severity": str(ctx.get("sev") or "medium"),
+        "session_ctx": {
+            k: v
+            for k, v in ctx.items()
+            if k not in ("p", "a", "rid", "tool", "sev")
+        },
+    }
+
+
+# =====================================================================
+# Outbound: render
+# =====================================================================
+
+
+async def render(
+    channel: "QQChannel",
+    to_handle: str,
+    event: Any,
+    send_meta: Dict[str, Any],
+    meta: Dict[str, Any],
+) -> bool:
+    """Render a tool-guard event as a markdown + keyboard message."""
+    request_id = str(meta.get("approval_request_id") or "")
+    if not request_id:
+        return False
+
+    if not channel.enabled:
+        return False
+
+    tool_name = str(meta.get("tool_name") or "tool")
+    severity = str(meta.get("severity") or "medium")
+
+    session_ctx = context.build_session_ctx(to_handle, send_meta)
+
+    keyboard = build_approval_keyboard(
+        request_id=request_id,
+        tool_name=tool_name,
+        severity=severity,
+        session_ctx=session_ctx,
+    )
+
+    body_text = context.extract_body_text(getattr(event, "content", None))
+    markdown_content = build_approval_markdown(tool_name, severity, body_text)
+
+    # Resolve send path from meta
+    message_type = str(send_meta.get("message_type") or "c2c")
+    sender_id = str(send_meta.get("sender_id") or to_handle)
+    msg_id = str(send_meta.get("message_id") or "")
+    group_openid = str(send_meta.get("group_openid") or "")
+    channel_id = str(send_meta.get("channel_id") or "")
+    guild_id = str(send_meta.get("guild_id") or "")
+
+    try:
+        token = await channel._get_access_token_async()
+    except Exception:
+        logger.exception("qq approval card: get token failed")
+        return False
+
+    try:
+        await _send_keyboard_message(
+            channel,
+            token=token,
+            message_type=message_type,
+            sender_id=sender_id,
+            group_openid=group_openid,
+            channel_id=channel_id,
+            guild_id=guild_id,
+            msg_id=msg_id,
+            markdown_content=markdown_content,
+            keyboard=keyboard,
+        )
+        logger.info(
+            "qq approval card sent: request_id=%s tool=%s",
+            request_id[:8],
+            tool_name,
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "qq approval card send failed: request_id=%s",
+            request_id[:8],
+        )
+        return False
+
+
+async def _send_keyboard_message(
+    channel: "QQChannel",
+    *,
+    token: str,
+    message_type: str,
+    sender_id: str,
+    group_openid: str,
+    channel_id: str,
+    guild_id: str,
+    msg_id: str,
+    markdown_content: str,
+    keyboard: Dict[str, Any],
+) -> None:
+    """Send a markdown message with keyboard buttons via QQ API."""
+    from ..channel import _api_request_async, _get_next_msg_seq
+
+    path, use_msg_seq, seq_key = channel._resolve_send_path(
+        message_type, sender_id, channel_id, group_openid, guild_id=guild_id,
+    )
+
+    body: Dict[str, Any] = {
+        "markdown": {"content": markdown_content},
+        "keyboard": keyboard,
+        "msg_type": 2,
+    }
+    if use_msg_seq:
+        body["msg_seq"] = _get_next_msg_seq(msg_id or seq_key)
+    if msg_id:
+        body["msg_id"] = msg_id
+
+    await _api_request_async(
+        channel._http,
+        token,
+        "POST",
+        path,
+        body,
+    )
+
+
+# =====================================================================
+# Inbound: handle
+# =====================================================================
+
+
+# Track processed request_ids to prevent duplicate button clicks.
+_processed_requests: Dict[str, str] = {}
+_PROCESSED_MAX_SIZE = 500
+
+
+def _mark_processed(request_id: str, action: str) -> bool:
+    """Mark a request_id as processed. Returns True if already processed."""
+    if request_id in _processed_requests:
+        return True
+    _processed_requests[request_id] = action
+    # Evict oldest entries when cache grows too large.
+    if len(_processed_requests) > _PROCESSED_MAX_SIZE:
+        keys = list(_processed_requests.keys())
+        for key in keys[: len(keys) // 2]:
+            _processed_requests.pop(key, None)
+    return False
+
+
+async def handle(
+    channel: "QQChannel",
+    event_data: Dict[str, Any],
+) -> None:
+    """Process a tool-guard INTERACTION_CREATE button callback.
+
+    1. Check for duplicate clicks (ACK with code=3 if already handled).
+    2. Acknowledge the interaction (required by QQ).
+    3. Send a resolved status message showing who approved/denied.
+    4. Inject /approval command into the message queue.
+    """
+    parsed = parse_interaction_event(event_data)
+    if not parsed:
+        return
+
+    action = parsed["action"]
+    request_id = parsed["request_id"]
+    tool_name = parsed.get("tool_name") or "tool"
+    session_ctx = parsed.get("session_ctx") or {}
+
+    # Extract operator info from the interaction event
+    # group: group_member_openid, c2c: user_openid, guild: data.resolved.user_id
+    operator_member_openid = str(
+        event_data.get("group_member_openid")
+        or event_data.get("user_openid")
+        or event_data.get("data", {}).get("resolved", {}).get("user_id")
+        or "",
+    )
+
+    interaction_id = str(event_data.get("id") or "")
+
+    # 1. Deduplication: if already processed, ACK with "duplicate" code.
+    if _mark_processed(request_id, action):
+        logger.info(
+            "qq card event: duplicate click ignored request_id=%s",
+            request_id[:8],
+        )
+        if interaction_id:
+            await _ack_interaction(channel, interaction_id, code=3)
+        return
+
+    logger.info(
+        "qq card event: action=%s request_id=%s operator=%s",
+        action,
+        request_id[:8],
+        operator_member_openid[:20],
+    )
+
+    # 2. Acknowledge the interaction
+    if interaction_id:
+        await _ack_interaction(channel, interaction_id)
+
+    # 3. Resolve operator display (openid last 6 chars; QQ API doesn't
+    #    expose nicknames in group/c2c openid scenarios).
+    operator_display = operator_member_openid[-6:] if operator_member_openid else ""
+
+    # 4. Send resolved status message showing who approved/denied
+    await _send_resolved_message(
+        channel,
+        session_ctx=session_ctx,
+        tool_name=tool_name,
+        action=action,
+        operator_display=operator_display,
+    )
+
+    # 5. Inject /approval command into the message queue
+    _enqueue_approval_command(
+        channel,
+        action=action,
+        request_id=request_id,
+        session_ctx=session_ctx,
+        user_id=operator_member_openid,
+    )
+
+
+async def _ack_interaction(
+    channel: "QQChannel",
+    interaction_id: str,
+    code: int = 0,
+) -> None:
+    """Acknowledge an interaction event (PUT /interactions/{id}).
+
+    Codes: 0=success, 1=fail, 2=rate_limit, 3=duplicate, 4=no_perm.
+    """
+    from ..channel import _api_request_async
+
+    try:
+        token = await channel._get_access_token_async()
+        await _api_request_async(
+            channel._http,
+            token,
+            "PUT",
+            f"/interactions/{interaction_id}",
+            {"code": code},
+        )
+        logger.debug(
+            "qq interaction ack: id=%s code=%d", interaction_id[:20], code,
+        )
+    except Exception:
+        logger.exception(
+            "qq interaction ack failed: id=%s", interaction_id[:20],
+        )
+
+
+async def _send_resolved_message(
+    channel: "QQChannel",
+    *,
+    session_ctx: Dict[str, Any],
+    tool_name: str,
+    action: str,
+    operator_display: str,
+) -> None:
+    """Send a follow-up message showing the approval result and who acted."""
+    resolved_text = build_resolved_text(tool_name, action, operator_display)
+
+    message_type = str(session_ctx.get("mt") or "c2c")
+    sender_id = str(session_ctx.get("sender") or "")
+    group_openid = str(session_ctx.get("goid") or "")
+    channel_id = str(session_ctx.get("cid") or "")
+    guild_id = str(session_ctx.get("gid") or "")
+    msg_id = str(session_ctx.get("mid") or "")
+
+    if not sender_id and not group_openid and not channel_id:
+        logger.warning("qq resolved message: no target to send to")
+        return
+
+    try:
+        await channel._send_text_with_fallback(
+            message_type,
+            sender_id,
+            channel_id,
+            group_openid,
+            resolved_text,
+            msg_id,
+            await channel._get_access_token_async(),
+            channel._markdown_enabled,
+            guild_id=guild_id,
+        )
+        logger.info(
+            "qq resolved message sent: action=%s operator=%s",
+            action,
+            operator_display,
+        )
+    except Exception:
+        logger.exception("qq resolved message send failed")
+
+
+def _enqueue_approval_command(
+    channel: "QQChannel",
+    *,
+    action: str,
+    request_id: str,
+    session_ctx: Dict[str, Any],
+    user_id: str,
+) -> None:
+    """Inject ``/approval {action} {request_id}`` into the channel queue."""
+    from agentscope_runtime.engine.schemas.agent_schemas import (
+        ContentType,
+        TextContent,
+    )
+
+    enqueue = getattr(channel, "_enqueue", None)
+    if enqueue is None:
+        logger.warning(
+            "qq card action: channel enqueue not set, dropping %s %s",
+            action,
+            request_id[:8],
+        )
+        return
+
+    sender_id = str(session_ctx.get("sender") or user_id or "")
+    session_id = str(session_ctx.get("sid") or "")
+    message_type = str(session_ctx.get("mt") or "c2c")
+    group_openid = str(session_ctx.get("goid") or "")
+    is_group = message_type == "group"
+
+    command_text = f"/approval {action} {request_id}"
+    payload = {
+        "channel_id": "qq",
+        "sender_id": sender_id,
+        "user_id": sender_id,
+        "session_id": session_id,
+        "content_parts": [
+            TextContent(type=ContentType.TEXT, text=command_text),
+        ],
+        "meta": {
+            "message_type": message_type,
+            "sender_id": sender_id,
+            "group_openid": group_openid,
+            "is_group": is_group,
+            "from_card_action": True,
+        },
+    }
+    try:
+        enqueue(payload)
+        logger.info(
+            "qq card action enqueued: cmd=%s request=%s session=%s",
+            command_text,
+            request_id[:8],
+            session_id[:12],
+        )
+    except Exception:
+        logger.exception(
+            "qq card action: enqueue failed: %s %s",
+            action,
+            request_id[:8],
+        )

--- a/src/qwenpaw/app/channels/qq/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/qq/cards/tool_guard.py
@@ -140,26 +140,6 @@ def build_approval_keyboard(
     }
 
 
-def build_approval_markdown(
-    tool_name: str,
-    severity: str,
-    body_text: str = "",
-) -> str:
-    """Build the markdown content for the approval message.
-
-    Includes the full tool-guard details (body_text) so users see the
-    complete risk information alongside the approve/deny buttons.
-    """
-    severity_lower = (severity or "medium").lower()
-    header = (
-        f"🛡️ **Tool Approval Required**\n"
-        f"Tool: `{tool_name}` | Severity: `{severity_lower}`"
-    )
-    if body_text:
-        return f"{header}\n\n{body_text}"
-    return header
-
-
 def build_resolved_text(
     tool_name: str,
     action: str,
@@ -256,7 +236,7 @@ async def render(
     )
 
     body_text = context.extract_body_text(getattr(event, "content", None))
-    markdown_content = build_approval_markdown(tool_name, severity, body_text)
+    markdown_content = body_text or "🛡️ Tool Approval Required"
 
     # Resolve send path from meta
     message_type = str(send_meta.get("message_type") or "c2c")

--- a/src/qwenpaw/app/channels/qq/channel.py
+++ b/src/qwenpaw/app/channels/qq/channel.py
@@ -66,6 +66,7 @@ INTENT_PUBLIC_GUILD_MESSAGES = 1 << 30
 INTENT_DIRECT_MESSAGE = 1 << 12
 INTENT_GROUP_AND_C2C = 1 << 25
 INTENT_GUILD_MEMBERS = 1 << 1
+INTENT_INTERACTION = 1 << 26
 
 RECONNECT_DELAYS = [1, 2, 5, 10, 30, 60]
 RATE_LIMIT_DELAY = 60
@@ -370,7 +371,14 @@ async def _api_request_async(
     if body is not None:
         kwargs["json"] = body
     async with session.request(method, url, **kwargs) as resp:
-        data = await resp.json()
+        # Some endpoints (e.g. PUT /interactions/{id}) return empty body.
+        raw = await resp.read()
+        data: Dict[str, Any] = {}
+        if raw and raw.strip():
+            try:
+                data = json.loads(raw)
+            except (ValueError, TypeError):
+                data = {}
         if resp.status >= 400:
             raise QQApiError(path=path, status=resp.status, data=data)
         return data
@@ -701,6 +709,11 @@ class QQChannel(BaseChannel):
         self._token_lock = threading.Lock()
 
         self._http: Optional[aiohttp.ClientSession] = None
+
+        # Interactive card handler (tool-guard approval cards).
+        from .cards.dispatcher import QQCardHandler
+
+        self._card_handler = QQCardHandler(self)
 
     def _get_access_token_sync(self) -> str:
         """Sync get access_token for WebSocket thread. Instance-level cache."""
@@ -1463,6 +1476,7 @@ class QQChannel(BaseChannel):
                 break
         if not sender:
             return
+
         msg_id = d.get("id", "")
         att = d.get("attachments") or []
         meta: Dict[str, Any] = {
@@ -1538,6 +1552,35 @@ class QQChannel(BaseChannel):
         )
 
     # ------------------------------------------------------------------
+    # Interactive cards (tool-guard approval)
+    # ------------------------------------------------------------------
+
+    def _handle_interaction_event(self, d: Dict[str, Any]) -> None:
+        """Handle an INTERACTION_CREATE WebSocket event."""
+        self._card_handler.handle_interaction_event(d)
+
+    async def on_event_message_completed(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Render card-flagged events via the card handler; else default."""
+        if await self._card_handler.try_send_card_for_event(
+            to_handle,
+            event,
+            send_meta,
+        ):
+            return
+        await super().on_event_message_completed(
+            request,
+            to_handle,
+            event,
+            send_meta,
+        )
+
+    # ------------------------------------------------------------------
     # WebSocket: payload dispatch
     # ------------------------------------------------------------------
 
@@ -1578,6 +1621,7 @@ class QQChannel(BaseChannel):
                 )
             else:
                 intents = INTENT_PUBLIC_GUILD_MESSAGES | INTENT_GUILD_MEMBERS
+                intents |= INTENT_INTERACTION
                 if state.identify_fail_count < 3:
                     intents |= INTENT_DIRECT_MESSAGE | INTENT_GROUP_AND_C2C
                 ws.send(
@@ -1607,6 +1651,8 @@ class QQChannel(BaseChannel):
                 state.reconnect_attempts = 0
                 state.last_connect_time = time.time()
                 logger.info("qq session resumed")
+            elif t == "INTERACTION_CREATE":
+                self._handle_interaction_event(d or {})
             elif t in _MESSAGE_EVENT_SPECS:
                 self._handle_msg_event(t, d or {})
             return None


### PR DESCRIPTION
## Description

Add interactive keyboard-based tool-guard approval flow to QQ channel, following the same architectural pattern as WeCom (cards/ subpackage with dispatcher + context + tool_guard modules).

## Changes:

- New src/qwenpaw/app/channels/qq/cards/ subpackage:
    - dispatcher.py — routing-only QQCardHandler matching outbound message_type and inbound action.data prefix
    - context.py — shared helpers for metadata extraction and session context building
    - tool_guard.py — approval card builders, interaction event parser, render (outbound) and handle (inbound)
- Modified channel.py:
    - Subscribe INTENT_INTERACTION (1<<26) for button callback event delivery
    - Handle INTERACTION_CREATE WebSocket events
    - Override on_event_message_completed to intercept tool_guard messages and render as markdown+keyboard
    - Fix _api_request_async to gracefully handle empty response body (required by PUT /interactions/{id})

## Features:

- Full tool-guard details displayed in markdown alongside approve/deny buttons
- Button click deduplication (second click returns QQ code=3 "duplicate")
- Follow-up resolved message shows approval result and operator identity
- Graceful fallback to plain text rendering if keyboard send fails (e.g. guild scene)

<img width="430" height="829" alt="image" src="https://github.com/user-attachments/assets/0a7e21d2-8be9-4e1d-906d-cdb89ecd07ed" />

**Related Issue:** Fixes #4451 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
