### PR TITLE
feat(desktop): add tauri auto updater

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -482,6 +482,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
@@ -517,18 +520,21 @@ jobs:
           # Authenticate the python-build-standalone release lookup in
           # stage_python_runtime.py to avoid anonymous API rate limits.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ vars.TAURI_UPDATER_PUBKEY }}
+          TAURI_UPDATER_ENDPOINTS: ${{ vars.TAURI_UPDATER_ENDPOINTS }}
         run: ./scripts/pack-tauri/build_win_pyinstaller.ps1
 
-      - name: Stage Tauri Windows installer
+      - name: Stage Tauri Windows installer and updater assets
         shell: pwsh
         run: |
-          $installer = Get-ChildItem "console/src-tauri/target/release/bundle/nsis/*.exe" | Select-Object -First 1
-          if (-not $installer) {
-            throw "No Tauri Windows installer found"
-          }
-          $target = "dist/QwenPaw-Tauri-${{ steps.version.outputs.version }}-Windows-setup.exe"
-          Copy-Item -Force $installer.FullName $target
-          Write-Host "Staged Tauri Windows installer: $target"
+          python scripts/pack-tauri/generate_update_manifest.py stage `
+            --bundle-dir console/src-tauri/target/release/bundle/nsis `
+            --pattern '*-setup.exe' `
+            --target windows-x86_64 `
+            --output "dist/QwenPaw-Tauri-${{ steps.version.outputs.version }}-Windows-setup.exe" `
+            --pubkey-config console/src-tauri/tauri.version.conf.json
 
       - name: Install verify deps (Playwright + Chromium)
         shell: pwsh
@@ -597,6 +603,15 @@ jobs:
           name: QwenPaw-Desktop-Tauri-Windows-${{ steps.version.outputs.version }}
           path: dist/QwenPaw-Tauri-*-Windows-setup.exe
 
+      - name: Upload Tauri Windows updater metadata
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_to_oss == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-updater-meta-windows
+          path: |
+            dist/QwenPaw-Tauri-*-Windows-setup.exe.sig
+            dist/tauri-windows-x86_64-updater.json
+
   build-tauri-macos:
     needs: [check-release-secrets]
     if: |
@@ -620,6 +635,9 @@ jobs:
           PIP_NO_CACHE_DIR: "1"
         with:
           python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -648,6 +666,10 @@ jobs:
           # Authenticate the python-build-standalone release lookup in
           # stage_python_runtime.py to avoid anonymous API rate limits.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ vars.TAURI_UPDATER_PUBKEY }}
+          TAURI_UPDATER_ENDPOINTS: ${{ vars.TAURI_UPDATER_ENDPOINTS }}
         run: |
           chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
           bash scripts/pack-tauri/build_macos_pyinstaller.sh
@@ -714,6 +736,16 @@ jobs:
           name: QwenPaw-Desktop-Tauri-macOS-${{ steps.version.outputs.version }}
           path: dist/QwenPaw-Tauri-*-macOS.zip
 
+      - name: Upload Tauri macOS updater metadata
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_to_oss == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-updater-meta-macos
+          path: |
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig
+            dist/tauri-darwin-*-updater.json
+
   upload-release:
     needs: [build-windows, build-macos, build-tauri-windows, build-tauri-macos]
     if: github.event_name == 'release'
@@ -721,6 +753,21 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout (for scripts)
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
+      - name: Get version
+        id: version
+        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
 
@@ -730,6 +777,29 @@ jobs:
           mv QwenPaw-Desktop-macOS-*/QwenPaw-*.zip . 2>/dev/null || true
           mv QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe . 2>/dev/null || true
           mv QwenPaw-Desktop-Tauri-macOS-*/QwenPaw-Tauri-*-macOS.zip . 2>/dev/null || true
+          # Updater metadata from internal artifacts
+          mv tauri-updater-meta-windows/QwenPaw-Tauri-*-Windows-setup.exe.sig . 2>/dev/null || true
+          mv tauri-updater-meta-windows/tauri-windows-*-updater.json . 2>/dev/null || true
+          mv tauri-updater-meta-macos/QwenPaw-Tauri-*-macOS.app.tar.gz . 2>/dev/null || true
+          mv tauri-updater-meta-macos/QwenPaw-Tauri-*-macOS.app.tar.gz.sig . 2>/dev/null || true
+          mv tauri-updater-meta-macos/tauri-darwin-*-updater.json . 2>/dev/null || true
+
+      - name: Generate Tauri updater manifest
+        env:
+          # Pass release.body via env so quotes/newlines/$ in markdown are safe.
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          metadata_args=()
+          for f in tauri-windows-*-updater.json tauri-darwin-*-updater.json; do
+            [ -f "$f" ] && metadata_args+=(--metadata "$f")
+          done
+          NOTES="${RELEASE_BODY:-QwenPaw Desktop ${{ steps.version.outputs.version }}}"
+          python scripts/pack-tauri/generate_update_manifest.py manifest \
+            --version "${{ steps.version.outputs.version }}" \
+            --base-url "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}" \
+            "${metadata_args[@]}" \
+            --notes "$NOTES" \
+            --output qwenpaw-tauri-latest.json
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v2
@@ -739,6 +809,8 @@ jobs:
             QwenPaw-[0-9]*-macOS.zip
             QwenPaw-Tauri-*-Windows-setup.exe
             QwenPaw-Tauri-*-macOS.zip
+            QwenPaw-Tauri-*-macOS.app.tar.gz
+            qwenpaw-tauri-latest.json
           fail-on-unmatched-files: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -746,8 +818,18 @@ jobs:
   upload-oss:
     needs: [build-windows, build-macos, build-tauri-windows, build-tauri-macos]
     # Run on: 1) release trigger, or 2) manual trigger with upload_to_oss checked
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_to_oss == 'true')
+    if: |
+      always() &&
+      (github.event_name == 'release' ||
+       (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_to_oss == 'true')) &&
+      needs.build-windows.result == 'success' &&
+      needs.build-macos.result == 'success' &&
+      needs.build-tauri-windows.result == 'success' &&
+      needs.build-tauri-macos.result == 'success'
     runs-on: ubuntu-latest
+    env:
+      OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
+      OSS_PUBLIC_BASE_URL: ${{ vars.OSS_PUBLIC_BASE_URL || 'https://download.qwenpaw.agentscope.io/files/apps/desktop' }}
     steps:
       - name: Checkout (for scripts)
         uses: actions/checkout@v4
@@ -756,6 +838,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
 
       - name: Get version
         id: version
@@ -802,25 +887,25 @@ jobs:
 
           # Upload file (versioned)
           ossutil cp "$WIN_EXE" \
-            "oss://qwenpaw-download/files/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe" \
             --acl public-read \
             --force
 
           # Upload file (latest)
           ossutil cp "$WIN_EXE" \
-            "oss://qwenpaw-download/files/apps/desktop/win/QwenPaw-Setup-latest.exe" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/win/QwenPaw-Setup-latest.exe" \
             --acl public-read \
             --force
 
           # Upload metadata (versioned)
           ossutil cp win-metadata.json \
-            "oss://qwenpaw-download/metadata/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe.json" \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-${VERSION}.exe.json" \
             --acl public-read \
             --force
 
           # Upload metadata (latest)
           ossutil cp win-metadata.json \
-            "oss://qwenpaw-download/metadata/apps/desktop/win/QwenPaw-Setup-latest.exe.json" \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/win/QwenPaw-Setup-latest.exe.json" \
             --acl public-read \
             --force
 
@@ -849,25 +934,25 @@ jobs:
 
           # Upload file (versioned)
           ossutil cp "$MAC_ZIP" \
-            "oss://qwenpaw-download/files/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip" \
             --acl public-read \
             --force
 
           # Upload file (latest)
           ossutil cp "$MAC_ZIP" \
-            "oss://qwenpaw-download/files/apps/desktop/mac/QwenPaw-latest-macOS.zip" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac/QwenPaw-latest-macOS.zip" \
             --acl public-read \
             --force
 
           # Upload metadata (versioned)
           ossutil cp mac-metadata.json \
-            "oss://qwenpaw-download/metadata/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip.json" \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-${VERSION}-macOS.zip.json" \
             --acl public-read \
             --force
 
           # Upload metadata (latest)
           ossutil cp mac-metadata.json \
-            "oss://qwenpaw-download/metadata/apps/desktop/mac/QwenPaw-latest-macOS.zip.json" \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/mac/QwenPaw-latest-macOS.zip.json" \
             --acl public-read \
             --force
 
@@ -902,19 +987,19 @@ jobs:
               --output "${metadata}"
 
             ossutil cp "${artifact}" \
-              "oss://qwenpaw-download/files/apps/desktop/${platform}/${versioned_name}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
               --acl public-read \
               --force
             ossutil cp "${artifact}" \
-              "oss://qwenpaw-download/files/apps/desktop/${platform}/${latest_name}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}" \
               --acl public-read \
               --force
             ossutil cp "${metadata}" \
-              "oss://qwenpaw-download/metadata/apps/desktop/${platform}/${versioned_name}.json" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
               --acl public-read \
               --force
             ossutil cp "${metadata}" \
-              "oss://qwenpaw-download/metadata/apps/desktop/${platform}/${latest_name}.json" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json" \
               --acl public-read \
               --force
           }
@@ -935,12 +1020,71 @@ jobs:
             "QwenPaw-Tauri-latest-macOS.zip" \
             "mac-tauri-metadata.json"
 
+      - name: Upload Tauri macOS updater archive to OSS
+        # The .zip is for first-install; the auto-updater pulls .app.tar.gz.
+        if: hashFiles('tauri-updater-meta-macos/*.app.tar.gz') != ''
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          APP_TAR_GZ=$(find tauri-updater-meta-macos -name "QwenPaw-Tauri-*-macOS.app.tar.gz" | head -1)
+          if [ -z "$APP_TAR_GZ" ]; then
+            echo "No macOS .app.tar.gz found, skipping"
+            exit 0
+          fi
+          ossutil cp "$APP_TAR_GZ" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz" \
+            --acl public-read \
+            --force
+
+      - name: Link artifacts into updater-meta dirs for manifest generation
+        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
+        run: |
+          # The manifest generator expects the artifact binary alongside the
+          # sidecar JSON.  After artifact splitting the exe lives in a separate
+          # artifact directory, so we symlink it into the meta directory.
+          for f in QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe; do
+            [ -f "$f" ] && ln -sf "../$f" tauri-updater-meta-windows/ 2>/dev/null || true
+          done
+
+      - name: Generate and upload OSS updater manifest
+        # Mirror the GitHub-pointing manifest with one whose URLs point at
+        # OSS, so mainland users can hit a CN-fast endpoint first and fall
+        # back to GitHub if OSS is unreachable.
+        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
+        env:
+          # Pass release.body via env so quotes/newlines/$ in markdown are safe.
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          OSS_BASE="${OSS_PUBLIC_BASE_URL%/}"
+          metadata_args=()
+          for f in tauri-updater-meta-windows/tauri-windows-*-updater.json \
+                   tauri-updater-meta-macos/tauri-darwin-*-updater.json; do
+            [ -f "$f" ] && metadata_args+=(--metadata "$f")
+          done
+          if [ ${#metadata_args[@]} -eq 0 ]; then
+            echo "No Tauri updater sidecars found, skipping OSS manifest"
+            exit 0
+          fi
+          NOTES="${RELEASE_BODY:-QwenPaw Desktop ${VERSION}}"
+          python scripts/pack-tauri/generate_update_manifest.py manifest \
+            --version "$VERSION" \
+            --base-url "$OSS_BASE" \
+            --target-base "windows-x86_64=${OSS_BASE}/win-tauri" \
+            --target-base "darwin-aarch64=${OSS_BASE}/mac-tauri" \
+            "${metadata_args[@]}" \
+            --notes "$NOTES" \
+            --output qwenpaw-tauri-latest-oss.json
+          ossutil cp qwenpaw-tauri-latest-oss.json \
+            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json" \
+            --acl public-read \
+            --force
+
       - name: Update desktop index
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
           # Download existing desktop/index.json if exists
-          ossutil cp "oss://qwenpaw-download/metadata/apps/desktop/index.json" \
+          ossutil cp "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
             desktop-index.json 2>/dev/null || cat > desktop-index.json << 'EOF'
           {
             "product": "desktop",
@@ -1005,7 +1149,7 @@ jobs:
 
           # Upload updated desktop/index.json
           ossutil cp desktop-index.json \
-            "oss://qwenpaw-download/metadata/apps/desktop/index.json" \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
             --acl public-read \
             --force
 
@@ -1014,7 +1158,7 @@ jobs:
       - name: Update main index
         run: |
           # Download main index if exists
-          ossutil cp "oss://qwenpaw-download/metadata/index.json" \
+          ossutil cp "oss://${OSS_BUCKET}/metadata/index.json" \
             main-index.json 2>/dev/null || cat > main-index.json << 'EOF'
           {
             "version": "1.0",
@@ -1048,7 +1192,7 @@ jobs:
 
           # Upload main index
           ossutil cp main-index.json \
-            "oss://qwenpaw-download/metadata/index.json" \
+            "oss://${OSS_BUCKET}/metadata/index.json" \
             --acl public-read \
             --force
 

--- a/console/src-tauri/Cargo.lock
+++ b/console/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +629,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +901,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1435,6 +1465,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1754,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1981,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2159,6 +2246,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,6 +2333,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +2352,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2557,16 +2676,21 @@ dependencies = [
 name = "qwenpaw-desktop"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "futures-util",
  "log",
+ "minisign-verify",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tokio",
 ]
 
@@ -2751,15 +2875,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2793,6 +2922,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2857,6 +3000,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,6 +3104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2939,6 +3177,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3204,6 +3465,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3405,7 +3682,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3445,6 +3722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,7 +3755,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3665,6 +3953,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.3",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,7 +3995,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3697,7 +4018,7 @@ checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3762,6 +4083,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3884,6 +4218,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4181,6 +4525,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4500,6 +4850,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4727,6 +5086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5112,7 +5480,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5166,6 +5534,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5233,6 +5611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5263,6 +5647,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -21,8 +21,13 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+semver = "1"
+base64 = "0.22"
+minisign-verify = "0.2"
+sha2 = "0.10"
 tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
 tokio = { version = "1", features = ["fs", "io-util"] }

--- a/console/src-tauri/capabilities/default.json
+++ b/console/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "backend",
     "backend-download",
     "core:default",
+    "desktop-updater-check",
+    "desktop-updater-install",
     "dialog:allow-save",
     "open-external-link"
   ]

--- a/console/src-tauri/permissions/desktop-updater.toml
+++ b/console/src-tauri/permissions/desktop-updater.toml
@@ -1,0 +1,15 @@
+"$schema" = "schemas/schema.json"
+
+[[permission]]
+identifier = "desktop-updater-check"
+description = "Allows the frontend to check desktop update availability and cached update state."
+commands.allow = ["check_desktop_update", "check_cached_update"]
+
+[[permission]]
+identifier = "desktop-updater-install"
+description = "Allows the frontend to download, install, and restart into desktop updates."
+commands.allow = [
+    "download_desktop_update",
+    "install_desktop_update",
+    "install_downloaded_update",
+]

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 mod backend;
 mod backend_download;
 mod external_link;
+mod updates;
 
 use tauri::{Manager, RunEvent, WindowEvent};
 
@@ -12,12 +13,18 @@ pub fn run() {
     let build_result = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             backend_download::download_backend_file,
             backend::backend_port,
             backend::backend_startup_error,
             backend::restart_backend,
             external_link::open_external_link,
+            updates::check_desktop_update,
+            updates::install_desktop_update,
+            updates::download_desktop_update,
+            updates::install_downloaded_update,
+            updates::check_cached_update,
         ])
         .manage(backend::BackendState::default())
         .setup(backend::setup)

--- a/console/src-tauri/src/updates.rs
+++ b/console/src-tauri/src/updates.rs
@@ -1,0 +1,287 @@
+//! Tauri commands for desktop auto-updates via tauri-plugin-updater.
+
+mod cache;
+mod events;
+mod guard;
+mod remote;
+mod signature;
+mod version;
+
+use serde::Serialize;
+use tauri::AppHandle;
+
+use crate::backend;
+
+use cache::{
+    cached_artifact_path, cached_update_dir, ensure_current_platform, has_cached_update_meta,
+    persist_cached_update, read_cached_update_meta, remove_cached_update, supports_cached_updates,
+};
+use events::{emit, emit_error, emit_updater_error};
+use guard::begin_update;
+use remote::{check_and_download, check_installable_update};
+use signature::verify_cached_update;
+use version::version_lte;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DesktopUpdate {
+    version: String,
+    body: Option<String>,
+    supports_later_install: bool,
+}
+
+#[tauri::command]
+pub(crate) async fn check_desktop_update(app: AppHandle) -> Result<Option<DesktopUpdate>, String> {
+    let update = check_installable_update(&app)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(update.map(|u| DesktopUpdate {
+        version: u.version,
+        body: u.body,
+        supports_later_install: supports_cached_updates(),
+    }))
+}
+
+#[tauri::command]
+pub(crate) fn install_desktop_update(app: AppHandle) -> Result<(), String> {
+    let guard = begin_update()?;
+    tauri::async_runtime::spawn(async move {
+        let _guard = guard;
+        run_install(app).await;
+    });
+    Ok(())
+}
+
+async fn run_install(app: AppHandle) {
+    let Some((update, bytes)) = check_and_download(&app).await else {
+        return;
+    };
+
+    log::info!(
+        "[updates] installing desktop update version={}",
+        update.version
+    );
+    emit(&app, "update:install-start", &serde_json::json!({}));
+
+    if let Err(err) = update.install(bytes) {
+        return emit_updater_error(&app, "install", &err);
+    }
+
+    backend::stop(&app);
+    app.restart();
+}
+
+#[tauri::command]
+pub(crate) fn download_desktop_update(app: AppHandle) -> Result<(), String> {
+    if !supports_cached_updates() {
+        return Err("background update download is not supported on this platform".into());
+    }
+
+    let guard = begin_update()?;
+    tauri::async_runtime::spawn(async move {
+        let _guard = guard;
+        run_background_download(app).await;
+    });
+    Ok(())
+}
+
+async fn run_background_download(app: AppHandle) {
+    let Some((update, bytes)) = check_and_download(&app).await else {
+        return;
+    };
+
+    if let Err(err) = persist_cached_update(&app, &update, &bytes) {
+        return emit_error(&app, "download", &err);
+    }
+
+    log::info!(
+        "[updates] background download ready: version={}",
+        update.version
+    );
+    emit(
+        &app,
+        "update:download-done",
+        &serde_json::json!({ "version": update.version }),
+    );
+}
+
+#[tauri::command]
+pub(crate) fn install_downloaded_update(app: AppHandle) -> Result<(), String> {
+    if !supports_cached_updates() {
+        return Err("cached updates are not supported on this platform".into());
+    }
+
+    let guard = begin_update()?;
+    tauri::async_runtime::spawn(async move {
+        let _guard = guard;
+        run_cached_install(app).await;
+    });
+    Ok(())
+}
+
+async fn run_cached_install(app: AppHandle) {
+    let Some(cache_dir) = cached_update_dir(&app) else {
+        return emit_error(&app, "install", &"cannot determine app data directory");
+    };
+
+    let meta = match read_cached_update_meta(&cache_dir) {
+        Ok(meta) => meta,
+        Err(err) => {
+            remove_cached_update(&cache_dir);
+            return emit_error(&app, "install", &err);
+        }
+    };
+
+    if let Err(err) = ensure_current_platform(&meta) {
+        remove_cached_update(&cache_dir);
+        return emit_error(&app, "install", &err);
+    }
+
+    let artifact_path = cached_artifact_path(&cache_dir, &meta);
+    if !artifact_path.is_file() {
+        remove_cached_update(&cache_dir);
+        return emit_error(
+            &app,
+            "install",
+            &"cached update artifact not found - please download again",
+        );
+    }
+
+    // The cache lives in a user-writable directory, so "verified at download
+    // time" is not enough. Re-verify the on-disk bytes against the configured
+    // updater public key right before install.
+    let bytes = match std::fs::read(&artifact_path) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            remove_cached_update(&cache_dir);
+            return emit_error(
+                &app,
+                "install",
+                &format!("cannot read cached update: {err}"),
+            );
+        }
+    };
+    if let Err(err) = verify_cached_update(&app, &meta, &bytes) {
+        remove_cached_update(&cache_dir);
+        return emit_error(&app, "install", &err);
+    }
+
+    log::info!(
+        "[updates] installing cached update version={} artifact={}",
+        meta.version,
+        artifact_path.display()
+    );
+    emit(&app, "update:install-start", &serde_json::json!({}));
+
+    match meta.platform.as_str() {
+        "windows" => install_cached_windows(&app, &artifact_path),
+        "macos" => install_cached_macos(&app, &cache_dir, &meta, bytes).await,
+        _ => {
+            remove_cached_update(&cache_dir);
+            emit_error(&app, "install", &"cached update platform is unsupported");
+        }
+    }
+}
+
+fn install_cached_windows(app: &AppHandle, exe_path: &std::path::Path) {
+    backend::stop(app);
+    if let Err(err) = std::process::Command::new(exe_path)
+        .args(["/P", "/R", "/UPDATE", "/NO_QWENPAW_PATH"])
+        .spawn()
+    {
+        return emit_error(
+            app,
+            "install",
+            &format!("failed to launch installer: {err}"),
+        );
+    }
+    // Mirrors tauri-plugin-updater's Windows path: after NSIS is launched the
+    // current process must exit so the installer can replace locked files.
+    app.cleanup_before_exit();
+    std::process::exit(0);
+}
+
+async fn install_cached_macos(
+    app: &AppHandle,
+    cache_dir: &std::path::Path,
+    meta: &cache::UpdateMeta,
+    bytes: Vec<u8>,
+) {
+    let update = match check_installable_update(app).await {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            remove_cached_update(cache_dir);
+            return emit_error(
+                app,
+                "install",
+                &"cached update is no longer available - please download again",
+            );
+        }
+        Err(err) => return emit_updater_error(app, "check", &err),
+    };
+
+    if update.version != meta.version
+        || update.target != meta.target
+        || update.signature != meta.signature
+    {
+        remove_cached_update(cache_dir);
+        return emit_error(
+            app,
+            "install",
+            &"cached update no longer matches the latest release - please download again",
+        );
+    }
+
+    if let Err(err) = update.install(bytes) {
+        return emit_updater_error(app, "install", &err);
+    }
+
+    backend::stop(app);
+    app.restart();
+}
+
+#[tauri::command]
+pub(crate) async fn check_cached_update(app: AppHandle) -> Result<Option<String>, String> {
+    if !supports_cached_updates() {
+        return Ok(None);
+    }
+
+    let Some(cache_dir) = cached_update_dir(&app) else {
+        return Ok(None);
+    };
+
+    if !has_cached_update_meta(&cache_dir) {
+        return Ok(None);
+    }
+
+    let Ok(meta) = read_cached_update_meta(&cache_dir) else {
+        remove_cached_update(&cache_dir);
+        return Ok(None);
+    };
+
+    if ensure_current_platform(&meta).is_err() {
+        remove_cached_update(&cache_dir);
+        return Ok(None);
+    }
+
+    // Compare with current app version. If cached version <= current, it's stale.
+    let current_version = app.config().version.clone().unwrap_or_default();
+
+    if version_lte(&meta.version, &current_version) {
+        log::info!(
+            "[updates] cleaning stale cached update: cached={} current={}",
+            meta.version,
+            current_version
+        );
+        remove_cached_update(&cache_dir);
+        return Ok(None);
+    }
+
+    if !cached_artifact_path(&cache_dir, &meta).is_file() {
+        remove_cached_update(&cache_dir);
+        return Ok(None);
+    }
+
+    Ok(Some(meta.version))
+}

--- a/console/src-tauri/src/updates/cache.rs
+++ b/console/src-tauri/src/updates/cache.rs
@@ -1,0 +1,160 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+use super::signature::sha256_hex;
+
+const CACHED_UPDATE_DIR: &str = "cached-update";
+const UPDATE_META_FILE: &str = "update-meta.json";
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct UpdateMeta {
+    pub(super) version: String,
+    pub(super) artifact_file: String,
+    #[serde(default)]
+    pub(super) platform: String,
+    #[serde(default)]
+    pub(super) target: String,
+    /// Base64 minisign signature string from the update manifest (same value
+    /// `tauri-plugin-updater` verifies at download time). Re-verified before a
+    /// cached update is installed.
+    #[serde(default)]
+    pub(super) signature: String,
+    /// Hex SHA-256 of the persisted update bytes, for a fast corruption
+    /// check before the (more expensive) signature verification.
+    #[serde(default)]
+    pub(super) sha256: String,
+}
+
+pub(super) fn supports_cached_updates() -> bool {
+    current_platform().is_some()
+}
+
+pub(super) fn current_platform() -> Option<&'static str> {
+    if cfg!(windows) {
+        Some("windows")
+    } else if cfg!(target_os = "macos") {
+        Some("macos")
+    } else {
+        None
+    }
+}
+
+pub(super) fn cached_update_dir(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_local_data_dir()
+        .ok()
+        .map(|p| p.join(CACHED_UPDATE_DIR))
+}
+
+pub(super) fn has_cached_update_meta(cache_dir: &Path) -> bool {
+    cache_dir.join(UPDATE_META_FILE).exists()
+}
+
+pub(super) fn read_cached_update_meta(cache_dir: &Path) -> Result<UpdateMeta, String> {
+    let meta_str = std::fs::read_to_string(cache_dir.join(UPDATE_META_FILE))
+        .map_err(|e| format!("no cached update found: {e}"))?;
+    let meta: UpdateMeta =
+        serde_json::from_str(&meta_str).map_err(|e| format!("invalid update meta: {e}"))?;
+    validate_artifact_file(&meta.artifact_file)?;
+    Ok(meta)
+}
+
+pub(super) fn remove_cached_update(cache_dir: &Path) {
+    let _ = std::fs::remove_dir_all(cache_dir);
+}
+
+/// Persist the downloaded update artifact plus its metadata so a later
+/// "Update Now" only needs to verify and install it.
+pub(super) fn persist_cached_update(
+    app: &AppHandle,
+    update: &tauri_plugin_updater::Update,
+    bytes: &[u8],
+) -> Result<(), String> {
+    let platform = current_platform().ok_or("cached updates are not supported on this platform")?;
+    validate_artifact(platform, bytes)?;
+
+    let cache_dir = cached_update_dir(app).ok_or("cannot determine app data directory")?;
+    if cache_dir.exists() {
+        std::fs::remove_dir_all(&cache_dir).map_err(|e| e.to_string())?;
+    }
+    std::fs::create_dir_all(&cache_dir).map_err(|e| e.to_string())?;
+
+    let artifact_path = write_artifact(platform, bytes, &cache_dir, &update.version)?;
+    let artifact_file = artifact_path
+        .strip_prefix(&cache_dir)
+        .ok()
+        .and_then(|p| p.to_str())
+        .ok_or("cached update path is invalid")?
+        .to_string();
+
+    let meta = UpdateMeta {
+        version: update.version.clone(),
+        artifact_file,
+        platform: platform.to_string(),
+        target: update.target.clone(),
+        signature: update.signature.clone(),
+        sha256: sha256_hex(bytes),
+    };
+    let meta_json = serde_json::to_string_pretty(&meta).map_err(|e| e.to_string())?;
+    std::fs::write(cache_dir.join(UPDATE_META_FILE), meta_json).map_err(|e| e.to_string())
+}
+
+pub(super) fn ensure_current_platform(meta: &UpdateMeta) -> Result<(), String> {
+    let Some(platform) = current_platform() else {
+        return Err("cached updates are not supported on this platform".into());
+    };
+    if meta.platform != platform {
+        return Err("cached update is for a different platform - please download again".into());
+    }
+    Ok(())
+}
+
+pub(super) fn validate_artifact(platform: &str, bytes: &[u8]) -> Result<(), String> {
+    match platform {
+        "windows" if !bytes.starts_with(b"MZ") => {
+            Err("downloaded update is not a Windows installer executable".into())
+        }
+        "macos" if !bytes.starts_with(&[0x1f, 0x8b]) => {
+            Err("downloaded update is not a macOS app archive".into())
+        }
+        "windows" | "macos" => Ok(()),
+        _ => Err("cached updates are not supported on this platform".into()),
+    }
+}
+
+fn write_artifact(
+    platform: &str,
+    bytes: &[u8],
+    dest_dir: &Path,
+    version: &str,
+) -> Result<PathBuf, String> {
+    let file_name = match platform {
+        "windows" => format!("QwenPaw-Desktop_{version}_x64-setup.exe"),
+        "macos" => format!("QwenPaw-Desktop_{version}_macos.app.tar.gz"),
+        _ => return Err("cached updates are not supported on this platform".into()),
+    };
+    let path = dest_dir.join(file_name);
+    std::fs::write(&path, bytes).map_err(|e| e.to_string())?;
+    Ok(path)
+}
+
+pub(super) fn cached_artifact_path(cache_dir: &Path, meta: &UpdateMeta) -> PathBuf {
+    cache_dir.join(&meta.artifact_file)
+}
+
+fn validate_artifact_file(file: &str) -> Result<(), String> {
+    let is_single_file = !file.is_empty()
+        && !file.contains('/')
+        && !file.contains('\\')
+        && Path::new(file)
+            .components()
+            .all(|part| matches!(part, std::path::Component::Normal(_)));
+    if is_single_file {
+        Ok(())
+    } else {
+        Err("cached update artifact path is invalid".into())
+    }
+}

--- a/console/src-tauri/src/updates/events.rs
+++ b/console/src-tauri/src/updates/events.rs
@@ -1,0 +1,56 @@
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+pub(super) fn emit<S: Serialize>(app: &AppHandle, name: &str, payload: &S) {
+    if let Err(err) = app.emit(name, payload) {
+        log::warn!("[updates] failed to emit {name}: {err}");
+    }
+}
+
+pub(super) fn emit_error(app: &AppHandle, stage: &'static str, err: &dyn std::fmt::Display) {
+    emit_error_kind(app, stage, "other", &err.to_string());
+}
+
+/// Emit an update error whose `kind` is derived from the concrete
+/// `tauri-plugin-updater` error variant rather than fragile string matching on
+/// the (library-/locale-dependent) message text.
+pub(super) fn emit_updater_error(
+    app: &AppHandle,
+    stage: &'static str,
+    err: &tauri_plugin_updater::Error,
+) {
+    emit_error_kind(app, stage, classify_updater_error(err), &err.to_string());
+}
+
+fn emit_error_kind(app: &AppHandle, stage: &'static str, kind: &'static str, message: &str) {
+    log::warn!("[updates] error stage={stage} kind={kind} message={message}");
+    let _ = app.emit(
+        "update:error",
+        serde_json::json!({
+            "stage": stage,
+            "kind": kind,
+            "message": message,
+        }),
+    );
+}
+
+fn classify_updater_error(err: &tauri_plugin_updater::Error) -> &'static str {
+    use tauri_plugin_updater::Error as E;
+    match err {
+        E::Reqwest(_)
+        | E::Network(_)
+        | E::Http(_)
+        | E::ReleaseNotFound
+        | E::EmptyEndpoints
+        | E::InsecureTransportProtocol
+        | E::UrlParse(_) => "network",
+        E::Minisign(_) | E::SignatureUtf8(_) | E::Base64(_) => "signature",
+        _ if cfg!(target_os = "macos") && is_read_only_filesystem_error(err) => "appLocation",
+        _ => "other",
+    }
+}
+
+fn is_read_only_filesystem_error(err: &tauri_plugin_updater::Error) -> bool {
+    let message = err.to_string();
+    message.contains("read-only file system") || message.contains("os error: 30")
+}

--- a/console/src-tauri/src/updates/guard.rs
+++ b/console/src-tauri/src/updates/guard.rs
@@ -1,0 +1,30 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Guards against concurrent update operations (check/download/install). Each
+/// of the public commands acquires this before spawning work and releases it
+/// when the work finishes, so repeated clicks can't race on the cache dir.
+static UPDATE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// RAII token: holding it means an update operation is in flight; dropping it
+/// (including on early returns / errors) clears the flag.
+pub(super) struct InFlightGuard;
+
+impl InFlightGuard {
+    fn try_acquire() -> Option<Self> {
+        UPDATE_IN_FLIGHT
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| InFlightGuard)
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        UPDATE_IN_FLIGHT.store(false, Ordering::Release);
+    }
+}
+
+pub(super) fn begin_update() -> Result<InFlightGuard, String> {
+    InFlightGuard::try_acquire()
+        .ok_or_else(|| "an update operation is already in progress".to_string())
+}

--- a/console/src-tauri/src/updates/remote.rs
+++ b/console/src-tauri/src/updates/remote.rs
@@ -1,0 +1,103 @@
+use std::time::{Duration, Instant};
+
+use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
+
+use crate::backend;
+
+use super::events::{emit, emit_error, emit_updater_error};
+
+/// Shared prologue for both update flows: announce the check, find an
+/// installable update and download (and signature-verify) it. Errors are
+/// emitted to the frontend; `None` means the caller should stop.
+pub(super) async fn check_and_download(
+    app: &AppHandle,
+) -> Option<(tauri_plugin_updater::Update, Vec<u8>)> {
+    emit(app, "update:check-start", &serde_json::json!({}));
+
+    let update = match check_installable_update(app).await {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            emit_error(app, "check", &"no desktop update available");
+            return None;
+        }
+        Err(err) => {
+            emit_updater_error(app, "check", &err);
+            return None;
+        }
+    };
+
+    log::info!(
+        "[updates] downloading desktop update version={}",
+        update.version
+    );
+    match download_update(app, &update).await {
+        Ok(bytes) => Some((update, bytes)),
+        Err(err) => {
+            emit_updater_error(app, "download", &err);
+            None
+        }
+    }
+}
+
+pub(super) async fn check_installable_update(
+    app: &AppHandle,
+) -> Result<Option<tauri_plugin_updater::Update>, tauri_plugin_updater::Error> {
+    let updater = app
+        .updater_builder()
+        .on_before_exit({
+            let app = app.clone();
+            move || {
+                backend::stop(&app);
+                app.cleanup_before_exit();
+            }
+        })
+        .build()?;
+
+    updater.check().await
+}
+
+async fn download_update(
+    app: &AppHandle,
+    update: &tauri_plugin_updater::Update,
+) -> Result<Vec<u8>, tauri_plugin_updater::Error> {
+    let mut last_emit: Option<Instant> = None;
+    let mut downloaded: u64 = 0;
+
+    let bytes = update
+        .download(
+            |chunk_len, content_len| {
+                downloaded = downloaded.saturating_add(chunk_len as u64);
+                let should_emit = last_emit
+                    .map(|t| t.elapsed() >= Duration::from_millis(200))
+                    .unwrap_or(true);
+                if should_emit {
+                    emit(
+                        app,
+                        "update:download-progress",
+                        &serde_json::json!({
+                            "downloaded": downloaded,
+                            "total": content_len,
+                        }),
+                    );
+                    last_emit = Some(Instant::now());
+                }
+            },
+            || {
+                log::info!("[updates] desktop update download complete");
+            },
+        )
+        .await?;
+
+    // Final progress frame (forces UI to land on 100%).
+    emit(
+        app,
+        "update:download-progress",
+        &serde_json::json!({
+            "downloaded": downloaded,
+            "total": Some(downloaded),
+        }),
+    );
+
+    Ok(bytes)
+}

--- a/console/src-tauri/src/updates/signature.rs
+++ b/console/src-tauri/src/updates/signature.rs
@@ -1,0 +1,68 @@
+use base64::Engine;
+use minisign_verify::{PublicKey, Signature};
+use sha2::{Digest, Sha256};
+use tauri::AppHandle;
+
+use super::cache::UpdateMeta;
+
+pub(super) fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Read the updater public key from the (build-injected) Tauri config so we can
+/// verify cached updates with the exact key the plugin uses.
+fn updater_pubkey(app: &AppHandle) -> Option<String> {
+    app.config()
+        .plugins
+        .0
+        .get("updater")
+        .and_then(|cfg| cfg.get("pubkey"))
+        .and_then(|val| val.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Verify `data` against a base64-encoded minisign signature and public key,
+/// mirroring `tauri-plugin-updater`'s own `verify_signature`.
+fn verify_minisign(data: &[u8], signature_b64: &str, pubkey_b64: &str) -> Result<(), String> {
+    let pubkey_text = base64_to_string(pubkey_b64)?;
+    let public_key = PublicKey::decode(pubkey_text.trim()).map_err(|e| e.to_string())?;
+
+    let signature_text = base64_to_string(signature_b64)?;
+    let signature = Signature::decode(signature_text.trim()).map_err(|e| e.to_string())?;
+
+    public_key
+        .verify(data, &signature, true)
+        .map_err(|e| e.to_string())
+}
+
+fn base64_to_string(value: &str) -> Result<String, String> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(value.trim())
+        .map_err(|e| e.to_string())?;
+    String::from_utf8(decoded).map_err(|e| e.to_string())
+}
+
+/// Pre-install integrity + authenticity gate for a previously downloaded
+/// update artifact. Cheap SHA-256 corruption check first, then the
+/// cryptographic signature check that closes the "user-writable cache" gap.
+pub(super) fn verify_cached_update(
+    app: &AppHandle,
+    meta: &UpdateMeta,
+    bytes: &[u8],
+) -> Result<(), String> {
+    if !meta.sha256.is_empty() && sha256_hex(bytes) != meta.sha256 {
+        return Err("cached update is corrupted - please download again".into());
+    }
+    if meta.signature.trim().is_empty() {
+        return Err("cached update has no signature - please download again".into());
+    }
+    let pubkey = updater_pubkey(app).ok_or("cannot read updater public key from config")?;
+    verify_minisign(bytes, &meta.signature, &pubkey)
+        .map_err(|err| format!("cached update signature invalid: {err}"))
+}

--- a/console/src-tauri/src/updates/version.rs
+++ b/console/src-tauri/src/updates/version.rs
@@ -1,0 +1,24 @@
+use semver::Version;
+
+pub(super) fn version_lte(a: &str, b: &str) -> bool {
+    let a = a.trim_start_matches('v');
+    let b = b.trim_start_matches('v');
+    match (Version::parse(a), Version::parse(b)) {
+        (Ok(va), Ok(vb)) => va <= vb,
+        // If either version is unparseable we cannot prove the cached update is
+        // newer than the running app, so treat it as stale (true) and let the
+        // caller drop the cache rather than advertising an unverifiable update.
+        (Err(err), _) => {
+            log::warn!(
+                "[updates] cannot parse cached update version {a}, treating as stale: {err}"
+            );
+            true
+        }
+        (_, Err(err)) => {
+            log::warn!(
+                "[updates] cannot parse current app version {b}, treating cache as stale: {err}"
+            );
+            true
+        }
+    }
+}

--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -66,7 +66,20 @@
           "Russian": "nsis-languages/Russian.nsh",
           "PortugueseBR": "nsis-languages/PortugueseBR.nsh"
         },
+        "compression": "zlib",
         "displayLanguageSelector": false
+      }
+    }
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE0MkMxRjE4MUM4Njc0RjAKUldUd2RJWWNHQjhzcEhoZ2FWWkxVRXp0bFMyS1JEand6YXZURCs5YnlNcFlzRCtNalhRcjJwamMK",
+      "endpoints": [
+        "https://download.qwenpaw.agentscope.io/metadata/qwenpaw-tauri-latest.json",
+        "https://github.com/agentscope-ai/QwenPaw/releases/latest/download/qwenpaw-tauri-latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
       }
     }
   }

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -26,6 +26,8 @@ import MainLayout from "./layouts/MainLayout";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import { PluginProvider, usePlugins } from "./plugins/PluginContext";
 import { ApprovalProvider } from "./contexts/ApprovalContext";
+import { DesktopUpdateProvider } from "./contexts/DesktopUpdateContext";
+import { UpdateTakeoverGate } from "./components/UpdateTakeoverPage";
 import { Suspense } from "react";
 import { lazyImportWithRetry } from "./utils/lazyWithRetry";
 
@@ -189,26 +191,30 @@ function AppInner() {
         }}
       >
         <AntdApp>
-          <ApprovalProvider>
-            <Routes>
-              <Route
-                path="/login"
-                element={
-                  <Suspense fallback={null}>
-                    <LoginPage />
-                  </Suspense>
-                }
-              />
-              <Route
-                path="/*"
-                element={
-                  <AuthGuard>
-                    <MainLayout />
-                  </AuthGuard>
-                }
-              />
-            </Routes>
-          </ApprovalProvider>
+          <DesktopUpdateProvider>
+            <UpdateTakeoverGate>
+              <ApprovalProvider>
+                <Routes>
+                  <Route
+                    path="/login"
+                    element={
+                      <Suspense fallback={null}>
+                        <LoginPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="/*"
+                    element={
+                      <AuthGuard>
+                        <MainLayout />
+                      </AuthGuard>
+                    }
+                  />
+                </Routes>
+              </ApprovalProvider>
+            </UpdateTakeoverGate>
+          </DesktopUpdateProvider>
         </AntdApp>
       </ConfigProvider>
     </BrowserRouter>

--- a/console/src/components/UpdateTakeoverPage/index.module.less
+++ b/console/src/components/UpdateTakeoverPage/index.module.less
@@ -1,0 +1,70 @@
+.takeover {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: var(--color-bg-base, #fff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.center {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.title {
+  margin: 24px 0 8px;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--color-text, rgba(0, 0, 0, 0.88));
+}
+
+.subtitle {
+  margin: 0 0 4px;
+  font-size: 14px;
+  color: var(--color-text-secondary, rgba(0, 0, 0, 0.65));
+}
+
+.willRestart {
+  margin: 8px 0 24px;
+  font-size: 13px;
+  color: var(--color-text-tertiary, rgba(0, 0, 0, 0.45));
+}
+
+.steps {
+  margin: 16px 0 12px;
+  width: 100%;
+  max-width: 360px;
+}
+
+.progressLine {
+  margin: 4px 0 16px;
+  font-size: 13px;
+  color: var(--color-text-secondary, rgba(0, 0, 0, 0.65));
+  font-variant-numeric: tabular-nums;
+}
+
+.errorMessage {
+  margin: 16px 0 0;
+  padding: 8px 12px;
+  max-width: 100%;
+  font-size: 12px;
+  font-family: ui-monospace, "Cascadia Code", Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  color: var(--color-text-secondary, rgba(0, 0, 0, 0.65));
+}
+
+.actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 12px;
+}

--- a/console/src/components/UpdateTakeoverPage/index.tsx
+++ b/console/src/components/UpdateTakeoverPage/index.tsx
@@ -1,0 +1,115 @@
+import { Progress, Spin, Steps } from "antd";
+import { Button } from "@agentscope-ai/design";
+import { type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { useDesktopUpdate } from "../../contexts/DesktopUpdateContext";
+import styles from "./index.module.less";
+
+export function UpdateTakeoverGate({ children }: { children: ReactNode }) {
+  const { phase, isBackground } = useDesktopUpdate();
+  const isActive =
+    phase === "checking" ||
+    phase === "downloading" ||
+    phase === "installing" ||
+    phase === "failed";
+  const shouldTakeover = isActive && !isBackground;
+  return shouldTakeover ? <UpdateTakeoverPage /> : <>{children}</>;
+}
+
+const KEY_PREFIX = "sidebar.updateModal";
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let i = 0;
+  let v = bytes;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(v >= 100 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function UpdateTakeoverPage() {
+  const { t } = useTranslation();
+  const update = useDesktopUpdate();
+
+  if (update.phase === "failed") {
+    const errorKind = update.error?.kind ?? "other";
+    return (
+      <div className={styles.takeover}>
+        <div className={styles.center}>
+          <Progress type="circle" percent={100} status="exception" size={96} />
+          <h1 className={styles.title}>{t(`${KEY_PREFIX}.failedTitle`)}</h1>
+          <p className={styles.subtitle}>
+            {t(`${KEY_PREFIX}.errors.${errorKind}`)}
+          </p>
+          {update.error?.message && (
+            <pre className={styles.errorMessage}>{update.error.message}</pre>
+          )}
+          <div className={styles.actions}>
+            <Button onClick={update.dismissFailure}>
+              {t(`${KEY_PREFIX}.back`)}
+            </Button>
+            <Button type="primary" onClick={update.retry}>
+              {t(`${KEY_PREFIX}.retry`)}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const stepIndex =
+    update.phase === "downloading" ? 1 : update.phase === "installing" ? 2 : 0;
+
+  const isDownloading = update.phase === "downloading";
+  const total = update.total ?? null;
+  const percent =
+    isDownloading && total && total > 0
+      ? Math.min(100, Math.round((update.downloaded / total) * 100))
+      : null;
+
+  const title = t(`${KEY_PREFIX}.${update.phase}`);
+  const subtitle =
+    update.phase === "checking"
+      ? t(`${KEY_PREFIX}.checkingHint`)
+      : t(`${KEY_PREFIX}.downloadingTo`, { version: update.version });
+
+  return (
+    <div className={styles.takeover}>
+      <div className={styles.center}>
+        {percent !== null ? (
+          <Progress type="circle" percent={percent} size={96} />
+        ) : (
+          <Spin size="large" />
+        )}
+
+        <h1 className={styles.title}>{title}</h1>
+        <p className={styles.subtitle}>{subtitle}</p>
+        <p className={styles.willRestart}>{t(`${KEY_PREFIX}.willRestart`)}</p>
+
+        <Steps
+          size="small"
+          current={stepIndex}
+          className={styles.steps}
+          items={[
+            { title: t(`${KEY_PREFIX}.stepPrepare`) },
+            { title: t(`${KEY_PREFIX}.stepDownloading`) },
+            { title: t(`${KEY_PREFIX}.stepInstalling`) },
+          ]}
+        />
+
+        {isDownloading && (
+          <p className={styles.progressLine}>
+            {t(`${KEY_PREFIX}.downloadProgress`, {
+              done: formatBytes(update.downloaded),
+              total: total ? formatBytes(total) : "-",
+              rate: `${formatBytes(update.throughputBps)}/s`,
+            })}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/console/src/contexts/DesktopUpdateContext.tsx
+++ b/console/src/contexts/DesktopUpdateContext.tsx
@@ -1,0 +1,257 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  checkDesktopUpdate,
+  checkCachedUpdate,
+  downloadDesktopUpdate,
+  installDesktopUpdate,
+  installDownloadedUpdate,
+  onUpdateEvent,
+  type UpdateError,
+  type UpdateProgress,
+} from "../tauri/desktopUpdate";
+import { isDesktopApp } from "../tauri/backendRuntime";
+
+export type UpdatePhase =
+  | "idle"
+  | "checking"
+  | "downloading"
+  | "installing"
+  | "downloaded"
+  | "failed";
+
+interface ContextValue {
+  phase: UpdatePhase;
+  isBackground: boolean;
+  hasUpdate: boolean;
+  supportsLaterInstall: boolean;
+  version: string;
+  body: string;
+  downloaded: number;
+  total: number | null;
+  throughputBps: number;
+  error: UpdateError | null;
+  startInstall: () => Promise<void>;
+  startBackgroundDownload: () => Promise<void>;
+  installDownloaded: () => Promise<void>;
+  retry: () => Promise<void>;
+  dismissFailure: () => void;
+}
+
+const DesktopUpdateContext = createContext<ContextValue | null>(null);
+
+const THROUGHPUT_WINDOW_MS = 5_000;
+
+function toErrorMessage(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return JSON.stringify(err);
+}
+
+export function DesktopUpdateProvider({ children }: { children: ReactNode }) {
+  const [phase, setPhase] = useState<UpdatePhase>("idle");
+  const [isBackground, setIsBackground] = useState(false);
+  const [hasUpdate, setHasUpdate] = useState(false);
+  const [supportsLaterInstall, setSupportsLaterInstall] = useState(false);
+  const [version, setVersion] = useState("");
+  const [body, setBody] = useState("");
+  const [downloaded, setDownloaded] = useState(0);
+  const [total, setTotal] = useState<number | null>(null);
+  const [throughputBps, setThroughputBps] = useState(0);
+  const [error, setError] = useState<UpdateError | null>(null);
+
+  const samplesRef = useRef<{ t: number; downloaded: number }[]>([]);
+
+  // Probe on mount: check remote update + check cached update on disk.
+  useEffect(() => {
+    if (!isDesktopApp()) return;
+    let cancelled = false;
+
+    // Check if there's a cached (already downloaded) update on disk.
+    checkCachedUpdate()
+      .then((cachedVersion) => {
+        if (cancelled || !cachedVersion) return;
+        setVersion(cachedVersion);
+        setHasUpdate(true);
+        setSupportsLaterInstall(true);
+        setPhase("downloaded");
+        setIsBackground(true);
+      })
+      .catch(() => {});
+
+    // Also check remote for new updates.
+    checkDesktopUpdate()
+      .then((info) => {
+        if (cancelled || !info) return;
+        setVersion((prev) => prev || info.version);
+        setBody(info.body?.trim() ?? "");
+        setHasUpdate(true);
+        setSupportsLaterInstall(Boolean(info.supportsLaterInstall));
+      })
+      .catch((err) => {
+        console.warn("[updates] desktop update check failed", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleProgress = useCallback((p: UpdateProgress) => {
+    const now = Date.now();
+    samplesRef.current.push({ t: now, downloaded: p.downloaded });
+    samplesRef.current = samplesRef.current.filter(
+      (s) => now - s.t <= THROUGHPUT_WINDOW_MS,
+    );
+    const oldest = samplesRef.current[0];
+    const dt = oldest ? (now - oldest.t) / 1000 : 0;
+    const dBytes = oldest ? p.downloaded - oldest.downloaded : 0;
+    setPhase("downloading");
+    setDownloaded(p.downloaded);
+    setTotal(p.total ?? null);
+    setThroughputBps(dt > 0 ? Math.max(0, dBytes / dt) : 0);
+  }, []);
+
+  const beginUpdate = useCallback((background: boolean) => {
+    samplesRef.current = [];
+    setIsBackground(background);
+    setPhase("checking");
+    setDownloaded(0);
+    setTotal(null);
+    setThroughputBps(0);
+    setError(null);
+  }, []);
+
+  // Subscribe to Rust-side update:* events.
+  useEffect(() => {
+    if (!isDesktopApp()) return;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    onUpdateEvent({
+      onCheckStart: () => setPhase("checking"),
+      onDownloadProgress: handleProgress,
+      onInstallStart: () => setPhase("installing"),
+      onDownloadDone: (payload) => {
+        setPhase("downloaded");
+        setVersion(payload.version);
+      },
+      onError: (err) => {
+        setPhase("failed");
+        setError(err);
+      },
+    }).then((u) => {
+      if (cancelled) u();
+      else unlisten = u;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [handleProgress]);
+
+  // "Install and Restart" immediate full takeover path.
+  const startInstall = useCallback(async () => {
+    beginUpdate(false);
+    try {
+      await installDesktopUpdate();
+    } catch (err) {
+      setPhase("failed");
+      setError({ stage: "check", kind: "other", message: toErrorMessage(err) });
+    }
+  }, [beginUpdate]);
+
+  // "Update Later" caches the update in the background, no UI takeover.
+  const startBackgroundDownload = useCallback(async () => {
+    beginUpdate(true);
+    try {
+      await downloadDesktopUpdate();
+    } catch (err) {
+      setPhase("failed");
+      setError({ stage: "check", kind: "other", message: toErrorMessage(err) });
+    }
+  }, [beginUpdate]);
+
+  // Install a previously downloaded update.
+  const installDownloadedFn = useCallback(async () => {
+    setIsBackground(false);
+    setPhase("installing");
+    setError(null);
+    try {
+      await installDownloadedUpdate();
+    } catch (err) {
+      setPhase("failed");
+      setIsBackground(false);
+      setError({
+        stage: "install",
+        kind: "other",
+        message: toErrorMessage(err),
+      });
+    }
+  }, []);
+
+  const dismissFailure = useCallback(() => {
+    setPhase("idle");
+    setError(null);
+    setIsBackground(false);
+  }, []);
+
+  const value = useMemo<ContextValue>(
+    () => ({
+      phase,
+      isBackground,
+      hasUpdate,
+      supportsLaterInstall,
+      version,
+      body,
+      downloaded,
+      total,
+      throughputBps,
+      error,
+      startInstall,
+      startBackgroundDownload,
+      installDownloaded: installDownloadedFn,
+      retry: startInstall,
+      dismissFailure,
+    }),
+    [
+      phase,
+      isBackground,
+      hasUpdate,
+      supportsLaterInstall,
+      version,
+      body,
+      downloaded,
+      total,
+      throughputBps,
+      error,
+      startInstall,
+      startBackgroundDownload,
+      installDownloadedFn,
+      dismissFailure,
+    ],
+  );
+
+  return (
+    <DesktopUpdateContext.Provider value={value}>
+      {children}
+    </DesktopUpdateContext.Provider>
+  );
+}
+
+export function useDesktopUpdate(): ContextValue {
+  const ctx = useContext(DesktopUpdateContext);
+  if (!ctx) {
+    throw new Error(
+      "useDesktopUpdate must be used inside <DesktopUpdateProvider>",
+    );
+  }
+  return ctx;
+}

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -1,4 +1,4 @@
-import { Layout, Space, Badge, Spin, Tooltip, Dropdown } from "antd";
+import { Layout, Space, Badge, Spin, Tooltip, Dropdown, Popover } from "antd";
 import type { MenuProps } from "antd";
 import LanguageSwitcher, {
   LANGUAGE_LIST,
@@ -27,6 +27,8 @@ import { useState, useEffect } from "react";
 import { Slot } from "../plugins/registry/Slot";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useDesktopUpdate } from "../contexts/DesktopUpdateContext";
+import { isDesktopApp } from "../tauri/backendRuntime";
 import {
   CopyOutlined,
   CheckOutlined,
@@ -37,6 +39,9 @@ import {
   PlayCircleOutlined,
   InfoCircleOutlined,
   DownOutlined,
+  SyncOutlined,
+  CheckCircleOutlined,
+  ExclamationCircleOutlined,
 } from "@ant-design/icons";
 
 const { Header: AntHeader } = Layout;
@@ -69,6 +74,8 @@ function UpdateCodeBlock({ code }: { code: string }) {
 export default function Header() {
   const { t, i18n } = useTranslation();
   const { isDark, setThemeMode } = useTheme();
+  const desktop = useDesktopUpdate();
+  const onDesktop = isDesktopApp();
   const [version, setVersion] = useState<string>("");
   const [latestVersion, setLatestVersion] = useState<string>("");
   const [updateModalOpen, setUpdateModalOpen] = useState(false);
@@ -81,7 +88,10 @@ export default function Header() {
       .catch(() => {});
   }, []);
 
+  // Web-only PyPI fallback: desktop path is owned by DesktopUpdateContext.
   useEffect(() => {
+    if (onDesktop) return;
+
     fetch(PYPI_URL)
       .then((res) => res.json())
       .then((data) => {
@@ -123,10 +133,15 @@ export default function Header() {
         }
       })
       .catch(() => {});
-  }, []);
+  }, [onDesktop]);
 
-  const hasUpdate =
-    !!version && !!latestVersion && compareVersions(latestVersion, version) > 0;
+  const hasUpdate = onDesktop
+    ? desktop.hasUpdate
+    : !!version &&
+      !!latestVersion &&
+      compareVersions(latestVersion, version) > 0;
+
+  const modalVersion = onDesktop ? desktop.version : latestVersion;
 
   const resourcesMenuItems: MenuProps["items"] = [
     {
@@ -207,6 +222,17 @@ export default function Header() {
       : i18n.language?.startsWith("ru")
       ? "ru"
       : "en";
+
+    if (onDesktop) {
+      setUpdateMarkdown(
+        desktop.body ||
+          t("sidebar.updateModal.desktopInstallHint", {
+            version: desktop.version,
+          }),
+      );
+      return;
+    }
+
     const faqLang = lang === "zh" ? "zh" : "en";
     const url = `https://qwenpaw.agentscope.io/docs/faq.${faqLang}.md`;
     fetch(url, { cache: "no-cache" })
@@ -226,9 +252,47 @@ export default function Header() {
       });
   };
 
+  const handleStartInstall = () => {
+    setUpdateModalOpen(false);
+    void desktop.startInstall();
+  };
+
+  const handleUpdateLater = () => {
+    setUpdateModalOpen(false);
+    void desktop.startBackgroundDownload();
+  };
+
+  const handleRestartNow = () => {
+    void desktop.installDownloaded();
+  };
+
   const handleNavClick = (url: string) => {
     openExternalLink(url);
   };
+
+  // Background download/ready state for inline header indicator.
+  const isBackgroundActive =
+    onDesktop &&
+    desktop.isBackground &&
+    (desktop.phase === "checking" || desktop.phase === "downloading");
+  const isReady = onDesktop && desktop.phase === "downloaded";
+  const isApplyingDownloadedUpdate =
+    onDesktop && desktop.phase === "installing";
+  const isBackgroundFailed =
+    onDesktop && desktop.isBackground && desktop.phase === "failed";
+  const backgroundDownloadPercent =
+    isBackgroundActive && desktop.phase === "downloading" && desktop.total
+      ? Math.min(99, Math.round((desktop.downloaded / desktop.total) * 100))
+      : undefined;
+  const backgroundDownloadTitle =
+    backgroundDownloadPercent !== undefined
+      ? `${t(
+          `sidebar.updateModal.backgroundDownloading`,
+        )} ${backgroundDownloadPercent}%`
+      : t(`sidebar.updateModal.backgroundDownloading`);
+  const backgroundFailureTitle = desktop.error?.message
+    ? `${t(`sidebar.updateModal.backgroundFailed`)}: ${desktop.error.message}`
+    : t(`sidebar.updateModal.backgroundFailed`);
 
   return (
     <>
@@ -250,21 +314,78 @@ export default function Header() {
           <div className={styles.logoDivider} />
           {version && (
             <Badge
-              dot={!!hasUpdate}
+              dot={!!hasUpdate && !isReady && !isBackgroundActive}
               color="rgba(255, 157, 77, 1)"
               offset={[4, 28]}
             >
               <span
                 className={`${styles.versionBadge} ${
-                  hasUpdate
+                  hasUpdate || isReady
                     ? styles.versionBadgeClickable
                     : styles.versionBadgeDefault
                 }`}
-                onClick={() => hasUpdate && handleOpenUpdateModal()}
+                onClick={() => {
+                  if (isReady) return; // handled by Popover
+                  if (hasUpdate) handleOpenUpdateModal();
+                }}
               >
                 v{version}
               </span>
             </Badge>
+          )}
+          {isBackgroundActive && (
+            <Tooltip title={backgroundDownloadTitle}>
+              <SyncOutlined
+                spin
+                style={{
+                  marginLeft: 6,
+                  fontSize: 14,
+                  color: "rgba(255, 157, 77, 1)",
+                }}
+              />
+            </Tooltip>
+          )}
+          {isReady && (
+            <Popover
+              content={
+                <div style={{ textAlign: "center" }}>
+                  <p style={{ marginBottom: 12 }}>
+                    {t(`sidebar.updateModal.readyToInstallHint`, {
+                      version: desktop.version,
+                    })}
+                  </p>
+                  <Button
+                    type="primary"
+                    size="small"
+                    onClick={handleRestartNow}
+                    loading={isApplyingDownloadedUpdate}
+                  >
+                    {t(`sidebar.updateModal.restartNow`)}
+                  </Button>
+                </div>
+              }
+              title={t(`sidebar.updateModal.readyToInstall`)}
+              trigger="click"
+            >
+              <Tooltip title={t(`sidebar.updateModal.readyToInstall`)}>
+                <CheckCircleOutlined
+                  style={{ marginLeft: 6, fontSize: 14, color: "#52c41a" }}
+                />
+              </Tooltip>
+            </Popover>
+          )}
+          {isBackgroundFailed && (
+            <Tooltip title={backgroundFailureTitle}>
+              <ExclamationCircleOutlined
+                style={{
+                  marginLeft: 6,
+                  fontSize: 14,
+                  color: "#ff4d4f",
+                  cursor: "pointer",
+                }}
+                onClick={() => void desktop.startBackgroundDownload()}
+              />
+            </Tooltip>
           )}
         </div>
         <Slot name="header.left" kind="fill" />
@@ -317,15 +438,31 @@ export default function Header() {
           <Button key="close" onClick={() => setUpdateModalOpen(false)}>
             {t("common.close")}
           </Button>,
-          <Button
-            key="releases"
-            type="primary"
-            className={styles.updateViewReleasesBtn}
-            onClick={() => handleNavClick(getReleaseNotesUrl(i18n.language))}
-          >
-            {t("sidebar.updateModal.viewReleases")}
-          </Button>,
-        ]}
+          onDesktop && desktop.supportsLaterInstall ? (
+            <Button key="later" onClick={handleUpdateLater}>
+              {t("sidebar.updateModal.updateLater")}
+            </Button>
+          ) : null,
+          onDesktop ? (
+            <Button
+              key="install"
+              type="primary"
+              className={styles.updateViewReleasesBtn}
+              onClick={handleStartInstall}
+            >
+              {t("sidebar.updateModal.installDesktopUpdate")}
+            </Button>
+          ) : (
+            <Button
+              key="releases"
+              type="primary"
+              className={styles.updateViewReleasesBtn}
+              onClick={() => handleNavClick(getReleaseNotesUrl(i18n.language))}
+            >
+              {t("sidebar.updateModal.viewReleases")}
+            </Button>
+          ),
+        ].filter(Boolean)}
         width={960}
         className={styles.updateModal}
       >
@@ -334,11 +471,11 @@ export default function Header() {
           <div className={styles.updateModalBannerLeft}>
             <span className={styles.updateModalVersionTag}>
               <TagOutlined />
-              Version {latestVersion || version}
+              Version {modalVersion || version}
             </span>
             <div className={styles.updateModalBannerTitle}>
               {t("sidebar.updateModal.title", {
-                version: latestVersion || version,
+                version: modalVersion || version,
               })}
             </div>
           </div>

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -75,7 +75,33 @@
     "updateModal": {
       "title": "New version available: v{{version}}",
       "viewReleases": "View Releases",
-      "close": "Close"
+      "installDesktopUpdate": "Update Now",
+      "desktopInstallHint": "QwenPaw Desktop {{version}} is ready to install. The app will restart after the update.",
+      "checking": "Checking for updates…",
+      "checkingHint": "Confirming the latest release",
+      "downloading": "Downloading update",
+      "downloadingTo": "Updating to version {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "Installing update",
+      "willRestart": "The app will restart automatically when done.",
+      "stepPrepare": "Prepare",
+      "stepDownloading": "Download",
+      "stepInstalling": "Install",
+      "failedTitle": "Update failed",
+      "back": "Back",
+      "retry": "Retry",
+      "errors": {
+        "network": "Couldn't reach the update server. Check your internet and try again.",
+        "signature": "Update file signature invalid. Try downloading again.",
+        "appLocation": "QwenPaw is running from a read-only macOS location. Move QwenPaw.app to the Applications folder, launch it from there, then try updating again.",
+        "other": "Update failed."
+      },
+      "updateLater": "Download in Background",
+      "backgroundDownloading": "Downloading in background…",
+      "readyToInstall": "Update ready",
+      "readyToInstallHint": "v{{version}} update is downloaded. Restart to install and launch the new version.",
+      "restartNow": "Update Now",
+      "backgroundFailed": "Background download failed"
     },
     "settings": {
       "language": "Language",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -87,7 +87,33 @@
     "updateModal": {
       "title": "Versi baru tersedia: v{{version}}",
       "viewReleases": "Lihat Rilis",
-      "close": "Tutup"
+      "installDesktopUpdate": "Perbarui Sekarang",
+      "desktopInstallHint": "QwenPaw Desktop {{version}} siap dipasang. Aplikasi akan dimulai ulang setelah pembaruan.",
+      "checking": "Memeriksa pembaruan…",
+      "checkingHint": "Memeriksa versi terbaru",
+      "downloading": "Mengunduh pembaruan",
+      "downloadingTo": "Memperbarui ke versi {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "Memasang pembaruan",
+      "willRestart": "Aplikasi akan dimulai ulang otomatis setelah selesai.",
+      "stepPrepare": "Persiapan",
+      "stepDownloading": "Unduh",
+      "stepInstalling": "Pasang",
+      "failedTitle": "Pembaruan gagal",
+      "back": "Kembali",
+      "retry": "Coba Lagi",
+      "errors": {
+        "network": "Tidak dapat menjangkau server pembaruan. Periksa internet dan coba lagi.",
+        "signature": "Tanda tangan file pembaruan tidak valid. Coba unduh lagi.",
+        "appLocation": "QwenPaw berjalan dari lokasi macOS yang hanya-baca. Pindahkan QwenPaw.app ke folder Applications, jalankan dari sana, lalu coba perbarui lagi.",
+        "other": "Pembaruan gagal."
+      },
+      "updateLater": "Unduh di Latar Belakang",
+      "backgroundDownloading": "Mengunduh di latar belakang…",
+      "readyToInstall": "Pembaruan siap",
+      "readyToInstallHint": "Pembaruan v{{version}} telah diunduh. Mulai ulang untuk memasang dan membuka versi baru.",
+      "restartNow": "Perbarui Sekarang",
+      "backgroundFailed": "Unduhan latar belakang gagal"
     },
     "settings": {
       "language": "Bahasa",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1609,7 +1609,33 @@
     "updateModal": {
       "title": "新しいバージョンが利用可能です: v{{version}}",
       "viewReleases": "リリースを見る",
-      "close": "閉じる"
+      "installDesktopUpdate": "今すぐ更新",
+      "desktopInstallHint": "QwenPaw Desktop {{version}} のインストール準備が整いました。更新後にアプリが再起動します。",
+      "checking": "更新を確認中…",
+      "checkingHint": "最新バージョンを確認しています",
+      "downloading": "更新をダウンロード中",
+      "downloadingTo": "バージョン {{version}} に更新中",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "更新をインストール中",
+      "willRestart": "アプリはインストール完了後に自動的に再起動します",
+      "stepPrepare": "準備",
+      "stepDownloading": "ダウンロード",
+      "stepInstalling": "インストール",
+      "failedTitle": "更新に失敗しました",
+      "back": "戻る",
+      "retry": "再試行",
+      "errors": {
+        "network": "更新サーバーに接続できませんでした。インターネット接続を確認して再試行してください。",
+        "signature": "更新ファイルの署名検証に失敗しました。もう一度ダウンロードしてください。",
+        "appLocation": "QwenPaw は読み取り専用の macOS の場所から実行されています。QwenPaw.app を Applications フォルダーへ移動し、そこから起動してからもう一度更新してください。",
+        "other": "更新に失敗しました。"
+      },
+      "updateLater": "バックグラウンドでダウンロード",
+      "backgroundDownloading": "バックグラウンドでダウンロード中…",
+      "readyToInstall": "更新の準備が完了",
+      "readyToInstallHint": "v{{version}} の更新をダウンロードしました。再起動してインストールし、新しいバージョンを起動します。",
+      "restartNow": "今すぐ更新",
+      "backgroundFailed": "バックグラウンドダウンロード失敗"
     },
     "settings": {
       "language": "言語",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1821,7 +1821,33 @@
     "updateModal": {
       "title": "Novo Versao available: v{{version}}",
       "viewReleases": "Visualizar Releases",
-      "close": "Fechar"
+      "installDesktopUpdate": "Atualizar agora",
+      "desktopInstallHint": "QwenPaw Desktop {{version}} está pronto para instalar. O aplicativo será reiniciado após a atualização.",
+      "checking": "Verificando atualizações…",
+      "checkingHint": "Confirmando a versão mais recente",
+      "downloading": "Baixando atualização",
+      "downloadingTo": "Atualizando para a versão {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "Instalando atualização",
+      "willRestart": "O aplicativo será reiniciado automaticamente após a conclusão.",
+      "stepPrepare": "Preparar",
+      "stepDownloading": "Baixar",
+      "stepInstalling": "Instalar",
+      "failedTitle": "Falha na atualização",
+      "back": "Voltar",
+      "retry": "Tentar Novamente",
+      "errors": {
+        "network": "Não foi possível alcançar o servidor de atualização. Verifique sua internet e tente novamente.",
+        "signature": "Assinatura do arquivo de atualização inválida. Tente baixar novamente.",
+        "appLocation": "O QwenPaw está sendo executado a partir de um local somente leitura do macOS. Mova QwenPaw.app para a pasta Aplicativos, abra-o a partir de lá e tente atualizar novamente.",
+        "other": "Falha na atualização."
+      },
+      "updateLater": "Baixar em segundo plano",
+      "backgroundDownloading": "Baixando em segundo plano…",
+      "readyToInstall": "Atualização pronta",
+      "readyToInstallHint": "A atualização v{{version}} foi baixada. Reinicie para instalar e abrir a nova versão.",
+      "restartNow": "Atualizar agora",
+      "backgroundFailed": "Falha no download em segundo plano"
     },
     "settings": {
       "language": "Idioma",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1624,7 +1624,33 @@
     "updateModal": {
       "title": "Доступна новая версия: v{{version}}",
       "viewReleases": "Открыть релизы",
-      "close": "Закрыть"
+      "installDesktopUpdate": "Обновить сейчас",
+      "desktopInstallHint": "QwenPaw Desktop {{version}} готов к установке. Приложение перезапустится после обновления.",
+      "checking": "Проверка обновлений…",
+      "checkingHint": "Проверяем последнюю версию",
+      "downloading": "Загрузка обновления",
+      "downloadingTo": "Обновление до версии {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "Установка обновления",
+      "willRestart": "Приложение перезапустится автоматически после установки.",
+      "stepPrepare": "Подготовка",
+      "stepDownloading": "Загрузка",
+      "stepInstalling": "Установка",
+      "failedTitle": "Обновление не удалось",
+      "back": "Назад",
+      "retry": "Повторить",
+      "errors": {
+        "network": "Не удалось подключиться к серверу обновлений. Проверьте интернет и повторите попытку.",
+        "signature": "Не удалось проверить подпись файла обновления. Попробуйте загрузить ещё раз.",
+        "appLocation": "QwenPaw запущен из macOS-пути только для чтения. Переместите QwenPaw.app в папку Applications, запустите его оттуда и повторите обновление.",
+        "other": "Обновление не удалось."
+      },
+      "updateLater": "Скачать в фоне",
+      "backgroundDownloading": "Загрузка в фоновом режиме…",
+      "readyToInstall": "Обновление готово",
+      "readyToInstallHint": "Обновление v{{version}} загружено. Перезапустите приложение, чтобы установить и открыть новую версию.",
+      "restartNow": "Обновить сейчас",
+      "backgroundFailed": "Фоновая загрузка не удалась"
     },
     "settings": {
       "language": "Язык",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -75,7 +75,33 @@
     "updateModal": {
       "title": "发现新版本 v{{version}}",
       "viewReleases": "查看 Releases",
-      "close": "关闭"
+      "installDesktopUpdate": "现在更新",
+      "desktopInstallHint": "QwenPaw 桌面端 {{version}} 已准备好安装，更新后应用将自动重启。",
+      "checking": "检查更新中…",
+      "checkingHint": "正在确认最新版本",
+      "downloading": "正在下载更新",
+      "downloadingTo": "正在更新到版本 {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "正在安装更新",
+      "willRestart": "应用将在安装完成后自动重启,请稍候…",
+      "stepPrepare": "准备",
+      "stepDownloading": "下载",
+      "stepInstalling": "安装",
+      "failedTitle": "更新失败",
+      "back": "返回",
+      "retry": "重试",
+      "errors": {
+        "network": "连接不上更新服务器，请检查网络后重试。",
+        "signature": "更新文件签名校验失败，请重新尝试下载。",
+        "appLocation": "QwenPaw 正在从 macOS 只读位置运行。请先将 QwenPaw.app 移动到“应用程序”文件夹，从那里启动后再重试更新。",
+        "other": "更新失败。"
+      },
+      "updateLater": "后台下载",
+      "backgroundDownloading": "正在后台下载更新…",
+      "readyToInstall": "更新已就绪",
+      "readyToInstallHint": "v{{version}} 更新已下载，重启后将安装并启动新版本。",
+      "restartNow": "现在更新",
+      "backgroundFailed": "后台下载失败"
     },
     "settings": {
       "language": "语言",

--- a/console/src/tauri/BackendReadyGate.tsx
+++ b/console/src/tauri/BackendReadyGate.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect } from "react";
 import BackendLoadingPage from "./BackendLoadingPage";
 import useBackendReadyPolling from "./useBackendReadyPolling";
+import { withDesktopMarker } from "./backendRuntime";
 
 interface Props {
   children: ReactNode;
@@ -19,7 +20,7 @@ export default function BackendReadyGate({ children }: Props) {
 
   useEffect(() => {
     if (shouldGate && status === "ready" && readyUrl) {
-      window.location.replace(readyUrl);
+      window.location.replace(withDesktopMarker(readyUrl));
     }
   }, [readyUrl, shouldGate, status]);
 

--- a/console/src/tauri/backendRuntime.ts
+++ b/console/src/tauri/backendRuntime.ts
@@ -2,10 +2,45 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 
 declare const VITE_API_BASE_URL: string;
 
+const DESKTOP_QUERY_KEY = "desktop";
+const DESKTOP_SESSION_KEY = "qpDesktop";
+
 let initRuntimeApiBaseUrlPromise: Promise<string> | null = null;
 
 export function isTauriRuntime(): boolean {
   return isTauri();
+}
+
+/**
+ * Reliably detect whether we're running inside the Tauri desktop app, even
+ * after the webview has navigated to the backend-hosted console where
+ * `__TAURI_INTERNALS__` may or may not be reachable. The bootstrap gate tags
+ * the redirect URL with `?desktop=1` and we persist it in sessionStorage so
+ * subsequent reloads keep the answer.
+ */
+export function isDesktopApp(): boolean {
+  if (typeof window === "undefined") return false;
+  if (isTauriRuntime()) return true;
+  try {
+    if (sessionStorage.getItem(DESKTOP_SESSION_KEY) === "1") return true;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get(DESKTOP_QUERY_KEY) === "1") {
+      sessionStorage.setItem(DESKTOP_SESSION_KEY, "1");
+      return true;
+    }
+  } catch {
+    /* sessionStorage unavailable (e.g., privacy mode) */
+  }
+  return false;
+}
+
+/**
+ * Append the desktop marker to a URL so the backend-hosted console can detect
+ * it after the bootstrap redirect.
+ */
+export function withDesktopMarker(url: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}${DESKTOP_QUERY_KEY}=1`;
 }
 
 export function shouldUseTauriStartupGate(): boolean {

--- a/console/src/tauri/desktopUpdate.ts
+++ b/console/src/tauri/desktopUpdate.ts
@@ -1,0 +1,93 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { isDesktopApp } from "./backendRuntime";
+
+export interface DesktopUpdateInfo {
+  version: string;
+  body?: string | null;
+  supportsLaterInstall?: boolean;
+}
+
+export interface UpdateProgress {
+  downloaded: number;
+  total: number | null;
+}
+
+export interface UpdateError {
+  stage: "check" | "download" | "install";
+  kind: "network" | "signature" | "appLocation" | "other";
+  message: string;
+}
+
+export interface DownloadDonePayload {
+  version: string;
+}
+
+export async function checkDesktopUpdate(): Promise<DesktopUpdateInfo | null> {
+  if (!isDesktopApp()) return null;
+  return invoke<DesktopUpdateInfo | null>("check_desktop_update");
+}
+
+export async function installDesktopUpdate(): Promise<void> {
+  if (!isDesktopApp()) return;
+  await invoke<void>("install_desktop_update");
+}
+
+export async function downloadDesktopUpdate(): Promise<void> {
+  if (!isDesktopApp()) return;
+  await invoke<void>("download_desktop_update");
+}
+
+export async function installDownloadedUpdate(): Promise<void> {
+  if (!isDesktopApp()) return;
+  await invoke<void>("install_downloaded_update");
+}
+
+export async function checkCachedUpdate(): Promise<string | null> {
+  if (!isDesktopApp()) return null;
+  return invoke<string | null>("check_cached_update");
+}
+
+export interface UpdateEventHandlers {
+  onCheckStart?: () => void;
+  onDownloadProgress?: (progress: UpdateProgress) => void;
+  onInstallStart?: () => void;
+  onDownloadDone?: (payload: DownloadDonePayload) => void;
+  onError?: (error: UpdateError) => void;
+}
+
+export async function onUpdateEvent(
+  handlers: UpdateEventHandlers,
+): Promise<UnlistenFn> {
+  const unlisteners: UnlistenFn[] = [];
+
+  const addListener = async <T>(
+    eventName: string,
+    handler?: (payload: T) => void,
+  ) => {
+    if (!handler) return;
+    unlisteners.push(
+      await listen<T>(eventName, (event) => handler(event.payload)),
+    );
+  };
+
+  const withoutPayload = (
+    handler?: () => void,
+  ): ((payload: unknown) => void) | undefined =>
+    handler ? () => handler() : undefined;
+
+  await Promise.all([
+    addListener("update:check-start", withoutPayload(handlers.onCheckStart)),
+    addListener("update:download-progress", handlers.onDownloadProgress),
+    addListener(
+      "update:install-start",
+      withoutPayload(handlers.onInstallStart),
+    ),
+    addListener("update:download-done", handlers.onDownloadDone),
+    addListener("update:error", handlers.onError),
+  ]);
+
+  return () => {
+    unlisteners.forEach((u) => u());
+  };
+}

--- a/scripts/pack-tauri/build_macos_pyinstaller.sh
+++ b/scripts/pack-tauri/build_macos_pyinstaller.sh
@@ -168,6 +168,18 @@ else
 fi
 echo ""
 
+UPDATER_NAME="${DIST_ROOT}/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz"
+case "$(uname -m)" in
+    arm64 | aarch64) UPDATER_TARGET="darwin-aarch64" ;;
+    *) UPDATER_TARGET="darwin-x86_64" ;;
+esac
+python "${REPO_ROOT}/scripts/pack-tauri/generate_update_manifest.py" stage \
+    --bundle-dir "${BUNDLE_DIR}/macos" \
+    --pattern '*.app.tar.gz' \
+    --target "${UPDATER_TARGET}" \
+    --output "${UPDATER_NAME}" \
+    --pubkey-config "${REPO_ROOT}/console/src-tauri/tauri.version.conf.json"
+
 echo ""
 echo "========================================="
 echo "Build Complete!"
@@ -175,6 +187,7 @@ echo "========================================="
 echo "App:          ${APP_PATH}"
 echo "Distribution: ${DIST_DIR}"
 echo "Archive:      ${ZIP_NAME}"
+echo "Updater:      ${UPDATER_NAME}"
 echo ""
 echo "Test: open \"${STAGED_APP_PATH}\""
 echo ""

--- a/scripts/pack-tauri/generate_update_manifest.py
+++ b/scripts/pack-tauri/generate_update_manifest.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tauri updater helper: stage per-platform artifacts and build the manifest.
+
+Subcommands:
+  stage     Copy a Tauri-built updater archive (and its .sig) into the dist
+            tree, then write a small JSON sidecar describing it.
+  manifest  Aggregate one or more stage-produced sidecar JSON files into the
+            unified `qwenpaw-tauri-latest.json` consumed by tauri-plugin-updater.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+from packaging.version import InvalidVersion, Version
+
+
+def to_semver(version: str) -> str:
+    try:
+        parsed = Version(version)
+    except InvalidVersion as err:
+        raise SystemExit(
+            f"unsupported Python version for Tauri: {version}",
+        ) from err
+
+    if parsed.epoch or parsed.local is not None or len(parsed.release) != 3:
+        raise SystemExit(f"unsupported Python version for Tauri: {version}")
+
+    major, minor, patch = parsed.release
+    prerelease_map = {"a": "alpha", "b": "beta", "rc": "rc"}
+    labels: list[str] = []
+    if parsed.pre:
+        prerelease, prerelease_n = parsed.pre
+        labels.append(f"{prerelease_map[prerelease]}.{prerelease_n}")
+    if parsed.post is not None:
+        labels.append(f"post.{parsed.post}")
+    if parsed.dev is not None:
+        labels.append(f"dev.{parsed.dev}")
+    suffix = f"-{'.'.join(labels)}" if labels else ""
+    return f"{major}.{minor}.{patch}{suffix}"
+
+
+# stage
+
+
+def _find_source(bundle_dir: Path, pattern: str) -> Path:
+    matches = sorted(bundle_dir.glob(pattern))
+    if not matches:
+        raise SystemExit(
+            f"no artifact matching {pattern!r} under {bundle_dir}",
+        )
+    return matches[0]
+
+
+def cmd_stage(args: argparse.Namespace) -> None:
+    bundle_dir = Path(args.bundle_dir)
+    source = _find_source(bundle_dir, args.pattern)
+    sig_source = source.with_suffix(source.suffix + ".sig")
+    if not sig_source.is_file():
+        raise SystemExit(f"no updater signature found at {sig_source}")
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, output)
+    shutil.copyfile(sig_source, output.with_suffix(output.suffix + ".sig"))
+
+    metadata = {
+        "target": args.target,
+        "artifact": output.name,
+        "signature": output.name + ".sig",
+    }
+    sidecar = output.parent / f"tauri-{args.target}-updater.json"
+    sidecar.write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    if args.pubkey_config:
+        verify_signature_key_id(
+            signature_path=output.with_suffix(output.suffix + ".sig"),
+            pubkey_config=Path(args.pubkey_config),
+        )
+    print(f"staged {output.name} ({args.target}); sidecar {sidecar.name}")
+
+
+# manifest
+
+
+def _read_metadata(path: Path) -> dict[str, str]:
+    with path.open("r", encoding="utf-8-sig") as f:
+        data = json.load(f)
+    required = {"target", "artifact", "signature"}
+    missing = required - set(data)
+    if missing:
+        raise SystemExit(
+            f"{path} missing required keys: {', '.join(sorted(missing))}",
+        )
+    return {key: str(data[key]) for key in required}
+
+
+def _signature_text(path: Path) -> str:
+    if not path.is_file():
+        raise SystemExit(f"signature file not found: {path}")
+    return path.read_text(encoding="utf-8-sig").strip()
+
+
+def _decode_base64_minisign_text(value: str, *, kind: str) -> str:
+    try:
+        text = base64.b64decode(value, validate=True).decode("utf-8")
+    except Exception as err:
+        raise SystemExit(
+            f"{kind} is not valid base64 minisign text: {err}",
+        ) from err
+    if "untrusted comment:" not in text:
+        raise SystemExit(f"{kind} is not a minisign text block")
+    return text
+
+
+def _minisign_key_id(text: str, *, kind: str) -> str:
+    lines = [
+        line.strip() for line in text.strip().splitlines() if line.strip()
+    ]
+    try:
+        raw = base64.b64decode(lines[1], validate=True)
+        key_id = raw[2:10]
+        if len(key_id) != 8:
+            raise ValueError("missing key id")
+    except IndexError as err:
+        raise SystemExit(f"{kind} is not a valid minisign text block") from err
+    except Exception as err:
+        raise SystemExit(
+            f"{kind} has invalid minisign key/signature data: {err}",
+        ) from err
+    return key_id.hex()
+
+
+def _pubkey_from_config(config_path: Path) -> str:
+    with config_path.open("r", encoding="utf-8-sig") as f:
+        config = json.load(f)
+    try:
+        pubkey = config["plugins"]["updater"]["pubkey"]
+    except KeyError as err:
+        raise SystemExit(
+            f"{config_path} missing plugins.updater.pubkey: {err}",
+        ) from err
+    if not isinstance(pubkey, str) or not pubkey.strip():
+        raise SystemExit(f"{config_path} has an empty plugins.updater.pubkey")
+    return _decode_base64_minisign_text(pubkey.strip(), kind=str(config_path))
+
+
+def verify_signature_key_id(signature_path: Path, pubkey_config: Path) -> None:
+    signature_text = _decode_base64_minisign_text(
+        _signature_text(signature_path),
+        kind=str(signature_path),
+    )
+    pubkey_text = _pubkey_from_config(pubkey_config)
+    signature_key_id = _minisign_key_id(
+        signature_text,
+        kind=str(signature_path),
+    )
+    pubkey_key_id = _minisign_key_id(pubkey_text, kind=str(pubkey_config))
+    if signature_key_id != pubkey_key_id:
+        raise SystemExit(
+            "updater signature key id does not match configured pubkey: "
+            f"signature={signature_key_id} pubkey={pubkey_key_id}",
+        )
+    print(f"verified updater signature key id: {signature_key_id}")
+
+
+def cmd_manifest(args: argparse.Namespace) -> None:
+    target_overrides: dict[str, str] = {}
+    for entry in args.target_base or []:
+        target, _, url = entry.partition("=")
+        if not target or not url:
+            raise SystemExit(
+                f"--target-base expects 'target=URL', got {entry!r}",
+            )
+        target_overrides[target] = url
+
+    platforms: dict[str, dict[str, str]] = {}
+    for raw in args.metadata:
+        meta_path = Path(raw)
+        meta = _read_metadata(meta_path)
+        workdir = meta_path.parent
+        artifact_path = workdir / meta["artifact"]
+        if not artifact_path.is_file():
+            raise SystemExit(f"artifact file not found: {artifact_path}")
+        base = target_overrides.get(meta["target"], args.base_url).rstrip(
+            "/",
+        )
+        platforms[meta["target"]] = {
+            "url": f"{base}/{quote(meta['artifact'])}",
+            "signature": _signature_text(workdir / meta["signature"]),
+        }
+    if not platforms:
+        raise SystemExit("no updater platforms were provided")
+
+    manifest = {
+        "version": to_semver(args.version),
+        "notes": args.notes,
+        "pub_date": args.pub_date,
+        "platforms": platforms,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(
+        f"wrote manifest {output} (platforms: {', '.join(sorted(platforms))})",
+    )
+
+
+# cli
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_stage = sub.add_parser(
+        "stage",
+        help="Copy a Tauri updater archive + .sig into dist and write a sidecar.",
+    )
+    p_stage.add_argument(
+        "--bundle-dir",
+        required=True,
+        help="Tauri bundle output dir (e.g., target/release/bundle/nsis).",
+    )
+    p_stage.add_argument(
+        "--pattern",
+        required=True,
+        help="Glob to find the artifact (e.g., '*-setup.exe', '*.app.tar.gz').",
+    )
+    p_stage.add_argument(
+        "--target",
+        required=True,
+        help="Updater target (e.g., windows-x86_64, darwin-aarch64).",
+    )
+    p_stage.add_argument(
+        "--output",
+        required=True,
+        help="Destination artifact path; .sig is staged alongside.",
+    )
+    p_stage.add_argument(
+        "--pubkey-config",
+        help=(
+            "Optional tauri.conf.json path. When provided, fail if the staged "
+            "signature key id does not match plugins.updater.pubkey."
+        ),
+    )
+    p_stage.set_defaults(func=cmd_stage)
+
+    p_manifest = sub.add_parser(
+        "manifest",
+        help="Aggregate per-platform sidecars into the updater manifest JSON.",
+    )
+    p_manifest.add_argument("--version", required=True)
+    p_manifest.add_argument(
+        "--base-url",
+        required=True,
+        help="Default URL prefix for platforms without --target-base override.",
+    )
+    p_manifest.add_argument(
+        "--target-base",
+        action="append",
+        default=[],
+        help=(
+            "Per-target URL prefix override 'target=URL', repeatable. "
+            "Used when platforms live under different paths "
+            "(e.g., OSS lays win-tauri/ and mac-tauri/ separately)."
+        ),
+    )
+    p_manifest.add_argument(
+        "--metadata",
+        action="append",
+        default=[],
+        help="Path to a sidecar JSON file (repeatable).",
+    )
+    p_manifest.add_argument("--notes", default="")
+    p_manifest.add_argument(
+        "--pub-date",
+        default=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+    p_manifest.add_argument("--output", required=True)
+    p_manifest.set_defaults(func=cmd_manifest)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -155,7 +155,6 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 
-
 def script_entry(file_name):
     for item in a.scripts:
         if Path(item[1]).name == file_name:

--- a/scripts/pack-tauri/sync_tauri_version.mjs
+++ b/scripts/pack-tauri/sync_tauri_version.mjs
@@ -8,6 +8,10 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const versionFile = path.join(repoRoot, "src/qwenpaw/__version__.py");
+const tauriConfigFile = path.join(
+  repoRoot,
+  "console/src-tauri/tauri.conf.json",
+);
 const tauriVersionConfigFile = path.join(
   repoRoot,
   "console/src-tauri/tauri.version.conf.json",
@@ -44,11 +48,81 @@ function toSemver(version) {
   }`;
 }
 
+function readBaseUpdaterConfig() {
+  const config = JSON.parse(fs.readFileSync(tauriConfigFile, "utf8"));
+  const updater = config?.plugins?.updater ?? {};
+  if (!updater.pubkey) {
+    throw new Error(
+      `Could not read plugins.updater.pubkey from ${tauriConfigFile}`,
+    );
+  }
+  return updater;
+}
+
+function readUpdaterEndpoints(baseUpdater) {
+  const raw = process.env.TAURI_UPDATER_ENDPOINTS?.trim();
+  if (!raw) return baseUpdater.endpoints;
+
+  if (raw.startsWith("[")) {
+    const parsed = JSON.parse(raw);
+    if (
+      !Array.isArray(parsed) ||
+      parsed.some((entry) => typeof entry !== "string")
+    ) {
+      throw new Error(
+        "TAURI_UPDATER_ENDPOINTS JSON must be an array of strings",
+      );
+    }
+    return parsed;
+  }
+
+  return raw
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function shouldCreateUpdaterArtifacts() {
+  return Boolean(process.env.TAURI_SIGNING_PRIVATE_KEY?.trim());
+}
+
 function writeTauriVersionConfig(file, version) {
+  const baseUpdater = readBaseUpdaterConfig();
+  const pubkey = process.env.TAURI_UPDATER_PUBKEY?.trim() || baseUpdater.pubkey;
+  const endpoints = readUpdaterEndpoints(baseUpdater);
+  const createUpdaterArtifacts = shouldCreateUpdaterArtifacts();
   const config = {
     version,
+    ...(createUpdaterArtifacts
+      ? {
+          bundle: {
+            createUpdaterArtifacts: true,
+          },
+        }
+      : {}),
+    plugins: {
+      updater: {
+        pubkey,
+        ...(endpoints?.length ? { endpoints } : {}),
+      },
+    },
   };
   fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+  console.log(
+    `Using updater pubkey from ${
+      process.env.TAURI_UPDATER_PUBKEY?.trim()
+        ? "TAURI_UPDATER_PUBKEY"
+        : "tauri.conf.json"
+    }`,
+  );
+  if (process.env.TAURI_UPDATER_ENDPOINTS?.trim()) {
+    console.log("Using updater endpoints from TAURI_UPDATER_ENDPOINTS");
+  }
+  console.log(
+    createUpdaterArtifacts
+      ? "Creating Tauri updater artifacts"
+      : "Skipping Tauri updater artifacts because TAURI_SIGNING_PRIVATE_KEY is not set",
+  );
 }
 
 const semver = toSemver(readPythonVersion());


### PR DESCRIPTION
﻿## Summary

Adds a first-pass Tauri desktop auto-update flow on top of PR #3813.

- registers `tauri-plugin-updater` and exposes desktop update check/install commands through the Tauri shell
- wires the Console header to show Tauri desktop updates separately from the existing PyPI/manual update prompt
- enables updater artifact generation in the generated Tauri config with a GitHub Release manifest endpoint
- stages Windows/macOS updater artifacts and signatures in the desktop release workflow, then generates `qwenpaw-tauri-latest.json`

## Notes

The updater public key is compiled into the generated Tauri config. Release signing requires GitHub Actions secrets:

- `TAURI_SIGNING_PRIVATE_KEY`
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` if the key is password-protected

The generated local private key for this branch is intentionally not committed.

## Validation

- `cargo check --manifest-path console/src-tauri/Cargo.toml`
- `npm exec -- tsc -b --noEmit` from `console/`
- targeted Prettier check for changed Console/workflow files
- `python -m py_compile scripts/pack-tauri/generate_update_manifest.py`
- `git diff --check`

`npm run format:check` still reports repo-wide existing Prettier warnings, including generated Tauri target files before ignore updates; the TypeScript portion passed and changed files pass targeted Prettier.
