### PR TITLE
Fix Unix shell command newline handling

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -52,102 +52,29 @@ def _windows_shell_creationflags() -> int:
     return flags
 
 
-def _collapse_newlines_outside_quotes(cmd: str) -> str:
-    r"""Collapse newlines outside quoted strings; preserve those inside.
-
-    Used only on Unix where sh/bash correctly handles newlines in quotes.
-    Handles backslash-newline (line continuation) by removing both chars,
-    and treats single-quoted content as fully literal per POSIX.
-    """
-    result: list[str] = []
-    in_single_quote = False
-    in_double_quote = False
-    i = 0
-    length = len(cmd)
-
-    while i < length:
-        char = cmd[i]
-
-        # Toggle quote state
-        if char == "'" and not in_double_quote:
-            in_single_quote = not in_single_quote
-            result.append(char)
-            i += 1
-            continue
-
-        if char == '"' and not in_single_quote:
-            in_double_quote = not in_double_quote
-            result.append(char)
-            i += 1
-            continue
-
-        # Inside single quotes: everything is literal (POSIX)
-        if in_single_quote:
-            result.append(char)
-            i += 1
-            continue
-
-        # Backslash-newline (line continuation): remove both chars
-        if char == "\\" and i + 1 < length and cmd[i + 1] in ("\r", "\n"):
-            i += 2
-            # \r\n sequence: skip the \n as well
-            if i < length and cmd[i - 1] == "\r" and cmd[i] == "\n":
-                i += 1
-            continue
-
-        # Backslash escape (non-newline): keep both chars
-        if char == "\\" and i + 1 < length:
-            result.append(char)
-            result.append(cmd[i + 1])
-            i += 2
-            continue
-
-        # Newlines
-        if char in ("\r", "\n"):
-            if in_double_quote:
-                # Preserve newlines inside double quotes
-                result.append(char)
-            else:
-                # Collapse \r\n as a single space
-                if char == "\r" and i + 1 < length and cmd[i + 1] == "\n":
-                    i += 1
-                result.append(" ")
-            i += 1
-            continue
-
-        result.append(char)
-        i += 1
-
-    return "".join(result)
-
-
 def _collapse_embedded_newlines(cmd: str) -> str:
-    r"""Replace embedded newline characters with spaces in a command string.
+    r"""Normalize embedded newline characters in a command string.
 
     LLMs produce tool-call arguments in JSON where ``\n`` is parsed as an
-    actual newline character.  In the original shell command the user
-    intended the *literal* two-character sequence ``\n`` (e.g. inside a
-    ``--content`` flag), but after JSON decoding it becomes a real line
-    break.  When passed to a shell:
+    actual newline character. QwenPaw normalizes these newlines by platform:
 
-    * **Windows** ``cmd.exe`` truncates the command at the first newline
-      regardless of quoting context — this is a hard limitation of the
-      Windows command processor.  All newlines must be collapsed.
-    * **Unix** ``sh -c`` treats an unquoted newline as a command separator,
-      but correctly handles newlines inside quoted strings.
-
-    On Unix/macOS, newlines inside quoted strings are preserved so that
-    downstream commands receive the correct multi-line content (e.g.
-    ``--text "Hello\nWorld"``).  On Windows, all newlines are collapsed
-    to ensure the command at least executes successfully.
+    * **Windows** commands are kept compatible with the existing behavior by
+      collapsing embedded newlines and carriage returns. This avoids command
+      truncation in ``cmd.exe`` and keeps the Windows path conservative even
+      if the configured shell executable changes.
+    * **Unix-like platforms** already handle newlines correctly in ``sh`` and
+      ``bash``: as command separators outside quotes, as literal characters
+      inside quotes, and as heredoc delimiters. Rewriting them at this layer
+      would break valid multi-line scripts, heredocs, and case/if blocks, so
+      non-Windows platforms pass the command through unchanged.
     """
-    if "\n" not in cmd:
+    if "\n" not in cmd and "\r" not in cmd:
         return cmd
     if sys.platform == "win32":
         # cmd.exe truncates at newlines regardless of quoting — must
         # collapse all to ensure the command executes at all.
-        return cmd.replace("\r\n", " ").replace("\n", " ")
-    return _collapse_newlines_outside_quotes(cmd)
+        return cmd.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    return cmd
 
 
 def _sanitize_win_cmd(cmd: str) -> str:

--- a/tests/unit/agents/tools/test_shell_newlines.py
+++ b/tests/unit/agents/tools/test_shell_newlines.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Tests for shell command newline normalization."""
+
+# pylint: disable=protected-access
+import sys
+
+from qwenpaw.agents.tools.shell import _collapse_embedded_newlines
+
+
+def test_unix_preserves_newlines_for_multi_command_scripts(monkeypatch):
+    """Unix shells parse newlines natively as command separators."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    cmd = "echo A\necho B"
+
+    assert _collapse_embedded_newlines(cmd) == cmd
+
+
+def test_unix_preserves_heredoc_delimiters(monkeypatch):
+    """Heredocs require real newline delimiters and must not be collapsed."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    cmd = "cat <<'EOF'\nline1\nline2\nEOF"
+
+    assert _collapse_embedded_newlines(cmd) == cmd
+
+
+def test_unix_preserves_multiline_control_blocks(monkeypatch):
+    """Valid multi-line shell blocks should be passed through unchanged."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    cmd = "for i in 1 2 3; do\n  echo n$i\ndone"
+
+    assert _collapse_embedded_newlines(cmd) == cmd
+
+
+def test_windows_collapses_newlines(monkeypatch):
+    """cmd.exe cannot handle embedded newlines reliably, so keep old behavior."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    cmd = "echo A\necho B"
+
+    assert _collapse_embedded_newlines(cmd) == "echo A echo B"
+
+
+def test_windows_collapses_carriage_returns(monkeypatch):
+    """Windows newline normalization also handles carriage-return-only input."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    cmd = "echo A\recho B"
+
+    assert _collapse_embedded_newlines(cmd) == "echo A echo B"

--- a/tests/unit/agents/tools/test_shell_newlines.py
+++ b/tests/unit/agents/tools/test_shell_newlines.py
@@ -35,7 +35,7 @@ def test_unix_preserves_multiline_control_blocks(monkeypatch):
 
 
 def test_windows_collapses_newlines(monkeypatch):
-    """cmd.exe cannot handle embedded newlines reliably, so keep old behavior."""
+    """Keep newline collapsing on Windows for cmd.exe compatibility."""
     monkeypatch.setattr(sys, "platform", "win32")
 
     cmd = "echo A\necho B"
@@ -44,7 +44,7 @@ def test_windows_collapses_newlines(monkeypatch):
 
 
 def test_windows_collapses_carriage_returns(monkeypatch):
-    """Windows newline normalization also handles carriage-return-only input."""
+    """Also handle carriage-return-only input on Windows."""
     monkeypatch.setattr(sys, "platform", "win32")
 
     cmd = "echo A\recho B"


### PR DESCRIPTION
## Description

This PR fixes `execute_shell_command` newline handling on Unix-like platforms.

Previously `_collapse_embedded_newlines()` collapsed newlines outside quotes on Unix. This changed valid multi-line shell commands into a single line and broke shell constructs that require real newline boundaries, such as:

- multi-line commands
- heredocs
- multi-line `for`/`if`/`case` blocks

For example:

```bash
echo A
echo B
```

was normalized into:

```bash
echo A echo B
```

Heredocs also failed because their delimiters must remain on separate lines.

Unix shells such as `sh` and `bash` already parse newlines correctly, so this PR preserves command strings unchanged on non-Windows platforms. Windows behavior is kept conservative and continues to collapse embedded newlines/carriage returns for compatibility with the existing Windows command path.

## Type of Change

- Bug fix

## Components Affected

- Core
- Tools
- Tests

## Changes

- Preserve embedded newlines on non-Windows platforms.
- Keep newline and carriage-return collapsing behavior on Windows.
- Remove the now-unused Unix newline-collapsing helper.
- Add unit tests for:
  - Unix multi-line commands
  - Unix heredocs
  - Unix multi-line control blocks
  - Windows newline collapsing behavior
  - Windows carriage-return-only collapsing behavior

## Checklist

- [x] Added regression tests for the changed behavior.
- [x] Ran syntax checks for the modified files.
- [x] Ran focused tests for the affected shell tool behavior.
- [x] Ran the relevant `agents/tools` unit test suite for the affected component.
- [x] Documentation update is not required for this internal command-normalization fix.

## Testing

Syntax check:

```bash
python -m py_compile src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell_newlines.py
```

Focused regression tests:

```bash
python -m pytest -q tests/unit/agents/tools/test_shell_newlines.py
```

Result:

```text
5 passed in 1.72s
```

Affected component test suite:

```bash
python -m pytest -q tests/unit/agents/tools -k 'not test_walk_and_grep_file_read_error'
```

Result:

```text
51 passed, 1 deselected
```
