### PR TITLE
fix(coding): standardize copy-to-chat refs and keep IDE on chat nav

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -48,6 +48,7 @@ import { clearAuthToken } from "../api/config";
 import { authApi } from "../api/modules/auth";
 import api from "../api";
 import { usePlugins } from "../plugins/PluginContext";
+import { useCodingMode } from "../stores/codingModeStore";
 import styles from "./index.module.less";
 import { useTheme } from "../contexts/ThemeContext";
 import { KEY_TO_PATH, DEFAULT_OPEN_KEYS } from "./constants";
@@ -80,6 +81,10 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const { message } = useAppMessage();
   const { isDark } = useTheme();
   const { pluginRoutes } = usePlugins();
+  // When coding mode is on, the sidebar "Chat" entry should land on /coding
+  // (FileTree + Editor + Chat panel) rather than the bare Chat page.
+  const { codingMode } = useCodingMode();
+  const chatPath = codingMode ? "/coding" : "/chat";
   const [authEnabled, setAuthEnabled] = useState(false);
   const [accountModalOpen, setAccountModalOpen] = useState(false);
   const [accountLoading, setAccountLoading] = useState(false);
@@ -211,7 +216,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     {
       key: "chat",
       icon: <SparkChatTabFill size={18} />,
-      path: "/chat",
+      path: chatPath,
       label: t("nav.chat"),
     },
     {
@@ -578,7 +583,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                     ? ` ${styles.stickyChatButtonActive}`
                     : ""
                 }`}
-                onClick={() => navigate("/chat")}
+                onClick={() => navigate(chatPath)}
               >
                 <SparkChatTabFill size={16} />
                 <span>{t("nav.chat")}</span>

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -6,7 +6,7 @@
  *       - Switches to DiffEditor (renderSideBySide: false → VS Code inline style)
  *       - "Keep" accepts the new content; "Undo" reverts to original
  *   • Preview mode for images, Markdown, PDF, CSV (toggle per tab)
- *   • Ctrl/Cmd+C copies code with @file:Lx-y context for Chat injection
+ *   • Ctrl/Cmd+C copies code with `path:line[-line]` context for Chat
  *   • Cmd/Ctrl+S to save
  */
 
@@ -105,17 +105,69 @@ function appendToChat(text: string): void {
   textarea.focus();
 }
 
+type CopyMode = "whole-file" | "lines-only" | "with-code";
+
+const stripTrailingNewlines = (s: string) => s.replace(/\n+$/, "");
+
+// Classify a Monaco selection into one of three copy modes:
+//   • whole-file  → output just the path (file contents fully covered)
+//   • lines-only  → output `path:Lx-y` (selection spans complete lines)
+//   • with-code   → output `path:Lx-y` + fenced code block (column-level partial)
+// Geometric quirk handled: a triple-click style selection ending at column 1
+// of the next line is normalised so the displayed end line is the previous one.
+function detectCopyMode(
+  selection: {
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+  },
+  model: MonacoEditor.ITextModel,
+): {
+  mode: CopyMode;
+  code: string;
+  startLine: number;
+  endLine: number;
+} {
+  const code = model.getValueInRange(selection);
+  const startLine = selection.startLineNumber;
+  let endLine = selection.endLineNumber;
+  if (endLine > startLine && selection.endColumn === 1) {
+    endLine -= 1;
+  }
+
+  if (stripTrailingNewlines(code) === stripTrailingNewlines(model.getValue())) {
+    return { mode: "whole-file", code, startLine, endLine };
+  }
+
+  const lines: string[] = [];
+  for (let l = startLine; l <= endLine; l += 1) {
+    lines.push(model.getLineContent(l));
+  }
+  if (stripTrailingNewlines(code) === lines.join("\n")) {
+    return { mode: "lines-only", code, startLine, endLine };
+  }
+
+  return { mode: "with-code", code, startLine, endLine };
+}
+
 function formatSelectionForChat(
   filePath: string,
   code: string,
   startLine: number,
   endLine: number,
+  mode: CopyMode,
 ): string {
-  const lang = getLanguage(filePath);
+  if (mode === "whole-file") {
+    return filePath;
+  }
   const lineRange =
-    startLine === endLine ? `L${startLine}` : `L${startLine}-${endLine}`;
-  const fileName = filePath.split("/").pop() ?? filePath;
-  return `\`${fileName}\` \`${lineRange}\`\n\`\`\`${lang}\n// ${filePath}:${lineRange}\n${code}\n\`\`\``;
+    startLine === endLine ? `${startLine}` : `${startLine}-${endLine}`;
+  if (mode === "lines-only") {
+    return `${filePath}:${lineRange}`;
+  }
+  const lang = getLanguage(filePath);
+  return `${filePath}:${lineRange}\n\`\`\`${lang}\n${code}\n\`\`\``;
 }
 
 // ---------------------------------------------------------------------------
@@ -246,7 +298,7 @@ export default function TabbedEditor({
         );
       });
 
-      // Ctrl/Cmd+C → copy with @file:Lx-y context
+      // Ctrl/Cmd+C → copy with `path:line[-line]` context
       editor.addCommand(
         monaco.KeyMod.CtrlCmd | (monaco.KeyCode.KeyC as unknown as number),
         () => {
@@ -257,20 +309,17 @@ export default function TabbedEditor({
           }
           const model = editor.getModel();
           if (!model) return;
-          const code = model.getValueInRange(sel);
           const filePath = activeTabPathRef.current;
           if (!filePath) {
-            navigator.clipboard.writeText(code).catch(() => undefined);
+            navigator.clipboard
+              .writeText(model.getValueInRange(sel))
+              .catch(() => undefined);
             return;
           }
+          const { mode, code, startLine, endLine } = detectCopyMode(sel, model);
           navigator.clipboard
             .writeText(
-              formatSelectionForChat(
-                filePath,
-                code,
-                sel.startLineNumber,
-                sel.endLineNumber,
-              ),
+              formatSelectionForChat(filePath, code, startLine, endLine, mode),
             )
             .catch(() => undefined);
         },
@@ -297,20 +346,17 @@ export default function TabbedEditor({
           }
           const model = modifiedEditor.getModel();
           if (!model) return;
-          const code = model.getValueInRange(sel);
           const filePath = activeTabPathRef.current;
           if (!filePath) {
-            navigator.clipboard.writeText(code).catch(() => undefined);
+            navigator.clipboard
+              .writeText(model.getValueInRange(sel))
+              .catch(() => undefined);
             return;
           }
+          const { mode, code, startLine, endLine } = detectCopyMode(sel, model);
           navigator.clipboard
             .writeText(
-              formatSelectionForChat(
-                filePath,
-                code,
-                sel.startLineNumber,
-                sel.endLineNumber,
-              ),
+              formatSelectionForChat(filePath, code, startLine, endLine, mode),
             )
             .catch(() => undefined);
         },
@@ -356,15 +402,16 @@ export default function TabbedEditor({
     if (!selection) return;
     const model = editor.getModel();
     if (!model) return;
-    const code = selection.isEmpty()
-      ? model.getValue()
-      : model.getValueInRange(selection);
-    const startLine = selection.isEmpty() ? 1 : selection.startLineNumber;
-    const endLine = selection.isEmpty()
-      ? model.getLineCount()
-      : selection.endLineNumber;
+    // Empty selection ≡ whole-file copy via button.
+    if (selection.isEmpty()) {
+      appendToChat(
+        formatSelectionForChat(activeTabPath, "", 1, 1, "whole-file"),
+      );
+      return;
+    }
+    const { mode, code, startLine, endLine } = detectCopyMode(selection, model);
     appendToChat(
-      formatSelectionForChat(activeTabPath, code, startLine, endLine),
+      formatSelectionForChat(activeTabPath, code, startLine, endLine, mode),
     );
   }, [activeTabPath]);
 

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -111,8 +111,8 @@ const stripTrailingNewlines = (s: string) => s.replace(/\n+$/, "");
 
 // Classify a Monaco selection into one of three copy modes:
 //   • whole-file  → output just the path (file contents fully covered)
-//   • lines-only  → output `path:Lx-y` (selection spans complete lines)
-//   • with-code   → output `path:Lx-y` + fenced code block (column-level partial)
+//   • lines-only  → output `path:x-y` (selection spans complete lines)
+//   • with-code   → output `path:x-y` + fenced code block (column-level partial)
 // Geometric quirk handled: a triple-click style selection ending at column 1
 // of the next line is normalised so the displayed end line is the previous one.
 function detectCopyMode(

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -477,9 +477,13 @@ export default function TabbedEditor({
     // If an undo revert write is in flight, don't create a diff
     if (undoInProgressRef.current.has(path)) return;
 
+    // Treat `added` the same as `modified` for an already-open tab: atomic
+    // saves (e.g. macOS `sed -i ''`, vim, VSCode) replace the file via
+    // rename, which FSEvents reports as a creation rather than a content
+    // change. From the editor's POV, the path's contents just differ.
     const affected = events.some(
       (e) =>
-        e.change === "modified" &&
+        (e.change === "modified" || e.change === "added") &&
         e.path.replace(/\\/g, "/") === path.replace(/\\/g, "/"),
     );
     if (!affected) return;


### PR DESCRIPTION
- TabbedEditor: copy/Ctrl-C now emits IDE-jumpable `path:Lx-y` refs instead of the non-standard `\`fileName\` \`Lx-y\`` header + redundant inline comment. Output adapts to selection: • whole file → `path` • complete lines → `path:Lx-y` • column-level partial → `path:Lx-y` + fenced code block
- Sidebar: "Chat" entry now routes to `/coding` when coding mode is active. Previously it hardcoded `/chat`, so leaving coding mode to any other page and clicking Chat dropped users into the bare Chat view while the toggle still believed coding mode was on — forcing two clicks on the toggle to restore the IDE.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
