### PR TITLE
fix(normalizer): strip cross-provider unsigned thinking blocks for Anthropic

### DIFF
--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -63,6 +63,28 @@ def _clean_provider_specific_fields(
                 block.pop(field, None)
 
 
+def _strip_unsigned_thinking_for_anthropic(msgs: list[Msg]) -> None:
+    """Drop thinking blocks that lack a non-empty ``signature``.
+
+    Anthropic requires ``thinking.signature`` on every thinking block in the
+    request. Blocks carried over from other providers (OpenAI/Qwen reasoning,
+    Gemini thoughts, etc.) have no signature and would 400 the request. Native
+    Claude thinking blocks always carry one, so they survive untouched.
+    """
+    for msg in msgs:
+        if not isinstance(msg.content, list):
+            continue
+        msg.content = [
+            block
+            for block in msg.content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "thinking"
+                and not block.get("signature")
+            )
+        ]
+
+
 def _clone_msg(msg: Msg) -> Msg:
     """Return a deep copy of an AgentScope message."""
     return Msg.from_dict(deepcopy(msg.to_dict()))
@@ -150,6 +172,8 @@ def normalize_messages_for_model_request(
     # the repair has had its chance.
     normalized = _sanitize_tool_messages(normalized)
     _clean_provider_specific_fields(normalized, target_family)
+    if target_family == "anthropic":
+        _strip_unsigned_thinking_for_anthropic(normalized)
     if not supports_multimodal:
         _strip_media_blocks_in_place(normalized)
     return normalized

--- a/tests/unit/agents/test_cross_provider_normalization.py
+++ b/tests/unit/agents/test_cross_provider_normalization.py
@@ -333,8 +333,10 @@ def test_thinking_blocks_preserved_for_openai(monkeypatch) -> None:
     assert thinking_blocks[0]["thinking"] == "Let me consider..."
 
 
-def test_thinking_blocks_preserved_for_anthropic(monkeypatch) -> None:
-    """Thinking blocks must survive normalization for Anthropic."""
+def test_unsigned_thinking_blocks_dropped_for_anthropic(monkeypatch) -> None:
+    """Cross-provider thinking blocks without ``signature`` must be dropped
+    before sending to Anthropic — the API rejects unsigned thinking blocks
+    with ``messages.*.content.*.thinking.signature: Field required``."""
     if AnthropicChatFormatter is None:
         pytest.skip("AnthropicChatFormatter not available")
 
@@ -356,7 +358,53 @@ def test_thinking_blocks_preserved_for_anthropic(monkeypatch) -> None:
 
     blocks = normalized[1].content
     thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
+    assert thinking_blocks == []
+    text_blocks = [b for b in blocks if b.get("type") == "text"]
+    assert len(text_blocks) == 1
+
+
+def test_signed_thinking_blocks_preserved_for_anthropic(monkeypatch) -> None:
+    """Native Claude thinking blocks carry a ``signature`` and must be
+    preserved across normalization so extended-thinking chains stay intact."""
+    if AnthropicChatFormatter is None:
+        pytest.skip("AnthropicChatFormatter not available")
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+
+    history = [
+        Msg(name="user", role="user", content="Think about this"),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "Let me consider...",
+                    "signature": "sig-from-claude",
+                },
+                {"type": "text", "text": "Here is my answer."},
+            ],
+        ),
+    ]
+
+    (
+        normalized,
+        _is_anthropic,
+        _is_gemini,
+    ) = model_factory._normalize_messages_for_formatter(
+        history,
+        AnthropicChatFormatter,
+        SimpleNamespace(),
+    )
+
+    blocks = normalized[1].content
+    thinking_blocks = [b for b in blocks if b.get("type") == "thinking"]
     assert len(thinking_blocks) == 1
+    assert thinking_blocks[0]["signature"] == "sig-from-claude"
 
 
 def test_thinking_blocks_preserved_for_gemini(monkeypatch) -> None:


### PR DESCRIPTION
## Description

- Anthropic's API rejects requests whose assistant messages contain `thinking` blocks without a `signature` (`messages.*.content.*.thinking.signature: Field required`). This 400'd whenever the user reasoned with a non-Claude thinking model (OpenAI/Qwen/etc.) and then switched to a Claude thinking model — the prior turn's `{"type": "thinking", ...}` block had no signature.
- Extended `_clean_provider_specific_fields` in the request normalizer to drop unsigned `thinking` blocks when the target provider family is `anthropic`. Native Claude thinking blocks always carry a signature and are preserved, so extended-thinking chains across consecutive Claude turns are unaffected.

## Test plan
- [x] New unit test: unsigned thinking blocks are dropped before sending to
      Anthropic.
- [x] New unit test: signed (native Claude) thinking blocks survive normalization.
- [x] Existing OpenAI/Gemini thinking-block preservation tests still pass.
- [ ] Manual: reproduce the original flow (reason with a non-Claude thinking
      model, then switch to Claude) and confirm no more 400.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
