### PR TITLE
feat(providers): route non-standard generate_kwargs into extra_body

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -269,9 +269,38 @@ def _sanitize_tool_schemas(
     return sanitized
 
 
+_OPENAI_CREATE_PARAMS = frozenset({
+    "messages", "model", "audio", "frequency_penalty", "function_call",
+    "functions", "logit_bias", "logprobs", "max_completion_tokens",
+    "max_tokens", "metadata", "modalities", "n", "parallel_tool_calls",
+    "prediction", "presence_penalty", "prompt_cache_key",
+    "prompt_cache_retention", "reasoning_effort", "response_format",
+    "safety_identifier", "seed", "service_tier", "stop", "store",
+    "stream", "stream_options", "temperature", "tool_choice", "tools",
+    "top_logprobs", "top_p", "user", "verbosity", "web_search_options",
+    "extra_headers", "extra_query", "extra_body", "timeout",
+})
+
+
 class OpenAIChatModelCompat(OpenAIChatModel):
     """OpenAIChatModel with robust parsing for malformed tool-call chunks
     and transparent ``extra_content`` (Gemini thought_signature) relay."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if self.generate_kwargs:
+            extra_body = self.generate_kwargs.pop("extra_body", None) or {}
+            non_standard = {
+                k: v
+                for k, v in list(self.generate_kwargs.items())
+                if k not in _OPENAI_CREATE_PARAMS
+            }
+            for k in non_standard:
+                del self.generate_kwargs[k]
+            if non_standard:
+                extra_body = {**extra_body, **non_standard}
+            if extra_body:
+                self.generate_kwargs["extra_body"] = extra_body
 
     def _format_tools_json_schemas(
         self,

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -269,6 +269,12 @@ def _sanitize_tool_schemas(
     return sanitized
 
 
+# Parameters accepted by OpenAI SDK's chat.completions.create().
+# Non-standard params (e.g. enable_search) are moved to extra_body.
+# API: https://developers.openai.com/api/reference/resources
+#      /chat/subresources/completions/methods/create
+# SDK: https://github.com/openai/openai-python
+#      ?tab=readme-ov-file#undocumented-request-params
 _OPENAI_CREATE_PARAMS = frozenset(
     {
         "messages",

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -269,17 +269,49 @@ def _sanitize_tool_schemas(
     return sanitized
 
 
-_OPENAI_CREATE_PARAMS = frozenset({
-    "messages", "model", "audio", "frequency_penalty", "function_call",
-    "functions", "logit_bias", "logprobs", "max_completion_tokens",
-    "max_tokens", "metadata", "modalities", "n", "parallel_tool_calls",
-    "prediction", "presence_penalty", "prompt_cache_key",
-    "prompt_cache_retention", "reasoning_effort", "response_format",
-    "safety_identifier", "seed", "service_tier", "stop", "store",
-    "stream", "stream_options", "temperature", "tool_choice", "tools",
-    "top_logprobs", "top_p", "user", "verbosity", "web_search_options",
-    "extra_headers", "extra_query", "extra_body", "timeout",
-})
+_OPENAI_CREATE_PARAMS = frozenset(
+    {
+        "messages",
+        "model",
+        "audio",
+        "frequency_penalty",
+        "function_call",
+        "functions",
+        "logit_bias",
+        "logprobs",
+        "max_completion_tokens",
+        "max_tokens",
+        "metadata",
+        "modalities",
+        "n",
+        "parallel_tool_calls",
+        "prediction",
+        "presence_penalty",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "reasoning_effort",
+        "response_format",
+        "safety_identifier",
+        "seed",
+        "service_tier",
+        "stop",
+        "store",
+        "stream",
+        "stream_options",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p",
+        "user",
+        "verbosity",
+        "web_search_options",
+        "extra_headers",
+        "extra_query",
+        "extra_body",
+        "timeout",
+    },
+)
 
 
 class OpenAIChatModelCompat(OpenAIChatModel):


### PR DESCRIPTION
## Description

Non-standard provider parameters (e.g. DashScope's `enable_search`) configured in `generate_kwargs` are silently rejected by the OpenAI Python SDK, because `client.chat.completions.create()` does not accept unknown keyword arguments.

This PR adds an `__init__` override in `OpenAIChatModelCompat` that automatically moves unrecognized `generate_kwargs` keys into `extra_body`, so they are correctly included in the HTTP request body.

Users can now simply configure `{"enable_search": true}` in a model's `generate_kwargs` and DashScope web search will work.

**Related Issue:** Fixes #4688

**Security Considerations:** N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Configure `{"enable_search": true}` in a DashScope model's `generate_kwargs` via UI
2. Send a query requiring real-time info (e.g. "今天的新闻")
3. Verify model response includes web search results
4. Verify standard params (`temperature`, `max_tokens`) still work as top-level kwargs
5. Verify explicit `{"extra_body": {"enable_search": true}}` form also works

## Local Verification Evidence

```bash
pre-commit run --all-files
# All passed

pytest
# Collection errors in unrelated test files (pre-existing)
```

## Additional Notes

The `_OPENAI_CREATE_PARAMS` frozenset is derived from the OpenAI Python SDK's `AsyncCompletions.create()` method signature. If the SDK adds new parameters in future versions, they would simply remain as top-level kwargs (correct behavior) — no update needed unless a new SDK param name collides with a provider-specific param name (extremely unlikely).