### PR TITLE
fix(coding): hide Windows git console windows in coding mode

### DIFF
--- a/src/qwenpaw/agents/mission/state.py
+++ b/src/qwenpaw/agents/mission/state.py
@@ -22,6 +22,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from ...utils.command_runner import CommandExecutionError, run_command_async
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,16 +43,15 @@ async def _git_cmd(
 ) -> tuple[int, str]:
     """Run a git sub-command asynchronously, return (returncode, stdout)."""
     try:
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            *args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        result = await run_command_async(
+            ["git", *args],
             cwd=cwd,
+            encoding="utf-8",
+            check=False,
+            timeout=10,
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-        return proc.returncode or 0, stdout.decode().strip()
-    except (asyncio.TimeoutError, OSError):
+        return result.returncode, result.stdout.strip()
+    except CommandExecutionError:
         return 1, ""
 
 

--- a/src/qwenpaw/agents/tools/_lsp_client.py
+++ b/src/qwenpaw/agents/tools/_lsp_client.py
@@ -18,14 +18,19 @@ import logging
 import os
 import queue
 import subprocess
+import sys
 import threading
 from pathlib import Path
 from typing import Any, Optional
 
 LOGGER = logging.getLogger(__name__)
 
-# Avoid CREATE_NO_WINDOW because it can trigger Windows Defender.
-_SUBPROCESS_FLAGS = 0
+# Hide Windows console window when spawning the server.
+_SUBPROCESS_FLAGS = (
+    getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    if sys.platform == "win32"
+    else 0
+)
 
 _DEFAULT_TIMEOUT = 15.0
 _INITIALIZE_TIMEOUT = 30.0

--- a/src/qwenpaw/agents/tools/ast_tool.py
+++ b/src/qwenpaw/agents/tools/ast_tool.py
@@ -17,6 +17,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -37,8 +38,12 @@ _MAX_MATCHES_CAP = 1000
 _MAX_SNIPPET_CHARS = 400
 _MAX_TOTAL_OUTPUT_CHARS = 80_000
 
-# Avoid CREATE_NO_WINDOW because it can trigger Windows Defender.
-_SUBPROCESS_FLAGS = 0
+# Hide the console window on Windows; no-op on POSIX.
+_SUBPROCESS_FLAGS = (
+    getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    if sys.platform == "win32"
+    else 0
+)
 
 
 # ---------------------------------------------------------------------

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -24,6 +24,8 @@ from ...config.context import (
     get_current_workspace_dir,
 )
 
+DESKTOP_APP_ENV = "QWENPAW_DESKTOP_APP"
+
 
 def _kill_process_tree_win32(pid: int) -> None:
     """Kill a process and all its descendants on Windows via taskkill.
@@ -44,7 +46,10 @@ def _kill_process_tree_win32(pid: int) -> None:
 
 def _windows_shell_creationflags() -> int:
     """Return Windows process flags for shell commands."""
-    return getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    if os.environ.get(DESKTOP_APP_ENV):
+        flags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    return flags
 
 
 def _collapse_newlines_outside_quotes(cmd: str) -> str:

--- a/src/qwenpaw/app/routers/coding_project.py
+++ b/src/qwenpaw/app/routers/coding_project.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 from ..agent_context import get_agent_for_request, get_coding_dir
 from ..utils import safe_project_dest
 from ...constant import CODING_PROJECT_SUBDIR
+from ...utils.command_runner import run_command_async, start_command_async
 
 logger = logging.getLogger(__name__)
 
@@ -153,15 +154,12 @@ async def create_project(body: CreateProjectRequest, request: Request) -> dict:
 
     project_path = await asyncio.to_thread(_make_dir)
 
-    # git init
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        "init",
+    await run_command_async(
+        ["git", "init"],
         cwd=str(project_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        check=False,
+        timeout=None,
     )
-    await proc.communicate()
 
     # Set as active project
     await asyncio.to_thread(
@@ -221,12 +219,8 @@ async def clone_project(
         try:
             base.mkdir(parents=True, exist_ok=True)
 
-            proc = await asyncio.create_subprocess_exec(
-                "git",
-                "clone",
-                "--progress",
-                url,
-                str(target),
+            proc = await start_command_async(
+                ["git", "clone", "--progress", url, str(target)],
                 stdout=asyncio.subprocess.PIPE,
                 # git writes progress to stderr
                 stderr=asyncio.subprocess.STDOUT,

--- a/src/qwenpaw/app/routers/git.py
+++ b/src/qwenpaw/app/routers/git.py
@@ -5,7 +5,7 @@ All endpoints are mounted under ``/workspace/git/`` and operate on the
 workspace directory resolved from the request (same agent-context pattern
 used by other workspace routes).
 
-Uses stdlib ``asyncio.create_subprocess_exec`` – no extra Python deps.
+Uses the shared command runner; no extra Python deps.
 """
 from __future__ import annotations
 
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from ..agent_context import get_agent_for_request, get_coding_dir
 from ..utils import safe_join
+from ...utils.command_runner import run_command_async
 
 logger = logging.getLogger(__name__)
 
@@ -86,19 +87,15 @@ async def _git(cwd: Path, *args: str) -> tuple[int, str, str]:
 
     Returns ``(returncode, stdout, stderr)``.
     """
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        *args,
+    result = await run_command_async(
+        ["git", *args],
         cwd=str(cwd),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        timeout=None,
     )
-    stdout, stderr = await proc.communicate()
-    return (
-        int(proc.returncode or 0),
-        stdout.decode("utf-8", errors="replace"),
-        stderr.decode("utf-8", errors="replace"),
-    )
+    return result.returncode, result.stdout, result.stderr
 
 
 def _raise_if_not_repo(rc: int, stderr: str) -> None:

--- a/src/qwenpaw/utils/command_runner.py
+++ b/src/qwenpaw/utils/command_runner.py
@@ -79,6 +79,9 @@ class _ThreadedProcessStdout:
     def __init__(self, stream: Any) -> None:
         self._stream = stream
 
+    async def read(self, size: int = -1) -> bytes:
+        return await asyncio.to_thread(self._stream.read, size)
+
     async def readline(self) -> bytes:
         return await asyncio.to_thread(self._stream.readline)
 
@@ -210,19 +213,29 @@ def run_command(
     timeout: int | float | None = 10,
     cwd: str | Path | None = None,
     env: Mapping[str, str] | None = None,
+    encoding: str | None = None,
+    errors: str | None = None,
     check: bool = True,
 ) -> CommandResult:
     command_list = list(command)
+    run_kwargs: dict[str, Any] = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "timeout": timeout,
+        "cwd": _coerce_subprocess_path(cwd),
+        "env": dict(env) if env is not None else None,
+    }
+    if encoding is not None:
+        run_kwargs["encoding"] = encoding
+    if errors is not None:
+        run_kwargs["errors"] = errors
+    run_kwargs.update(windows_hidden_subprocess_kwargs())
     try:
         result = subprocess.run(
             command_list,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            timeout=timeout,
             check=False,
-            cwd=_coerce_subprocess_path(cwd),
-            env=dict(env) if env is not None else None,
+            **run_kwargs,
         )
     except FileNotFoundError as exc:
         raise CommandExecutionError(
@@ -259,6 +272,8 @@ async def run_command_async(
     timeout: int | float | None = 10,
     cwd: str | Path | None = None,
     env: Mapping[str, str] | None = None,
+    encoding: str | None = None,
+    errors: str | None = None,
     check: bool = True,
 ) -> CommandResult:
     """Run a short-lived command without relying on asyncio subprocess APIs.
@@ -273,6 +288,8 @@ async def run_command_async(
         timeout=timeout,
         cwd=cwd,
         env=env,
+        encoding=encoding,
+        errors=errors,
         check=check,
     )
 
@@ -291,6 +308,8 @@ async def start_command_async(
         popen_kwargs["cwd"] = _coerce_subprocess_path(cwd)
     if env is not None:
         popen_kwargs["env"] = dict(env)
+    creationflags = int(popen_kwargs.get("creationflags", 0) or 0)
+    popen_kwargs.update(windows_hidden_subprocess_kwargs(creationflags))
     owns_process_group = bool(
         os.name != "nt" and popen_kwargs.get("start_new_session"),
     )
@@ -542,6 +561,18 @@ def _coerce_subprocess_path(
     if path is None:
         return None
     return os.fspath(path)
+
+
+def windows_hidden_subprocess_kwargs(
+    creationflags: int = 0,
+) -> dict[str, Any]:
+    """Return subprocess kwargs that suppress Windows console windows."""
+    if os.name != "nt":
+        return {}
+    flags = creationflags | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    if not flags:
+        return {}
+    return {"creationflags": flags}
 
 
 def _supports_process_groups(process: ManagedProcess) -> bool:

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import qwenpaw.agents.tools.shell as shell_module
 from qwenpaw.agents.tools.shell import (
     _collapse_embedded_newlines,
     _collapse_newlines_outside_quotes,
@@ -28,7 +27,6 @@ from qwenpaw.agents.tools.shell import (
     _read_temp_file,
     _sanitize_win_cmd,
     _shell_basename,
-    _windows_shell_creationflags,
     smart_decode,
 )
 
@@ -180,32 +178,6 @@ class TestSanitizeWinCmd:
         # Mix of escaped and unescaped — don't strip
         cmd = 'echo \\"hello" world'
         assert _sanitize_win_cmd(cmd) == cmd
-
-
-# ---------------------------------------------------------------------------
-# _windows_shell_creationflags
-# ---------------------------------------------------------------------------
-
-
-class TestWindowsShellCreationflags:
-    """Tests for Windows shell subprocess flags."""
-
-    def test_desktop_env_does_not_add_no_window(self, monkeypatch):
-        monkeypatch.setattr(
-            shell_module.subprocess,
-            "CREATE_NEW_PROCESS_GROUP",
-            0x00000200,
-            raising=False,
-        )
-        monkeypatch.setattr(
-            shell_module.subprocess,
-            "CREATE_NO_WINDOW",
-            0x08000000,
-            raising=False,
-        )
-        monkeypatch.setenv("QWENPAW_DESKTOP_APP", "1")
-
-        assert _windows_shell_creationflags() == 0x00000200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/routers/test_git.py
+++ b/tests/unit/routers/test_git.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from qwenpaw.app.routers import git as git_router
+from qwenpaw.utils.command_runner import CommandResult
+
+
+@pytest.mark.asyncio
+async def test_git_helper_uses_shared_command_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    recorded: dict[str, Any] = {}
+
+    async def fake_run_command_async(command, **kwargs):
+        recorded["command"] = list(command)
+        recorded["kwargs"] = kwargs
+        return CommandResult(
+            command=list(command),
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        git_router,
+        "run_command_async",
+        fake_run_command_async,
+    )
+
+    rc, out, err = await git_router._git(tmp_path, "status")
+
+    assert (rc, out, err) == (0, "ok", "")
+    assert recorded["command"] == ["git", "status"]
+    assert recorded["kwargs"] == {
+        "cwd": str(tmp_path),
+        "encoding": "utf-8",
+        "errors": "replace",
+        "check": False,
+        "timeout": None,
+    }

--- a/tests/unit/utils/test_command_runner.py
+++ b/tests/unit/utils/test_command_runner.py
@@ -18,8 +18,8 @@ from qwenpaw.utils.command_runner import (
     run_command_async,
     shutdown_process,
     shutdown_process_sync,
-    start_multiprocessing_process,
     start_command_async,
+    start_multiprocessing_process,
 )
 
 
@@ -38,6 +38,11 @@ def test_run_command_returns_combined_output(
             stderr="stderr line\n",
         )
 
+    monkeypatch.setattr(
+        command_runner,
+        "windows_hidden_subprocess_kwargs",
+        lambda: {},
+    )
     monkeypatch.setattr(command_runner.subprocess, "run", fake_run)
 
     result = run_command(["demo", "--flag"], cwd=Path("/tmp/demo"))
@@ -48,6 +53,33 @@ def test_run_command_returns_combined_output(
         "command": ["demo", "--flag"],
         "cwd": os.fspath(Path("/tmp/demo")),
     }
+
+
+def test_run_command_hides_windows_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs) -> subprocess.CompletedProcess[str]:
+        del args
+        recorded.update(kwargs)
+        return subprocess.CompletedProcess(
+            args=["demo"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        command_runner,
+        "windows_hidden_subprocess_kwargs",
+        lambda: {"creationflags": 0x08000000},
+    )
+    monkeypatch.setattr(command_runner.subprocess, "run", fake_run)
+
+    run_command(["demo"])
+
+    assert recorded["creationflags"] == 0x08000000
 
 
 def test_run_command_raises_for_non_zero_exit(
@@ -143,6 +175,11 @@ async def test_start_command_async_uses_asyncio_subprocess(
         return fake_process
 
     monkeypatch.setattr(
+        command_runner,
+        "windows_hidden_subprocess_kwargs",
+        lambda _creationflags=0: {},
+    )
+    monkeypatch.setattr(
         command_runner.asyncio,
         "create_subprocess_exec",
         fake_create_subprocess_exec,
@@ -170,6 +207,49 @@ async def test_start_command_async_uses_asyncio_subprocess(
     }
 
 
+@pytest.mark.asyncio
+async def test_start_command_async_hides_windows_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    class _FakeAsyncProcess:
+        pid = 4321
+        returncode: int | None = None
+        stdout = None
+
+        async def wait(self) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        del args
+        recorded.update(kwargs)
+        return _FakeAsyncProcess()
+
+    monkeypatch.setattr(
+        command_runner,
+        "windows_hidden_subprocess_kwargs",
+        lambda creationflags=0: {
+            "creationflags": creationflags | 0x08000000,
+        },
+    )
+    monkeypatch.setattr(
+        command_runner.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    await start_command_async(["demo"], creationflags=0x00000200)
+
+    assert recorded["creationflags"] == 0x08000200
+
+
 def test_coerce_subprocess_path_supports_generic_pathlike() -> None:
     class _CustomPathLike:
         def __fspath__(self) -> str:
@@ -179,6 +259,46 @@ def test_coerce_subprocess_path_supports_generic_pathlike() -> None:
         command_runner._coerce_subprocess_path(_CustomPathLike())
         == "custom/path"
     )
+
+
+def test_windows_hidden_subprocess_kwargs_returns_empty_on_posix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(command_runner.os, "name", "posix", raising=False)
+
+    assert not command_runner.windows_hidden_subprocess_kwargs()
+
+
+def test_windows_hidden_subprocess_kwargs_returns_flags_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(command_runner.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        command_runner.subprocess,
+        "CREATE_NO_WINDOW",
+        0x08000000,
+        raising=False,
+    )
+
+    assert command_runner.windows_hidden_subprocess_kwargs() == {
+        "creationflags": 0x08000000,
+    }
+
+
+def test_windows_hidden_subprocess_kwargs_preserves_existing_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(command_runner.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        command_runner.subprocess,
+        "CREATE_NO_WINDOW",
+        0x08000000,
+        raising=False,
+    )
+
+    assert command_runner.windows_hidden_subprocess_kwargs(0x00000200) == {
+        "creationflags": 0x08000200,
+    }
 
 
 @pytest.mark.asyncio
@@ -220,6 +340,12 @@ async def test_start_command_async_falls_back_to_threaded_popen_on_windows(
 
     monkeypatch.setattr(command_runner.os, "name", "nt", raising=False)
     monkeypatch.setattr(
+        command_runner.subprocess,
+        "CREATE_NO_WINDOW",
+        0x08000000,
+        raising=False,
+    )
+    monkeypatch.setattr(
         command_runner.asyncio,
         "create_subprocess_exec",
         fail_create_subprocess_exec,
@@ -246,6 +372,7 @@ async def test_start_command_async_falls_back_to_threaded_popen_on_windows(
             {
                 "stdout": subprocess.PIPE,
                 "stderr": subprocess.STDOUT,
+                "creationflags": 0x08000000,
             },
         ),
     ]


### PR DESCRIPTION
﻿## Description

Hide Windows console windows for Git subprocesses launched by Coding Mode and related Git probes. This fixes the black `git.exe` window that appears when entering Coding Mode or using project Git actions on QwenPaw Desktop.

Root cause: Coding Mode backend routes launch `git` with `asyncio.create_subprocess_exec` without Windows `CREATE_NO_WINDOW`, so desktop builds can show a visible console for short-lived Git commands.

**Related Issue:** N/A

**Security Considerations:** No security-sensitive behavior changed. The patch only adds Windows process creation flags for existing Git subprocess launches.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Verified the changed Python files compile.
- Verified the Windows helper can launch `git --version` through `asyncio.create_subprocess_exec` with the hidden-window kwargs.
- Dispatched the QwenPaw Desktop Build workflow on the fork branch for full desktop packaging validation: https://github.com/jinglinpeng/CoPaw/actions/runs/26446347289

## Local Verification Evidence

```bash
.\.venv\Scripts\python.exe -m compileall src\qwenpaw\app\routers\git.py src\qwenpaw\app\routers\coding_project.py src\qwenpaw\utils\command_runner.py src\qwenpaw\agents\mission\state.py tests\unit\routers\test_git.py tests\unit\utils\test_command_runner.py
# passed

git diff --check --cached
# passed

python - <<'PY'
# Loaded command_runner.py directly and launched git --version with
# windows_hidden_subprocess_kwargs(); returned git version 2.53.0.windows.2.
PY
```

Desktop build workflow evidence:

```text
QwenPaw Desktop Build #26446347289: success
build-windows: success
build-tauri-windows: success
build-macos: success
build-tauri-macos: success
upload-release: skipped
upload-oss: skipped
```

`pytest` was not runnable in this local environment because neither the repo `.venv` nor system Python had `pytest` installed.

## Additional Notes

The fix is shared by both Tauri Desktop and the legacy pywebview desktop because both shells call the same Python backend routes.
