### PR TITLE
feat(chat): display per-message timestamps in conversation UI

### DIFF
--- a/console/src/pages/Chat/components/MessageTimestamp/index.tsx
+++ b/console/src/pages/Chat/components/MessageTimestamp/index.tsx
@@ -1,0 +1,22 @@
+import dayjs from "dayjs";
+
+interface MessageTimestampProps {
+  data: {
+    created_at: number | string;
+  };
+}
+
+export default function MessageTimestamp({ data }: MessageTimestampProps) {
+  const { created_at } = data;
+  if (!created_at) return null;
+  const t =
+    typeof created_at === "number"
+      ? dayjs.unix(created_at)
+      : dayjs(created_at);
+  if (!t.isValid()) return null;
+  return (
+    <span style={{ fontSize: 11, color: "var(--colorTextSecondary)" }}>
+      {t.format("YYYY-MM-DD HH:mm:ss")}
+    </span>
+  );
+}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -28,6 +28,10 @@ import { IconButton } from "@agentscope-ai/design";
 import ChatActionGroup from "./components/ChatActionGroup";
 import ChatHeaderTitle from "./components/ChatHeaderTitle";
 import ChatSessionInitializer from "./components/ChatSessionInitializer";
+import MessageTimestamp from "./components/MessageTimestamp";
+import {
+  patchLastUserMessageWithTimestamp,
+} from "./utils";
 import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
@@ -999,6 +1003,9 @@ export default function ChatPage() {
         ...buildAuthHeaders(),
       };
 
+      // Add timestamp to the user message that was just created
+      patchLastUserMessageWithTimestamp(chatRef);
+
       try {
         const activeModels = await providerApi.getActiveModels({
           scope: "effective",
@@ -1261,6 +1268,9 @@ export default function ChatPage() {
       },
       customToolRenderConfig:
         Object.keys(toolRenderConfig).length > 0 ? toolRenderConfig : undefined,
+      cards: {
+        MessageTimestamp: MessageTimestamp as React.FC<any>,
+      },
       actions: {
         list: [
           {
@@ -1271,6 +1281,13 @@ export default function ChatPage() {
             ),
             onClick: ({ data }: { data: CopyableResponse }) => {
               void copyResponse(data);
+            },
+          },
+          {
+            render: ({ data: wrapper }: any) => {
+              const completed_at = wrapper?.data?.completed_at;
+              if (!completed_at) return null;
+              return <MessageTimestamp data={{ created_at: completed_at }} />;
             },
           },
         ],

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -9,7 +9,7 @@ import api, {
   type ChatStatus,
   type Message,
 } from "../../../api";
-import { toDisplayUrl } from "../utils";
+import { toDisplayUrl, getMessageCreatedAt, getMessageCompletedAt, createTimestampCard } from "../utils";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -166,25 +166,31 @@ const toOutputMessage = (msg: Message): OutputMessage => ({
 });
 
 /** Build a user card (AgentScopeRuntimeRequestCard) from a user message. */
-function buildUserCard(msg: Message): IAgentScopeRuntimeWebUIMessage {
+function buildUserCard(msg: Message, createdAt?: number | string): IAgentScopeRuntimeWebUIMessage {
   const contentParts = contentToRequestParts(msg.content);
+  const cards: IAgentScopeRuntimeWebUIMessage["cards"] = [
+    {
+      code: "AgentScopeRuntimeRequestCard",
+      data: {
+        input: [
+          {
+            role: "user",
+            type: "message",
+            content: contentParts,
+          },
+        ],
+      },
+    },
+  ];
+
+  if (createdAt) {
+    cards.push(createTimestampCard(createdAt));
+  }
+
   return {
     id: (msg.id as string) || generateId(),
     role: "user",
-    cards: [
-      {
-        code: "AgentScopeRuntimeRequestCard",
-        data: {
-          input: [
-            {
-              role: "user",
-              type: "message",
-              content: contentParts,
-            },
-          ],
-        },
-      },
-    ],
+    cards,
   };
 }
 
@@ -194,8 +200,11 @@ function buildUserCard(msg: Message): IAgentScopeRuntimeWebUIMessage {
  */
 const buildResponseCard = (
   outputMessages: OutputMessage[],
+  createdAt?: number | string,
+  completedAt?: number | string,
 ): IAgentScopeRuntimeWebUIMessage => {
-  const now = Math.floor(Date.now() / 1000);
+  const startTime = createdAt;
+  const endTime = completedAt ?? createdAt;
   const maxSeq = outputMessages.reduce(
     (max, m) => Math.max(max, m.sequence_number || 0),
     0,
@@ -217,10 +226,10 @@ const buildResponseCard = (
           output: normalizedMessages,
           object: "response",
           status: "completed",
-          created_at: now,
+          created_at: startTime,
           sequence_number: maxSeq + 1,
           error: null,
-          completed_at: now,
+          completed_at: endTime,
           usage: null,
         },
       },
@@ -245,13 +254,21 @@ const convertMessages = (
 
   while (i < messages.length) {
     if (messages[i].role === ROLE_USER) {
-      result.push(buildUserCard(messages[i++]));
+      result.push(buildUserCard(messages[i++], getMessageCreatedAt(messages[i - 1])));
     } else {
       const outputMsgs: OutputMessage[] = [];
       while (i < messages.length && messages[i].role !== ROLE_USER) {
         outputMsgs.push(toOutputMessage(messages[i++]));
       }
-      if (outputMsgs.length) result.push(buildResponseCard(outputMsgs));
+      if (outputMsgs.length) {
+        result.push(
+          buildResponseCard(
+            outputMsgs,
+            getMessageCreatedAt(outputMsgs[0]),
+            getMessageCompletedAt(outputMsgs[outputMsgs.length - 1]),
+          ),
+        );
+      }
     }
   }
 

--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -2,6 +2,9 @@ import { describe, it, test, expect, vi } from "vitest";
 import {
   extractCopyableText,
   extractUserMessageText,
+  getMessageCreatedAt,
+  getMessageCompletedAt,
+  createTimestampCard,
   buildModelError,
   toStoredName,
   normalizeContentUrls,
@@ -241,5 +244,86 @@ describe("toDisplayUrl", () => {
     expect(toDisplayUrl("file:///uploads/img.png")).toBe(
       "http://localhost:8000/uploads/img.png",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMessageCreatedAt
+// ---------------------------------------------------------------------------
+describe("getMessageCreatedAt", () => {
+  it("extracts created_at from metadata", () => {
+    const msg = { metadata: { created_at: 1710000000 } };
+    expect(getMessageCreatedAt(msg)).toBe(1710000000);
+  });
+
+  it("handles string timestamps", () => {
+    const msg = { metadata: { created_at: "2026-05-26 19:30:48.149" } };
+    expect(getMessageCreatedAt(msg)).toBe("2026-05-26 19:30:48.149");
+  });
+
+  it("returns undefined when metadata is missing", () => {
+    expect(getMessageCreatedAt({})).toBeUndefined();
+  });
+
+  it("returns undefined when created_at is not set", () => {
+    const msg = { metadata: {} };
+    expect(getMessageCreatedAt(msg)).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined input", () => {
+    expect(getMessageCreatedAt(null)).toBeUndefined();
+    expect(getMessageCreatedAt(undefined)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMessageCompletedAt
+// ---------------------------------------------------------------------------
+describe("getMessageCompletedAt", () => {
+  it("extracts completed_at from nested metadata", () => {
+    const msg = {
+      metadata: { metadata: { completed_at: "2026-05-26 19:30:51.191" } },
+    };
+    expect(getMessageCompletedAt(msg)).toBe("2026-05-26 19:30:51.191");
+  });
+
+  it("returns undefined when outer metadata is missing", () => {
+    expect(getMessageCompletedAt({})).toBeUndefined();
+  });
+
+  it("returns undefined when inner metadata is missing", () => {
+    const msg = { metadata: {} };
+    expect(getMessageCompletedAt(msg)).toBeUndefined();
+  });
+
+  it("returns undefined when completed_at is not set", () => {
+    const msg = { metadata: { metadata: {} } };
+    expect(getMessageCompletedAt(msg)).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined input", () => {
+    expect(getMessageCompletedAt(null)).toBeUndefined();
+    expect(getMessageCompletedAt(undefined)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTimestampCard
+// ---------------------------------------------------------------------------
+describe("createTimestampCard", () => {
+  it("builds correct card structure with number timestamp", () => {
+    const card = createTimestampCard(1710000000);
+    expect(card).toEqual({
+      code: "MessageTimestamp",
+      data: { created_at: 1710000000 },
+    });
+  });
+
+  it("builds correct card structure with string timestamp", () => {
+    const card = createTimestampCard("2026-05-26 19:30:48.149");
+    expect(card).toEqual({
+      code: "MessageTimestamp",
+      data: { created_at: "2026-05-26 19:30:48.149" },
+    });
   });
 });

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -2,6 +2,7 @@
 // Types
 // ---------------------------------------------------------------------------
 import { chatApi } from "../../api/modules/chat";
+import type { IAgentScopeRuntimeWebUIRef } from "@agentscope-ai/chat";
 export type CopyableContent = {
   type?: string;
   text?: string;
@@ -187,6 +188,59 @@ export function toDisplayUrl(url: string | undefined): string {
 // ---------------------------------------------------------------------------
 // DOM utilities
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Timestamp utilities
+// ---------------------------------------------------------------------------
+
+/** Extract created_at from a backend message's metadata. */
+export function getMessageCreatedAt(
+  msg: Record<string, unknown> | null | undefined,
+): number | string | undefined {
+  const meta = msg?.metadata as { created_at?: number | string } | undefined;
+  return meta?.created_at;
+}
+
+/** Extract completed_at from a backend message's metadata. */
+export function getMessageCompletedAt(
+  msg: Record<string, unknown> | null | undefined,
+): number | string | undefined {
+  const outer = msg?.metadata as Record<string, unknown> | undefined;
+  const inner = outer?.metadata as { completed_at?: number | string } | undefined;
+  return inner?.completed_at;
+}
+
+/** Build a MessageTimestamp card object. */
+export function createTimestampCard(
+  createdAt: number | string,
+): { code: string; data: { created_at: number | string } } {
+  return { code: "MessageTimestamp", data: { created_at: createdAt } };
+}
+
+/**
+ * Patch the last user message in the current session with a timestamp card.
+ * Safe to call multiple times — skips messages that already have one.
+ */
+export function patchLastUserMessageWithTimestamp(
+  chatRef: { current: IAgentScopeRuntimeWebUIRef | null },
+): void {
+  const msgs = chatRef.current?.messages?.getMessages() || [];
+  const lastUserMsg = [...msgs].reverse().find((m) => m.role === "user");
+  if (!lastUserMsg) return;
+
+  const alreadyPatched = lastUserMsg.cards?.some(
+    (c) => c.code === "MessageTimestamp",
+  );
+  if (alreadyPatched) return;
+
+  chatRef.current?.messages?.updateMessage({
+    id: lastUserMsg.id,
+    cards: [
+      ...(lastUserMsg.cards || []),
+      createTimestampCard(Math.floor(Date.now() / 1000)),
+    ],
+  });
+}
 
 /** Set textarea value and trigger input event for React state sync.
  * Uses native value setter to bypass React's internal value tracker.

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine
 
@@ -942,6 +943,15 @@ class AgentRunner(Runner):
                         len(new_messages) if new_messages else 0,
                         session_id,
                     )
+
+                # Stamp the last Msg with the response completion time so
+                # the frontend can display the same timestamp after refresh.
+                if agent is not None and agent.memory is not None:
+                    mem_content = agent.memory.content
+                    if mem_content:
+                        mem_content[-1][0].metadata["completed_at"] = (
+                            datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                        )
 
                 await self.session.save_session_state(
                     session_id=session_id,

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -361,6 +361,7 @@ def agentscope_msg_to_message(
             "original_id": msg.id,
             "original_name": msg.name,
             "metadata": msg.metadata,
+            "created_at": msg.timestamp,
         }
 
         if isinstance(msg.content, str):


### PR DESCRIPTION
## Description

Add HH:mm:ss timestamps next to each message in the chat interface. User messages show creation time, assistant messages show completion time. Timestamps persist correctly across page refreshes.

**Related Issue:** 

Relates to #4662

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Additional Notes
时间戳效果如下：
<img width="1194" height="859" alt="image" src="https://github.com/user-attachments/assets/4d20c8e0-ea18-4d61-8b69-4df3f5b2186d" />

[Optional: any other context]
