### PR TITLE
fix(tools): handle ToolResponse text blocks robustly

### DIFF
--- a/src/qwenpaw/agents/memory/proactive/proactive_utils.py
+++ b/src/qwenpaw/agents/memory/proactive/proactive_utils.py
@@ -251,7 +251,13 @@ async def _analyze_screen_activity(
 
         content = screenshot_result.content
         if isinstance(content, list) and len(content) > 0:
-            result_text = content[0].get("text", "")
+            first_block = content[0]
+            if hasattr(first_block, "text"):
+                result_text = str(getattr(first_block, "text", ""))
+            elif isinstance(first_block, dict):
+                result_text = str(first_block.get("text", ""))
+            else:
+                result_text = str(first_block)
         else:
             result_text = str(content)
 

--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -332,7 +332,13 @@ async def edit_file(
     )
 
     if write_response.content and len(write_response.content) > 0:
-        write_text = write_response.content[0].get("text", "")
+        first_block = write_response.content[0]
+        if hasattr(first_block, "text"):
+            write_text = str(getattr(first_block, "text", ""))
+        elif isinstance(first_block, dict):
+            write_text = str(first_block.get("text", ""))
+        else:
+            write_text = str(first_block)
         if write_text.startswith("Error:"):
             return write_response
 


### PR DESCRIPTION
## Description
Fix runtime crash when accessing ToolResponse content blocks as attributes instead of dicts. Replace `content[0].get("text", "")` with a robust fallback (`hasattr(.text)` → `isinstance(dict)` → `str()`) in `_analyze_screen_activity` and `edit_file`, matching the existing pattern in `extract_content()`.

## Type of Change
- [x] Bug fix

## Component(s) Affected
- [x] Core

## Checklist
- [x] Run and pass `pre-commit run --all-files`
- [x] Run and pass relevant tests

## Testing
Existing tests pass. Reproduced crash by calling `desktop_screenshot()` → `_analyze_screen_activity` with TextBlock content, confirmed fix resolves `AttributeError`.

## Local Verification Evidence
```bash
pre-commit run --all-files
# passed

pytest
# passed
```
