### PR TITLE
# feat(coding): per-hunk Keep/Undo + smart copy-to-chat in diff editor

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -65,6 +65,7 @@ import {
   type RuntimeLoadingBridgeApi,
 } from "./utils";
 import { openExternalLink } from "../../utils/openExternalLink";
+import { getLastEditorCopy } from "../Coding/lastEditorCopy";
 
 const CHAT_ATTACHMENT_MAX_MB = 10;
 
@@ -564,6 +565,57 @@ function useChatInputDraft(isChatActive: () => boolean) {
   }, [isChatActive]);
 }
 
+/**
+ * When the user pastes into the chat textarea text that was just copied
+ * from the Coding-mode editor, swap the raw paste for the formatted
+ * `path:line[-line]` version (plus optional fenced code). Cmd/Ctrl+C in
+ * the editor stays as a plain-text copy for paste-anywhere; only Chat
+ * pastes get the editor-context format.
+ *
+ * Not gated by route: the Chat composer is also embedded in Coding
+ * mode (side-by-side with the editor), and that's the primary place
+ * users do an editor→chat copy. The handler is already selective (it
+ * checks the paste target is a sender textarea AND the pasted text
+ * matches the last editor copy), so a global listener is safe.
+ */
+function useChatPasteFromEditor() {
+  useEffect(() => {
+    // Anything older than this is treated as stale (different copy session).
+    const STALE_MS = 60_000;
+
+    const handlePaste = (e: ClipboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target || target.tagName !== "TEXTAREA") return;
+      if (!target.closest('[class*="sender"]')) return;
+
+      const last = getLastEditorCopy();
+      if (!last) return;
+      if (Date.now() - last.ts > STALE_MS) return;
+
+      const pasted = e.clipboardData?.getData("text/plain");
+      if (pasted == null || pasted !== last.text) return;
+
+      e.preventDefault();
+      const textarea = target as HTMLTextAreaElement;
+      const start = textarea.selectionStart ?? textarea.value.length;
+      const end = textarea.selectionEnd ?? textarea.value.length;
+      const before = textarea.value.slice(0, start);
+      const after = textarea.value.slice(end);
+      const next = before + last.formatted + after;
+      setTextareaValue(textarea, next);
+      const caret = before.length + last.formatted.length;
+      requestAnimationFrame(() => {
+        textarea.selectionStart = textarea.selectionEnd = caret;
+      });
+    };
+
+    document.addEventListener("paste", handlePaste, true);
+    return () => {
+      document.removeEventListener("paste", handlePaste, true);
+    };
+  }, []);
+}
+
 function RuntimeLoadingBridge({
   bridgeRef,
 }: {
@@ -826,6 +878,7 @@ export default function ChatPage() {
 
   useMessageHistoryNavigation(chatRef, isChatActive, isComposingRef);
   useChatInputDraft(isChatActive);
+  useChatPasteFromEditor();
 
   const onFileCardClick = useCallback(
     (fileInfo: { name?: string; size?: number; url?: string }) => {

--- a/console/src/pages/Coding/TabbedEditor.module.less
+++ b/console/src/pages/Coding/TabbedEditor.module.less
@@ -229,6 +229,71 @@
   overflow: hidden;
 }
 
+// ---- Diff editor wrap + per-hunk action overlays --------------------------
+// The wrap is a positioning context for the per-hunk Keep / Undo
+// overlays that float on top of the DiffEditor. Monaco renders inside
+// the wrap; the overlays are React siblings positioned by absolute
+// `top` (in px) driven by Monaco's view-zone onDomNodeTop callback.
+//
+// Why an overlay (not a Monaco widget): clicks on DOM that lives inside
+// Monaco's view-zones or content-widgets get hijacked by Monaco's mouse
+// handler (focus + preventDefault). Rendering buttons OUTSIDE Monaco
+// sidesteps the whole event-handler chain.
+.diffWrap {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.hunkWidget {
+  position: absolute;
+  right: 24px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 0;
+  background: transparent;
+  pointer-events: auto;
+  z-index: 5;
+}
+
+.hunkBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 18px;
+  padding: 0 8px;
+  font-size: 11px;
+  line-height: 1;
+  border: 1px solid;
+  border-radius: 3px;
+  background: var(--body-background, #fff);
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.hunkKeepBtn {
+  color: #52c41a;
+  border-color: rgba(82, 196, 26, 0.4);
+
+  &:hover {
+    background: rgba(82, 196, 26, 0.12);
+  }
+}
+
+.hunkUndoBtn {
+  color: #ff4d4f;
+  border-color: rgba(255, 77, 79, 0.35);
+
+  &:hover {
+    background: rgba(255, 77, 79, 0.1);
+  }
+}
+
 // ---- Empty state -----------------------------------------------------------
 .empty {
   height: 100%;
@@ -315,5 +380,25 @@
 
   .emptyText {
     color: rgba(255, 255, 255, 0.35);
+  }
+
+  .hunkBtn {
+    background: #2a2a2a;
+  }
+
+  .hunkKeepBtn {
+    border-color: rgba(82, 196, 26, 0.45);
+
+    &:hover {
+      background: rgba(82, 196, 26, 0.18);
+    }
+  }
+
+  .hunkUndoBtn {
+    border-color: rgba(255, 77, 79, 0.4);
+
+    &:hover {
+      background: rgba(255, 77, 79, 0.16);
+    }
   }
 }

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -4,9 +4,10 @@
  *   • Monaco model-per-path (undo history & cursor persist on tab switch)
  *   • Inline Diff view when Agent modifies the open file:
  *       - Switches to DiffEditor (renderSideBySide: false → VS Code inline style)
- *       - "Keep" accepts the new content; "Undo" reverts to original
+ *       - Per-hunk "Keep"/"Undo" widgets + global "Keep all"/"Undo all"
  *   • Preview mode for images, Markdown, PDF, CSV (toggle per tab)
- *   • Ctrl/Cmd+C copies code with `path:line[-line]` context for Chat
+ *   • Toolbar "Copy to Chat" button injects `path:line[-line]` context
+ *     into the Chat composer (raw Cmd/Ctrl+C still copies plain text)
  *   • Cmd/Ctrl+S to save
  */
 
@@ -34,6 +35,7 @@ import { workspaceApi } from "../../api/modules/workspace";
 import { useWorkspaceWatch } from "../../hooks/useWorkspaceWatch";
 import { useTheme } from "../../contexts/ThemeContext";
 import { setTextareaValue } from "../Chat/utils";
+import { setLastEditorCopy } from "./lastEditorCopy";
 import {
   useCurrentDiffs,
   useCodingTabsStore,
@@ -171,6 +173,76 @@ function formatSelectionForChat(
 }
 
 // ---------------------------------------------------------------------------
+// Hunk-level Keep / Undo helpers
+// ---------------------------------------------------------------------------
+
+interface Hunk {
+  originalStartLineNumber: number;
+  originalEndLineNumber: number;
+  modifiedStartLineNumber: number;
+  modifiedEndLineNumber: number;
+}
+
+// Convert Monaco's 1-indexed inclusive [startLine..endLine] range to a
+// 0-indexed [start, end) slice range. When endLine === 0 (or below
+// startLine) the change is a pure insert with no source-side lines, so
+// the range collapses to an empty slice at the insertion point.
+function rangeFromLines(
+  startLine: number,
+  endLine: number,
+): { start: number; end: number } {
+  if (endLine === 0 || endLine < startLine) {
+    return { start: startLine, end: startLine };
+  }
+  return { start: startLine - 1, end: endLine };
+}
+
+// Bake a hunk's modified content into the original baseline. The returned
+// string is the new `original` for the pending diff; the kept block
+// becomes equal on both sides and stops being a hunk, while other hunks
+// remain visible.
+function applyKeepHunk(original: string, modified: string, hunk: Hunk): string {
+  const origLines = original.split("\n");
+  const modLines = modified.split("\n");
+  const o = rangeFromLines(
+    hunk.originalStartLineNumber,
+    hunk.originalEndLineNumber,
+  );
+  const m = rangeFromLines(
+    hunk.modifiedStartLineNumber,
+    hunk.modifiedEndLineNumber,
+  );
+  const replacement = modLines.slice(m.start, m.end);
+  return [
+    ...origLines.slice(0, o.start),
+    ...replacement,
+    ...origLines.slice(o.end),
+  ].join("\n");
+}
+
+// Revert a hunk's modified content back to the original. The returned
+// string is the new `modified` (which the caller should also write back
+// to disk so the on-disk file matches the visible state).
+function applyUndoHunk(original: string, modified: string, hunk: Hunk): string {
+  const origLines = original.split("\n");
+  const modLines = modified.split("\n");
+  const o = rangeFromLines(
+    hunk.originalStartLineNumber,
+    hunk.originalEndLineNumber,
+  );
+  const m = rangeFromLines(
+    hunk.modifiedStartLineNumber,
+    hunk.modifiedEndLineNumber,
+  );
+  const replacement = origLines.slice(o.start, o.end);
+  return [
+    ...modLines.slice(0, m.start),
+    ...replacement,
+    ...modLines.slice(m.end),
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -225,7 +297,34 @@ export default function TabbedEditor({
    */
   const { selectedAgent } = useAgentStore();
   const pendingDiffs = useCurrentDiffs();
-  const { setDiff, removeDiff, updateDiffModified } = useCodingTabsStore();
+  const { setDiff, removeDiff, updateDiffModified, updateDiffOriginal } =
+    useCodingTabsStore();
+
+  /**
+   * Per-hunk Keep / Undo widgets are rendered as React JSX in an
+   * absolutely-positioned overlay layered on top of the DiffEditor,
+   * NOT inside Monaco's DOM. Earlier attempts using Monaco view zones
+   * or content widgets to host the buttons hit a wall: Monaco's mouse
+   * handler intercepts mousedown on its own children and prevents the
+   * click from firing. Rendering buttons outside Monaco entirely makes
+   * clicks fire normally.
+   *
+   * The empty view zones added below exist only to push code lines
+   * apart so the overlay has a 22px-tall gap to sit in (no source-text
+   * overlap). Monaco reports the pixel-top of each zone via
+   * `onDomNodeTop`, which is what drives the overlay positions.
+   */
+  const diffEditorRef = useRef<MonacoEditor.IStandaloneDiffEditor | null>(null);
+  const hunkZoneIdsRef = useRef<string[]>([]);
+
+  // Each overlay: the line-change it represents, plus the pixel-top of
+  // its view zone (kept in sync via onDomNodeTop and editor scroll).
+  interface HunkOverlay {
+    zoneId: string;
+    change: MonacoEditor.ILineChange;
+    top: number;
+  }
+  const [hunkOverlays, setHunkOverlays] = useState<HunkOverlay[]>([]);
 
   const activeTab = tabs.find((t) => t.path === activeTabPath) ?? null;
   const activeDiffRaw = activeTabPath ? pendingDiffs[activeTabPath] : undefined;
@@ -286,7 +385,7 @@ export default function TabbedEditor({
   }, []);
 
   const handleMount = useCallback(
-    (editor: MonacoEditor.IStandaloneCodeEditor, monaco: Monaco) => {
+    (editor: MonacoEditor.IStandaloneCodeEditor) => {
       editorRef.current = editor;
 
       editor.onDidChangeCursorSelection((e) => {
@@ -297,73 +396,135 @@ export default function TabbedEditor({
             sel.startColumn !== sel.endColumn,
         );
       });
-
-      // Ctrl/Cmd+C → copy with `path:line[-line]` context
-      editor.addCommand(
-        monaco.KeyMod.CtrlCmd | (monaco.KeyCode.KeyC as unknown as number),
-        () => {
-          const sel = editor.getSelection();
-          if (!sel || sel.isEmpty()) {
-            document.execCommand("copy");
-            return;
-          }
-          const model = editor.getModel();
-          if (!model) return;
-          const filePath = activeTabPathRef.current;
-          if (!filePath) {
-            navigator.clipboard
-              .writeText(model.getValueInRange(sel))
-              .catch(() => undefined);
-            return;
-          }
-          const { mode, code, startLine, endLine } = detectCopyMode(sel, model);
-          navigator.clipboard
-            .writeText(
-              formatSelectionForChat(filePath, code, startLine, endLine, mode),
-            )
-            .catch(() => undefined);
-        },
-      );
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
   /**
-   * Register the Ctrl/Cmd+C override on the modified (right) pane of the
-   * DiffEditor so copy-to-Chat context works even in diff review mode.
+   * Cmd/Ctrl+C in any of our editors (normal or diff-modified): let
+   * Monaco run its native copy (plain text → system clipboard), then
+   * snapshot the selection so the Chat composer's paste handler can
+   * swap in `path:line[-line]` format when the same text lands in the
+   * chat textarea.
+   *
+   * Registered at document level (capture) so it fires regardless of
+   * which Monaco instance owns the copy (regular vs diff editor) and
+   * regardless of bubbling quirks.
+   */
+  useEffect(() => {
+    const onCopy = () => {
+      const path = activeTabPathRef.current;
+      if (!path) return;
+      // Prefer the diff editor's modified pane when in diff mode,
+      // otherwise fall back to the regular editor.
+      const editor: MonacoEditor.IStandaloneCodeEditor | null =
+        diffEditorRef.current?.getModifiedEditor() ?? editorRef.current;
+      if (!editor) return;
+      // Only act when the copy originated from this editor (focused).
+      if (!editor.hasTextFocus()) return;
+      const sel = editor.getSelection();
+      const model = editor.getModel();
+      if (!sel || !model) return;
+      if (sel.isEmpty()) return;
+      const { mode, code, startLine, endLine } = detectCopyMode(sel, model);
+      const formatted = formatSelectionForChat(
+        path,
+        code,
+        startLine,
+        endLine,
+        mode,
+      );
+      if (formatted !== code) {
+        setLastEditorCopy({ text: code, formatted, ts: Date.now() });
+      }
+    };
+    document.addEventListener("copy", onCopy, true);
+    return () => document.removeEventListener("copy", onCopy, true);
+  }, []);
+
+  /**
+   * Re-create per-hunk spacer view zones to match the diff editor's
+   * current line changes, and seed the React overlay state for those
+   * zones. Called on mount and on every onDidUpdateDiff so spacers /
+   * overlays stay aligned with the diff state.
+   *
+   * The zones themselves are empty 22px placeholders — they exist only
+   * to push code lines apart so the floating overlay (rendered in JSX
+   * outside Monaco) has a gap to sit in without covering source text.
+   */
+  const refreshHunkWidgets = useCallback(() => {
+    const diffEditor = diffEditorRef.current;
+    if (!diffEditor) return;
+    const modifiedEditor = diffEditor.getModifiedEditor();
+
+    // Tear down previous spacer zones before adding fresh ones.
+    if (hunkZoneIdsRef.current.length > 0) {
+      modifiedEditor.changeViewZones((accessor) => {
+        for (const zoneId of hunkZoneIdsRef.current) {
+          accessor.removeZone(zoneId);
+        }
+      });
+      hunkZoneIdsRef.current = [];
+    }
+
+    const lineChanges = diffEditor.getLineChanges();
+    if (!lineChanges || lineChanges.length === 0) {
+      setHunkOverlays([]);
+      return;
+    }
+
+    // Build the next overlay list in a single React state update.
+    // Each zone is empty (just creates 22px of vertical space). Monaco
+    // calls onDomNodeTop with the zone's pixel-top whenever it changes
+    // (initial layout, scroll, content edits) — we use that to drive
+    // the React overlay's `top: …px` style.
+    const next: HunkOverlay[] = [];
+    modifiedEditor.changeViewZones((accessor) => {
+      for (const change of lineChanges) {
+        // afterLineNumber: 0 means "before line 1". For modification or
+        // pure addition, anchor the zone right above modifiedStart. For
+        // pure deletion (modifiedEndLineNumber === 0) Monaco reports
+        // the line *after* which the deletion appears, so we anchor
+        // there directly — the zone shows at the deletion gap.
+        const afterLine =
+          change.modifiedEndLineNumber === 0
+            ? change.modifiedStartLineNumber
+            : change.modifiedStartLineNumber - 1;
+
+        const spacer = document.createElement("div");
+        const zoneId = accessor.addZone({
+          afterLineNumber: Math.max(0, afterLine),
+          heightInPx: 22,
+          domNode: spacer,
+          onDomNodeTop: (top) => {
+            setHunkOverlays((prev) =>
+              prev.map((o) => (o.zoneId === zoneId ? { ...o, top } : o)),
+            );
+          },
+        });
+        hunkZoneIdsRef.current.push(zoneId);
+        next.push({ zoneId, change, top: 0 });
+      }
+    });
+    setHunkOverlays(next);
+  }, []);
+
+  /**
+   * Wire up per-hunk spacer view zones on the modified (right) pane of
+   * the DiffEditor. Monaco's `onDomNodeTop` callback (set per zone in
+   * refreshHunkWidgets) fires whenever a zone's on-screen top changes
+   * — including on scroll — so we don't need a separate scroll
+   * listener; the React overlay tops stay in sync automatically.
    */
   const handleDiffMount: DiffOnMount = useCallback(
-    (diffEditor, monaco) => {
-      const modifiedEditor = diffEditor.getModifiedEditor();
-      modifiedEditor.addCommand(
-        monaco.KeyMod.CtrlCmd | (monaco.KeyCode.KeyC as unknown as number),
-        () => {
-          const sel = modifiedEditor.getSelection();
-          if (!sel || sel.isEmpty()) {
-            document.execCommand("copy");
-            return;
-          }
-          const model = modifiedEditor.getModel();
-          if (!model) return;
-          const filePath = activeTabPathRef.current;
-          if (!filePath) {
-            navigator.clipboard
-              .writeText(model.getValueInRange(sel))
-              .catch(() => undefined);
-            return;
-          }
-          const { mode, code, startLine, endLine } = detectCopyMode(sel, model);
-          navigator.clipboard
-            .writeText(
-              formatSelectionForChat(filePath, code, startLine, endLine, mode),
-            )
-            .catch(() => undefined);
-        },
-      );
+    (diffEditor) => {
+      diffEditorRef.current = diffEditor;
+      diffEditor.onDidUpdateDiff(() => refreshHunkWidgets());
+      // Initial pass — Monaco may have already finished diffing by the
+      // time we mount (small files), so run once eagerly.
+      refreshHunkWidgets();
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [refreshHunkWidgets],
   );
 
   // ---- Save ---------------------------------------------------------------
@@ -464,6 +625,85 @@ export default function TabbedEditor({
     onTabContentChange,
     onTabDirtyChange,
   ]);
+
+  /**
+   * Keep a single hunk: bake its modified content into the original
+   * baseline. The kept block stops being a diff; remaining hunks stay.
+   * If this collapses the whole diff, drop it entirely.
+   */
+  const handleKeepHunk = useCallback(
+    (hunk: Hunk) => {
+      const diff = pendingDiffs[activeTabPath];
+      if (!diff || diff.modified === null) return;
+      const newOriginal = applyKeepHunk(diff.original, diff.modified, hunk);
+      if (newOriginal === diff.modified) {
+        removeDiff(selectedAgent, activeTabPath);
+        onTabContentChange(activeTabPath, diff.modified);
+        onTabDirtyChange(activeTabPath, false);
+      } else {
+        updateDiffOriginal(selectedAgent, activeTabPath, newOriginal);
+      }
+    },
+    [
+      activeTabPath,
+      pendingDiffs,
+      selectedAgent,
+      removeDiff,
+      updateDiffOriginal,
+      onTabContentChange,
+      onTabDirtyChange,
+    ],
+  );
+
+  /**
+   * Undo a single hunk: revert its modified content to the original and
+   * persist that to disk. Other hunks remain. If the file ends up equal
+   * to the original baseline, drop the diff entirely.
+   */
+  const handleUndoHunk = useCallback(
+    async (hunk: Hunk) => {
+      const diff = pendingDiffs[activeTabPath];
+      if (!diff || diff.modified === null) return;
+      const newModified = applyUndoHunk(diff.original, diff.modified, hunk);
+
+      undoInProgressRef.current.add(activeTabPath);
+      try {
+        await workspaceApi.saveCodeFile(activeTabPath, newModified);
+      } catch {
+        // ignore — UI state is updated below regardless
+      } finally {
+        setTimeout(() => undoInProgressRef.current.delete(activeTabPath), 1500);
+      }
+
+      if (newModified === diff.original) {
+        removeDiff(selectedAgent, activeTabPath);
+      } else {
+        updateDiffModified(selectedAgent, activeTabPath, newModified);
+      }
+      onTabContentChange(activeTabPath, newModified);
+      onTabDirtyChange(activeTabPath, false);
+    },
+    [
+      activeTabPath,
+      pendingDiffs,
+      selectedAgent,
+      removeDiff,
+      updateDiffModified,
+      onTabContentChange,
+      onTabDirtyChange,
+    ],
+  );
+
+  // When the diff goes away (Keep all, Undo all, or final hunk
+  // resolved), Monaco unmounts the DiffEditor — drop our local
+  // bookkeeping. Monaco disposes its own view zones on unmount.
+  const hasActiveDiff = activeDiff != null;
+  useEffect(() => {
+    if (hasActiveDiff) return;
+    hunkZoneIdsRef.current = [];
+    diffEditorRef.current = null;
+    setHunkOverlays([]);
+  }, [hasActiveDiff]);
 
   // ---- File-watch: show inline diff instead of silent reload ---------------
 
@@ -582,30 +822,30 @@ export default function TabbedEditor({
         </span>
 
         {activeDiff ? (
-          /* Diff mode: show Keep / Undo */
+          /* Diff mode: show global Keep all / Undo all */
           <div className={styles.diffActions}>
             <span className={styles.diffLabel}>
               <GitCompareArrows size={12} />
               Agent changed this file
             </span>
-            <Tooltip title="Keep changes (accept)">
+            <Tooltip title="Keep all changes in this file">
               <button
                 type="button"
                 className={`${styles.iconBtn} ${styles.keepBtn}`}
                 onClick={handleKeep}
               >
                 <Check size={13} />
-                Keep
+                Keep all
               </button>
             </Tooltip>
-            <Tooltip title="Undo changes (revert to original)">
+            <Tooltip title="Undo all changes in this file (revert to original)">
               <button
                 type="button"
                 className={`${styles.iconBtn} ${styles.undoBtn}`}
                 onClick={() => void handleUndo()}
               >
                 <RotateCcw size={13} />
-                Undo
+                Undo all
               </button>
             </Tooltip>
           </div>
@@ -670,26 +910,58 @@ export default function TabbedEditor({
           activeTab &&
           (activeDiff ? (
             /* ── Inline diff view (VS Code "Copilot Edits" style) ─────── */
-            <DiffEditor
-              height="100%"
-              original={activeDiff.original}
-              modified={activeDiff.modified}
-              language={getLanguage(activeTab.path)}
-              theme={isDark ? "vs-dark" : "light"}
-              beforeMount={handleBeforeMount}
-              onMount={handleDiffMount}
-              options={{
-                renderSideBySide: false,
-                readOnly: false,
-                originalEditable: false,
-                minimap: { enabled: false },
-                fontSize: 13,
-                lineNumbers: "on",
-                scrollBeyondLastLine: false,
-                wordWrap: "off",
-                renderOverviewRuler: false,
-              }}
-            />
+            <div className={styles.diffWrap}>
+              <DiffEditor
+                height="100%"
+                original={activeDiff.original}
+                modified={activeDiff.modified}
+                language={getLanguage(activeTab.path)}
+                theme={isDark ? "vs-dark" : "light"}
+                beforeMount={handleBeforeMount}
+                onMount={handleDiffMount}
+                options={{
+                  renderSideBySide: false,
+                  readOnly: false,
+                  originalEditable: false,
+                  minimap: { enabled: false },
+                  fontSize: 13,
+                  lineNumbers: "on",
+                  scrollBeyondLastLine: false,
+                  wordWrap: "off",
+                  renderOverviewRuler: false,
+                }}
+              />
+              {/* Per-hunk Keep / Undo overlays — rendered as React JSX
+                  OUTSIDE Monaco's DOM (positioned over the editor). The
+                  buttons must live outside Monaco because Monaco's
+                  mouseHandler captures mousedown on its own children
+                  (view zones, content widgets) and prevents the click
+                  from firing. */}
+              {hunkOverlays.map((ov) => (
+                <div
+                  key={ov.zoneId}
+                  className={styles.hunkWidget}
+                  style={{ top: ov.top }}
+                >
+                  <button
+                    type="button"
+                    className={`${styles.hunkBtn} ${styles.hunkKeepBtn}`}
+                    onClick={() => handleKeepHunk(ov.change)}
+                  >
+                    <Check size={11} style={{ marginRight: 4 }} />
+                    Keep
+                  </button>
+                  <button
+                    type="button"
+                    className={`${styles.hunkBtn} ${styles.hunkUndoBtn}`}
+                    onClick={() => void handleUndoHunk(ov.change)}
+                  >
+                    <RotateCcw size={11} style={{ marginRight: 4 }} />
+                    Undo
+                  </button>
+                </div>
+              ))}
+            </div>
           ) : (
             /* ── Normal editor ──────────────────────────────────────────── */
             <Editor
@@ -699,7 +971,7 @@ export default function TabbedEditor({
               language={getLanguage(activeTab.path)}
               theme={isDark ? "vs-dark" : "light"}
               beforeMount={handleBeforeMount}
-              onMount={(editor, monaco) => handleMount(editor, monaco)}
+              onMount={handleMount}
               onChange={(v) => {
                 onTabContentChange(activeTabPath, v ?? "");
                 onTabDirtyChange(activeTabPath, true);

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -35,7 +35,7 @@ import { workspaceApi } from "../../api/modules/workspace";
 import { useWorkspaceWatch } from "../../hooks/useWorkspaceWatch";
 import { useTheme } from "../../contexts/ThemeContext";
 import { setTextareaValue } from "../Chat/utils";
-import { setLastEditorCopy } from "./lastEditorCopy";
+import { clearLastEditorCopy, setLastEditorCopy } from "./lastEditorCopy";
 import {
   useCurrentDiffs,
   useCodingTabsStore,
@@ -413,19 +413,23 @@ export default function TabbedEditor({
    */
   useEffect(() => {
     const onCopy = () => {
+      // Any copy event that does NOT originate from our editor
+      // invalidates the cache — otherwise a same-text copy elsewhere
+      // (e.g. a markdown preview in the same page) would still trigger
+      // the formatted swap on the next chat paste.
       const path = activeTabPathRef.current;
-      if (!path) return;
-      // Prefer the diff editor's modified pane when in diff mode,
-      // otherwise fall back to the regular editor.
       const editor: MonacoEditor.IStandaloneCodeEditor | null =
         diffEditorRef.current?.getModifiedEditor() ?? editorRef.current;
-      if (!editor) return;
-      // Only act when the copy originated from this editor (focused).
-      if (!editor.hasTextFocus()) return;
+      if (!path || !editor || !editor.hasTextFocus()) {
+        clearLastEditorCopy();
+        return;
+      }
       const sel = editor.getSelection();
       const model = editor.getModel();
-      if (!sel || !model) return;
-      if (sel.isEmpty()) return;
+      if (!sel || !model || sel.isEmpty()) {
+        clearLastEditorCopy();
+        return;
+      }
       const { mode, code, startLine, endLine } = detectCopyMode(sel, model);
       const formatted = formatSelectionForChat(
         path,
@@ -436,6 +440,8 @@ export default function TabbedEditor({
       );
       if (formatted !== code) {
         setLastEditorCopy({ text: code, formatted, ts: Date.now() });
+      } else {
+        clearLastEditorCopy();
       }
     };
     document.addEventListener("copy", onCopy, true);

--- a/console/src/pages/Coding/lastEditorCopy.ts
+++ b/console/src/pages/Coding/lastEditorCopy.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-scoped record of the most recent copy-from-editor action.
+ *
+ * Cmd/Ctrl+C in the Coding-mode editor writes plain text to the system
+ * clipboard (default Monaco behavior) and ALSO stashes the copied text
+ * + source coordinates here. The Chat composer's paste handler reads
+ * this back: if the pasted text matches `text` exactly, the textarea
+ * receives the formatted `path:line[-line]` (plus optional fenced code)
+ * version instead of the raw text — so pastes outside Chat stay plain
+ * but Chat-bound pastes carry editor context.
+ */
+export interface LastEditorCopy {
+  text: string;
+  formatted: string;
+  // Wall-clock ms; consumers may ignore stale entries.
+  ts: number;
+}
+
+let last: LastEditorCopy | null = null;
+
+export function setLastEditorCopy(entry: LastEditorCopy): void {
+  last = entry;
+}
+
+export function getLastEditorCopy(): LastEditorCopy | null {
+  return last;
+}
+
+export function clearLastEditorCopy(): void {
+  last = null;
+}

--- a/console/src/stores/codingTabsStore.ts
+++ b/console/src/stores/codingTabsStore.ts
@@ -45,6 +45,7 @@ interface CodingTabsState {
   setDiff: (agentId: string, path: string, diff: PendingDiff) => void;
   removeDiff: (agentId: string, path: string) => void;
   updateDiffModified: (agentId: string, path: string, modified: string) => void;
+  updateDiffOriginal: (agentId: string, path: string, original: string) => void;
 }
 
 const omitKey = <T extends object>(obj: T, key: string): T => {
@@ -156,6 +157,22 @@ export const useCodingTabsStore = create<CodingTabsState>()(
               [agentId]: {
                 ...agentDiffs,
                 [path]: { ...existing, modified },
+              },
+            },
+          };
+        }),
+
+      updateDiffOriginal: (agentId, path, original) =>
+        set((state) => {
+          const agentDiffs = state.diffsByAgent[agentId] ?? {};
+          const existing = agentDiffs[path];
+          if (!existing) return state;
+          return {
+            diffsByAgent: {
+              ...state.diffsByAgent,
+              [agentId]: {
+                ...agentDiffs,
+                [path]: { ...existing, original },
               },
             },
           };


### PR DESCRIPTION
## Summary

- **Per-hunk Keep / Undo overlays** in the Coding-mode inline diff view, complementing the existing global *Keep all* / *Undo all* toolbar actions. Each hunk gets its own pair of buttons floating to the right of the hunk's top edge.
- **Smart copy-to-chat**: pasting editor-copied text into the Chat composer now auto-swaps the raw text for the `path:line[-line]` formatted version (with optional fenced code). Pasting *outside* the chat composer stays plain text — i.e. raw `Cmd/Ctrl+C` is unchanged for all other paste targets.

## Why

- Reviewing an Agent's multi-hunk edit was all-or-nothing. Users wanted to accept some hunks while reverting others without manual surgery.
- Cross-referencing code in chat ("look at this function") required either screenshotting or manually typing `foo.ts:42`. We now do it automatically, but only when the destination is the chat composer — so general copy/paste behavior is preserved.

## What changed

### Per-hunk Keep / Undo

| File | Change |
|---|---|
| `console/src/pages/Coding/TabbedEditor.tsx` | New `applyKeepHunk` / `applyUndoHunk` pure helpers; `handleKeepHunk` / `handleUndoHunk` reducers; spacer view zones via `onDomNodeTop` to track pixel positions; React overlay JSX layered over the `<DiffEditor>`. |
| `console/src/pages/Coding/TabbedEditor.module.less` | New `.diffWrap` positioning context + `.hunkWidget` / `.hunkBtn` / `.hunkKeepBtn` / `.hunkUndoBtn` styles (incl. dark-mode variants). |
| `console/src/stores/codingTabsStore.ts` | New `updateDiffOriginal` action so a single-hunk Keep can bake the kept block into the baseline while leaving other hunks visible. |

### Smart copy-to-chat

| File | Change |
|---|---|
| `console/src/pages/Coding/lastEditorCopy.ts` (new) | Module-scoped cache: stores `{ text, formatted, ts }` for the most recent editor copy. |
| `console/src/pages/Coding/TabbedEditor.tsx` | Document-level capture-phase `copy` listener writes the cache when a selection is copied from the regular Editor *or* DiffEditor modified pane (`hasTextFocus()` confirms the source). Existing `Cmd+C` Monaco override removed — plain text reaches the system clipboard unchanged. |
| `console/src/pages/Chat/index.tsx` | New `useChatPasteFromEditor` hook installs a document-level capture-phase `paste` listener. When the target is a sender textarea AND the pasted text exactly matches the last editor copy AND the entry is fresh (<60s), it swaps in the formatted version. |

## Design notes

### Why React-overlay, not Monaco widgets

The per-hunk buttons went through several iterations:

1. **Monaco `ContentWidget` + React** — clickable, but anchored above the line so for top-of-file hunks the widget rendered off-screen / overlapped source above.
2. **Monaco view zones with React (`createRoot`) inside the zone DOM** — fixed visibility but clicks silently never fired.
3. **Monaco view zones with plain DOM + native `addEventListener`** — still not clickable.
4. **Monaco view zones with `suppressMouseDown: false`** — still not clickable.

Root cause (from `monaco-editor`'s `mouseHandler.js`): Monaco's editor-level mouse handler classifies any pointer event landing on a view-zone descendant as a `CONTENT_VIEW_ZONE` target and runs `focus()` + `mouseDownOperation.start()` + `preventDefault()`, which interferes with the button's mouseup → click sequence. The flag named `suppressMouseDown` only changes *whether Monaco handles it as a cursor placement*; it doesn't take Monaco's mouse path out of the way.

The reliable fix: render the buttons **outside Monaco's DOM entirely**. Spacer view zones still push code lines apart (so the buttons have a 22px gap to sit in), but the buttons themselves are React JSX siblings of `<DiffEditor>` inside a `position: relative` wrapper. Monaco tells us each spacer zone's current pixel-top via the `onDomNodeTop` callback (which fires on initial layout *and* scroll), and we drive the React overlay's `top` style from that. Clicks fire normally because no Monaco event handler is in the path.

### Why the `copy` cache + paste swap (not `clipboardData.setData`)

Writing `path:line[...]` directly to the system clipboard via `setData('text/plain', ...)` would hijack `Cmd+V` everywhere, including the user's terminal, browser address bar, Slack, etc. — which is exactly what we don't want (and what previously frustrated users).

Instead, we:
1. Let Monaco's native copy do its thing — plain text goes to the system clipboard.
2. Stash the same selection + its formatted twin in a tiny module cache.
3. At paste time, in the chat composer only, if `clipboardData.getData('text/plain') === cache.text`, we swap the formatted version into the textarea in-place.

This means: paste into terminal → plain text. Paste into VS Code → plain text. Paste into our chat composer → enriched with file/line context. No global side effects.

## Test plan

- [ ] Have an Agent edit a file with **multiple hunks**; verify each hunk shows its own Keep / Undo overlay to the right of the gap above the hunk.
- [ ] Click per-hunk **Keep** on one hunk — that hunk dismisses; other hunks remain visible.
- [ ] Click per-hunk **Undo** on one hunk — that hunk reverts on disk; other hunks remain visible.
- [ ] After resolving all hunks individually, diff state clears and editor returns to normal mode.
- [ ] Global **Keep all** / **Undo all** still works.
- [ ] Hunk at **line 1** is visible and clickable (no top clipping).
- [ ] Scroll the diff — overlays follow their hunks correctly.
- [ ] Select code, `Cmd+C`, paste into **terminal / browser URL bar** → plain text.
- [ ] Select code, `Cmd+C`, paste into **chat composer** → comes through as `path:line\n\`\`\`lang\n…\n\`\`\``.
- [ ] Same test but in **Coding mode's embedded chat panel** (right side of `/coding`).
- [ ] Same test from the **diff editor's modified pane** (during an Agent edit).
- [ ] Dark mode: per-hunk buttons readable and styled correctly.
- [ ] Lint: `npx eslint src/pages/Coding/TabbedEditor.tsx` clean (no new errors).
- [ ] Typecheck: `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
