### PR TITLE
fix: avoid hidden Windows subprocess flags

### DIFF
--- a/src/qwenpaw/agents/tools/_lsp_client.py
+++ b/src/qwenpaw/agents/tools/_lsp_client.py
@@ -18,19 +18,14 @@ import logging
 import os
 import queue
 import subprocess
-import sys
 import threading
 from pathlib import Path
 from typing import Any, Optional
 
 LOGGER = logging.getLogger(__name__)
 
-# Hide Windows console window when spawning the server.
-_SUBPROCESS_FLAGS = (
-    getattr(subprocess, "CREATE_NO_WINDOW", 0)
-    if sys.platform == "win32"
-    else 0
-)
+# Avoid CREATE_NO_WINDOW because it can trigger Windows Defender.
+_SUBPROCESS_FLAGS = 0
 
 _DEFAULT_TIMEOUT = 15.0
 _INITIALIZE_TIMEOUT = 30.0

--- a/src/qwenpaw/agents/tools/ast_tool.py
+++ b/src/qwenpaw/agents/tools/ast_tool.py
@@ -17,7 +17,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -38,12 +37,8 @@ _MAX_MATCHES_CAP = 1000
 _MAX_SNIPPET_CHARS = 400
 _MAX_TOTAL_OUTPUT_CHARS = 80_000
 
-# Hide the console window on Windows; no-op on POSIX.
-_SUBPROCESS_FLAGS = (
-    getattr(subprocess, "CREATE_NO_WINDOW", 0)
-    if sys.platform == "win32"
-    else 0
-)
+# Avoid CREATE_NO_WINDOW because it can trigger Windows Defender.
+_SUBPROCESS_FLAGS = 0
 
 
 # ---------------------------------------------------------------------

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -24,9 +24,6 @@ from ...config.context import (
     get_current_workspace_dir,
 )
 
-DESKTOP_APP_ENV = "QWENPAW_DESKTOP_APP"
-
-
 def _kill_process_tree_win32(pid: int) -> None:
     """Kill a process and all its descendants on Windows via taskkill.
 
@@ -46,10 +43,7 @@ def _kill_process_tree_win32(pid: int) -> None:
 
 def _windows_shell_creationflags() -> int:
     """Return Windows process flags for shell commands."""
-    flags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-    if os.environ.get(DESKTOP_APP_ENV):
-        flags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
-    return flags
+    return getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 
 
 def _collapse_newlines_outside_quotes(cmd: str) -> str:

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -24,6 +24,7 @@ from ...config.context import (
     get_current_workspace_dir,
 )
 
+
 def _kill_process_tree_win32(pid: int) -> None:
     """Kill a process and all its descendants on Windows via taskkill.
 

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import qwenpaw.agents.tools.shell as shell_module
 from qwenpaw.agents.tools.shell import (
     _collapse_embedded_newlines,
     _collapse_newlines_outside_quotes,
@@ -27,6 +28,7 @@ from qwenpaw.agents.tools.shell import (
     _read_temp_file,
     _sanitize_win_cmd,
     _shell_basename,
+    _windows_shell_creationflags,
     smart_decode,
 )
 
@@ -178,6 +180,32 @@ class TestSanitizeWinCmd:
         # Mix of escaped and unescaped — don't strip
         cmd = 'echo \\"hello" world'
         assert _sanitize_win_cmd(cmd) == cmd
+
+
+# ---------------------------------------------------------------------------
+# _windows_shell_creationflags
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsShellCreationflags:
+    """Tests for Windows shell subprocess flags."""
+
+    def test_desktop_env_does_not_add_no_window(self, monkeypatch):
+        monkeypatch.setattr(
+            shell_module.subprocess,
+            "CREATE_NEW_PROCESS_GROUP",
+            0x00000200,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            shell_module.subprocess,
+            "CREATE_NO_WINDOW",
+            0x08000000,
+            raising=False,
+        )
+        monkeypatch.setenv("QWENPAW_DESKTOP_APP", "1")
+
+        assert _windows_shell_creationflags() == 0x00000200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove `CREATE_NO_WINDOW` from Windows agent subprocess flags to avoid Defender-triggering process creation
- keep `CREATE_NEW_PROCESS_GROUP` for shell process-group handling
- add a regression test for the desktop environment flag path

## Root Cause
PR #3813 reintroduced `CREATE_NO_WINDOW` for desktop shell commands after PR #3717 had removed it to avoid Windows Defender issues. PR #4578 also added the same hidden-window flag to new coding-mode subprocess helpers.

## Validation
- `.\.venv\Scripts\python.exe -m py_compile src\qwenpaw\agents\tools\shell.py src\qwenpaw\agents\tools\ast_tool.py src\qwenpaw\agents\tools\_lsp_client.py tests\unit\agents\tools\test_shell.py`
- `git diff --check`

Full pytest was not run locally because the current `.venv` does not have `pytest` installed.