### PR TITLE
fix(agents): preserve reasoning_content across file blocks in assistant messages

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -655,6 +655,13 @@ def _fix_image_mime_types(messages: list[dict]) -> None:
 
 _MEDIA_BLOCK_TYPES = ("image", "audio", "video")
 
+# Block types that the upstream agentscope OpenAI / Gemini formatters
+# silently drop. We track them here so we can predict which assistant
+# messages will be dropped before alignment in FileBlockSupportFormatter.
+# Keep this in sync with the `else: logger.warning("Unsupported block
+# type ...")` branch in agentscope's _openai_formatter.
+_FORMATTER_SKIPPED_TYPES = frozenset({"thinking", "file"})
+
 
 def _fixup_media_list(items: list) -> None:
     """Normalize media blocks in a list in-place.
@@ -662,6 +669,10 @@ def _fixup_media_list(items: list) -> None:
     - Strips ``file://`` prefixes from source URLs.
     - Replaces media blocks whose local file no longer exists with
       a text placeholder so the downstream formatter won't throw.
+    - Converts ``file`` blocks to text placeholders, since neither the
+      OpenAI nor the Anthropic top-level formatters accept ``file``
+      blocks (the upstream OpenAI formatter silently drops them, which
+      can drop the whole message if nothing else survives).
     - Recurses into ``tool_result`` output lists.
     """
     for i, block in enumerate(items):
@@ -694,6 +705,30 @@ def _fixup_media_list(items: list) -> None:
                         f" — file deleted from disk]"
                     ),
                 }
+        elif btype == "file":
+            source = block.get("source") or {}
+            file_url = (
+                source.get("url", "") if isinstance(source, dict) else ""
+            )
+            readable_path = (
+                _file_url_to_path(file_url)
+                if isinstance(file_url, str) and file_url.startswith("file://")
+                else file_url
+            )
+            filename = (
+                block.get("filename")
+                or block.get("name")
+                or (readable_path.rsplit("/", 1)[-1] if readable_path else "")
+                or "file"
+            )
+            items[i] = {
+                "type": "text",
+                "text": (
+                    f"File '{filename}' is available at: {readable_path}"
+                    if readable_path
+                    else f"File '{filename}'"
+                ),
+            }
         elif btype == "tool_result":
             output = block.get("output")
             if isinstance(output, list):
@@ -828,12 +863,19 @@ def _create_file_block_support_formatter(
                 for m in (
                     msg for msg in normalized_msgs if msg.role == "assistant"
                 ):
-                    is_thinking_only = (
+                    # A message is dropped by the base formatter when every
+                    # block is one the formatter skips (currently "thinking"
+                    # and "file" — see _FORMATTER_SKIPPED_TYPES). Predicting
+                    # this lets us align reasoning_content correctly.
+                    is_dropped_by_formatter = (
                         isinstance(m.content, list)
                         and m.content
-                        and all(b.get("type") == "thinking" for b in m.content)
+                        and all(
+                            b.get("type") in _FORMATTER_SKIPPED_TYPES
+                            for b in m.content
+                        )
                     )
-                    if not is_thinking_only:
+                    if not is_dropped_by_formatter:
                         aligned_reasoning.append(
                             reasoning_contents.get(id(m)),
                         )
@@ -843,10 +885,21 @@ def _create_file_block_support_formatter(
                 ]
 
                 if len(aligned_reasoning) != len(out_assistant):
+                    # A mismatch means a message was dropped by the base
+                    # formatter that our predictor did not anticipate
+                    # (likely a new block type that should be added to
+                    # _FORMATTER_SKIPPED_TYPES). Index-based alignment past
+                    # the drop point would attribute every subsequent
+                    # message's reasoning to the wrong response — actively
+                    # misleading. Skip injection for this turn only and
+                    # warn loudly so the gap can be closed at the source.
                     logger.warning(
                         "Assistant message count mismatch after formatting "
                         "(%d expected survivors, %d actual). "
-                        "Skipping reasoning_content injection.",
+                        "Skipping reasoning_content injection for this turn. "
+                        "A block type is likely being dropped by the base "
+                        "formatter without being listed in "
+                        "_FORMATTER_SKIPPED_TYPES — please investigate.",
                         len(aligned_reasoning),
                         len(out_assistant),
                     )

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -728,10 +728,15 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
 
     # ------------------------------------------------------------------
     # Media-block fallback: strip unsupported media blocks (image, audio,
-    # video) from memory and retry when the model rejects them.
+    # video, file) from memory and retry when the model rejects them.
+    # Unlike model_factory._fixup_media_list (which converts file blocks
+    # to text placeholders so the user-facing message history stays
+    # readable), this fallback strips them entirely — its purpose is to
+    # make a previously-rejected request retryable, so leaving residue
+    # would defeat the point.
     # ------------------------------------------------------------------
 
-    _MEDIA_BLOCK_TYPES = {"image", "audio", "video"}
+    _MEDIA_BLOCK_TYPES = {"image", "audio", "video", "file"}
 
     # ------------------------------------------------------------------
     # Plan gate: block non-create_plan tools when /plan gate is active

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -16,7 +16,13 @@ from agentscope.message import Msg
 from ...constant import MEDIA_UNSUPPORTED_PLACEHOLDER
 from .tool_message_utils import _sanitize_tool_messages
 
-_MEDIA_BLOCK_TYPES = {"image", "audio", "video"}
+# Block types stripped from copied messages during request-time normalization
+# when the target model cannot accept them. ``file`` is included so the
+# OpenAI/Anthropic strip path matches the model-rejection fallback in
+# QwenPawAgent. Note: model_factory._fixup_media_list converts ``file``
+# blocks to text placeholders rather than stripping them — that path
+# preserves user-facing history; this one prepares retryable requests.
+_MEDIA_BLOCK_TYPES = {"image", "audio", "video", "file"}
 
 # Fields that are provider-specific and should not leak across families.
 # Gemini: extra_content carries thought_signature.


### PR DESCRIPTION
## Description

- Convert top-level `file` blocks to text placeholders in `_fixup_media_list` so they survive the upstream OpenAI / Anthropic formatters instead of being silently dropped. Fixes the `[thinking, file]`-only assistant message case where the entire message vanished, throwing reasoning_content alignment off by one and permanently disabling injection for the rest of the session (issue #4691).
- Broaden the survivor predictor (`is_thinking_only` → `is_dropped_by_formatter`) via a new `_FORMATTER_SKIPPED_TYPES` constant so future formatter-dropped block types are easy to register.
- Add `"file"` to the two other `_MEDIA_BLOCK_TYPES` copies (`react_agent.py`, `message_request_normalizer.py`) so the model-rejection fallback and non-multimodal request normalization strip file blocks consistently.
- Improve the count-mismatch warning to point at `_FORMATTER_SKIPPED_TYPES` so the next unknown block type is fast to diagnose. Index-based "best-effort" alignment was rejected on review — misattributing reasoning to the wrong response is worse than skipping a turn.

Fixes #4691


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
