### PR TITLE
feat(telegram): add tool_guard interactive approval via inline keyboard

### DIFF
--- a/src/qwenpaw/app/channels/telegram/cards/__init__.py
+++ b/src/qwenpaw/app/channels/telegram/cards/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""Telegram channel interactive card support (inline keyboard buttons)."""
+from .dispatcher import CardKind, TelegramCardHandler
+
+__all__ = ["TelegramCardHandler", "CardKind"]

--- a/src/qwenpaw/app/channels/telegram/cards/context.py
+++ b/src/qwenpaw/app/channels/telegram/cards/context.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Shared helpers used by Telegram card kinds.
+
+Covers extracting metadata / body text from runtime Msg objects and
+building stateless routing context for button callbacks.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Event / message extraction
+# ---------------------------------------------------------------------
+
+
+def extract_meta(event: Any) -> Optional[Dict[str, Any]]:
+    """Return the original ``Msg.metadata`` dict, unwrapping the
+    ``metadata.metadata`` nesting the runtime introduces."""
+    metadata = getattr(event, "metadata", None) or {}
+    if not isinstance(metadata, dict):
+        return None
+    inner = metadata.get("metadata")
+    meta = inner if isinstance(inner, dict) else metadata
+    return meta if isinstance(meta, dict) else None
+
+
+def extract_body_text(content: Any) -> str:
+    """Flatten ``Message.content`` into a plain string."""
+    if not content:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for item in content:
+        if hasattr(item, "text") and item.text:
+            parts.append(item.text)
+        elif isinstance(item, dict) and item.get("type") == "text":
+            parts.append(item.get("text") or "")
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------
+# Routing context
+# ---------------------------------------------------------------------
+
+
+def build_session_ctx(
+    to_handle: str,
+    send_meta: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Routing info cached alongside callback_data so the inbound
+    handler can recover the original session/sender/chat."""
+    meta = send_meta or {}
+    chat_id = str(meta.get("chat_id") or to_handle or "")
+    sender_id = str(meta.get("sender_id") or meta.get("user_id") or "")
+    session_id = str(meta.get("session_id") or "")
+    is_group = bool(meta.get("is_group", False))
+    message_thread_id = meta.get("message_thread_id")
+
+    ctx: Dict[str, Any] = {
+        "chat_id": chat_id,
+        "sender_id": sender_id,
+        "session_id": session_id,
+        "is_group": is_group,
+    }
+    if message_thread_id is not None:
+        ctx["message_thread_id"] = message_thread_id
+    return ctx
+
+
+__all__ = [
+    "extract_meta",
+    "extract_body_text",
+    "build_session_ctx",
+]

--- a/src/qwenpaw/app/channels/telegram/cards/dispatcher.py
+++ b/src/qwenpaw/app/channels/telegram/cards/dispatcher.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Telegram interactive card dispatcher (routing-only).
+
+Two lookup tables drive the dispatch:
+
+* ``_by_message_type``        — outbound: ``metadata.message_type`` → ``render``.
+* ``_by_callback_data_prefix`` — inbound: ``callback_data`` prefix  → ``handle``.
+
+Public entry-points (called by :class:`~..channel.TelegramChannel`):
+:meth:`try_send_card_for_event` and :meth:`handle_callback_query`.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Optional,
+)
+
+from . import context
+
+if TYPE_CHECKING:
+    from ..channel import TelegramChannel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------
+# Registry record
+# ---------------------------------------------------------------------
+
+RenderFn = Callable[
+    ["TelegramChannel", str, Any, Dict[str, Any], Dict[str, Any]],
+    Awaitable[bool],
+]
+
+HandleFn = Callable[["TelegramChannel", Any], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class CardKind:
+    """Describes one kind of interactive card and its handlers."""
+
+    name: str
+    message_type: str
+    callback_data_prefix: str
+    render: RenderFn
+    handle: HandleFn
+
+
+# ---------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------
+
+
+class TelegramCardHandler:
+    """Routing-only dispatcher for Telegram inline keyboard cards."""
+
+    def __init__(self, channel: "TelegramChannel") -> None:
+        self._channel = channel
+        self._by_message_type: Dict[str, CardKind] = {}
+        self._by_callback_data_prefix: Dict[str, CardKind] = {}
+        self._register_kinds()
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(self, kind: CardKind) -> None:
+        """Install a card kind into both lookup tables."""
+        self._by_message_type[kind.message_type] = kind
+        self._by_callback_data_prefix[kind.callback_data_prefix] = kind
+
+    def _register_kinds(self) -> None:
+        """Register every built-in card kind."""
+        from . import tool_guard
+
+        self.register(
+            CardKind(
+                name=tool_guard.NAME,
+                message_type=tool_guard.MESSAGE_TYPE,
+                callback_data_prefix=tool_guard.CALLBACK_DATA_PREFIX,
+                render=tool_guard.render,
+                handle=tool_guard.handle,
+            ),
+        )
+
+    # ==================================================================
+    # Public entry-points
+    # ==================================================================
+
+    async def try_send_card_for_event(
+        self,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        *,
+        compact: bool = False,
+    ) -> bool:
+        """Render ``event`` as an inline keyboard card if any kind matches.
+
+        Returns ``True`` when a card was sent so the caller can skip
+        the default text rendering.
+
+        When ``compact=True`` (streaming mode), the render function
+        produces a minimal card (buttons only, no body text).
+        """
+        meta = context.extract_meta(event)
+        if meta is None:
+            return False
+        kind = self._by_message_type.get(str(meta.get("message_type") or ""))
+        if kind is None:
+            return False
+
+        try:
+            return await kind.render(
+                self._channel,
+                to_handle,
+                event,
+                send_meta,
+                meta,
+                compact=compact,
+            )
+        except Exception:
+            logger.exception(
+                "telegram card render failed: kind=%s",
+                kind.name,
+            )
+            return False
+
+    async def handle_callback_query(self, query: Any) -> None:
+        """Route a CallbackQuery to the matching card kind's handler.
+
+        Called from the CallbackQueryHandler registered in the
+        Application builder.
+        """
+        data = getattr(query, "data", None) or ""
+        kind = self._lookup_kind_for_callback(data)
+        if kind is None:
+            return
+
+        try:
+            await kind.handle(self._channel, query)
+        except Exception:
+            logger.exception(
+                "telegram card handle failed: kind=%s",
+                kind.name,
+            )
+
+    def is_card_event(self, event: Any) -> bool:
+        """Check if the event matches a registered interactive card kind."""
+        meta = context.extract_meta(event)
+        if meta is None:
+            return False
+        message_type = str(meta.get("message_type") or "")
+        return message_type in self._by_message_type
+
+    def _lookup_kind_for_callback(
+        self,
+        callback_data: str,
+    ) -> Optional[CardKind]:
+        """Find the CardKind matching the callback_data prefix."""
+        if not callback_data:
+            return None
+        for prefix, kind in self._by_callback_data_prefix.items():
+            if callback_data.startswith(prefix):
+                return kind
+        return None
+
+
+__all__ = ["TelegramCardHandler", "CardKind"]

--- a/src/qwenpaw/app/channels/telegram/cards/dispatcher.py
+++ b/src/qwenpaw/app/channels/telegram/cards/dispatcher.py
@@ -4,8 +4,8 @@
 
 Two lookup tables drive the dispatch:
 
-* ``_by_message_type``        — outbound: ``metadata.message_type`` → ``render``.
-* ``_by_callback_data_prefix`` — inbound: ``callback_data`` prefix  → ``handle``.
+* ``_by_message_type``  — outbound: message_type → render.
+* ``_by_callback_data_prefix`` — inbound: prefix → handle.
 
 Public entry-points (called by :class:`~..channel.TelegramChannel`):
 :meth:`try_send_card_for_event` and :meth:`handle_callback_query`.
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------
 
 RenderFn = Callable[
-    ["TelegramChannel", str, Any, Dict[str, Any], Dict[str, Any]],
+    ...,
     Awaitable[bool],
 ]
 

--- a/src/qwenpaw/app/channels/telegram/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/telegram/cards/tool_guard.py
@@ -1,0 +1,505 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Telegram tool-guard approval card (inline keyboard buttons).
+
+Uses Telegram's InlineKeyboardMarkup to send approve/deny buttons.
+Inbound button clicks arrive as CallbackQuery updates.
+
+Non-streaming: body text + inline keyboard in one message; after
+approval the message is edited to show the resolved status.
+
+Streaming: body text was already streamed; a compact card (tool name
++ buttons) is sent separately; edited on approval.
+
+Telegram Bot API refs:
+  https://core.telegram.org/bots/api#inlinekeyboardbutton
+  https://core.telegram.org/bots/api#callbackquery
+  https://core.telegram.org/bots/api#editmessagetext
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.constants import ParseMode
+from telegram.error import BadRequest
+
+from . import context
+
+if TYPE_CHECKING:
+    from ..channel import TelegramChannel
+
+logger = logging.getLogger(__name__)
+
+
+# =====================================================================
+# Module-level metadata (read by the dispatcher when registering)
+# =====================================================================
+
+NAME = "tool_guard_approval"
+
+# Outbound metadata.message_type that triggers this card kind.
+MESSAGE_TYPE = "tool_guard_approval"
+
+# Prefix in callback_data to identify our button callbacks.
+# Format: "tga:{request_id_short}" or "tgd:{request_id_short}"
+CALLBACK_DATA_PREFIX = "tg"
+
+# =====================================================================
+# Constants
+# =====================================================================
+
+APPROVE_PREFIX = "tga:"
+DENY_PREFIX = "tgd:"
+
+# In-memory cache mapping request_id → full context.
+# Telegram callback_data is limited to 64 bytes, so we store the full
+# context here and only pass a short key in callback_data.
+_request_context_cache: Dict[str, Dict[str, Any]] = {}
+_CACHE_MAX_SIZE = 500
+
+# Track processed request_ids to prevent duplicate button clicks.
+_processed_requests: Dict[str, str] = {}
+_PROCESSED_MAX_SIZE = 500
+
+
+# =====================================================================
+# Cache helpers
+# =====================================================================
+
+
+def _cache_request_context(
+    request_id: str,
+    tool_name: str,
+    severity: str,
+    body_text: str,
+    session_ctx: Dict[str, Any],
+) -> None:
+    """Store full request context keyed by request_id."""
+    _request_context_cache[request_id] = {
+        "tool_name": tool_name,
+        "severity": severity,
+        "body_text": body_text,
+        "session_ctx": session_ctx,
+    }
+    # Evict oldest entries when cache grows too large.
+    if len(_request_context_cache) > _CACHE_MAX_SIZE:
+        keys = list(_request_context_cache.keys())
+        for key in keys[: len(keys) // 2]:
+            _request_context_cache.pop(key, None)
+
+
+def _get_request_context(request_id: str) -> Optional[Dict[str, Any]]:
+    """Retrieve cached request context."""
+    return _request_context_cache.get(request_id)
+
+
+def _mark_processed(request_id: str, action: str) -> bool:
+    """Mark a request_id as processed. Returns True if already processed."""
+    if request_id in _processed_requests:
+        return True
+    _processed_requests[request_id] = action
+    if len(_processed_requests) > _PROCESSED_MAX_SIZE:
+        keys = list(_processed_requests.keys())
+        for key in keys[: len(keys) // 2]:
+            _processed_requests.pop(key, None)
+    return False
+
+
+# =====================================================================
+# Builders
+# =====================================================================
+
+
+def build_approval_keyboard(request_id: str) -> InlineKeyboardMarkup:
+    """Build an InlineKeyboardMarkup with Approve/Deny buttons.
+
+    callback_data format: "tga:{request_id}" / "tgd:{request_id}"
+    Must stay within 64 bytes.
+    """
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "✅ Approve",
+                    callback_data=f"{APPROVE_PREFIX}{request_id}",
+                ),
+                InlineKeyboardButton(
+                    "❌ Deny",
+                    callback_data=f"{DENY_PREFIX}{request_id}",
+                ),
+            ],
+        ],
+    )
+
+
+def build_approval_text(body_text: str) -> str:
+    """Build the full approval message text (non-streaming mode).
+
+    No title/header — just the raw tool_guard body text.  Buttons are
+    attached via ``reply_markup`` (InlineKeyboardMarkup).
+    """
+    return body_text or "🛡️ Tool Approval Required"
+
+
+def build_compact_text(tool_name: str, severity: str) -> str:
+    """Build a compact card text (streaming mode — body already sent)."""
+    return (
+        f"🛡️ *Tool Approval Required*\n"
+        f"*Tool*: `{tool_name}`  |  *Severity*: {severity}"
+    )
+
+
+def build_resolved_text(
+    tool_name: str,
+    action: str,
+    operator_display: str = "",
+    body_text: str = "",
+) -> str:
+    """Build the text shown after a button click.
+
+    When ``body_text`` is present (non-streaming), returns plain text
+    to avoid MarkdownV2 parse errors from special characters in the
+    raw body.  When empty (streaming compact card), uses MarkdownV2.
+    """
+    if body_text:
+        # Plain text mode — no markdown formatting.
+        by_text = f" by {operator_display}" if operator_display else ""
+        if action == "approve":
+            status_line = f"✅ Approved{by_text}  |  Tool: {tool_name}"
+        elif action == "deny":
+            status_line = f"🚫 Denied{by_text}  |  Tool: {tool_name}"
+        else:
+            status_line = f"⌛ Expired  |  Tool: {tool_name}"
+        return f"{body_text}\n\n{status_line}"
+
+    # Compact (streaming) — no body, safe to use MarkdownV2.
+    by_text = f" by *{operator_display}*" if operator_display else ""
+    if action == "approve":
+        return f"✅ *Approved*{by_text}  |  Tool: `{tool_name}`"
+    if action == "deny":
+        return f"🚫 *Denied*{by_text}  |  Tool: `{tool_name}`"
+    return f"⌛ *Expired*  |  Tool: `{tool_name}`"
+
+
+# =====================================================================
+# Outbound: render
+# =====================================================================
+
+
+async def render(
+    channel: "TelegramChannel",
+    to_handle: str,
+    event: Any,
+    send_meta: Dict[str, Any],
+    meta: Dict[str, Any],
+    *,
+    compact: bool = False,
+) -> bool:
+    """Render a tool-guard event as an inline keyboard message.
+
+    Non-streaming (compact=False): full body text + buttons in one message.
+    Streaming (compact=True): compact text (tool name only) + buttons.
+    """
+    request_id = str(meta.get("approval_request_id") or "")
+    if not request_id:
+        return False
+
+    if not channel.enabled or not channel._application:
+        return False
+
+    bot = channel._application.bot
+    if not bot:
+        return False
+
+    tool_name = str(meta.get("tool_name") or "tool")
+    severity = str(meta.get("severity") or "medium")
+    chat_id = str(send_meta.get("chat_id") or to_handle)
+    message_thread_id = send_meta.get("message_thread_id")
+
+    if not chat_id:
+        logger.warning("telegram approval card: no chat_id")
+        return False
+
+    body_text = context.extract_body_text(getattr(event, "content", None))
+    session_ctx = context.build_session_ctx(to_handle, send_meta)
+
+    # Cache full context for the callback handler.
+    # In compact mode (streaming), don't cache body_text — it was already
+    # sent in the streamed message above, so the resolved card should
+    # stay compact and not repeat the body.
+    _cache_request_context(
+        request_id,
+        tool_name,
+        severity,
+        "" if compact else body_text,
+        session_ctx,
+    )
+
+    keyboard = build_approval_keyboard(request_id)
+
+    if compact:
+        text = build_compact_text(tool_name, severity)
+        parse_mode = ParseMode.MARKDOWN_V2
+    else:
+        text = build_approval_text(body_text)
+        parse_mode = None  # raw body text, no HTML formatting
+
+    try:
+        kwargs: Dict[str, Any] = {
+            "chat_id": chat_id,
+            "text": text,
+            "reply_markup": keyboard,
+        }
+        if parse_mode:
+            kwargs["parse_mode"] = parse_mode
+        if message_thread_id is not None:
+            kwargs["message_thread_id"] = message_thread_id
+
+        await bot.send_message(**kwargs)
+        logger.info(
+            "telegram approval card sent: request_id=%s tool=%s compact=%s",
+            request_id[:8],
+            tool_name,
+            compact,
+        )
+        return True
+    except BadRequest:
+        logger.exception(
+            "telegram approval card send failed (BadRequest): request_id=%s",
+            request_id[:8],
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "telegram approval card send failed: request_id=%s",
+            request_id[:8],
+        )
+        return False
+
+
+# =====================================================================
+# Inbound: handle
+# =====================================================================
+
+
+async def handle(
+    channel: "TelegramChannel",
+    query: Any,
+) -> None:
+    """Process a tool-guard CallbackQuery button click.
+
+    1. Parse callback_data to determine action and request_id.
+    2. Check for duplicate clicks.
+    3. Answer the callback query (toast).
+    4. Edit the original message to show resolved status.
+    5. Inject /approval command into the message queue.
+    """
+    callback_data = str(getattr(query, "data", "") or "")
+    parsed = _parse_callback_data(callback_data)
+    if not parsed:
+        return
+
+    action = parsed["action"]
+    request_id = parsed["request_id"]
+
+    # Resolve operator display from the callback query sender.
+    from_user = getattr(query, "from_user", None)
+    operator_display = ""
+    if from_user:
+        username = getattr(from_user, "username", None)
+        first_name = getattr(from_user, "first_name", None)
+        if username:
+            operator_display = f"@{username}"
+        elif first_name:
+            operator_display = first_name
+        else:
+            operator_display = str(getattr(from_user, "id", ""))
+
+    user_id = str(getattr(from_user, "id", "")) if from_user else ""
+
+    # 1. Deduplication
+    if _mark_processed(request_id, action):
+        logger.info(
+            "telegram card event: duplicate click ignored request_id=%s",
+            request_id[:8],
+        )
+        try:
+            await query.answer(
+                text="Already processed.",
+                show_alert=False,
+            )
+        except Exception:
+            pass
+        return
+
+    logger.info(
+        "telegram card event: action=%s request_id=%s operator=%s",
+        action,
+        request_id[:8],
+        operator_display,
+    )
+
+    # 2. Retrieve cached context
+    cached = _get_request_context(request_id)
+    tool_name = cached.get("tool_name", "tool") if cached else "tool"
+    body_text = cached.get("body_text", "") if cached else ""
+    session_ctx = cached.get("session_ctx", {}) if cached else {}
+
+    # 3. Answer the callback query (toast)
+    toast_text = (
+        f"✅ Approved: {tool_name}"
+        if action == "approve"
+        else f"🚫 Denied: {tool_name}"
+    )
+    try:
+        await query.answer(text=toast_text, show_alert=False)
+    except Exception:
+        logger.debug("telegram: answer_callback_query failed")
+
+    # 4. Edit the original message to show resolved status
+    await _update_message_resolved(
+        query,
+        tool_name=tool_name,
+        action=action,
+        operator_display=operator_display,
+        body_text=body_text,
+    )
+
+    # 5. Inject /approval command into the message queue
+    _enqueue_approval_command(
+        channel,
+        action=action,
+        request_id=request_id,
+        session_ctx=session_ctx,
+        user_id=user_id,
+    )
+
+
+# =====================================================================
+# Internals
+# =====================================================================
+
+
+def _parse_callback_data(
+    callback_data: str,
+) -> Optional[Dict[str, str]]:
+    """Parse callback_data like 'tga:{request_id}' or 'tgd:{request_id}'."""
+    if callback_data.startswith(APPROVE_PREFIX):
+        return {
+            "action": "approve",
+            "request_id": callback_data[len(APPROVE_PREFIX):],
+        }
+    if callback_data.startswith(DENY_PREFIX):
+        return {
+            "action": "deny",
+            "request_id": callback_data[len(DENY_PREFIX):],
+        }
+    return None
+
+
+async def _update_message_resolved(
+    query: Any,
+    *,
+    tool_name: str,
+    action: str,
+    operator_display: str,
+    body_text: str,
+) -> None:
+    """Edit the original approval message to show resolved status."""
+    resolved_text = build_resolved_text(
+        tool_name=tool_name,
+        action=action,
+        operator_display=operator_display,
+        body_text=body_text,
+    )
+    # Use MarkdownV2 only for compact (no body) cards; plain text when
+    # body is present to avoid parse errors from special characters.
+    parse_mode = None if body_text else ParseMode.MARKDOWN_V2
+    try:
+        kwargs: Dict[str, Any] = {
+            "text": resolved_text,
+            "reply_markup": None,
+        }
+        if parse_mode:
+            kwargs["parse_mode"] = parse_mode
+        await query.edit_message_text(**kwargs)
+        logger.info(
+            "telegram approval card updated: action=%s operator=%s",
+            action,
+            operator_display,
+        )
+    except BadRequest as exc:
+        if "not modified" not in str(exc).lower():
+            logger.warning(
+                "telegram approval card update failed: %s",
+                exc,
+            )
+    except Exception:
+        logger.exception("telegram approval card update failed")
+
+
+def _enqueue_approval_command(
+    channel: "TelegramChannel",
+    *,
+    action: str,
+    request_id: str,
+    session_ctx: Dict[str, Any],
+    user_id: str,
+) -> None:
+    """Inject ``/approval {action} {request_id}`` into the channel queue."""
+    from agentscope_runtime.engine.schemas.agent_schemas import (
+        ContentType,
+        TextContent,
+    )
+
+    enqueue = getattr(channel, "_enqueue", None)
+    if enqueue is None:
+        logger.warning(
+            "telegram card action: channel enqueue not set, dropping %s %s",
+            action,
+            request_id[:8],
+        )
+        return
+
+    sender_id = str(session_ctx.get("sender_id") or user_id or "")
+    session_id = str(session_ctx.get("session_id") or "")
+    chat_id = str(session_ctx.get("chat_id") or "")
+    is_group = bool(session_ctx.get("is_group", False))
+
+    command_text = f"/approval {action} {request_id}"
+    payload = {
+        "channel_id": channel.channel,
+        "sender_id": sender_id,
+        "user_id": sender_id,
+        "session_id": session_id,
+        "content_parts": [
+            TextContent(type=ContentType.TEXT, text=command_text),
+        ],
+        "meta": {
+            "chat_id": chat_id,
+            "user_id": sender_id,
+            "is_group": is_group,
+            "from_card_action": True,
+        },
+    }
+
+    message_thread_id = session_ctx.get("message_thread_id")
+    if message_thread_id is not None:
+        payload["meta"]["message_thread_id"] = message_thread_id
+
+    try:
+        enqueue(payload)
+        logger.info(
+            "telegram card action enqueued: cmd=%s request=%s session=%s",
+            command_text,
+            request_id[:8],
+            session_id[:12],
+        )
+    except Exception:
+        logger.exception(
+            "telegram card action: enqueue failed: %s %s",
+            action,
+            request_id[:8],
+        )

--- a/src/qwenpaw/app/channels/telegram/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/telegram/cards/tool_guard.py
@@ -163,24 +163,26 @@ def build_resolved_text(
     to avoid MarkdownV2 parse errors from special characters in the
     raw body.  When empty (streaming compact card), uses MarkdownV2.
     """
-    if body_text:
-        # Plain text mode — no markdown formatting.
+    use_md = not body_text
+    if use_md:
+        by_text = f" by *{operator_display}*" if operator_display else ""
+    else:
         by_text = f" by {operator_display}" if operator_display else ""
-        if action == "approve":
-            status_line = f"✅ Approved{by_text}  |  Tool: {tool_name}"
-        elif action == "deny":
-            status_line = f"🚫 Denied{by_text}  |  Tool: {tool_name}"
-        else:
-            status_line = f"⌛ Expired  |  Tool: {tool_name}"
-        return f"{body_text}\n\n{status_line}"
 
-    # Compact (streaming) — no body, safe to use MarkdownV2.
-    by_text = f" by *{operator_display}*" if operator_display else ""
-    if action == "approve":
-        return f"✅ *Approved*{by_text}  |  Tool: `{tool_name}`"
-    if action == "deny":
-        return f"🚫 *Denied*{by_text}  |  Tool: `{tool_name}`"
-    return f"⌛ *Expired*  |  Tool: `{tool_name}`"
+    status_map = {
+        "approve": ("✅", "Approved"),
+        "deny": ("🚫", "Denied"),
+    }
+    icon, word = status_map.get(action, ("⌛", "Expired"))
+
+    if use_md:
+        status_line = f"{icon} *{word}*{by_text}  |  Tool: `{tool_name}`"
+    else:
+        status_line = f"{icon} {word}{by_text}  |  Tool: {tool_name}"
+
+    if body_text:
+        return f"{body_text}\n\n{status_line}"
+    return status_line
 
 
 # =====================================================================
@@ -203,10 +205,7 @@ async def render(
     Streaming (compact=True): compact text (tool name only) + buttons.
     """
     request_id = str(meta.get("approval_request_id") or "")
-    if not request_id:
-        return False
-
-    if not channel.enabled or not channel._application:
+    if not request_id or not channel.enabled or not channel._application:
         return False
 
     bot = channel._application.bot
@@ -389,12 +388,12 @@ def _parse_callback_data(
     if callback_data.startswith(APPROVE_PREFIX):
         return {
             "action": "approve",
-            "request_id": callback_data[len(APPROVE_PREFIX):],
+            "request_id": callback_data[len(APPROVE_PREFIX) :],
         }
     if callback_data.startswith(DENY_PREFIX):
         return {
             "action": "deny",
-            "request_id": callback_data[len(DENY_PREFIX):],
+            "request_id": callback_data[len(DENY_PREFIX) :],
         }
     return None
 
@@ -487,7 +486,9 @@ def _enqueue_approval_command(
 
     message_thread_id = session_ctx.get("message_thread_id")
     if message_thread_id is not None:
-        payload["meta"]["message_thread_id"] = message_thread_id
+        meta_dict = payload["meta"]
+        assert isinstance(meta_dict, dict)
+        meta_dict["message_thread_id"] = message_thread_id
 
     try:
         enqueue(payload)

--- a/src/qwenpaw/app/channels/telegram/cards/tool_guard.py
+++ b/src/qwenpaw/app/channels/telegram/cards/tool_guard.py
@@ -19,6 +19,7 @@ Telegram Bot API refs:
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
@@ -147,7 +148,8 @@ def build_compact_text(tool_name: str, severity: str) -> str:
     """Build a compact card text (streaming mode — body already sent)."""
     return (
         f"🛡️ *Tool Approval Required*\n"
-        f"*Tool*: `{tool_name}`  |  *Severity*: {severity}"
+        f"*Tool*: `{_escape_mdv2(tool_name)}`"
+        f"  \\|  *Severity*: {_escape_mdv2(severity)}"
     )
 
 
@@ -159,30 +161,38 @@ def build_resolved_text(
 ) -> str:
     """Build the text shown after a button click.
 
-    When ``body_text`` is present (non-streaming), returns plain text
-    to avoid MarkdownV2 parse errors from special characters in the
-    raw body.  When empty (streaming compact card), uses MarkdownV2.
+    When body_text is present (non-streaming), the body is kept as
+    plain text and the status line is appended without formatting
+    (parse_mode=None).  When body is empty (compact/streaming),
+    MarkdownV2 formatting is used.
     """
-    use_md = not body_text
-    if use_md:
-        by_text = f" by *{operator_display}*" if operator_display else ""
-    else:
-        by_text = f" by {operator_display}" if operator_display else ""
-
     status_map = {
         "approve": ("✅", "Approved"),
         "deny": ("🚫", "Denied"),
     }
     icon, word = status_map.get(action, ("⌛", "Expired"))
 
-    if use_md:
-        status_line = f"{icon} *{word}*{by_text}  |  Tool: `{tool_name}`"
-    else:
-        status_line = f"{icon} {word}{by_text}  |  Tool: {tool_name}"
-
     if body_text:
+        # Plain text — no markdown, no escape needed.
+        by_text = f" by {operator_display}" if operator_display else ""
+        status_line = f"{icon} {word}{by_text}  |  Tool: {tool_name}"
         return f"{body_text}\n\n{status_line}"
-    return status_line
+
+    # Compact (streaming) — MarkdownV2.
+    by = _escape_mdv2(operator_display)
+    by_text = f" by *{by}*" if operator_display else ""
+    return (
+        f"{icon} *{word}*{by_text}" f"  \\|  Tool: `{_escape_mdv2(tool_name)}`"
+    )
+
+
+# MarkdownV2 special characters that must be escaped.
+_MDV2_ESCAPE_RE = re.compile(r"([_*\[\]()~`>#+\-=|{}.!\\])")
+
+
+def _escape_mdv2(text: str) -> str:
+    """Escape special characters for Telegram MarkdownV2."""
+    return _MDV2_ESCAPE_RE.sub(r"\\\1", text)
 
 
 # =====================================================================
@@ -243,7 +253,7 @@ async def render(
         parse_mode = ParseMode.MARKDOWN_V2
     else:
         text = build_approval_text(body_text)
-        parse_mode = None  # raw body text, no HTML formatting
+        parse_mode = None  # raw body text, no formatting
 
     try:
         kwargs: Dict[str, Any] = {
@@ -414,16 +424,15 @@ async def _update_message_resolved(
         body_text=body_text,
     )
     # Use MarkdownV2 only for compact (no body) cards; plain text when
-    # body is present to avoid parse errors from special characters.
-    parse_mode = None if body_text else ParseMode.MARKDOWN_V2
+    # body is present to avoid parse errors from raw body content.
+    edit_kwargs: Dict[str, Any] = {
+        "text": resolved_text,
+        "reply_markup": None,
+    }
+    if not body_text:
+        edit_kwargs["parse_mode"] = ParseMode.MARKDOWN_V2
     try:
-        kwargs: Dict[str, Any] = {
-            "text": resolved_text,
-            "reply_markup": None,
-        }
-        if parse_mode:
-            kwargs["parse_mode"] = parse_mode
-        await query.edit_message_text(**kwargs)
+        await query.edit_message_text(**edit_kwargs)
         logger.info(
             "telegram approval card updated: action=%s operator=%s",
             action,

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -351,6 +351,12 @@ class TelegramChannel(BaseChannel):
         self._pending_reconnect_delay_s = _RECONNECT_INITIAL_S
         self._polling_network_error_count = 0
         self._polling_conflict_count = 0
+
+        # Interactive card handler (tool-guard approval cards).
+        from .cards.dispatcher import TelegramCardHandler
+
+        self._card_handler = TelegramCardHandler(self)
+
         if self.enabled and self._bot_token:
             try:
                 self._application = self._build_application()
@@ -372,6 +378,7 @@ class TelegramChannel(BaseChannel):
         from telegram import Update
         from telegram.ext import (
             Application,
+            CallbackQueryHandler,
             ContextTypes,
             MessageHandler,
             filters,
@@ -449,6 +456,19 @@ class TelegramChannel(BaseChannel):
                 logger.warning("telegram: _enqueue not set, message dropped")
 
         app.add_handler(MessageHandler(filters.ALL, handle_message))
+
+        # Inline keyboard callback handler (tool-guard approval buttons).
+        async def handle_callback_query(
+            update: Update,
+            context: ContextTypes.DEFAULT_TYPE,  # noqa: ARG001
+        ) -> None:
+            del context  # required by PTB handler signature
+            query = update.callback_query
+            if query is None:
+                return
+            await self._card_handler.handle_callback_query(query)
+
+        app.add_handler(CallbackQueryHandler(handle_callback_query))
         return app
 
     def _apply_no_text_debounce(
@@ -1079,10 +1099,8 @@ class TelegramChannel(BaseChannel):
         # normal send so the reply is not silently lost.
         if not msg_id:
             await self.send(to_handle, final_text, send_meta)
-            return
-
-        # If text fits in a single message, edit in place
-        if len(final_text) <= TELEGRAM_SEND_CHUNK_SIZE:
+        elif len(final_text) <= TELEGRAM_SEND_CHUNK_SIZE:
+            # Text fits in a single message — edit in place.
             html_text = markdown_to_telegram_html(final_text)
             success = await self._edit_stream_message(
                 chat_id,
@@ -1097,12 +1115,23 @@ class TelegramChannel(BaseChannel):
                     final_text,
                     use_html=False,
                 )
-            return
+        else:
+            # Text too long for a single edit — delete placeholder and
+            # use the normal chunked send path (same as non-streaming).
+            await self._delete_message(chat_id, msg_id)
+            await self.send(to_handle, final_text, send_meta)
 
-        # Text too long for a single edit — delete placeholder and use
-        # the normal chunked send path (same as non-streaming).
-        await self._delete_message(chat_id, msg_id)
-        await self.send(to_handle, final_text, send_meta)
+        # Card events (e.g. tool_guard) consumed by streaming need a
+        # compact interactive card sent after the streaming card.
+        if stream_type == "message" and self._card_handler.is_card_event(
+            event,
+        ):
+            await self._card_handler.try_send_card_for_event(
+                to_handle,
+                event,
+                send_meta,
+                compact=True,
+            )
 
     # ------------------------------------------------------------------
     # Event hooks
@@ -1115,7 +1144,16 @@ class TelegramChannel(BaseChannel):
         event,
         send_meta: dict,
     ) -> None:
-        """Message completed — send content but keep typing active."""
+        """Render card-flagged events via the card handler; else default."""
+        if await self._card_handler.try_send_card_for_event(
+            to_handle,
+            event,
+            send_meta,
+        ):
+            # Re-start typing after sending, in case more tool calls follow.
+            if self._is_processing.get(to_handle, False):
+                self._start_typing(to_handle)
+            return
         await super().on_event_message_completed(
             request,
             to_handle,

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -1366,7 +1366,7 @@ class TelegramChannel(BaseChannel):
 
         await app.updater.start_polling(
             bootstrap_retries=0,
-            allowed_updates=["message", "edited_message"],
+            allowed_updates=["message", "edited_message", "callback_query"],
             error_callback=_on_poll_error,
         )
         await app.start()


### PR DESCRIPTION
## Description

Add interactive tool-guard approval card support for the Telegram channel using Telegram Bot API's InlineKeyboardMarkup + CallbackQuery mechanism. Follows the same cards/ directory pattern as QQ and WeCom channels.

### New files (src/qwenpaw/app/channels/telegram/cards/):

- __init__.py — package exports
- context.py — shared helpers (meta extraction, body text flattening, session context builder)
- dispatcher.py — TelegramCardHandler with registry-based routing
- tool_guard.py — approval card: builders, render, handle, enqueue

### Modified channel.py:

- Initialize TelegramCardHandler in constructor
- Register CallbackQueryHandler in _build_application() for inline button clicks
- Override on_event_message_completed() to intercept card events
- Extend on_streaming_end() to send compact approval card after streaming completes
- Fix early-return bug that would skip post-streaming card dispatch

### Behavior:

- Non-streaming: raw body text + Approve/Deny inline buttons in one message; on click, buttons are replaced with approval status line while preserving body text
- Streaming: body text streamed normally, then a compact MarkdownV2 card (tool name + buttons) sent separately; on click, updated to show status
- In-memory cache stores full request context to work around Telegram's 64-byte callback_data limit
- Deduplication prevents double-click issues
- Resolved card shows who approved/denied (Telegram @username)

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
