### PR TITLE
fix(cron): display schedule time and timezone in user's local timezone

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -893,7 +893,7 @@
     "cronExample": "Common examples: '0 9 * * *' = 9 AM daily | '*/30 * * * *' = every 30 min | '0 */2 * * *' = every 2 hours | '0 0 * * 0' = Sunday midnight",
     "cronHelper": "New to Cron expressions?",
     "cronHelperLink": "Use online generator",
-    "timezoneTooltip": "Timezone for the cron schedule. Default: UTC",
+    "timezoneTooltip": "Timezone for the cron schedule. Defaults to your system timezone.",
     "taskTypeTooltip": "Choose 'text' for simple message tasks, or 'agent' for complex agent workflows.",
     "textTooltip": "Simple message task: this is the actual message body. Required when task type is 'text'.",
     "requestInputTooltip": "Message content in JSON format. This is what the agent will receive and process. Required when task type is 'agent'.",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -732,7 +732,7 @@
     "cronExample": "常用示例：'0 9 * * *' = 每天9点 | '*/30 * * * *' = 每30分钟 | '0 */2 * * *' = 每2小时 | '0 0 * * 0' = 每周日0点",
     "cronHelper": "不熟悉 Cron 表达式？",
     "cronHelperLink": "使用在线工具生成",
-    "timezoneTooltip": "Cron 计划使用的时区。默认：UTC",
+    "timezoneTooltip": "Cron 计划使用的时区。默认：您的系统时区",
     "taskTypeTooltip": "选择 'text' 用于简单消息任务，选择 'agent' 用于复杂的智能体工作流。",
     "textTooltip": "简单消息任务：此处为实际的消息正文，任务类型为'text'时必填。",
     "requestInputTooltip": "JSON 格式的消息内容。这是智能体将接收和处理的内容，任务类型为'agent'时必填。",

--- a/console/src/pages/Control/CronJobs/components/columns.tsx
+++ b/console/src/pages/Control/CronJobs/components/columns.tsx
@@ -4,10 +4,15 @@ import type { MenuProps } from "antd";
 import type { CronJobSpecOutput } from "../../../../api/types";
 import { CopyOutlined, MoreOutlined } from "@ant-design/icons";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
 import { TFunction } from "i18next";
 import { parseCron } from "./parseCron";
 import styles from "../index.module.less";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 type CronJob = CronJobSpecOutput;
 
@@ -18,6 +23,7 @@ interface ColumnHandlers {
   onEdit: (job: CronJob) => void;
   onDelete: (jobId: string) => void;
   t: TFunction;
+  userTimezone: string;
 }
 
 const createCopyToClipboard = (t: TFunction) => async (text: string) => {
@@ -99,11 +105,26 @@ export const createColumns = (
       width: 180,
       render: (schedule: any) => {
         if (schedule?.type === "once") {
-          const displayText = schedule?.run_at
-            ? dayjs(schedule.run_at).format("YYYY-MM-DD HH:mm")
-            : "-";
+          const schedTz =
+            schedule?.timezone ||
+            Intl.DateTimeFormat().resolvedOptions().timeZone;
+          const userTz = handlers.userTimezone;
+          let displayText = "-";
+          let tooltipTitle: string = schedule?.run_at || "-";
+          if (schedule?.run_at) {
+            // 将存储时间转换到用户时区显示
+            const inUserTz = dayjs(schedule.run_at).tz(userTz);
+            displayText = inUserTz.format("YYYY-MM-DD HH:mm");
+            // tooltip 显示原始存储时区的时间，方便对照
+            if (schedTz !== userTz) {
+              const inSchedTz = dayjs(schedule.run_at).tz(schedTz);
+              tooltipTitle = `${inSchedTz.format("YYYY-MM-DD HH:mm")} (${schedTz})`;
+            } else {
+              tooltipTitle = displayText;
+            }
+          }
           return (
-            <Tooltip title={schedule?.run_at || displayText}>
+            <Tooltip title={tooltipTitle}>
               <span className={styles.cronText}>{displayText}</span>
             </Tooltip>
           );
@@ -111,18 +132,31 @@ export const createColumns = (
         const cron = schedule?.cron || "0 9 * * *";
         // Parse cron to friendly text
         const cronParts = parseCron(cron);
+        const taskTz = schedule?.timezone || "UTC";
+        const userTz = handlers.userTimezone;
+
+        // Convert hour:minute from task timezone to user timezone
+        const convertToUserTz = (hour: number, minute: number): { hour: number; minute: number } => {
+          const ref = dayjs().tz(taskTz).hour(hour).minute(minute).second(0).millisecond(0);
+          const inUserTz = ref.tz(userTz);
+          return { hour: inUserTz.hour(), minute: inUserTz.minute() };
+        };
+
         let displayText = "";
 
         switch (cronParts.type) {
           case "hourly":
             displayText = handlers.t("cronJobs.cronTypeHourly");
             break;
-          case "daily":
+          case "daily": {
+            const converted = convertToUserTz(cronParts.hour ?? 0, cronParts.minute ?? 0);
             displayText = `${handlers.t("cronJobs.cronTypeDaily")} ${String(
-              cronParts.hour,
-            ).padStart(2, "0")}:${String(cronParts.minute).padStart(2, "0")}`;
+              converted.hour,
+            ).padStart(2, "0")}:${String(converted.minute).padStart(2, "0")}`;
             break;
+          }
           case "weekly": {
+            const converted = convertToUserTz(cronParts.hour ?? 0, cronParts.minute ?? 0);
             const dayNames = (cronParts.daysOfWeek || [])
               .map((d) => {
                 const dayMap: Record<string, string> = {
@@ -139,8 +173,8 @@ export const createColumns = (
               .join(",");
             displayText = `${handlers.t(
               "cronJobs.cronTypeWeekly",
-            )} ${dayNames} ${String(cronParts.hour).padStart(2, "0")}:${String(
-              cronParts.minute,
+            )} ${dayNames} ${String(converted.hour).padStart(2, "0")}:${String(
+              converted.minute,
             ).padStart(2, "0")}`;
             break;
           }
@@ -173,6 +207,14 @@ export const createColumns = (
       dataIndex: ["schedule", "timezone"],
       key: "timezone",
       width: 170,
+      render: () => {
+        const offset = dayjs().tz(handlers.userTimezone).utcOffset();
+        const sign = offset >= 0 ? "+" : "-";
+        const h = Math.floor(Math.abs(offset) / 60);
+        const m = Math.abs(offset) % 60;
+        const display = m === 0 ? `UTC${sign}${h}` : `UTC${sign}${h}:${String(m).padStart(2, "0")}`;
+        return <span>{display}</span>;
+      },
     },
     {
       title: "TaskType",

--- a/console/src/pages/Control/CronJobs/components/constants.ts
+++ b/console/src/pages/Control/CronJobs/components/constants.ts
@@ -7,7 +7,7 @@ export const DEFAULT_FORM_VALUES = {
   schedule: {
     type: "cron" as const,
     cron: "0 9 * * *",
-    timezone: "UTC",
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   },
   onceRunAt: dayjs().add(1, "hour"),
   onceRepeatEnabled: false,

--- a/console/src/pages/Control/CronJobs/index.tsx
+++ b/console/src/pages/Control/CronJobs/index.tsx
@@ -381,6 +381,7 @@ function CronJobsPage() {
     onEdit: handleEdit,
     onDelete: handleDelete,
     t,
+    userTimezone,
   });
 
   const HISTORY_ERROR_PREVIEW_LINES = 4;


### PR DESCRIPTION
## Description

The Cron Jobs list page displayed schedule times in the task's stored timezone
(defaulting to UTC) rather than the user's configured timezone, which was
confusing. This PR makes the schedule display consistent with the user's timezone.

**Changes:**
- **Execution time column (recurring tasks)**: For daily/weekly tasks, the
  cron hour/minute is converted from the task's stored timezone to the user's
  timezone before display. e.g. a task stored as `0 22 * * *` (UTC) now shows
  as `每天 06:00` for UTC+8 users.
- **Execution time column (once-type tasks)**: `run_at` is converted to the
  user's timezone for display (previously shown in UTC with no conversion).
  When the task timezone differs from the user's, hovering the cell shows the
  original task-timezone time (e.g. `2026-05-29 06:00 (UTC)`) for reference,
  instead of the raw ISO string shown before.
- **Timezone column**: Instead of showing the task's stored timezone string,
  the column now displays the user's timezone as a UTC offset (e.g. `UTC+8`).
- **New task default timezone**: Changed from hardcoded `UTC` to the browser's
  local timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`), so new
  tasks default to the user's timezone.
- **i18n** (en/zh): Updated `timezoneTooltip` wording to reflect the new default.

**Related Issue:** N/A

**Security Considerations:** None

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Console (frontend web UI)

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open the Cron Jobs page
2. Verify recurring tasks show times in your local timezone
   (e.g. `0 22 * * *` UTC → `每天 06:00` for UTC+8 users)
3. Verify the timezone column shows `UTC+8` instead of `UTC`
4. Create a new task — verify the timezone field defaults to your local timezone
5. For once-type tasks: verify the execution time is shown in your local
   timezone, and hovering shows the original UTC time for reference

## Additional Notes

`userTimezone` is sourced from the existing `/config/user-timezone` API.
If the user has not configured a timezone, it falls back to UTC — that is a
separate concern and not addressed here.
