### PR TITLE
chore(release): bump version to v1.1.10-beta.1

### DIFF
--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.1.9"
+__version__ = "1.1.10b1"


### PR DESCRIPTION
## Description

Bump version from `1.1.9` to `1.1.10b1` to begin the v1.1.10 pre-release cycle.

This is a metadata-only change — no runtime behavior is affected.

**Related Issue:** N/A

**Security Considerations:** None — version metadata only.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

No runtime code changes. Verify by importing the version:

```bash
python -c "from qwenpaw.__version__ import __version__; print(__version__)"
# Expected: 1.1.10b1
```

## Additional Notes

README release notes for v1.1.9 are left unchanged — they are historical records.
