### PR TITLE
fix(console): clear chat input draft after message is sent

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -480,6 +480,7 @@ function useMessageHistoryNavigation(
 // ---------------------------------------------------------------------------
 
 const DRAFT_STORAGE_KEY = "qwenpaw_chat_input_draft";
+let draftSuppressed = false;
 
 interface DraftState {
   value: string;
@@ -557,11 +558,14 @@ function useChatInputDraft(isChatActive: () => boolean) {
       if (saveTimer) clearTimeout(saveTimer);
       document.removeEventListener("input", handleInput, true);
 
-      // Final save on unmount
-      const textarea = getTextarea();
-      if (textarea) {
-        saveDraft(textarea);
+      // Final save on unmount (skip if message was just sent)
+      if (!draftSuppressed) {
+        const textarea = getTextarea();
+        if (textarea) {
+          saveDraft(textarea);
+        }
       }
+      draftSuppressed = false;
     };
   }, [isChatActive]);
 }
@@ -1214,6 +1218,8 @@ export default function ChatPage() {
 
     const handleBeforeSubmit = async () => {
       if (isComposingRef.current) return false;
+      localStorage.removeItem(DRAFT_STORAGE_KEY);
+      draftSuppressed = true;
       return true;
     };
 


### PR DESCRIPTION
When a message was sent and the user navigated away then back, the sent message would be refilled into the input box. This happened because useChatInputDraft's unmount cleanup saved the textarea content before Sender cleared it.

Fix: remove draft from localStorage in handleBeforeSubmit and suppress the unmount final-save via a module-level flag.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
