### PR TITLE
fix(console): center shield icon and adjust rule table column widths

### DIFF
--- a/console/src/pages/Settings/Security/components/AllowNoAuthHostsTab.tsx
+++ b/console/src/pages/Settings/Security/components/AllowNoAuthHostsTab.tsx
@@ -112,7 +112,7 @@ export function AllowNoAuthHostsTab({ onSave }: AllowNoAuthHostsTabProps = {}) {
       dataIndex: "host",
       key: "host",
       render: (host: string) => (
-        <Space>
+        <Space className={styles.hostRow}>
           <Shield size={16} style={{ color: "#52c41a" }} />
           <code style={{ fontSize: "13px" }}>{host}</code>
           {isDefaultHost(host) && (

--- a/console/src/pages/Settings/Security/components/RuleTable.tsx
+++ b/console/src/pages/Settings/Security/components/RuleTable.tsx
@@ -66,7 +66,7 @@ export function RuleTable({
       title: t("security.rules.id"),
       dataIndex: "id",
       key: "id",
-      width: 220,
+      width: 280,
       render: (id: string, record: MergedRule) => (
         <span style={{ opacity: record.disabled ? 0.4 : 1 }}>{id}</span>
       ),
@@ -155,7 +155,7 @@ export function RuleTable({
     {
       title: t("security.rules.actions"),
       key: "actions",
-      width: 160,
+      width: 100,
       render: (_: unknown, record: MergedRule) => (
         <Space size="small">
           <Tooltip

--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -636,3 +636,10 @@
   font-size: 14px;
   color: #ff4d4f;
 }
+
+/* ---- Host row (shield icon centering) ---- */
+
+.hostRow {
+  display: inline-flex;
+  align-items: center;
+}


### PR DESCRIPTION

## Description

优化安全页面的 UI 样式，包含两个改动：

### 1. shield 图标垂直居中
- **文件**: `AllowNoAuthHostsTab.tsx` + `Security/index.module.less`
- **问题**: 免主机认证页面的 shield 图标不居中
- **修复**: 给 `<Space>` 加了 CSS Module class，设置为 `display: inline-flex; align-items: center`

### 2. 检测规则表列宽调整
- **文件**: `RuleTable.tsx`
- **问题**: 
  - 规则 ID 列（220px）不够宽，最长 ID (`TOOL_CMD_PRIVILEGE_ESCALATION`) 实际宽度 231px 导致换行
  - 操作列（160px）留白过多
- **修复**:
  - 规则 ID: 220px → 280px
  - 操作: 160px → 100px
  - 固定列总和保持不变（680px）


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
