### PR TITLE
fix(console): antd 5.29 deprecation cleanup and AllowNoAuthHosts icon fix

### DIFF
--- a/console/src/components/AgentSelector/index.tsx
+++ b/console/src/components/AgentSelector/index.tsx
@@ -120,11 +120,11 @@ export default function AgentSelector({
         placeholder={t("agent.selectAgent")}
         optionLabelProp="label"
         popupClassName={styles.agentSelectorDropdown}
-        onDropdownVisibleChange={setDropdownOpen}
+        onOpenChange={setDropdownOpen}
         suffixIcon={
           dropdownOpen ? <SparkUpLine size={20} /> : <SparkDownLine size={20} />
         }
-        dropdownRender={(menu) => (
+        popupRender={(menu) => (
           <>
             <div className={styles.dropdownHeader}>
               <span className={styles.dropdownHeaderTitle}>

--- a/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
+++ b/console/src/pages/Agent/ACP/components/ACPDrawer.tsx
@@ -147,7 +147,7 @@ export function ACPDrawer({
           </div>
         </div>
       }
-      destroyOnClose
+      destroyOnHidden
     >
       <Form
         form={form}

--- a/console/src/pages/Agent/Skills/components/SkillDrawer.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillDrawer.tsx
@@ -285,7 +285,7 @@ export function SkillDrawer({
       title={editingSkill ? t("skills.viewSkill") : t("skills.createSkill")}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       footer={drawerFooter}
     >
       <Form form={form} layout="vertical" onFinish={handleSubmit}>

--- a/console/src/pages/Agent/Skills/components/SkillsToolbar.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillsToolbar.tsx
@@ -46,11 +46,11 @@ export function SkillsToolbar({
           value={searchTags}
           onChange={onTagsChange}
           open={filterOpen}
-          onDropdownVisibleChange={onFilterOpenChange}
+          onOpenChange={onFilterOpenChange}
           allowClear
           maxTagCount="responsive"
           notFoundContent={<></>}
-          dropdownRender={() =>
+          popupRender={() =>
             allTags.length > 0 ? (
               <SkillFilterDropdown
                 allTags={allTags}

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -302,7 +302,7 @@ export default function ModelSelector() {
     <Dropdown
       open={open}
       onOpenChange={handleOpenChange}
-      dropdownRender={() => dropdownContent}
+      popupRender={() => dropdownContent}
       trigger={["click"]}
       placement="bottomLeft"
     >

--- a/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
+++ b/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
@@ -259,7 +259,7 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
     <Drawer
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       placement="right"
       width={360}
       closable={false}

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -164,7 +164,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Current value of the rename input */
   const [editValue, setEditValue] = useState("");
 
-  /** Whether the session list is being fetched (default true because destroyOnClose re-mounts) */
+  /** Whether the session list is being fetched (default true because destroyOnHidden re-mounts) */
   const [listLoading, setListLoading] = useState(true);
 
   /** Height of the virtual list container, measured via ResizeObserver */
@@ -499,7 +499,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     <Drawer
       open={props.open}
       onClose={props.pinned ? undefined : props.onClose}
-      destroyOnClose={!props.pinned}
+      destroyOnHidden={!props.pinned}
       placement="right"
       width={360}
       closable={false}

--- a/console/src/pages/Coding/GitPanel.tsx
+++ b/console/src/pages/Coding/GitPanel.tsx
@@ -281,7 +281,7 @@ export default function GitPanel() {
             value: b.name,
             label: b.name,
           }))}
-          dropdownRender={(menu) => (
+          popupRender={(menu) => (
             <>
               {menu}
               <div

--- a/console/src/pages/Control/Channels/components/AccessControlDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/AccessControlDrawer.tsx
@@ -219,7 +219,7 @@ export function AccessControlDrawer({
       title={t("channels.manageAccessControl")}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
     >
       <Tabs
         activeKey={activeTab}
@@ -326,7 +326,7 @@ export function AccessControlDrawer({
           setAddModalOpen(false);
         }}
         okButtonProps={{ disabled: !newUserId.trim() }}
-        destroyOnClose
+        destroyOnHidden
       >
         <Space direction="vertical" style={{ width: "100%" }} size={16}>
           <div>

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1291,7 +1291,7 @@ export function ChannelDrawer({
       title={drawerTitle}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       footer={drawerFooter}
       key={activeKey} // Force remount when switching channels
     >

--- a/console/src/pages/Control/Channels/components/PendingApprovalsDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/PendingApprovalsDrawer.tsx
@@ -267,7 +267,7 @@ export function PendingApprovalsDrawer({
       title={t("channels.pendingApprovals")}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
     >
       <div
         style={{

--- a/console/src/pages/Control/CronJobs/components/JobDrawer.tsx
+++ b/console/src/pages/Control/CronJobs/components/JobDrawer.tsx
@@ -133,7 +133,7 @@ export function JobDrawer({
       title={editingJob ? t("cronJobs.editJob") : t("cronJobs.createJob")}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       footer={
         <div className={styles.formActions}>
           <Button onClick={onClose}>{t("common.cancel")}</Button>

--- a/console/src/pages/Control/Sessions/components/SessionDrawer.tsx
+++ b/console/src/pages/Control/Sessions/components/SessionDrawer.tsx
@@ -39,7 +39,7 @@ export function SessionDrawer({
       title={t("sessions.editSession")}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       footer={drawerFooter}
     >
       <Form form={form} layout="vertical" onFinish={onSubmit}>

--- a/console/src/pages/Inbox/components/CreateHarvestModal.tsx
+++ b/console/src/pages/Inbox/components/CreateHarvestModal.tsx
@@ -79,7 +79,7 @@ export function CreateHarvestModal({
           <Sparkles size={18} /> Create Harvest
         </span>
       }
-      destroyOnClose
+      destroyOnHidden
     >
       <div className={styles.templateGrid}>
         {TEMPLATES.map((template) => (

--- a/console/src/pages/Inbox/components/MagazineStackViewer.tsx
+++ b/console/src/pages/Inbox/components/MagazineStackViewer.tsx
@@ -30,7 +30,7 @@ export function MagazineStackViewer({
       footer={null}
       width={1100}
       title={`${harvest.name} · History`}
-      destroyOnClose
+      destroyOnHidden
     >
       <div className={styles.viewerContainer}>
         <div className={styles.mainArea}>

--- a/console/src/pages/Settings/Market/components/DetailDrawer.tsx
+++ b/console/src/pages/Settings/Market/components/DetailDrawer.tsx
@@ -79,7 +79,7 @@ export const DetailDrawer = memo(function DetailDrawer({
       title={t("market.detail.title")}
       open={open}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       footer={
         item ? (
           <div className={styles.drawerFooter}>

--- a/console/src/pages/Settings/Security/components/AllowNoAuthHostsTab.tsx
+++ b/console/src/pages/Settings/Security/components/AllowNoAuthHostsTab.tsx
@@ -132,7 +132,9 @@ export function AllowNoAuthHostsTab({ onSave }: AllowNoAuthHostsTabProps = {}) {
           okText={t("common.delete")}
           cancelText={t("common.cancel")}
         >
-          <Button type="text" danger icon={<Trash2 size={16} />} size="small" />
+          <Button type="text" danger size="small">
+            <Trash2 size={14} />
+          </Button>
         </Popconfirm>
       ),
     },

--- a/console/src/pages/Settings/Security/components/RuleModal.tsx
+++ b/console/src/pages/Settings/Security/components/RuleModal.tsx
@@ -90,7 +90,7 @@ export function RuleModal({
       okText={t("common.confirm")}
       cancelText={t("common.cancel")}
       width={640}
-      destroyOnClose
+      destroyOnHidden
     >
       <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
         <Form.Item

--- a/console/src/pages/Settings/SkillPool/components/PoolSkillDrawer.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillDrawer.tsx
@@ -60,7 +60,7 @@ export function PoolSkillDrawer({
       }
       open={mode === "create" || mode === "edit"}
       onClose={onClose}
-      destroyOnClose
+      destroyOnHidden
       footer={
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           <Button onClick={onClose}>{t("common.cancel")}</Button>

--- a/console/src/pages/Settings/SkillPool/index.tsx
+++ b/console/src/pages/Settings/SkillPool/index.tsx
@@ -188,11 +188,11 @@ function SkillPoolPage() {
                 value={pool.searchTags}
                 onChange={pool.setSearchTags}
                 open={pool.filterOpen}
-                onDropdownVisibleChange={pool.setFilterOpen}
+                onOpenChange={pool.setFilterOpen}
                 allowClear
                 maxTagCount="responsive"
                 notFoundContent={<></>}
-                dropdownRender={() =>
+                popupRender={() =>
                   pool.allTags.length > 0 ? (
                     <SkillFilterDropdown
                       allTags={pool.allTags}

--- a/plugins/bundle/qwenpaw-pet/frontend/src/index.tsx
+++ b/plugins/bundle/qwenpaw-pet/frontend/src/index.tsx
@@ -549,7 +549,7 @@ function PetControlPage() {
             onCancel: () => {
               if (!importing) setImportOpen(false);
             },
-            destroyOnClose: true,
+            destroyOnHidden: true,
           },
           React.createElement(
             Space,


### PR DESCRIPTION
## Description

Fixes #4768

Fix: Adapting to Ant Design 5.29 deprecated APIs
destroyOnClose → destroyOnHidden (Drawer/Modal)
onDropdownVisibleChange → onOpenChange (Select)
dropdownRender → popupRender (Select/Dropdown)
Button icon prop changed to child element to fix type warnings

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
