### PR TITLE
fix(onebot): auto-restart WebSocket server on connection loss via TCP health probe

### DIFF
--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -108,6 +108,11 @@ class OneBotChannel(BaseChannel):
         # Bot self ID (populated on first meta_event/lifecycle)
         self._self_id: Optional[int] = None
 
+        # Watchdog for auto-restart
+        self._watchdog_task: Optional[asyncio.Task] = None
+        self._watchdog_interval: float = 10.0  # seconds
+        self._stopping: bool = False
+
     # ------------------------------------------------------------------
     # Factory methods
     # ------------------------------------------------------------------
@@ -222,6 +227,25 @@ class OneBotChannel(BaseChannel):
         if not self.enabled:
             logger.debug("onebot channel disabled")
             return
+        self._stopping = False
+        await self._start_ws_server()
+        self._watchdog_task = asyncio.create_task(self._watchdog_loop())
+
+    async def stop(self) -> None:
+        if not self.enabled:
+            return
+        self._stopping = True
+        if self._watchdog_task and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+            try:
+                await self._watchdog_task
+            except asyncio.CancelledError:
+                pass
+            self._watchdog_task = None
+        await self._stop_ws_server()
+
+    async def _start_ws_server(self) -> None:
+        """Create and start the aiohttp WebSocket server."""
         self._app = web.Application()
         self._app.router.add_get("/ws", self._handle_ws_connection)
         self._app.router.add_get("/ws/", self._handle_ws_connection)
@@ -239,17 +263,25 @@ class OneBotChannel(BaseChannel):
             self._ws_port,
         )
 
-    async def stop(self) -> None:
-        if not self.enabled:
-            return
+    async def _stop_ws_server(self) -> None:
+        """Tear down the WebSocket server and clean up connections."""
         for ws in list(self._connections):
-            await ws.close()
+            try:
+                await ws.close()
+            except Exception:
+                pass
         self._connections.clear()
         if self._site:
-            await self._site.stop()
+            try:
+                await self._site.stop()
+            except Exception:
+                pass
             self._site = None
         if self._runner:
-            await self._runner.cleanup()
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
             self._runner = None
         self._app = None
         # Cancel pending API futures
@@ -257,6 +289,28 @@ class OneBotChannel(BaseChannel):
             if not fut.done():
                 fut.cancel()
         self._pending_calls.clear()
+
+    async def _watchdog_loop(self) -> None:
+        """Periodically check server health; restart if not listening."""
+        while not self._stopping:
+            await asyncio.sleep(self._watchdog_interval)
+            if self._stopping:
+                break
+            if self._site is None:
+                logger.warning(
+                    "onebot: watchdog detected server not running, "
+                    "restarting...",
+                )
+                try:
+                    await self._stop_ws_server()
+                    await self._start_ws_server()
+                    logger.info("onebot: watchdog restarted server OK")
+                except Exception:
+                    logger.exception(
+                        "onebot: watchdog failed to restart server, "
+                        "will retry in %ss",
+                        self._watchdog_interval,
+                    )
 
     # ------------------------------------------------------------------
     # WebSocket connection handling

--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -296,9 +296,9 @@ class OneBotChannel(BaseChannel):
             await asyncio.sleep(self._watchdog_interval)
             if self._stopping:
                 break
-            if self._site is None:
+            if not await self._is_server_healthy():
                 logger.warning(
-                    "onebot: watchdog detected server not running, "
+                    "onebot: watchdog detected server not healthy, "
                     "restarting...",
                 )
                 try:
@@ -311,6 +311,44 @@ class OneBotChannel(BaseChannel):
                         "will retry in %ss",
                         self._watchdog_interval,
                     )
+
+    def _get_listen_port(self) -> int:
+        """Return the actual port the server is listening on.
+
+        When ``ws_port=0`` the OS assigns a random port; we read it
+        from the site's underlying sockets.
+        """
+        if self._site is None:
+            return self._ws_port
+        server = getattr(self._site, "_server", None)
+        if server is not None:
+            for sock in server.sockets or []:
+                return sock.getsockname()[1]
+        return self._ws_port
+
+    async def _is_server_healthy(self) -> bool:
+        """Check if the WS server is actually accepting connections.
+
+        Returns True if the TCP port is reachable, False otherwise.
+        This catches cases where ``_site`` is not None but the
+        underlying socket has stopped accepting connections.
+        """
+        if self._site is None:
+            return False
+        probe_host = (
+            "127.0.0.1" if self._ws_host == "0.0.0.0" else self._ws_host
+        )
+        probe_port = self._get_listen_port()
+        try:
+            _, writer = await asyncio.wait_for(
+                asyncio.open_connection(probe_host, probe_port),
+                timeout=3.0,
+            )
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except (OSError, asyncio.TimeoutError):
+            return False
 
     # ------------------------------------------------------------------
     # WebSocket connection handling

--- a/tests/unit/channels/test_onebot_channel.py
+++ b/tests/unit/channels/test_onebot_channel.py
@@ -718,9 +718,68 @@ class TestLifecycle:
         assert ch._app is not None
         assert ch._runner is not None
         assert ch._site is not None
+        assert ch._watchdog_task is not None
+        assert not ch._watchdog_task.done()
         await ch.stop()
         assert ch._site is None
         assert ch._runner is None
+        assert ch._stopping is True
+
+
+# ===================================================================
+# Watchdog / reconnect
+# ===================================================================
+
+
+class TestWatchdog:
+    async def test_watchdog_restarts_when_site_is_none(self):
+        """Watchdog should restart the WS server if _site becomes None."""
+        ch = _make_channel(ws_port=0)
+        ch._watchdog_interval = 0.05  # speed up for test
+        await ch.start()
+        assert ch._site is not None
+
+        # Simulate server crash: clear server state without full stop
+        old_site = ch._site
+        await old_site.stop()
+        await ch._runner.cleanup()
+        ch._site = None
+        ch._runner = None
+        ch._app = None
+
+        # Wait for watchdog to detect and restart
+        await asyncio.sleep(0.2)
+
+        assert ch._site is not None, "watchdog should have restarted server"
+        assert ch._app is not None
+        assert ch._runner is not None
+
+        await ch.stop()
+
+    async def test_watchdog_stops_on_channel_stop(self):
+        """Watchdog task should be cancelled when channel stops."""
+        ch = _make_channel(ws_port=0)
+        ch._watchdog_interval = 0.05
+        await ch.start()
+        watchdog = ch._watchdog_task
+        assert watchdog is not None
+
+        await ch.stop()
+        assert watchdog.done()
+
+    async def test_watchdog_no_restart_when_healthy(self):
+        """Watchdog should not touch a healthy server."""
+        ch = _make_channel(ws_port=0)
+        ch._watchdog_interval = 0.05
+        await ch.start()
+        original_site = ch._site
+
+        # Wait a couple of watchdog cycles
+        await asyncio.sleep(0.15)
+
+        # Site should remain the same object (not recreated)
+        assert ch._site is original_site
+        await ch.stop()
 
 
 # ===================================================================

--- a/tests/unit/channels/test_onebot_channel.py
+++ b/tests/unit/channels/test_onebot_channel.py
@@ -756,6 +756,29 @@ class TestWatchdog:
 
         await ch.stop()
 
+    async def test_watchdog_restarts_when_port_unreachable(self):
+        """Watchdog should restart if _site exists but port is dead."""
+        ch = _make_channel(ws_port=0)
+        ch._watchdog_interval = 0.05
+        await ch.start()
+        assert ch._site is not None
+
+        # Simulate TCPSite still exists but underlying socket is dead:
+        # stop the site but keep the Python object reference
+        old_site = ch._site
+        await old_site.stop()
+        # _site is NOT None, but the port is no longer listening
+
+        # Wait for watchdog to detect via TCP probe and restart
+        await asyncio.sleep(0.3)
+
+        assert ch._site is not None
+        assert (
+            ch._site is not old_site
+        ), "watchdog should have created a new site"
+
+        await ch.stop()
+
     async def test_watchdog_stops_on_channel_stop(self):
         """Watchdog task should be cancelled when channel stops."""
         ch = _make_channel(ws_port=0)
@@ -780,6 +803,18 @@ class TestWatchdog:
         # Site should remain the same object (not recreated)
         assert ch._site is original_site
         await ch.stop()
+
+    async def test_is_server_healthy_when_listening(self):
+        """_is_server_healthy returns True when port is accepting."""
+        ch = _make_channel(ws_port=0)
+        await ch._start_ws_server()
+        assert await ch._is_server_healthy() is True
+        await ch._stop_ws_server()
+
+    async def test_is_server_healthy_when_site_none(self):
+        """_is_server_healthy returns False when _site is None."""
+        ch = _make_channel(ws_port=0)
+        assert await ch._is_server_healthy() is False
 
 
 # ===================================================================


### PR DESCRIPTION
## Description

The OneBot channel's reverse WebSocket server may stop accepting connections after prolonged operation, requiring manual config re-save to recover. This PR adds a watchdog that periodically probes the listening port and automatically restarts the server if it becomes unresponsive.

### Changes:

- Refactor start()/stop() by extracting _start_ws_server()/_stop_ws_server() for independent server lifecycle control
- Add _watchdog_loop() running every 10s with real TCP connectivity check via _is_server_healthy()
- _is_server_healthy() uses asyncio.open_connection to verify the port is actually accepting connections, covering both site-object-gone and socket-dead-but-object-alive scenarios
- Add _get_listen_port() to resolve the actual bound port from server sockets
- Add 6 unit tests covering: site-none restart, port-unreachable restart, watchdog cancellation, healthy no-op, and health check utility


**Related Issue:** Fixes #4788 
**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
