### PR TITLE
fix(console): chatcode

### DIFF
--- a/console/src/pages/Coding/FileTree.tsx
+++ b/console/src/pages/Coding/FileTree.tsx
@@ -15,6 +15,8 @@ import { codingProjectApi } from "../../api/modules/codingProject";
 import { useWorkspaceWatch } from "../../hooks/useWorkspaceWatch";
 import { useProjectDir } from "../../stores/codingModeStore";
 import { useCodeFileCacheStore } from "../../stores/codeFileCacheStore";
+import { useCodingTabsStore } from "../../stores/codingTabsStore";
+import { useAgentStore } from "../../stores/agentStore";
 import ProjectSelectModal from "../../components/ProjectSelectModal";
 import type { MdFileInfo } from "../../api/types";
 import styles from "./FileTree.module.less";
@@ -399,9 +401,14 @@ export default function FileTree({ onFileSelect }: FileTreeProps) {
     [onFileSelect],
   );
 
+  const { selectedAgent } = useAgentStore();
+  const { clearAgent } = useCodingTabsStore();
+
   const handleProjectConfirm = (_path: string | null) => {
     setProjectModalOpen(false);
-    // Reload file tree after project switch
+    // Clear editor tabs from the previous project so stale files don't linger
+    clearAgent(selectedAgent);
+    // Reload file tree for the new project
     void load();
   };
 

--- a/console/src/stores/codingTabsStore.ts
+++ b/console/src/stores/codingTabsStore.ts
@@ -42,6 +42,8 @@ interface CodingTabsState {
   setTabContent: (agentId: string, path: string, content: string) => void;
   setTabDirty: (agentId: string, path: string, dirty: boolean) => void;
 
+  clearAgent: (agentId: string) => void;
+
   setDiff: (agentId: string, path: string, diff: PendingDiff) => void;
   removeDiff: (agentId: string, path: string) => void;
   updateDiffModified: (agentId: string, path: string, modified: string) => void;
@@ -61,6 +63,13 @@ export const useCodingTabsStore = create<CodingTabsState>()(
       tabsByAgent: {},
       activeTabByAgent: {},
       diffsByAgent: {},
+
+      clearAgent: (agentId) =>
+        set((state) => ({
+          tabsByAgent: { ...state.tabsByAgent, [agentId]: [] },
+          activeTabByAgent: { ...state.activeTabByAgent, [agentId]: "" },
+          diffsByAgent: { ...state.diffsByAgent, [agentId]: {} },
+        })),
 
       openTab: (agentId, tab) =>
         set((state) => {


### PR DESCRIPTION
## Description

When switching projects in Coding mode, the open file tab in the editor window still displays files from the old project and is not cleared when switching projects.

##Solution

Editor tabs will be cleared — `clearAgent(selectedAgent)` is called in `handleProjectConfirm` to clear all tabs, activeTab, and diffs of the current agent.

The file tree will be refreshed — loading the file list of the new project.

`projectDir` will be updated — `setProjectDir` will be called internally in `ProjectSelectModal` to update to the new project path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
