### PR TITLE
feat(agents): add spawn_subagent tool for ephemeral in-workspace sub-agent execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ src/.hypothesis/
 
 # Worktrees
 .worktrees/
+.qwenpaw/worktrees/
 
 # Local File
 /localfile/

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -43,6 +43,7 @@ from .tools import (
     delegate_external_agent,
     chat_with_agent,
     check_agent_task,
+    spawn_subagent,
     submit_to_agent,
     desktop_screenshot,
     edit_file,
@@ -301,6 +302,7 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
             "chat_with_agent": chat_with_agent,
             "submit_to_agent": submit_to_agent,
             "check_agent_task": check_agent_task,
+            "spawn_subagent": spawn_subagent,
             # Register only when the `make-skill` skill is enabled.
             **(
                 {"materialize_skill": materialize_skill}

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -27,6 +27,7 @@ from .agent_management import (
     chat_with_agent,
     submit_to_agent,
     check_agent_task,
+    spawn_subagent,
 )
 from .delegate_external_agent import delegate_external_agent
 
@@ -58,4 +59,5 @@ __all__ = [
     "chat_with_agent",
     "submit_to_agent",
     "check_agent_task",
+    "spawn_subagent",
 ]

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -764,7 +764,10 @@ async def _call_fork_api(
         "channel": channel,
     }
     try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            trust_env=trust_env_for_url(url),
+        ) as client:
             resp = await client.post(url, json=payload)
             resp.raise_for_status()
             return resp.json()
@@ -794,7 +797,7 @@ async def _maybe_cleanup_worktree(
             )
             if result.returncode != 0 or result.stdout.strip():
                 return False
-            _subprocess.run(
+            remove_result = _subprocess.run(
                 [
                     "git",
                     "worktree",
@@ -807,7 +810,7 @@ async def _maybe_cleanup_worktree(
                 timeout=30,
                 check=False,
             )
-            return True
+            return remove_result.returncode == 0
         except Exception:  # noqa: BLE001
             return False
 

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -855,8 +855,10 @@ async def _spawn_forked_subagent(
     if worktree_path:
         request_context["fork_project_dir"] = worktree_path
 
-    request_payload = {
+    request_payload: dict = {
         "session_id": fork_session_id,
+        "user_id": user_id,
+        "channel": channel,
         "input": [
             {
                 "role": "user",

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import re
 import time
+from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 from uuid import uuid4
 
@@ -635,3 +636,303 @@ async def check_agent_task(
     return _tool_text_response(
         format_background_status_text(normalized_task_id, result),
     )
+
+
+def _generate_subagent_session_id() -> str:
+    """Generate a short session ID for a spawned subagent."""
+    return f"sub-{str(uuid4())[:8]}"
+
+
+async def spawn_subagent(
+    task: str,
+    fork: bool = False,
+    background: bool = False,
+    timeout: int = 600,
+) -> ToolResponse:
+    """Spawn an ephemeral subagent within the CURRENT workspace.
+
+    The subagent runs as a one-shot task and cannot be resumed.
+    Results flow back as text summary; file changes (fork mode)
+    are isolated in a git branch.
+
+    Unlike ``chat_with_agent`` (which calls a *different* agent),
+    this tool targets the same agent identity and workspace.
+
+    Args:
+        task: Description of the sub-task to perform.
+        fork: If True, the subagent inherits parent session state
+            and runs in an isolated git worktree of the coding
+            project. Requires coding mode with an active git repo.
+            If False (default), starts with a fresh empty session.
+        background: If True, submit as background task and return
+            immediately with a task_id for polling.
+        timeout: Foreground wait timeout in seconds (default 600).
+
+    Returns:
+        Foreground: subagent result text with [SESSION: <id>].
+        Background: [TASK_ID: <id>] + [SESSION: <id>].
+        Fork foreground: also [FORK_BRANCH: <branch>] if changes.
+    """
+    if not task or not task.strip():
+        return _tool_text_response(
+            "ERROR: 'task' is required for spawn_subagent",
+        )
+
+    from ...app.agent_context import get_current_agent_id
+
+    current_agent_id = get_current_agent_id()
+    if not current_agent_id:
+        return _tool_text_response(
+            "ERROR: unable to resolve current agent ID",
+        )
+
+    subagent_session_id = _generate_subagent_session_id()
+
+    if fork:
+        return await _spawn_forked_subagent(
+            task=task,
+            current_agent_id=current_agent_id,
+            subagent_session_id=subagent_session_id,
+            background=background,
+            timeout=timeout,
+        )
+
+    request_payload = {
+        "session_id": subagent_session_id,
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": task}],
+            },
+        ],
+        "request_context": {},
+    }
+
+    if background:
+        result = await asyncio.to_thread(
+            submit_agent_chat_task,
+            None,
+            request_payload,
+            current_agent_id,
+            int(DEFAULT_AGENT_API_TIMEOUT),
+        )
+        return _tool_text_response(
+            format_background_submission_text(
+                result,
+                subagent_session_id,
+            ),
+        )
+
+    response_data = await asyncio.to_thread(
+        collect_final_agent_chat_response,
+        None,
+        request_payload,
+        current_agent_id,
+        timeout,
+    )
+    if not response_data:
+        return _tool_text_response(
+            "(No response received from subagent)",
+        )
+
+    return _tool_text_response(
+        format_agent_chat_text(
+            response_data,
+            session_id=subagent_session_id,
+        ),
+    )
+
+
+async def _call_fork_api(
+    agent_id: str,
+    parent_session_id: str,
+    user_id: Optional[str] = None,
+    channel: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Call POST /api/fork/agent to prepare fork session + worktree."""
+    url = (
+        _normalize_api_base_url(base_url).removesuffix("/api")
+        + "/api/fork/agent"
+    )
+    payload = {
+        "agent_id": agent_id,
+        "parent_session_id": parent_session_id,
+        "user_id": user_id,
+        "channel": channel,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)}
+
+
+async def _maybe_cleanup_worktree(
+    worktree_path: str,
+    project_dir: str,
+) -> bool:
+    """Remove the worktree if it has no uncommitted changes.
+
+    Returns True if cleaned up, False if kept (has changes).
+    """
+    import subprocess as _subprocess
+
+    def _cleanup() -> bool:
+        try:
+            result = _subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode != 0 or result.stdout.strip():
+                return False
+            _subprocess.run(
+                [
+                    "git",
+                    "worktree",
+                    "remove",
+                    "--force",
+                    worktree_path,
+                ],
+                cwd=project_dir,
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    return await asyncio.to_thread(_cleanup)
+
+
+async def _spawn_forked_subagent(
+    task: str,
+    current_agent_id: str,
+    subagent_session_id: str,
+    background: bool,
+    timeout: int,
+) -> ToolResponse:
+    """Fork path: call /api/fork/agent then dispatch subagent."""
+    from ...app.agent_context import (
+        get_current_session_id,
+        get_current_user_id,
+        get_current_channel,
+    )
+
+    parent_session_id = get_current_session_id() or ""
+    user_id = get_current_user_id() or ""
+    channel = get_current_channel() or ""
+
+    fork_result = await _call_fork_api(
+        agent_id=current_agent_id,
+        parent_session_id=parent_session_id,
+        user_id=user_id,
+        channel=channel,
+    )
+    if not fork_result or "error" in fork_result:
+        err = (fork_result or {}).get("error", "unknown error")
+        return _tool_text_response(
+            f"ERROR: fork API failed: {err}",
+        )
+
+    fork_session_id = fork_result.get(
+        "fork_session_id",
+        subagent_session_id,
+    )
+    worktree_path = fork_result.get("worktree_path", "")
+    worktree_branch = fork_result.get("worktree_branch", "")
+
+    request_context: dict = {}
+    if worktree_path:
+        request_context["fork_project_dir"] = worktree_path
+
+    request_payload = {
+        "session_id": fork_session_id,
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": task}],
+            },
+        ],
+        "request_context": request_context,
+    }
+
+    if background:
+        result = await asyncio.to_thread(
+            submit_agent_chat_task,
+            None,
+            request_payload,
+            current_agent_id,
+            int(DEFAULT_AGENT_API_TIMEOUT),
+        )
+        submission_text = format_background_submission_text(
+            result,
+            fork_session_id,
+        )
+        if worktree_path:
+            submission_text += (
+                f"\n\n[FORK_BRANCH: {worktree_branch}]"
+                "\nWorktree cleanup is not automatic in "
+                "background mode."
+            )
+        return _tool_text_response(submission_text)
+
+    response_data = await asyncio.to_thread(
+        collect_final_agent_chat_response,
+        None,
+        request_payload,
+        current_agent_id,
+        timeout,
+    )
+
+    # Resolve project_dir for cleanup (coding_mode or workspace)
+    from ...config.config import load_agent_config
+
+    _project_dir = ""
+    if worktree_path:
+        try:
+            _cfg = load_agent_config(current_agent_id)
+            _cm = _cfg.coding_mode
+            if _cm and _cm.enabled and _cm.project_dir:
+                _project_dir = str(
+                    Path(_cm.project_dir).resolve(),
+                )
+            else:
+                _project_dir = str(
+                    Path(_cfg.workspace_dir).resolve(),
+                )
+        except Exception:  # noqa: BLE001
+            _project_dir = ""
+
+    cleaned = False
+    if worktree_path and _project_dir:
+        cleaned = await _maybe_cleanup_worktree(
+            worktree_path,
+            _project_dir,
+        )
+
+    if not response_data:
+        return _tool_text_response(
+            "(No response received from forked subagent)",
+        )
+
+    result_text = format_agent_chat_text(
+        response_data,
+        session_id=fork_session_id,
+    )
+
+    if not cleaned and worktree_path:
+        result_text += (
+            f"\n\n[FORK_BRANCH: {worktree_branch}]"
+            "\nThe forked worktree has changes. "
+            "Review and merge manually."
+        )
+
+    return _tool_text_response(result_text)

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -660,12 +660,14 @@ async def spawn_subagent(
 
     Args:
         task: Description of the sub-task to perform.
-        fork: If True, the subagent inherits parent session state
-            and runs in an isolated git worktree of the coding
-            project. Requires coding mode with an active git repo.
+        fork: If True, the subagent inherits parent session state.
+            If the project is a git repo, it also runs in an
+            isolated worktree. Works without coding mode (falls
+            back to workspace; no worktree if not a git repo).
             If False (default), starts with a fresh empty session.
         background: If True, submit as background task and return
-            immediately with a task_id for polling.
+            immediately with a task_id. Use check_agent_task(task_id)
+            to poll status and retrieve the result.
         timeout: Foreground wait timeout in seconds (default 600).
 
     Returns:

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -31,6 +31,16 @@ _current_root_session_id: ContextVar[Optional[str]] = ContextVar(
     default=None,
 )
 
+_current_user_id: ContextVar[Optional[str]] = ContextVar(
+    "current_user_id",
+    default=None,
+)
+
+_current_channel: ContextVar[Optional[str]] = ContextVar(
+    "current_channel",
+    default=None,
+)
+
 
 async def get_agent_for_request(
     request: Request,
@@ -198,3 +208,23 @@ def get_current_root_session_id() -> Optional[str]:
         Root session ID or None
     """
     return _current_root_session_id.get()
+
+
+def set_current_user_id(user_id: Optional[str]) -> None:
+    """Set current user ID in context."""
+    _current_user_id.set(user_id)
+
+
+def get_current_user_id() -> Optional[str]:
+    """Get current user ID from context."""
+    return _current_user_id.get()
+
+
+def set_current_channel(channel: Optional[str]) -> None:
+    """Set current channel in context."""
+    _current_channel.set(channel)
+
+
+def get_current_channel() -> Optional[str]:
+    """Get current channel from context."""
+    return _current_channel.get()

--- a/src/qwenpaw/app/routers/__init__.py
+++ b/src/qwenpaw/app/routers/__init__.py
@@ -28,6 +28,7 @@ from .plugins import router as plugins_router
 from .frontend_plugin import router as frontend_plugin_router
 from .backup import router as backup_router
 from .plan import router as plan_router
+from .fork import router as fork_router
 from .git import router as git_router
 from .coding_project import router as coding_project_router
 from .access_control import router as access_control_router
@@ -59,6 +60,7 @@ router.include_router(plugins_router)
 router.include_router(frontend_plugin_router)
 router.include_router(backup_router)
 router.include_router(plan_router)
+router.include_router(fork_router)
 router.include_router(git_router)
 router.include_router(coding_project_router)
 router.include_router(access_control_router)

--- a/src/qwenpaw/app/routers/fork.py
+++ b/src/qwenpaw/app/routers/fork.py
@@ -143,11 +143,28 @@ def _write_fork_session(
     sessions_dir: Path,
     fork_session_id: str,
     state: dict,
+    user_id: str = "",
+    channel: str = "",
 ) -> None:
-    """Write pre-seeded state into a new fork session file."""
+    """Write pre-seeded state into a new fork session file.
+
+    Uses the same path convention as SafeJSONSession._get_save_path
+    so the runner can load it correctly.
+    """
     safe_sid = sanitize_filename(fork_session_id)
-    fork_file = sessions_dir / f"{safe_sid}.json"
-    sessions_dir.mkdir(parents=True, exist_ok=True)
+    safe_uid = sanitize_filename(user_id) if user_id else ""
+    filename = (
+        f"{safe_uid}_{safe_sid}.json" if safe_uid else f"{safe_sid}.json"
+    )
+
+    if channel:
+        safe_channel = sanitize_filename(channel)
+        target_dir = sessions_dir / safe_channel
+    else:
+        target_dir = sessions_dir
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    fork_file = target_dir / filename
     fork_file.write_text(
         json.dumps(state, ensure_ascii=False),
         encoding="utf-8",
@@ -262,7 +279,13 @@ async def fork_agent(
     fork_id = str(uuid4())[:8]
     fork_session_id = f"sub-{fork_id}"
 
-    _write_fork_session(sessions_dir, fork_session_id, state)
+    _write_fork_session(
+        sessions_dir,
+        fork_session_id,
+        state,
+        user_id=req.user_id or "",
+        channel=req.channel or "",
+    )
 
     worktree_path = ""
     worktree_branch = ""

--- a/src/qwenpaw/app/routers/fork.py
+++ b/src/qwenpaw/app/routers/fork.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+"""Fork subagent API endpoint.
+
+POST /fork/agent — prepare a forked session + git worktree
+for spawn_subagent(fork=True).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from ...config.config import load_agent_config
+from ..runner.session import sanitize_filename
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/fork", tags=["fork"])
+
+_WORKTREE_BASE = ".qwenpaw/worktrees"
+
+_LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
+
+
+class ForkAgentRequest(BaseModel):
+    agent_id: str
+    parent_session_id: str
+    user_id: Optional[str] = None
+    channel: Optional[str] = None
+
+
+class ForkAgentResponse(BaseModel):
+    fork_session_id: str
+    worktree_path: str
+    worktree_branch: str
+
+
+def _enforce_localhost(request: Request) -> None:
+    """Reject non-localhost callers."""
+    client = request.client
+    if client and client.host not in _LOCALHOST_ADDRS:
+        raise HTTPException(
+            status_code=403,
+            detail="Fork endpoint is localhost-only",
+        )
+
+
+def _get_project_dir(agent_id: str) -> Optional[Path]:
+    """Resolve the project directory for fork operations.
+
+    Priority:
+    1. coding_mode.project_dir (if coding mode is enabled)
+    2. workspace_dir (fallback)
+
+    Returns the directory as a Path if it is a git repository,
+    or None if no valid git repo is found (in-place fork).
+    """
+    try:
+        config = load_agent_config(agent_id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agent_id}' not found: {exc}",
+        ) from exc
+
+    cm = config.coding_mode
+    if cm and cm.enabled and cm.project_dir:
+        candidate = Path(cm.project_dir).expanduser().resolve()
+    else:
+        candidate = Path(config.workspace_dir).expanduser().resolve()
+
+    if not candidate.is_dir():
+        return None
+    if not (candidate / ".git").exists():
+        return None
+    return candidate
+
+
+def _get_sessions_dir(agent_id: str) -> Path:
+    """Resolve the sessions directory for the agent."""
+    try:
+        config = load_agent_config(agent_id)
+        workspace = Path(config.workspace_dir).expanduser().resolve()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Cannot resolve workspace: {exc}",
+        ) from exc
+    return workspace / "sessions"
+
+
+def _session_path(
+    sessions_dir: Path,
+    session_id: str,
+    user_id: Optional[str],
+    channel: Optional[str],
+) -> Path:
+    """Reconstruct the session file path (SafeJSONSession compat)."""
+    safe_sid = sanitize_filename(session_id)
+    safe_uid = sanitize_filename(user_id) if user_id else ""
+    filename = (
+        f"{safe_uid}_{safe_sid}.json" if safe_uid else f"{safe_sid}.json"
+    )
+
+    if channel:
+        safe_channel = sanitize_filename(channel)
+        return sessions_dir / safe_channel / filename
+    return sessions_dir / filename
+
+
+def _read_session_state(session_file: Path) -> dict:
+    """Read full session state dict (SafeJSONSession format).
+
+    The file format is: {"agent": {state_dict}, ...} keyed by
+    module name.
+    """
+    if not session_file.exists():
+        return {}
+    try:
+        data = json.loads(
+            session_file.read_text(encoding="utf-8"),
+        )
+        if isinstance(data, dict):
+            return data
+        return {}
+    except Exception as exc:
+        logger.warning(
+            "Failed to read session file %s: %s",
+            session_file,
+            exc,
+        )
+        return {}
+
+
+def _write_fork_session(
+    sessions_dir: Path,
+    fork_session_id: str,
+    state: dict,
+) -> None:
+    """Write pre-seeded state into a new fork session file."""
+    safe_sid = sanitize_filename(fork_session_id)
+    fork_file = sessions_dir / f"{safe_sid}.json"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    fork_file.write_text(
+        json.dumps(state, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    logger.info(
+        "Fork session written: %s (%d keys)",
+        fork_file,
+        len(state),
+    )
+
+
+def _create_worktree(
+    project_dir: Path,
+    worktree_id: str,
+) -> tuple[Path, str]:
+    """Create git worktree at <project_dir>/.qwenpaw/worktrees/<id>.
+
+    Returns (worktree_path, branch_name).
+    """
+    branch = f"fork/{worktree_id}"
+    worktree_path = project_dir / _WORKTREE_BASE / worktree_id
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        [
+            "git",
+            "worktree",
+            "add",
+            str(worktree_path),
+            "-b",
+            branch,
+        ],
+        cwd=str(project_dir),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=(f"git worktree add failed: " f"{result.stderr.strip()}"),
+        )
+
+    logger.info(
+        "Created worktree: %s branch=%s",
+        worktree_path,
+        branch,
+    )
+    _copy_worktreeinclude_files(project_dir, worktree_path)
+    return worktree_path, branch
+
+
+def _copy_worktreeinclude_files(src: Path, dst: Path) -> None:
+    """Copy files listed in .worktreeinclude into the worktree."""
+    include_file = src / ".worktreeinclude"
+    if not include_file.exists():
+        return
+
+    import shutil
+
+    for line in include_file.read_text(
+        encoding="utf-8",
+    ).splitlines():
+        name = line.strip()
+        if not name or name.startswith("#"):
+            continue
+        src_file = src / name
+        dst_file = dst / name
+        if src_file.exists():
+            try:
+                dst_file.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(str(src_file), str(dst_file))
+            except OSError as exc:
+                logger.warning(
+                    "Failed to copy %s: %s",
+                    src_file,
+                    exc,
+                )
+
+
+@router.post("/agent", response_model=ForkAgentResponse)
+async def fork_agent(
+    req: ForkAgentRequest,
+    request: Request,
+) -> ForkAgentResponse:
+    """Prepare a forked subagent: copy session state + optional worktree.
+
+    This endpoint is internal (localhost-only) and called by
+    ``spawn_subagent(fork=True)`` in the tool layer.
+
+    Steps:
+    1. Resolve project dir (coding_mode.project_dir or workspace).
+    2. Read parent session state.
+    3. Write fork session file with inherited state.
+    4. If project_dir is a git repo, create worktree.
+    5. If worktree created, copy ``.worktreeinclude`` files.
+    """
+    _enforce_localhost(request)
+
+    project_dir = _get_project_dir(req.agent_id)
+    sessions_dir = _get_sessions_dir(req.agent_id)
+
+    parent_file = _session_path(
+        sessions_dir,
+        req.parent_session_id,
+        req.user_id,
+        req.channel,
+    )
+    state = _read_session_state(parent_file)
+
+    fork_id = str(uuid4())[:8]
+    fork_session_id = f"sub-{fork_id}"
+
+    _write_fork_session(sessions_dir, fork_session_id, state)
+
+    worktree_path = ""
+    worktree_branch = ""
+
+    if project_dir is not None:
+        wt_path, wt_branch = await asyncio.to_thread(
+            _create_worktree,
+            project_dir,
+            fork_id,
+        )
+        worktree_path = str(wt_path)
+        worktree_branch = wt_branch
+
+    return ForkAgentResponse(
+        fork_session_id=fork_session_id,
+        worktree_path=worktree_path,
+        worktree_branch=worktree_branch,
+    )

--- a/src/qwenpaw/app/routers/fork.py
+++ b/src/qwenpaw/app/routers/fork.py
@@ -206,7 +206,7 @@ def _create_worktree(
     if result.returncode != 0:
         raise HTTPException(
             status_code=500,
-            detail=(f"git worktree add failed: " f"{result.stderr.strip()}"),
+            detail=f"git worktree add failed: {result.stderr.strip()}",
         )
 
     logger.info(
@@ -226,15 +226,34 @@ def _copy_worktreeinclude_files(src: Path, dst: Path) -> None:
 
     import shutil
 
+    src_resolved = src.resolve()
+    dst_resolved = dst.resolve()
+
     for line in include_file.read_text(
         encoding="utf-8",
     ).splitlines():
         name = line.strip()
         if not name or name.startswith("#"):
             continue
-        src_file = src / name
-        dst_file = dst / name
-        if src_file.exists():
+        rel = Path(name)
+        if rel.is_absolute() or ".." in rel.parts:
+            logger.warning(
+                "Skipping unsafe .worktreeinclude path: %s",
+                name,
+            )
+            continue
+        src_file = (src / rel).resolve()
+        dst_file = (dst / rel).resolve()
+        try:
+            src_file.relative_to(src_resolved)
+            dst_file.relative_to(dst_resolved)
+        except ValueError:
+            logger.warning(
+                "Skipping worktreeinclude outside project: %s",
+                name,
+            )
+            continue
+        if src_file.is_file():
             try:
                 dst_file.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(str(src_file), str(dst_file))

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -385,6 +385,8 @@ class AgentRunner(Runner):
             set_current_agent_id,
             set_current_session_id,
             set_current_root_session_id,
+            set_current_user_id,
+            set_current_channel,
         )
 
         set_current_agent_id(self.agent_id)
@@ -400,6 +402,8 @@ class AgentRunner(Runner):
             session_id = request.session_id
             user_id = request.user_id
             channel = getattr(request, "channel", DEFAULT_CHANNEL)
+            set_current_user_id(user_id)
+            set_current_channel(channel)
 
             logger.info(
                 "Handle agent query:\n%s",
@@ -444,6 +448,28 @@ class AgentRunner(Runner):
                 and getattr(_cm, "project_dir", None)
                 else None
             )
+
+            # Fork subagent: override project_dir with worktree path.
+            _payload_ctx = getattr(request, "request_context", None)
+            _fork_project = (
+                _payload_ctx.get("fork_project_dir", "")
+                if isinstance(_payload_ctx, dict)
+                else ""
+            )
+            if _fork_project:
+                _resolved_fork = Path(_fork_project).resolve()
+                _marker = f".qwenpaw{os.sep}worktrees{os.sep}"
+                if _marker in str(_resolved_fork) and (
+                    _resolved_fork.is_dir()
+                ):
+                    _coding_project_dir = str(_resolved_fork)
+                else:
+                    logger.warning(
+                        "Rejected fork_project_dir outside "
+                        "allowed subtree: %s",
+                        _fork_project,
+                    )
+
             env_context = build_env_context(
                 session_id=session_id,
                 user_id=user_id,

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -457,11 +457,26 @@ class AgentRunner(Runner):
                 else ""
             )
             if _fork_project:
-                _resolved_fork = Path(_fork_project).resolve()
-                _marker = f".qwenpaw{os.sep}worktrees{os.sep}"
-                if _marker in str(_resolved_fork) and (
-                    _resolved_fork.is_dir()
-                ):
+                _resolved_fork = Path(_fork_project).expanduser().resolve()
+                _project_base = (
+                    Path(
+                        _coding_project_dir
+                        or (
+                            str(self.workspace_dir)
+                            if self.workspace_dir
+                            else str(WORKING_DIR)
+                        ),
+                    )
+                    .expanduser()
+                    .resolve()
+                )
+                _allowed_base = _project_base / ".qwenpaw" / "worktrees"
+                try:
+                    _resolved_fork.relative_to(_allowed_base)
+                    _is_allowed = _resolved_fork.is_dir()
+                except ValueError:
+                    _is_allowed = False
+                if _is_allowed:
                     _coding_project_dir = str(_resolved_fork)
                 else:
                     logger.warning(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1522,6 +1522,14 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
             description="Check the status of a background agent task",
             icon="⏳",
         ),
+        "spawn_subagent": BuiltinToolConfig(
+            name="spawn_subagent",
+            enabled=True,
+            description=(
+                "Spawn an ephemeral sub-task within the current " "workspace"
+            ),
+            icon="🔀",
+        ),
     }
 
     # Merge dynamically registered tools from plugins

--- a/tests/unit/security/skill_scanner/test_init.py
+++ b/tests/unit/security/skill_scanner/test_init.py
@@ -580,8 +580,12 @@ class TestCacheHelpers:
         # Modify directory to change mtime
         import time
 
-        (tmp_path / "new_file.txt").write_text("change")
-        time.sleep(0.1)  # Ensure mtime difference
+        new_file = tmp_path / "new_file.txt"
+        new_file.write_text("change")
+        import os
+
+        future = time.time() + 2
+        os.utime(str(new_file), (future, future))
         cached = _get_cached_result(tmp_path)
         # After modification, cache should be invalidated
         # (mtime changed, so cached result is None)

--- a/website/public/docs/multi-agent.en.md
+++ b/website/public/docs/multi-agent.en.md
@@ -696,8 +696,6 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 
 ---
 
----
-
 ## Part 3: In-Workspace Subagents (spawn_subagent)
 
 > Introduced in **v1.1.10**.

--- a/website/public/docs/multi-agent.en.md
+++ b/website/public/docs/multi-agent.en.md
@@ -707,11 +707,11 @@ QwenPaw also supports spawning ephemeral sub-tasks **within the current project*
 
 ### Three Collaboration Modes Compared
 
-| Mode | Workspace | History | Best for |
-|---|---|---|---|
-| `chat_with_agent` | Target agent's own workspace | None (text only) | Calling a specialist agent (QA, code review, etc.) |
-| `spawn_subagent(fork=False)` | Same project as parent | None (blank session) | Clean, independent sub-tasks |
-| `spawn_subagent(fork=True)` | Depends on environment (see below) | Full parent history | Context-aware side tasks that may modify files |
+| Mode                         | Workspace                          | History              | Best for                                           |
+| ---------------------------- | ---------------------------------- | -------------------- | -------------------------------------------------- |
+| `chat_with_agent`            | Target agent's own workspace       | None (text only)     | Calling a specialist agent (QA, code review, etc.) |
+| `spawn_subagent(fork=False)` | Same project as parent             | None (blank session) | Clean, independent sub-tasks                       |
+| `spawn_subagent(fork=True)`  | Depends on environment (see below) | Full parent history  | Context-aware side tasks that may modify files     |
 
 ### Key Characteristics
 
@@ -721,17 +721,18 @@ QwenPaw also supports spawning ephemeral sub-tasks **within the current project*
 
 ### fork=True Behavior by Environment
 
-| Environment | Behavior |
-|---|---|
-| Coding Mode ON + project_dir is git repo | Creates a **git worktree** under `<project_dir>/.qwenpaw/worktrees/`. Subagent works in the isolated worktree. |
-| Coding Mode OFF + workspace is git repo | Creates a **git worktree** under `<workspace_dir>/.qwenpaw/worktrees/`. Subagent works in the isolated worktree. |
-| No git repo available | **In-place fork**: inherits conversation context, works in the same directory as the parent. No file isolation. |
+| Environment                              | Behavior                                                                                                         |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Coding Mode ON + project_dir is git repo | Creates a **git worktree** under `<project_dir>/.qwenpaw/worktrees/`. Subagent works in the isolated worktree.   |
+| Coding Mode OFF + workspace is git repo  | Creates a **git worktree** under `<workspace_dir>/.qwenpaw/worktrees/`. Subagent works in the isolated worktree. |
+| No git repo available                    | **In-place fork**: inherits conversation context, works in the same directory as the parent. No file isolation.  |
 
 The core guarantee of `fork=True` is **conversation context inheritance**. Git worktree isolation is an automatic bonus when the project is a git repository.
 
 ### When to Use spawn_subagent?
 
 **Use `spawn_subagent(fork=False)` (default, most common)**:
+
 - Sub-task needs to read/write **files in the current project**
 - Sub-task is self-contained and **doesn't need conversation context**
 
@@ -742,6 +743,7 @@ The core guarantee of `fork=True` is **conversation context inheritance**. Git w
 ```
 
 **Use `spawn_subagent(fork=True)`**:
+
 - Sub-task **needs the full conversation context** (e.g. based on what we just discussed)
 - Sub-task **modifies files** but shouldn't affect the current working tree (requires git repo)
 - Sub-task needs context but **doesn't modify files** (works anywhere)
@@ -753,6 +755,7 @@ The core guarantee of `fork=True` is **conversation context inheritance**. Git w
 ```
 
 **Use `chat_with_agent` (cross-agent)**:
+
 - You need a specialist agent with its own configuration and tools
 
 ### Usage Examples
@@ -831,12 +834,14 @@ subagent can run without missing configuration.
 **Q: Can I use both spawn_subagent and chat_with_agent together?**
 
 Yes. They are complementary:
+
 - `spawn_subagent` — in-project file tasks (same agent, ephemeral)
 - `chat_with_agent` — specialist agents in other workspaces
 
 **Q: Does fork=True require Coding Mode?**
 
 No. `fork=True` always works:
+
 - With a git repo (Coding Mode or workspace): you get worktree isolation + context inheritance.
 - Without a git repo: you get context inheritance only (in-place work, no file isolation).
 

--- a/website/public/docs/multi-agent.en.md
+++ b/website/public/docs/multi-agent.en.md
@@ -696,6 +696,171 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 
 ---
 
+---
+
+## Part 3: In-Workspace Subagents (spawn_subagent)
+
+> Introduced in **v1.1.10**.
+
+Beyond collaborating with agents in **separate workspaces** (`chat_with_agent`),
+QwenPaw also supports spawning ephemeral sub-tasks **within the current project**.
+
+### Three Collaboration Modes Compared
+
+| Mode | Workspace | History | Best for |
+|---|---|---|---|
+| `chat_with_agent` | Target agent's own workspace | None (text only) | Calling a specialist agent (QA, code review, etc.) |
+| `spawn_subagent(fork=False)` | Same project as parent | None (blank session) | Clean, independent sub-tasks |
+| `spawn_subagent(fork=True)` | Depends on environment (see below) | Full parent history | Context-aware side tasks that may modify files |
+
+### Key Characteristics
+
+- **Ephemeral**: Subagents cannot be resumed. Each call creates a fresh session that is discarded after completion.
+- **Same Agent**: The subagent runs as the same agent (same config, persona, tools), just in a separate session.
+- **Always available**: `fork=True` works regardless of whether Coding Mode is enabled.
+
+### fork=True Behavior by Environment
+
+| Environment | Behavior |
+|---|---|
+| Coding Mode ON + project_dir is git repo | Creates a **git worktree** under `<project_dir>/.qwenpaw/worktrees/`. Subagent works in the isolated worktree. |
+| Coding Mode OFF + workspace is git repo | Creates a **git worktree** under `<workspace_dir>/.qwenpaw/worktrees/`. Subagent works in the isolated worktree. |
+| No git repo available | **In-place fork**: inherits conversation context, works in the same directory as the parent. No file isolation. |
+
+The core guarantee of `fork=True` is **conversation context inheritance**. Git worktree isolation is an automatic bonus when the project is a git repository.
+
+### When to Use spawn_subagent?
+
+**Use `spawn_subagent(fork=False)` (default, most common)**:
+- Sub-task needs to read/write **files in the current project**
+- Sub-task is self-contained and **doesn't need conversation context**
+
+```
+"List all API endpoints under src/core"
+"Run the test suite and summarize failures"
+"Scan the codebase for security vulnerabilities"
+```
+
+**Use `spawn_subagent(fork=True)`**:
+- Sub-task **needs the full conversation context** (e.g. based on what we just discussed)
+- Sub-task **modifies files** but shouldn't affect the current working tree (requires git repo)
+- Sub-task needs context but **doesn't modify files** (works anywhere)
+
+```
+"Based on our discussion, write unit tests for the parser module"
+"Try an alternative implementation in a separate branch for comparison"
+"Summarize what we've discussed so far into a spec document"
+```
+
+**Use `chat_with_agent` (cross-agent)**:
+- You need a specialist agent with its own configuration and tools
+
+### Usage Examples
+
+#### Foreground (waits for result)
+
+```
+User: Analyze performance bottlenecks in src/core
+
+Agent internally calls:
+spawn_subagent(task="Analyze performance bottlenecks in src/core and report findings")
+→ Returns: [SESSION: sub-ab12]
+            Detailed analysis...
+```
+
+#### Background (returns immediately, poll later)
+
+```
+spawn_subagent(
+    task="Scan the entire codebase for security vulnerabilities",
+    background=True,
+)
+→ Returns: [TASK_ID: task-cd34]
+            [SESSION: sub-ef56]
+            Task submitted. Poll with check_agent_task(task_id="task-cd34").
+```
+
+#### fork=True with git repo — Inherit History, Isolated Worktree
+
+```
+spawn_subagent(
+    task="Based on our discussion, write unit tests for the parser module",
+    fork=True,
+)
+→ [SESSION: sub-gh78]
+   Tests written to src/tests/...
+   [FORK_BRANCH: fork/ab12ef34]
+   The forked worktree has uncommitted changes. Review and merge manually.
+
+# If the subagent makes no file changes → worktree is cleaned up automatically
+```
+
+#### fork=True without git repo — In-place with Context
+
+```
+spawn_subagent(
+    task="Based on our earlier discussion, draft the API spec",
+    fork=True,
+)
+→ [SESSION: sub-ij90]
+   API spec drafted...
+
+# No worktree involved — subagent inherits context and works in-place
+```
+
+### .worktreeinclude — Auto-copy Config Files into Worktree
+
+When a git worktree is created, files ignored by `.gitignore` (like `.env`)
+are not included. Create a `.worktreeinclude` file in the project root to
+specify files that should be copied into the worktree automatically:
+
+```
+# .worktreeinclude
+.env
+.env.local
+config/local.json
+```
+
+QwenPaw copies these files into the worktree when it is created, so the
+subagent can run without missing configuration.
+
+> Note: `.worktreeinclude` only applies when a git worktree is created.
+
+### FAQ
+
+**Q: Can I use both spawn_subagent and chat_with_agent together?**
+
+Yes. They are complementary:
+- `spawn_subagent` — in-project file tasks (same agent, ephemeral)
+- `chat_with_agent` — specialist agents in other workspaces
+
+**Q: Does fork=True require Coding Mode?**
+
+No. `fork=True` always works:
+- With a git repo (Coding Mode or workspace): you get worktree isolation + context inheritance.
+- Without a git repo: you get context inheritance only (in-place work, no file isolation).
+
+**Q: Is the worktree cleaned up automatically?**
+
+- **With file changes**: kept. Returns `[FORK_BRANCH]` with the branch name. Merge manually, then remove with `git worktree remove`.
+- **No file changes**: automatically removed.
+- **No git repo**: no worktree is created, so no cleanup needed.
+
+**Q: What about cleanup in background=True mode?**
+
+Background mode skips automatic cleanup. Manage manually:
+
+```bash
+git worktree list
+git worktree remove .qwenpaw/worktrees/<id>
+```
+
+**Q: Can I resume a subagent session?**
+
+No. Subagents are ephemeral by design. If you need multi-turn interaction with another agent, use `chat_with_agent` with a `session_id`.
+
+---
+
 ## Related Pages
 
 - [CLI Commands](./cli) - Detailed CLI reference

--- a/website/public/docs/multi-agent.zh.md
+++ b/website/public/docs/multi-agent.zh.md
@@ -696,8 +696,6 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 
 ---
 
----
-
 ## 第三部分：子 Agent 派发（spawn_subagent）
 
 > 本功能在 **v1.1.10** 中引入。

--- a/website/public/docs/multi-agent.zh.md
+++ b/website/public/docs/multi-agent.zh.md
@@ -706,11 +706,11 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 
 ### 三种协作模式对比
 
-| 模式 | 工作区 | 历史上下文 | 适用场景 |
-|---|---|---|---|
-| `chat_with_agent` | 目标 Agent 独立 workspace | 无（只传 text） | 调用专长 Agent（QA、代码审查等） |
-| `spawn_subagent(fork=False)` | 与当前 Agent 相同的项目 | 无（空白 session） | 干净独立子任务 |
-| `spawn_subagent(fork=True)` | 取决于环境（见下方） | 继承完整对话历史 | 需要背景的侧任务，且可能改文件 |
+| 模式                         | 工作区                    | 历史上下文         | 适用场景                         |
+| ---------------------------- | ------------------------- | ------------------ | -------------------------------- |
+| `chat_with_agent`            | 目标 Agent 独立 workspace | 无（只传 text）    | 调用专长 Agent（QA、代码审查等） |
+| `spawn_subagent(fork=False)` | 与当前 Agent 相同的项目   | 无（空白 session） | 干净独立子任务                   |
+| `spawn_subagent(fork=True)`  | 取决于环境（见下方）      | 继承完整对话历史   | 需要背景的侧任务，且可能改文件   |
 
 ### 核心特性
 
@@ -720,17 +720,18 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 
 ### fork=True 在不同环境下的行为
 
-| 环境 | 行为 |
-|---|---|
-| 开启 Coding Mode + project_dir 是 git 仓库 | 在 `<project_dir>/.qwenpaw/worktrees/` 下创建 **git worktree**，子 Agent 在隔离的 worktree 中工作 |
+| 环境                                       | 行为                                                                                                |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| 开启 Coding Mode + project_dir 是 git 仓库 | 在 `<project_dir>/.qwenpaw/worktrees/` 下创建 **git worktree**，子 Agent 在隔离的 worktree 中工作   |
 | 未开启 Coding Mode + workspace 是 git 仓库 | 在 `<workspace_dir>/.qwenpaw/worktrees/` 下创建 **git worktree**，子 Agent 在隔离的 worktree 中工作 |
-| 没有可用的 git 仓库 | **原地 fork**：继承对话上下文，在与 parent 相同的目录中工作。无文件隔离 |
+| 没有可用的 git 仓库                        | **原地 fork**：继承对话上下文，在与 parent 相同的目录中工作。无文件隔离                             |
 
 `fork=True` 的核心保证是**对话上下文继承**。Git worktree 隔离是项目为 git 仓库时的自动附加能力。
 
 ### 何时使用 spawn_subagent？
 
 **使用 `spawn_subagent(fork=False)`（推荐，最常用）**：
+
 - 子任务需要读写**当前项目的文件**
 - 子任务相对独立，**不需要当前对话的背景**
 
@@ -741,6 +742,7 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 ```
 
 **使用 `spawn_subagent(fork=True)`**：
+
 - 子任务**需要完整对话背景**（如基于刚才讨论的内容）
 - 子任务**会改动文件**，但不希望影响当前工作区（需要 git 仓库）
 - 子任务需要对话背景但**不改动文件**（任何环境都可用）
@@ -752,6 +754,7 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 ```
 
 **使用 `chat_with_agent`（跨 Agent）**：
+
 - 需要调用有特定专长的其他 Agent（QA Agent、代码审查 Agent 等）
 
 ### 调用方式
@@ -829,12 +832,14 @@ QwenPaw 在创建 worktree 时会自动将这些文件复制过去，确保子�
 **Q：spawn_subagent 和 chat_with_agent 可以同时用吗？**
 
 可以。两者互不冲突：
+
 - `spawn_subagent` 在当前项目内执行文件操作类子任务（同 Agent，临时 session）
 - `chat_with_agent` 调用其他专长 Agent
 
 **Q：fork=True 需要开启 Coding Mode 吗？**
 
 不需要。`fork=True` 始终可用：
+
 - 有 git 仓库时（无论是 Coding Mode 的 project_dir 还是 workspace）：获得 worktree 隔离 + 上下文继承
 - 没有 git 仓库时：仅获得上下文继承（原地工作，无文件隔离）
 
@@ -847,6 +852,7 @@ QwenPaw 在创建 worktree 时会自动将这些文件复制过去，确保子�
 **Q：background=True 时的 worktree 怎么处理？**
 
 后台模式下不自动清理，需手动检查：
+
 ```bash
 git worktree list
 git worktree remove .qwenpaw/worktrees/<id>

--- a/website/public/docs/multi-agent.zh.md
+++ b/website/public/docs/multi-agent.zh.md
@@ -696,6 +696,168 @@ cp -r ~/.qwenpaw/workspaces ~/backups/workspaces-$(date +%Y%m%d)
 
 ---
 
+---
+
+## 第三部分：子 Agent 派发（spawn_subagent）
+
+> 本功能在 **v1.1.10** 中引入。
+
+除了与**不同 workspace 的其他 Agent** 协作（`chat_with_agent`），QwenPaw 还支持在**当前项目内**派发临时子任务。
+
+### 三种协作模式对比
+
+| 模式 | 工作区 | 历史上下文 | 适用场景 |
+|---|---|---|---|
+| `chat_with_agent` | 目标 Agent 独立 workspace | 无（只传 text） | 调用专长 Agent（QA、代码审查等） |
+| `spawn_subagent(fork=False)` | 与当前 Agent 相同的项目 | 无（空白 session） | 干净独立子任务 |
+| `spawn_subagent(fork=True)` | 取决于环境（见下方） | 继承完整对话历史 | 需要背景的侧任务，且可能改文件 |
+
+### 核心特性
+
+- **临时性（Ephemeral）**：子 Agent 不可恢复。每次调用创建一个新 session，完成后即丢弃。
+- **同一 Agent**：子 Agent 使用相同的 Agent 配置（persona、tools），只是在独立 session 中运行。
+- **无需额外配置**：`fork=True` 始终可用，无论是否开启 Coding Mode。
+
+### fork=True 在不同环境下的行为
+
+| 环境 | 行为 |
+|---|---|
+| 开启 Coding Mode + project_dir 是 git 仓库 | 在 `<project_dir>/.qwenpaw/worktrees/` 下创建 **git worktree**，子 Agent 在隔离的 worktree 中工作 |
+| 未开启 Coding Mode + workspace 是 git 仓库 | 在 `<workspace_dir>/.qwenpaw/worktrees/` 下创建 **git worktree**，子 Agent 在隔离的 worktree 中工作 |
+| 没有可用的 git 仓库 | **原地 fork**：继承对话上下文，在与 parent 相同的目录中工作。无文件隔离 |
+
+`fork=True` 的核心保证是**对话上下文继承**。Git worktree 隔离是项目为 git 仓库时的自动附加能力。
+
+### 何时使用 spawn_subagent？
+
+**使用 `spawn_subagent(fork=False)`（推荐，最常用）**：
+- 子任务需要读写**当前项目的文件**
+- 子任务相对独立，**不需要当前对话的背景**
+
+```
+"分析 src/core 下所有 API 端点并生成清单"
+"运行测试套件并汇总失败原因"
+"扫描整个代码库的安全漏洞"
+```
+
+**使用 `spawn_subagent(fork=True)`**：
+- 子任务**需要完整对话背景**（如基于刚才讨论的内容）
+- 子任务**会改动文件**，但不希望影响当前工作区（需要 git 仓库）
+- 子任务需要对话背景但**不改动文件**（任何环境都可用）
+
+```
+"基于我们刚才的讨论，为解析器模块补充单元测试"
+"试试另一个实现思路，做成独立分支方便比较"
+"把我们讨论的内容整理成一份规格文档"
+```
+
+**使用 `chat_with_agent`（跨 Agent）**：
+- 需要调用有特定专长的其他 Agent（QA Agent、代码审查 Agent 等）
+
+### 调用方式
+
+#### 前台同步（等待结果）
+
+```
+用户：分析 src/core 下的性能瓶颈
+
+Agent 内部执行：
+spawn_subagent(task="分析 src/core 下的性能瓶颈并给出报告")
+→ 返回: [SESSION: sub-ab12]
+         分析结果详情...
+```
+
+#### 后台异步（立即返回，稍后查询）
+
+```
+spawn_subagent(
+    task="扫描整个代码库安全漏洞",
+    background=True,
+)
+→ 返回: [TASK_ID: task-cd34]
+         [SESSION: sub-ef56]
+         任务已提交，用 check_agent_task(task_id="task-cd34") 查询进度
+```
+
+#### fork=True + git 仓库 — 继承历史，隔离 worktree
+
+```
+spawn_subagent(
+    task="基于我们刚才的讨论，为 parser 模块写单元测试",
+    fork=True,
+)
+→ [SESSION: sub-gh78]
+   测试代码已写入...
+   [FORK_BRANCH: fork/ab12ef34]
+   有文件改动，请手动合并分支。
+
+# 如果子任务完成后没有改动文件 → worktree 自动清理
+```
+
+#### fork=True + 非 git 仓库 — 原地继承上下文
+
+```
+spawn_subagent(
+    task="基于我们之前的讨论，起草 API 规格文档",
+    fork=True,
+)
+→ [SESSION: sub-ij90]
+   API 规格文档已起草...
+
+# 无 worktree 创建 — 子 Agent 继承上下文后原地工作
+```
+
+### .worktreeinclude — 自动复制配置文件
+
+当 git worktree 被创建时，被 `.gitignore` 忽略的文件（如 `.env`）不会被包含。
+
+在项目根目录创建 `.worktreeinclude` 文件，列出需要复制到 worktree 的文件：
+
+```
+# .worktreeinclude
+.env
+.env.local
+config/local.json
+```
+
+QwenPaw 在创建 worktree 时会自动将这些文件复制过去，确保子任务能正常运行。
+
+> 注意：`.worktreeinclude` 仅在 git worktree 被创建时生效。
+
+### 常见问题
+
+**Q：spawn_subagent 和 chat_with_agent 可以同时用吗？**
+
+可以。两者互不冲突：
+- `spawn_subagent` 在当前项目内执行文件操作类子任务（同 Agent，临时 session）
+- `chat_with_agent` 调用其他专长 Agent
+
+**Q：fork=True 需要开启 Coding Mode 吗？**
+
+不需要。`fork=True` 始终可用：
+- 有 git 仓库时（无论是 Coding Mode 的 project_dir 还是 workspace）：获得 worktree 隔离 + 上下文继承
+- 没有 git 仓库时：仅获得上下文继承（原地工作，无文件隔离）
+
+**Q：worktree 会自动清理吗？**
+
+- **有文件改动**：保留，返回 `[FORK_BRANCH]` 分支名。需手动合并后执行 `git worktree remove` 清理
+- **无文件改动**：自动清理
+- **无 git 仓库**：不创建 worktree，无需清理
+
+**Q：background=True 时的 worktree 怎么处理？**
+
+后台模式下不自动清理，需手动检查：
+```bash
+git worktree list
+git worktree remove .qwenpaw/worktrees/<id>
+```
+
+**Q：可以恢复子 Agent 的 session 吗？**
+
+不可以。子 Agent 设计为临时性的。如需多轮交互，请使用 `chat_with_agent` 并指定 `session_id`。
+
+---
+
 ## 相关页面
 
 - [CLI 命令](./cli) - 命令行工具详细说明


### PR DESCRIPTION
## Description

Add `spawn_subagent` as a built-in tool that allows an agent to delegate ephemeral sub-tasks within its own workspace — complementing the existing `chat_with_agent` (cross-workspace) tool.

**Three collaboration modes are now available:**

| Mode | Workspace | History | Use case |
|---|---|---|---|
| `chat_with_agent` | Target agent's own workspace | None (text only) | Calling a specialist agent |
| `spawn_subagent(fork=False)` | Same project as parent | None (blank session) | Clean, independent sub-tasks |
| `spawn_subagent(fork=True)` | git worktree (if available) | Full parent history | Context-aware side tasks |

**Key design decisions:**
- **Ephemeral**: subagents cannot be resumed — each call creates a disposable session
- **`fork=True` always works** regardless of Coding Mode:
  - Coding Mode ON + git repo → worktree isolation + context inheritance
  - Coding Mode OFF + workspace is git repo → worktree isolation + context inheritance
  - No git repo → in-place fork with context inheritance only
- **Runtime-only override**: `fork_project_dir` is passed via `request_context`, never persisted to config
- **Auto-cleanup**: foreground fork removes worktree if no file changes were made

**Related Issue:** N/A (new feature)

**Security Considerations:** `fork_project_dir` override in runner is validated to contain `.qwenpaw/worktrees/` path marker. Fork endpoint is localhost-only.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

### Manual Testing

1. Start QwenPaw server, create an agent with Coding Mode enabled (project_dir = a git repo)
2. In chat, trigger `spawn_subagent(task="list files in src/", fork=False)` → should return file listing in a fresh session
3. Trigger `spawn_subagent(task="summarize our conversation", fork=True)` → should inherit full conversation context
4. For fork=True with git repo: verify worktree created under `.qwenpaw/worktrees/`, and auto-cleaned if no changes
5. For fork=True without git repo: verify in-place fork with context inheritance (no worktree)
6. Background mode: `spawn_subagent(task="...", background=True)` → returns task_id, poll with `check_agent_task`

### Verification Commands

```bash
pre-commit run --files src/qwenpaw/agents/tools/agent_management.py \
  src/qwenpaw/app/routers/fork.py \
  src/qwenpaw/app/runner/runner.py \
  src/qwenpaw/app/agent_context.py
# All passed

pytest tests/unit/agents/tools/test_spawn_subagent.py -v
# 13 passed (test file removed from commit per request, but validated locally)
```

## Local Verification Evidence

```bash
pre-commit run --all-files
# All hooks passed

pytest tests/unit/agents/tools/test_spawn_subagent.py -v
# 13 passed, 1 warning
```

## Additional Notes

### Files Changed

| File | Change |
|---|---|
| `src/qwenpaw/app/agent_context.py` | Add `user_id`/`channel` contextvars + getters/setters |
| `src/qwenpaw/app/runner/runner.py` | Set new contextvars + `fork_project_dir` override logic |
| `src/qwenpaw/agents/tools/agent_management.py` | `spawn_subagent` tool + `_call_fork_api`, `_spawn_forked_subagent`, `_maybe_cleanup_worktree` helpers |
| `src/qwenpaw/app/routers/fork.py` | New `POST /api/fork/agent` endpoint (localhost-only) |
| `src/qwenpaw/app/routers/__init__.py` | Register `fork_router` |
| `src/qwenpaw/agents/tools/__init__.py` | Export `spawn_subagent` |
| `src/qwenpaw/agents/react_agent.py` | Register `spawn_subagent` in tool_functions |
| `.gitignore` | Add `.qwenpaw/worktrees/` |
| `website/public/docs/multi-agent.en.md` | Part 3: spawn_subagent documentation |
| `website/public/docs/multi-agent.zh.md` | Part 3: spawn_subagent 文档 |

### Architecture

```
User → Agent → spawn_subagent(task, fork=True)
                    │
                    ├─ _call_fork_api() → POST /api/fork/agent
                    │       ├─ Read parent session state
                    │       ├─ Write fork session (same path convention)
                    │       └─ git worktree add (if git repo available)
                    │
                    ├─ Dispatch subagent via /agent/process
                    │       └─ request_context: {fork_project_dir: worktree_path}
                    │
                    └─ On completion:
                            ├─ No changes → auto-remove worktree
                            └─ Has changes → return [FORK_BRANCH: ...]
```
