### PR TITLE
feat(providers): add OpenRouter app attribution headers for ranking visibility

### DIFF
--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -19,9 +19,16 @@ from qwenpaw.providers.provider import (
 class OpenRouterProvider(Provider):
     """OpenRouter provider with required HTTP-Referer and X-Title headers."""
 
+    _OPENROUTER_CATEGORIES = (
+        "cli-agent,cloud-agent,programming-app,"
+        "creative-writing,writing-assistant,"
+        "general-chat,personal-agent"
+    )
+
     _DEFAULT_HEADERS = {
         "HTTP-Referer": "https://qwenpaw.agentscope.io/",
-        "X-Title": "QwenPaw",
+        "X-OpenRouter-Title": "QwenPaw",
+        "X-OpenRouter-Categories": _OPENROUTER_CATEGORIES,
         "User-Agent": "QwenPaw/1.1",
     }
 


### PR DESCRIPTION
## Description

Add OpenRouter app attribution headers (`X-OpenRouter-Title` and `X-OpenRouter-Categories`) to ensure QwenPaw is properly tracked and appears on the OpenRouter coding leaderboard.

Previously we only sent `X-Title` (legacy) and lacked category headers entirely, which prevented QwenPaw from appearing in the category-specific rankings despite having 20B+ tokens of usage.

Changes:
- Replaced `X-Title` with the official `X-OpenRouter-Title` header
- Added `X-OpenRouter-Categories` with values matching OpenClaw's attribution policy: `cli-agent,cloud-agent,programming-app,creative-writing,writing-assistant,general-chat,personal-agent`

Reference:
- OpenRouter docs: https://openrouter.ai/docs/app-attribution
- OpenClaw implementation: https://github.com/openclaw/openclaw/blob/main/src/agents/provider-attribution.ts

**Related Issue:** N/A

**Security Considerations:** None. These are non-sensitive attribution headers for public ranking purposes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Deploy with updated headers
2. Make API requests through OpenRouter
3. Verify app appears at https://openrouter.ai/apps?url=https://qwenpaw.agentscope.io/ with correct categories
4. Monitor https://openrouter.ai/apps/category/coding for QwenPaw listing (may take 24-48h for rankings to update)

## Local Verification Evidence

```bash
pre-commit run --file src/qwenpaw/providers/openrouter_provider.py
# All checks passed (ast, docstring, encoding, private key, trailing whitespace,
# trailing commas, mypy, black, flake8, pylint)
```

## Additional Notes

OpenRouter rankings update on daily/weekly/monthly cadence. After merging, QwenPaw should start appearing in category leaderboards once the new headers are live in production traffic.
