### PR TITLE
feat(console): Add current-agent skills to slash command suggestions with UI optimizations

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -82,15 +82,28 @@
   align-items: flex-start;
   gap: 12px;
   min-width: 0;
-  width: 100%;
+  width: min(520px, calc(100vw - 48px));
+  max-width: 100%;
   line-height: 1.4;
+}
+
+.suggestionLabelCompact {
+  width: auto;
 }
 
 .suggestionCommand {
   flex: 0 0 88px;
+  min-width: 0;
   color: #ff7f16;
   font-weight: 600;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.suggestionLabelCompact .suggestionCommand {
+  flex-basis: auto;
+  max-width: min(320px, calc(100vw - 96px));
 }
 
 .suggestionDescription {
@@ -101,6 +114,19 @@
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+}
+
+:global {
+  .qwenpaw-suggestion .qwenpaw-cascader-menu,
+  .qwenpaw-suggestion .ant-cascader-menu,
+  .ant-cascader-dropdown.qwenpaw-suggestion .qwenpaw-cascader-menu,
+  .ant-cascader-dropdown.qwenpaw-suggestion .ant-cascader-menu {
+    height: auto !important;
+    max-height: 210px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+  }
 }
 
 :global(.dark-mode) {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -15,10 +15,11 @@ import sessionApi from "./sessionApi";
 import defaultConfig, { getDefaultConfig } from "./OptionsPanel/defaultConfig";
 import { chatApi } from "../../api/modules/chat";
 import { agentApi } from "../../api/modules/agent";
+import { skillApi } from "../../api/modules/skill";
 import { getApiUrl } from "../../api/config";
 import { buildAuthHeaders } from "../../api/authHeaders";
 import { providerApi } from "../../api/modules/provider";
-import type { ProviderInfo, ModelInfo } from "../../api/types";
+import type { ProviderInfo, ModelInfo, SkillSpec } from "../../api/types";
 import ModelSelector from "./ModelSelector";
 import { useTheme } from "../../contexts/ThemeContext";
 import { useAgentStore } from "../../stores/agentStore";
@@ -129,11 +130,17 @@ function payloadCompletesResponse(payload: unknown): boolean {
   return record.object === "response" && record.status === "completed";
 }
 
-function renderSuggestionLabel(command: string, description: string) {
+function renderSuggestionLabel(command: string, description?: string) {
   return (
-    <div className={styles.suggestionLabel}>
+    <div
+      className={`${styles.suggestionLabel} ${
+        description ? "" : styles.suggestionLabelCompact
+      }`}
+    >
       <span className={styles.suggestionCommand}>{command}</span>
-      <span className={styles.suggestionDescription}>{description}</span>
+      {description ? (
+        <span className={styles.suggestionDescription}>{description}</span>
+      ) : null}
     </div>
   );
 }
@@ -144,6 +151,12 @@ function renderSuggestionLabel(command: string, description: string) {
 
 const DEFAULT_USER_ID = "default";
 const DEFAULT_CHANNEL = "console";
+
+function isSkillAvailableInConsole(skill: SkillSpec): boolean {
+  if (!skill.enabled) return false;
+  const channels = skill.channels?.length ? skill.channels : ["all"];
+  return channels.includes("all") || channels.includes(DEFAULT_CHANNEL);
+}
 
 // ---------------------------------------------------------------------------
 // Custom hooks
@@ -697,6 +710,11 @@ export default function ChatPage() {
     Map<string, ApprovalMessageData>
   >(new Map());
   const [planEnabled, setPlanEnabled] = useState(false);
+  const [chatSkills, setChatSkills] = useState<SkillSpec[]>([]);
+  const consoleSkills = useMemo(
+    () => chatSkills.filter(isSkillAvailableInConsole),
+    [chatSkills],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -711,11 +729,66 @@ export default function ChatPage() {
     };
   }, [selectedAgent]);
 
+  useEffect(() => {
+    let cancelled = false;
+    skillApi
+      .listSkills(selectedAgent)
+      .then((skills) => {
+        if (cancelled) return;
+        const nextSkills = Array.isArray(skills) ? skills : [];
+        setChatSkills(nextSkills);
+      })
+      .catch((error) => {
+        console.warn("[ChatSkills] failed to load slash skills", {
+          selectedAgent,
+          error,
+        });
+        if (!cancelled) setChatSkills([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAgent]);
+
   const isChatActiveRef = useRef(false);
   isChatActiveRef.current =
     location.pathname === "/" || location.pathname.startsWith("/chat");
 
   const isChatActive = useCallback(() => isChatActiveRef.current, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab" || !isChatActive()) return;
+      const textarea = event.target;
+      if (!(textarea instanceof HTMLTextAreaElement)) return;
+      if (!textarea.closest('[class*="sender"]')) return;
+      if (
+        !textarea.value.startsWith("/") ||
+        /\s/.test(textarea.value.slice(1))
+      ) {
+        return;
+      }
+
+      const selectedItem =
+        document.querySelector(
+          '[role="menuitemcheckbox"][aria-checked="true"]',
+        ) || document.querySelector('[role="menuitem"][aria-current="true"]');
+      if (!(selectedItem instanceof HTMLElement)) return;
+
+      const selectedValue = selectedItem.getAttribute("data-path-key")?.trim();
+      if (!selectedValue) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      setTextareaValue(textarea, `/${selectedValue} `);
+      textarea.focus();
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [isChatActive]);
 
   // Consume approvals from Context and filter by current session.
   // Uses a serialized key to avoid creating a new Map (and triggering
@@ -1221,6 +1294,18 @@ export default function ChatPage() {
         description: t("chat.commands.plan.description"),
       });
     }
+    const reservedCommands = new Set(
+      commandSuggestions.map((item) => item.value.trim()),
+    );
+    const skillSuggestions: CommandSuggestion[] = consoleSkills
+      .filter((skill) => !reservedCommands.has(skill.name))
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((skill) => ({
+        command: `/${skill.name}`,
+        value: skill.name,
+        description: "",
+      }));
+    const senderSuggestions = [...commandSuggestions, ...skillSuggestions];
 
     const handleBeforeSubmit = async () => {
       if (isComposingRef.current) return false;
@@ -1291,7 +1376,7 @@ export default function ChatPage() {
           customRequest: handleFileUpload,
         },
         placeholder: t("chat.inputPlaceholder"),
-        suggestions: commandSuggestions.map((item) => ({
+        suggestions: senderSuggestions.map((item) => ({
           label: renderSuggestionLabel(item.command, item.description),
           value: item.value,
         })),
@@ -1416,6 +1501,8 @@ export default function ChatPage() {
     toolRenderConfig,
     scheduleHistoryClear,
     planEnabled,
+    consoleSkills,
+    selectedAgent,
     onFileCardClick,
     whisperChecked,
     whisperEnabled,


### PR DESCRIPTION
- Add available current-agent skills to slash command suggestions
- Show only skill names for skill suggestions to keep the popup compact
- Limit the suggestion popup to 5 visible items with scrolling
- Add ChatSkills debug logs for skill loading and filtering

feat(console): 优化聊天输入框 slash 技能提示
- 在 / 指令提示中加入当前 agent 可用的技能
- 技能提示仅显示技能名，避免长描述撑大弹框
- 限制指令弹框最多显示 5 条，超出后滚动
- 添加 ChatSkills 调试日志，便于排查技能加载与过滤结果

Jun 1 update:

I have now optimized the slash command related to /skills.

When a user enters a slash command prefix similar to /skills, such as /s or /sk, the available skills will be filtered and displayed in the slash command suggestion menu. The user can then use the Down arrow key to select a skill.


Snapshot:
<img width="2892" height="1512" alt="image" src="https://github.com/user-attachments/assets/85a75535-ee33-4744-a2cb-e5a43738b5d5" />


Jun 2 update:
1. Changed skill suggestion value from skills/ to just skill.name, so Sender’s built-in value.includes(keyword) filtering now works correctly. For example, /d can match /docx, while /s no longer matches every skill through the skills/ prefix. Removed normalizeSelectedSkillSuggestion and the previous global click/keydown normalization listener.
2. Removed the .slice(0, 50) cap so skills are not truncated before filtering.
3. Added scoped Tab completion support for the chat sender textarea. When a highlighted suggestion exists, Tab reads its data-path-key, writes /${value} via setTextareaValue, and prevents the default focus jump.
4. Extracted console-available skills into a single consoleSkills useMemo and reused it when building suggestions.


## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
