### PR TITLE
fix(context): normalize inline source URL strings in media blocks dur…

### DIFF
--- a/src/qwenpaw/agents/context/as_msg_handler.py
+++ b/src/qwenpaw/agents/context/as_msg_handler.py
@@ -53,6 +53,8 @@ class AsMsgHandler:
 
                 elif block_type in ["image", "audio", "video", "file"]:
                     source = block.get("source", {})
+                    if isinstance(source, str):
+                        source = {"url": source}
                     if source.get("type") == "base64":
                         data = source.get("data", "")
                         total_token_count += len(data) // 4 if data else 10
@@ -122,6 +124,8 @@ class AsMsgHandler:
 
             elif block_type in ("image", "audio", "video", "file"):
                 source = block.get("source", {})
+                if isinstance(source, str):
+                    source = {"url": source}
                 url = source.get("url", "")
                 if source.get("type") == "base64":
                     data = source.get("data", "")

--- a/tests/unit/agents/context/test_as_msg_handler.py
+++ b/tests/unit/agents/context/test_as_msg_handler.py
@@ -467,3 +467,110 @@ class TestAsMsgHandlerToolAlignment:
         assert (
             tool_use_ids_in_keep == tool_result_ids_in_keep
         ), f"tool_use ids: {tool_use_ids_in_keep}, tool_result ids: {tool_result_ids_in_keep}"
+
+
+class TestAsMsgHandlerInlineSourceUrl:
+    """Test that media blocks with inline source URL strings are handled."""
+
+    @pytest.mark.asyncio
+    async def test_stat_message_with_inline_source_url(self):
+        """stat_message should handle source as a plain URL string."""
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+
+        message = Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {"type": "text", "text": "Here is the image:"},
+                {"type": "image", "source": "https://example.com/img.png"},
+            ],
+            metadata={},
+        )
+
+        stat = await handler.stat_message(message)
+        assert len(stat.content) == 2
+        assert stat.content[1].block_type == "image"
+        assert stat.content[1].media_url == "https://example.com/img.png"
+
+    @pytest.mark.asyncio
+    async def test_stat_message_with_dict_source_url(self):
+        """stat_message should still handle source as a dict with url key."""
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+
+        message = Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                {
+                    "type": "image",
+                    "source": {"url": "https://example.com/img.png"},
+                },
+            ],
+            metadata={},
+        )
+
+        stat = await handler.stat_message(message)
+        assert len(stat.content) == 1
+        assert stat.content[0].block_type == "image"
+        assert stat.content[0].media_url == "https://example.com/img.png"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_with_inline_source_url(self):
+        """tool_result containing media with inline source URL should be handled."""
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+
+        message = Msg(
+            name="system",
+            role="system",
+            content=[
+                {
+                    "type": "tool_result",
+                    "id": "tool-001",
+                    "name": "test_tool",
+                    "output": [
+                        {"type": "text", "text": "result:"},
+                        {
+                            "type": "image",
+                            "source": "https://example.com/img.png",
+                        },
+                    ],
+                },
+            ],
+            metadata={},
+        )
+
+        stat = await handler.stat_message(message)
+        assert len(stat.content) == 1
+        assert stat.content[0].block_type == "tool_result"
+        assert "result:" in stat.content[0].tool_output
+        assert "https://example.com/img.png" in stat.content[0].tool_output
+
+    @pytest.mark.asyncio
+    async def test_context_check_with_inline_source_url(self):
+        """context_check should not crash when messages contain inline source URLs."""
+        token_counter = MockTokenCounter()
+        handler = AsMsgHandler(token_counter)
+
+        messages = [
+            Msg(name="user", role="user", content="Hello", metadata={}),
+            Msg(
+                name="assistant",
+                role="assistant",
+                content=[
+                    {"type": "text", "text": "Here is the image:"},
+                    {"type": "image", "source": "https://example.com/img.png"},
+                ],
+                metadata={},
+            ),
+        ]
+
+        result = await handler.context_check(
+            messages=messages,
+            context_compact_threshold=100,
+            context_compact_reserve=100,
+        )
+        _, msgs_to_keep, _, _ = result
+        assert len(msgs_to_keep) == 2


### PR DESCRIPTION
…ing compaction (#4811)

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
