### PR TITLE
fix(crons): fix share_session cron agent tasks producing empty traces (#4818)

### DIFF
--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -22,15 +22,25 @@ class CronExecutor:
         self._runner = runner
         self._channel_manager = channel_manager
 
-    async def _is_session_busy(self) -> bool:
-        """Check if the target session has an active task in TaskTracker."""
+    async def _wait_for_session_idle(self) -> None:
+        """Wait for any active tasks in the target session to complete.
+
+        When share_session=True, the cron job must execute serially after
+        existing tasks finish so it can inherit the shared context rather
+        than silently dropping it by falling back to an isolated session.
+        """
         task_tracker = getattr(self._runner, "_task_tracker", None)
         if task_tracker is None:
-            return False
+            return
         try:
-            return await task_tracker.has_active_tasks()
+            if await task_tracker.has_active_tasks():
+                logger.info(
+                    "cron share_session: waiting for active tasks to "
+                    "complete before executing in shared session",
+                )
+                await task_tracker.wait_all_done()
         except Exception:  # pylint: disable=broad-except
-            return False
+            pass
 
     # pylint: disable=too-many-statements
     async def execute(self, job: CronJobSpec) -> dict[str, Any]:
@@ -101,24 +111,13 @@ class CronExecutor:
 
         # Determine session_id based on share_session
         share_session = job.runtime.share_session
-        session_fell_back = False
         if share_session:
-            # Auto-fallback: if the target session has an active task,
-            # sharing it would cause concurrent access / empty traces.
-            if await self._is_session_busy():
-                logger.warning(
-                    "cron share_session fallback: job_id=%s target session "
-                    "%s is busy, falling back to isolated session",
-                    job.id,
-                    target_session_id[:40] if target_session_id else "",
-                )
-                share_session = False
-                session_fell_back = True
+            # Wait serially for any active tasks to complete so the cron
+            # job can inherit the shared context rather than losing it.
+            await self._wait_for_session_idle()
 
         if share_session:
             req["session_id"] = target_session_id or f"cron:{job.id}"
-            # Even in shared mode, mark session_source so the runner can
-            # distinguish cron-originated queries from interactive ones.
             req["session_source"] = "cron:shared"
         else:
             # Use job.id (not run_id) so all runs of this job accumulate in the
@@ -190,13 +189,11 @@ class CronExecutor:
             if not delta:
                 logger.warning(
                     "cron agent produced empty trace: job_id=%s "
-                    "session_id=%s share_session=%s fell_back=%s "
-                    "baseline_count=%d. The session may have been "
-                    "overwritten by a concurrent query.",
+                    "session_id=%s share_session=%s "
+                    "baseline_count=%d.",
                     job.id,
                     req["session_id"][:40],
                     job.runtime.share_session,
-                    session_fell_back,
                     baseline_count,
                 )
             await finalize_trace(
@@ -209,7 +206,6 @@ class CronExecutor:
                 "delivery_status": "failed" if delivery_error else "success",
                 "delivery_error": delivery_error,
                 "trace_event_count": len(delta),
-                "session_fell_back": session_fell_back,
             }
         except asyncio.TimeoutError:
             logger.warning(

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -22,6 +22,16 @@ class CronExecutor:
         self._runner = runner
         self._channel_manager = channel_manager
 
+    async def _is_session_busy(self) -> bool:
+        """Check if the target session has an active task in TaskTracker."""
+        task_tracker = getattr(self._runner, "_task_tracker", None)
+        if task_tracker is None:
+            return False
+        try:
+            return await task_tracker.has_active_tasks()
+        except Exception:  # pylint: disable=broad-except
+            return False
+
     # pylint: disable=too-many-statements
     async def execute(self, job: CronJobSpec) -> dict[str, Any]:
         """Execute one job once.
@@ -91,8 +101,25 @@ class CronExecutor:
 
         # Determine session_id based on share_session
         share_session = job.runtime.share_session
+        session_fell_back = False
+        if share_session:
+            # Auto-fallback: if the target session has an active task,
+            # sharing it would cause concurrent access / empty traces.
+            if await self._is_session_busy():
+                logger.warning(
+                    "cron share_session fallback: job_id=%s target session "
+                    "%s is busy, falling back to isolated session",
+                    job.id,
+                    target_session_id[:40] if target_session_id else "",
+                )
+                share_session = False
+                session_fell_back = True
+
         if share_session:
             req["session_id"] = target_session_id or f"cron:{job.id}"
+            # Even in shared mode, mark session_source so the runner can
+            # distinguish cron-originated queries from interactive ones.
+            req["session_source"] = "cron:shared"
         else:
             # Use job.id (not run_id) so all runs of this job accumulate in the
             # same dedicated session, giving users a complete history.
@@ -152,7 +179,7 @@ class CronExecutor:
                 _run(),
                 timeout=job.runtime.timeout_seconds,
             )
-            await append_trace_from_session_delta(
+            delta = await append_trace_from_session_delta(
                 run_id=run_id,
                 runner=self._runner,
                 session_id=req["session_id"],
@@ -160,12 +187,29 @@ class CronExecutor:
                 channel=target_channel,
                 baseline_count=baseline_count,
             )
-            await finalize_trace(run_id, status="success")
+            if not delta:
+                logger.warning(
+                    "cron agent produced empty trace: job_id=%s "
+                    "session_id=%s share_session=%s fell_back=%s "
+                    "baseline_count=%d. The session may have been "
+                    "overwritten by a concurrent query.",
+                    job.id,
+                    req["session_id"][:40],
+                    job.runtime.share_session,
+                    session_fell_back,
+                    baseline_count,
+                )
+            await finalize_trace(
+                run_id,
+                status="success" if delta else "warning",
+            )
             return {
                 "task_type": "agent",
                 "run_id": run_id,
                 "delivery_status": "failed" if delivery_error else "success",
                 "delivery_error": delivery_error,
+                "trace_event_count": len(delta),
+                "session_fell_back": session_fell_back,
             }
         except asyncio.TimeoutError:
             logger.warning(

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -156,12 +156,12 @@ class JobRuntimeSpec(BaseModel):
     timeout_seconds: int = Field(default=120, ge=1)
     misfire_grace_seconds: int = Field(default=60, ge=0)
     share_session: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Whether to share session with target user. "
-            "If False, creates isolated context with unique run ID. "
-            "Sharing is discouraged for agent tasks because concurrent "
-            "access can corrupt session state and produce empty traces."
+            "If True, the cron job waits for active tasks to complete "
+            "and inherits the shared context. "
+            "If False, creates isolated context with unique run ID."
         ),
     )
 

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -156,10 +156,12 @@ class JobRuntimeSpec(BaseModel):
     timeout_seconds: int = Field(default=120, ge=1)
     misfire_grace_seconds: int = Field(default=60, ge=0)
     share_session: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Whether to share session with target user. "
-            "If False, creates isolated context with unique run ID."
+            "If False, creates isolated context with unique run ID. "
+            "Sharing is discouraged for agent tasks because concurrent "
+            "access can corrupt session state and produce empty traces."
         ),
     )
 

--- a/src/qwenpaw/app/runner/models.py
+++ b/src/qwenpaw/app/runner/models.py
@@ -21,6 +21,7 @@ class SessionSource(str, Enum):
 
     chat = "chat"
     cron = "cron"
+    cron_shared = "cron:shared"
 
 
 class ChatSpec(BaseModel):

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -841,14 +841,13 @@ class AgentRunner(Runner):
 
             # Isolated cron: run without any prior context so each execution
             # is independent (saves tokens, avoids stale-context interference).
-            # Also applies to "cron:shared" mode (share_session=true) to
-            # prevent concurrent session state corruption.
+            # Only applies to session_source="cron" (share_session=false).
+            # For session_source="cron:shared" (share_session=true), the
+            # user explicitly wants the cron to inherit the shared context,
+            # so we must NOT clear agent memory.
             _extra = getattr(request, "model_extra", None) or {}
             _session_source = _extra.get("session_source", "")
-            if (
-                _session_source in ("cron", "cron:shared")
-                and agent.memory is not None
-            ):
+            if _session_source == "cron" and agent.memory is not None:
                 # Snapshot the full history before clearing
                 _cron_memory_snapshot = agent.memory.state_dict()
                 await agent.memory.clear()

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -841,9 +841,12 @@ class AgentRunner(Runner):
 
             # Isolated cron: run without any prior context so each execution
             # is independent (saves tokens, avoids stale-context interference).
+            # Also applies to "cron:shared" mode (share_session=true) to
+            # prevent concurrent session state corruption.
             _extra = getattr(request, "model_extra", None) or {}
+            _session_source = _extra.get("session_source", "")
             if (
-                _extra.get("session_source") == "cron"
+                _session_source in ("cron", "cron:shared")
                 and agent.memory is not None
             ):
                 # Snapshot the full history before clearing

--- a/tests/unit/app/test_cron_executor.py
+++ b/tests/unit/app/test_cron_executor.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-"""Tests for CronExecutor share_session fix (GitHub issue #4818).
+"""Tests for CronExecutor share_session serial-wait behavior.
 
 Covers:
-- ``_is_session_busy()`` delegation to TaskTracker
-- Auto-fallback when ``share_session=True`` and session is busy
+- ``_wait_for_session_idle()`` delegation to TaskTracker
+- Serial waiting when ``share_session=True`` and session is busy
 - ``session_source`` values: ``"cron"`` vs ``"cron:shared"``
 - Empty delta detection and ``"warning"`` trace status
-- Return dict fields: ``trace_event_count``, ``session_fell_back``
-- ``JobRuntimeSpec.share_session`` default is now ``False``
+- Return dict fields: ``trace_event_count``
+- ``JobRuntimeSpec.share_session`` default is ``True``
 - ``SessionSource.cron_shared`` enum value
 """
 from __future__ import annotations
@@ -35,7 +35,7 @@ from qwenpaw.app.runner.models import SessionSource
 
 def _make_job(
     *,
-    share_session: bool = False,
+    share_session: bool = True,
     task_type: str = "agent",
     text: str | None = None,
     request: CronJobRequest | None = None,
@@ -72,6 +72,7 @@ def _make_executor(
         task_tracker.has_active_tasks = AsyncMock(
             return_value=session_busy,
         )
+        task_tracker.wait_all_done = AsyncMock(return_value=True)
         runner._task_tracker = task_tracker
     else:
         runner._task_tracker = None
@@ -92,55 +93,58 @@ def _make_executor(
 
 
 # ---------------------------------------------------------------------------
-# _is_session_busy
+# _wait_for_session_idle
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_is_session_busy_no_tracker():
-    """Returns False when runner has no _task_tracker attribute."""
+async def test_wait_for_session_idle_no_tracker():
+    """Returns immediately when runner has no _task_tracker attribute."""
     executor, _ = _make_executor(has_task_tracker=False)
+    # Should not raise
     # pylint: disable=protected-access
-    result = await executor._is_session_busy()
-    assert result is False
+    await executor._wait_for_session_idle()
 
 
 @pytest.mark.asyncio
-async def test_is_session_busy_tracker_says_idle():
-    """Returns False when TaskTracker has no active tasks."""
-    executor, _ = _make_executor(has_task_tracker=True, session_busy=False)
-    # pylint: disable=protected-access
-    result = await executor._is_session_busy()
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_is_session_busy_tracker_says_busy():
-    """Returns True when TaskTracker has active tasks."""
-    executor, _ = _make_executor(has_task_tracker=True, session_busy=True)
-    # pylint: disable=protected-access
-    result = await executor._is_session_busy()
-    assert result is True
-
-
-@pytest.mark.asyncio
-async def test_is_session_busy_tracker_exception():
-    """Returns False if TaskTracker.has_active_tasks() raises."""
+async def test_wait_for_session_idle_not_busy():
+    """Does not wait when TaskTracker has no active tasks."""
     executor, runner = _make_executor(
         has_task_tracker=True,
         session_busy=False,
     )
     # pylint: disable=protected-access
+    await executor._wait_for_session_idle()
+    runner._task_tracker.wait_all_done.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_idle_busy_waits():
+    """Waits for active tasks when TaskTracker reports busy."""
+    executor, runner = _make_executor(has_task_tracker=True, session_busy=True)
+    # pylint: disable=protected-access
+    await executor._wait_for_session_idle()
+    runner._task_tracker.has_active_tasks.assert_called_once()
+    runner._task_tracker.wait_all_done.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_idle_tracker_exception():
+    """Silently ignores exceptions from TaskTracker."""
+    executor, runner = _make_executor(
+        has_task_tracker=True,
+        session_busy=True,
+    )
+    # pylint: disable=protected-access
     runner._task_tracker.has_active_tasks = AsyncMock(
         side_effect=RuntimeError("boom"),
     )
-    # pylint: disable=protected-access
-    result = await executor._is_session_busy()
-    assert result is False
+    # Should not raise
+    await executor._wait_for_session_idle()
 
 
 # ---------------------------------------------------------------------------
-# share_session auto-fallback
+# share_session serial wait (no fallback)
 # ---------------------------------------------------------------------------
 
 
@@ -152,55 +156,24 @@ async def test_is_session_busy_tracker_exception():
     "qwenpaw.app.crons.executor.read_session_messages",
     new_callable=AsyncMock,
 )
-async def test_share_session_fallback_when_busy(
+async def test_share_session_waits_when_busy(
     mock_read,
     _mock_create,
     mock_delta,
     _mock_finalize,
 ):
-    """When share_session=True and session is busy, falls back to isolated."""
+    """When share_session=True and session is busy, waits serially."""
     mock_read.return_value = []
     mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
 
     executor, runner = _make_executor(session_busy=True)
     job = _make_job(share_session=True)
 
-    result = await executor.execute(job)
+    await executor.execute(job)
 
-    # Should have fallen back
-    assert result["session_fell_back"] is True
-
-    # Verify the request used the isolated session_id pattern
-    call_args = runner.stream_query.call_args
-    req = call_args[0][0]
-    assert req["session_id"] == "sess-1:cron:job-1"
-    assert req["session_source"] == "cron"
-
-
-@pytest.mark.asyncio
-@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
-@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
-@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
-@patch(
-    "qwenpaw.app.crons.executor.read_session_messages",
-    new_callable=AsyncMock,
-)
-async def test_share_session_no_fallback_when_idle(
-    mock_read,
-    _mock_create,
-    mock_delta,
-    _mock_finalize,
-):
-    """When share_session=True and session is idle, uses shared session."""
-    mock_read.return_value = []
-    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
-
-    executor, runner = _make_executor(session_busy=False)
-    job = _make_job(share_session=True)
-
-    result = await executor.execute(job)
-
-    assert result["session_fell_back"] is False
+    # Should have waited and then used the shared session
+    # pylint: disable=protected-access
+    runner._task_tracker.wait_all_done.assert_called_once()
 
     call_args = runner.stream_query.call_args
     req = call_args[0][0]
@@ -216,22 +189,55 @@ async def test_share_session_no_fallback_when_idle(
     "qwenpaw.app.crons.executor.read_session_messages",
     new_callable=AsyncMock,
 )
-async def test_isolated_session_default_no_fallback(
+async def test_share_session_no_wait_when_idle(
     mock_read,
     _mock_create,
     mock_delta,
     _mock_finalize,
 ):
-    """When share_session=False (default), no fallback logic runs."""
+    """When share_session=True and session is idle, uses shared session."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
+
+    executor, runner = _make_executor(session_busy=False)
+    job = _make_job(share_session=True)
+
+    await executor.execute(job)
+
+    # pylint: disable=protected-access
+    runner._task_tracker.wait_all_done.assert_not_called()
+
+    call_args = runner.stream_query.call_args
+    req = call_args[0][0]
+    assert req["session_id"] == "sess-1"
+    assert req["session_source"] == "cron:shared"
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_isolated_session_no_wait(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """When share_session=False, no wait logic runs."""
     mock_read.return_value = []
     mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
 
     executor, runner = _make_executor(session_busy=True)
     job = _make_job(share_session=False)
 
-    result = await executor.execute(job)
+    await executor.execute(job)
 
-    assert result["session_fell_back"] is False
+    # pylint: disable=protected-access
+    runner._task_tracker.wait_all_done.assert_not_called()
 
     call_args = runner.stream_query.call_args
     req = call_args[0][0]
@@ -258,7 +264,7 @@ async def test_session_source_cron_shared(
     mock_delta,
     _mock_finalize,
 ):
-    """share_session=True + idle session sets session_source=cron:shared."""
+    """share_session=True sets session_source=cron:shared."""
     mock_read.return_value = []
     mock_delta.return_value = [{"role": "assistant", "content": "x"}]
 
@@ -384,7 +390,7 @@ async def test_agent_return_fields(
     mock_delta,
     _mock_finalize,
 ):
-    """Agent result includes trace_event_count and session_fell_back."""
+    """Agent result includes trace_event_count."""
     mock_read.return_value = []
     mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
 
@@ -396,9 +402,7 @@ async def test_agent_return_fields(
     assert result["task_type"] == "agent"
     assert "run_id" in result
     assert "trace_event_count" in result
-    assert "session_fell_back" in result
     assert result["trace_event_count"] == 1
-    assert result["session_fell_back"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -425,10 +429,10 @@ async def test_text_task_does_not_check_session():
 # ---------------------------------------------------------------------------
 
 
-def test_job_runtime_share_session_default_is_false():
-    """JobRuntimeSpec.share_session defaults to False."""
+def test_job_runtime_share_session_default_is_true():
+    """JobRuntimeSpec.share_session defaults to True."""
     runtime = JobRuntimeSpec()
-    assert runtime.share_session is False
+    assert runtime.share_session is True
 
 
 def test_session_source_cron_shared_enum():

--- a/tests/unit/app/test_cron_executor.py
+++ b/tests/unit/app/test_cron_executor.py
@@ -1,0 +1,438 @@
+# -*- coding: utf-8 -*-
+"""Tests for CronExecutor share_session fix (GitHub issue #4818).
+
+Covers:
+- ``_is_session_busy()`` delegation to TaskTracker
+- Auto-fallback when ``share_session=True`` and session is busy
+- ``session_source`` values: ``"cron"`` vs ``"cron:shared"``
+- Empty delta detection and ``"warning"`` trace status
+- Return dict fields: ``trace_event_count``, ``session_fell_back``
+- ``JobRuntimeSpec.share_session`` default is now ``False``
+- ``SessionSource.cron_shared`` enum value
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from qwenpaw.app.crons.executor import CronExecutor
+from qwenpaw.app.crons.models import (
+    CronJobRequest,
+    CronJobSpec,
+    DispatchSpec,
+    DispatchTarget,
+    JobRuntimeSpec,
+    ScheduleSpec,
+)
+from qwenpaw.app.runner.models import SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_job(
+    *,
+    share_session: bool = False,
+    task_type: str = "agent",
+    text: str | None = None,
+    request: CronJobRequest | None = None,
+) -> CronJobSpec:
+    """Build a minimal CronJobSpec for testing."""
+    target = DispatchTarget(user_id="user-1", session_id="sess-1")
+    if task_type == "agent" and request is None:
+        request = CronJobRequest(input="hello")
+    return CronJobSpec(
+        id="job-1",
+        name="test-job",
+        schedule=ScheduleSpec(type="cron", cron="0 9 * * mon"),
+        task_type=task_type,
+        text=text,
+        request=request,
+        dispatch=DispatchSpec(channel="test", target=target),
+        runtime=JobRuntimeSpec(share_session=share_session),
+    )
+
+
+def _make_executor(
+    *,
+    has_task_tracker: bool = True,
+    session_busy: bool = False,
+) -> tuple[CronExecutor, MagicMock]:
+    """Build a CronExecutor with a mocked runner and channel_manager.
+
+    Returns (executor, runner_mock).
+    """
+    runner = MagicMock()
+    # pylint: disable=protected-access
+    if has_task_tracker:
+        task_tracker = AsyncMock()
+        task_tracker.has_active_tasks = AsyncMock(
+            return_value=session_busy,
+        )
+        runner._task_tracker = task_tracker
+    else:
+        runner._task_tracker = None
+    # pylint: enable=protected-access
+
+    # stream_query must be an async generator
+    async def _fake_stream(_req):
+        yield {"type": "text", "content": "ok"}
+
+    runner.stream_query = MagicMock(return_value=_fake_stream({}))
+
+    channel_manager = MagicMock()
+    channel_manager.send_text = AsyncMock()
+    channel_manager.send_event = AsyncMock()
+
+    executor = CronExecutor(runner=runner, channel_manager=channel_manager)
+    return executor, runner
+
+
+# ---------------------------------------------------------------------------
+# _is_session_busy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_is_session_busy_no_tracker():
+    """Returns False when runner has no _task_tracker attribute."""
+    executor, _ = _make_executor(has_task_tracker=False)
+    # pylint: disable=protected-access
+    result = await executor._is_session_busy()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_session_busy_tracker_says_idle():
+    """Returns False when TaskTracker has no active tasks."""
+    executor, _ = _make_executor(has_task_tracker=True, session_busy=False)
+    # pylint: disable=protected-access
+    result = await executor._is_session_busy()
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_session_busy_tracker_says_busy():
+    """Returns True when TaskTracker has active tasks."""
+    executor, _ = _make_executor(has_task_tracker=True, session_busy=True)
+    # pylint: disable=protected-access
+    result = await executor._is_session_busy()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_is_session_busy_tracker_exception():
+    """Returns False if TaskTracker.has_active_tasks() raises."""
+    executor, runner = _make_executor(
+        has_task_tracker=True,
+        session_busy=False,
+    )
+    # pylint: disable=protected-access
+    runner._task_tracker.has_active_tasks = AsyncMock(
+        side_effect=RuntimeError("boom"),
+    )
+    # pylint: disable=protected-access
+    result = await executor._is_session_busy()
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# share_session auto-fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_share_session_fallback_when_busy(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """When share_session=True and session is busy, falls back to isolated."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
+
+    executor, runner = _make_executor(session_busy=True)
+    job = _make_job(share_session=True)
+
+    result = await executor.execute(job)
+
+    # Should have fallen back
+    assert result["session_fell_back"] is True
+
+    # Verify the request used the isolated session_id pattern
+    call_args = runner.stream_query.call_args
+    req = call_args[0][0]
+    assert req["session_id"] == "sess-1:cron:job-1"
+    assert req["session_source"] == "cron"
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_share_session_no_fallback_when_idle(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """When share_session=True and session is idle, uses shared session."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
+
+    executor, runner = _make_executor(session_busy=False)
+    job = _make_job(share_session=True)
+
+    result = await executor.execute(job)
+
+    assert result["session_fell_back"] is False
+
+    call_args = runner.stream_query.call_args
+    req = call_args[0][0]
+    assert req["session_id"] == "sess-1"
+    assert req["session_source"] == "cron:shared"
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_isolated_session_default_no_fallback(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """When share_session=False (default), no fallback logic runs."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
+
+    executor, runner = _make_executor(session_busy=True)
+    job = _make_job(share_session=False)
+
+    result = await executor.execute(job)
+
+    assert result["session_fell_back"] is False
+
+    call_args = runner.stream_query.call_args
+    req = call_args[0][0]
+    assert req["session_id"] == "sess-1:cron:job-1"
+    assert req["session_source"] == "cron"
+
+
+# ---------------------------------------------------------------------------
+# session_source values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_session_source_cron_shared(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """share_session=True + idle session sets session_source=cron:shared."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "x"}]
+
+    executor, runner = _make_executor(session_busy=False)
+    job = _make_job(share_session=True)
+
+    await executor.execute(job)
+
+    req = runner.stream_query.call_args[0][0]
+    assert req["session_source"] == "cron:shared"
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_session_source_cron_isolated(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """share_session=False sets session_source=cron."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "x"}]
+
+    executor, runner = _make_executor(session_busy=False)
+    job = _make_job(share_session=False)
+
+    await executor.execute(job)
+
+    req = runner.stream_query.call_args[0][0]
+    assert req["session_source"] == "cron"
+
+
+# ---------------------------------------------------------------------------
+# Empty delta detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_empty_delta_sets_warning_status(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    mock_finalize,
+):
+    """When delta is empty, finalize_trace is called with status='warning'."""
+    mock_read.return_value = []
+    mock_delta.return_value = []  # empty delta
+
+    executor, _ = _make_executor(session_busy=False)
+    job = _make_job(share_session=False)
+
+    result = await executor.execute(job)
+
+    assert result["trace_event_count"] == 0
+    mock_finalize.assert_called_once()
+    call_kwargs = mock_finalize.call_args
+    assert (
+        call_kwargs[1]["status"] == "warning" or call_kwargs[0][1] == "warning"
+    )
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_nonempty_delta_sets_success_status(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    mock_finalize,
+):
+    """When delta is non-empty, finalize_trace has status='success'."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
+
+    executor, _ = _make_executor(session_busy=False)
+    job = _make_job(share_session=False)
+
+    result = await executor.execute(job)
+
+    assert result["trace_event_count"] == 1
+    mock_finalize.assert_called_once()
+    call_kwargs = mock_finalize.call_args
+    assert (
+        call_kwargs[1]["status"] == "success" or call_kwargs[0][1] == "success"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Return dict fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("qwenpaw.app.crons.executor.finalize_trace", new_callable=AsyncMock)
+@patch("qwenpaw.app.crons.executor.append_trace_from_session_delta")
+@patch("qwenpaw.app.crons.executor.create_trace", new_callable=AsyncMock)
+@patch(
+    "qwenpaw.app.crons.executor.read_session_messages",
+    new_callable=AsyncMock,
+)
+async def test_agent_return_fields(
+    mock_read,
+    _mock_create,
+    mock_delta,
+    _mock_finalize,
+):
+    """Agent result includes trace_event_count and session_fell_back."""
+    mock_read.return_value = []
+    mock_delta.return_value = [{"role": "assistant", "content": "hi"}]
+
+    executor, _ = _make_executor(session_busy=False)
+    job = _make_job(share_session=False)
+
+    result = await executor.execute(job)
+
+    assert result["task_type"] == "agent"
+    assert "run_id" in result
+    assert "trace_event_count" in result
+    assert "session_fell_back" in result
+    assert result["trace_event_count"] == 1
+    assert result["session_fell_back"] is False
+
+
+# ---------------------------------------------------------------------------
+# text task_type (unchanged behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_task_does_not_check_session():
+    """Text tasks bypass session-busy check entirely."""
+    executor, runner = _make_executor(session_busy=True)
+    job = _make_job(task_type="text", text="hello world")
+
+    result = await executor.execute(job)
+
+    assert result["task_type"] == "text"
+    assert result["delivery_status"] == "success"
+    # stream_query should NOT have been called for text tasks
+    runner.stream_query.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Model defaults
+# ---------------------------------------------------------------------------
+
+
+def test_job_runtime_share_session_default_is_false():
+    """JobRuntimeSpec.share_session defaults to False."""
+    runtime = JobRuntimeSpec()
+    assert runtime.share_session is False
+
+
+def test_session_source_cron_shared_enum():
+    """SessionSource has cron_shared with value 'cron:shared'."""
+    assert SessionSource.cron_shared.value == "cron:shared"
+    # Round-trip through string construction
+    assert SessionSource("cron:shared") is SessionSource.cron_shared


### PR DESCRIPTION
fix(crons): fix share_session cron agent tasks producing empty traces (#4818)
## Description

  - Add _is_session_busy() to detect active tasks via TaskTracker                                                                                                    
  - Auto-fallback to isolated session when share_session=true and session is busy                                                                                    
  - Set session_source="cron:shared" for shared mode so runner applies memory protection                                                                             
  - Extend runner memory snapshot/restore to also cover "cron:shared" sessions                                                                                       
  - Detect empty delta after execution and set trace status="warning" instead of "success"                                                                           
  - Add trace_event_count and session_fell_back to executor return dict                                                                                              
  - Change JobRuntimeSpec.share_session default from True to False                                                                                                   
  - Add SessionSource.cron_shared enum value                                                                                                                         
  - Add unit tests for CronExecutor (15 test cases)

**Related Issue:** Fixes #4818

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
