### PR TITLE
fix(config): add ProviderManager fallback to get_model_max_input_length

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2142,6 +2142,14 @@ def get_model_max_input_length(
     from ..providers import ProviderManager
 
     model_slot = agent_config.active_model
+    # Fallback: if agent.json doesn't have active_model, try ProviderManager
+    if not model_slot or not model_slot.provider_id:
+        try:
+            manager = ProviderManager.get_instance()
+            model_slot = manager.get_active_model()
+        except Exception:
+            pass
+
     if model_slot and model_slot.provider_id and model_slot.model:
         try:
             manager = ProviderManager.get_instance()


### PR DESCRIPTION
## Description

Fix a bug where `get_model_max_input_length` returns the fallback value 128×1024 (131072) instead of the user-configured value from `active_model.json`, causing the context compression threshold to be incorrect.

### Root Cause

`get_model_max_input_length` only reads `agent_config.active_model` from `agent.json`. When an agent is created without `--provider-id` / `--model-id`, `active_model` is `None` in `agent.json` (it's never written because `save_agent_config` uses `exclude_none=True`). The function then falls through to the hardcoded `128 * 1024`.

Meanwhile, `create_model_and_formatter` (used for normal chat) correctly falls back to `ProviderManager.get_active_chat_model()` which reads from `active_model.json` — so the configured value works in dialogs but not in context compression.

**Call chain:**
```
pre_reasoning()
  → load_agent_config(self.agent_id)       ← reads agent.json
  → get_model_max_input_length(agent_config)
    → agent_config.active_model → None     ❌ not in agent.json
    → return 128 * 1024                     ← 131072, not user's 800000!

create_model_and_formatter()               ← normal chat path
  → agent_config.active_model → None       ← also None
  → ProviderManager.get_active_chat_model() ✅ reads active_model.json
```

### Changes Made

**`src/qwenpaw/config/config.py`** — Added a `ProviderManager.get_active_model()` fallback in `get_model_max_input_length` when `agent_config.active_model` is `None` or has no `provider_id`, making it consistent with `create_model_and_formatter`.

### Type of Change

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Breaking change
- [ ] Documentation

### Component(s) Affected

- [x] Core

### Checklist

- [x] pre-commit run --files src/qwenpaw/config/config.py (all passed)
- [x] pytest tests/unit/providers/ tests/unit/utils/ tests/unit/workspace/ (203 passed)

### Testing

1. **Before fix** — agent created without `--provider-id` / `--model-id`, `get_model_max_input_length` returns 131072 regardless of `active_model.json` setting
2. **After fix** — same scenario, `get_model_max_input_length` falls back to `ProviderManager.get_active_model()` and returns the correct value from `active_model.json`

### Local Verification

**pre-commit**
```
mypy........Passed
black.......Passed
flake8......Passed
prettier....Passed
```

**pytest**
```
203 passed, 1 warning in 6.91s
```
