### PR TITLE
fix(skill): preserve tag, enable/disable, channel config during update

### DIFF
--- a/src/qwenpaw/agents/skill_system/pool_service.py
+++ b/src/qwenpaw/agents/skill_system/pool_service.py
@@ -850,7 +850,9 @@ class SkillPoolService:
                 "channels": prior.get("channels") or ["all"],
                 "source": metadata["source"],
                 "installed_from": pool_installed_from,
-                "config": prior["config"] if "config" in prior else pool_config,
+                "config": prior["config"]
+                if "config" in prior
+                else pool_config,
                 "metadata": metadata,
                 "requirements": metadata["requirements"],
                 "updated_at": metadata["updated_at"],

--- a/src/qwenpaw/agents/skill_system/pool_service.py
+++ b/src/qwenpaw/agents/skill_system/pool_service.py
@@ -836,6 +836,7 @@ class SkillPoolService:
 
         def _update(payload: dict[str, Any]) -> None:
             payload.setdefault("skills", {})
+            prior = payload["skills"].get(final_name) or {}
             metadata = build_skill_metadata(
                 final_name,
                 target_dir,
@@ -845,11 +846,11 @@ class SkillPoolService:
                 protected=False,
             )
             ws_entry: dict[str, Any] = {
-                "enabled": True,
-                "channels": ["all"],
+                "enabled": bool(prior.get("enabled", True)),
+                "channels": prior.get("channels") or ["all"],
                 "source": metadata["source"],
                 "installed_from": pool_installed_from,
-                "config": pool_config,
+                "config": prior["config"] if "config" in prior else pool_config,
                 "metadata": metadata,
                 "requirements": metadata["requirements"],
                 "updated_at": metadata["updated_at"],
@@ -859,7 +860,10 @@ class SkillPoolService:
             )
             if entry.get("source") == "builtin" and pool_lang:
                 ws_entry["builtin_language"] = pool_lang
-            if pool_tags is not None:
+            prior_tags = prior.get("tags")
+            if prior_tags is not None:
+                ws_entry["tags"] = prior_tags
+            elif pool_tags is not None:
                 ws_entry["tags"] = pool_tags
             payload["skills"][final_name] = ws_entry
 


### PR DESCRIPTION
## Description

Previous pool download to workspace overwrite user preference.
This PR fix the above issue.

**Related Issue:** Fixes #4807


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

