### PR TITLE
fix(skill): ignore ~ started stale skills during pip

### DIFF
--- a/src/qwenpaw/agents/skill_system/pool_service.py
+++ b/src/qwenpaw/agents/skill_system/pool_service.py
@@ -27,6 +27,7 @@ from .store import (
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
     import_skill_dir,
+    is_ignored_skill_entry,
     mutate_json,
     normalize_skill_dir_name,
     read_json,
@@ -246,7 +247,11 @@ class SkillPoolService:
                 set(
                     manifest.get("skills", {}).keys(),
                 )
-                | {p.name for p in pool_dir.iterdir() if p.is_dir()}
+                | {
+                    p.name
+                    for p in pool_dir.iterdir()
+                    if p.is_dir() and not is_ignored_skill_entry(p.name)
+                }
                 if pool_dir.exists()
                 else set(
                     manifest.get("skills", {}).keys(),

--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -31,6 +31,7 @@ from .store import (
     get_skill_pool_dir,
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
+    is_ignored_skill_entry,
     is_pool_builtin_entry,
     mutate_json,
     normalize_skill_manifest_entry,
@@ -216,6 +217,8 @@ def _iter_packaged_builtin_dirs() -> Iterator[Path]:
     if not builtin_dir.exists():
         return
     for skill_dir in sorted(builtin_dir.iterdir()):
+        if is_ignored_skill_entry(skill_dir.name):
+            continue
         if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
             yield skill_dir
 
@@ -893,7 +896,9 @@ def reconcile_pool_manifest() -> dict[str, Any]:
         discovered = {
             path.name: path
             for path in pool_dir.iterdir()
-            if path.is_dir() and (path / "SKILL.md").exists()
+            if not is_ignored_skill_entry(path.name)
+            and path.is_dir()
+            and (path / "SKILL.md").exists()
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):
@@ -997,7 +1002,9 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
         discovered = {
             path.name: path
             for path in workspace_skills_dir.iterdir()
-            if path.is_dir() and (path / "SKILL.md").exists()
+            if not is_ignored_skill_entry(path.name)
+            and path.is_dir()
+            and (path / "SKILL.md").exists()
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):

--- a/src/qwenpaw/agents/skill_system/store.py
+++ b/src/qwenpaw/agents/skill_system/store.py
@@ -394,8 +394,14 @@ def classify_pool_skill_source(
 # ---------------------------------------------------------------------------
 
 
-def _is_hidden(name: str) -> bool:
-    return name in _IGNORED_SKILL_ARTIFACTS
+def is_ignored_skill_entry(name: str) -> bool:
+    """Names to skip when enumerating skill-candidate directories.
+
+    Single extension point for "not a real skill" name rules used by every
+    skill-dir enumeration (registry scanners, pool / workspace conflict
+    checks, zip imports). Add new patterns here when they appear.
+    """
+    return name in _IGNORED_SKILL_ARTIFACTS or name.startswith("~")
 
 
 def _extract_and_validate_zip(data: bytes, tmp_dir: Path) -> None:
@@ -621,7 +627,11 @@ def workspace_skill_name_conflict(
     if not (skill_root / normalized_name).exists():
         return None
     existing = (
-        {p.name for p in skill_root.iterdir() if p.is_dir()}
+        {
+            p.name
+            for p in skill_root.iterdir()
+            if p.is_dir() and not is_ignored_skill_entry(p.name)
+        }
         if skill_root.exists()
         else set()
     )
@@ -843,7 +853,9 @@ def extract_zip_skills(data: bytes) -> tuple[Path, list[tuple[Path, str]]]:
     tmp_dir = Path(tempfile.mkdtemp(prefix="qwenpaw_skill_upload_"))
     _extract_and_validate_zip(data, tmp_dir)
     real_entries = [
-        path for path in tmp_dir.iterdir() if not _is_hidden(path.name)
+        path
+        for path in tmp_dir.iterdir()
+        if not is_ignored_skill_entry(path.name)
     ]
     extract_root = (
         real_entries[0]
@@ -856,7 +868,7 @@ def extract_zip_skills(data: bytes) -> tuple[Path, list[tuple[Path, str]]]:
         found = [
             (path, _resolve_skill_name(path))
             for path in sorted(extract_root.iterdir())
-            if not _is_hidden(path.name)
+            if not is_ignored_skill_entry(path.name)
             and path.is_dir()
             and (path / "SKILL.md").exists()
         ]

--- a/src/qwenpaw/agents/skill_system/workspace_service.py
+++ b/src/qwenpaw/agents/skill_system/workspace_service.py
@@ -24,6 +24,7 @@ from .store import (
     get_workspace_skill_manifest_path,
     get_workspace_skills_dir,
     import_skill_dir,
+    is_ignored_skill_entry,
     mutate_json,
     normalize_skill_dir_name,
     read_skill_from_dir,
@@ -258,7 +259,11 @@ class SkillService:
         target_dir = safe_skill_dir(skill_root, final_name)
         if target_dir.exists() and not overwrite:
             existing = (
-                {p.name for p in skill_root.iterdir() if p.is_dir()}
+                {
+                    p.name
+                    for p in skill_root.iterdir()
+                    if p.is_dir() and not is_ignored_skill_entry(p.name)
+                }
                 if skill_root.exists()
                 else set()
             )
@@ -466,7 +471,11 @@ class SkillService:
                 for d, n in found
             ]
             existing_on_disk = (
-                {p.name for p in skill_root.iterdir() if p.is_dir()}
+                {
+                    p.name
+                    for p in skill_root.iterdir()
+                    if p.is_dir() and not is_ignored_skill_entry(p.name)
+                }
                 if skill_root.exists()
                 else set()
             )


### PR DESCRIPTION
## Description

On Windows, after upgrading QwenPaw via pip install --upgrade qwenpaw, stale copies of builtin skill directories remain in the package with ~-prefixed names (e.g., ~ron-en, ~-on-en, ~hat_with_agent-zh). 

This PR helps the skill system to ignore such broken skills and forbid them to pollute the manifest.

However, the user still needs to clear these ~started skills locally.

**Related Issue:** Fixes #4839

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review