### PR TITLE
feat(skills): enhanced make-skill flow to support self-evolving skill creation  

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -55,6 +55,7 @@ from .tools import (
     list_agents,
     materialize_skill,
     read_file,
+    run_tool_batch,
     send_file_to_user,
     set_user_timezone,
     view_image,
@@ -303,6 +304,7 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
             "submit_to_agent": submit_to_agent,
             "check_agent_task": check_agent_task,
             "spawn_subagent": spawn_subagent,
+            "run_tool_batch": run_tool_batch,
             # Register only when the `make-skill` skill is enabled.
             **(
                 {"materialize_skill": materialize_skill}
@@ -1423,9 +1425,11 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
             set_current_session_id,
             set_current_shell_command_timeout,
             set_current_shell_command_executable,
+            set_current_toolkit,
         )
 
         set_current_workspace_dir(self._workspace_dir)
+        set_current_toolkit(self.toolkit)
         set_current_session_id(
             self._request_context.get("session_id") or None,
         )

--- a/src/qwenpaw/agents/skills/make-skill-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/make-skill-en/SKILL.md
@@ -2,7 +2,7 @@
 name: make-skill
 description: "Use this skill when sedimenting a session into a reusable workspace skill. Triggers when the user wants to turn the current conversation, workflow, or troubleshooting path into a SKILL.md. Phrases like 'turn this into a skill', 'remember how I did X', 'save this workflow', 'make a skill from this', and any /make-skill <focus> invocation should fire this skill."
 metadata:
-  builtin_skill_version: "1.0"
+  builtin_skill_version: "1.1"
   qwenpaw:
     emoji: "✍️"
     requires: {}
@@ -24,11 +24,60 @@ You orchestrate a two-phase flow:
 * **Phase B.** On approval, write the full SKILL.md body based on THIS
   conversation, then persist via `materialize_skill`.
 
-Do **not** call `write_file` to save the SKILL.md directly. Always go through
-`materialize_skill`, which runs the security scanner and writes the manifest
-atomically.
+Do **not** call `write_file` to create the SKILL.md or any auxiliary files
+(scripts, JSON, etc.) directly. All initial file creation must go through
+`materialize_skill` (via the `body` and `extra_files` parameters), which runs
+the security scanner and writes the manifest atomically. After successful
+creation, use `edit_file` to modify existing files if needed.
 
-## Step 0. Determine the focus and derive a skill name
+## Step 0. Choose execution mode, determine the focus, and derive a skill name
+
+### 0a. Choose execution mode
+
+Ask the user which execution mode they prefer:
+
+> **Run in the current conversation** or **run in the background**?
+>
+> - **Current conversation**: complete the full flow in this turn
+>   (propose plan → user approves → write SKILL.md → persist). Best
+>   when iterative refinement is needed or the conversation itself is
+>   the skill source.
+> - **Background**: delegate the writing and persistence work to a
+>   subagent via `spawn_subagent(task=..., fork=True)`. The subagent
+>   inherits the full context of THIS conversation (it can see all
+>   previous messages). Best when the conversation is long and you
+>   don't want to block the current interaction.
+
+**Current conversation** mode: follow Steps 0b–5 below as normal.
+
+**Background** mode:
+
+In this step you do **not** need to call `materialize_skill` or perform
+any skill-creation work yourself — just assemble a task description and
+submit it to the subagent, which will handle everything.
+
+1. Assemble the following into a task description for the subagent:
+   - The focus and derived `skill_name`
+   - Clear instructions: "Based on the current session context, execute
+     make-skill Steps 1–5 in full: plan autonomously, write the
+     SKILL.md body, call materialize_skill to persist, verify batch
+     references, test-run the batch. Report the result when done.
+     **Note: in the current mode, do NOT call `create_plan`, skip
+     user approval of the plan, and complete the entire flow
+     autonomously.**"
+2. Call:
+   ```
+   spawn_subagent(
+       task="<task description above>. Current mode: do NOT call create_plan, skip user approve, complete all steps autonomously.",
+       fork=True,
+       background=True,
+   )
+   ```
+3. Inform the user the task has been submitted. They can check progress
+   via `check_agent_task(task_id=...)`. The subagent will create the
+   skill in the workspace without requiring user approval mid-process.
+
+### 0b. Determine the focus
 
 Two invocation paths:
 
@@ -37,6 +86,8 @@ Two invocation paths:
   "把刚才的 X 流程变成 skill"). Derive a short focus phrase from the
   conversation topic the user wants to capture. If ambiguous, ask a
   one-line clarification first.
+
+### 0c. Derive the skill name
 
 Derive the skill name from focus with **this exact rule**:
 
@@ -71,18 +122,38 @@ Call `create_plan` with **all four required arguments**
       a bit pushy on synonyms.
     * **I/O.** What inputs it expects, what outputs it produces.
     Not yet SKILL.md frontmatter format; that gets distilled later.
-  * **Part 2: Step outline.** Numbered list, one short verb phrase per
-    line. No per-step detail, no parameters, no error handling, no
-    sub-bullets, no `##` sub-headings. Just the shape, so the user can
-    judge ordering and scope and refine. Example layout (do NOT copy
-    this content):
-    ```
-    1. <verb phrase, ~5-10 words>
-    2. <verb phrase, ~5-10 words>
-    3. <…>
-    ```
-    Draw step names from what actually happened in THIS conversation.
-    Don't fabricate; omit anything not grounded in the conversation.
+  * **Part 2: Step outline and batch plan.** Two parts:
+    * **Step outline.** Numbered list, one short verb phrase per line.
+      No per-step detail, no parameters, no error handling, no
+      sub-bullets, no `##` sub-headings. Just the shape, so the user
+      can judge ordering and scope. Draw step names from what actually
+      happened in THIS conversation. Don't fabricate; omit anything
+      not grounded in the conversation.
+      Example layout (do NOT copy this content):
+      ```
+      1. <verb phrase, ~5-10 words>
+      2. <verb phrase, ~5-10 words>
+      3. <…>
+      ```
+    * **Batch plan.** Briefly describe how the steps above will be
+      organised into `run_tool_batch` JSON files:
+      * Which steps chain into one batch (or need to be split into
+        multiple batch files).
+      * Which intermediate steps would normally require agent
+        involvement but can actually be replaced by scripts (regex
+        matching, keyword filtering, JSON parsing, etc.), reducing
+        agent interaction and keeping more steps in the automated
+        batch.
+      * List the expected files, e.g.:
+        ```
+        scripts/main.json      — main batch workflow
+        scripts/parse.py       — parse snapshot to extract target content
+        ```
+      The goal is to replace as much agent-in-the-loop judgement as
+      possible with scripts, so the skill executes with a single
+      `run_tool_batch` call and avoids multi-round agent-tool
+      interaction. This lets the user see the batch structure before
+      approving.
 * **`expected_outcome`** (plan-level, REQUIRED — distinct from the
   subtask's `expected_outcome`): one concrete sentence about what
   success looks like for the whole skill creation. Use the literal
@@ -105,7 +176,9 @@ refine, or cancel. The `/plan` mode's standard machinery handles the rest:
 
 When presenting the plan, render the standard plan card. Do NOT add ad-hoc
 fields like `Subtask: …` or `Focus: …` in the chat message. Use the
-normalised `plan.name`, not the raw focus.
+normalised `plan.name`, not the raw focus. This step only proposes the
+plan and waits for user confirmation — do **not** call `materialize_skill`
+here.
 
 ### Plan-tools-unavailable fallback
 
@@ -141,29 +214,286 @@ Body sections align 1-to-1 with `plan.description` Part 2: same order, same
 scope. Use the step's verb phrase as the section heading. If the user
 refined Part 2 during approval, follow the **refined** version.
 
-### 2b. Fill each step from THIS conversation
+### 2b. Organise the full workflow into a batch JSON (preferred execution method)
 
-For every step, answer four concrete questions grounded in what actually
-happened in the session, not in common knowledge:
+**The core of the SKILL.md body is a `run_tool_batch` call.** When the
+future agent triggers this skill, it should **call the batch directly**
+rather than executing tools step by step. Per-step notes serve only as
+supplementary reference for debugging (see 2c), not as the primary
+execution instructions.
+
+Review the tool-call sequence from THIS session and capture the skill's
+**complete end-to-end workflow** as a single `run_tool_batch` JSON file.
+From start to finish, all steps that **can be executed unconditionally
+in sequence** should go into the batch.
+
+#### When applicable
+
+* The skill's core workflow contains **≥ 2 tool-call steps**.
+* Typical scenarios: bulk file operations, search-then-process, multi-
+  file modification pipelines, multi-step browser automation, etc.
+* **Most workflows can be fully automated with scripts.** Don't give up
+  on including a step in the batch just because it "looks like it needs
+  judgement". The vast majority of intermediate processing — content
+  extraction, result filtering, format conversion, conditional logic,
+  data cleaning — can be programmed by inserting
+  `execute_shell_command` calls into the batch. Two approaches:
+  * **Inline short scripts**: write `python3 -c "..."` one-liners
+    directly in `command`.
+  * **Standalone script files**: put complex logic in `.py` or `.sh`
+    files etc. under `scripts/` (bundled via `extra_files`), and call
+    them in the batch with `execute_shell_command`, e.g.
+    `"command": "python3 <skill_dir>/scripts/parse.py --param1 ${steps.<index1>.<path>} --param2 ${steps.<index2>.<path>}"`.
+  Pass previous steps' output to scripts via command-line arguments
+  (`${steps.<index>.<path>}`), and the script's stdout feeds subsequent
+  steps through `${steps}` references. This chains the entire workflow
+  into a single batch with no manual intervention. Only steps that
+  **truly require real-time user decisions** (e.g. "ask the user which
+  option to pick", "wait for user confirmation") need to be excluded.
+
+  `${steps.<index>.<path>}` is not limited to script calls — any tool's
+  arguments can reference previous steps' output. For example, pass
+  `read_file` results to `write_file`, or feed a `browser_use` snapshot
+  into `execute_shell_command`.
+
+  Example — take a browser snapshot, extract keyword-matching content
+  with a standalone Python script, and write the result to a file.
+  `${args.keyword}` etc. are runtime variables passed in via the `args`
+  parameter when calling `run_tool_batch`, substituted before execution.
+
+  `scripts/extract_headings.py` (bundled via `extra_files`):
+  ```python
+  import sys, re, json
+
+  keyword = sys.argv[1]
+  snapshot_file = sys.argv[2]
+  with open(snapshot_file) as f:
+      text = f.read()
+  items = [
+      m.group(1)
+      for m in re.finditer(
+          r'heading "([^"]*' + re.escape(keyword) + r'[^"]*)" \[ref=(\w+)\]',
+          text,
+      )
+  ]
+  print(json.dumps(items, ensure_ascii=False))
+  ```
+
+  Batch JSON (`scripts/extract.json`):
+  ```json
+  [
+    {
+      "tool_name": "browser_use",
+      "arguments": {"action": "snapshot"}
+    },
+    {
+      "tool_name": "write_file",
+      "arguments": {
+        "file_path": "${args.work_dir}/snapshot.txt",
+        "content": "${steps.0.text}"
+      }
+    },
+    {
+      "tool_name": "execute_shell_command",
+      "arguments": {
+        "command": "python3 ${args.skill_dir}/scripts/extract_headings.py ${args.keyword} ${args.work_dir}/snapshot.txt"
+      }
+    },
+    {
+      "tool_name": "write_file",
+      "arguments": {
+        "file_path": "${args.output_file}",
+        "content": "${steps.2.text}"
+      }
+    }
+  ]
+  ```
+  This automates the "extract keyword-matching content from a snapshot"
+  step that would otherwise require manual inspection: step 0 takes the
+  page snapshot, step 1 writes it to a temp file, step 2 calls the
+  standalone script which reads the file and extracts matches with
+  regex, step 3 writes the result to the output file. Complex parsing
+  logic goes into standalone `.py` files under `scripts/`. Both scripts
+  and batch JSON are bundled into the skill directory via `extra_files`.
+  When triggering the skill, just call:
+  ```
+  run_tool_batch(
+    file_path="<skill_dir>/scripts/extract.json",
+    args={
+      "keyword": "search keyword",
+      "skill_dir": "<this skill dir>",
+      "work_dir": "<working directory>",
+      "output_file": "result.json"
+    }
+  )
+  ```
+
+#### When NOT applicable (fall back to pure step-by-step)
+
+The vast majority of workflows can be automated. Only fall back to
+step-by-step logic when ALL of the following apply:
+
+* **Content understanding cannot be rule-based** — impossible to handle
+  with keyword matching, regex, JSON parsing, or any rule-based
+  approach; requires semantic understanding. (Note: if the user provides
+  explicit search terms or filter criteria, that IS rule-based and
+  should go into the batch.)
+* **Branching decisions cannot be predetermined** — the user must judge
+  what to do next based on runtime context, rather than being able to
+  supply all parameters upfront when triggering the skill.
+* The entire skill is a single tool call (no batch needed).
+
+Even when a workflow contains steps requiring human judgement, **still
+extract all mergeable consecutive steps into batch files**. This means a
+skill may ship with multiple batch files — e.g. `scripts/phase1.json`
+(data acquisition phase) and `scripts/phase2.json` (result processing
+phase), with the agent making semantic decisions in between. Automate as
+much as possible.
+
+#### SKILL.md body structure (when using batch)
+
+The body should lead with the batch call:
+
+````markdown
+## Execution
+
+This skill ships with a batch JSON file `scripts/<name>.json`.
+
+**Call `run_tool_batch` strictly in the format below, using `file_path`
+to load the file. Do not construct your own `actions` list inline.**
+
+`run_tool_batch` requires an **absolute path** for `file_path`. Use the
+absolute directory path you see when reading this SKILL.md to construct
+the full path.
+
+```
+run_tool_batch(
+  file_path="<this skill dir>/scripts/<name>.json",
+  args={
+    "param1": "<actual sample value>",
+    "param2": "<actual sample value>"
+  }
+)
+```
+
+## Batch Parameters
+
+Explain every parameter in `args`. Every variable used in the batch JSON
+as `${args.<name>}` must be listed here:
+
+* `param1`: what it controls; when the user should change it; the
+  default/recommended value; example: `<actual sample value>`.
+* `param2`: what it controls; when the user should change it; the
+  default/recommended value; example: `<actual sample value>`.
+
+When calling `run_tool_batch`, pass all parameters listed above. **Do not
+pass `args={}` and do not omit `args`** when the batch JSON contains
+`${args.<name>}` references; otherwise the placeholder may be used as a
+literal filename, URL, or command argument.
+
+## Batch failure handling
+
+If `run_tool_batch` fails (returns `ok: false` or errors mid-way):
+1. First verify every parameter listed in "Batch Parameters" was passed
+   with a real value, especially that you did not pass empty `args={}`;
+   then fix parameters based on the error message and retry.
+2. If it still fails, try using `run_tool_batch` with an inline
+   `actions` list instead of `file_path`.
+3. If inline execution also fails, fall back to manual step-by-step
+   execution using the "Step-by-step reference" section below.
+4. After completing the task, tell the user: "The batch execution hit an
+   issue so I completed the task manually. Would you like me to use
+   edit_file to adjust and optimise this skill's batch script so it
+   works correctly next time?"
+
+## Step-by-step reference
+
+The following details each batch step, for debugging or manual execution
+only:
+
+1. ...
+2. ...
+
+## Notes
+
+(Place skill-specific notes here, such as parameter optimisation tips,
+data format requirements, etc.)
+
+**Execution reminder**: When triggering this skill, just call
+`run_tool_batch(file_path=..., args=...)` as shown above to complete the
+entire workflow. There is no need to write each action yourself
+step by step. Only follow the "Batch failure handling" fallback if the
+batch execution fails.
+````
+
+> **Path note**: `run_tool_batch` only accepts absolute paths. Batch
+> JSON files are written into the skill directory via the `extra_files`
+> parameter of `materialize_skill`. The agent receives the skill
+> directory's absolute path in its system prompt (the `{dir}` in
+> `Check "{dir}/SKILL.md"`). The SKILL.md body **must** explicitly tell
+> the future agent to use that absolute directory to construct the
+> `file_path`.
+
+#### Batch JSON writing guidelines
+
+* **`file_path` must be an absolute path.** The SKILL.md body should
+  explicitly say: "use the directory path you see when reading this
+  SKILL.md and append `scripts/xxx.json`", so the future agent can
+  construct the absolute path.
+* **Use `${args.<name>}`** to parameterise all values that vary by
+  context (file paths, search keywords, URLs, etc.). Hard-code values
+  that are always the same. The brace-delimited syntax is required so
+  placeholders are unambiguous inside mixed-content strings like shell
+  commands.
+* **The SKILL.md body must include a `## Batch Parameters` section**.
+  That section must explain every `${args.<name>}` used in the batch
+  JSON: meaning, when the user should change it, default/recommended
+  value, and one concrete sample value that can be used for a test run.
+  The `run_tool_batch` example's `args` must contain those concrete
+  sample values. Do not write `{}`, `null`, `<description>`, or only
+  placeholder prose for required args.
+* **Use `${steps.<index>.<path>}`** for inter-step references — later
+  steps can reference earlier steps' output. For example,
+  `"content": "${steps.0.text}"` references step 0's text result.
+  The `<path>` depends on the actual return value structure of the
+  preceding tool. `materialize_skill` will automatically analyse all
+  `${steps}` references in the batch JSON and list them in its response.
+  **You must follow the prompts to call each referenced tool and verify
+  that its return value actually contains the referenced field.** If a
+  field doesn't exist, use `edit_file` to fix the batch JSON file
+  directly in the skill directory.
+* Each action uses `"tool_name"` and `"arguments"` fields (`"tool"` +
+  `"args"` also accepted).
+* Max 50 steps per batch file. Split into multiple files if needed.
+* JSON files are bundled into the skill directory via `extra_files`
+  (see Step 3).
+
+### 2c. Add step-by-step notes (reference documentation for the batch)
+
+After the batch call section, provide brief per-step notes. These are
+reference material for the future agent when debugging or running
+manually — **not the primary execution instructions**.
+
+For each step, answer from **session facts** (not common knowledge):
 
 * **Which tool, API, file, or command actually worked?** Cite the real
   name. If multiple were tried, cite **only** the one that worked.
-* **What concrete parameters did it take?** Use real argument values from
-  the session, not placeholders. The next agent should be able to copy
-  and run without guessing.
+* **What concrete parameters did it take?** Use real argument values
+  from the session.
 * **What errors hit this path, and how to avoid them?** Phrase as
-  preventive guidance. Example: *"Note: the endpoint returns 429 if
-  called more than once per second. Pass `delay=2` from the start to
-  avoid the retry loop we saw earlier."*
-* **What dead-ends should be skipped?** If three paths were tried and
-  one worked, document the winning path in full. Mention failed paths
-  **only** as terse `avoid X` reminders, not as full sub-procedures.
+  preventive guidance.
+* **What dead-ends should be skipped?** Mention failed paths **only**
+  as terse `avoid X` reminders.
 
 If the conversation doesn't contain a real answer for a question, **omit**
 it instead of inventing one. Inventing parameters or error notes is the
 most common failure mode of this skill.
 
-### 2c. Optional sections
+When the skill is not suitable for batch (requires branching logic),
+these step-by-step notes become the body's main content and the future
+agent executes them sequentially.
+
+### 2d. Optional sections
 
 Add these only when they help a future agent. No fixed schema:
 
@@ -178,7 +508,7 @@ Add these only when they help a future agent. No fixed schema:
 Skip anything that doesn't apply. Empty sections are worse than omitted
 ones.
 
-### 2d. Output format (only if stable)
+### 2e. Output format (only if stable)
 
 If the session settled on a stable output shape (table, JSON schema,
 markdown template), document it **once** at the top of the producing step
@@ -194,7 +524,7 @@ ALWAYS use this exact template:
 
 Skip this for skills whose output is genuinely free-form.
 
-### 2e. Self-check before persisting
+### 2f. Self-check before persisting
 
 Re-read the body once and verify ALL THREE. Single pass, no second round:
 
@@ -217,12 +547,102 @@ Call `materialize_skill` with:
   so a slightly pushy description is better than a narrow one).
 * **`body`**: the reviewed SKILL.md body. No frontmatter; the tool renders
   it.
+* **`extra_files`** (optional): if Step 2c produced batch JSON files or
+  other auxiliary files, bundle them here. Keys are relative paths
+  (e.g. `"scripts/check-config.json"`), values are file content strings.
+  Example:
+  ```python
+  materialize_skill(
+      name="my-skill",
+      description="Use this skill when ...",
+      body="...",
+      extra_files={
+          "scripts/check-config.json": '{"actions": [...]}',
+      },
+  )
+  ```
+  `extra_files` keys are paths relative to the skill directory. The
+  files are written into the corresponding locations under the skill
+  directory. The SKILL.md body should tell the future agent to use the
+  skill directory's absolute path (visible in the system prompt) to
+  construct the full `file_path` for `run_tool_batch`.
 
-Do **not** call `write_file` to save SKILL.md directly.
+Do **not** call `write_file` to create SKILL.md or auxiliary files directly.
+All initial creation must go through `materialize_skill`. After creation, use
+`edit_file` to modify existing files.
 
-## Step 4. Handle errors from `materialize_skill`
+## Step 4. Handle `materialize_skill` response
 
-### Conflict (skill name already taken)
+### 4a. Verify `$steps` references (when batch JSON is included)
+
+When `extra_files` contains `run_tool_batch` JSON files,
+`materialize_skill` automatically analyses all `${steps.<index>.<path>}`
+references and lists each reference's source tool and referenced field
+in its response.
+
+**You must check the returned reference list and verify that each
+referenced tool's return value actually contains the referenced field.**
+Record your verification in a markdown table like this:
+
+| Reference expression | Source tool | Referenced field | Verification method | Result |
+|---------------------|------------|-----------------|-------------------|--------|
+| `${steps.0.text}` | `read_file` | `text` | Check previous `read_file` call result in this session | ✅ exists |
+| `${steps.2.content}` | `grep_search` | `content` | Call `grep_search` once with sample args to confirm | ❌ field missing, should be `text` |
+
+Two verification methods, in order of preference:
+
+1. **Check session history**: if you already called that tool in this
+   session, inspect the previous return value for the field.
+2. **Call and test**: if you haven't called that tool yet, call it once
+   with sample arguments and observe the returned JSON structure.
+
+If any field reference is incorrect:
+
+1. Use `edit_file` to edit the batch JSON file directly in the skill
+   directory, fixing the `$steps` path. The skill directory's absolute
+   path is available from `materialize_skill`'s success response.
+2. If the SKILL.md body contains related reference documentation that
+   also needs updating, edit the `SKILL.md` in the skill directory
+   directly with `edit_file`.
+
+Do not call `materialize_skill` again — the skill is already created,
+just edit the files in place.
+
+**All references must pass verification** before proceeding to 4f.
+
+### 4f. Test-run the batch (when batch JSON is included)
+
+After reference verification passes, try running the batch once with sample
+arguments to confirm the entire chain works end-to-end:
+
+```python
+run_tool_batch(
+    file_path="<skill_dir>/scripts/<name>.json",
+    args={
+        "param1": "concrete sample value matching the SKILL.md Batch Parameters section",
+        ...
+    }
+)
+```
+
+If the batch JSON contains any `${args.<name>}` references, the test run
+must pass concrete sample values for those args. **Do not test-run with
+`args={}` or `args=None`**, because that does not verify argument
+expansion.
+
+* If it returns `ok: true`, the batch works — proceed to Step 5.
+* If it returns an error, use `edit_file` to fix the batch JSON or helper
+  scripts based on the error message, then re-run. Iterate until it passes
+  or you confirm the issue cannot be fixed in the current environment
+  (e.g. missing external dependencies, requires live network, etc.).
+* If environment constraints prevent a test run (e.g. requires a browser,
+  specific files that don't exist yet, etc.), skip the test and note in
+  Step 5: "Batch was not test-run; recommend verifying on first use."
+
+Only proceed to Step 5 after the test run passes (or is explicitly skipped
+due to environment constraints).
+
+### 4b. Conflict (skill name already taken)
 
 The tool returns the conflicting name and a suggested rename. **Recover
 automatically; don't gate this on a user question.**
@@ -238,24 +658,26 @@ automatically; don't gate this on a user question.**
    `cooking` was already in your workspace. Delete the old one and re-run
    if you want the original name back."*
 
-### Format error
+### 4c. Format error
 
 Fix the SKILL.md content (frontmatter fields, body sections, etc.) and
 call `materialize_skill` again. Do NOT call `finish_subtask` until it
 returns success.
 
-### Security-scan rejection
+### 4d. Security-scan rejection
 
 Remove the flagged patterns from the body and retry.
 
-### Other errors
+### 4e. Other errors
 
 Adjust inputs and retry, or abandon the plan if the failure is not
 recoverable.
 
 ## Step 5. Finish
 
-Once `materialize_skill` returns success:
+Once Step 4a reference verification and 4f test-run pass (or test-run is
+skipped due to environment constraints), and `materialize_skill` returns
+success:
 
 1. Call `finish_subtask` for the single subtask.
 2. Call `finish_plan` with `state="completed"`.

--- a/src/qwenpaw/agents/skills/make-skill-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/make-skill-en/SKILL.md
@@ -30,54 +30,9 @@ Do **not** call `write_file` to create the SKILL.md or any auxiliary files
 the security scanner and writes the manifest atomically. After successful
 creation, use `edit_file` to modify existing files if needed.
 
-## Step 0. Choose execution mode, determine the focus, and derive a skill name
+## Step 0. Determine the focus and derive a skill name
 
-### 0a. Choose execution mode
-
-Ask the user which execution mode they prefer:
-
-> **Run in the current conversation** or **run in the background**?
->
-> - **Current conversation**: complete the full flow in this turn
->   (propose plan → user approves → write SKILL.md → persist). Best
->   when iterative refinement is needed or the conversation itself is
->   the skill source.
-> - **Background**: delegate the writing and persistence work to a
->   subagent via `spawn_subagent(task=..., fork=True)`. The subagent
->   inherits the full context of THIS conversation (it can see all
->   previous messages). Best when the conversation is long and you
->   don't want to block the current interaction.
-
-**Current conversation** mode: follow Steps 0b–5 below as normal.
-
-**Background** mode:
-
-In this step you do **not** need to call `materialize_skill` or perform
-any skill-creation work yourself — just assemble a task description and
-submit it to the subagent, which will handle everything.
-
-1. Assemble the following into a task description for the subagent:
-   - The focus and derived `skill_name`
-   - Clear instructions: "Based on the current session context, execute
-     make-skill Steps 1–5 in full: plan autonomously, write the
-     SKILL.md body, call materialize_skill to persist, verify batch
-     references, test-run the batch. Report the result when done.
-     **Note: in the current mode, do NOT call `create_plan`, skip
-     user approval of the plan, and complete the entire flow
-     autonomously.**"
-2. Call:
-   ```
-   spawn_subagent(
-       task="<task description above>. Current mode: do NOT call create_plan, skip user approve, complete all steps autonomously.",
-       fork=True,
-       background=True,
-   )
-   ```
-3. Inform the user the task has been submitted. They can check progress
-   via `check_agent_task(task_id=...)`. The subagent will create the
-   skill in the workspace without requiring user approval mid-process.
-
-### 0b. Determine the focus
+### 0a. Determine the focus
 
 Two invocation paths:
 
@@ -87,7 +42,7 @@ Two invocation paths:
   conversation topic the user wants to capture. If ambiguous, ask a
   one-line clarification first.
 
-### 0c. Derive the skill name
+### 0b. Derive the skill name
 
 Derive the skill name from focus with **this exact rule**:
 
@@ -179,6 +134,63 @@ fields like `Subtask: …` or `Focus: …` in the chat message. Use the
 normalised `plan.name`, not the raw focus. This step only proposes the
 plan and waits for user confirmation — do **not** call `materialize_skill`
 here.
+
+### Choose execution mode
+
+After the user approves, ask about execution mode (yield one turn):
+
+> Plan approved. Should Phase B (writing and persistence) **continue in
+> the current conversation** or **run in the background via subagent**?
+>
+> - **Current conversation**: complete Phase B in this turn. Best when
+>   iterative refinement is needed.
+> - **Background**: delegate Phase B to a subagent without blocking the
+>   current conversation. The subagent inherits this session's full
+>   context and the approved plan.
+
+**Yield the turn** and wait for the user's reply. If the user does not
+explicitly choose, default to current-conversation mode.
+
+* **Current conversation** mode: follow Steps 2–5 below as normal.
+* **Background** mode: see the "Background Phase B" section below.
+
+**If you are already a subagent** (spawned by the main agent via
+`spawn_subagent`), skip the question and execute Steps 2–4 directly
+(the main agent already handled plan closure; do not call any
+plan-related tools).
+
+### Background Phase B
+
+Phase A (Steps 0–1) is already complete in the foreground. The user has
+approved the plan. Now delegate Phase B to a subagent.
+
+In this step you do **not** need to call `materialize_skill` or perform
+any skill-creation work yourself — just assemble a task description and
+submit it to the subagent, which will handle everything.
+
+1. Assemble the following into a task description for the subagent:
+   - The approved `plan.name` (`skill_name`) and plan content
+   - Clear instructions: "Based on the current session context and the
+     approved plan, execute make-skill Steps 2–4 in full: write the
+     SKILL.md body, call materialize_skill to persist, verify batch
+     references, test-run the batch. Report the result when done.
+     **Do NOT call any plan-related tools (`create_plan`,
+     `finish_subtask`, `finish_plan`). Skip user approval and complete
+     all steps autonomously.**"
+2. Call:
+   ```
+   spawn_subagent(
+       task="<task description above>. Do NOT call any plan-related tools. Complete all steps autonomously.",
+       fork=True,
+       background=True,
+   )
+   ```
+3. Immediately call `finish_subtask` for the single subtask, then call
+   `finish_plan` with `state="completed"`. Do not wait for the subagent
+   to finish.
+4. Inform the user the task has been submitted. They can check progress
+   via `check_agent_task(task_id=...)`. The subagent will create the
+   skill in the workspace without requiring user approval mid-process.
 
 ### Plan-tools-unavailable fallback
 
@@ -355,7 +367,7 @@ much as possible.
 The body should lead with the batch call:
 
 ````markdown
-## Execution
+### Execution
 
 This skill ships with a batch JSON file `scripts/<name>.json`.
 
@@ -376,7 +388,7 @@ run_tool_batch(
 )
 ```
 
-## Batch Parameters
+### Batch Parameters
 
 Explain every parameter in `args`. Every variable used in the batch JSON
 as `${args.<name>}` must be listed here:
@@ -391,7 +403,7 @@ pass `args={}` and do not omit `args`** when the batch JSON contains
 `${args.<name>}` references; otherwise the placeholder may be used as a
 literal filename, URL, or command argument.
 
-## Batch failure handling
+### Batch failure handling
 
 If `run_tool_batch` fails (returns `ok: false` or errors mid-way):
 1. First verify every parameter listed in "Batch Parameters" was passed
@@ -406,7 +418,7 @@ If `run_tool_batch` fails (returns `ok: false` or errors mid-way):
    edit_file to adjust and optimise this skill's batch script so it
    works correctly next time?"
 
-## Step-by-step reference
+### Step-by-step reference
 
 The following details each batch step, for debugging or manual execution
 only:
@@ -414,7 +426,7 @@ only:
 1. ...
 2. ...
 
-## Notes
+### Notes
 
 (Place skill-specific notes here, such as parameter optimisation tips,
 data format requirements, etc.)
@@ -445,7 +457,7 @@ batch execution fails.
   that are always the same. The brace-delimited syntax is required so
   placeholders are unambiguous inside mixed-content strings like shell
   commands.
-* **The SKILL.md body must include a `## Batch Parameters` section**.
+* **The SKILL.md body must include a `### Batch Parameters` section**.
   That section must explain every `${args.<name>}` used in the batch
   JSON: meaning, when the user should change it, default/recommended
   value, and one concrete sample value that can be used for a test run.
@@ -608,9 +620,9 @@ If any field reference is incorrect:
 Do not call `materialize_skill` again — the skill is already created,
 just edit the files in place.
 
-**All references must pass verification** before proceeding to 4f.
+**All references must pass verification** before proceeding to 4b.
 
-### 4f. Test-run the batch (when batch JSON is included)
+### 4b. Test-run the batch (when batch JSON is included)
 
 After reference verification passes, try running the batch once with sample
 arguments to confirm the entire chain works end-to-end:
@@ -642,7 +654,7 @@ expansion.
 Only proceed to Step 5 after the test run passes (or is explicitly skipped
 due to environment constraints).
 
-### 4b. Conflict (skill name already taken)
+### 4c. Conflict (skill name already taken)
 
 The tool returns the conflicting name and a suggested rename. **Recover
 automatically; don't gate this on a user question.**
@@ -658,24 +670,24 @@ automatically; don't gate this on a user question.**
    `cooking` was already in your workspace. Delete the old one and re-run
    if you want the original name back."*
 
-### 4c. Format error
+### 4d. Format error
 
 Fix the SKILL.md content (frontmatter fields, body sections, etc.) and
 call `materialize_skill` again. Do NOT call `finish_subtask` until it
 returns success.
 
-### 4d. Security-scan rejection
+### 4e. Security-scan rejection
 
 Remove the flagged patterns from the body and retry.
 
-### 4e. Other errors
+### 4f. Other errors
 
 Adjust inputs and retry, or abandon the plan if the failure is not
 recoverable.
 
 ## Step 5. Finish
 
-Once Step 4a reference verification and 4f test-run pass (or test-run is
+Once Step 4a reference verification and 4b test-run pass (or test-run is
 skipped due to environment constraints), and `materialize_skill` returns
 success:
 
@@ -683,3 +695,29 @@ success:
 2. Call `finish_plan` with `state="completed"`.
 3. Tell the user the new skill is created and enabled, and they can
    invoke it via `/<skill_name>`.
+
+---
+
+## Complete flow summary
+
+```
+Step 0   Determine focus → derive skill_name
+          │
+Step 1   create_plan → yield turn → user approves/refines/cancels
+          │
+       Choose execution mode → yield turn → user picks foreground/background
+          │
+          ├─ Foreground ──────────────────────────────────────┐
+          │                                                    │
+          │  Step 2  Write SKILL.md body (batch-first)         │
+          │  Step 3  Call materialize_skill to persist          │
+          │  Step 4  Verify refs → test-run batch → handle err │
+          │  Step 5  finish_subtask + finish_plan + inform     │
+          │                                                    │
+          ├─ Background ──────────────────────────────────────┐
+          │                                                    │
+          │  spawn_subagent(fork=True, background=True)        │
+          │  Main agent immediately finish_subtask+finish_plan │
+          │  Subagent executes Steps 2–4 (no plan tools)       │
+          └────────────────────────────────────────────────────┘
+```

--- a/src/qwenpaw/agents/skills/make-skill-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/make-skill-zh/SKILL.md
@@ -29,49 +29,9 @@ metadata:
 `extra_files` 参数），它会跑安全扫描并原子写入 manifest。创建成功后，
 如需修改可以使用 `edit_file` 编辑已有文件。
 
-## 步骤 0. 选择执行方式、确定 focus、派生 skill 名
+## 步骤 0. 确定 focus、派生 skill 名
 
-### 0a. 选择执行方式
-
-询问用户希望以哪种方式执行 make-skill：
-
-> **在当前对话执行** 还是 **后台执行**？
->
-> - **当前对话**：在本轮对话中完成全部流程（提出计划 → 用户 approve →
->   撰写 SKILL.md → 持久化）。适合需要反复 refine、或对话本身就是 skill
->   来源的场景。
-> - **后台执行**：通过 `spawn_subagent(task=..., fork=True)` 将撰写和
->   持久化工作交给 subagent 在后台完成。subagent 继承当前对话的完整上下
->   文（能看到 THIS 会话的所有内容），执行完毕后返回结果摘要。适合对话
->   较长、不想阻塞当前交互的场景。
-
-**当前对话**模式：按下方步骤 0b–5 正常执行。
-
-**后台执行**模式：
-
-这一步你自己**不需要**调用 `materialize_skill` 或执行任何 skill 创建
-操作——只需组装 task 描述并提交给 subagent，由 subagent 完成全部后续
-工作。
-
-1. 直接将以下信息组装成 task 描述传给 subagent：
-   - focus 和派生的 `skill_name`
-   - 明确指令：「基于当前会话上下文，按 make-skill 步骤 1–5 完整执行：
-     自行规划、撰写 SKILL.md 正文、调用 materialize_skill 持久化、验证
-     batch 引用、试跑 batch。完成后报告结果。**注意：当前模式下无需调用
-     `create_plan`，无需等待用户 approve 计划，直接自行完成全部流程。**」
-2. 调用：
-   ```
-   spawn_subagent(
-       task="<上述 task 描述>。当前模式：无需调用 create_plan，跳过用户 approve，直接完成全部流程。",
-       fork=True,
-       background=True,
-   )
-   ```
-3. 告知用户已提交后台任务，可通过 `check_agent_task(task_id=...)` 查看
-   进度。subagent 完成后会在 workspace 中创建 skill，无需用户中途
-   approve。
-
-### 0b. 确定 focus
+### 0a. 确定 focus
 
 两种触发入口：
 
@@ -80,7 +40,7 @@ metadata:
   变成 skill」「make a skill from this」）。从用户想保存的对话主题里
   提炼一个简短 focus 短语。如果模糊，先问一句澄清。
 
-### 0c. 派生 skill 名
+### 0b. 派生 skill 名
 
 按**这条规则**从 focus 派生 skill 名：
 
@@ -162,6 +122,56 @@ cancel。`/plan` 模式的标准机制接管：
 `Subtask: …` / `Focus: …` 这种自定义字段，用标准化后的 `plan.name`，
 不要用 raw focus。本步骤只负责提出计划并等待用户确认，**不要**在此步
 调用 `materialize_skill`。
+
+### 选择执行方式
+
+用户 approve 后，询问执行方式（让出一轮 turn）：
+
+> 计划已 approve。Phase B（撰写与持久化）要**在当前对话继续执行**，
+> 还是**交给后台 subagent 执行**？
+>
+> - **当前对话**：在本轮对话中完成。适合需要反复 refine 的场景。
+> - **后台**：交给 subagent 完成，不阻塞当前对话。subagent 继承本会话
+>   完整上下文和已批准的计划。
+
+**让出 turn**，等用户回复后再继续。如果用户没有明确选择，默认使用
+当前对话模式。
+
+* **当前对话**模式：按下方步骤 2–5 正常执行。
+* **后台**模式：见下方「后台执行 Phase B」小节。
+
+**如果你当前已经是 subagent**（由主 agent 通过 `spawn_subagent`
+派生），跳过询问，直接执行步骤 2–4（主 agent 已完成 plan 收尾，
+subagent 无需调用任何 plan 相关工具）。
+
+### 后台执行 Phase B
+
+Phase A（步骤 0–1）已在前台完成，用户已经 approve 了计划。现在将
+Phase B 交给 subagent 执行。
+
+这一步你自己**不需要**调用 `materialize_skill` 或执行任何 skill 创建
+操作——只需组装 task 描述并提交给 subagent，由 subagent 完成全部后续
+工作。
+
+1. 将以下信息组装成 task 描述传给 subagent：
+   - 已 approve 的 `plan.name`（`skill_name`）和计划内容
+   - 明确指令：「基于当前会话上下文和已 approve 的计划，按 make-skill
+     步骤 2–4 完整执行：撰写 SKILL.md 正文、调用 materialize_skill
+     持久化、验证 batch 引用、试跑 batch。完成后报告结果。**无需调用
+     任何 plan 相关工具（`create_plan`、`finish_subtask`、
+     `finish_plan`），无需等待用户 approve，直接自行完成全部流程。**」
+2. 调用：
+   ```
+   spawn_subagent(
+       task="<上述 task 描述>。无需调用任何 plan 相关工具，直接完成全部流程。",
+       fork=True,
+       background=True,
+   )
+   ```
+3. 立即对唯一的 subtask 调 `finish_subtask`，再调 `finish_plan` with
+   `state="completed"` 收尾。不需要等 subagent 完成。
+4. 告知用户已提交后台任务，可通过 `check_agent_task(task_id=...)` 查看
+   进度。subagent 完成后会在 workspace 中创建 skill。
 
 ### Plan 工具不可用时的 fallback
 
@@ -320,7 +330,7 @@ batch 的补充参考（见 2c），不是主要执行指令。
 正文应以 batch 调用为主体，格式如下：
 
 ````markdown
-## 执行
+### 执行
 
 本 skill 附带了 batch JSON 文件 `scripts/<name>.json`。
 
@@ -341,7 +351,7 @@ run_tool_batch(
 )
 ```
 
-## Batch 参数
+### Batch 参数
 
 逐项说明 `args` 中的每个参数。凡是 batch JSON 中出现
 `${args.<name>}` 的变量，这里都必须列出，不能遗漏：
@@ -355,7 +365,7 @@ run_tool_batch(
 `args={}`，也不要省略 `args`**，否则 `${args.<name>}` 不会展开，可能被
 当作字面量文件名、URL 或命令参数使用。
 
-## Batch 失败处理
+### Batch 失败处理
 
 如果 `run_tool_batch` 执行失败（返回 `ok: false` 或中途报错），请：
 1. 先检查「Batch 参数」中列出的每个参数是否都已传入实际值，尤其不要
@@ -367,14 +377,14 @@ run_tool_batch(
    是否需要我用 edit_file 调整和优化这个 skill 的 batch 脚本，以便下次
    能正常运行？」
 
-## 分步参考
+### 分步参考
 
 以下是 batch 中每一步的详细说明，仅在需要调试或手动执行时参考：
 
 1. ...
 2. ...
 
-## 注意事项
+### 注意事项
 
 （此处放置 skill 特定的注意事项，如参数优化建议、数据格式要求等。）
 
@@ -397,7 +407,7 @@ action。只有当 batch 执行失败时，才参照「Batch 失败处理」中�
 * **用 `${args.<name>}` 参数化**所有因场景而变的值（文件路径、搜索关键
   词、URL 等）。固定不变的值直接写死。花括号语法是必须的，这样在
   shell 命令等混合内容字符串中不会产生歧义。
-* **SKILL.md 必须包含 `## Batch 参数` 小节**。该小节要逐项解释 batch
+* **SKILL.md 必须包含 `### Batch 参数` 小节**。该小节要逐项解释 batch
   JSON 中每个 `${args.<name>}`：含义、何时需要用户修改、默认/推荐值、
   以及一个可直接用于试跑的实际示例值。`run_tool_batch` 示例中的
   `args` 必须填这些实际示例值，不能写 `{}`、`null`、`<说明>` 或只写
@@ -535,9 +545,9 @@ ALWAYS use this exact template:
 
 不要重新调用 `materialize_skill`——skill 已经创建，直接编辑文件即可。
 
-**所有引用验证通过后**，进入 4f 试跑。
+**所有引用验证通过后**，进入 4b 试跑。
 
-### 4f. 试跑 batch（当包含 batch JSON 时）
+### 4b. 试跑 batch（当包含 batch JSON 时）
 
 引用验证通过后，尽量用示例参数实际跑一次 `run_tool_batch`，确认整条
 链路能跑通：
@@ -566,7 +576,7 @@ run_tool_batch(
 
 试跑通过后才能进入步骤 5。
 
-### 4b. 命名冲突（skill 名已存在）
+### 4c. 命名冲突（skill 名已存在）
 
 工具会返回冲突 skill 名 + 一个建议的改名。**自动恢复，不要再问用户。**
 
@@ -580,24 +590,50 @@ run_tool_batch(
    *「已存为 `cooking-v2`，因为 `cooking` 已被占用。如果想用回原名，
    可以删掉旧的再跑 `/make-skill`。」*
 
-### 4c. 格式错误
+### 4d. 格式错误
 
 修正 SKILL.md 内容（frontmatter 字段、正文章节等）再调一次。
 **`materialize_skill` 没成功前不要**调 `finish_subtask`。
 
-### 4d. 安全扫描拒绝
+### 4e. 安全扫描拒绝
 
 移除被 flag 的模式再重试。
 
-### 4e. 其他错误
+### 4f. 其他错误
 
 调整输入再重试，或如果不可恢复就 abandon 计划。
 
 ## 步骤 5. 收尾
 
-步骤 4a 引用验证通过、4f 试跑通过（或因环境限制跳过）、
+步骤 4a 引用验证通过、4b 试跑通过（或因环境限制跳过）、
 `materialize_skill` 返回成功后：
 
 1. 对唯一的 subtask 调 `finish_subtask`。
 2. 调 `finish_plan` with `state="completed"`。
 3. 告知用户：新 skill 已创建并启用，可通过 `/<skill_name>` 调用。
+
+---
+
+## 完整流程总结
+
+```
+步骤 0  确定 focus → 派生 skill_name
+         │
+步骤 1  create_plan → 让出 turn → 用户 approve/refine/cancel
+         │
+      选择执行方式 → 让出 turn → 用户选择前台/后台
+         │
+         ├─ 前台 ─────────────────────────────────────────┐
+         │                                                 │
+         │  步骤 2  撰写 SKILL.md 正文（batch 优先）       │
+         │  步骤 3  调用 materialize_skill 持久化          │
+         │  步骤 4  验证引用 → 试跑 batch → 处理错误       │
+         │  步骤 5  finish_subtask + finish_plan + 告知    │
+         │                                                 │
+         ├─ 后台 ─────────────────────────────────────────┐
+         │                                                 │
+         │  spawn_subagent(fork=True, background=True)     │
+         │  主 agent 立即 finish_subtask + finish_plan     │
+         │  subagent 执行步骤 2–4（无需 plan 工具）        │
+         └─────────────────────────────────────────────────┘
+```

--- a/src/qwenpaw/agents/skills/make-skill-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/make-skill-zh/SKILL.md
@@ -2,7 +2,7 @@
 name: make-skill
 description: "用于把当前会话沉淀为可复用的 workspace skill。当用户希望把当前对话、工作流或排错路径写成 SKILL.md 时触发。触发表达包括「把这个变成 skill」「记住我是怎么做 X 的」「保存这个工作流」「make a skill from this」以及任何 /make-skill <focus> 调用。"
 metadata:
-  builtin_skill_version: "1.0"
+  builtin_skill_version: "1.1"
   qwenpaw:
     emoji: "✍️"
     requires: {}
@@ -24,10 +24,54 @@ metadata:
 * **Phase B.** 用户 approve 后，基于 THIS 会话撰写完整 SKILL.md 正文，
   通过 `materialize_skill` 持久化。
 
-**不要**用 `write_file` 直接写 SKILL.md。必须走 `materialize_skill`，
-它会跑安全扫描并原子写入 manifest。
+**不要**用 `write_file` 直接创建 SKILL.md 或其附属文件（脚本、JSON
+等）。所有文件的首次创建必须走 `materialize_skill`（通过 `body` 和
+`extra_files` 参数），它会跑安全扫描并原子写入 manifest。创建成功后，
+如需修改可以使用 `edit_file` 编辑已有文件。
 
-## 步骤 0. 确定 focus 并派生 skill 名
+## 步骤 0. 选择执行方式、确定 focus、派生 skill 名
+
+### 0a. 选择执行方式
+
+询问用户希望以哪种方式执行 make-skill：
+
+> **在当前对话执行** 还是 **后台执行**？
+>
+> - **当前对话**：在本轮对话中完成全部流程（提出计划 → 用户 approve →
+>   撰写 SKILL.md → 持久化）。适合需要反复 refine、或对话本身就是 skill
+>   来源的场景。
+> - **后台执行**：通过 `spawn_subagent(task=..., fork=True)` 将撰写和
+>   持久化工作交给 subagent 在后台完成。subagent 继承当前对话的完整上下
+>   文（能看到 THIS 会话的所有内容），执行完毕后返回结果摘要。适合对话
+>   较长、不想阻塞当前交互的场景。
+
+**当前对话**模式：按下方步骤 0b–5 正常执行。
+
+**后台执行**模式：
+
+这一步你自己**不需要**调用 `materialize_skill` 或执行任何 skill 创建
+操作——只需组装 task 描述并提交给 subagent，由 subagent 完成全部后续
+工作。
+
+1. 直接将以下信息组装成 task 描述传给 subagent：
+   - focus 和派生的 `skill_name`
+   - 明确指令：「基于当前会话上下文，按 make-skill 步骤 1–5 完整执行：
+     自行规划、撰写 SKILL.md 正文、调用 materialize_skill 持久化、验证
+     batch 引用、试跑 batch。完成后报告结果。**注意：当前模式下无需调用
+     `create_plan`，无需等待用户 approve 计划，直接自行完成全部流程。**」
+2. 调用：
+   ```
+   spawn_subagent(
+       task="<上述 task 描述>。当前模式：无需调用 create_plan，跳过用户 approve，直接完成全部流程。",
+       fork=True,
+       background=True,
+   )
+   ```
+3. 告知用户已提交后台任务，可通过 `check_agent_task(task_id=...)` 查看
+   进度。subagent 完成后会在 workspace 中创建 skill，无需用户中途
+   approve。
+
+### 0b. 确定 focus
 
 两种触发入口：
 
@@ -35,6 +79,8 @@ metadata:
 * 自然语言（「把这个变成 skill」「保存这个工作流」「把刚才的 X 流程
   变成 skill」「make a skill from this」）。从用户想保存的对话主题里
   提炼一个简短 focus 短语。如果模糊，先问一句澄清。
+
+### 0c. 派生 skill 名
 
 按**这条规则**从 focus 派生 skill 名：
 
@@ -68,17 +114,31 @@ skill_name = "-".join(focus.split())
       同义词。
     * **I/O.** 期望什么输入，产出什么输出。
     这里不是 SKILL.md frontmatter 格式，frontmatter 后面再 distill。
-  * **Part 2：步骤大纲。** 编号列表，每行一个简短动词短语。不写细
-    节、不写参数、不写错误处理、不写 sub-bullet、不写 `##` 子标题。
-    只给出形状，让用户能快速判断顺序和范围，决定要不要改。
-    格式示例（**不要**抄这个内容）：
-    ```
-    1. <verb phrase, ~5-10 words>
-    2. <verb phrase, ~5-10 words>
-    3. <…>
-    ```
-    步骤名要从 THIS 会话里实际发生的事情里提取。不要编造；会话里没
-    依据的就省略。
+  * **Part 2：步骤大纲与 batch 规划。** 两部分内容：
+    * **步骤大纲。** 编号列表，每行一个简短动词短语。不写细节、不写
+      参数、不写错误处理、不写 sub-bullet、不写 `##` 子标题。只给出
+      形状，让用户能快速判断顺序和范围。步骤名要从 THIS 会话里实际
+      发生的事情里提取。不要编造；会话里没依据的就省略。
+      格式示例（**不要**抄这个内容）：
+      ```
+      1. <verb phrase, ~5-10 words>
+      2. <verb phrase, ~5-10 words>
+      3. <…>
+      ```
+    * **Batch 规划。** 简要说明如何将上述步骤组织成 `run_tool_batch`
+      的 JSON 文件：
+      * 哪些步骤可以串成一个 batch（或需要拆成多个 batch 文件）。
+      * 哪些中间环节原本需要 agent 介入判断，但实际上可以通过编写
+        脚本（正则匹配、关键词筛选、JSON 解析等）来替代，从而减少
+        agent 交互次数，让更多步骤纳入自动化 batch。
+      * 列出预计需要的文件清单，如：
+        ```
+        scripts/main.json      — 主 batch 流程
+        scripts/parse.py       — 解析 snapshot 提取目标内容
+        ```
+      目标是尽可能用脚本替代 agent 的中间判断，让 skill 执行时只需
+      一次 `run_tool_batch` 调用即可完成，避免 agent 与工具之间的
+      多轮交互。这让用户在 approve 前就能看到 batch 的整体结构。
 * **`expected_outcome`**（plan 顶层，**必填**，与 subtask 的
   `expected_outcome` 不是同一个）：一句具体描述整个 skill 创建的成功
   状态。直接用这个字面值（替换 `<skill_name>`）即可：
@@ -100,7 +160,8 @@ cancel。`/plan` 模式的标准机制接管：
 
 向用户呈现计划时用标准 plan card 格式。**不要**在 chat 里另搞
 `Subtask: …` / `Focus: …` 这种自定义字段，用标准化后的 `plan.name`，
-不要用 raw focus。
+不要用 raw focus。本步骤只负责提出计划并等待用户确认，**不要**在此步
+调用 `materialize_skill`。
 
 ### Plan 工具不可用时的 fallback
 
@@ -133,25 +194,246 @@ cancel。`/plan` 模式的标准机制接管：
 标题用对应步骤的动词短语。如果用户在 approve 阶段对 Part 2 做了
 refine，**按 refined 版本**写。
 
-### 2b. 每个步骤从 THIS 会话取实料
+### 2b. 将完整流程整理为 batch JSON（首选执行方式）
 
-对每个步骤，**从会话事实出发**回答四个具体问题（不是凭常识猜）：
+**SKILL.md 正文的核心是一个 `run_tool_batch` 调用。** future agent 触发
+skill 时应**直接调用 batch**，而不是逐步手动执行。分步说明只作为
+batch 的补充参考（见 2c），不是主要执行指令。
+
+回顾 THIS 会话中的工具调用序列，把 skill 的**完整端到端流程**整理成一
+个 `run_tool_batch` JSON 文件。从流程起点到终点，所有**可以无条件串联
+执行**的步骤都应纳入 batch。
+
+#### 何时适用
+
+* skill 的核心流程包含 **≥ 2 步的工具调用链**。
+* 典型场景：批量文件操作、搜索后处理、多文件修改流水线、多步浏览器
+  操作等。
+* **大部分流程都可以通过脚本实现自动化。** 不要因为某个步骤「看起来
+  需要判断」就放弃把它纳入 batch。绝大多数中间处理——提取内容、筛选
+  结果、格式转换、条件判断、数据清洗——都能通过在 batch 中插入
+  `execute_shell_command` 调用脚本来程序化。两种方式：
+  * **内联短脚本**：直接在 `command` 中写
+    `python3 -c "..."` 单行处理。
+  * **独立脚本文件**：将复杂逻辑写成 `.py` 或 `.sh` 等文件放在
+    `scripts/` 目录下（通过 `extra_files` 打包），batch 中用
+    `execute_shell_command` 执行，如
+    `"command": "python3 <skill_dir>/scripts/parse.py --param1 ${steps.<index1>.<path>} --param2 ${steps.<index2>.<path>}"`。
+  通过命令行参数将前面步骤的输出（`${steps.<index>.<path>}`）传给
+  脚本，脚本处理后的 stdout 供后续步骤通过 `${steps}` 引用。这样整个
+  工作流就能串成一条完整的 batch 链，无需人工介入。只有**真正需要用户
+  实时决策**的环节（如「让用户选择哪个选项」「等待用户确认是否继续」）
+  才需要排除。
+
+  `${steps.<index>.<path>}` 不只用于脚本调用——任何工具的参数都可以
+  引用前面步骤的输出。例如将 `read_file` 的结果传给 `write_file`，
+  或将 `browser_use` snapshot 的内容传给 `execute_shell_command`。
+
+  示例——获取浏览器 snapshot，用独立 Python 脚本提取包含关键词的
+  内容并写入文件。其中 `${args.keyword}` 等是调用 `run_tool_batch`
+  时通过 `args` 参数传入的运行时变量，在执行前会被替换为实际值。
+
+  `scripts/extract_headings.py`（通过 `extra_files` 打包）：
+  ```python
+  import sys, re, json
+
+  keyword = sys.argv[1]
+  snapshot_file = sys.argv[2]
+  with open(snapshot_file) as f:
+      text = f.read()
+  items = [
+      m.group(1)
+      for m in re.finditer(
+          r'heading "([^"]*' + re.escape(keyword) + r'[^"]*)" \[ref=(\w+)\]',
+          text,
+      )
+  ]
+  print(json.dumps(items, ensure_ascii=False))
+  ```
+
+  batch JSON（`scripts/extract.json`）：
+  ```json
+  [
+    {
+      "tool_name": "browser_use",
+      "arguments": {"action": "snapshot"}
+    },
+    {
+      "tool_name": "write_file",
+      "arguments": {
+        "file_path": "${args.work_dir}/snapshot.txt",
+        "content": "${steps.0.text}"
+      }
+    },
+    {
+      "tool_name": "execute_shell_command",
+      "arguments": {
+        "command": "python3 ${args.skill_dir}/scripts/extract_headings.py ${args.keyword} ${args.work_dir}/snapshot.txt"
+      }
+    },
+    {
+      "tool_name": "write_file",
+      "arguments": {
+        "file_path": "${args.output_file}",
+        "content": "${steps.2.text}"
+      }
+    }
+  ]
+  ```
+  这样「从 snapshot 中筛选包含关键词的内容」这个原本需要人工判断的
+  步骤就被自动化了：第 0 步获取页面 snapshot，第 1 步将 snapshot
+  写入临时文件，第 2 步调用独立脚本读取文件并正则提取，第 3 步把
+  结果写入目标文件。复杂的解析逻辑写成独立的 `.py` 文件放在
+  `scripts/` 目录下，脚本和 batch JSON 都通过 `extra_files` 一并
+  打包到 skill 目录中。触发 skill 时直接调用即可：
+  ```
+  run_tool_batch(
+    file_path="<skill_dir>/scripts/extract.json",
+    args={
+      "keyword": "搜索关键词",
+      "skill_dir": "<本skill目录>",
+      "work_dir": "<工作目录>",
+      "output_file": "result.json"
+    }
+  )
+  ```
+
+#### 何时不适用（退回纯分步说明）
+
+绝大部分流程都可以自动化。只有同时满足以下条件时才退回分步逻辑：
+
+* **内容理解无法规则化**——完全无法通过关键词匹配、正则、JSON 解析等
+  基于规则的方式处理，必须依赖语义理解才能完成（注意：如果用户已给出
+  明确的搜索词、筛选条件，那就是可以规则化的，应该纳入 batch）。
+* **分支决策无法预先确定**——需要用户在执行过程中根据上下文实时判断
+  下一步走哪条路，而不是用户在触发 skill 时就能一次性给定所有参数。
+* 整个 skill 只有一次工具调用（无需 batch 封装）。
+
+即使流程中存在需要人工判断的环节，也要**尽量把可以合并的连续步骤整理
+成 batch**。这意味着一个 skill 可能包含多个 batch 文件——例如
+`scripts/phase1.json`（获取数据阶段）和 `scripts/phase2.json`（处理
+结果阶段），中间由 agent 基于语义判断决定如何衔接。能自动化的部分越多
+越好。
+
+#### SKILL.md 正文结构（当使用 batch 时）
+
+正文应以 batch 调用为主体，格式如下：
+
+````markdown
+## 执行
+
+本 skill 附带了 batch JSON 文件 `scripts/<name>.json`。
+
+**严格按照以下格式调用 `run_tool_batch`，使用 `file_path` 加载文件
+执行。不要自行构造 `actions` 列表内联传入。**
+
+`run_tool_batch` 的 `file_path` 需要**绝对路径**。你在读取本 SKILL.md
+时看到的目录路径即为本 skill 的绝对目录，请用它拼接出完整的
+`file_path`。
+
+```
+run_tool_batch(
+  file_path="<本skill目录>/scripts/<name>.json",
+  args={
+    "param1": "<实际示例值>",
+    "param2": "<实际示例值>"
+  }
+)
+```
+
+## Batch 参数
+
+逐项说明 `args` 中的每个参数。凡是 batch JSON 中出现
+`${args.<name>}` 的变量，这里都必须列出，不能遗漏：
+
+* `param1`：说明它控制什么；何时需要用户改；默认/推荐值是什么；示例：
+  `<实际示例值>`。
+* `param2`：说明它控制什么；何时需要用户改；默认/推荐值是什么；示例：
+  `<实际示例值>`。
+
+调用 `run_tool_batch` 时必须传入上面列出的所有参数。**不要传
+`args={}`，也不要省略 `args`**，否则 `${args.<name>}` 不会展开，可能被
+当作字面量文件名、URL 或命令参数使用。
+
+## Batch 失败处理
+
+如果 `run_tool_batch` 执行失败（返回 `ok: false` 或中途报错），请：
+1. 先检查「Batch 参数」中列出的每个参数是否都已传入实际值，尤其不要
+   使用空的 `args={}`；再根据错误信息修正参数后重试。
+2. 如果仍然失败，可以尝试使用 `run_tool_batch` 的 `actions` 参数
+   内联传入动作序列来执行。
+3. 如果内联执行也失败，改为参照下方「分步参考」手动逐步执行完成任务。
+4. 执行完毕后，提示用户：「本次 batch 执行遇到问题，已改为手动完成。
+   是否需要我用 edit_file 调整和优化这个 skill 的 batch 脚本，以便下次
+   能正常运行？」
+
+## 分步参考
+
+以下是 batch 中每一步的详细说明，仅在需要调试或手动执行时参考：
+
+1. ...
+2. ...
+
+## 注意事项
+
+（此处放置 skill 特定的注意事项，如参数优化建议、数据格式要求等。）
+
+**执行方式提醒**：触发本 skill 时，直接使用上方的 `run_tool_batch(
+file_path=..., args=...)` 调用即可完成全部流程，无需自己逐步编写每一个
+action。只有当 batch 执行失败时，才参照「Batch 失败处理」中的降级方案。
+````
+
+> **路径说明**：`run_tool_batch` 只接受绝对路径。batch JSON 文件通过
+> `materialize_skill` 的 `extra_files` 参数写入 skill 目录。agent 在
+> system prompt 中会收到 skill 目录的绝对路径（即
+> `Check "{dir}/SKILL.md"` 中的 `{dir}`），SKILL.md 正文中**必须**
+> 明确告知 future agent 用该绝对目录拼出 `file_path`。
+
+#### batch JSON 编写要点
+
+* **`file_path` 必须是绝对路径**。SKILL.md 正文中应明确写出：
+  「用你读取本 SKILL.md 时看到的目录路径拼接
+  `scripts/xxx.json`」，让 future agent 构造出绝对路径。
+* **用 `${args.<name>}` 参数化**所有因场景而变的值（文件路径、搜索关键
+  词、URL 等）。固定不变的值直接写死。花括号语法是必须的，这样在
+  shell 命令等混合内容字符串中不会产生歧义。
+* **SKILL.md 必须包含 `## Batch 参数` 小节**。该小节要逐项解释 batch
+  JSON 中每个 `${args.<name>}`：含义、何时需要用户修改、默认/推荐值、
+  以及一个可直接用于试跑的实际示例值。`run_tool_batch` 示例中的
+  `args` 必须填这些实际示例值，不能写 `{}`、`null`、`<说明>` 或只写
+  占位描述。
+* **用 `${steps.<index>.<path>}` 做步骤间引用**——后续步骤可引用前面步骤
+  的输出。例如 `"content": "${steps.0.text}"` 引用第 0 步的文本结果。
+  `<path>` 取决于上一步工具的实际返回值结构。`materialize_skill` 会
+  自动分析 batch JSON 中的所有 `${steps}` 引用，并在返回中列出需要验证
+  的引用关系。**你需要按提示逐个调用被引用的工具，确认其返回值确实
+  包含所引用的字段**。如果字段不存在，用 `edit_file` 直接修正 skill
+  目录下的 batch JSON 文件。
+* 每个 action 使用 `"tool_name"` 和 `"arguments"` 字段（也兼容
+  `"tool"` + `"args"`）。
+* 一个 batch 文件最多 50 步。超过时拆成多个文件。
+* JSON 文件通过 `extra_files` 打包进 skill 目录（详见步骤 3）。
+
+### 2c. 补充分步说明（batch 的参考文档）
+
+在 batch 调用之后，为每个步骤提供简要的分步说明。这些说明是 future
+agent 在调试或手动执行时的参考，**不是主要执行指令**。
+
+对每个步骤，**从会话事实出发**回答（不是凭常识猜）：
 
 * **真正跑通的是哪个 tool、API、文件、命令？** 直接写真名。如果尝试
   过多个，**只**记录跑通的那个。
-* **它使用的具体参数是什么？** 用会话中真实的参数值，不要占位符。
-  未来的 agent 要能照搬直接跑。
-* **本路径上撞过哪些错？怎么提前避开？** 写成预防性提示。例如：
-  *「注意：该 endpoint 每秒被调用超过一次就返回 429。直接传
-  `delay=2` 避开之前出现的重试循环。」*
-* **哪些死路要跳过？** 试过三条路一条跑通时，只把跑通的那条完整写
-  出。失败的那几条**仅**以简短的「避免 X」提醒带过，不要展开成
-  子流程。
+* **它使用的具体参数是什么？** 用会话中真实的参数值。
+* **本路径上撞过哪些错？怎么提前避开？** 写成预防性提示。
+* **哪些死路要跳过？** 失败路径**仅**以简短「避免 X」提醒带过。
 
 如果会话里没有某个问题的真实答案，**省略**这一项，不要编造。编造参
 数或错误提示是本 skill 最常见的失败模式。
 
-### 2c. 可选小节
+当 skill 不适合 batch（需要分支决策），这些分步说明就是正文主体，
+future agent 按步骤逐个执行。
+
+### 2d. 可选小节
 
 只在能帮到 future agent 时才加，没有固定 schema：
 
@@ -162,7 +444,7 @@ refine，**按 refined 版本**写。
 
 不适用就跳过。**空章节比省略更糟。**
 
-### 2d. 输出格式（仅当稳定时）
+### 2e. 输出格式（仅当稳定时）
 
 如果会话里输出形态固定下来（表格、JSON schema、markdown 模板），在产
 出该输出的步骤顶部用 `ALWAYS use this template:` 块**写一次**即可：
@@ -177,7 +459,7 @@ ALWAYS use this exact template:
 
 如果输出本质是自由形态，跳过本步。
 
-### 2e. 持久化前自查
+### 2f. 持久化前自查
 
 完整通读一遍正文，**单 pass** 检查全部三项：
 
@@ -200,12 +482,91 @@ ALWAYS use this exact template:
   义更可靠）。
 * **`body`**：已 review 过的 SKILL.md 正文。**不含 frontmatter**，工
   具会自己渲染。
+* **`extra_files`**（可选）：如果步骤 2c 中提取了 batch JSON 文件或其
+  他辅助文件，通过此参数一并打包。key 是相对路径（如
+  `"scripts/check-config.json"`），value 是文件内容字符串。示例：
+  ```python
+  materialize_skill(
+      name="my-skill",
+      description="Use this skill when ...",
+      body="...",
+      extra_files={
+          "scripts/check-config.json": '{"actions": [...]}',
+      },
+  )
+  ```
+  `extra_files` 的 key 是相对于 skill 目录的路径。文件会被写入 skill
+  目录下对应位置。SKILL.md 正文中应指引 future agent 用 skill 目录
+  的绝对路径（system prompt 中可见）拼接出 `file_path` 的完整路径。
 
-**不要**用 `write_file` 直接写 SKILL.md。
+**不要**用 `write_file` 直接创建 SKILL.md 或附属文件。所有文件的首次
+创建必须通过 `materialize_skill`。创建成功后如需修改，使用 `edit_file`。
 
-## 步骤 4. 处理 `materialize_skill` 的错误
+## 步骤 4. 处理 `materialize_skill` 的返回
 
-### 命名冲突（skill 名已存在）
+### 4a. 验证 `$steps` 引用（当包含 batch JSON 时）
+
+当 `extra_files` 中包含 `run_tool_batch` 的 JSON 文件时，
+`materialize_skill` 会自动分析其中所有的 `${steps.<index>.<path>}`
+引用，并在返回中列出每条引用的来源工具和被引用字段。
+
+**你需要对照返回的引用列表，逐条验证被引用工具的返回值是否确实包含
+该字段。** 用 markdown 表格记录验证结果，格式如下：
+
+| 引用表达式 | 来源工具 | 引用字段 | 验证方式 | 结果 |
+|-----------|---------|---------|---------|------|
+| `${steps.0.text}` | `read_file` | `text` | 查看本会话中之前的 `read_file` 调用结果 | ✅ 存在 |
+| `${steps.2.content}` | `grep_search` | `content` | 用示例参数调用一次 `grep_search` 确认 | ❌ 字段不存在，应改为 `text` |
+
+验证方式有两种，按优先级选择：
+
+1. **查看本会话历史**：如果本会话中已经调用过该工具，直接检查之前的
+   返回结果中是否包含该字段。
+2. **重新调用测试**：如果本会话中没有调用过该工具，用示例参数调用
+   一次，观察返回的 JSON 结构。
+
+如果发现任何字段引用不正确：
+
+1. 用 `edit_file` 直接编辑 skill 目录下对应的 batch JSON 文件，修正
+   `$steps` path。skill 目录的绝对路径可从 `materialize_skill` 的成功
+   返回中获取。
+2. 如果 SKILL.md 正文中有引用相关说明也需要同步修正，同样用
+   `edit_file` 直接编辑 skill 目录下的 `SKILL.md`。
+
+不要重新调用 `materialize_skill`——skill 已经创建，直接编辑文件即可。
+
+**所有引用验证通过后**，进入 4f 试跑。
+
+### 4f. 试跑 batch（当包含 batch JSON 时）
+
+引用验证通过后，尽量用示例参数实际跑一次 `run_tool_batch`，确认整条
+链路能跑通：
+
+```python
+run_tool_batch(
+    file_path="<skill目录>/scripts/<name>.json",
+    args={
+        "param1": "与 SKILL.md Batch 参数小节一致的实际示例值",
+        ...
+    }
+)
+```
+
+如果 batch JSON 中包含任何 `${args.<name>}`，试跑时必须传入对应的实际
+示例值。**禁止用 `args={}` 或 `args=None` 试跑**，否则不能验证参数展开
+是否正确。
+
+* 如果返回 `ok: true`，说明 batch 可正常工作，进入步骤 5。
+* 如果返回错误，根据错误信息用 `edit_file` 修正 batch JSON 或辅助
+  脚本，然后再跑一次。反复修正直到跑通或确认问题无法在当前环境修复
+  （如缺少外部依赖、需要真实网络请求等）。
+* 如果因环境限制无法试跑（例如需要浏览器、需要特定文件存在等），跳过
+  试跑，在步骤 5 报告时告知用户：「batch 未经试跑，建议首次使用时关注
+  执行结果。」
+
+试跑通过后才能进入步骤 5。
+
+### 4b. 命名冲突（skill 名已存在）
 
 工具会返回冲突 skill 名 + 一个建议的改名。**自动恢复，不要再问用户。**
 
@@ -219,21 +580,22 @@ ALWAYS use this exact template:
    *「已存为 `cooking-v2`，因为 `cooking` 已被占用。如果想用回原名，
    可以删掉旧的再跑 `/make-skill`。」*
 
-### 格式错误
+### 4c. 格式错误
 
 修正 SKILL.md 内容（frontmatter 字段、正文章节等）再调一次。
 **`materialize_skill` 没成功前不要**调 `finish_subtask`。
 
-### 安全扫描拒绝
+### 4d. 安全扫描拒绝
 
 移除被 flag 的模式再重试。
 
-### 其他错误
+### 4e. 其他错误
 
 调整输入再重试，或如果不可恢复就 abandon 计划。
 
 ## 步骤 5. 收尾
 
+步骤 4a 引用验证通过、4f 试跑通过（或因环境限制跳过）、
 `materialize_skill` 返回成功后：
 
 1. 对唯一的 subtask 调 `finish_subtask`。

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -34,6 +34,7 @@ from .delegate_external_agent import delegate_external_agent
 # Registered via react_agent's hardcoded tool_functions; kept out of
 # __all__ so it's always enabled, not gated on agent config.
 from .make_skill_tools import materialize_skill  # noqa: F401
+from .run_tool_batch import run_tool_batch  # noqa: F401
 
 __all__ = [
     "execute_python_code",
@@ -60,4 +61,5 @@ __all__ = [
     "submit_to_agent",
     "check_agent_task",
     "spawn_subagent",
+    "run_tool_batch",
 ]

--- a/src/qwenpaw/agents/tools/make_skill_tools.py
+++ b/src/qwenpaw/agents/tools/make_skill_tools.py
@@ -136,12 +136,29 @@ def _tool_text_response(text: str) -> ToolResponse:
     return ToolResponse(content=[TextBlock(type="text", text=text)])
 
 
+def _parse_extra_files(
+    extra_files: dict[str, str] | str | None,
+) -> dict[str, str] | None:
+    """Accept either a mapping or its JSON string representation."""
+    if extra_files is None or isinstance(extra_files, dict):
+        return extra_files
+    try:
+        parsed = json.loads(extra_files)
+    except json.JSONDecodeError as exc:
+        raise SkillsError(
+            message="extra_files string must be a valid JSON object",
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise SkillsError(message="extra_files string must parse to an object")
+    return parsed
+
+
 # pylint: disable=too-many-return-statements,too-many-branches,too-many-locals
 async def materialize_skill(
     name: str,
     description: str,
     body: str,
-    extra_files: dict[str, str] | None = None,
+    extra_files: dict[str, str] | str | None = None,
 ) -> ToolResponse:
     """Persist a confirmed skill proposal into the workspace.
 
@@ -157,10 +174,10 @@ async def materialize_skill(
             don't under-trigger.
         body: The SKILL.md body, no frontmatter.
         extra_files: Additional files to include alongside SKILL.md.
-            Keys are relative paths (e.g. ``"scripts/batch.json"``),
-            values are file contents as strings. Useful for bundling
-            ``run_tool_batch`` JSON files or helper scripts referenced
-            by the skill body.
+            Pass either a dict or a JSON object string. Keys are relative
+            paths (e.g. ``"scripts/batch.json"``), values are file
+            contents as strings. Useful for bundling ``run_tool_batch``
+            JSON files or helper scripts referenced by the skill body.
     """
     if not name or not description or not body:
         return _tool_text_response(
@@ -211,11 +228,12 @@ async def materialize_skill(
     )
 
     try:
+        parsed_extra_files = _parse_extra_files(extra_files)
         service = SkillService(workspace_dir)
         skill_name = service.create_skill(
             name=normalized_name,
             content=content,
-            extra_files=extra_files or None,
+            extra_files=parsed_extra_files or None,
             enable=True,
             source="agent",
         )
@@ -254,8 +272,8 @@ async def materialize_skill(
 
     # Analyse batch JSON files for $steps references
     verification = ""
-    if extra_files:
-        refs = _analyse_batch_refs(extra_files)
+    if parsed_extra_files:
+        refs = _analyse_batch_refs(parsed_extra_files)
         verification = _format_ref_verification(refs)
 
     return _tool_text_response(

--- a/src/qwenpaw/agents/tools/make_skill_tools.py
+++ b/src/qwenpaw/agents/tools/make_skill_tools.py
@@ -136,6 +136,7 @@ def _tool_text_response(text: str) -> ToolResponse:
     return ToolResponse(content=[TextBlock(type="text", text=text)])
 
 
+# pylint: disable=too-many-return-statements,too-many-branches,too-many-locals
 async def materialize_skill(
     name: str,
     description: str,
@@ -262,3 +263,6 @@ async def materialize_skill(
         f"Visible via `/skills`; invoke with `/{skill_name}`."
         f"{verification}",
     )
+
+
+# pylint: enable=too-many-return-statements,too-many-branches,too-many-locals

--- a/src/qwenpaw/agents/tools/make_skill_tools.py
+++ b/src/qwenpaw/agents/tools/make_skill_tools.py
@@ -2,7 +2,9 @@
 """Tool backing the ``/make-skill`` flow."""
 from __future__ import annotations
 
+import json
 import logging
+import re
 
 from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
@@ -19,6 +21,115 @@ from ..skill_system.workspace_service import SkillService
 
 logger = logging.getLogger(__name__)
 
+# Only the brace-delimited form ${steps.N.path} is recognised.
+_STEP_REF_INLINE = re.compile(
+    r"\$\{steps\.(\d+)(?:\.([A-Za-z0-9_.-]+))?\}",
+)
+
+
+def _analyse_batch_refs(
+    extra_files: dict[str, str],
+) -> list[dict[str, str]]:
+    """Parse batch JSON files in extra_files and extract $steps references.
+
+    Returns a list of dicts, each with:
+      - file: the extra_files key (relative path)
+      - step_index: the step index being referenced
+      - path: the dotted path into the step result (or "" for whole result)
+      - tool_name: the tool at that step index (if resolvable)
+      - referencing_step: which step contains this reference
+      - referencing_tool: the tool_name of the referencing step
+    """
+    refs = []
+    for file_key, content in extra_files.items():
+        if not file_key.endswith(".json"):
+            continue
+        try:
+            data = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        actions = data if isinstance(data, list) else data.get("actions", [])
+        if not isinstance(actions, list):
+            continue
+        for step_idx, action in enumerate(actions):
+            if not isinstance(action, dict):
+                continue
+            referencing_tool = str(
+                action.get("tool_name") or action.get("tool") or "",
+            )
+            # Scan all string values in arguments for ${steps} refs
+            step_args = action.get("arguments") or action.get("args") or {}
+            if not isinstance(step_args, dict):
+                continue
+            for _val in _iter_strings(step_args):
+                for m in _STEP_REF_INLINE.finditer(_val):
+                    ref_index = int(m.group(1))
+                    ref_path = m.group(2) or ""
+                    source_tool = ""
+                    if 0 <= ref_index < len(actions):
+                        source_tool = str(
+                            actions[ref_index].get("tool_name")
+                            or actions[ref_index].get("tool")
+                            or "",
+                        )
+                    refs.append(
+                        {
+                            "file": file_key,
+                            "step_index": str(ref_index),
+                            "path": ref_path,
+                            "tool_name": source_tool,
+                            "referencing_step": str(step_idx),
+                            "referencing_tool": referencing_tool,
+                        },
+                    )
+    return refs
+
+
+def _iter_strings(obj: object) -> list[str]:
+    """Recursively collect all string values from dicts/lists."""
+    results: list[str] = []
+    if isinstance(obj, str):
+        results.append(obj)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            results.extend(_iter_strings(v))
+    elif isinstance(obj, list):
+        for v in obj:
+            results.extend(_iter_strings(v))
+    return results
+
+
+def _format_ref_verification(refs: list[dict[str, str]]) -> str:
+    """Format $steps references into a verification prompt."""
+    if not refs:
+        return ""
+
+    lines = [
+        "\n\n---\n"
+        "**Batch JSON contains `${steps}` references that need "
+        "verification.**\n"
+        "Before calling `finish_subtask`, please run each referenced tool "
+        "or check previous tool use history "
+        "to confirm its return value contains the expected fields:\n",
+    ]
+    for ref in refs:
+        source = ref["tool_name"] or f"step {ref['step_index']}"
+        path = ref["path"] or "(whole result)"
+        lines.append(
+            f"- `{ref['file']}`: step {ref['referencing_step']} "
+            f"(`{ref['referencing_tool']}`) references "
+            f"`${{steps.{ref['step_index']}.{ref['path']}}}` "
+            f"→ verify that `{source}` returns a field `{path}`",
+        )
+    lines.append(
+        "\nCall each source tool with sample arguments, or check previous "
+        "tool use history in this conversation, and verify "
+        "that the returned JSON contains the referenced path. "
+        "If a field doesn't exist, use `edit_file` to fix the batch JSON "
+        "file directly in the skill directory.",
+    )
+    return "\n".join(lines)
+
 
 def _tool_text_response(text: str) -> ToolResponse:
     """Wrap text in a single-TextBlock ToolResponse."""
@@ -29,6 +140,7 @@ async def materialize_skill(
     name: str,
     description: str,
     body: str,
+    extra_files: dict[str, str] | None = None,
 ) -> ToolResponse:
     """Persist a confirmed skill proposal into the workspace.
 
@@ -43,6 +155,11 @@ async def materialize_skill(
             push on synonyms / adjacent phrasings so future agents
             don't under-trigger.
         body: The SKILL.md body, no frontmatter.
+        extra_files: Additional files to include alongside SKILL.md.
+            Keys are relative paths (e.g. ``"scripts/batch.json"``),
+            values are file contents as strings. Useful for bundling
+            ``run_tool_batch`` JSON files or helper scripts referenced
+            by the skill body.
     """
     if not name or not description or not body:
         return _tool_text_response(
@@ -97,6 +214,7 @@ async def materialize_skill(
         skill_name = service.create_skill(
             name=normalized_name,
             content=content,
+            extra_files=extra_files or None,
             enable=True,
             source="agent",
         )
@@ -133,7 +251,14 @@ async def materialize_skill(
             )
         return _tool_text_response(text)
 
+    # Analyse batch JSON files for $steps references
+    verification = ""
+    if extra_files:
+        refs = _analyse_batch_refs(extra_files)
+        verification = _format_ref_verification(refs)
+
     return _tool_text_response(
         f"**Skill created and enabled**: `{skill_name}`\n\n"
-        f"Visible via `/skills`; invoke with `/{skill_name}`.",
+        f"Visible via `/skills`; invoke with `/{skill_name}`."
+        f"{verification}",
     )

--- a/src/qwenpaw/agents/tools/run_tool_batch.py
+++ b/src/qwenpaw/agents/tools/run_tool_batch.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import logging
 import re
@@ -99,8 +98,9 @@ def _response_payload(response: ToolResponse) -> dict[str, Any]:
     - Plain-text error prefixes (``Error:``, ``Command failed``).
     - Exceptions caught in ``_call_tool`` (already ``ok: False``).
 
-    The original content blocks are preserved under ``content`` so
-    that the final batch response can re-emit them.
+    The original content blocks are preserved under ``_raw_blocks``
+    (an internal key that avoids colliding with tool payloads that
+    contain their own ``content`` field).
     """
     text = _extract_text(response)
     content = list(response.content or [])
@@ -111,16 +111,16 @@ def _response_payload(response: ToolResponse) -> dict[str, Any]:
         if isinstance(payload, dict):
             if "ok" not in payload:
                 payload["ok"] = "error" not in payload
-            payload["content"] = content
+            payload["_raw_blocks"] = content
             return payload
-        return {"ok": True, "value": payload, "content": content}
+        return {"ok": True, "value": payload, "_raw_blocks": content}
     except (json.JSONDecodeError, TypeError):
         pass
 
     # Plain-text response — check for known error patterns.
     if _is_error_text(text):
-        return {"ok": False, "error": text, "content": content}
-    return {"ok": True, "text": text, "content": content}
+        return {"ok": False, "error": text, "_raw_blocks": content}
+    return {"ok": True, "text": text, "_raw_blocks": content}
 
 
 # --- Step-reference resolution --------------------------------------------
@@ -304,7 +304,12 @@ async def _call_tool(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> ToolResponse:
-    """Call a registered tool function by name via the current Toolkit."""
+    """Call a registered tool function by name via the current Toolkit.
+
+    Uses ``Toolkit.call_tool_function`` so that ToolGuard interception,
+    preset kwargs, postprocess hooks, and group-activity checks all
+    apply — the same pipeline as a normal agent tool call.
+    """
     toolkit = get_current_toolkit()
     if toolkit is None:
         return _json_tool_response(
@@ -320,21 +325,23 @@ async def _call_tool(
             },
         )
 
-    tool_func = toolkit.tools[tool_name]
+    tool_call = {"name": tool_name, "input": arguments}
     try:
-        if inspect.iscoroutinefunction(tool_func.original_func):
-            result = await tool_func.original_func(**arguments)
-        else:
-            result = tool_func.original_func(**arguments)
+        response: ToolResponse | None = None
+        async for chunk in await toolkit.call_tool_function(tool_call):
+            response = chunk
+        if response is None:
+            return _json_tool_response(
+                {
+                    "ok": False,
+                    "error": f"Tool {tool_name} returned no response",
+                },
+            )
+        return response
     except Exception as exc:  # pylint: disable=broad-except
         return _json_tool_response(
             {"ok": False, "error": f"{type(exc).__name__}: {exc}"},
         )
-
-    if isinstance(result, ToolResponse):
-        return result
-    # Wrap unexpected return types.
-    return _json_tool_response({"ok": True, "value": str(result)})
 
 
 # --- Step execution loop --------------------------------------------------
@@ -353,7 +360,7 @@ async def _run_steps(  # pylint: disable=too-many-branches
     all_content_blocks: list[Any] = []
 
     for index, step in enumerate(actions):
-        # --- Validate step structure ---
+        # --- Validate step structure (always fatal) ---
         if not isinstance(step, dict):
             results.append(
                 {
@@ -362,9 +369,7 @@ async def _run_steps(  # pylint: disable=too-many-branches
                     "error": "step must be an object",
                 },
             )
-            if stop_on_error:
-                break
-            continue
+            break
 
         tool_name = str(
             step.get("tool_name") or step.get("tool") or "",
@@ -377,9 +382,7 @@ async def _run_steps(  # pylint: disable=too-many-branches
                     "error": "step must include tool_name",
                 },
             )
-            if stop_on_error:
-                break
-            continue
+            break
 
         # Prevent recursive batch calls.
         if tool_name == "run_tool_batch":
@@ -391,9 +394,7 @@ async def _run_steps(  # pylint: disable=too-many-branches
                     "error": "Recursive run_tool_batch is not allowed",
                 },
             )
-            if stop_on_error:
-                break
-            continue
+            break
 
         arguments = step.get("arguments") or step.get("args") or {}
         if not isinstance(arguments, dict):
@@ -405,9 +406,7 @@ async def _run_steps(  # pylint: disable=too-many-branches
                     "error": "arguments must be an object",
                 },
             )
-            if stop_on_error:
-                break
-            continue
+            break
 
         step_stop = step.get("stop_on_error", stop_on_error)
 
@@ -431,7 +430,7 @@ async def _run_steps(  # pylint: disable=too-many-branches
         response = await _call_tool(tool_name, arguments)
         result = _response_payload(response)
 
-        step_content = result.pop("content", [])
+        step_content = result.pop("_raw_blocks", [])
         all_content_blocks.extend(step_content)
 
         results.append(

--- a/src/qwenpaw/agents/tools/run_tool_batch.py
+++ b/src/qwenpaw/agents/tools/run_tool_batch.py
@@ -36,6 +36,7 @@ _STEP_REF_INLINE_PATTERN = re.compile(
 
 # --- Helpers --------------------------------------------------------------
 
+
 def _json_tool_response(payload: dict[str, Any]) -> ToolResponse:
     """Wrap a JSON-serialisable dict in a single-TextBlock ToolResponse."""
     return ToolResponse(
@@ -56,7 +57,7 @@ def _extract_text(response: ToolResponse) -> str:
     ``TextBlock``.  We scan all blocks to find the first one whose
     ``type`` is ``"text"``.
     """
-    for block in (response.content or []):
+    for block in response.content or []:
         block_type = (
             block.get("type", "")
             if isinstance(block, dict)
@@ -78,7 +79,7 @@ def _extract_text(response: ToolResponse) -> str:
 #   agent_management (chat/submit/check)   →  "ERROR: ..."
 #   shell (non-zero exit)                  →  "Command failed ..."
 _ERROR_PREFIXES = (
-    "error:",           # covers "Error:" and "ERROR:" (case-insensitive)
+    "error:",  # covers "Error:" and "ERROR:" (case-insensitive)
     "command failed ",  # shell non-zero exit code
 )
 
@@ -124,6 +125,7 @@ def _response_payload(response: ToolResponse) -> dict[str, Any]:
 
 # --- Step-reference resolution --------------------------------------------
 
+
 def resolve_step_refs(
     value: Any,
     results: list[dict[str, Any]],
@@ -150,7 +152,10 @@ def _resolve_step_ref_string(
     match = _STEP_REF_PATTERN.match(value)
     if match:
         return _lookup_step_ref(
-            match.group(1), match.group(2), results, value,
+            match.group(1),
+            match.group(2),
+            results,
+            value,
         )
 
     # Inline match – substitute into the surrounding string.
@@ -161,8 +166,13 @@ def _resolve_step_ref_string(
             results,
             value,
         )
-        return resolved if isinstance(resolved, str) else json.dumps(
-            resolved, ensure_ascii=False,
+        return (
+            resolved
+            if isinstance(resolved, str)
+            else json.dumps(
+                resolved,
+                ensure_ascii=False,
+            )
         )
 
     return _STEP_REF_INLINE_PATTERN.sub(_replace, value)
@@ -264,8 +274,13 @@ def _resolve_args(value: Any, args: dict[str, Any]) -> Any:
 
         def _replace(m: re.Match[str]) -> str:
             resolved = _lookup_arg(m.group(1), args)
-            return resolved if isinstance(resolved, str) else json.dumps(
-                resolved, ensure_ascii=False,
+            return (
+                resolved
+                if isinstance(resolved, str)
+                else json.dumps(
+                    resolved,
+                    ensure_ascii=False,
+                )
             )
 
         return _ARG_REF_INLINE_PATTERN.sub(_replace, value)
@@ -283,6 +298,7 @@ def _lookup_arg(path: str, args: dict[str, Any]) -> Any:
 
 
 # --- Single-step execution ------------------------------------------------
+
 
 async def _call_tool(
     tool_name: str,
@@ -322,6 +338,7 @@ async def _call_tool(
 
 
 # --- Step execution loop --------------------------------------------------
+
 
 async def _run_steps(  # pylint: disable=too-many-branches
     actions: list[dict[str, Any]],
@@ -467,6 +484,7 @@ def _build_batch_response(
 
 # --- Main entry point -----------------------------------------------------
 
+
 async def run_tool_batch(  # pylint: disable=too-many-return-statements
     actions: list[dict[str, Any]] | None = None,
     file_path: str = "",
@@ -580,5 +598,8 @@ async def run_tool_batch(  # pylint: disable=too-many-return-statements
     # --- Execute ---
     results, all_content_blocks = await _run_steps(actions, stop_on_error)
     return _build_batch_response(
-        actions, results, all_content_blocks, last_only=last_only,
+        actions,
+        results,
+        all_content_blocks,
+        last_only=last_only,
     )

--- a/src/qwenpaw/agents/tools/run_tool_batch.py
+++ b/src/qwenpaw/agents/tools/run_tool_batch.py
@@ -1,0 +1,584 @@
+# -*- coding: utf-8 -*-
+"""Run a batch of tool calls sequentially with step-result references."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from agentscope.message import TextBlock
+from agentscope.tool import ToolResponse
+
+from ...config.context import get_current_toolkit
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of steps allowed in a single batch.
+MAX_BATCH_STEPS = 50
+
+# --- Step-reference patterns -----------------------------------------------
+# Only the brace-delimited form ${steps.N.path} is recognised.  This avoids
+# ambiguity when $-prefixed text appears inside shell commands or other
+# mixed-content strings.
+
+_STEP_REF_PATTERN = re.compile(
+    r"^\$\{steps\.(\d+)(?:\.([A-Za-z0-9_.-]+))?\}$",
+)
+_STEP_REF_INLINE_PATTERN = re.compile(
+    r"\$\{steps\.(\d+)(?:\.([A-Za-z0-9_.-]+))?\}",
+)
+
+
+# --- Helpers --------------------------------------------------------------
+
+def _json_tool_response(payload: dict[str, Any]) -> ToolResponse:
+    """Wrap a JSON-serialisable dict in a single-TextBlock ToolResponse."""
+    return ToolResponse(
+        content=[
+            TextBlock(
+                type="text",
+                text=json.dumps(payload, ensure_ascii=False),
+            ),
+        ],
+    )
+
+
+def _extract_text(response: ToolResponse) -> str:
+    """Extract text from the first TextBlock in a ToolResponse.
+
+    Some tools (``view_image``, ``send_file``, etc.) return an
+    ``ImageBlock`` / ``FileBlock`` / ``VideoBlock`` before the
+    ``TextBlock``.  We scan all blocks to find the first one whose
+    ``type`` is ``"text"``.
+    """
+    for block in (response.content or []):
+        block_type = (
+            block.get("type", "")
+            if isinstance(block, dict)
+            else getattr(block, "type", "")
+        )
+        if block_type == "text":
+            return (
+                block.get("text", "")
+                if isinstance(block, dict)
+                else getattr(block, "text", "")
+            )
+    return ""
+
+
+# Error prefixes/patterns used by built-in tools (plain-text responses).
+# Covers:
+#   file_io / file_search / view_media / send_file / get_current_time
+#       / delegate_external_agent          →  "Error: ..."
+#   agent_management (chat/submit/check)   →  "ERROR: ..."
+#   shell (non-zero exit)                  →  "Command failed ..."
+_ERROR_PREFIXES = (
+    "error:",           # covers "Error:" and "ERROR:" (case-insensitive)
+    "command failed ",  # shell non-zero exit code
+)
+
+
+def _is_error_text(text: str) -> bool:
+    """Heuristically detect error responses from plain-text tools."""
+    lower = text.lower()
+    return any(lower.startswith(p) for p in _ERROR_PREFIXES)
+
+
+def _response_payload(response: ToolResponse) -> dict[str, Any]:
+    """Convert a ToolResponse into a normalised result dict.
+
+    The ``ok`` field is inferred from:
+    - JSON responses with an explicit ``ok`` field (``browser_use``,
+      ``desktop_screenshot``).
+    - Plain-text error prefixes (``Error:``, ``Command failed``).
+    - Exceptions caught in ``_call_tool`` (already ``ok: False``).
+
+    The original content blocks are preserved under ``content`` so
+    that the final batch response can re-emit them.
+    """
+    text = _extract_text(response)
+    content = list(response.content or [])
+
+    # Try JSON first — some tools return structured JSON with ``ok``.
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            if "ok" not in payload:
+                payload["ok"] = "error" not in payload
+            payload["content"] = content
+            return payload
+        return {"ok": True, "value": payload, "content": content}
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Plain-text response — check for known error patterns.
+    if _is_error_text(text):
+        return {"ok": False, "error": text, "content": content}
+    return {"ok": True, "text": text, "content": content}
+
+
+# --- Step-reference resolution --------------------------------------------
+
+def resolve_step_refs(
+    value: Any,
+    results: list[dict[str, Any]],
+) -> Any:
+    """Recursively resolve ``$steps.<index>.<path>`` references."""
+    if isinstance(value, dict):
+        return {
+            key: resolve_step_refs(item, results)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [resolve_step_refs(item, results) for item in value]
+    if isinstance(value, str):
+        return _resolve_step_ref_string(value, results)
+    return value
+
+
+def _resolve_step_ref_string(
+    value: str,
+    results: list[dict[str, Any]],
+) -> Any:
+    """Resolve ``${steps}`` placeholders in a single string value."""
+    # Exact match – return the raw resolved value (preserves type).
+    match = _STEP_REF_PATTERN.match(value)
+    if match:
+        return _lookup_step_ref(
+            match.group(1), match.group(2), results, value,
+        )
+
+    # Inline match – substitute into the surrounding string.
+    def _replace(match_obj: re.Match[str]) -> str:
+        resolved = _lookup_step_ref(
+            match_obj.group(1),
+            match_obj.group(2),
+            results,
+            value,
+        )
+        return resolved if isinstance(resolved, str) else json.dumps(
+            resolved, ensure_ascii=False,
+        )
+
+    return _STEP_REF_INLINE_PATTERN.sub(_replace, value)
+
+
+def _lookup_step_ref(
+    step_index_text: str,
+    path: str | None,
+    results: list[dict[str, Any]],
+    original: str,
+) -> Any:
+    """Look up one step-result reference."""
+    step_index = int(step_index_text)
+    if step_index >= len(results):
+        raise ValueError(f"Step reference out of range: {original}")
+    current: Any = results[step_index]
+    if not path:
+        return current
+    for part in path.split("."):
+        if isinstance(current, list):
+            if not part.isdigit():
+                raise ValueError(
+                    f"Invalid list index in step reference: {original}",
+                )
+            idx = int(part)
+            if idx >= len(current):
+                raise ValueError(
+                    f"List index out of range in step reference: {original}",
+                )
+            current = current[idx]
+        elif isinstance(current, dict):
+            if part not in current:
+                raise ValueError(
+                    f"Missing key '{part}' in step reference: {original}",
+                )
+            current = current[part]
+        else:
+            raise ValueError(
+                f"Cannot resolve step reference: {original}",
+            )
+    return current
+
+
+# --- Batch file loading & $args resolution --------------------------------
+
+# Only the brace-delimited form ${args.name} is recognised.
+_ARG_REF_PATTERN = re.compile(r"^\$\{args\.([A-Za-z0-9_.-]+)\}$")
+_ARG_REF_INLINE_PATTERN = re.compile(r"\$\{args\.([A-Za-z0-9_.-]+)\}")
+
+
+def _load_batch_file(file_path: str) -> list[dict[str, Any]]:
+    """Load actions from a JSON batch file.
+
+    The file may be a plain JSON array of actions, or an object with an
+    ``actions`` key.  ``file_path`` must be an absolute path.
+
+    Raises ``ValueError`` on any validation failure.
+    """
+    path_text = (file_path or "").strip()
+    if not path_text:
+        raise ValueError("file_path is required")
+
+    path = Path(path_text).expanduser().resolve()
+
+    if not path.is_file():
+        raise ValueError(f"Batch file not found: {path}")
+    if path.suffix.lower() != ".json":
+        raise ValueError("file_path must point to a .json file")
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON at {path}: {exc}") from exc
+
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        actions = data.get("actions")
+        if isinstance(actions, list):
+            return actions
+    raise ValueError(
+        "Batch JSON must be an array of actions or an object "
+        "with an 'actions' array",
+    )
+
+
+def _resolve_args(value: Any, args: dict[str, Any]) -> Any:
+    """Recursively replace ``${args.<name>}`` placeholders in actions."""
+    if isinstance(value, dict):
+        return {k: _resolve_args(v, args) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_args(v, args) for v in value]
+    if isinstance(value, str):
+        # Exact match — return the raw value (preserves type).
+        match = _ARG_REF_PATTERN.match(value)
+        if match:
+            return _lookup_arg(match.group(1), args)
+        # Inline — substitute into the string.
+
+        def _replace(m: re.Match[str]) -> str:
+            resolved = _lookup_arg(m.group(1), args)
+            return resolved if isinstance(resolved, str) else json.dumps(
+                resolved, ensure_ascii=False,
+            )
+
+        return _ARG_REF_INLINE_PATTERN.sub(_replace, value)
+    return value
+
+
+def _lookup_arg(path: str, args: dict[str, Any]) -> Any:
+    """Walk a dotted path into the args dict."""
+    current: Any = args
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise ValueError(f"Missing arg: $args.{path}")
+        current = current[part]
+    return current
+
+
+# --- Single-step execution ------------------------------------------------
+
+async def _call_tool(
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> ToolResponse:
+    """Call a registered tool function by name via the current Toolkit."""
+    toolkit = get_current_toolkit()
+    if toolkit is None:
+        return _json_tool_response(
+            {"ok": False, "error": "No toolkit available in current context"},
+        )
+
+    if tool_name not in toolkit.tools:
+        return _json_tool_response(
+            {
+                "ok": False,
+                "error": f"Unknown tool: {tool_name}",
+                "available": sorted(toolkit.tools.keys()),
+            },
+        )
+
+    tool_func = toolkit.tools[tool_name]
+    try:
+        if inspect.iscoroutinefunction(tool_func.original_func):
+            result = await tool_func.original_func(**arguments)
+        else:
+            result = tool_func.original_func(**arguments)
+    except Exception as exc:  # pylint: disable=broad-except
+        return _json_tool_response(
+            {"ok": False, "error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    if isinstance(result, ToolResponse):
+        return result
+    # Wrap unexpected return types.
+    return _json_tool_response({"ok": True, "value": str(result)})
+
+
+# --- Step execution loop --------------------------------------------------
+
+async def _run_steps(  # pylint: disable=too-many-branches
+    actions: list[dict[str, Any]],
+    stop_on_error: bool = True,
+) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Execute a list of actions sequentially.
+
+    Returns ``(results, all_content_blocks)`` — the per-step result
+    dicts and the accumulated raw content blocks from every step.
+    """
+    results: list[dict[str, Any]] = []
+    all_content_blocks: list[Any] = []
+
+    for index, step in enumerate(actions):
+        # --- Validate step structure ---
+        if not isinstance(step, dict):
+            results.append(
+                {
+                    "step": index,
+                    "ok": False,
+                    "error": "step must be an object",
+                },
+            )
+            if stop_on_error:
+                break
+            continue
+
+        tool_name = str(
+            step.get("tool_name") or step.get("tool") or "",
+        ).strip()
+        if not tool_name:
+            results.append(
+                {
+                    "step": index,
+                    "ok": False,
+                    "error": "step must include tool_name",
+                },
+            )
+            if stop_on_error:
+                break
+            continue
+
+        # Prevent recursive batch calls.
+        if tool_name == "run_tool_batch":
+            results.append(
+                {
+                    "step": index,
+                    "tool_name": tool_name,
+                    "ok": False,
+                    "error": "Recursive run_tool_batch is not allowed",
+                },
+            )
+            if stop_on_error:
+                break
+            continue
+
+        arguments = step.get("arguments") or step.get("args") or {}
+        if not isinstance(arguments, dict):
+            results.append(
+                {
+                    "step": index,
+                    "tool_name": tool_name,
+                    "ok": False,
+                    "error": "arguments must be an object",
+                },
+            )
+            if stop_on_error:
+                break
+            continue
+
+        step_stop = step.get("stop_on_error", stop_on_error)
+
+        # --- Resolve $steps references ---
+        try:
+            arguments = resolve_step_refs(arguments, results)
+        except ValueError as exc:
+            results.append(
+                {
+                    "step": index,
+                    "tool_name": tool_name,
+                    "ok": False,
+                    "error": str(exc),
+                },
+            )
+            if step_stop:
+                break
+            continue
+
+        # --- Execute ---
+        response = await _call_tool(tool_name, arguments)
+        result = _response_payload(response)
+
+        step_content = result.pop("content", [])
+        all_content_blocks.extend(step_content)
+
+        results.append(
+            {"step": index, "tool_name": tool_name, **result},
+        )
+
+        if not result.get("ok", True) and step_stop:
+            break
+
+        # Optional wait between steps.
+        wait = float(step.get("wait") or 0)
+        if wait > 0:
+            await asyncio.sleep(wait)
+
+    return results, all_content_blocks
+
+
+def _build_batch_response(
+    actions: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+    all_content_blocks: list[Any],
+    *,
+    last_only: bool = False,
+) -> ToolResponse:
+    """Build the final ToolResponse for a batch run."""
+    completed = sum(1 for r in results if r.get("ok", False))
+    all_ok = completed == len(actions)
+
+    if last_only and results:
+        payload = {
+            "ok": all_ok,
+            "total": len(actions),
+            "completed": completed,
+            "result": results[-1],
+        }
+    else:
+        payload = {
+            "ok": all_ok,
+            "total": len(actions),
+            "completed": completed,
+            "results": results,
+        }
+
+    summary = TextBlock(
+        type="text",
+        text=json.dumps(payload, ensure_ascii=False),
+    )
+    return ToolResponse(content=[summary, *all_content_blocks])
+
+
+# --- Main entry point -----------------------------------------------------
+
+async def run_tool_batch(  # pylint: disable=too-many-return-statements
+    actions: list[dict[str, Any]] | None = None,
+    file_path: str = "",
+    args: dict[str, Any] | None = None,
+    stop_on_error: bool = True,
+    last_only: bool = False,
+) -> ToolResponse:
+    """Execute a batch of tool calls from a JSON file.
+
+    Load actions from a JSON batch file and execute them sequentially.
+    The JSON file should contain an ``actions`` array (or be a plain
+    array). Each action object contains:
+
+    - ``tool_name`` (str): Name of a registered tool function.
+    - ``arguments`` (dict): Keyword arguments for the tool.
+    - ``stop_on_error`` (bool, optional): Override per-step.
+    - ``wait`` (float, optional): Seconds to sleep after this step.
+
+    Use ``${args.<name>}`` placeholders in argument values for parts
+    that vary at runtime. Use ``${steps.<index>.<path>}`` to reference
+    earlier steps' output. The brace-delimited syntax is required so
+    that placeholders are unambiguous inside mixed-content strings
+    (e.g. shell commands).
+
+    Example::
+
+        run_tool_batch(
+            file_path="/absolute/path/to/batch.json",
+            args={"file_path": "/app/config.yaml", "pattern": "database"},
+        )
+
+    Args:
+        file_path: Absolute path to a JSON batch file.
+        args: Values to substitute ``${args.<name>}`` placeholders
+            in the batch file.
+        stop_on_error: Default stop-on-error behaviour for all steps.
+        last_only: If true, only return the last step's result instead
+            of all steps. Useful when only the final output matters.
+
+    Returns:
+        ToolResponse containing a JSON summary TextBlock followed by
+        all content blocks collected from each step's ToolResponse
+        (ImageBlock, FileBlock, VideoBlock, etc.).
+    """
+    # --- Resolve actions source ---
+    if file_path and actions:
+        return _json_tool_response(
+            {
+                "ok": False,
+                "error": "Provide either 'actions' or 'file_path', not both",
+            },
+        )
+
+    # Coerce args from JSON string if the model serialised it as text.
+    if isinstance(args, str):
+        try:
+            args = json.loads(args)
+        except (json.JSONDecodeError, TypeError):
+            return _json_tool_response(
+                {
+                    "ok": False,
+                    "error": "args must be an object or JSON string",
+                },
+            )
+    if args is not None and not isinstance(args, dict):
+        return _json_tool_response(
+            {"ok": False, "error": "args must be an object"},
+        )
+
+    # Coerce actions from JSON string if needed.
+    if isinstance(actions, str):
+        try:
+            actions = json.loads(actions)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    if file_path:
+        try:
+            actions = _load_batch_file(file_path)
+        except ValueError as exc:
+            return _json_tool_response({"ok": False, "error": str(exc)})
+        # Substitute $args placeholders if provided.
+        if args:
+            try:
+                actions = _resolve_args(actions, args)
+            except ValueError as exc:
+                return _json_tool_response({"ok": False, "error": str(exc)})
+
+    if not isinstance(actions, list) or not actions:
+        return _json_tool_response(
+            {
+                "ok": False,
+                "error": (
+                    "actions must be a non-empty list, or provide "
+                    "file_path to load from a JSON file"
+                ),
+            },
+        )
+
+    if len(actions) > MAX_BATCH_STEPS:
+        return _json_tool_response(
+            {
+                "ok": False,
+                "error": (
+                    f"Too many steps ({len(actions)}). "
+                    f"Maximum allowed is {MAX_BATCH_STEPS}."
+                ),
+            },
+        )
+
+    # --- Execute ---
+    results, all_content_blocks = await _run_steps(actions, stop_on_error)
+    return _build_batch_response(
+        actions, results, all_content_blocks, last_only=last_only,
+    )

--- a/src/qwenpaw/config/context.py
+++ b/src/qwenpaw/config/context.py
@@ -5,8 +5,14 @@ This module provides a context variable to pass the agent's workspace
 directory to tool functions, allowing them to resolve relative paths
 correctly in a multi-agent environment.
 """
+from __future__ import annotations
+
 from contextvars import ContextVar
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentscope.tool import Toolkit
 
 # Context variable to store the current agent's workspace directory
 current_workspace_dir: ContextVar[Path | None] = ContextVar(
@@ -130,3 +136,28 @@ def set_current_session_id(session_id: str | None) -> None:
         session_id: Session ID to store in context.
     """
     current_session_id.set(session_id)
+
+
+# Context variable to store the current agent's Toolkit instance
+current_toolkit: ContextVar[Toolkit | None] = ContextVar(
+    "current_toolkit",
+    default=None,
+)
+
+
+def get_current_toolkit() -> Toolkit | None:
+    """Get the current agent's Toolkit instance from context.
+
+    Returns:
+        The current Toolkit instance, or None if not set.
+    """
+    return current_toolkit.get()
+
+
+def set_current_toolkit(toolkit: Toolkit | None) -> None:
+    """Set the current agent's Toolkit instance in context.
+
+    Args:
+        toolkit: Toolkit instance to store in context.
+    """
+    current_toolkit.set(toolkit)


### PR DESCRIPTION
## Description

Enhanced the make-skill flow to support self-evolving skill creation. Key changes:

1. **Background execution mode** — Users can now choose to run make-skill in the background via `spawn_subagent(fork=True)`. The subagent inherits full conversation context and completes the entire skill creation flow autonomously without blocking the current conversation.

2. **`run_tool_batch` tool** — New batch execution tool that runs multi-step scripted actions (defined as JSON) in a single call. Supports step reference interpolation (`${steps.N.key}`), `stop_on_error`, and `last_only` return mode. This enables skills to encode complex multi-tool workflows into a single batch script, eliminating agent-tool multi-turn overhead.

3. **Enhanced batch usage in make-skill** — Updated SKILL.md to encourage the model to consolidate consecutive tool calls into a single `run_tool_batch` script (with helper scripts for parsing/filtering), so the resulting skill can be executed stably and quickly with minimal agent interaction.

> **Note on `run_tool_batch`:** This tool may bypass normal per-call tool invocation. Currently it is only used during skill creation (make-skill) and is not exposed in general conversation.

Accompanied with /make-skill, QwenPaw can now organize a complex tool-use chain (e.g. executing Python scripts, browser automation, writing files, sending files to the user) into a single `batch.json`. Once materialized, invoking `run_tool_batch(file_path="path/to/batch.json", args : {xxx})` is all it takes to reliably reproduce the entire workflow in one shot:

<img width="879" height="777" alt="image" src="https://github.com/user-attachments/assets/20e0fec5-e039-45d2-8e2b-7395cbb9d354" />


**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

N/A

## Testing

- Invoke `/make-skill` in conversation mode → verify plan proposal and materialize flow works as before
- Invoke `/make-skill` and choose background mode → verify `spawn_subagent` is called with correct task description
- Call `run_tool_batch` with a multi-step JSON → verify step references resolve, `last_only` returns only final result, and `stop_on_error` halts on failure
- Verify args/actions JSON string coercion handles model serialization edge case

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

- `run_tool_batch` handles model serialization quirk where `args`/`actions` are passed as JSON strings instead of objects (agentscope does not perform type-based coercion)
- Background mode instructs the subagent to skip `create_plan` and user approval, completing all steps autonomously
