### PR TITLE
Fix: Clean up stale Windows skill dirs (#4839)

### DIFF
--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -210,12 +210,74 @@ def _select_builtin_variant(
     )
 
 
+def cleanup_stale_skill_dirs(target_dir: Path | None = None) -> None:
+    """Remove stale ``~``-prefixed directories left by pip upgrades on Windows.
+
+    On Windows, ``pip install --upgrade`` sometimes fails to fully delete
+    old skill directories, leaving behind truncated copies with ``~``-prefixed
+    names (e.g. ``~ron-en`` instead of ``cron-en``).  These ghost directories
+    pollute the skill pool UI (#4839).
+
+    Safety strategy:
+      - **Whitelist check**: Only directories that *both* start with ``~``
+        *and* contain a ``SKILL.md`` file are deleted (confirmed to be stale
+        skill copies, not user data).
+      - **Non-whitelisted**: If a ``~``-prefixed directory does *not* contain
+        ``SKILL.md``, a warning is logged but the directory is left intact.
+      - **Error tolerance**: Deletion failures (e.g. antivirus locks) are
+        logged as warnings and never crash the application.
+    """
+    import shutil
+
+    skill_dir = target_dir or get_builtin_skills_dir()
+    if not skill_dir.exists():
+        return
+
+    for path in sorted(skill_dir.iterdir()):
+        if not path.is_dir() or not path.name.startswith("~"):
+            continue
+
+        # Strategy A: whitelist — only delete if it looks like a skill dir.
+        if (path / "SKILL.md").exists():
+            try:
+                shutil.rmtree(path)
+                logger.info(
+                    "Removed stale skill directory: %s",
+                    path.name,
+                )
+            except OSError as exc:
+                logger.warning(
+                    "Failed to remove stale skill directory '%s': %s. "
+                    "You may delete it manually.",
+                    path,
+                    exc,
+                )
+        else:
+            # Strategy B: not a confirmed skill dir — warn only.
+            logger.warning(
+                "Detected possible stale directory '%s' in skills folder. "
+                "It does not contain SKILL.md so it was not auto-deleted. "
+                "Please remove it manually if it is not needed.",
+                path,
+            )
+
+
 def _iter_packaged_builtin_dirs() -> Iterator[Path]:
-    """Yield packaged builtin skill directories in stable order."""
+    """Yield packaged builtin skill directories in stable order.
+
+    Skips ``~``-prefixed directories (stale pip upgrade remnants on
+    Windows, see #4839) and runs cleanup on first scan.
+    """
     builtin_dir = get_builtin_skills_dir()
     if not builtin_dir.exists():
         return
+
+    # Best-effort cleanup of stale dirs before scanning.
+    cleanup_stale_skill_dirs(builtin_dir)
+
     for skill_dir in sorted(builtin_dir.iterdir()):
+        if skill_dir.name.startswith("~"):
+            continue
         if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
             yield skill_dir
 
@@ -893,7 +955,9 @@ def reconcile_pool_manifest() -> dict[str, Any]:
         discovered = {
             path.name: path
             for path in pool_dir.iterdir()
-            if path.is_dir() and (path / "SKILL.md").exists()
+            if path.is_dir()
+            and not path.name.startswith("~")
+            and (path / "SKILL.md").exists()
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):
@@ -997,7 +1061,9 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
         discovered = {
             path.name: path
             for path in workspace_skills_dir.iterdir()
-            if path.is_dir() and (path / "SKILL.md").exists()
+            if path.is_dir()
+            and not path.name.startswith("~")
+            and (path / "SKILL.md").exists()
         }
 
         for skill_name, skill_dir in sorted(discovered.items()):

--- a/tests/unit/skill_system/test_stale_cleanup.py
+++ b/tests/unit/skill_system/test_stale_cleanup.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for stale skill directory cleanup (#4839).
+
+Verifies that ~-prefixed directories left by pip upgrades on Windows
+are properly handled: deleted if they contain SKILL.md (confirmed stale
+skill), or warned about if they don't.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from qwenpaw.agents.skill_system.registry import cleanup_stale_skill_dirs
+
+
+class TestCleanupStaleSkillDirs:
+    """Tests for cleanup_stale_skill_dirs()."""
+
+    def test_removes_tilde_dir_with_skill_md(self, tmp_path):
+        """~-prefixed dir containing SKILL.md should be deleted."""
+        stale = tmp_path / "~ron-en"
+        stale.mkdir()
+        (stale / "SKILL.md").write_text("# Stale skill")
+
+        cleanup_stale_skill_dirs(tmp_path)
+
+        assert not stale.exists()
+
+    def test_preserves_normal_skill_dirs(self, tmp_path):
+        """Normal skill directories should not be touched."""
+        normal = tmp_path / "cron-en"
+        normal.mkdir()
+        (normal / "SKILL.md").write_text("# Real skill")
+
+        cleanup_stale_skill_dirs(tmp_path)
+
+        assert normal.exists()
+        assert (normal / "SKILL.md").exists()
+
+    def test_warns_tilde_dir_without_skill_md(self, tmp_path):
+        """~-prefixed dir without SKILL.md should only produce a warning."""
+        suspicious = tmp_path / "~_pycache__"
+        suspicious.mkdir()
+        (suspicious / "some_file.py").write_text("# not a skill")
+
+        with patch(
+            "qwenpaw.agents.skill_system.registry.logger",
+        ) as mock_logger:
+            cleanup_stale_skill_dirs(tmp_path)
+
+        assert suspicious.exists()  # Not deleted
+        mock_logger.warning.assert_called_once()
+        assert (
+            "possible stale directory"
+            in mock_logger.warning.call_args[0][0].lower()
+        )
+
+    def test_handles_permission_error(self, tmp_path):
+        """Deletion failure should log warning, not crash."""
+        stale = tmp_path / "~hat_with_agent-en"
+        stale.mkdir()
+        (stale / "SKILL.md").write_text("# Stale")
+
+        with patch(
+            "qwenpaw.agents.skill_system.registry.logger",
+        ) as mock_logger:
+            with patch("shutil.rmtree", side_effect=OSError("Access denied")):
+                cleanup_stale_skill_dirs(tmp_path)
+
+        mock_logger.warning.assert_called_once()
+        assert (
+            "failed to remove" in mock_logger.warning.call_args[0][0].lower()
+        )
+
+    def test_nonexistent_directory(self):
+        """Should not raise for non-existent target directory."""
+        cleanup_stale_skill_dirs(Path("/nonexistent/path/12345"))
+
+    def test_multiple_stale_dirs(self, tmp_path):
+        """Multiple stale dirs should all be cleaned."""
+        names = ["~ron-en", "~-on-en", "~uidance-zh"]
+        for name in names:
+            d = tmp_path / name
+            d.mkdir()
+            (d / "SKILL.md").write_text("# Stale")
+
+        # Also create a normal dir
+        normal = tmp_path / "cron-en"
+        normal.mkdir()
+        (normal / "SKILL.md").write_text("# Real")
+
+        cleanup_stale_skill_dirs(tmp_path)
+
+        for name in names:
+            assert not (tmp_path / name).exists()
+        assert normal.exists()
+
+    def test_files_starting_with_tilde_ignored(self, tmp_path):
+        """Regular files starting with ~ should not be affected."""
+        tilde_file = tmp_path / "~tempfile.txt"
+        tilde_file.write_text("temp")
+
+        cleanup_stale_skill_dirs(tmp_path)
+
+        assert tilde_file.exists()


### PR DESCRIPTION
## Summary

**Fixes #4839** — Cleans up `~`-prefixed ghost skill directories left behind by Windows `pip upgrade`.

Complements PR #4851 (UI filtering) by **actively removing** these stale files from disk at startup, while retaining defensive filtering as a safety net.

## Problem

On Windows, `pip install --upgrade` often fails to fully delete old skill directories. They remain as truncated `~`-prefixed folders (e.g., `~ron-en`). 
These "ghost skills" are detected by the scanner, polluting the "Update Builtin Skills" UI with invalid entries.

## Solution

### 1. Active Cleanup (`cleanup_stale_skill_dirs`)
Executed before the first skill scan. Implements a two-tier safety strategy:

| Condition | Action | Rationale |
| :--- | :--- | :--- |
| `~` prefix **+** contains `SKILL.md` | **Delete**  | Confirmed stale skill copy (safe to remove). |
| `~` prefix **without** `SKILL.md` | **Log Warning** | Suspicious dir; might be user data (preserved). |
| Deletion fails (locked by AV, etc.) | **Log Warning** | Defensive fallback; never crashes the app. |

### Shift-Left Filtering
Added `not path.name.startswith("~")` guard clauses to:
- `_iter_packaged_builtin_dirs()` — Prevents loading stale builtins.
- `reconcile_pool_manifest()` & `reconcile_workspace_manifest()` — Defensive filtering for discovery.

> **Note:** The filtering acts as a "seatbelt" in case cleanup fails due to file locks.

## Changes

| File | Description |
| :--- | :--- |
| `src/qwenpaw/agents/skill_system/registry.py` | Added cleanup logic + filtering in 3 scan functions. |
| `tests/unit/skill_system/test_stale_cleanup.py` | **New** — Comprehensive unit tests (7 cases). |

## Testing
- ✅ 7 unit tests: cleanup success, normal dir preservation, permission errors, edge cases.
- ✅ All linters pass (mypy, black, pylint).