### PR TITLE
feat(providers): add MiniMax M3 to MiniMax built-in models (default)

### DIFF
--- a/src/qwenpaw/providers/capability_baseline.py
+++ b/src/qwenpaw/providers/capability_baseline.py
@@ -634,8 +634,7 @@ class ExpectedCapabilityRegistry:
         # ---------------------------------------------------------------
         _mm_doc = "https://www.minimax.io/platform/document/announcement"
         for mid in (
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
         ):
@@ -655,8 +654,7 @@ class ExpectedCapabilityRegistry:
         # ---------------------------------------------------------------
         _mm_cn_doc = "https://platform.minimaxi.com/document/announcement"
         for mid in (
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
+            "MiniMax-M3",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
         ):

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -436,15 +436,8 @@ AZURE_OPENAI_MODELS: List[ModelInfo] = [
 
 MINIMAX_MODELS: List[ModelInfo] = [
     ModelInfo(
-        id="MiniMax-M2.5",
-        name="MiniMax M2.5",
-        supports_image=False,
-        supports_video=False,
-        probe_source="documentation",
-    ),
-    ModelInfo(
-        id="MiniMax-M2.5-highspeed",
-        name="MiniMax M2.5 Highspeed",
+        id="MiniMax-M3",
+        name="MiniMax M3",
         supports_image=False,
         supports_video=False,
         probe_source="documentation",


### PR DESCRIPTION
## What

Add the new `MiniMax-M3` flagship model to the built-in `MINIMAX_MODELS` list shared by `PROVIDER_MINIMAX` (International, `https://api.minimax.io/anthropic`) and `PROVIDER_MINIMAX_CN` (China, `https://api.minimaxi.com/anthropic`). M3 is placed first in the list so it becomes the default model when a user selects the MiniMax provider without specifying one. The corresponding `ExpectedCapability` baselines in `capability_baseline.py` are updated to match.

The previous-generation `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries are removed; `MiniMax-M2.7` / `MiniMax-M2.7-highspeed` are kept so users still on that generation are not forced to migrate immediately.

## Why

MiniMax released M3 as the new flagship Anthropic-compatible model (512K context window, up to 128K output, with image-input support). Surfacing it as a built-in option (and the new default) lets users pick it from the model dropdown without manually editing the provider config. Other built-in providers (e.g. Gemini, DeepSeek, Kimi) already keep their lists in sync with the latest publicly available models in the same file, so this PR follows the existing convention.

Reference: <https://www.minimax.io/platform/document/announcement>

## Scope

- Only the `minimax` and `minimax-cn` providers are touched.
- Other providers that happen to expose MiniMax models as part of their own offering (e.g. OpenCode, Aliyun coding/token plans, Volcengine coding plan) are left untouched — their model lists reflect what those upstreams actually serve, not what MiniMax ships directly.
- Base URLs, \`freeze_url\`, \`support_connection_check\`, and TTS configuration are not changed.

## Changes

- \`src/qwenpaw/providers/provider_manager.py\` — replace the M2.5 entries in \`MINIMAX_MODELS\` with a single M3 entry (placed first → new default), keep M2.7 + M2.7-highspeed.
- \`src/qwenpaw/providers/capability_baseline.py\` — update the \`minimax\` and \`minimax-cn\` expected-capability registrations to match (M3 + M2.7 + M2.7-highspeed).

Final list: \`MiniMax-M3\` (default), \`MiniMax-M2.7\`, \`MiniMax-M2.7-highspeed\`. Diff is ~4 lines per file, no other files touched.