### PR TITLE
fix(channel): cron messages fail to deliver to wechat/wecom with shar…

### DIFF
--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -315,12 +315,15 @@ class WeChatChannel(BaseChannel):
         return h
 
     def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
-        return session_id or f"wechat:{user_id}"
+        if session_id and session_id.startswith("wechat:"):
+            return session_id
+        return f"wechat:{user_id}"
 
     def get_to_handle_from_request(self, request: Any) -> str:
-        session_id = getattr(request, "session_id", "") or ""
-        user_id = getattr(request, "user_id", "") or ""
-        return session_id or f"wechat:{user_id}"
+        return self.to_handle_from_target(
+            user_id=getattr(request, "user_id", "") or "",
+            session_id=getattr(request, "session_id", "") or "",
+        )
 
     def get_on_reply_sent_args(self, request: Any, to_handle: str) -> tuple:
         return (

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -327,13 +327,16 @@ class WecomChannel(BaseChannel):
         return h
 
     def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
-        """Return send handle; session_id takes priority."""
-        return session_id or f"wecom:{user_id}"
+        """Return send handle; session_id used if properly prefixed."""
+        if session_id and session_id.startswith("wecom:"):
+            return session_id
+        return f"wecom:{user_id}"
 
     def get_to_handle_from_request(self, request: Any) -> str:
-        session_id = getattr(request, "session_id", "") or ""
-        user_id = getattr(request, "user_id", "") or ""
-        return session_id or f"wecom:{user_id}"
+        return self.to_handle_from_target(
+            user_id=getattr(request, "user_id", "") or "",
+            session_id=getattr(request, "session_id", "") or "",
+        )
 
     def get_on_reply_sent_args(
         self,

--- a/tests/unit/channels/test_wechat.py
+++ b/tests/unit/channels/test_wechat.py
@@ -459,6 +459,34 @@ class TestWeChatResolveSession:
 
         assert result == "wechat:user123"
 
+    def test_to_handle_from_target_custom_session_ignored(
+        self,
+        wechat_channel,
+    ):
+        """to_handle_from_target ignores custom session_id without prefix.
+
+        When a cron job uses share_session=false, session_id is a custom
+        string (e.g. 'cat_monitor_cron_session') without the 'wechat:'
+        prefix. We must not use it as the handle because
+        _parse_user_id_from_handle cannot extract the correct user_id
+        from it — the handle must always carry the 'wechat:' prefix.
+        """
+        result = wechat_channel.to_handle_from_target(
+            user_id="o9cq803Ccv8lpYRWNsXSz67tXEhM@im.wechat",
+            session_id="cat_monitor_cron_session",
+        )
+
+        assert result == "wechat:o9cq803Ccv8lpYRWNsXSz67tXEhM@im.wechat"
+
+    def test_to_handle_from_target_prefixed_session_used(self, wechat_channel):
+        """to_handle_from_target should use session_id with wechat: prefix."""
+        result = wechat_channel.to_handle_from_target(
+            user_id="user123",
+            session_id="wechat:o9cq803Ccv8lpYRWNsXSz67tXEhM@im.wechat",
+        )
+
+        assert result == "wechat:o9cq803Ccv8lpYRWNsXSz67tXEhM@im.wechat"
+
     def test_get_to_handle_from_request(self, wechat_channel):
         """get_to_handle_from_request should extract handle from request."""
         mock_request = MagicMock()
@@ -468,6 +496,29 @@ class TestWeChatResolveSession:
         result = wechat_channel.get_to_handle_from_request(mock_request)
 
         assert result == "wechat:session_abc"
+
+    def test_get_to_handle_from_request_custom_session_ignored(
+        self,
+        wechat_channel,
+    ):
+        """get_to_handle_from_request should ignore non-prefixed session_id."""
+        mock_request = MagicMock()
+        mock_request.session_id = "custom_cron_session"
+        mock_request.user_id = "o9cq803Ccv8lpYRWNsXSz67tXEhM@im.wechat"
+
+        result = wechat_channel.get_to_handle_from_request(mock_request)
+
+        assert result == "wechat:o9cq803Ccv8lpYRWNsXSz67tXEhM@im.wechat"
+
+    def test_get_to_handle_from_request_empty_session(self, wechat_channel):
+        """get_to_handle_from_request should fallback when session_id empty."""
+        mock_request = MagicMock()
+        mock_request.session_id = ""
+        mock_request.user_id = "user123"
+
+        result = wechat_channel.get_to_handle_from_request(mock_request)
+
+        assert result == "wechat:user123"
 
     def test_get_on_reply_sent_args(self, wechat_channel):
         """get_on_reply_sent_args should return correct tuple."""


### PR DESCRIPTION
…e_session=false

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
