### PR TITLE
fix(channel): stop old channel before starting new in replace_channel (#4877)

### DIFF
--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -707,8 +707,10 @@ class ChannelManager:
     ) -> None:
         """Replace a single channel by name.
 
-        Flow: set enqueue callback → start new (outside lock)
-        → swap + stop old (inside lock). Lock only guards the swap+stop.
+        Flow: set enqueue callback → stop old (inside lock)
+        → start new (outside lock) → add new (inside lock).
+        Stop old before starting new to avoid port/resource conflicts.
+        If new fails to start, attempt to restore the old channel.
 
         Args:
             new_channel: New channel instance to replace with
@@ -723,8 +725,28 @@ class ChannelManager:
         if getattr(new_channel, "uses_manager_queue", True):
             new_channel.set_enqueue(self._make_enqueue_cb(new_channel_name))
 
-        # 2) Start new channel outside lock (may be slow, e.g. DingTalk)
-        logger.info(f"Pre-starting new channel: {new_channel_name}")
+        # 2) Stop old channel inside lock and remove from list
+        async with self._lock:
+            old_channel = None
+            for i, ch in enumerate(self.channels):
+                if ch.channel == new_channel_name:
+                    old_channel = ch
+                    self.channels.pop(i)
+                    break
+
+        if old_channel is not None:
+            logger.info(f"Stopping old channel: {old_channel.channel}")
+            try:
+                await old_channel.stop()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception(
+                    f"Failed to stop old channel: {old_channel.channel}",
+                )
+
+        # 3) Start new channel outside lock (may be slow, e.g. DingTalk)
+        logger.info(f"Starting new channel: {new_channel_name}")
         try:
             await new_channel.start()
         except Exception:
@@ -735,30 +757,26 @@ class ChannelManager:
                 await new_channel.stop()
             except Exception:
                 pass
-            raise
-
-        # 3) Swap + stop old inside lock
-        async with self._lock:
-            old_channel = None
-            for i, ch in enumerate(self.channels):
-                if ch.channel == new_channel_name:
-                    old_channel = ch
-                    self.channels[i] = new_channel
-                    break
-
-            if old_channel is None:
-                logger.info(f"Adding new channel: {new_channel_name}")
-                self.channels.append(new_channel)
-            else:
-                logger.info(f"Stopping old channel: {old_channel.channel}")
+            # Attempt to restore old channel if it was stopped
+            if old_channel is not None:
                 try:
-                    await old_channel.stop()
-                except asyncio.CancelledError:
-                    pass
+                    await old_channel.start()
+                    async with self._lock:
+                        self.channels.append(old_channel)
+                    logger.info(
+                        f"Restored old channel after failed replace: "
+                        f"{old_channel.channel}",
+                    )
                 except Exception:
                     logger.exception(
-                        f"Failed to stop old channel: {old_channel.channel}",
+                        f"Failed to restore old channel: "
+                        f"{old_channel.channel}",
                     )
+            raise
+
+        # 4) Add new channel to list inside lock
+        async with self._lock:
+            self.channels.append(new_channel)
 
     async def send_event(
         self,

--- a/tests/unit/channels/test_channel_manager.py
+++ b/tests/unit/channels/test_channel_manager.py
@@ -1,0 +1,411 @@
+# -*- coding: utf-8 -*-
+"""
+ChannelManager.replace_channel Unit Tests
+=========================================
+
+Verifies the stop-old-then-start-new ordering and error recovery
+logic introduced to fix issue #4877.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from qwenpaw.app.channels.base import BaseChannel, ProcessHandler
+from qwenpaw.app.channels.manager import ChannelManager
+
+
+# ---------------------------------------------------------------------------
+# Stub channel for isolated replace_channel tests
+# ---------------------------------------------------------------------------
+
+
+class StubChannel(BaseChannel):
+    """Minimal concrete BaseChannel used only in these tests."""
+
+    channel = "stub"
+
+    def __init__(
+        self,
+        channel_name: str = "stub",
+        *,
+        start_side_effect: Optional[Exception] = None,
+        stop_side_effect: Optional[Exception] = None,
+    ) -> None:
+        self._channel_name = channel_name
+        self._start_side_effect = start_side_effect
+        self._stop_side_effect = stop_side_effect
+        self.start_called = False
+        self.stop_called = False
+        self._enqueue = None
+
+    # -- BaseChannel abstract stubs --
+
+    @property
+    def channel(self) -> str:  # type: ignore[override]
+        return self._channel_name
+
+    async def start(self) -> None:
+        self.start_called = True
+        if self._start_side_effect:
+            raise self._start_side_effect
+
+    async def stop(self) -> None:
+        self.stop_called = True
+        if self._stop_side_effect:
+            raise self._stop_side_effect
+
+    # Remaining abstract methods — not used by replace_channel
+
+    async def send(
+        self,
+        to_handle: str,
+        text: str,
+        meta: Optional[dict] = None,
+    ) -> None:
+        pass
+
+    @classmethod
+    def from_config(cls, process, config, on_reply_sent=None, **kwargs):
+        return cls()
+
+    async def consume_one(self, payload: Any) -> None:
+        pass
+
+    def _is_native_payload(self, payload: Any) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(*channels: StubChannel) -> ChannelManager:
+    mgr = ChannelManager(list(channels))
+    mgr._loop = asyncio.get_running_loop()
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceChannelOrdering:
+    """Verify that stop(old) happens before start(new)."""
+
+    @pytest.mark.asyncio
+    async def test_old_stopped_before_new_started(self):
+        """Old must release resources before the new channel tries to
+        acquire them."""
+        old = StubChannel("mych")
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        call_order: list[str] = []
+
+        orig_old_stop = old.stop
+        orig_new_start = new.start
+
+        async def _old_stop():
+            call_order.append("old_stop")
+            await orig_old_stop()
+
+        async def _new_start():
+            call_order.append("new_start")
+            await orig_new_start()
+
+        old.stop = _old_stop  # type: ignore[assignment]
+        new.start = _new_start  # type: ignore[assignment]
+
+        await mgr.replace_channel(new)
+
+        assert call_order == ["old_stop", "new_start"]
+
+    @pytest.mark.asyncio
+    async def test_old_removed_from_list_before_new_starts(self):
+        """While the new channel is starting, the old channel must already
+        be gone from self.channels so concurrent lookups don't see a stale
+        (stopped) channel."""
+        old = StubChannel("mych")
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        channels_during_new_start: list[list[str]] = []
+
+        orig_new_start = new.start
+
+        async def _new_start():
+            channels_during_new_start.append(
+                [c.channel for c in mgr.channels],
+            )
+            await orig_new_start()
+
+        new.start = _new_start  # type: ignore[assignment]
+
+        await mgr.replace_channel(new)
+
+        # During new.start(), old is already removed and new is not yet added
+        assert channels_during_new_start == [[]]
+
+    @pytest.mark.asyncio
+    async def test_new_added_to_list_after_start(self):
+        """After replace_channel succeeds, only the new channel is in the list."""
+        old = StubChannel("mych")
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        await mgr.replace_channel(new)
+
+        assert len(mgr.channels) == 1
+        assert mgr.channels[0] is new
+
+    @pytest.mark.asyncio
+    async def test_old_is_stopped(self):
+        """The old channel instance must have stop() called."""
+        old = StubChannel("mych")
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        await mgr.replace_channel(new)
+
+        assert old.stop_called is True
+
+    @pytest.mark.asyncio
+    async def test_new_is_started(self):
+        """The new channel instance must have start() called."""
+        old = StubChannel("mych")
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        await mgr.replace_channel(new)
+
+        assert new.start_called is True
+
+
+class TestReplaceChannelNewChannel:
+    """When there is no existing channel with the same name, the new one
+    should simply be added."""
+
+    @pytest.mark.asyncio
+    async def test_add_new_channel(self):
+        new = StubChannel("fresh")
+        mgr = _make_manager()
+
+        await mgr.replace_channel(new)
+
+        assert len(mgr.channels) == 1
+        assert mgr.channels[0] is new
+        assert new.start_called is True
+
+    @pytest.mark.asyncio
+    async def test_add_new_channel_no_old_stop(self):
+        """No old channel to stop, so stop should not be called on anything."""
+        new = StubChannel("fresh")
+        mgr = _make_manager()
+
+        await mgr.replace_channel(new)
+
+        # No exception means no spurious stop was attempted
+        assert new.stop_called is False
+
+
+class TestReplaceChannelNewStartFails:
+    """Error recovery when the new channel fails to start."""
+
+    @pytest.mark.asyncio
+    async def test_old_restored_on_new_start_failure(self):
+        """If the new channel fails to start, the old channel should be
+        restored (restarted and added back to the list)."""
+        old = StubChannel("mych")
+        new = StubChannel("mych", start_side_effect=RuntimeError("port busy"))
+        mgr = _make_manager(old)
+
+        with pytest.raises(RuntimeError, match="port busy"):
+            await mgr.replace_channel(new)
+
+        # Old channel should be restored
+        assert old in mgr.channels
+        assert old.start_called is True  # restarted
+        assert new not in mgr.channels
+
+    @pytest.mark.asyncio
+    async def test_new_is_stopped_after_start_failure(self):
+        """A new channel that failed to start should have stop() called
+        for cleanup."""
+        new = StubChannel("mych", start_side_effect=RuntimeError("boom"))
+        mgr = _make_manager()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await mgr.replace_channel(new)
+
+        assert new.stop_called is True
+
+    @pytest.mark.asyncio
+    async def test_original_exception_propagates(self):
+        """The original start exception should propagate to the caller."""
+        new = StubChannel("mych", start_side_effect=ConnectionError("refused"))
+        mgr = _make_manager()
+
+        with pytest.raises(ConnectionError, match="refused"):
+            await mgr.replace_channel(new)
+
+    @pytest.mark.asyncio
+    async def test_restore_failure_does_not_swallow_original(self):
+        """If restoring the old channel also fails, the original exception
+        should still propagate (not the restore failure)."""
+        old = StubChannel(
+            "mych",
+            stop_side_effect=None,
+            start_side_effect=RuntimeError("old also broken"),
+        )
+        # First stop works, then on restore start fails
+        new = StubChannel("mych", start_side_effect=RuntimeError("new broken"))
+        mgr = _make_manager(old)
+
+        with pytest.raises(RuntimeError, match="new broken"):
+            await mgr.replace_channel(new)
+
+    @pytest.mark.asyncio
+    async def test_no_old_channel_new_start_fails(self):
+        """When adding a brand-new channel that fails to start, there's
+        no old channel to restore — just raise."""
+        new = StubChannel("fresh", start_side_effect=RuntimeError("fail"))
+        mgr = _make_manager()
+
+        with pytest.raises(RuntimeError, match="fail"):
+            await mgr.replace_channel(new)
+
+        assert len(mgr.channels) == 0
+
+
+class TestReplaceChannelOldStopFails:
+    """When the old channel's stop() raises, the replace should still
+    proceed (stop errors are logged, not re-raised)."""
+
+    @pytest.mark.asyncio
+    async def test_old_stop_error_does_not_block_replace(self):
+        old = StubChannel("mych", stop_side_effect=RuntimeError("stop err"))
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        # Should NOT raise — old stop errors are caught and logged
+        await mgr.replace_channel(new)
+
+        assert new in mgr.channels
+        assert new.start_called is True
+        assert old.stop_called is True
+
+    @pytest.mark.asyncio
+    async def test_old_stop_cancelled_error_handled(self):
+        """asyncio.CancelledError from old.stop() should be silently caught."""
+        old = StubChannel("mych", stop_side_effect=asyncio.CancelledError())
+        new = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        await mgr.replace_channel(new)
+
+        assert new in mgr.channels
+
+
+class TestReplaceChannelEnqueueCallback:
+    """Verify enqueue callback is set on the new channel."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_callback_set_for_manager_queue_channel(self):
+        new = StubChannel("mych")
+        new.uses_manager_queue = True
+        mgr = _make_manager()
+
+        await mgr.replace_channel(new)
+
+        assert new._enqueue is not None
+
+    @pytest.mark.asyncio
+    async def test_enqueue_callback_not_set_for_non_manager_queue(self):
+        new = StubChannel("mych")
+        new.uses_manager_queue = False
+        mgr = _make_manager()
+
+        await mgr.replace_channel(new)
+
+        assert new._enqueue is None
+
+
+class TestReplaceChannelConcurrency:
+    """Concurrent replace_channel calls for the same channel name."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_replaces_do_not_duplicate(self):
+        """Two concurrent replace_channel calls for the same channel should
+        not result in duplicate entries."""
+        old = StubChannel("mych")
+        mgr = _make_manager(old)
+
+        # Slow starts so they overlap
+        new1 = StubChannel("mych")
+        new2 = StubChannel("mych")
+
+        delay_event = asyncio.Event()
+
+        orig_start1 = new1.start
+
+        async def slow_start1():
+            # Wait a bit to let the second replace also proceed
+            await asyncio.sleep(0.05)
+            await orig_start1()
+
+        new1.start = slow_start1  # type: ignore[assignment]
+
+        # Run both concurrently
+        results = await asyncio.gather(
+            mgr.replace_channel(new1),
+            mgr.replace_channel(new2),
+            return_exceptions=True,
+        )
+
+        # No exceptions expected (both should succeed)
+        for r in results:
+            assert not isinstance(r, Exception), f"Unexpected error: {r}"
+
+        # At least one of the new channels should be in the list
+        channel_names = [c.channel for c in mgr.channels]
+        assert channel_names.count("mych") >= 1
+
+
+class TestReplaceChannelMultipleChannels:
+    """Verify replace_channel only affects the target channel."""
+
+    @pytest.mark.asyncio
+    async def test_other_channels_untouched(self):
+        ch_a = StubChannel("alpha")
+        ch_b = StubChannel("beta")
+        new_b = StubChannel("beta")
+        mgr = _make_manager(ch_a, ch_b)
+
+        await mgr.replace_channel(new_b)
+
+        assert ch_a in mgr.channels
+        assert ch_b not in mgr.channels
+        assert new_b in mgr.channels
+        assert ch_a.stop_called is False
+        assert ch_b.stop_called is True
+
+    @pytest.mark.asyncio
+    async def test_replace_preserves_order(self):
+        """After replace, the new channel should be appended at the end."""
+        ch_a = StubChannel("alpha")
+        ch_b = StubChannel("beta")
+        ch_c = StubChannel("gamma")
+        new_b = StubChannel("beta")
+        mgr = _make_manager(ch_a, ch_b, ch_c)
+
+        await mgr.replace_channel(new_b)
+
+        names = [c.channel for c in mgr.channels]
+        # Old ch_b was removed from its position, new_b appended
+        assert names == ["alpha", "gamma", "beta"]

--- a/tests/unit/channels/test_channel_manager.py
+++ b/tests/unit/channels/test_channel_manager.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
 """
 ChannelManager.replace_channel Unit Tests
 =========================================
@@ -10,11 +11,10 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from qwenpaw.app.channels.base import BaseChannel, ProcessHandler
+from qwenpaw.app.channels.base import BaseChannel
 from qwenpaw.app.channels.manager import ChannelManager
 
 
@@ -25,8 +25,6 @@ from qwenpaw.app.channels.manager import ChannelManager
 
 class StubChannel(BaseChannel):
     """Minimal concrete BaseChannel used only in these tests."""
-
-    channel = "stub"
 
     def __init__(
         self,
@@ -69,7 +67,7 @@ class StubChannel(BaseChannel):
         pass
 
     @classmethod
-    def from_config(cls, process, config, on_reply_sent=None, **kwargs):
+    def from_config(cls, process, config, on_reply_sent=None):
         return cls()
 
     async def consume_one(self, payload: Any) -> None:
@@ -128,9 +126,9 @@ class TestReplaceChannelOrdering:
 
     @pytest.mark.asyncio
     async def test_old_removed_from_list_before_new_starts(self):
-        """While the new channel is starting, the old channel must already
-        be gone from self.channels so concurrent lookups don't see a stale
-        (stopped) channel."""
+        """While the new channel is starting, the old channel must
+        already be gone from self.channels so concurrent lookups
+        don't see a stale (stopped) channel."""
         old = StubChannel("mych")
         new = StubChannel("mych")
         mgr = _make_manager(old)
@@ -149,12 +147,13 @@ class TestReplaceChannelOrdering:
 
         await mgr.replace_channel(new)
 
-        # During new.start(), old is already removed and new is not yet added
+        # During new.Start(), old is removed and new not yet added
         assert channels_during_new_start == [[]]
 
     @pytest.mark.asyncio
     async def test_new_added_to_list_after_start(self):
-        """After replace_channel succeeds, only the new channel is in the list."""
+        """After replace_channel succeeds, only the new channel is
+        in the list."""
         old = StubChannel("mych")
         new = StubChannel("mych")
         mgr = _make_manager(old)
@@ -188,8 +187,8 @@ class TestReplaceChannelOrdering:
 
 
 class TestReplaceChannelNewChannel:
-    """When there is no existing channel with the same name, the new one
-    should simply be added."""
+    """When there is no existing channel with the same name, the new
+    one should simply be added."""
 
     @pytest.mark.asyncio
     async def test_add_new_channel(self):
@@ -204,13 +203,12 @@ class TestReplaceChannelNewChannel:
 
     @pytest.mark.asyncio
     async def test_add_new_channel_no_old_stop(self):
-        """No old channel to stop, so stop should not be called on anything."""
+        """No old channel to stop, so stop should not be called."""
         new = StubChannel("fresh")
         mgr = _make_manager()
 
         await mgr.replace_channel(new)
 
-        # No exception means no spurious stop was attempted
         assert new.stop_called is False
 
 
@@ -219,25 +217,30 @@ class TestReplaceChannelNewStartFails:
 
     @pytest.mark.asyncio
     async def test_old_restored_on_new_start_failure(self):
-        """If the new channel fails to start, the old channel should be
-        restored (restarted and added back to the list)."""
+        """If the new channel fails to start, the old channel should
+        be restored (restarted and added back to the list)."""
         old = StubChannel("mych")
-        new = StubChannel("mych", start_side_effect=RuntimeError("port busy"))
+        new = StubChannel(
+            "mych",
+            start_side_effect=RuntimeError("port busy"),
+        )
         mgr = _make_manager(old)
 
         with pytest.raises(RuntimeError, match="port busy"):
             await mgr.replace_channel(new)
 
-        # Old channel should be restored
         assert old in mgr.channels
         assert old.start_called is True  # restarted
         assert new not in mgr.channels
 
     @pytest.mark.asyncio
     async def test_new_is_stopped_after_start_failure(self):
-        """A new channel that failed to start should have stop() called
-        for cleanup."""
-        new = StubChannel("mych", start_side_effect=RuntimeError("boom"))
+        """A new channel that failed to start should have stop()
+        called for cleanup."""
+        new = StubChannel(
+            "mych",
+            start_side_effect=RuntimeError("boom"),
+        )
         mgr = _make_manager()
 
         with pytest.raises(RuntimeError, match="boom"):
@@ -247,8 +250,11 @@ class TestReplaceChannelNewStartFails:
 
     @pytest.mark.asyncio
     async def test_original_exception_propagates(self):
-        """The original start exception should propagate to the caller."""
-        new = StubChannel("mych", start_side_effect=ConnectionError("refused"))
+        """The original start exception should propagate."""
+        new = StubChannel(
+            "mych",
+            start_side_effect=ConnectionError("refused"),
+        )
         mgr = _make_manager()
 
         with pytest.raises(ConnectionError, match="refused"):
@@ -256,15 +262,17 @@ class TestReplaceChannelNewStartFails:
 
     @pytest.mark.asyncio
     async def test_restore_failure_does_not_swallow_original(self):
-        """If restoring the old channel also fails, the original exception
-        should still propagate (not the restore failure)."""
+        """If restoring the old channel also fails, the original
+        exception should still propagate (not the restore failure)."""
         old = StubChannel(
             "mych",
             stop_side_effect=None,
             start_side_effect=RuntimeError("old also broken"),
         )
-        # First stop works, then on restore start fails
-        new = StubChannel("mych", start_side_effect=RuntimeError("new broken"))
+        new = StubChannel(
+            "mych",
+            start_side_effect=RuntimeError("new broken"),
+        )
         mgr = _make_manager(old)
 
         with pytest.raises(RuntimeError, match="new broken"):
@@ -272,9 +280,12 @@ class TestReplaceChannelNewStartFails:
 
     @pytest.mark.asyncio
     async def test_no_old_channel_new_start_fails(self):
-        """When adding a brand-new channel that fails to start, there's
-        no old channel to restore — just raise."""
-        new = StubChannel("fresh", start_side_effect=RuntimeError("fail"))
+        """When adding a brand-new channel that fails to start,
+        there's no old channel to restore — just raise."""
+        new = StubChannel(
+            "fresh",
+            start_side_effect=RuntimeError("fail"),
+        )
         mgr = _make_manager()
 
         with pytest.raises(RuntimeError, match="fail"):
@@ -284,16 +295,18 @@ class TestReplaceChannelNewStartFails:
 
 
 class TestReplaceChannelOldStopFails:
-    """When the old channel's stop() raises, the replace should still
-    proceed (stop errors are logged, not re-raised)."""
+    """When the old channel's stop() raises, the replace should
+    still proceed (stop errors are logged, not re-raised)."""
 
     @pytest.mark.asyncio
     async def test_old_stop_error_does_not_block_replace(self):
-        old = StubChannel("mych", stop_side_effect=RuntimeError("stop err"))
+        old = StubChannel(
+            "mych",
+            stop_side_effect=RuntimeError("stop err"),
+        )
         new = StubChannel("mych")
         mgr = _make_manager(old)
 
-        # Should NOT raise — old stop errors are caught and logged
         await mgr.replace_channel(new)
 
         assert new in mgr.channels
@@ -302,8 +315,12 @@ class TestReplaceChannelOldStopFails:
 
     @pytest.mark.asyncio
     async def test_old_stop_cancelled_error_handled(self):
-        """asyncio.CancelledError from old.stop() should be silently caught."""
-        old = StubChannel("mych", stop_side_effect=asyncio.CancelledError())
+        """asyncio.CancelledError from old.stop() should be
+        silently caught."""
+        old = StubChannel(
+            "mych",
+            stop_side_effect=asyncio.CancelledError(),
+        )
         new = StubChannel("mych")
         mgr = _make_manager(old)
 
@@ -316,7 +333,7 @@ class TestReplaceChannelEnqueueCallback:
     """Verify enqueue callback is set on the new channel."""
 
     @pytest.mark.asyncio
-    async def test_enqueue_callback_set_for_manager_queue_channel(self):
+    async def test_enqueue_callback_set_for_manager_queue(self):
         new = StubChannel("mych")
         new.uses_manager_queue = True
         mgr = _make_manager()
@@ -341,38 +358,31 @@ class TestReplaceChannelConcurrency:
 
     @pytest.mark.asyncio
     async def test_concurrent_replaces_do_not_duplicate(self):
-        """Two concurrent replace_channel calls for the same channel should
-        not result in duplicate entries."""
+        """Two concurrent replace_channel calls for the same channel
+        should not result in duplicate entries."""
         old = StubChannel("mych")
         mgr = _make_manager(old)
 
-        # Slow starts so they overlap
         new1 = StubChannel("mych")
         new2 = StubChannel("mych")
-
-        delay_event = asyncio.Event()
 
         orig_start1 = new1.start
 
         async def slow_start1():
-            # Wait a bit to let the second replace also proceed
             await asyncio.sleep(0.05)
             await orig_start1()
 
         new1.start = slow_start1  # type: ignore[assignment]
 
-        # Run both concurrently
         results = await asyncio.gather(
             mgr.replace_channel(new1),
             mgr.replace_channel(new2),
             return_exceptions=True,
         )
 
-        # No exceptions expected (both should succeed)
         for r in results:
-            assert not isinstance(r, Exception), f"Unexpected error: {r}"
+            assert not isinstance(r, Exception), f"Error: {r}"
 
-        # At least one of the new channels should be in the list
         channel_names = [c.channel for c in mgr.channels]
         assert channel_names.count("mych") >= 1
 
@@ -397,7 +407,8 @@ class TestReplaceChannelMultipleChannels:
 
     @pytest.mark.asyncio
     async def test_replace_preserves_order(self):
-        """After replace, the new channel should be appended at the end."""
+        """After replace, the new channel should be appended at
+        the end."""
         ch_a = StubChannel("alpha")
         ch_b = StubChannel("beta")
         ch_c = StubChannel("gamma")
@@ -407,5 +418,5 @@ class TestReplaceChannelMultipleChannels:
         await mgr.replace_channel(new_b)
 
         names = [c.channel for c in mgr.channels]
-        # Old ch_b was removed from its position, new_b appended
+        # Old ch_b removed from position, new_b appended
         assert names == ["alpha", "gamma", "beta"]


### PR DESCRIPTION
fix(channel): stop old channel before starting new in replace_channel (#4877)

## Description

  The replace_channel method previously started the new channel before                                                                                                                                             
  stopping the old one. For channels that bind ports or hold exclusive                                                                                                                                             
  resources, the new channel cannot start while the old one still holds                                                                                                                                            
  them, resulting in the new channel failing silently and the old one                                                                                                                                              
  being stopped — leaving no listener at all. 

**Related Issue:** Fixes #4877

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
