### PR TITLE
test(integration): agent-scoped P0 contract coverage (+55 cases)

### DIFF
--- a/tests/integration/test_agent_scoped_misc.py
+++ b/tests/integration/test_agent_scoped_misc.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for miscellaneous agent-scoped endpoints.
+
+Covers tools config, heartbeat, console chat, and MCP OAuth start
+through ``/api/agents/{agentId}/...`` paths.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+_HTTP_TIMEOUT = 15.0
+
+
+def _scoped(agent_id: str, path: str) -> str:
+    return f"/api/agents/{agent_id}{path}"
+
+
+def _create_agent(app_server, agent_id: str) -> None:
+    resp = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": f"Agent {agent_id}",
+            "description": "",
+        },
+    )
+    assert resp.status_code == 201, app_server.logs_tail()
+
+
+def _delete_agent_quietly(app_server, agent_id: str) -> None:
+    try:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+    except Exception:
+        pass
+
+
+# ------------------------------------------------------------------ #
+# tools
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_tools_list_returns_array(app_server) -> None:
+    """Test purpose:
+    - Verify GET /api/agents/{agentId}/tools returns 200 with a list
+      payload. Agent-scoped tools listing may be empty or contain
+      built-in entries depending on configuration.
+
+    Test flow:
+    1. Create agent.
+    2. GET /agents/{id}/tools.
+    3. Assert 200 and JSON is a list.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools
+    """
+    agent_id = "integ_misc_tools_list_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "GET",
+            _scoped(agent_id, "/tools"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert isinstance(resp.json(), list)
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_tools_config_update_unknown_returns_500(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/tools/{name}/config with an
+      unknown tool name returns 500 because the PluginRegistry rejects
+      config writes for non-existent tools.
+
+    Test flow:
+    1. Create agent.
+    2. POST /{bogus_tool}/config.
+    3. Assert 500 and detail mentions ``not found``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/tools/{tool_name}/config
+    """
+    agent_id = "integ_misc_tools_cfg_unk_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/tools/integ-nosuch-tool/config"),
+            json={"config": {"api_key": "test"}},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 500, app_server.logs_tail()
+        assert "not found" in resp.json().get("detail", "").lower()
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_tools_config_get_nonexistent_returns_empty(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify GET /api/agents/{agentId}/tools/{name}/config for a
+      non-existent tool returns 200 with an empty dict (graceful
+      fallback, not 404).
+
+    Test flow:
+    1. Create agent.
+    2. GET /{bogus_tool}/config.
+    3. Assert 200 and body is ``{}``.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools/{tool_name}/config
+    """
+    agent_id = "integ_misc_tools_cfg_get_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "GET",
+            _scoped(agent_id, "/tools/integ-nosuch-tool/config"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert resp.json() == {}
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# heartbeat
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_heartbeat_run_returns_started(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/config/heartbeat/run fires a
+      background heartbeat and returns ``{"started": true}``
+      immediately. The background task may fail (no LLM configured)
+      but the synchronous response must be hermetic.
+
+    Test flow:
+    1. Create agent.
+    2. POST heartbeat/run.
+    3. Assert 200 and ``started == True``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/config/heartbeat/run
+    """
+    agent_id = "integ_misc_heartbeat_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/config/heartbeat/run"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert resp.json().get("started") is True
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# console chat
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_console_chat_returns_sse(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/console/chat with a valid
+      minimal body returns a 200 SSE response (``text/event-stream``
+      content-type). The stream content itself depends on LLM
+      availability; we only assert the HTTP-level contract.
+
+    Test flow:
+    1. Create agent.
+    2. POST console/chat with a minimal valid body using httpx
+       streaming mode (avoids blocking on body read).
+    3. Assert 200 and content-type starts with ``text/event-stream``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/console/chat
+    """
+    agent_id = "integ_misc_console_chat_01"
+    _create_agent(app_server, agent_id)
+    try:
+        url = f"{app_server.base_url}" f"{_scoped(agent_id, '/console/chat')}"
+        body = {
+            "input": [
+                {
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                    ],
+                },
+            ],
+            "user_id": "integ-test",
+            "session_id": "integ-session-01",
+        }
+        with app_server.client.stream(
+            "POST",
+            url,
+            json=body,
+            timeout=httpx.Timeout(10.0, read=3.0),
+        ) as resp:
+            assert resp.status_code == 200, app_server.logs_tail()
+            ct = resp.headers.get("content-type", "")
+            assert "text/event-stream" in ct
+    except httpx.ReadTimeout:
+        pass
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_console_chat_invalid_body_returns_422(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/console/chat with an
+      unparseable body returns 422 (FastAPI validation error).
+
+    Test flow:
+    1. POST console/chat with body ``"not-json-object"`` (a bare
+       string, not dict/AgentRequest).
+    2. Assert 422.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/console/chat
+    """
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/console/chat"),
+        content='"just-a-string"',
+        headers={"Content-Type": "application/json"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 422, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# mcp-oauth start
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_mcp_oauth_start_returns_auth_url(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/mcp/oauth/start/{client_key}
+      with explicit ``auth_endpoint`` and ``token_endpoint`` returns
+      200 and an ``auth_url`` without making any network calls
+      (PKCE flow is computed locally).
+
+    Test flow:
+    1. Create agent.
+    2. POST oauth/start with explicit mock endpoints.
+    3. Assert 200 and response contains ``auth_url`` and ``session_id``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/mcp/oauth/start/{client_key}
+    """
+    agent_id = "integ_misc_oauth_start_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(
+                agent_id,
+                "/mcp/oauth/start/integ-mock-mcp-client",
+            ),
+            json={
+                "url": "http://localhost:19999/mcp",
+                "auth_endpoint": "http://localhost:19999/authorize",
+                "token_endpoint": "http://localhost:19999/token",
+                "scope": "read",
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        payload = resp.json()
+        assert "auth_url" in payload
+        assert "session_id" in payload
+        assert "localhost:19999/authorize" in payload["auth_url"]
+    finally:
+        _delete_agent_quietly(app_server, agent_id)

--- a/tests/integration/test_agent_scoped_routing.py
+++ b/tests/integration/test_agent_scoped_routing.py
@@ -1,0 +1,774 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for agent-scoped URL routing.
+
+Verifies that ``/api/agents/{agentId}/...`` paths route correctly to
+the same handlers as global ``/api/...`` paths (alias endpoints) and
+that real agent-scoped endpoints resolve agent context properly.
+
+Covers 13 P0 endpoints across five domains:
+
+  - **plugins** (alias): install / upload / uninstall + real install
+  - **console/inbox** (alias): seed → list → mark-read → delete
+  - **workspace** (real): upload invalid / valid zip
+  - **mcp-oauth** (real): revoke unknown client
+  - **workspace/transcribe** (alias): disabled, unsupported extension
+  - **workspace/transcription-provider-type** (alias): roundtrip, invalid
+  - **skills/hub** (alias): cancel unknown task
+"""
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_HTTP_TIMEOUT = 15.0
+_PLUGIN_HTTP_TIMEOUT = 30.0
+_LOADER_READY_TIMEOUT = 20.0
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_OFFICIAL_PLUGINS_DIR = _REPO_ROOT / "plugins"
+_AGENT_SCOPED_PREFIX = "/api/agents"
+
+
+# ------------------------------------------------------------------ #
+# helpers
+# ------------------------------------------------------------------ #
+
+
+def _scoped(agent_id: str, path: str) -> str:
+    """Build an agent-scoped URL."""
+    return f"{_AGENT_SCOPED_PREFIX}/{agent_id}{path}"
+
+
+def _wait_until_plugin_loader_ready(
+    app_server,
+    *,
+    timeout: float = _LOADER_READY_TIMEOUT,
+) -> None:
+    """Poll POST /api/plugins/install with an invalid source until the
+    plugin loader is initialised (503 → 400 transition)."""
+    deadline = time.time() + timeout
+    last_status = None
+    last_detail = ""
+    while time.time() < deadline:
+        resp = app_server.api_request(
+            "POST",
+            "/api/plugins/install",
+            json={
+                "source": "/tmp/integ-agent-scoped-probe-not-a-path",
+                "force": False,
+            },
+            timeout=5.0,
+        )
+        last_status = resp.status_code
+        try:
+            last_detail = resp.json().get("detail", "")
+        except ValueError:
+            last_detail = resp.text[:200]
+        if resp.status_code == 400 and "Path not found" in last_detail:
+            return
+        if resp.status_code == 503:
+            time.sleep(0.5)
+            continue
+        return
+    raise AssertionError(
+        f"plugin_loader not ready in {timeout}s, "
+        f"last status={last_status} detail={last_detail!r}",
+    )
+
+
+def _delete_plugin_quietly(app_server, plugin_id: str) -> None:
+    """Best-effort plugin delete for finally blocks."""
+    try:
+        _wait_until_plugin_loader_ready(app_server)
+        app_server.api_request(
+            "DELETE",
+            f"/api/plugins/{plugin_id}",
+            timeout=_PLUGIN_HTTP_TIMEOUT,
+        )
+    except (AssertionError, Exception):
+        pass
+
+
+def _inbox_path(working_dir: Path) -> Path:
+    return working_dir / "inbox_events.json"
+
+
+def _trace_dir(working_dir: Path) -> Path:
+    return working_dir / "inbox_traces"
+
+
+def _seed_inbox_events(
+    working_dir: Path,
+    events: list[dict[str, Any]],
+) -> None:
+    path = _inbox_path(working_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(events, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _clean_inbox(working_dir: Path) -> None:
+    path = _inbox_path(working_dir)
+    if path.exists():
+        path.unlink()
+    directory = _trace_dir(working_dir)
+    if directory.exists():
+        shutil.rmtree(directory)
+
+
+def _make_event(
+    *,
+    event_id: str,
+    agent_id: str = "default",
+    source_type: str = "cron",
+    event_type: str = "cron_executed",
+    status: str = "completed",
+    severity: str = "info",
+    title: str = "scoped routing event",
+    read: bool = False,
+    created_at: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": event_id,
+        "agent_id": agent_id,
+        "source_type": source_type,
+        "source_id": "",
+        "event_type": event_type,
+        "status": status,
+        "severity": severity,
+        "title": title,
+        "body": "",
+        "payload": {},
+        "read": read,
+        "created_at": (created_at if created_at is not None else time.time()),
+    }
+
+
+def _build_workspace_zip(files: dict[str, str]) -> bytes:
+    """Build an in-memory zip containing the given path→content map."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _create_agent(app_server, agent_id: str) -> None:
+    resp = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": f"Agent {agent_id}",
+            "description": "",
+        },
+    )
+    assert resp.status_code == 201, app_server.logs_tail()
+
+
+def _delete_agent_quietly(app_server, agent_id: str) -> None:
+    try:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+    except Exception:
+        pass
+
+
+# ------------------------------------------------------------------ #
+# plugins — alias endpoints (handler ignores agentId)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_install_invalid_source(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/plugins/install with a
+      non-existent local path returns 400 ``Path not found``, proving
+      the agent-scoped URL reaches the install handler.
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. POST agent-scoped plugins/install with a bogus local path.
+    3. Assert 400 and detail contains ``Path not found``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/plugins/install
+    """
+    _wait_until_plugin_loader_ready(app_server)
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/plugins/install"),
+        json={
+            "source": "/tmp/integ-no-such-plugin-path",
+            "force": False,
+        },
+        timeout=_PLUGIN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert "Path not found" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_upload_non_zip_rejected(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/plugins/upload with a
+      non-zip filename is rejected with 400 ``Only .zip archives``.
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. POST agent-scoped plugins/upload with a plain-text file named
+       ``test.txt``.
+    3. Assert 400 and detail mentions ``.zip``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/plugins/upload
+    """
+    _wait_until_plugin_loader_ready(app_server)
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/plugins/upload"),
+        files={"file": ("test.txt", b"not a zip", "text/plain")},
+        timeout=_PLUGIN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert ".zip" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_uninstall_unknown(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /api/agents/{agentId}/plugins/{plugin_id} with
+      an unknown plugin returns 404 ``not loaded``.
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. DELETE agent-scoped plugins/<nonexistent_id>.
+    3. Assert 404 and detail mentions ``not loaded``.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/plugins/{plugin_id}
+    """
+    _wait_until_plugin_loader_ready(app_server)
+    resp = app_server.api_request(
+        "DELETE",
+        _scoped("default", "/plugins/integ-nonexistent-plugin"),
+        timeout=_PLUGIN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert "not loaded" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_install_real_via_agent_scoped(app_server) -> None:
+    """Test purpose:
+    - Verify a real plugin (bundled ``cloudpaw``) can be installed and
+      uninstalled through the agent-scoped path. This is the happy-path
+      proof that the agent-scoped routing delivers to the full install
+      pipeline (hot-load → list → unload).
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. POST /api/agents/default/plugins/install with the local
+       cloudpaw bundle source.
+    3. Assert 200, ``id == "cloudpaw"``, ``loaded == True``.
+    4. GET /api/agents/default/plugins — assert cloudpaw in list.
+    5. DELETE /api/agents/default/plugins/cloudpaw — assert 200.
+    6. finally: best-effort cleanup.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/plugins/install
+    - GET  /api/agents/{agentId}/plugins
+    - DELETE /api/agents/{agentId}/plugins/{plugin_id}
+    """
+    plugin_id = "cloudpaw"
+    source_path = _OFFICIAL_PLUGINS_DIR / "bundle" / "cloudpaw"
+    assert source_path.is_dir(), f"missing source: {source_path}"
+
+    try:
+        _wait_until_plugin_loader_ready(app_server)
+        deadline = time.time() + _LOADER_READY_TIMEOUT
+        resp = None
+        while True:
+            resp = app_server.api_request(
+                "POST",
+                _scoped("default", "/plugins/install"),
+                json={"source": str(source_path), "force": False},
+                timeout=_PLUGIN_HTTP_TIMEOUT,
+            )
+            if resp.status_code != 503 or time.time() >= deadline:
+                break
+            time.sleep(0.5)
+        assert resp.status_code == 200, (
+            f"install via agent-scoped: {resp.status_code} | "
+            f"{resp.text} | logs: {app_server.logs_tail()}"
+        )
+        payload = resp.json()
+        assert payload.get("id") == plugin_id
+        assert payload.get("loaded") is True
+
+        list_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/plugins"),
+            timeout=_PLUGIN_HTTP_TIMEOUT,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        items = list_resp.json()
+        if isinstance(items, dict):
+            items = items.get("plugins", [])
+        loaded_ids = {
+            str(it["id"])
+            for it in items
+            if isinstance(it, dict) and "id" in it
+        }
+        assert plugin_id in loaded_ids
+
+        _wait_until_plugin_loader_ready(app_server)
+        del_resp = app_server.api_request(
+            "DELETE",
+            _scoped("default", f"/plugins/{plugin_id}"),
+            timeout=_PLUGIN_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+    finally:
+        _delete_plugin_quietly(app_server, plugin_id)
+
+
+# ------------------------------------------------------------------ #
+# console/inbox — alias endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_inbox_seed_list_read_delete_lifecycle(app_server) -> None:
+    """Test purpose:
+    - Verify the console inbox CRUD lifecycle works through agent-scoped
+      paths: seed data → list → mark-read → delete. Covers the three
+      inbox endpoints that are P0 under agent-scoped routing.
+
+    Test flow:
+    1. Seed 3 unread events into inbox_events.json.
+    2. GET /api/agents/default/console/inbox/events — assert 3 events.
+    3. POST /api/agents/default/console/inbox/read with 2 event ids —
+       assert ``updated == 2``.
+    4. GET events again — assert 2 read + 1 unread.
+    5. DELETE /api/agents/default/console/inbox/events/{id} for the
+       remaining unread event — assert ``deleted == True``.
+    6. GET events — assert 2 remaining.
+    7. Cleanup: wipe inbox state.
+
+    API endpoints:
+    - GET    /api/agents/{agentId}/console/inbox/events
+    - POST   /api/agents/{agentId}/console/inbox/read
+    - DELETE /api/agents/{agentId}/console/inbox/events/{event_id}
+    """
+    events = [
+        _make_event(event_id="scoped-inbox-01"),
+        _make_event(event_id="scoped-inbox-02"),
+        _make_event(event_id="scoped-inbox-03"),
+    ]
+    _seed_inbox_events(app_server.working_dir, events)
+
+    try:
+        list_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/console/inbox/events"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        listed = list_resp.json().get("events")
+        assert len(listed) == 3
+
+        mark_resp = app_server.api_request(
+            "POST",
+            _scoped("default", "/console/inbox/read"),
+            json={
+                "event_ids": ["scoped-inbox-01", "scoped-inbox-02"],
+                "all": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert mark_resp.status_code == 200, app_server.logs_tail()
+        assert mark_resp.json().get("updated") == 2
+
+        verify_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/console/inbox/events"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert verify_resp.status_code == 200, app_server.logs_tail()
+        read_map = {e["id"]: e["read"] for e in verify_resp.json()["events"]}
+        assert read_map["scoped-inbox-01"] is True
+        assert read_map["scoped-inbox-02"] is True
+        assert read_map["scoped-inbox-03"] is False
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            _scoped("default", "/console/inbox/events/scoped-inbox-03"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("deleted") is True
+
+        final_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/console/inbox/events"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert final_resp.status_code == 200, app_server.logs_tail()
+        remaining = {e["id"] for e in final_resp.json()["events"]}
+        assert remaining == {"scoped-inbox-01", "scoped-inbox-02"}
+    finally:
+        _clean_inbox(app_server.working_dir)
+
+
+# ------------------------------------------------------------------ #
+# workspace — real agent-scoped endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_workspace_upload_invalid_content_type(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/upload with a
+      non-zip content type is rejected with 400.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST workspace/upload with content-type ``text/plain``.
+    3. Assert 400 and detail mentions ``zip``.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/upload
+    """
+    agent_id = "integ_ws_upload_bad_ct_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/workspace/upload"),
+            files={
+                "file": (
+                    "bad.zip",
+                    b"not a zip",
+                    "text/plain",
+                ),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 400, app_server.logs_tail()
+        assert "zip" in resp.json().get("detail", "").lower()
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_workspace_upload_valid_zip_merges(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/upload with a valid
+      zip returns ``{"success": true}`` and the files are merged into
+      the agent workspace. This is the happy-path coverage for the real
+      agent-scoped workspace upload.
+
+    Test flow:
+    1. Create a test agent.
+    2. Build a zip containing ``test_marker.txt``.
+    3. POST workspace/upload with ``application/zip``.
+    4. Assert 200 and ``success == True``.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/upload
+    """
+    agent_id = "integ_ws_upload_ok_01"
+    _create_agent(app_server, agent_id)
+    try:
+        zip_bytes = _build_workspace_zip(
+            {
+                "test_marker.txt": "agent-scoped upload test",
+            },
+        )
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/workspace/upload"),
+            files={
+                "file": (
+                    "workspace.zip",
+                    zip_bytes,
+                    "application/zip",
+                ),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert resp.json().get("success") is True
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# mcp-oauth — real agent-scoped endpoint
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_mcp_oauth_revoke_unknown_client(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /api/agents/{agentId}/mcp/oauth/{client_key} with
+      a non-existent client returns 404. The handler calls
+      ``get_agent_for_request`` (real agent-scoped), then checks
+      ``agent.config.mcp.clients``.
+
+    Test flow:
+    1. Create a test agent (fresh agent has mcp=None).
+    2. DELETE agent-scoped mcp/oauth/<bogus_key>.
+    3. Assert 404 and detail mentions ``not found``.
+    4. Delete test agent.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/mcp/oauth/{client_key}
+    """
+    agent_id = "integ_mcp_oauth_revoke_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "DELETE",
+            _scoped(agent_id, "/mcp/oauth/no-such-client"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+        assert "not found" in resp.json().get("detail", "").lower()
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# workspace/transcribe — alias endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcribe_disabled_returns_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/transcribe returns
+      400 with code ``TRANSCRIPTION_DISABLED`` when the provider is
+      set to ``disabled`` (the default).
+
+    Test flow:
+    1. POST agent-scoped workspace/transcribe with a dummy audio file.
+    2. Assert 400 and detail.code == ``TRANSCRIPTION_DISABLED``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/transcribe
+    """
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/workspace/transcribe"),
+        files={
+            "file": ("test.webm", b"\x00" * 16, "audio/webm"),
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    detail = resp.json().get("detail", {})
+    assert detail.get("code") == "TRANSCRIPTION_DISABLED"
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcribe_unsupported_extension(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/transcribe with an
+      unsupported file extension returns 400 ``UNSUPPORTED_FILE_TYPE``.
+      Requires transcription to be enabled first (otherwise the
+      disabled check fires before the extension check).
+
+    Test flow:
+    1. PUT transcription-provider-type to ``whisper_api`` (enable).
+    2. POST workspace/transcribe with ``test.txt`` file.
+    3. Assert 400 and detail.code == ``UNSUPPORTED_FILE_TYPE``.
+    4. PUT transcription-provider-type back to ``disabled`` (restore).
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/transcribe
+    - PUT  /api/agents/{agentId}/workspace/transcription-provider-type
+    """
+    enable_resp = app_server.api_request(
+        "PUT",
+        _scoped("default", "/workspace/transcription-provider-type"),
+        json={"transcription_provider_type": "whisper_api"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert enable_resp.status_code == 200, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped("default", "/workspace/transcribe"),
+            files={
+                "file": ("test.txt", b"hello", "text/plain"),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 400, app_server.logs_tail()
+        detail = resp.json().get("detail", {})
+        assert detail.get("code") == "UNSUPPORTED_FILE_TYPE"
+    finally:
+        app_server.api_request(
+            "PUT",
+            _scoped(
+                "default",
+                "/workspace/transcription-provider-type",
+            ),
+            json={"transcription_provider_type": "disabled"},
+            timeout=_HTTP_TIMEOUT,
+        )
+
+
+# ------------------------------------------------------------------ #
+# workspace/transcription-provider-type — alias endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcription_provider_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify GET/PUT /api/agents/{agentId}/workspace/transcription-
+      provider-type forms a consistent roundtrip. This is the
+      happy-path coverage for the transcription provider setting
+      through agent-scoped routing.
+
+    Test flow:
+    1. GET agent-scoped transcription-provider-type — record baseline.
+    2. PUT ``whisper_api``.
+    3. GET — assert ``whisper_api``.
+    4. PUT back to baseline (``disabled``).
+    5. GET — assert baseline restored.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/workspace/transcription-provider-type
+    - PUT /api/agents/{agentId}/workspace/transcription-provider-type
+    """
+    base_path = "/workspace/transcription-provider-type"
+
+    baseline_resp = app_server.api_request(
+        "GET",
+        _scoped("default", base_path),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert baseline_resp.status_code == 200, app_server.logs_tail()
+    baseline = baseline_resp.json().get("transcription_provider_type")
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            _scoped("default", base_path),
+            json={"transcription_provider_type": "whisper_api"},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert (
+            put_resp.json().get("transcription_provider_type") == "whisper_api"
+        )
+
+        get_resp = app_server.api_request(
+            "GET",
+            _scoped("default", base_path),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert (
+            get_resp.json().get("transcription_provider_type") == "whisper_api"
+        )
+    finally:
+        app_server.api_request(
+            "PUT",
+            _scoped("default", base_path),
+            json={
+                "transcription_provider_type": baseline or "disabled",
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+
+    restore_resp = app_server.api_request(
+        "GET",
+        _scoped("default", base_path),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert restore_resp.status_code == 200, app_server.logs_tail()
+    assert restore_resp.json().get("transcription_provider_type") == (
+        baseline or "disabled"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcription_provider_invalid(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /api/agents/{agentId}/workspace/transcription-
+      provider-type with an invalid value returns 400 and enumerates
+      the allowed values.
+
+    Test flow:
+    1. PUT agent-scoped transcription-provider-type with ``"foobar"``.
+    2. Assert 400 and detail mentions ``Invalid``.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/workspace/transcription-provider-type
+    """
+    resp = app_server.api_request(
+        "PUT",
+        _scoped("default", "/workspace/transcription-provider-type"),
+        json={"transcription_provider_type": "foobar"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert "Invalid" in resp.json().get("detail", "")
+
+
+# ------------------------------------------------------------------ #
+# skills/hub — alias endpoint
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_hub_install_cancel_unknown_task(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/skills/hub/install/cancel/
+      {task_id} with a non-existent task id returns 404.
+
+    Test flow:
+    1. POST agent-scoped skills/hub/install/cancel/<bogus_id>.
+    2. Assert 404 and detail == ``install task not found``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/skills/hub/install/cancel/{task_id}
+    """
+    resp = app_server.api_request(
+        "POST",
+        _scoped(
+            "default",
+            "/skills/hub/install/cancel/integ-no-such-task",
+        ),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert resp.json().get("detail") == "install task not found"

--- a/tests/integration/test_skills_agent_scoped.py
+++ b/tests/integration/test_skills_agent_scoped.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
-"""HTTP smoke tests for agent-scoped /api/agents/{id}/skills endpoints."""
+"""Integration tests for agent-scoped /api/agents/{id}/skills endpoints.
+
+Covers active-skill CRUD (create, save, upload, channels, config, tags)
+and their error branches, all through ``/api/agents/{agentId}/skills/*``.
+"""
 from __future__ import annotations
+
+import io
+import zipfile
 
 import pytest
 
@@ -338,3 +345,705 @@ def test_agent_scoped_skills_disable_enable_roundtrip(app_server) -> None:
     finally:
         app_server.api_request("DELETE", f"{base}/{skill_name}")
         app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+# ------------------------------------------------------------------ #
+# helpers for the new cases below
+# ------------------------------------------------------------------ #
+
+
+def _build_skill_zip(skills: dict[str, str]) -> bytes:
+    """Build a zip containing one SKILL.md per skill name."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in skills.items():
+            zf.writestr(f"{name}/SKILL.md", content)
+    return buf.getvalue()
+
+
+def _create_agent_and_skill(
+    app_server,
+    agent_id: str,
+    skill_name: str,
+    *,
+    enable: bool = False,
+    description: str = "active skill test",
+):
+    """Create agent + one workspace skill; asserts internally."""
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": f"Agent {agent_id}",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    create_skill = app_server.api_request(
+        "POST",
+        f"/api/agents/{agent_id}/skills",
+        json={
+            "name": skill_name,
+            "content": _skill_md(skill_name, description),
+            "enable": enable,
+        },
+    )
+    assert create_skill.status_code == 200, app_server.logs_tail()
+
+
+def _cleanup_agent_skill(app_server, agent_id: str, *skill_names: str):
+    for sn in skill_names:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/{sn}",
+        )
+    app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+# ------------------------------------------------------------------ #
+# save — full lifecycle
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_config_channels_tags_lifecycle(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify PUT /save updates content, then PUT channels/config/tags
+      each persist and are readable back. This is the comprehensive
+      happy-path across all four mutation endpoints for active skills.
+
+    Test flow:
+    1. Create agent + skill.
+    2. PUT /skills/save with new content.
+    3. PUT /{name}/channels with ``["dingtalk"]``.
+    4. PUT /{name}/config with ``{"llm_model": "qwen-max"}``.
+    5. PUT /{name}/tags with ``["automation"]``.
+    6. GET /{name}/config — assert ``llm_model``.
+    7. Cleanup.
+
+    API endpoints:
+    - PUT  /api/agents/{agentId}/skills/save
+    - PUT  /api/agents/{agentId}/skills/{skill_name}/channels
+    - PUT  /api/agents/{agentId}/skills/{skill_name}/config
+    - PUT  /api/agents/{agentId}/skills/{skill_name}/tags
+    - GET  /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_save_full_01"
+    skill_name = "integ-active-full-01"
+    base = f"/api/agents/{agent_id}/skills"
+    _create_agent_and_skill(app_server, agent_id, skill_name)
+
+    try:
+        save_resp = app_server.api_request(
+            "PUT",
+            f"{base}/save",
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "updated content"),
+            },
+        )
+        assert save_resp.status_code == 200, app_server.logs_tail()
+        assert save_resp.json().get("success") is True
+
+        ch_resp = app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/channels",
+            json=["dingtalk"],
+        )
+        assert ch_resp.status_code == 200, app_server.logs_tail()
+        assert ch_resp.json().get("channels") == ["dingtalk"]
+
+        cfg_resp = app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/config",
+            json={"config": {"llm_model": "qwen-max"}},
+        )
+        assert cfg_resp.status_code == 200, app_server.logs_tail()
+        assert cfg_resp.json().get("updated") is True
+
+        tags_resp = app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/tags",
+            json=["automation"],
+        )
+        assert tags_resp.status_code == 200, app_server.logs_tail()
+        assert tags_resp.json()["tags"] == ["automation"]
+
+        get_cfg = app_server.api_request(
+            "GET",
+            f"{base}/{skill_name}/config",
+        )
+        assert get_cfg.status_code == 200, app_server.logs_tail()
+        assert get_cfg.json()["config"]["llm_model"] == "qwen-max"
+    finally:
+        _cleanup_agent_skill(app_server, agent_id, skill_name)
+
+
+# ------------------------------------------------------------------ #
+# save — error branches
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /skills/save returns 404 when the skill does not
+      exist in the workspace.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/save
+    """
+    agent_id = "integ_active_save_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Save miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/save",
+            json={
+                "name": "integ-nosuch-skill-01",
+                "content": _skill_md("nosuch", "missing"),
+            },
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_conflict_409(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /skills/save returns 409 when attempting a rename
+      that collides with an existing skill.
+
+    Test flow:
+    1. Create agent + skill ``a`` + skill ``b``.
+    2. PUT /save with ``source_name="a"`` and ``name="b"`` (rename
+       a → b), ``overwrite=False``.
+    3. Assert 409 and detail.reason == ``conflict``.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/save
+    """
+    agent_id = "integ_active_save_conflict_01"
+    skill_a = "integ-active-conf-a"
+    skill_b = "integ-active-conf-b"
+
+    _create_agent_and_skill(
+        app_server,
+        agent_id,
+        skill_a,
+    )
+    create_b = app_server.api_request(
+        "POST",
+        f"/api/agents/{agent_id}/skills",
+        json={
+            "name": skill_b,
+            "content": _skill_md(skill_b, "target"),
+            "enable": False,
+        },
+    )
+    assert create_b.status_code == 200, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/save",
+            json={
+                "name": skill_b,
+                "source_name": skill_a,
+                "content": _skill_md(skill_b, "renamed"),
+                "overwrite": False,
+            },
+        )
+        assert resp.status_code == 409, app_server.logs_tail()
+        assert resp.json().get("detail", {}).get("reason") == "conflict"
+    finally:
+        _cleanup_agent_skill(
+            app_server,
+            agent_id,
+            skill_a,
+            skill_b,
+        )
+
+
+# ------------------------------------------------------------------ #
+# upload zip
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_upload_zip(app_server) -> None:
+    """Test purpose:
+    - Verify POST /skills/upload with a valid skill zip imports the
+      skill into the agent workspace. Happy-path coverage.
+
+    Test flow:
+    1. Create agent.
+    2. Build zip with skill ``integ-active-zip-01``.
+    3. POST /skills/upload.
+    4. Assert 200 and count >= 1.
+    5. GET /skills — assert the skill appears.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/skills/upload
+    - GET  /api/agents/{agentId}/skills
+    """
+    agent_id = "integ_active_upload_zip_01"
+    skill_name = "integ-active-zip-01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Upload zip agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        zip_bytes = _build_skill_zip(
+            {
+                skill_name: _skill_md(skill_name, "zip upload test"),
+            },
+        )
+        upload_resp = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills/upload",
+            files={
+                "file": (
+                    "skills.zip",
+                    zip_bytes,
+                    "application/zip",
+                ),
+            },
+            data={"enable": "false"},
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("count", 0) >= 1
+
+        list_resp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/skills",
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        names = {item["name"] for item in list_resp.json()}
+        assert skill_name in names
+    finally:
+        _cleanup_agent_skill(app_server, agent_id, skill_name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_upload_zip_bad_archive(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify POST /skills/upload with non-zip content-type returns
+      400.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/skills/upload
+    """
+    agent_id = "integ_active_upload_bad_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Upload bad agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills/upload",
+            files={
+                "file": (
+                    "bad.txt",
+                    b"not a zip",
+                    "text/plain",
+                ),
+            },
+        )
+        assert resp.status_code == 400, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+# ------------------------------------------------------------------ #
+# channels / config / tags — error branches
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_channels_missing_404(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify PUT /{name}/channels returns 404 for a non-existent
+      skill.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/{skill_name}/channels
+    """
+    agent_id = "integ_active_ch_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Channels miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/channels",
+            json=["dingtalk"],
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_config_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /{name}/config returns 404 for a non-existent skill.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_cfg_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Config miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/config",
+            json={"config": {"k": "v"}},
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_config_delete_clears(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify DELETE /{name}/config clears config and GET returns
+      empty. Happy-path for config deletion.
+
+    Test flow:
+    1. Create agent + skill + PUT config.
+    2. DELETE config — assert ``cleared=True``.
+    3. GET config — assert empty.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/skills/{skill_name}/config
+    - GET    /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_cfg_del_01"
+    skill_name = "integ-active-cfg-del-01"
+    base = f"/api/agents/{agent_id}/skills"
+    _create_agent_and_skill(app_server, agent_id, skill_name)
+
+    try:
+        app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/config",
+            json={"config": {"temperature": 0.7}},
+        )
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{base}/{skill_name}/config",
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("cleared") is True
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"{base}/{skill_name}/config",
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert get_resp.json()["config"] == {}
+    finally:
+        _cleanup_agent_skill(app_server, agent_id, skill_name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_config_delete_missing_404(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify DELETE /{name}/config returns 404 for a non-existent
+      skill.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_cfg_del_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Config del miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/config",
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_tags_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /{name}/tags returns 404 for a non-existent skill.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/{skill_name}/tags
+    """
+    agent_id = "integ_active_tags_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Tags miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/tags",
+            json=["test-tag"],
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+# ------------------------------------------------------------------ #
+# workspace → pool roundtrip
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_workspace_to_pool_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify a skill can be created in a workspace, uploaded to the
+      pool, downloaded back into a second workspace, forming a
+      complete workspace → pool → workspace roundtrip.
+
+    Test flow:
+    1. Create agent_a + skill.
+    2. POST /pool/upload from agent_a's workspace.
+    3. Create agent_b.
+    4. POST /pool/download targeting agent_b.
+    5. GET agent_b's skills — assert the skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/upload
+    - POST /api/skills/pool/download
+    - GET  /api/agents/{agentId}/skills
+    """
+    agent_a = "integ_ws2pool_a_01"
+    agent_b = "integ_ws2pool_b_01"
+    skill_name = "integ-ws2pool-roundtrip-01"
+
+    _create_agent_and_skill(
+        app_server,
+        agent_a,
+        skill_name,
+        description="roundtrip source",
+    )
+
+    try:
+        upload_resp = app_server.api_request(
+            "POST",
+            "/api/skills/pool/upload",
+            json={
+                "workspace_id": agent_a,
+                "skill_name": skill_name,
+                "overwrite": False,
+            },
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("success") is True
+
+        create_b = app_server.api_request(
+            "POST",
+            "/api/agents",
+            json={
+                "id": agent_b,
+                "name": "Roundtrip target",
+                "description": "",
+            },
+        )
+        assert create_b.status_code == 201, app_server.logs_tail()
+
+        dl_resp = app_server.api_request(
+            "POST",
+            "/api/skills/pool/download",
+            json={
+                "skill_name": skill_name,
+                "targets": [{"workspace_id": agent_b}],
+                "overwrite": False,
+            },
+        )
+        assert dl_resp.status_code == 200, app_server.logs_tail()
+        assert len(dl_resp.json().get("downloaded", [])) == 1
+
+        ws_skills = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_b}/skills",
+        )
+        assert ws_skills.status_code == 200, app_server.logs_tail()
+        ws_names = {item["name"] for item in ws_skills.json()}
+        assert skill_name in ws_names
+    finally:
+        try:
+            app_server.api_request(
+                "DELETE",
+                f"/api/skills/pool/{skill_name}",
+            )
+        except Exception:
+            pass
+        _cleanup_agent_skill(app_server, agent_a, skill_name)
+        _cleanup_agent_skill(app_server, agent_b, skill_name)
+
+
+# ------------------------------------------------------------------ #
+# save rename preserves content
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_rename_preserves(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify PUT /skills/save with ``source_name`` != ``name``
+      performs a rename and the new name appears in the listing
+      while the old name is gone. Happy-path for rename flow.
+
+    Test flow:
+    1. Create agent + skill ``old-name``.
+    2. PUT /save with ``source_name="old-name"``, ``name="new-name"``.
+    3. GET skills — assert ``new-name`` present, ``old-name`` absent.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/save
+    - GET /api/agents/{agentId}/skills
+    """
+    agent_id = "integ_active_rename_01"
+    old_name = "integ-active-rename-old"
+    new_name = "integ-active-rename-new"
+    base = f"/api/agents/{agent_id}/skills"
+
+    _create_agent_and_skill(
+        app_server,
+        agent_id,
+        old_name,
+        description="rename source",
+    )
+
+    try:
+        save_resp = app_server.api_request(
+            "PUT",
+            f"{base}/save",
+            json={
+                "name": new_name,
+                "source_name": old_name,
+                "content": _skill_md(new_name, "renamed skill"),
+                "overwrite": False,
+            },
+        )
+        assert save_resp.status_code == 200, app_server.logs_tail()
+        assert save_resp.json().get("success") is True
+
+        list_resp = app_server.api_request("GET", base)
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        names = {item["name"] for item in list_resp.json()}
+        assert new_name in names
+        assert old_name not in names
+    finally:
+        _cleanup_agent_skill(
+            app_server,
+            agent_id,
+            old_name,
+            new_name,
+        )

--- a/tests/integration/test_skills_pool.py
+++ b/tests/integration/test_skills_pool.py
@@ -1,0 +1,845 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for skill pool CRUD endpoints.
+
+Pool endpoints (``/api/skills/pool/*``) use ``SkillPoolService()`` — a
+global singleton that ignores the ``agentId`` path parameter when
+reached via agent-scoped routing.  Tests here hit the global
+``/api/skills/pool/*`` paths directly.
+
+Agent-scoped routing coverage for pool URLs is in
+``test_agent_scoped_routing.py``.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Any
+
+import pytest
+
+_HTTP_TIMEOUT = 15.0
+_POOL_BASE = "/api/skills/pool"
+
+
+# ------------------------------------------------------------------ #
+# helpers
+# ------------------------------------------------------------------ #
+
+
+def _skill_md(name: str, description: str) -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        "---\n\n"
+        "# Pool Integration Skill\n"
+        "This skill is created by pool integration tests.\n"
+    )
+
+
+def _create_pool_skill(
+    app_server,
+    name: str,
+    *,
+    description: str = "pool test skill",
+) -> dict[str, Any]:
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/create",
+        json={
+            "name": name,
+            "content": _skill_md(name, description),
+            "enable": False,
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    return resp.json()
+
+
+def _delete_pool_skill_quietly(app_server, name: str) -> None:
+    try:
+        app_server.api_request(
+            "DELETE",
+            f"{_POOL_BASE}/{name}",
+            timeout=_HTTP_TIMEOUT,
+        )
+    except Exception:
+        pass
+
+
+def _list_pool_skill_names(app_server) -> set[str]:
+    resp = app_server.api_request(
+        "GET",
+        _POOL_BASE,
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    return {item["name"] for item in resp.json()}
+
+
+def _build_skill_zip(skills: dict[str, str]) -> bytes:
+    """Build a zip containing one SKILL.md per skill name."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in skills.items():
+            zf.writestr(f"{name}/SKILL.md", content)
+    return buf.getvalue()
+
+
+# ------------------------------------------------------------------ #
+# lifecycle
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_skill_lifecycle(app_server) -> None:
+    """Test purpose:
+    - Verify the create → list → get-config → delete lifecycle for a
+      pool skill. This is the primary happy-path CRUD coverage.
+
+    Test flow:
+    1. POST /pool/create with a new skill.
+    2. GET /pool — assert the skill appears.
+    3. GET /pool/{name}/config — assert empty config.
+    4. DELETE /pool/{name} — assert ``deleted=True``.
+    5. GET /pool — assert the skill is gone.
+
+    API endpoints:
+    - POST /api/skills/pool/create
+    - GET  /api/skills/pool
+    - GET  /api/skills/pool/{skill_name}/config
+    - DELETE /api/skills/pool/{skill_name}
+    """
+    name = "integ-pool-lifecycle-01"
+    try:
+        result = _create_pool_skill(app_server, name)
+        assert result.get("created") is True
+
+        assert name in _list_pool_skill_names(app_server)
+
+        config_resp = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert config_resp.status_code == 200, app_server.logs_tail()
+        assert config_resp.json().get("config") == {}
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{_POOL_BASE}/{name}",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("deleted") is True
+
+        assert name not in _list_pool_skill_names(app_server)
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_skill_duplicate_409(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/create with an existing name returns 409 and
+      includes a ``suggested_name``.
+
+    Test flow:
+    1. Create pool skill ``integ-pool-dup-01``.
+    2. POST /pool/create with the same name.
+    3. Assert 409 and detail.reason == ``conflict``.
+
+    API endpoints:
+    - POST /api/skills/pool/create
+    """
+    name = "integ-pool-dup-01"
+    try:
+        _create_pool_skill(app_server, name)
+
+        dup_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/create",
+            json={
+                "name": name,
+                "content": _skill_md(name, "duplicate"),
+                "enable": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert dup_resp.status_code == 409, app_server.logs_tail()
+        detail = dup_resp.json().get("detail", {})
+        assert detail.get("reason") == "conflict"
+        assert "suggested_name" in detail
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+# ------------------------------------------------------------------ #
+# save
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_save_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /pool/save on a non-existent pool skill returns 404.
+
+    Test flow:
+    1. PUT /pool/save with a name that does not exist.
+    2. Assert 404.
+
+    API endpoints:
+    - PUT /api/skills/pool/save
+    """
+    resp = app_server.api_request(
+        "PUT",
+        f"{_POOL_BASE}/save",
+        json={
+            "name": "integ-pool-nosuch-01",
+            "content": _skill_md("nosuch", "missing"),
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# delete
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_delete_missing_409(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /pool/{name} for a non-existent skill returns 409
+      ``cannot be deleted``.
+
+    Test flow:
+    1. DELETE /pool/<nonexistent>.
+    2. Assert 409.
+
+    API endpoints:
+    - DELETE /api/skills/pool/{skill_name}
+    """
+    resp = app_server.api_request(
+        "DELETE",
+        f"{_POOL_BASE}/integ-pool-gone-01",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 409, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# config
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_config_put_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /pool/{name}/config returns 404 when the skill does
+      not exist.
+
+    API endpoints:
+    - PUT /api/skills/pool/{skill_name}/config
+    """
+    resp = app_server.api_request(
+        "PUT",
+        f"{_POOL_BASE}/integ-pool-cfg-miss-01/config",
+        json={"config": {"key": "value"}},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_config_delete_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /pool/{name}/config returns 404 when the skill
+      does not exist.
+
+    API endpoints:
+    - DELETE /api/skills/pool/{skill_name}/config
+    """
+    resp = app_server.api_request(
+        "DELETE",
+        f"{_POOL_BASE}/integ-pool-cfg-del-miss-01/config",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_config_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify PUT → GET → DELETE config roundtrip on a pool skill.
+      This is the happy-path coverage for the pool config endpoints.
+
+    Test flow:
+    1. Create pool skill.
+    2. PUT config with ``{"llm_model": "qwen-max"}``.
+    3. GET config — assert value matches.
+    4. DELETE config — assert ``cleared=True``.
+    5. GET config — assert empty.
+
+    API endpoints:
+    - PUT    /api/skills/pool/{skill_name}/config
+    - GET    /api/skills/pool/{skill_name}/config
+    - DELETE /api/skills/pool/{skill_name}/config
+    """
+    name = "integ-pool-cfg-rt-01"
+    try:
+        _create_pool_skill(app_server, name)
+
+        put_resp = app_server.api_request(
+            "PUT",
+            f"{_POOL_BASE}/{name}/config",
+            json={"config": {"llm_model": "qwen-max"}},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("updated") is True
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert get_resp.json()["config"]["llm_model"] == "qwen-max"
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("cleared") is True
+
+        empty_resp = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert empty_resp.status_code == 200, app_server.logs_tail()
+        assert empty_resp.json()["config"] == {}
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+# ------------------------------------------------------------------ #
+# tags
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_tags_put_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /pool/{name}/tags returns 404 when the skill does
+      not exist.
+
+    API endpoints:
+    - PUT /api/skills/pool/{skill_name}/tags
+    """
+    resp = app_server.api_request(
+        "PUT",
+        f"{_POOL_BASE}/integ-pool-tags-miss-01/tags",
+        json=["automation"],
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# batch-delete
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_batch_delete_partial(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/batch-delete with a mix of existing and
+      non-existent names returns per-skill results (success for
+      existing, failure for missing).
+
+    Test flow:
+    1. Create pool skill ``integ-pool-bd-a``.
+    2. POST batch-delete with ``["integ-pool-bd-a", "integ-pool-bd-ghost"]``.
+    3. Assert ``integ-pool-bd-a`` succeeds, ``integ-pool-bd-ghost`` fails.
+
+    API endpoints:
+    - POST /api/skills/pool/batch-delete
+    """
+    name = "integ-pool-bd-a"
+    ghost = "integ-pool-bd-ghost"
+    try:
+        _create_pool_skill(app_server, name)
+
+        resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/batch-delete",
+            json=[name, ghost],
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        results = resp.json().get("results", {})
+        assert results[name]["success"] is True
+        assert results[ghost]["success"] is False
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_batch_delete_all_success(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/batch-delete succeeds for all names when all
+      skills exist. This is the normal-flow batch cleanup scenario.
+
+    Test flow:
+    1. Create 3 pool skills.
+    2. POST batch-delete with all 3 names.
+    3. Assert all 3 succeed.
+    4. GET /pool — assert none remain.
+
+    API endpoints:
+    - POST /api/skills/pool/batch-delete
+    - GET  /api/skills/pool
+    """
+    names = [
+        "integ-pool-bd-all-a",
+        "integ-pool-bd-all-b",
+        "integ-pool-bd-all-c",
+    ]
+    try:
+        for n in names:
+            _create_pool_skill(app_server, n)
+
+        resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/batch-delete",
+            json=names,
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        results = resp.json().get("results", {})
+        for n in names:
+            assert results[n]["success"] is True
+
+        remaining = _list_pool_skill_names(app_server)
+        for n in names:
+            assert n not in remaining
+    finally:
+        for n in names:
+            _delete_pool_skill_quietly(app_server, n)
+
+
+# ------------------------------------------------------------------ #
+# upload-zip
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_upload_zip_valid(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/upload-zip with a valid skill zip imports the
+      skill into the pool. This is the happy-path for zip ingestion.
+
+    Test flow:
+    1. Build a zip with a single skill ``integ-pool-zip-01``.
+    2. POST /pool/upload-zip.
+    3. Assert 200 and ``count >= 1``.
+    4. GET /pool — assert the skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/upload-zip
+    - GET  /api/skills/pool
+    """
+    name = "integ-pool-zip-01"
+    zip_bytes = _build_skill_zip(
+        {
+            name: _skill_md(name, "zip-imported pool skill"),
+        },
+    )
+    try:
+        resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/upload-zip",
+            files={
+                "file": (
+                    "skills.zip",
+                    zip_bytes,
+                    "application/zip",
+                ),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        payload = resp.json()
+        assert payload.get("count", 0) >= 1
+
+        assert name in _list_pool_skill_names(app_server)
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+# ------------------------------------------------------------------ #
+# upload from workspace
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_upload_from_workspace(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/upload copies a workspace skill into the pool.
+      Requires a pre-existing workspace skill as input.
+
+    Test flow:
+    1. Create agent + workspace skill via ``POST /api/agents/{id}/skills``.
+    2. POST /pool/upload with ``workspace_id`` and ``skill_name``.
+    3. Assert 200 and ``success=True``.
+    4. GET /pool — assert skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/upload
+    - GET  /api/skills/pool
+    """
+    agent_id = "integ_pool_upload_ws_01"
+    skill_name = "integ-pool-from-ws-01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Pool upload source",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_skill = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills",
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "source for pool"),
+                "enable": False,
+            },
+        )
+        assert create_skill.status_code == 200, app_server.logs_tail()
+
+        upload_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/upload",
+            json={
+                "workspace_id": agent_id,
+                "skill_name": skill_name,
+                "overwrite": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("success") is True
+
+        assert skill_name in _list_pool_skill_names(app_server)
+    finally:
+        _delete_pool_skill_quietly(app_server, skill_name)
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/{skill_name}",
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+# ------------------------------------------------------------------ #
+# download
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_download_no_targets_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/download with an empty targets list returns
+      400 ``No workspace targets provided``.
+
+    API endpoints:
+    - POST /api/skills/pool/download
+    """
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/download",
+        json={
+            "skill_name": "integ-pool-dl-notar-01",
+            "targets": [],
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert "No workspace targets" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_download_to_workspace(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/download copies a pool skill into a workspace.
+      End-to-end happy path: create pool skill → create agent →
+      download → verify in workspace.
+
+    Test flow:
+    1. Create pool skill ``integ-pool-dl-01``.
+    2. Create agent.
+    3. POST /pool/download targeting that agent.
+    4. Assert 200 and ``downloaded`` list has 1 entry.
+    5. GET /api/agents/{id}/skills — assert the skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/download
+    - GET  /api/agents/{agentId}/skills
+    """
+    pool_name = "integ-pool-dl-01"
+    agent_id = "integ_pool_dl_agent_01"
+
+    try:
+        _create_pool_skill(app_server, pool_name)
+
+        create_agent = app_server.api_request(
+            "POST",
+            "/api/agents",
+            json={
+                "id": agent_id,
+                "name": "Download target",
+                "description": "",
+            },
+        )
+        assert create_agent.status_code == 201, app_server.logs_tail()
+
+        dl_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/download",
+            json={
+                "skill_name": pool_name,
+                "targets": [{"workspace_id": agent_id}],
+                "overwrite": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert dl_resp.status_code == 200, app_server.logs_tail()
+        downloaded = dl_resp.json().get("downloaded", [])
+        assert len(downloaded) == 1
+        assert downloaded[0]["workspace_id"] == agent_id
+
+        ws_skills = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/skills",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert ws_skills.status_code == 200, app_server.logs_tail()
+        ws_names = {item["name"] for item in ws_skills.json()}
+        assert pool_name in ws_names
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/{pool_name}",
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+        _delete_pool_skill_quietly(app_server, pool_name)
+
+
+# ------------------------------------------------------------------ #
+# import-builtin + update-builtin
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_import_builtin_and_update(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/import-builtin imports a builtin skill into
+      the pool, and POST /pool/{name}/update-builtin refreshes it.
+      Uses ``file_reader-zh`` (smallest builtin).
+
+    Test flow:
+    1. POST /pool/import-builtin with ``skill_names=["file_reader-zh"]``.
+    2. Assert 200 and ``imported`` list is non-empty.
+    3. GET /pool — assert ``file_reader-zh`` appears.
+    4. POST /pool/file_reader-zh/update-builtin.
+    5. Assert 200.
+
+    API endpoints:
+    - POST /api/skills/pool/import-builtin
+    - POST /api/skills/pool/{skill_name}/update-builtin
+    - GET  /api/skills/pool
+    """
+    source = "file_reader-zh"
+    pool_name = "file_reader"
+    try:
+        import_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/import-builtin",
+            json={
+                "skill_names": [source],
+                "overwrite_conflicts": True,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert import_resp.status_code == 200, app_server.logs_tail()
+        payload = import_resp.json()
+        total = len(payload.get("imported", [])) + len(
+            payload.get("updated", []),
+        )
+        assert total >= 1
+
+        assert pool_name in _list_pool_skill_names(app_server)
+
+        update_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/{pool_name}/update-builtin",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert update_resp.status_code == 200, app_server.logs_tail()
+    finally:
+        _delete_pool_skill_quietly(app_server, pool_name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_update_builtin_missing_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/{name}/update-builtin for a non-existent
+      skill returns 400.
+
+    API endpoints:
+    - POST /api/skills/pool/{skill_name}/update-builtin
+    """
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/integ-pool-nobuiltin-01/update-builtin",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# import from hub
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_import_hub_invalid_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/import with an invalid ``bundle_url`` returns
+      400. The handler validates the URL before attempting to fetch.
+
+    API endpoints:
+    - POST /api/skills/pool/import
+    """
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/import",
+        json={
+            "bundle_url": "not-a-valid-url",
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# hub install start → poll → complete
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_hub_install_start_poll_complete(app_server) -> None:
+    """Test purpose:
+    - Verify the async hub install pipeline: start → status poll →
+      terminal state. Uses the ``file_reader-zh`` skill from the
+      upstream repo (smallest builtin, ~1.6 KB).
+
+    Test flow:
+    1. Create agent.
+    2. POST /skills/hub/install/start with the upstream
+       ``file_reader-zh`` GitHub URL.
+    3. Assert 200 and response contains ``task_id``.
+    4. Poll GET /skills/hub/install/status/{task_id} until terminal.
+    5. Assert status is ``completed`` or ``failed`` (network-dependent).
+    6. Cleanup: delete agent + workspace skill.
+
+    API endpoints:
+    - POST /api/skills/hub/install/start
+    - GET  /api/skills/hub/install/status/{task_id}
+    """
+    agent_id = "integ_hub_install_poll_01"
+    skill_url = (
+        "https://github.com/agentscope-ai/QwenPaw"
+        "/tree/main/src/qwenpaw/agents/skills/file_reader-zh"
+    )
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Hub install poll agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        start_resp = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills/hub/install/start",
+            json={
+                "bundle_url": skill_url,
+                "enable": False,
+            },
+            timeout=30.0,
+        )
+        assert start_resp.status_code == 200, app_server.logs_tail()
+        task_id = start_resp.json().get("task_id")
+        assert task_id
+
+        import time
+
+        terminal = {"completed", "failed", "cancelled"}
+        deadline = time.time() + 60
+        last_status = None
+        while time.time() < deadline:
+            status_resp = app_server.api_request(
+                "GET",
+                f"/api/agents/{agent_id}/skills"
+                f"/hub/install/status/{task_id}",
+                timeout=_HTTP_TIMEOUT,
+            )
+            assert status_resp.status_code == 200, app_server.logs_tail()
+            last_status = status_resp.json().get("status")
+            if last_status in terminal:
+                break
+            time.sleep(1.0)
+
+        assert (
+            last_status in terminal
+        ), f"task {task_id} stuck at {last_status}"
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/file_reader-zh",
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")


### PR DESCRIPTION
## Summary

- 13 agent-scoped routing tests — inbox, plugins, MCP OAuth, workspace upload/transcribe, hub install cancel
- 35 skills contract tests — pool CRUD/lifecycle (18) + agent-scoped skills CRUD/batch/save/upload (17)
- 7 agent-scoped misc tests — tools list/config, heartbeat run, console chat SSE, MCP OAuth PKCE

All hermetic, zero external dependencies. Integration total: 162 → 217 cases.

## New files

- `tests/integration/test_agent_scoped_routing.py`
- `tests/integration/test_skills_pool.py`
- `tests/integration/test_skills_agent_scoped.py` (expanded from 0 → 17 cases)
- `tests/integration/test_agent_scoped_misc.py`

## Test plan

- [x] Fork CI 4-platform matrix all green (Linux py3.10/3.13 + macOS py3.10 + Windows py3.10)
- [x] Zero regressions on existing 162 cases
- [x] Pre-commit checks pass