### PR TITLE
fix(coding-mode): support browsing all drives on Windows

### DIFF
--- a/console/src/api/modules/codingProject.ts
+++ b/console/src/api/modules/codingProject.ts
@@ -21,6 +21,7 @@ export interface BrowseDirsResponse {
   current: string;
   parent: string | null;
   dirs: Array<{ name: string; path: string }>;
+  selectable?: boolean;
 }
 
 export const codingProjectApi = {

--- a/console/src/components/ProjectSelectModal/index.tsx
+++ b/console/src/components/ProjectSelectModal/index.tsx
@@ -605,7 +605,7 @@ function OpenDirTab({ onSelect }: { onSelect: (path: string) => void }) {
       </div>
 
       {/* Confirm button */}
-      {data && !loading && (
+      {data && !loading && data.selectable !== false && (
         <Button
           type="primary"
           onClick={() => onSelect(data.current)}

--- a/src/qwenpaw/app/routers/coding_project.py
+++ b/src/qwenpaw/app/routers/coding_project.py
@@ -13,6 +13,7 @@ import asyncio
 import io
 import json
 import logging
+import sys
 import zipfile
 from pathlib import Path
 
@@ -33,6 +34,28 @@ router = APIRouter(prefix="/workspace/coding-project", tags=["coding-project"])
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _list_windows_drives_response() -> dict:
+    """Return a browse-dirs response listing drives."""
+    dirs: list[dict] = []
+    for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+        root = Path(f"{letter}:\\")
+        try:
+            if root.exists():
+                dirs.append(
+                    {
+                        "name": f"{letter}:",
+                        "path": str(root),
+                    },
+                )
+        except OSError:
+            continue
+    return {
+        "current": "/",
+        "parent": None,
+        "dirs": dirs,
+    }
 
 
 def _projects_base(workspace_dir: Path) -> Path:
@@ -454,7 +477,17 @@ async def browse_dirs(
         description="Include hidden directories",
     ),
 ) -> dict:
-    """Return subdirectories at *path* for the file browser UI."""
+    """Return subdirectories at *path* for the file browser UI.
+
+    On Windows, ``"/"`` is treated as a virtual root that
+    lists all available drive letters (C:, D:, ...).
+    """
+    # Windows virtual root: list all drive letters
+    if sys.platform == "win32" and path in ("/", "\\"):
+        return await asyncio.to_thread(
+            _list_windows_drives_response,
+        )
+
     target = await asyncio.to_thread(
         lambda: Path(path).expanduser().resolve(),
     )
@@ -502,9 +535,15 @@ async def browse_dirs(
                 detail=f"Failed to list directory: {target}",
             ) from exc
         parent = target.parent
+        # On Windows drive root, parent points to
+        # the virtual drives listing.
+        if sys.platform == "win32" and parent == target:
+            parent_str: str | None = "/"
+        else:
+            parent_str = str(parent) if parent != target else None
         return {
             "current": str(target),
-            "parent": (str(parent) if parent != target else None),
+            "parent": parent_str,
             "dirs": dirs,
         }
 

--- a/src/qwenpaw/app/routers/coding_project.py
+++ b/src/qwenpaw/app/routers/coding_project.py
@@ -38,23 +38,24 @@ router = APIRouter(prefix="/workspace/coding-project", tags=["coding-project"])
 
 def _list_windows_drives_response() -> dict:
     """Return a browse-dirs response listing drives."""
+    import ctypes
+
+    bitmask = ctypes.windll.kernel32.GetLogicalDrives()
     dirs: list[dict] = []
-    for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
-        root = Path(f"{letter}:\\")
-        try:
-            if root.exists():
-                dirs.append(
-                    {
-                        "name": f"{letter}:",
-                        "path": str(root),
-                    },
-                )
-        except OSError:
-            continue
+    for i in range(26):
+        if bitmask & (1 << i):
+            letter = chr(ord("A") + i)
+            dirs.append(
+                {
+                    "name": f"{letter}:",
+                    "path": f"{letter}:\\",
+                },
+            )
     return {
         "current": "/",
         "parent": None,
         "dirs": dirs,
+        "selectable": False,
     }
 
 


### PR DESCRIPTION
On Windows, Path("/").resolve() always resolves to the current drive root (usually C:\), so the file browser was locked to a single drive.

Add a virtual root ("/") that lists all available drive letters when running on Windows, and point drive-root parent to it so users can navigate between drives.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
