### PR TITLE
fix(console): session list kept spinning

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -101,17 +101,6 @@
   }
 }
 
-/* Background loading indicator — visible through unrendered gaps during fast scroll */
-.virtualListBackground {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 0;
-  pointer-events: none;
-}
-
 /* Top fade gradient overlay */
 .topGradient {
   position: absolute;

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -575,13 +575,6 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           </div>
         ) : (
           <>
-            {/* Background loading — only show when content overflows the container,
-                so it's visible through unrendered gaps during fast scroll */}
-            {sortedSessions.length * ITEM_HEIGHT > listHeight && (
-              <div className={styles.virtualListBackground}>
-                <Spin size="small" />
-              </div>
-            )}
             <FixedSizeList
               height={listHeight}
               width="100%"

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -287,14 +287,13 @@ const chatSpecToSession = (chat: ChatSpec): ExtendedSession =>
 /** Returns true when id is a pure numeric local timestamp (not a backend UUID). */
 const isLocalTimestamp = (id: string): boolean => /^\d+$/.test(id);
 
-/** Detect if backend is still generating content for this chat. */
+/** Detect if backend is still generating content for this chat.
+ *  Only trust the explicit `status` field from the backend.
+ *  When status is missing (undefined) treat the chat as idle to avoid
+ *  false-positive reconnects that cause infinite loading (issue #4903).
+ */
 const isGenerating = (chatHistory: ChatHistory): boolean => {
-  if (chatHistory.status === "running") return true;
-  if (chatHistory.status === "idle") return false;
-  const msgs = chatHistory.messages || [];
-  if (msgs.length === 0) return false;
-  const last = msgs[msgs.length - 1];
-  return last.role === ROLE_USER;
+  return chatHistory.status === "running";
 };
 
 /**
@@ -643,7 +642,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         next.id = existing.id;
         next.realId = existing.realId;
       }
-      if (existing.generating !== undefined) {
+      // Only carry over generating=true from the old session when the
+      // backend hasn't explicitly reported the chat as idle.  Previously
+      // the flag was inherited unconditionally, so once set it could never
+      // be cleared — causing a permanent spinner in the session list
+      // (issue #4903).
+      if (existing.generating && sExt.status !== "idle") {
         next.generating = existing.generating;
       }
       return next as IAgentScopeRuntimeWebUISession;


### PR DESCRIPTION
## Description

An abnormal loading state occurred when switching chat sessions—the spinner in the session list kept spinning (Issue #4903).

Fixes #4903 

## Solution

isGenerating: Simplifies to only check status === "running"
applyChatsToSessionList: Inherits the old generating only if the backend does not report idle
ChatSessionDrawer: Removes the virtualListBackground background spin and its CSS (overscanCount: 20 is sufficient to cover fast scroll gaps)
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
