### PR TITLE
chore(deps): update reme-ai dependency to version 0.3.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.3.1.8",
+    "reme-ai==0.3.1.10",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -33,7 +33,7 @@ from ...constant import EnvVarLoader
 logger = logging.getLogger(__name__)
 
 _REME_STORE_VERSION = "v1"
-_EXPECTED_REME_VERSION = "0.3.1.8"
+_EXPECTED_REME_VERSION = "0.3.1.10"
 # Maximum number of tokens from query splitting
 MAX_QUERY_TOKENS = 50
 


### PR DESCRIPTION
File Watcher Reliability Fixes
  
  1. Stop-event not reset on restart (base_file_watcher.py)

  Problem: When the watcher was stopped via close(), the internal _stop_event was set to signalled state. If start() was called again afterward, the old signalled event was still in place, causing the new watch loop to exit
  immediately — the watcher appeared to start but never actually watched anything.

  Fix: Re-initialize _stop_event to a fresh asyncio.Event() at the top of start(), before launching the watch task. This guarantees a clean, unsignalled event for every new lifecycle.

  ---
  2. Null file_store guard (base_file_watcher.py)
  
  Problem: When rebuild_index_on_start was enabled but no file store was configured (e.g. in profile-only or lightweight setups), calling file_store.clear_all() raised an AttributeError on None.

  Fix: Guard the clear_all() call behind if self.file_store is not None. The file scan still runs regardless — only the index-clearing step is skipped when there is no store to clear.

  ---
  3. Force polling for awatch (base_file_watcher.py)
  
  Problem: The watchfiles library relies on OS-native file-system event APIs (FSEvents on macOS, inotify on Linux). These can silently miss changes in certain environments: network-mounted volumes (NFS/SMB), Docker bind-mounts, and
  some virtualized or FUSE-based filesystems where kernel notifications are unreliable or absent entirely.

  Fix: Pass force_polling=True to awatch(). This switches from kernel-event mode to periodic stat-based polling. It trades a small amount of CPU for guaranteed detection regardless of the underlying filesystem driver.

  ---
  ReMeLight Path Corrections
  
  4. Directory naming: tool_result → tool_results (reme_light.py)

  Problem: The directory was named tool_result (singular), inconsistent with the plural convention used elsewhere in the codebase and in documentation references. External tools or scripts expecting tool_results/ would fail to find
  it.

  Fix: Rename to tool_results in both the path construction and the docstring.

  ---
  5. Duplicate watch paths on case-insensitive filesystems (reme_light.py)
  
  Problem: The default watch list included both MEMORY.md and memory.md. On macOS (APFS/HFS+) and Windows (NTFS), these resolve to the same physical file. Passing duplicates to watchfiles caused it to emit duplicate change events for
  a single file edit, triggering double-processing of memory updates.

  Fix: Detect which variant actually exists on disk (preferring MEMORY.md as the canonical name) and include only that single path in the watch list. When neither exists yet, default to MEMORY.md so a single file is created on first
  write.