### PR TITLE
 fix(memory): dream should use cron runner's workspace, not stale instance dir

### DIFF
--- a/src/qwenpaw/agents/memory/base_memory_manager.py
+++ b/src/qwenpaw/agents/memory/base_memory_manager.py
@@ -5,7 +5,8 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from datetime import datetime
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional
 
 from agentscope.message import Msg
 from agentscope.tool import ToolResponse
@@ -115,7 +116,15 @@ class BaseMemoryManager(ABC):
         return None
 
     # pylint: disable=unused-argument
-    async def dream(self, **kwargs) -> None:
+    async def dream(
+        self,
+        *,
+        runner: Any = None,
+        channel_manager: Any = None,
+        agent_id: Optional[str] = None,
+        workspace_dir: Optional[Path] = None,
+        **kwargs,
+    ) -> None:
         """Optimize memory files via a background agent pass.
 
         NOTE: This method is optional. Subclasses may override this method
@@ -124,6 +133,20 @@ class BaseMemoryManager(ABC):
 
         Runs a lightweight ReAct agent with file-editing tools to
         consolidate redundant or outdated memory entries.
+
+        The signature mirrors ``run_heartbeat_once`` so cron callbacks
+        can pass the same set of runner-derived values to either entry.
+
+        Args:
+            runner: Agent runner instance (typically supplied by the cron
+                callback).
+            channel_manager: Optional channel manager for dispatching
+                results (reserved for future use).
+            agent_id: Agent ID for loading config. Subclasses may fall
+                back to ``self.agent_id`` when omitted.
+            workspace_dir: Workspace directory used to locate memory
+                files. Subclasses may fall back to ``self.working_dir``
+                when omitted.
         """
         return None
 

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -651,7 +651,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         dream_toolkit.register_tool_function(read_file)
         dream_toolkit.register_tool_function(write_file)
         dream_toolkit.register_tool_function(edit_file)
-        
+
         set_current_workspace_dir(workspace_path)
         pruning_cfg = light_ctx.tool_result_pruning_config
         recent_max_bytes = pruning_cfg.pruning_recent_msg_max_bytes

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -8,6 +8,7 @@ import shutil
 import uuid
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Optional
 
 from agentscope.agent import ReActAgent
 from agentscope.message import Msg, TextBlock, ToolResultBlock, ToolUseBlock
@@ -591,15 +592,52 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             if recent_messages:
                 self.add_summarize_task(messages=recent_messages)
 
-    async def dream(self, **kwargs) -> None:
-        """Run one dream-based memory optimization pass."""
+    async def dream(
+        self,
+        *,
+        runner: Any = None,
+        channel_manager: Any = None,
+        agent_id: Optional[str] = None,
+        workspace_dir: Optional[Path] = None,
+        **kwargs,
+    ) -> None:
+        """
+        Run one dream-based memory optimization pass.
+
+        Args:
+            runner: Agent runner instance (typically supplied by the cron
+                callback). Reserved here to mirror ``run_heartbeat_once``'s
+                signature.
+            channel_manager: Optional channel manager. Reserved for future
+                use (e.g. dispatching an optimization summary); accepted
+                here to mirror ``run_heartbeat_once``'s signature.
+            agent_id: Agent ID for loading config. Falls back to
+                ``self.agent_id`` when omitted.
+            workspace_dir: Workspace directory used to locate MEMORY.md
+                and write backups. Required — raises ``ValueError`` when
+                omitted (so a misconfigured cron fails loudly instead of
+                writing to the process CWD).
+        """
+        del runner, channel_manager, kwargs  # mirror run_heartbeat_once
         logger.info("running dream-based memory optimization")
 
-        agent_config = load_agent_config(self.agent_id)
-        light_ctx = agent_config.running.light_context_config
-        chat_model, formatter = create_model_and_formatter(self.agent_id)
+        # Use agent_id if provided, otherwise fall back to instance default
+        if not agent_id:
+            agent_id = self.agent_id
 
-        set_current_workspace_dir(Path(self.working_dir))
+        agent_config = load_agent_config(agent_id)
+        light_ctx = agent_config.running.light_context_config
+        chat_model, formatter = create_model_and_formatter(agent_id)
+
+        # Refuse to run when neither is available — running with
+        # an empty path would silently target the process CWD.
+        if not workspace_dir:
+            raise ValueError(
+                "dream requires a workspace_dir",
+            )
+        workspace_path = Path(workspace_dir)
+
+        set_current_workspace_dir(workspace_path)
         pruning_cfg = light_ctx.tool_result_pruning_config
         recent_max_bytes = pruning_cfg.pruning_recent_msg_max_bytes
         set_current_recent_max_bytes(recent_max_bytes)
@@ -615,10 +653,10 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             logger.debug("dream optimization skipped: empty query")
             return
 
-        backup_path = Path(self.working_dir).absolute() / "backup"
+        backup_path = workspace_path.absolute() / "backup"
         backup_path.mkdir(parents=True, exist_ok=True)
 
-        memory_file = Path(self.working_dir) / "MEMORY.md"
+        memory_file = workspace_path / "MEMORY.md"
         if memory_file.exists():
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             backup_filename = f"memory_backup_{timestamp}.md"

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -669,12 +669,27 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         else:
             logger.debug("No existing MEMORY.md file to backup")
 
+        # Build a dedicated toolkit for the dream agent so it stays
+        # isolated from self.summary_toolkit (which the summarize path
+        # shares). Decoupling avoids any future tool change on either
+        # side accidentally affecting the other.
+        from qwenpaw.agents.tools import (  # noqa: PLC0415
+            read_file,
+            write_file,
+            edit_file,
+        )
+
+        dream_toolkit = Toolkit()
+        dream_toolkit.register_tool_function(read_file)
+        dream_toolkit.register_tool_function(write_file)
+        dream_toolkit.register_tool_function(edit_file)
+
         dream_agent = ReActAgent(
             name="DreamOptimizer",
             model=chat_model,
             sys_prompt="You are a Dream Memory Organizer specialized"
             " in optimizing long-term memory files.",
-            toolkit=self.summary_toolkit,
+            toolkit=dream_toolkit,
             formatter=formatter,
         )
         dream_agent.set_console_output_enabled(False)

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -637,6 +637,21 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             )
         workspace_path = Path(workspace_dir)
 
+        # Build a dedicated toolkit for the dream agent so it stays
+        # isolated from self.summary_toolkit (which the summarize path
+        # shares). Decoupling avoids any future tool change on either
+        # side accidentally affecting the other.
+        from qwenpaw.agents.tools import (  # noqa: PLC0415
+            read_file,
+            write_file,
+            edit_file,
+        )
+
+        dream_toolkit = Toolkit()
+        dream_toolkit.register_tool_function(read_file)
+        dream_toolkit.register_tool_function(write_file)
+        dream_toolkit.register_tool_function(edit_file)
+        
         set_current_workspace_dir(workspace_path)
         pruning_cfg = light_ctx.tool_result_pruning_config
         recent_max_bytes = pruning_cfg.pruning_recent_msg_max_bytes
@@ -668,21 +683,6 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 logger.error(f"Failed to create MEMORY.md backup: {e}")
         else:
             logger.debug("No existing MEMORY.md file to backup")
-
-        # Build a dedicated toolkit for the dream agent so it stays
-        # isolated from self.summary_toolkit (which the summarize path
-        # shares). Decoupling avoids any future tool change on either
-        # side accidentally affecting the other.
-        from qwenpaw.agents.tools import (  # noqa: PLC0415
-            read_file,
-            write_file,
-            edit_file,
-        )
-
-        dream_toolkit = Toolkit()
-        dream_toolkit.register_tool_function(read_file)
-        dream_toolkit.register_tool_function(write_file)
-        dream_toolkit.register_tool_function(edit_file)
 
         dream_agent = ReActAgent(
             name="DreamOptimizer",

--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -487,14 +487,22 @@ class CronManager:
     async def _dream_callback(self) -> None:
         """Run one dream-based memory optimization task."""
         try:
-            # Run dream task
-            await self._runner.memory_manager.dream()
-            logger.debug("Dream task executed successfully")
+            # Get workspace_dir from runner if available
+            workspace_dir = None
+            if hasattr(self._runner, "workspace_dir"):
+                workspace_dir = self._runner.workspace_dir
+
+            await self._runner.memory_manager.dream(
+                runner=self._runner,
+                channel_manager=self._channel_manager,
+                agent_id=self._agent_id,
+                workspace_dir=workspace_dir,
+            )
         except asyncio.CancelledError:
-            logger.info("Dream task was cancelled")
+            logger.info("dream cancelled")
             raise
-        except Exception as e:  # pylint: disable=broad-except
-            logger.error(f"Failed to execute dream task: {e}", exc_info=True)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("dream run failed")
 
     # pylint: disable-next=too-many-branches,too-many-statements
     async def _execute_once(


### PR DESCRIPTION
## Description

`memory_manager` is registered as a reusable service (`workspace.py:189`): on workspace reload the previous instance is carried over via `set_reusable_components`, so `self.working_dir` / `self.agent_id` freeze at the values they had when the previous workspace was started. The cron's `self._runner.workspace_dir`, however, always points at the current workspace.

Previously `dream()` resolved every path from `self.working_dir` (`set_current_workspace_dir`, `backup_path`, `MEMORY.md`), so after any workspace reload the dream cron silently wrote backups and rewrote `MEMORY.md` inside the **previous** workspace.

This PR makes `dream()` use the cron's workspace by threading runner-derived values through, mirroring `_heartbeat_callback` / `run_heartbeat_once`:

- `dream()` now takes keyword-only `runner` / `channel_manager` /  `agent_id` / `workspace_dir`. `agent_id` falls back to `self.agent_id`; `workspace_dir` is required and raises `ValueError` when missing (so a misconfigured cron fails loudly instead of writing to the process CWD).
- `_dream_callback` passes `self._runner` / `self._channel_manager` / `self._agent_id` / `self._runner.workspace_dir`, matching the shape of `_heartbeat_callback` exactly.
- `backup_path` and `MEMORY.md` path are now derived from the resolved `workspace_path`, never from `self.working_dir`.
- `BaseMemoryManager.dream` signature widened to declare the same keyword params (all `Optional`, plus `**kwargs`) so the override is LSP-compatible.

**Related Issue:** #4888 #3905 

**Security Considerations:** Empty `workspace_dir` now raises rather than falling through to `Path("")` / process CWD, eliminating the silent cross-workspace write path.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected
- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Checklist
- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start an agent, then trigger a workspace reload (so the `memory_manager` instance is carried over via `set_reusable_components` while `runner.workspace_dir` updates to the new workspace).
2. Let `dream_cron` tick. Confirm the backup file appears under`<NEW workspace>/backup/memory_backup_<ts>.md` and that `MEMORY.md` inside the **previous** workspace is untouched. Pre-fix it was the other way around.
3. Manually invoke `await memory_manager.dream(runner=runner)` with `runner.workspace_dir = None` — expect `ValueError("dream requires a workspace_dir")`, surfaced via `logger.exception("dream run failed")` in `_dream_callback`.

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast.........................................................Passed
# sort simple yaml files...............................(no files to check)Skipped
# check yaml...............................................................Passed
# check xml................................................................Passed
# check toml...............................................................Passed
# check docstring is first.................................................Passed
# check json...............................................................Passed
# fix python encoding pragma...............................................Passed
# detect private key.......................................................Passed
# trim trailing whitespace.................................................Passed
# Add trailing commas......................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed
# prettier.................................................................Passed

pytest tests/unit/agents/memory/ tests/integration/test_cron.py tests/integration/test_cron_header.py
# 76 passed in 13.40s
```

Additional Notes

runner / channel_manager are accepted but currently unused inside
dream() (del runner, channel_manager, kwargs) — reserved so future
enhancements (e.g. dispatching an optimization summary to the last
channel) don't need another signature change.