### PR TITLE
fix(integration): upload size limit + plugin loader timeout resilience

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -314,6 +314,7 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     env["QWENPAW_SECRET_DIR"] = str(secret_dir)
     env["QWENPAW_BACKUP_DIR"] = str(backups_dir)
     env["QWENPAW_AUTH_ENABLED"] = "false"
+    env["QWENPAW_UPLOAD_MAX_SIZE_MB"] = "10"
     env["NO_PROXY"] = "*"
     env["PYTHONUNBUFFERED"] = "1"
     # Force UTF-8 stdio in the subprocess so non-ASCII log lines (e.g.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -370,10 +370,10 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
         )
         log_thread.start()
 
-        # 15s default lets cold-start endpoints (ACP getter, heartbeat)
-        # finish without hiding real deadlocks; 30s in coverage mode
-        # for tracer overhead.
-        http_timeout = 30.0 if _integration_coverage_requested() else 15.0
+        # 30s lets cold-start endpoints (ACP getter, heartbeat) and
+        # agent creation (workspace init) finish on slower runners
+        # (Windows CI ~50% slower) without hiding real deadlocks.
+        http_timeout = 30.0
         client = httpx.Client(timeout=http_timeout, trust_env=False)
 
         try:

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -23,6 +23,7 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
 _PLUGIN_HTTP_TIMEOUT = 30.0
@@ -159,15 +160,19 @@ def _wait_until_plugin_loader_ready(
     last_status = None
     last_detail = ""
     while time.time() < deadline:
-        resp = app_server.api_request(
-            "POST",
-            "/api/plugins/install",
-            json={
-                "source": "/tmp/integ-loader-readiness-probe-not-a-path",
-                "force": False,
-            },
-            timeout=5.0,
-        )
+        try:
+            resp = app_server.api_request(
+                "POST",
+                "/api/plugins/install",
+                json={
+                    "source": "/tmp/integ-loader-readiness-probe-not-a-path",
+                    "force": False,
+                },
+                timeout=5.0,
+            )
+        except httpx.TimeoutException:
+            time.sleep(0.5)
+            continue
         last_status = resp.status_code
         try:
             last_detail = resp.json().get("detail", "")
@@ -199,12 +204,18 @@ def _install_local_official_plugin(
     resp = None
     while True:
         _wait_until_plugin_loader_ready(app_server)
-        resp = app_server.api_request(
-            "POST",
-            "/api/plugins/install",
-            json={"source": str(source_path), "force": False},
-            timeout=_PLUGIN_HTTP_TIMEOUT,
-        )
+        try:
+            resp = app_server.api_request(
+                "POST",
+                "/api/plugins/install",
+                json={"source": str(source_path), "force": False},
+                timeout=_PLUGIN_HTTP_TIMEOUT,
+            )
+        except httpx.TimeoutException:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.5)
+            continue
         if resp.status_code != 503 or time.time() >= deadline:
             break
         time.sleep(0.5)
@@ -240,11 +251,17 @@ def _upload_plugin_zip(
     deadline = time.time() + _LOADER_READY_TIMEOUT
     while True:
         _wait_until_plugin_loader_ready(app_server)
-        resp = app_server.api_request(
-            "POST",
-            "/api/plugins/upload",
-            **kwargs,
-        )
+        try:
+            resp = app_server.api_request(
+                "POST",
+                "/api/plugins/upload",
+                **kwargs,
+            )
+        except httpx.TimeoutException:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.5)
+            continue
         if resp.status_code != 503 or time.time() >= deadline:
             return resp
         time.sleep(0.5)


### PR DESCRIPTION
## Summary

- Set `QWENPAW_UPLOAD_MAX_SIZE_MB=10` in test env — upstream 842d76f1 made the upload limit configurable (default None=unlimited), breaking `test_console_upload_header_rejects_oversized_file` on nightly (all 4 platforms)
- Catch `httpx.TimeoutException` in plugin loader readiness probe and install/upload retry loops — on slower runners (py3.10 + ubuntu) the loader init can exceed the 5s probe timeout, crashing the test instead of retrying

## Test plan

- [x] Fork CI 4-platform matrix all green
- [x] `test_console_upload_header_rejects_oversized_file` passes
- [x] `test_plugins_install_official_cloudpaw_lifecycle` stable
- [x] Pre-commit checks pass