### PR TITLE
fix(skill): increase zip download file size

### DIFF
--- a/src/qwenpaw/agents/skill_system/hub.py
+++ b/src/qwenpaw/agents/skill_system/hub.py
@@ -100,9 +100,9 @@ RETRYABLE_HTTP_STATUS = {
     504,
 }
 
-LOBEHUB_MAX_ZIP_ENTRIES = 256
-LOBEHUB_MAX_ZIP_BYTES = 5 * 1024 * 1024
-HTTP_READ_CHUNK_BYTES = 64 * 1024
+SKILL_PACKAGE_MAX_ENTRIES = 4096
+SKILL_PACKAGE_MAX_BYTES = 200 * 1024 * 1024
+HTTP_READ_CHUNK_BYTES = 256 * 1024
 
 _GITHUB_CACHE_DEFAULT_TTL = 300  # 5 minutes
 _GITHUB_CACHE_MISS = object()
@@ -1236,7 +1236,7 @@ async def _github_collect_tree_files(
     repo: str,
     ref: str,
     root: str,
-    max_files: int = 200,
+    max_files: int = 4096,
 ) -> dict[str, str]:
     files: dict[str, str] = {}
     pending = [root] if root else [""]
@@ -1524,12 +1524,12 @@ def _lobehub_zip_to_bundle(identifier: str, payload: bytes) -> dict[str, Any]:
                 if info.is_dir():
                     continue
                 entry_count += 1
-                if entry_count > LOBEHUB_MAX_ZIP_ENTRIES:
+                if entry_count > SKILL_PACKAGE_MAX_ENTRIES:
                     raise SkillsError(
                         message="LobeHub skill package has too many files",
                     )
                 total_bytes += max(0, info.file_size)
-                if total_bytes > LOBEHUB_MAX_ZIP_BYTES:
+                if total_bytes > SKILL_PACKAGE_MAX_BYTES:
                     raise SkillsError(
                         message="LobeHub skill package is too large to import",
                     )
@@ -1589,7 +1589,7 @@ async def _fetch_bundle_from_lobehub_url(
             _lobehub_download_url(identifier),
             params=params,
             accept="application/zip, application/octet-stream, */*",
-            max_bytes=LOBEHUB_MAX_ZIP_BYTES,
+            max_bytes=SKILL_PACKAGE_MAX_BYTES,
         )
     except httpx.HTTPStatusError as e:
         raise SkillsError(
@@ -1625,12 +1625,12 @@ def _modelscope_archive_to_bundle(
             if info.is_dir():
                 continue
             entry_count += 1
-            if entry_count > LOBEHUB_MAX_ZIP_ENTRIES:
+            if entry_count > SKILL_PACKAGE_MAX_ENTRIES:
                 raise SkillsError(
                     message="ModelScope archive has too many files",
                 )
             total_bytes += max(0, info.file_size)
-            if total_bytes > LOBEHUB_MAX_ZIP_BYTES:
+            if total_bytes > SKILL_PACKAGE_MAX_BYTES:
                 raise SkillsError(
                     message="ModelScope archive is too large to import",
                 )
@@ -1680,7 +1680,7 @@ async def _fetch_bundle_from_modelscope_url(
     try:
         payload = await _http_bytes_get(
             archive_url,
-            max_bytes=LOBEHUB_MAX_ZIP_BYTES,
+            max_bytes=SKILL_PACKAGE_MAX_BYTES,
         )
     except httpx.HTTPStatusError as e:
         raise SkillsError(


### PR DESCRIPTION
## Description

Increase skill pacakge related file size upper bound.

**Related Issue:** Fixes #4928.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic
