### PR TITLE
test(integration): agent-scoped P0 contract coverage (+55 cases)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,8 @@
 # Build QwenPaw multi-arch Docker image and push to DockerHub + Aliyun ACR on release.
 # Pre-release: update <version> and pre only.
 # Formal release: update <version>, pre and latest.
+#
+# Pipeline: verify (build amd64 + health-check) → build-and-push (multi-arch).
 name: Docker Build and Push on Release
 
 on:
@@ -23,7 +25,15 @@ env:
   IMAGE: agentscope/qwenpaw
 
 jobs:
+  # ── Stage 1: Verify Docker image boots correctly ───────────────────────────
+  verify-docker:
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_docker: true
+
+  # ── Stage 2: Build multi-arch and push ─────────────────────────────────────
   build-and-push:
+    needs: [verify-docker]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -30,6 +30,7 @@ jobs:
     uses: ./.github/workflows/release-verify.yml
     with:
       verify_docker: true
+    secrets: inherit
 
   # ── Stage 2: Build multi-arch and push ─────────────────────────────────────
   build-and-push:

--- a/.github/workflows/fork-verify.yml
+++ b/.github/workflows/fork-verify.yml
@@ -1,0 +1,83 @@
+# One-click release verification for fork repositories.
+# Builds the wheel, then runs all verification jobs (pip, Docker, script install).
+#
+# Docker uses public base images (node:20-slim, ghcr.io/astral-sh/uv) instead of
+# the private ACR registry, so forks can validate the full pipeline without credentials.
+#
+# Usage: trigger manually via Actions → Fork Release Verification → Run workflow.
+
+name: Fork Release Verification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Build wheel (same steps as publish-pypi.yml build job) ─────────────────
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up Node (for console build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Build console frontend
+        run: |
+          cd console && npm ci && npm run build
+
+      - name: Copy console build into package
+        run: |
+          rm -rf src/qwenpaw/console/*
+          mkdir -p src/qwenpaw/console
+          cp -R console/dist/* src/qwenpaw/console/
+
+      - name: Bundle docs into package
+        run: |
+          rm -rf src/qwenpaw/docs
+          mkdir -p src/qwenpaw/docs
+          cp website/public/docs/*.md src/qwenpaw/docs/
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload wheel for verification
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-wheel
+          path: dist/*.whl
+          retention-days: 7
+
+      - name: Upload version metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: src/qwenpaw/__version__.py
+          retention-days: 7
+
+  # ── Run all verification jobs ──────────────────────────────────────────────
+  verify:
+    needs: [build]
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_pip: true
+      verify_docker: true
+      verify_script_install: true
+      docker_node_image: "node:20-slim"
+      docker_uv_image: "ghcr.io/astral-sh/uv:latest"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,8 @@
 # Build includes console frontend (see scripts/wheel_build.sh).
 # Manual trigger: can optionally force push to PyPI or just upload artifacts.
 # Release trigger: publishes to PyPI.
+#
+# Pipeline: build → verify (install + boot + health-check) → publish.
 
 name: Publish Python Package to PyPI
 
@@ -20,7 +22,8 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  # ── Stage 1: Build wheel ───────────────────────────────────────────────────
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,16 +64,48 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Upload wheel to artifacts (manual trigger without force push)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi != 'true'
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist/
+          retention-days: 30
+
+      - name: Upload wheel for verification
         uses: actions/upload-artifact@v4
         with:
           name: qwenpaw-wheel
           path: dist/*.whl
           retention-days: 30
 
+      - name: Upload version metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: src/qwenpaw/__version__.py
+          retention-days: 30
+
+  # ── Stage 2: Verify installation ───────────────────────────────────────────
+  verify:
+    needs: [build]
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_pip: true
+      verify_script_install: true
+
+  # ── Stage 3: Publish to PyPI ───────────────────────────────────────────────
+  publish:
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi == 'true')
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist
+
       - name: Publish package to PyPI
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi == 'true')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -174,9 +174,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Docker image (amd64 only)
         run: |
           BUILD_ARGS=""
@@ -186,10 +183,8 @@ jobs:
           if [ -n "${{ inputs.docker_uv_image }}" ]; then
             BUILD_ARGS="$BUILD_ARGS --build-arg UV_IMAGE=${{ inputs.docker_uv_image }}"
           fi
-          docker buildx build \
-            --platform linux/amd64 \
+          docker build \
             -f deploy/Dockerfile \
-            --load \
             -t qwenpaw-verify:test \
             $BUILD_ARGS \
             .
@@ -313,7 +308,8 @@ jobs:
         run: |
           $env:PATH = "$env:USERPROFILE\.qwenpaw\bin;$env:PATH"
           qwenpaw init --defaults --accept-security
-          Start-Process -NoNewWindow -FilePath "qwenpaw" -ArgumentList "app","--host","127.0.0.1","--port","8088"
+          $python = "$env:USERPROFILE\.qwenpaw\venv\Scripts\python.exe"
+          Start-Process -NoNewWindow -FilePath $python -ArgumentList "-m","qwenpaw.cli.main","app","--host","127.0.0.1","--port","8088"
 
       - name: Wait for /api/version
         shell: bash

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,324 @@
+# Reusable verification gate: install the built artefacts, boot the server,
+# and hit /api/version before any publish step runs.
+# Called by publish-pypi.yml, docker-release.yml, and fork-verify.yml.
+
+name: Release Verification
+
+on:
+  workflow_call:
+    inputs:
+      verify_pip:
+        description: "Run pip-install-from-wheel verification"
+        type: boolean
+        default: false
+      verify_docker:
+        description: "Run Docker build + health-check verification"
+        type: boolean
+        default: false
+      verify_script_install:
+        description: "Run install-script (install.sh / install.ps1) verification"
+        type: boolean
+        default: false
+      docker_node_image:
+        description: "Override Dockerfile NODE_IMAGE build-arg (for fork without ACR access)"
+        type: string
+        default: ""
+      docker_uv_image:
+        description: "Override Dockerfile UV_IMAGE build-arg (for fork without ACR access)"
+        type: string
+        default: ""
+
+jobs:
+  # ── pip install wheel ──────────────────────────────────────────────────────
+  verify-pip:
+    if: inputs.verify_pip
+    name: Verify pip install - py${{ matrix.python-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
+
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-wheel
+          path: dist
+
+      - name: Download version file
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: version-meta
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install wheel in clean venv
+        shell: bash
+        run: |
+          python -m venv .verify-venv
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            source .verify-venv/Scripts/activate
+          else
+            source .verify-venv/bin/activate
+          fi
+          pip install --upgrade pip
+          pip install dist/*.whl
+
+      - name: Read expected version
+        id: expected
+        shell: bash
+        run: |
+          ver=$(python -c "
+          import re, pathlib
+          text = pathlib.Path('version-meta/__version__.py').read_text()
+          print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', text).group(1))
+          ")
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Verify CLI version
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            source .verify-venv/Scripts/activate
+          else
+            source .verify-venv/bin/activate
+          fi
+          actual=$(qwenpaw --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.]*' | head -1)
+          expected="${{ steps.expected.outputs.version }}"
+          echo "Expected: $expected"
+          echo "Actual:   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Version mismatch: expected=$expected actual=$actual"
+            exit 1
+          fi
+
+      - name: Verify Python import
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            source .verify-venv/Scripts/activate
+          else
+            source .verify-venv/bin/activate
+          fi
+          python -c "from qwenpaw.cli.main import cli; print('import OK')"
+
+      - name: Initialize and start server
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            source .verify-venv/Scripts/activate
+          else
+            source .verify-venv/bin/activate
+          fi
+          qwenpaw init --defaults --accept-security
+          qwenpaw app --host 127.0.0.1 --port 8088 &
+          echo $! > /tmp/qwenpaw.pid || true
+
+      - name: Wait for /api/version
+        shell: bash
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8088/api/version; then
+              echo ""
+              echo "Server is up after ~$((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Server did not respond within 120s"
+          exit 1
+
+      - name: Verify server version
+        shell: bash
+        run: |
+          response=$(curl -sf http://127.0.0.1:8088/api/version)
+          server_ver=$(echo "$response" | python -c "import sys,json; print(json.load(sys.stdin)['version'])")
+          expected="${{ steps.expected.outputs.version }}"
+          echo "Server version: $server_ver"
+          if [ "$server_ver" != "$expected" ]; then
+            echo "::error::Server version mismatch: expected=$expected server=$server_ver"
+            exit 1
+          fi
+
+      - name: Stop server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/qwenpaw.pid ]; then
+            kill "$(cat /tmp/qwenpaw.pid)" 2>/dev/null || true
+          fi
+          # Also kill by port in case PID file was not written
+          if [ "$RUNNER_OS" = "Linux" ] || [ "$RUNNER_OS" = "macOS" ]; then
+            lsof -ti:8088 | xargs kill 2>/dev/null || true
+          fi
+
+  # ── Docker build + health check ────────────────────────────────────────────
+  verify-docker:
+    if: inputs.verify_docker
+    name: Verify Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (amd64 only)
+        run: |
+          BUILD_ARGS=""
+          if [ -n "${{ inputs.docker_node_image }}" ]; then
+            BUILD_ARGS="$BUILD_ARGS --build-arg NODE_IMAGE=${{ inputs.docker_node_image }}"
+          fi
+          if [ -n "${{ inputs.docker_uv_image }}" ]; then
+            BUILD_ARGS="$BUILD_ARGS --build-arg UV_IMAGE=${{ inputs.docker_uv_image }}"
+          fi
+          docker buildx build \
+            --platform linux/amd64 \
+            -f deploy/Dockerfile \
+            --load \
+            -t qwenpaw-verify:test \
+            $BUILD_ARGS \
+            .
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name qwenpaw-test \
+            -p 8088:8088 \
+            qwenpaw-verify:test
+
+      - name: Wait for /api/version
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf http://127.0.0.1:8088/api/version; then
+              echo ""
+              echo "Container is up after ~$((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Container did not respond within 180s"
+          docker logs qwenpaw-test
+          exit 1
+
+      - name: Verify container version
+        run: |
+          response=$(curl -sf http://127.0.0.1:8088/api/version)
+          echo "Response: $response"
+          version=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
+          echo "Docker container version: $version"
+          if [ -z "$version" ]; then
+            echo "::error::Empty version in /api/version response"
+            exit 1
+          fi
+
+      - name: Show container logs
+        if: always()
+        run: docker logs qwenpaw-test 2>&1 | tail -50
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f qwenpaw-test 2>/dev/null || true
+
+  # ── Script install (install.sh / install.ps1) ──────────────────────────────
+  verify-script-install:
+    if: inputs.verify_script_install
+    name: Verify script install - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js (for console build during from-source install)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Build console frontend
+        shell: bash
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+        run: |
+          cd console && npm ci && npm run build
+
+      - name: Copy console build into package
+        shell: bash
+        run: |
+          rm -rf src/qwenpaw/console/*
+          mkdir -p src/qwenpaw/console
+          cp -R console/dist/* src/qwenpaw/console/
+
+      - name: Run install script (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          bash scripts/install.sh --from-source "$(pwd)"
+
+      - name: Run install script (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          .\scripts\install.ps1 -FromSource -SourceDir "$PWD"
+
+      - name: Verify CLI available
+        shell: bash
+        run: |
+          export PATH="$HOME/.qwenpaw/bin:$PATH"
+          qwenpaw --version
+
+      - name: Initialize and start server
+        shell: bash
+        run: |
+          export PATH="$HOME/.qwenpaw/bin:$PATH"
+          qwenpaw init --defaults --accept-security
+          qwenpaw app --host 127.0.0.1 --port 8088 &
+          echo $! > /tmp/qwenpaw.pid || true
+
+      - name: Wait for /api/version
+        shell: bash
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8088/api/version; then
+              echo ""
+              echo "Server is up after ~$((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Server did not respond within 120s"
+          exit 1
+
+      - name: Stop server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/qwenpaw.pid ]; then
+            kill "$(cat /tmp/qwenpaw.pid)" 2>/dev/null || true
+          fi
+          if [ "$RUNNER_OS" = "Linux" ] || [ "$RUNNER_OS" = "macOS" ]; then
+            lsof -ti:8088 | xargs kill 2>/dev/null || true
+          fi

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -296,7 +296,10 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
+            # install.ps1 creates qwenpaw.cmd / qwenpaw.ps1 — bash needs .cmd
             export PATH="$USERPROFILE/.qwenpaw/bin:$PATH"
+            shopt -s expand_aliases
+            alias qwenpaw='qwenpaw.cmd'
           else
             export PATH="$HOME/.qwenpaw/bin:$PATH"
           fi

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -296,16 +296,15 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
-            # install.ps1 creates qwenpaw.cmd / qwenpaw.ps1 — bash needs .cmd
-            export PATH="$USERPROFILE/.qwenpaw/bin:$PATH"
-            shopt -s expand_aliases
-            alias qwenpaw='qwenpaw.cmd'
+            # install.ps1 creates qwenpaw.cmd; call via venv python directly
+            QWENPAW="$USERPROFILE/.qwenpaw/venv/Scripts/python.exe -m qwenpaw.cli.main"
           else
             export PATH="$HOME/.qwenpaw/bin:$PATH"
+            QWENPAW="qwenpaw"
           fi
-          qwenpaw --version
-          qwenpaw init --defaults --accept-security
-          qwenpaw app --host 127.0.0.1 --port 8088 &
+          $QWENPAW --version
+          $QWENPAW init --defaults --accept-security
+          $QWENPAW app --host 127.0.0.1 --port 8088 &
           echo $! > /tmp/qwenpaw.pid || true
           for i in $(seq 1 60); do
             if curl -sf http://127.0.0.1:8088/api/version; then

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -171,8 +171,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    env:
+      ACR_REGISTRY: agentscope-registry.ap-southeast-1.cr.aliyuncs.com
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Log in to Aliyun ACR (when credentials available)
+        if: env.ACR_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACR_REGISTRY }}
+          username: ${{ secrets.ALIYUN_ACR_USERNAME }}
+          password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
+        env:
+          ACR_USERNAME: ${{ secrets.ALIYUN_ACR_USERNAME }}
 
       - name: Build Docker image (amd64 only)
         run: |

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -292,41 +292,18 @@ jobs:
         run: |
           .\scripts\install.ps1 -FromSource -SourceDir "$PWD"
 
-      - name: Verify CLI available (Linux/macOS)
-        if: runner.os != 'Windows'
+      - name: Verify CLI, init, start server, and health check
         shell: bash
         run: |
-          export PATH="$HOME/.qwenpaw/bin:$PATH"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            export PATH="$USERPROFILE/.qwenpaw/bin:$PATH"
+          else
+            export PATH="$HOME/.qwenpaw/bin:$PATH"
+          fi
           qwenpaw --version
-
-      - name: Verify CLI available (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:PATH = "$env:USERPROFILE\.qwenpaw\bin;$env:PATH"
-          qwenpaw --version
-
-      - name: Initialize and start server (Linux/macOS)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          export PATH="$HOME/.qwenpaw/bin:$PATH"
           qwenpaw init --defaults --accept-security
           qwenpaw app --host 127.0.0.1 --port 8088 &
-          echo $! > /tmp/qwenpaw.pid
-
-      - name: Initialize and start server (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:PATH = "$env:USERPROFILE\.qwenpaw\bin;$env:PATH"
-          qwenpaw init --defaults --accept-security
-          $python = "$env:USERPROFILE\.qwenpaw\venv\Scripts\python.exe"
-          Start-Process -NoNewWindow -FilePath $python -ArgumentList "-m","qwenpaw.cli.main","app","--host","127.0.0.1","--port","8088"
-
-      - name: Wait for /api/version
-        shell: bash
-        run: |
+          echo $! > /tmp/qwenpaw.pid || true
           for i in $(seq 1 60); do
             if curl -sf http://127.0.0.1:8088/api/version; then
               echo ""

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -73,7 +73,7 @@ jobs:
           else
             source .verify-venv/bin/activate
           fi
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           pip install dist/*.whl
 
       - name: Read expected version
@@ -284,19 +284,36 @@ jobs:
         run: |
           .\scripts\install.ps1 -FromSource -SourceDir "$PWD"
 
-      - name: Verify CLI available
+      - name: Verify CLI available (Linux/macOS)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           export PATH="$HOME/.qwenpaw/bin:$PATH"
           qwenpaw --version
 
-      - name: Initialize and start server
+      - name: Verify CLI available (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:PATH = "$env:USERPROFILE\.qwenpaw\bin;$env:PATH"
+          qwenpaw --version
+
+      - name: Initialize and start server (Linux/macOS)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           export PATH="$HOME/.qwenpaw/bin:$PATH"
           qwenpaw init --defaults --accept-security
           qwenpaw app --host 127.0.0.1 --port 8088 &
-          echo $! > /tmp/qwenpaw.pid || true
+          echo $! > /tmp/qwenpaw.pid
+
+      - name: Initialize and start server (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $env:PATH = "$env:USERPROFILE\.qwenpaw\bin;$env:PATH"
+          qwenpaw init --defaults --accept-security
+          Start-Process -NoNewWindow -FilePath "qwenpaw" -ArgumentList "app","--host","127.0.0.1","--port","8088"
 
       - name: Wait for /api/version
         shell: bash
@@ -321,4 +338,7 @@ jobs:
           fi
           if [ "$RUNNER_OS" = "Linux" ] || [ "$RUNNER_OS" = "macOS" ]; then
             lsof -ti:8088 | xargs kill 2>/dev/null || true
+          fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            taskkill //F //IM python.exe 2>/dev/null || true
           fi

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -296,15 +296,13 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
-            # install.ps1 creates qwenpaw.cmd; call via venv python directly
-            QWENPAW="$USERPROFILE/.qwenpaw/venv/Scripts/python.exe -m qwenpaw.cli.main"
+            source "$USERPROFILE/.qwenpaw/venv/Scripts/activate"
           else
             export PATH="$HOME/.qwenpaw/bin:$PATH"
-            QWENPAW="qwenpaw"
           fi
-          $QWENPAW --version
-          $QWENPAW init --defaults --accept-security
-          $QWENPAW app --host 127.0.0.1 --port 8088 &
+          qwenpaw --version
+          qwenpaw init --defaults --accept-security
+          qwenpaw app --host 127.0.0.1 --port 8088 &
           echo $! > /tmp/qwenpaw.pid || true
           for i in $(seq 1 60); do
             if curl -sf http://127.0.0.1:8088/api/version; then

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -19,6 +19,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@types/react-window": "^1.8.8",
         "@vvo/tzdb": "^6.198.0",
         "ahooks": "^3.9.6",
@@ -5928,6 +5929,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/console/package.json
+++ b/console/package.json
@@ -31,6 +31,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@types/react-window": "^1.8.8",
     "@vvo/tzdb": "^6.198.0",
     "ahooks": "^3.9.6",

--- a/console/src-tauri/Cargo.lock
+++ b/console/src-tauri/Cargo.lock
@@ -2142,6 +2142,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2556,13 +2557,17 @@ dependencies = [
 name = "qwenpaw-desktop"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "log",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]
@@ -2699,6 +2704,41 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2727,8 +2767,32 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2797,6 +2861,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2992,6 +3062,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3398,7 +3480,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3495,6 +3577,48 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4269,6 +4393,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -19,6 +19,10 @@ tauri-build = { version = "2.5.6", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 tauri = { version = "2.10.3", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-dialog = "2"
+tokio = { version = "1", features = ["fs", "io-util"] }

--- a/console/src-tauri/capabilities/default.json
+++ b/console/src-tauri/capabilities/default.json
@@ -3,5 +3,14 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "remote": {
+    "urls": ["http://127.0.0.1:*"]
+  },
+  "permissions": [
+    "backend",
+    "backend-download",
+    "core:default",
+    "dialog:allow-save",
+    "open-external-link"
+  ]
 }

--- a/console/src-tauri/nsis/stop-backend-sidecar.ps1
+++ b/console/src-tauri/nsis/stop-backend-sidecar.ps1
@@ -11,25 +11,29 @@ try {
   exit 0
 }
 
-$targets = Get-CimInstance Win32_Process -Filter "Name = 'qwenpaw-backend.exe'" |
-  Where-Object {
-    if (-not $_.ExecutablePath) {
-      return $false
+$processNames = @("qwenpaw-backend.exe", "qwenpaw.exe")
+
+$targets = foreach ($processName in $processNames) {
+  Get-CimInstance Win32_Process -Filter "Name = '$processName'" |
+    Where-Object {
+      if (-not $_.ExecutablePath) {
+        return $false
+      }
+
+      try {
+        $processPath = [System.IO.Path]::GetFullPath($_.ExecutablePath)
+      } catch {
+        return $false
+      }
+
+      return $processPath.StartsWith(
+        $installRoot,
+        [System.StringComparison]::OrdinalIgnoreCase
+      )
     }
+}
 
-    try {
-      $processPath = [System.IO.Path]::GetFullPath($_.ExecutablePath)
-    } catch {
-      return $false
-    }
-
-    return $processPath.StartsWith(
-      $installRoot,
-      [System.StringComparison]::OrdinalIgnoreCase
-    )
-  }
-
-$processIds = @($targets | ForEach-Object { $_.ProcessId })
+$processIds = @($targets | ForEach-Object { $_.ProcessId } | Sort-Object -Unique)
 
 foreach ($processId in $processIds) {
   Stop-Process -Id $processId -Force

--- a/console/src-tauri/permissions/backend-download.toml
+++ b/console/src-tauri/permissions/backend-download.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "backend-download"
+description = "Allows the frontend to save files streamed from the local backend."
+commands.allow = ["download_backend_file"]

--- a/console/src-tauri/permissions/backend.toml
+++ b/console/src-tauri/permissions/backend.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "backend"
+description = "Allows the bootstrap page to monitor and restart the bundled backend sidecar."
+commands.allow = ["backend_port", "backend_startup_error", "restart_backend"]

--- a/console/src-tauri/permissions/open-external-link.toml
+++ b/console/src-tauri/permissions/open-external-link.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "open-external-link"
+description = "Allows the frontend to open supported external links in the system browser."
+commands.allow = ["open_external_link"]

--- a/console/src-tauri/src/backend.rs
+++ b/console/src-tauri/src/backend.rs
@@ -129,7 +129,12 @@ pub(crate) fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Erro
     app.handle().plugin(
         tauri_plugin_log::Builder::default()
             .clear_targets()
-            .targets([Target::new(TargetKind::Stdout)])
+            .targets([
+                Target::new(TargetKind::Stdout),
+                Target::new(TargetKind::LogDir {
+                    file_name: Some("qwenpaw-desktop".into()),
+                }),
+            ])
             .level(log::LevelFilter::Info)
             .build(),
     )?;

--- a/console/src-tauri/src/backend_download.rs
+++ b/console/src-tauri/src/backend_download.rs
@@ -1,0 +1,141 @@
+//! Native downloads for files served by the bundled local backend.
+
+use std::{collections::HashMap, net::IpAddr, path::PathBuf, time::Duration};
+
+use futures_util::TryStreamExt;
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Url,
+};
+use serde::Deserialize;
+use tokio::{
+    fs::File,
+    io::{AsyncWriteExt, BufWriter},
+};
+
+const BACKEND_DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const BACKEND_DOWNLOAD_TOTAL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DownloadBackendFileRequest {
+    url: String,
+    file_path: String,
+    headers: Option<HashMap<String, String>>,
+}
+
+/// Stream a local backend response to the user-selected file path without using system proxies.
+#[tauri::command]
+pub(crate) async fn download_backend_file(
+    request: DownloadBackendFileRequest,
+) -> Result<(), String> {
+    let url = parse_local_backend_url(&request.url)?;
+    let file_path = parse_file_path(&request.file_path)?;
+    let headers = parse_headers(request.headers.unwrap_or_default())?;
+
+    let response = reqwest::Client::builder()
+        .no_proxy()
+        .connect_timeout(BACKEND_DOWNLOAD_CONNECT_TIMEOUT)
+        .timeout(BACKEND_DOWNLOAD_TOTAL_TIMEOUT)
+        .build()
+        .map_err(|err| format!("failed to create download client: {err}"))?
+        .get(url)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|err| format!("download request failed: {err}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "download request failed with status code {}",
+            response.status()
+        ));
+    }
+
+    let mut file = BufWriter::new(
+        File::create(&file_path)
+            .await
+            .map_err(|err| format!("failed to create file: {err}"))?,
+    );
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream
+        .try_next()
+        .await
+        .map_err(|err| format!("failed to read response stream: {err}"))?
+    {
+        file.write_all(&chunk)
+            .await
+            .map_err(|err| format!("failed to write file: {err}"))?;
+    }
+
+    file.flush()
+        .await
+        .map_err(|err| format!("failed to flush file: {err}"))
+}
+
+fn parse_local_backend_url(url: &str) -> Result<Url, String> {
+    let parsed = Url::parse(url).map_err(|err| format!("invalid download URL: {err}"))?;
+    if parsed.scheme() != "http" {
+        return Err("download URL protocol is not supported".into());
+    }
+    if !is_loopback_host(&parsed) {
+        return Err("download URL must target the local backend".into());
+    }
+    Ok(parsed)
+}
+
+fn is_loopback_host(url: &Url) -> bool {
+    match url.host_str() {
+        Some(host) if host.eq_ignore_ascii_case("localhost") => true,
+        Some(host) => host
+            .trim_matches(['[', ']'])
+            .parse::<IpAddr>()
+            .map(|ip| ip.is_loopback())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+fn parse_file_path(file_path: &str) -> Result<PathBuf, String> {
+    if file_path.trim().is_empty() {
+        return Err("download file path is empty".into());
+    }
+    Ok(PathBuf::from(file_path))
+}
+
+fn parse_headers(headers: HashMap<String, String>) -> Result<HeaderMap, String> {
+    let mut header_map = HeaderMap::new();
+    for (name, value) in headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|err| format!("invalid download header name: {err}"))?;
+        let header_value = HeaderValue::from_str(&value)
+            .map_err(|err| format!("invalid download header value: {err}"))?;
+        header_map.insert(header_name, header_value);
+    }
+    Ok(header_map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_local_backend_url;
+
+    #[test]
+    fn accepts_loopback_backend_urls() {
+        assert!(parse_local_backend_url("http://127.0.0.1:54377/api/backups/id/export").is_ok());
+        assert!(parse_local_backend_url("http://localhost:54377/api/workspace/download").is_ok());
+        assert!(parse_local_backend_url("http://[::1]:54377/api/workspace/download").is_ok());
+    }
+
+    #[test]
+    fn rejects_remote_download_urls() {
+        assert!(parse_local_backend_url("https://example.com/file.zip").is_err());
+        assert!(parse_local_backend_url("http://192.168.1.20/file.zip").is_err());
+    }
+
+    #[test]
+    fn rejects_non_http_download_urls() {
+        assert!(parse_local_backend_url("file:///C:/tmp/backup.zip").is_err());
+        assert!(parse_local_backend_url("mailto:support@example.com").is_err());
+    }
+}

--- a/console/src-tauri/src/external_link.rs
+++ b/console/src-tauri/src/external_link.rs
@@ -1,0 +1,50 @@
+//! Tauri command for opening vetted external URLs in the system browser.
+
+use tauri_plugin_shell::ShellExt;
+
+// Keep in sync with console/src/utils/openExternalLink.ts.
+const SUPPORTED_EXTERNAL_PREFIXES: [&str; 4] = ["http://", "https://", "mailto:", "tel:"];
+
+/// Validate and open an external URL through the OS shell.
+#[tauri::command]
+pub(crate) fn open_external_link(app: tauri::AppHandle, url: String) -> Result<(), String> {
+    if let Err(err) = validate_external_url(&url) {
+        log::warn!("[external-link] command rejected: {err}");
+        return Err(err);
+    }
+
+    #[allow(deprecated)]
+    let open_result = app.shell().open(url.clone(), None);
+
+    match open_result {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            log::warn!("[external-link] open failed: {err}");
+            Err(err.to_string())
+        }
+    }
+}
+
+/// Reject empty, ambiguous, or unsupported URL inputs before calling shell.open.
+fn validate_external_url(url: &str) -> Result<(), String> {
+    let trimmed_url = url.trim();
+    if trimmed_url.is_empty() {
+        return Err("external link is empty".into());
+    }
+    if trimmed_url != url {
+        return Err("external link has leading or trailing whitespace".into());
+    }
+    if trimmed_url.chars().any(char::is_control) {
+        return Err("external link contains control characters".into());
+    }
+
+    let lowercase_url = trimmed_url.to_ascii_lowercase();
+    if SUPPORTED_EXTERNAL_PREFIXES
+        .iter()
+        .any(|prefix| lowercase_url.starts_with(prefix))
+    {
+        return Ok(());
+    }
+
+    Err("external link protocol is not supported".into())
+}

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -1,15 +1,23 @@
+//! Tauri desktop entry point and plugin/command registration.
+
 mod backend;
+mod backend_download;
+mod external_link;
 
 use tauri::{Manager, RunEvent, WindowEvent};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+/// Build the desktop app, wire native plugins/commands, and stop the backend on exit.
 pub fn run() {
     let build_result = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
+            backend_download::download_backend_file,
             backend::backend_port,
             backend::backend_startup_error,
             backend::restart_backend,
+            external_link::open_external_link,
         ])
         .manage(backend::BackendState::default())
         .setup(backend::setup)

--- a/console/src/api/modules/backup.ts
+++ b/console/src/api/modules/backup.ts
@@ -1,6 +1,10 @@
 import { request } from "../request";
 import { getApiUrl } from "../config";
 import { buildAuthHeaders } from "../authHeaders";
+import {
+  DownloadCancelledError,
+  downloadFileFromUrl,
+} from "../../utils/downloadFileFromUrl";
 import type {
   BackupMeta,
   BackupTrustMode,
@@ -74,29 +78,17 @@ export const backupApi = {
   exportBackup: async (id: string, name: string) => {
     const url = getApiUrl(`/backups/${id}/export`);
 
-    // In pywebview desktop, <a>.click() downloads are silently ignored.
-    // Use the native save dialog exposed via the pywebview bridge instead.
-    const pywebview = (window as any).pywebview;
-    if (pywebview?.api?.save_file) {
-      // save_file needs a full URL; construct one from location + api path.
-      const fullUrl = url.startsWith("http")
-        ? url
-        : `${window.location.origin}${url}`;
-      const saved = await pywebview.api.save_file(fullUrl, `${name}.zip`);
-      // False means the user cancelled the OS save dialog — not an error.
-      if (!saved) return;
-      return;
+    try {
+      await downloadFileFromUrl(url, `${name}.zip`, {
+        headers: buildAuthHeaders(),
+        errorMessage: "Export failed",
+      });
+    } catch (error) {
+      if (error instanceof DownloadCancelledError) {
+        return;
+      }
+      throw error;
     }
-
-    // Fallback for regular browsers: trigger download via invisible <a>
-    const res = await fetch(url, { headers: buildAuthHeaders() });
-    if (!res.ok) throw new Error("Export failed");
-    const blob = await res.blob();
-    const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = `${name}.zip`;
-    a.click();
-    URL.revokeObjectURL(a.href);
   },
 
   importBackup: async (

--- a/console/src/api/modules/codingProject.ts
+++ b/console/src/api/modules/codingProject.ts
@@ -21,6 +21,7 @@ export interface BrowseDirsResponse {
   current: string;
   parent: string | null;
   dirs: Array<{ name: string; path: string }>;
+  selectable?: boolean;
 }
 
 export const codingProjectApi = {

--- a/console/src/api/modules/workspace.ts
+++ b/console/src/api/modules/workspace.ts
@@ -2,6 +2,7 @@ import { request } from "../request";
 import { getApiUrl } from "../config";
 import { buildAuthHeaders } from "../authHeaders";
 import { useCodeFileCacheStore } from "../../stores/codeFileCacheStore";
+import { downloadFileFromUrl } from "../../utils/downloadFileFromUrl";
 import type { MdFileInfo, MdFileContent, DailyMemoryFile } from "../types";
 
 function getSelectedAgentId(): string {
@@ -35,11 +36,6 @@ function generateFallbackFilename(): string {
   return `qwenpaw_workspace_${agentId}_${timestamp}.zip`;
 }
 
-export interface WorkspaceDownloadResult {
-  blob: Blob;
-  filename: string;
-}
-
 export const workspaceApi = {
   listFiles: () =>
     request<MdFileInfo[]>("/workspace/files").then((files) =>
@@ -62,37 +58,16 @@ export const workspaceApi = {
     ),
 
   // Workspace package download
-  downloadWorkspace: async (): Promise<WorkspaceDownloadResult> => {
-    const response = await fetch(getApiUrl("/workspace/download"), {
-      method: "GET",
-      headers: buildAuthHeaders(),
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `Workspace download failed: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const blob = await response.blob();
-
-    // Extract filename from Content-Disposition header
-    const disposition = response.headers.get("Content-Disposition");
-    let filename: string;
-
-    if (disposition) {
-      const filenameMatch = disposition.match(/filename="(.+?)"/);
-      if (filenameMatch && filenameMatch[1]) {
-        filename = filenameMatch[1];
-      } else {
-        filename = generateFallbackFilename();
-      }
-    } else {
-      filename = generateFallbackFilename();
-    }
-
-    return { blob, filename };
-  },
+  downloadWorkspace: () =>
+    downloadFileFromUrl(
+      getApiUrl("/workspace/download"),
+      generateFallbackFilename(),
+      {
+        headers: buildAuthHeaders(),
+        errorMessage: "Workspace download failed",
+        preferResponseFilename: true,
+      },
+    ),
 
   // File upload functionality
   uploadFile: async (

--- a/console/src/components/ProjectSelectModal/index.tsx
+++ b/console/src/components/ProjectSelectModal/index.tsx
@@ -605,7 +605,7 @@ function OpenDirTab({ onSelect }: { onSelect: (path: string) => void }) {
       </div>
 
       {/* Confirm button */}
-      {data && !loading && (
+      {data && !loading && data.selectable !== false && (
         <Button
           type="primary"
           onClick={() => onSelect(data.current)}

--- a/console/src/i18n.ts
+++ b/console/src/i18n.ts
@@ -29,8 +29,10 @@ const resources = {
 
 i18n.use(initReactI18next).init({
   resources,
-  lng: localStorage.getItem("language") || "en",
+  lng: localStorage.getItem("language") || navigator.language || "en",
   fallbackLng: "en",
+  supportedLngs: Object.keys(resources),
+  nonExplicitSupportedLngs: true,
   interpolation: {
     escapeValue: false,
   },

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { Button, Modal } from "@agentscope-ai/design";
 import styles from "./index.module.less";
 import api from "../api";
+import { openExternalLink } from "../utils/openExternalLink";
 import {
   GITHUB_URL,
   getDocsUrl,
@@ -152,14 +153,7 @@ export default function Header() {
   };
 
   const handleNavClick = (url: string) => {
-    if (url) {
-      const pywebview = (window as any).pywebview;
-      if (pywebview?.api) {
-        pywebview.api.open_external_link(url);
-      } else {
-        window.open(url, "_blank");
-      }
-    }
+    openExternalLink(url);
   };
 
   return (

--- a/console/src/pages/Agent/Workspace/index.tsx
+++ b/console/src/pages/Agent/Workspace/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/PageHeader";
 import { useAppMessage } from "../../../hooks/useAppMessage";
 import { useUploadLimitStore } from "../../../stores/uploadLimitStore";
+import { DownloadCancelledError } from "../../../utils/downloadFileFromUrl";
 
 export default function WorkspacePage() {
   const { t } = useTranslation();
@@ -44,20 +45,16 @@ export default function WorkspacePage() {
       duration: 0,
     });
     try {
-      const { blob, filename } = await workspaceApi.downloadWorkspace();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
+      await workspaceApi.downloadWorkspace();
       message.success({
         content: t("workspace.downloadSuccess"),
         key: "workspace-download",
       });
     } catch (error) {
+      if (error instanceof DownloadCancelledError) {
+        message.destroy("workspace-download");
+        return;
+      }
       console.error("Download failed:", error);
       message.error({
         content:

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -101,17 +101,6 @@
   }
 }
 
-/* Background loading indicator — visible through unrendered gaps during fast scroll */
-.virtualListBackground {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 0;
-  pointer-events: none;
-}
-
 /* Top fade gradient overlay */
 .topGradient {
   position: absolute;

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -575,13 +575,6 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           </div>
         ) : (
           <>
-            {/* Background loading — only show when content overflows the container,
-                so it's visible through unrendered gaps during fast scroll */}
-            {sortedSessions.length * ITEM_HEIGHT > listHeight && (
-              <div className={styles.virtualListBackground}>
-                <Spin size="small" />
-              </div>
-            )}
             <FixedSizeList
               height={listHeight}
               width="100%"

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -287,14 +287,13 @@ const chatSpecToSession = (chat: ChatSpec): ExtendedSession =>
 /** Returns true when id is a pure numeric local timestamp (not a backend UUID). */
 const isLocalTimestamp = (id: string): boolean => /^\d+$/.test(id);
 
-/** Detect if backend is still generating content for this chat. */
+/** Detect if backend is still generating content for this chat.
+ *  Only trust the explicit `status` field from the backend.
+ *  When status is missing (undefined) treat the chat as idle to avoid
+ *  false-positive reconnects that cause infinite loading (issue #4903).
+ */
 const isGenerating = (chatHistory: ChatHistory): boolean => {
-  if (chatHistory.status === "running") return true;
-  if (chatHistory.status === "idle") return false;
-  const msgs = chatHistory.messages || [];
-  if (msgs.length === 0) return false;
-  const last = msgs[msgs.length - 1];
-  return last.role === ROLE_USER;
+  return chatHistory.status === "running";
 };
 
 /**
@@ -643,7 +642,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         next.id = existing.id;
         next.realId = existing.realId;
       }
-      if (existing.generating !== undefined) {
+      // Only carry over generating=true from the old session when the
+      // backend hasn't explicitly reported the chat as idle.  Previously
+      // the flag was inherited unconditionally, so once set it could never
+      // be cleared — causing a permanent spinner in the session list
+      // (issue #4903).
+      if (existing.generating && sExt.status !== "idle") {
         next.generating = existing.generating;
       }
       return next as IAgentScopeRuntimeWebUISession;

--- a/console/src/pages/Settings/Models/components/providerIcon.ts
+++ b/console/src/pages/Settings/Models/components/providerIcon.ts
@@ -45,6 +45,8 @@ export const providerIcon = (provider: string) => {
     case "volcengine-cn":
     case "volcengine-cn-codingplan":
       return "https://img.alicdn.com/imgextra/i1/O1CN01KusRg42AJPkUV5ken_!!6000000008182-2-tps-1892-1660.png";
+    case "mimo-tokenplan":
+      return "https://img.alicdn.com/imgextra/i1/O1CN01TSCOAt1XP7fywLDei_!!6000000002915-2-tps-3483-3483.png";
     default:
       return "https://gw.alicdn.com/imgextra/i4/O1CN01IWnlOw1lebfpiFrIL_!!6000000004844-0-tps-100-100.jpg";
   }

--- a/console/src/utils/downloadFileFromUrl.ts
+++ b/console/src/utils/downloadFileFromUrl.ts
@@ -1,0 +1,197 @@
+/**
+ * Cross-runtime file download helper for browser, legacy pywebview, and Tauri.
+ * Tauri streams local backend downloads in Rust to avoid proxying localhost.
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
+import {
+  isDesktopTauriRuntime,
+  isHttpExternalUrl,
+  resolveExternalUrl,
+} from "./openExternalLink";
+import { getPyWebViewApi, type PyWebViewSaveFile } from "./pywebview";
+
+export interface DownloadFileOptions {
+  headers?: Record<string, string>;
+  errorMessage?: string;
+  /**
+   * Prefer Content-Disposition filenames when the browser path fetches the file.
+   * Native desktop paths use the fallback filename shown in the save dialog.
+   */
+  preferResponseFilename?: boolean;
+}
+
+interface DownloadBackendFileRequest {
+  url: string;
+  filePath: string;
+  headers?: Record<string, string>;
+}
+
+export class DownloadCancelledError extends Error {
+  constructor() {
+    super("Download cancelled");
+    this.name = "DownloadCancelledError";
+  }
+}
+
+/** Extract a suggested filename from the server's Content-Disposition header. */
+function filenameFromContentDisposition(value: string | null): string {
+  if (!value) return "";
+
+  const utf8Match = value.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {
+      return utf8Match[1];
+    }
+  }
+
+  const quotedMatch = value.match(/filename="([^"]+)"/i);
+  if (quotedMatch?.[1]) {
+    return quotedMatch[1];
+  }
+
+  const bareMatch = value.match(/filename=([^;]+)/i);
+  return bareMatch?.[1]?.trim() ?? "";
+}
+
+/** Trigger a normal browser download by clicking a temporary blob-backed link. */
+function triggerBrowserDownload(blob: Blob, filename: string): void {
+  const a = document.createElement("a");
+  const objectUrl = URL.createObjectURL(blob);
+  a.href = objectUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    URL.revokeObjectURL(objectUrl);
+    a.remove();
+  }, 0);
+}
+
+/** Normalize suggested filenames for native save dialogs across platforms. */
+function sanitizeSaveFilename(filename: string): string {
+  // Use Windows-safe names for native dialogs so suggested filenames work
+  // across both packaged desktop shells and all supported OS file systems.
+  const sanitized = filename
+    .replace(/[<>:"/\\|?*]/g, "_")
+    .trim()
+    .replace(/[. ]+$/g, "");
+  return sanitized || "download";
+}
+
+/** Save through the legacy pywebview bridge used by the old desktop package. */
+async function downloadWithPyWebView(
+  saveFile: PyWebViewSaveFile,
+  url: string,
+  filename: string,
+  options: DownloadFileOptions,
+): Promise<void> {
+  const headers = options.headers ?? {};
+  const saved =
+    Object.keys(headers).length > 0
+      ? await saveFile(url, filename, headers)
+      : await saveFile(url, filename);
+  if (!saved) {
+    throw new DownloadCancelledError();
+  }
+}
+
+/** Ask Tauri's native dialog plugin for the destination path. */
+async function getTauriSavePath(filename: string): Promise<string> {
+  const savePath = await save({
+    defaultPath: filename,
+  });
+  // No path means the user cancelled the native save dialog; it is not an error.
+  if (!savePath) {
+    throw new DownloadCancelledError();
+  }
+  return savePath;
+}
+
+/** Save in Tauri by streaming the local backend response through Rust. */
+async function downloadWithTauri(
+  url: string,
+  filename: string,
+  options: DownloadFileOptions,
+): Promise<void> {
+  const savePath = await getTauriSavePath(filename);
+  try {
+    await invoke("download_backend_file", {
+      request: {
+        url,
+        filePath: savePath,
+        headers: options.headers,
+      } satisfies DownloadBackendFileRequest,
+    });
+  } catch (error) {
+    if (options.errorMessage) {
+      const wrappedError = new Error(options.errorMessage) as Error & {
+        cause?: unknown;
+      };
+      wrappedError.cause = error;
+      throw wrappedError;
+    }
+    throw error;
+  }
+}
+
+/** Save in a regular browser by fetching a blob and clicking a download link. */
+async function downloadWithBrowser(
+  url: string,
+  filename: string,
+  options: DownloadFileOptions,
+): Promise<void> {
+  const res = await fetch(url, { headers: options.headers });
+  if (!res.ok) {
+    const error = new Error(
+      options.errorMessage || `Download failed: ${res.status}`,
+    ) as Error & { status?: number };
+    error.status = res.status;
+    throw error;
+  }
+
+  const responseFilename = options.preferResponseFilename
+    ? filenameFromContentDisposition(res.headers.get("Content-Disposition"))
+    : "";
+  triggerBrowserDownload(
+    await res.blob(),
+    responseFilename ? sanitizeSaveFilename(responseFilename) : filename,
+  );
+}
+
+/** Download a URL using the best available runtime path: pywebview, Tauri, or browser. */
+export async function downloadFileFromUrl(
+  url: string,
+  filename: string,
+  options: DownloadFileOptions = {},
+): Promise<void> {
+  if (!url) {
+    throw new Error(options.errorMessage || "Download URL is empty");
+  }
+
+  const requestUrl = resolveExternalUrl(url);
+  if (!requestUrl || !isHttpExternalUrl(requestUrl)) {
+    throw new Error(options.errorMessage || "Download URL is invalid");
+  }
+
+  const safeFilename = sanitizeSaveFilename(filename);
+  const pywebviewSaveFile = getPyWebViewApi()?.save_file;
+  if (pywebviewSaveFile) {
+    await downloadWithPyWebView(
+      pywebviewSaveFile,
+      requestUrl,
+      safeFilename,
+      options,
+    );
+    return;
+  }
+
+  if (isDesktopTauriRuntime()) {
+    await downloadWithTauri(requestUrl, safeFilename, options);
+    return;
+  }
+
+  await downloadWithBrowser(requestUrl, safeFilename, options);
+}

--- a/console/src/utils/openExternalLink.test.ts
+++ b/console/src/utils/openExternalLink.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tauriMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  isTauri: vi.fn(() => false),
+}));
+const dialogMocks = vi.hoisted(() => ({
+  save: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriMocks.invoke,
+  isTauri: tauriMocks.isTauri,
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: dialogMocks.save,
+}));
+
+import {
+  DownloadCancelledError,
+  downloadFileFromUrl,
+} from "./downloadFileFromUrl";
+import { openExternalLink } from "./openExternalLink";
+
+describe("openExternalLink", () => {
+  const windowOpen = vi.fn();
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    tauriMocks.invoke.mockReset();
+    tauriMocks.isTauri.mockReturnValue(false);
+    tauriMocks.invoke.mockResolvedValue(undefined);
+    dialogMocks.save.mockReset();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:download"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    windowOpen.mockReset();
+    vi.spyOn(window, "open").mockImplementation(windowOpen);
+    delete (window as any).pywebview;
+    delete (window as any).__TAURI_INTERNALS__;
+    localStorage.clear();
+    (globalThis as any).VITE_API_BASE_URL = "";
+    (globalThis as any).TOKEN = "";
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the pywebview bridge for the legacy desktop app", () => {
+    const openExternal = vi.fn();
+    (window as any).pywebview = {
+      api: {
+        open_external_link: openExternal,
+      },
+    };
+    tauriMocks.isTauri.mockReturnValue(true);
+
+    openExternalLink("https://github.com/agentscope-ai/QwenPaw");
+
+    expect(openExternal).toHaveBeenCalledWith(
+      "https://github.com/agentscope-ai/QwenPaw",
+    );
+    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not send non-HTTP links to the legacy pywebview bridge", () => {
+    const openExternal = vi.fn();
+    (window as any).pywebview = {
+      api: {
+        open_external_link: openExternal,
+      },
+    };
+
+    openExternalLink("mailto:support@example.com");
+
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(windowOpen).toHaveBeenCalledWith(
+      "mailto:support@example.com",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("ignores unsafe or fragment-only links", () => {
+    openExternalLink("javascript:alert(1)");
+    openExternalLink("#");
+
+    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("rejects ambiguous HTTP links without slashes before opening", () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+
+    openExternalLink("http:example.com");
+
+    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("uses the Tauri external link command for supported non-HTTP schemes", () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+
+    openExternalLink("mailto:support@example.com");
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+      url: "mailto:support@example.com",
+    });
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("uses the Tauri external link command in the Tauri desktop app", () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+
+    openExternalLink("https://qwenpaw.agentscope.io/docs/intro?lang=zh");
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+      url: "https://qwenpaw.agentscope.io/docs/intro?lang=zh",
+    });
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("uses injected Tauri internals when isTauri is false", () => {
+    (window as any).__TAURI_INTERNALS__ = {
+      invoke: vi.fn(),
+    };
+
+    openExternalLink("https://github.com/agentscope-ai/QwenPaw");
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+      url: "https://github.com/agentscope-ai/QwenPaw",
+    });
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("logs Tauri external link failures without falling back to window.open", async () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+    tauriMocks.invoke.mockRejectedValue(new Error("permission denied"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    openExternalLink("https://github.com/agentscope-ai/QwenPaw");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to window.open in the web console", () => {
+    openExternalLink("https://qwenpaw.agentscope.io/docs/intro?lang=en");
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://qwenpaw.agentscope.io/docs/intro?lang=en",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("uses the Tauri command from backend-hosted Tauri consoles", () => {
+    (window as any).__TAURI_INTERNALS__ = {
+      invoke: vi.fn(),
+    };
+    window.history.replaceState(null, "", "/console/inbox");
+
+    openExternalLink("https://github.com/agentscope-ai/QwenPaw");
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+      url: "https://github.com/agentscope-ai/QwenPaw",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+
+  it("uses window.open for backend-hosted browser consoles", () => {
+    window.history.replaceState(null, "", "/console/inbox");
+
+    openExternalLink("https://github.com/agentscope-ai/QwenPaw");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://github.com/agentscope-ai/QwenPaw",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("does not add auth query parameters to generic external links", () => {
+    localStorage.setItem("qwenpaw_auth_token", "tok");
+
+    openExternalLink("https://evil.example/api/foo");
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://evil.example/api/foo",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("resolves relative links before passing them to desktop bridges", () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+
+    openExternalLink("/docs/faq");
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+      url: "http://localhost:3000/docs/faq",
+    });
+  });
+
+  it("downloads Tauri files with headers through the native backend command", async () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+    dialogMocks.save.mockResolvedValue("C:\\Downloads\\server.zip");
+    localStorage.setItem("qwenpaw_auth_token", "tok");
+
+    await expect(
+      downloadFileFromUrl("/api/workspace/download", "workspace.zip", {
+        headers: { "X-Agent-Id": "agent-a" },
+        preferResponseFilename: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(dialogMocks.save).toHaveBeenCalledWith({
+      defaultPath: "workspace.zip",
+    });
+    expect(tauriMocks.invoke).toHaveBeenCalledWith("download_backend_file", {
+      request: {
+        url: "http://localhost:3000/api/workspace/download",
+        filePath: "C:\\Downloads\\server.zip",
+        headers: { "X-Agent-Id": "agent-a" },
+      },
+    });
+    expect(dialogMocks.save.mock.invocationCallOrder[0]).toBeLessThan(
+      tauriMocks.invoke.mock.invocationCallOrder[0],
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(
+      tauriMocks.invoke.mock.calls.some(
+        ([command]) => command === "open_external_link",
+      ),
+    ).toBe(false);
+  });
+
+  it("uses the pywebview save bridge for legacy desktop downloads", async () => {
+    const saveFile = vi.fn().mockResolvedValue(true);
+    (window as any).pywebview = {
+      api: {
+        save_file: saveFile,
+      },
+    };
+
+    await expect(
+      downloadFileFromUrl(
+        "/api/backups/abc/export",
+        "Backup 2026-05-22 14:13.zip",
+        {
+          headers: { Authorization: "Bearer tok" },
+          errorMessage: "Export failed",
+        },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(saveFile).toHaveBeenCalledWith(
+      "http://localhost:3000/api/backups/abc/export",
+      "Backup 2026-05-22 14_13.zip",
+      { Authorization: "Bearer tok" },
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dialogMocks.save).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy pywebview downloads backward-compatible without headers", async () => {
+    const saveFile = vi.fn().mockResolvedValue(true);
+    (window as any).pywebview = {
+      api: {
+        save_file: saveFile,
+      },
+    };
+
+    await expect(
+      downloadFileFromUrl("/api/backups/abc/export", "backup.zip"),
+    ).resolves.toBeUndefined();
+
+    expect(saveFile).toHaveBeenCalledWith(
+      "http://localhost:3000/api/backups/abc/export",
+      "backup.zip",
+    );
+  });
+
+  it("sanitizes Tauri save dialog filenames for Windows", async () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+    dialogMocks.save.mockResolvedValue("C:\\Downloads\\backup.zip");
+
+    await expect(
+      downloadFileFromUrl(
+        "/api/backups/abc/export",
+        "Backup 2026-05-22 14:13.zip",
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(dialogMocks.save).toHaveBeenCalledWith({
+      defaultPath: "Backup 2026-05-22 14_13.zip",
+    });
+    expect(tauriMocks.invoke).toHaveBeenCalledWith(
+      "download_backend_file",
+      expect.objectContaining({
+        request: expect.objectContaining({
+          filePath: "C:\\Downloads\\backup.zip",
+        }),
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports Tauri download cancellation before starting the native download", async () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+    dialogMocks.save.mockResolvedValue(null);
+    fetchMock.mockResolvedValue(new Response("zip"));
+
+    await expect(
+      downloadFileFromUrl("/api/workspace/download", "workspace.zip", {
+        headers: { "X-Agent-Id": "agent-a" },
+      }),
+    ).rejects.toBeInstanceOf(DownloadCancelledError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(tauriMocks.invoke).not.toHaveBeenCalledWith(
+      "download_backend_file",
+      expect.anything(),
+    );
+  });
+
+  it("surfaces Tauri native download failures with the caller's message", async () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+    dialogMocks.save.mockResolvedValue("C:\\Downloads\\server.zip");
+    tauriMocks.invoke.mockRejectedValue(new Error("HTTP 500"));
+
+    await expect(
+      downloadFileFromUrl("/api/workspace/download", "workspace.zip", {
+        errorMessage: "Export failed",
+      }),
+    ).rejects.toThrow("Export failed");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not add auth query parameters to external API-shaped downloads", async () => {
+    localStorage.setItem("qwenpaw_auth_token", "tok");
+    fetchMock.mockResolvedValue(new Response("zip"));
+
+    await expect(
+      downloadFileFromUrl("https://evil.example/api/export", "backup.zip", {
+        headers: { "X-Agent-Id": "agent-a" },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledWith("https://evil.example/api/export", {
+      headers: { "X-Agent-Id": "agent-a" },
+    });
+  });
+
+  it("rejects non-HTTP URLs before selecting a download runtime", async () => {
+    tauriMocks.isTauri.mockReturnValue(true);
+    dialogMocks.save.mockResolvedValue("C:\\Downloads\\mail.zip");
+
+    await expect(
+      downloadFileFromUrl("mailto:support@example.com", "mail.zip"),
+    ).rejects.toThrow("Download URL is invalid");
+
+    expect(dialogMocks.save).not.toHaveBeenCalled();
+    expect(tauriMocks.invoke).not.toHaveBeenCalledWith(
+      "download_backend_file",
+      expect.anything(),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects ambiguous HTTP downloads without slashes", async () => {
+    await expect(
+      downloadFileFromUrl("http:example.com/export.zip", "backup.zip"),
+    ).rejects.toThrow("Download URL is invalid");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(tauriMocks.invoke).not.toHaveBeenCalledWith(
+      "download_backend_file",
+      expect.anything(),
+    );
+  });
+
+  it("uses browser downloads outside Tauri", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("zip", {
+        headers: {
+          "Content-Disposition": "attachment; filename*=UTF-8''server.zip",
+        },
+      }),
+    );
+    const click = vi.fn();
+    const createElement = vi.spyOn(document, "createElement");
+    createElement.mockImplementation((tagName: string) => {
+      const element = document.createElementNS(
+        "http://www.w3.org/1999/xhtml",
+        tagName,
+      ) as HTMLElement;
+      if (tagName === "a") {
+        element.click = click;
+      }
+      return element;
+    });
+
+    await expect(
+      downloadFileFromUrl("/api/backups/abc/export", "backup.zip", {
+        preferResponseFilename: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(click).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith("blob:download");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+});

--- a/console/src/utils/openExternalLink.ts
+++ b/console/src/utils/openExternalLink.ts
@@ -1,10 +1,116 @@
 /**
- * Open an external URL, using the pywebview bridge in desktop app or
- * window.open in browser.
- *
- * @param url - The URL to open
- * @param target - Target window name (default: "_blank")
- * @param features - Window features string (default: "noopener,noreferrer")
+ * Cross-runtime external link opener for browser, legacy pywebview, and Tauri.
+ * It validates supported protocols and delegates desktop shells to native openers.
+ */
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { getPyWebViewApi } from "./pywebview";
+
+const URL_WITH_SCHEME_RE = /^[a-z][a-z\d+\-.]*:/i;
+const HTTP_PROTOCOLS = new Set(["http:", "https:"]);
+// Keep in sync with console/src-tauri/src/external_link.rs.
+const SUPPORTED_EXTERNAL_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "mailto:",
+  "tel:",
+]);
+const TAURI_OPEN_EXTERNAL_LINK_COMMAND = "open_external_link";
+type ExternalLinkRuntime = "pywebview" | "tauri" | "browser";
+
+function hasHttpUrlPrefix(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+/** Resolve absolute and app-relative URLs while ignoring empty or hash-only links. */
+export function resolveExternalUrl(url: string): string | null {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl || trimmedUrl.startsWith("#")) {
+    return null;
+  }
+
+  try {
+    if (URL_WITH_SCHEME_RE.test(trimmedUrl)) {
+      return trimmedUrl;
+    }
+    return new URL(trimmedUrl, window.location.origin).toString();
+  } catch {
+    return null;
+  }
+}
+
+function protocolOf(url: string): string {
+  return new URL(url).protocol;
+}
+
+/** Return true when a resolved URL is HTTP(S), the legacy desktop bridge's scope. */
+export function isHttpExternalUrl(url: string): boolean {
+  try {
+    return hasHttpUrlPrefix(url) && HTTP_PROTOCOLS.has(protocolOf(url));
+  } catch {
+    return false;
+  }
+}
+
+function isSupportedExternalUrl(url: string): boolean {
+  try {
+    const protocol = protocolOf(url);
+    if (HTTP_PROTOCOLS.has(protocol)) {
+      return hasHttpUrlPrefix(url);
+    }
+    return SUPPORTED_EXTERNAL_PROTOCOLS.has(protocol);
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve an input URL only if its protocol is safe to hand to external openers. */
+function resolveSupportedExternalUrl(url: string): string | null {
+  const resolvedUrl = resolveExternalUrl(url);
+  if (!resolvedUrl || !isSupportedExternalUrl(resolvedUrl)) {
+    return null;
+  }
+
+  return resolvedUrl;
+}
+
+/** Detect Tauri even after the app has navigated to the backend-hosted console. */
+export function isDesktopTauriRuntime(): boolean {
+  // When Tauri loads a remote-origin console, injected internals can still be
+  // available even when the SDK helper does not report the runtime.
+  return isTauri() || hasTauriInternals();
+}
+
+/** Check for Tauri's injected invoke hook when the SDK helper is unavailable. */
+function hasTauriInternals(): boolean {
+  if (typeof window === "undefined") return false;
+
+  return (
+    typeof (window as { __TAURI_INTERNALS__?: { invoke?: unknown } })
+      .__TAURI_INTERNALS__?.invoke === "function"
+  );
+}
+
+// Runtime priority is intentional: the legacy pywebview bridge has its own
+// opener, while packaged Tauri should use the native command exposed to the
+// WebView, including backend-hosted remote origins allowed by capabilities.
+/** Choose which runtime should handle a validated external URL. */
+function detectExternalLinkRuntime(fullUrl: string): ExternalLinkRuntime {
+  const pywebviewApi = getPyWebViewApi();
+  if (pywebviewApi?.open_external_link && isHttpExternalUrl(fullUrl)) {
+    return "pywebview";
+  }
+
+  if (isDesktopTauriRuntime()) {
+    return "tauri";
+  }
+
+  return "browser";
+}
+
+/**
+ * Open a supported external URL in the OS/browser-appropriate target.
+ * Desktop bridge failures are logged asynchronously because clicks are
+ * fire-and-forget from the UI's perspective.
  */
 export function openExternalLink(
   url: string,
@@ -13,17 +119,27 @@ export function openExternalLink(
 ): void {
   if (!url) return;
 
-  // Resolve relative URLs to absolute (needed for pywebview which runs outside the WebView context)
-  const fullUrl = url.startsWith("http")
-    ? url
-    : `${window.location.origin}${url}`;
+  const fullUrl = resolveSupportedExternalUrl(url);
+  if (!fullUrl) {
+    return;
+  }
 
-  const pywebview = (window as any).pywebview;
-  if (pywebview?.api?.open_external_link) {
-    // Desktop app: use pywebview bridge to open in system browser
-    pywebview.api.open_external_link(fullUrl);
-  } else {
-    // Web browser: use standard window.open
-    window.open(fullUrl, target, features);
+  const runtime = detectExternalLinkRuntime(fullUrl);
+
+  switch (runtime) {
+    case "pywebview": {
+      getPyWebViewApi()?.open_external_link?.(fullUrl);
+      return;
+    }
+    case "tauri": {
+      void invoke(TAURI_OPEN_EXTERNAL_LINK_COMMAND, { url: fullUrl }).catch(
+        (error) => {
+          console.warn("[external-link] Tauri open command failed", error);
+        },
+      );
+      return;
+    }
+    case "browser":
+      window.open(fullUrl, target, features);
   }
 }

--- a/console/src/utils/pywebview.ts
+++ b/console/src/utils/pywebview.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared access point for the legacy pywebview desktop bridge.
+ * Keeping the bridge type here prevents runtime helpers from drifting apart.
+ */
+
+export type PyWebViewApi = NonNullable<Window["pywebview"]>["api"];
+export type PyWebViewSaveFile = NonNullable<PyWebViewApi["save_file"]>;
+
+/** Return the legacy pywebview bridge when the old desktop shell injects it. */
+export function getPyWebViewApi(): PyWebViewApi | undefined {
+  return window.pywebview?.api;
+}

--- a/console/src/vite-env.d.ts
+++ b/console/src/vite-env.d.ts
@@ -12,8 +12,12 @@ declare module "*.less" {
 }
 
 interface PyWebViewAPI {
-  open_external_link: (url: string) => void;
-  save_file: (url: string, filename: string) => Promise<boolean>;
+  open_external_link?: (url: string) => void;
+  save_file?: (
+    url: string,
+    filename: string,
+    headers?: Record<string, string>,
+  ) => Promise<boolean>;
 }
 
 declare global {

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,15 +1,22 @@
+# Base images — override with --build-arg for environments without ACR access.
+ARG NODE_IMAGE=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim
+ARG UV_IMAGE=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/uv:latest
+
 # -----------------------------------------------------------------------------
 # Stage 1: build console frontend (dist not committed in repo).
 # -----------------------------------------------------------------------------
-FROM agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim AS console-builder
+FROM ${NODE_IMAGE} AS console-builder
 WORKDIR /app
 COPY console /app/console
 RUN cd /app/console && npm ci --include=dev && npm run build
 
+# Alias for uv binary so COPY --from can reference a build-arg image.
+FROM ${UV_IMAGE} AS uv-src
+
 # -----------------------------------------------------------------------------
 # Stage 2: runtime image with Python, Chromium, and app.
 # -----------------------------------------------------------------------------
-FROM agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim
+FROM ${NODE_IMAGE}
 
 # ENV variables
 ENV NODE_ENV=production
@@ -89,7 +96,7 @@ COPY website/public/docs/ ./src/qwenpaw/docs/
 # Inject console dist from build stage (repo does not commit dist).
 COPY --from=console-builder /app/console/dist/ ./src/qwenpaw/console/
 # Speed up Python package installation with uv.
-COPY --from=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/uv:latest /uv /bin/uv
+COPY --from=uv-src /uv /bin/uv
 RUN uv pip install --no-cache-dir . && rm -rf ./build
 
 

--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -39,9 +39,25 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_AUTOMATION_MEMORY_SKIP_SOURCES = {"cron", "heartbeat"}
+
+
 def _fmt_tokens(n: int) -> str:
     """Format token count as e.g. '82.3k' or '450'."""
     return f"{n / 1000:.1f}k" if n >= 1000 else str(n)
+
+
+def _request_context_source(agent: Any) -> str:
+    """Return normalized source tag from an agent request context."""
+    request_context = getattr(agent, "_request_context", {}) or {}
+    if not isinstance(request_context, dict):
+        return ""
+    return str(request_context.get("source") or "").strip().lower()
+
+
+def _should_skip_automation_memory(agent: Any) -> bool:
+    """Return True when the request is non-user automation."""
+    return _request_context_source(agent) in _AUTOMATION_MEMORY_SKIP_SOURCES
 
 
 @context_registry.register("light")
@@ -922,7 +938,9 @@ class LightContextManager(BaseContextManager):
             )
             logger.info(f"Marked {updated_count} messages as compacted")
 
-            if messages_to_compact:
+            if messages_to_compact and not _should_skip_automation_memory(
+                agent,
+            ):
                 await memory_manager.summarize_when_compact(
                     messages=messages_to_compact,
                 )
@@ -989,7 +1007,7 @@ class LightContextManager(BaseContextManager):
             memory = agent.memory
             all_messages = [msg for msg, _ in memory.content]
 
-            if all_messages:
+            if all_messages and not _should_skip_automation_memory(agent):
                 await memory_manager.auto_memory(
                     all_messages=all_messages,
                 )

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -92,6 +92,13 @@ class CronExecutor:
 
         req["channel"] = target_channel
         req["user_id"] = target_user_id or "cron"
+        raw_context = req.get("request_context")
+        request_context = (
+            dict(raw_context) if isinstance(raw_context, dict) else {}
+        )
+        request_context["source"] = "cron"
+        request_context["cron_job_id"] = job.id or ""
+        req["request_context"] = request_context
 
         # Determine session_id based on share_session
         share_session = job.runtime.share_session

--- a/src/qwenpaw/app/crons/heartbeat.py
+++ b/src/qwenpaw/app/crons/heartbeat.py
@@ -216,6 +216,7 @@ async def run_heartbeat_once(
         "session_id": "main",
         "user_id": "main",
         "channel": DEFAULT_CHANNEL,
+        "request_context": {"source": "heartbeat"},
     }
 
     # Get last_dispatch from agent config if agent_id provided

--- a/src/qwenpaw/app/routers/coding_project.py
+++ b/src/qwenpaw/app/routers/coding_project.py
@@ -13,6 +13,7 @@ import asyncio
 import io
 import json
 import logging
+import sys
 import zipfile
 from pathlib import Path
 
@@ -33,6 +34,29 @@ router = APIRouter(prefix="/workspace/coding-project", tags=["coding-project"])
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _list_windows_drives_response() -> dict:
+    """Return a browse-dirs response listing drives."""
+    import ctypes
+
+    bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+    dirs: list[dict] = []
+    for i in range(26):
+        if bitmask & (1 << i):
+            letter = chr(ord("A") + i)
+            dirs.append(
+                {
+                    "name": f"{letter}:",
+                    "path": f"{letter}:\\",
+                },
+            )
+    return {
+        "current": "/",
+        "parent": None,
+        "dirs": dirs,
+        "selectable": False,
+    }
 
 
 def _projects_base(workspace_dir: Path) -> Path:
@@ -454,7 +478,17 @@ async def browse_dirs(
         description="Include hidden directories",
     ),
 ) -> dict:
-    """Return subdirectories at *path* for the file browser UI."""
+    """Return subdirectories at *path* for the file browser UI.
+
+    On Windows, ``"/"`` is treated as a virtual root that
+    lists all available drive letters (C:, D:, ...).
+    """
+    # Windows virtual root: list all drive letters
+    if sys.platform == "win32" and path in ("/", "\\"):
+        return await asyncio.to_thread(
+            _list_windows_drives_response,
+        )
+
     target = await asyncio.to_thread(
         lambda: Path(path).expanduser().resolve(),
     )
@@ -502,9 +536,15 @@ async def browse_dirs(
                 detail=f"Failed to list directory: {target}",
             ) from exc
         parent = target.parent
+        # On Windows drive root, parent points to
+        # the virtual drives listing.
+        if sys.platform == "win32" and parent == target:
+            parent_str: str | None = "/"
+        else:
+            parent_str = str(parent) if parent != target else None
         return {
             "current": str(target),
-            "parent": (str(parent) if parent != target else None),
+            "parent": parent_str,
             "dirs": dirs,
         }
 

--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """CLI command: run QwenPaw app on a free port in a native webview window."""
+
 # pylint:disable=too-many-branches,too-many-statements,consider-using-with
 from __future__ import annotations
 
@@ -12,6 +13,7 @@ import threading
 import time
 import traceback
 import webbrowser
+from collections.abc import Mapping
 
 import click
 
@@ -35,7 +37,12 @@ class WebViewAPI:
             return
         webbrowser.open(url)
 
-    def save_file(self, url: str, filename: str) -> bool:
+    def save_file(
+        self,
+        url: str,
+        filename: str,
+        headers: Mapping[str, str] | None = None,
+    ) -> bool:
         """Download a file from *url* and save it via a native save dialog.
 
         Shows the OS "Save As" dialog so the user can pick a destination,
@@ -46,6 +53,7 @@ class WebViewAPI:
         Args:
             url: Full HTTP(S) URL of the file to download.
             filename: Default filename shown in the save dialog.
+            headers: Optional request headers supplied by the web console.
 
         Returns:
             True if the file was saved successfully, False if the user
@@ -74,8 +82,17 @@ class WebViewAPI:
 
             dest_path = result if isinstance(result, str) else result[0]
 
+            request = urllib.request.Request(
+                url,
+                headers={
+                    str(key): str(value)
+                    for key, value in (headers or {}).items()
+                    if value is not None
+                },
+            )
+
             # Download from the local backend and write to chosen path
-            with urllib.request.urlopen(url) as response:
+            with urllib.request.urlopen(request) as response:
                 with open(dest_path, "wb") as f:
                     shutil.copyfileobj(response, f)
 

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -84,6 +84,23 @@ DASHSCOPE_MODELS: List[ModelInfo] = [
     ),
 ]
 
+MIMO_TOKENPLAN_MODELS: List[ModelInfo] = [
+    ModelInfo(
+        id="mimo-v2.5-pro",
+        name="MiMo V2.5 Pro",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="mimo-v2.5",
+        name="MiMo V2.5",
+        supports_image=True,
+        supports_video=True,
+        probe_source="documentation",
+    ),
+]
+
 ALIYUN_TOKENPLAN_MODELS: List[ModelInfo] = [
     ModelInfo(
         id="qwen3.6-plus",
@@ -1002,6 +1019,15 @@ PROVIDER_VOLCENGINE_CN_CODINGPLAN = OpenAIProvider(
     support_model_discovery=False,
 )
 
+PROVIDER_MIMO_TOKENPLAN = OpenAIProvider(
+    id="mimo-tokenplan",
+    name="Xiaomi MiMo Token Plan",
+    base_url="https://token-plan-cn.xiaomimimo.com/v1",
+    api_key_prefix="",
+    models=MIMO_TOKENPLAN_MODELS,
+    freeze_url=True,
+)
+
 
 class ProviderManager:  # pylint: disable=too-many-public-methods
     """A manager class to handle all providers,
@@ -1071,6 +1097,7 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         self._add_builtin(PROVIDER_SILICONFLOW_INTL)
         self._add_builtin(PROVIDER_VOLCENGINE_CN)
         self._add_builtin(PROVIDER_VOLCENGINE_CN_CODINGPLAN)
+        self._add_builtin(PROVIDER_MIMO_TOKENPLAN)
 
     def _add_builtin(self, provider: Provider):
         self.builtin_providers[provider.id] = provider

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -314,6 +314,7 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
     env["QWENPAW_SECRET_DIR"] = str(secret_dir)
     env["QWENPAW_BACKUP_DIR"] = str(backups_dir)
     env["QWENPAW_AUTH_ENABLED"] = "false"
+    env["QWENPAW_UPLOAD_MAX_SIZE_MB"] = "10"
     env["NO_PROXY"] = "*"
     env["PYTHONUNBUFFERED"] = "1"
     # Force UTF-8 stdio in the subprocess so non-ASCII log lines (e.g.
@@ -369,10 +370,10 @@ def app_server(  # pylint: disable=too-many-statements,too-many-branches
         )
         log_thread.start()
 
-        # 15s default lets cold-start endpoints (ACP getter, heartbeat)
-        # finish without hiding real deadlocks; 30s in coverage mode
-        # for tracer overhead.
-        http_timeout = 30.0 if _integration_coverage_requested() else 15.0
+        # 30s lets cold-start endpoints (ACP getter, heartbeat) and
+        # agent creation (workspace init) finish on slower runners
+        # (Windows CI ~50% slower) without hiding real deadlocks.
+        http_timeout = 30.0
         client = httpx.Client(timeout=http_timeout, trust_env=False)
 
         try:

--- a/tests/integration/test_agent_scoped_misc.py
+++ b/tests/integration/test_agent_scoped_misc.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for miscellaneous agent-scoped endpoints.
+
+Covers tools config, heartbeat, console chat, and MCP OAuth start
+through ``/api/agents/{agentId}/...`` paths.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+_HTTP_TIMEOUT = 15.0
+
+
+def _scoped(agent_id: str, path: str) -> str:
+    return f"/api/agents/{agent_id}{path}"
+
+
+def _create_agent(app_server, agent_id: str) -> None:
+    resp = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": f"Agent {agent_id}",
+            "description": "",
+        },
+    )
+    assert resp.status_code == 201, app_server.logs_tail()
+
+
+def _delete_agent_quietly(app_server, agent_id: str) -> None:
+    try:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+    except Exception:
+        pass
+
+
+# ------------------------------------------------------------------ #
+# tools
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_tools_list_returns_array(app_server) -> None:
+    """Test purpose:
+    - Verify GET /api/agents/{agentId}/tools returns 200 with a list
+      payload. Agent-scoped tools listing may be empty or contain
+      built-in entries depending on configuration.
+
+    Test flow:
+    1. Create agent.
+    2. GET /agents/{id}/tools.
+    3. Assert 200 and JSON is a list.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools
+    """
+    agent_id = "integ_misc_tools_list_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "GET",
+            _scoped(agent_id, "/tools"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert isinstance(resp.json(), list)
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_tools_config_update_unknown_returns_500(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/tools/{name}/config with an
+      unknown tool name returns 500 because the PluginRegistry rejects
+      config writes for non-existent tools.
+
+    Test flow:
+    1. Create agent.
+    2. POST /{bogus_tool}/config.
+    3. Assert 500 and detail mentions ``not found``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/tools/{tool_name}/config
+    """
+    agent_id = "integ_misc_tools_cfg_unk_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/tools/integ-nosuch-tool/config"),
+            json={"config": {"api_key": "test"}},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 500, app_server.logs_tail()
+        assert "not found" in resp.json().get("detail", "").lower()
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_tools_config_get_nonexistent_returns_empty(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify GET /api/agents/{agentId}/tools/{name}/config for a
+      non-existent tool returns 200 with an empty dict (graceful
+      fallback, not 404).
+
+    Test flow:
+    1. Create agent.
+    2. GET /{bogus_tool}/config.
+    3. Assert 200 and body is ``{}``.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools/{tool_name}/config
+    """
+    agent_id = "integ_misc_tools_cfg_get_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "GET",
+            _scoped(agent_id, "/tools/integ-nosuch-tool/config"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert resp.json() == {}
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# heartbeat
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_heartbeat_run_returns_started(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/config/heartbeat/run fires a
+      background heartbeat and returns ``{"started": true}``
+      immediately. The background task may fail (no LLM configured)
+      but the synchronous response must be hermetic.
+
+    Test flow:
+    1. Create agent.
+    2. POST heartbeat/run.
+    3. Assert 200 and ``started == True``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/config/heartbeat/run
+    """
+    agent_id = "integ_misc_heartbeat_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/config/heartbeat/run"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert resp.json().get("started") is True
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# console chat
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_console_chat_returns_sse(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/console/chat with a valid
+      minimal body returns a 200 SSE response (``text/event-stream``
+      content-type). The stream content itself depends on LLM
+      availability; we only assert the HTTP-level contract.
+
+    Test flow:
+    1. Create agent.
+    2. POST console/chat with a minimal valid body using httpx
+       streaming mode (avoids blocking on body read).
+    3. Assert 200 and content-type starts with ``text/event-stream``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/console/chat
+    """
+    agent_id = "integ_misc_console_chat_01"
+    _create_agent(app_server, agent_id)
+    try:
+        url = f"{app_server.base_url}" f"{_scoped(agent_id, '/console/chat')}"
+        body = {
+            "input": [
+                {
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                    ],
+                },
+            ],
+            "user_id": "integ-test",
+            "session_id": "integ-session-01",
+        }
+        with app_server.client.stream(
+            "POST",
+            url,
+            json=body,
+            timeout=httpx.Timeout(10.0, read=3.0),
+        ) as resp:
+            assert resp.status_code == 200, app_server.logs_tail()
+            ct = resp.headers.get("content-type", "")
+            assert "text/event-stream" in ct
+    except httpx.ReadTimeout:
+        pass
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_console_chat_invalid_body_returns_422(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/console/chat with an
+      unparseable body returns 422 (FastAPI validation error).
+
+    Test flow:
+    1. POST console/chat with body ``"not-json-object"`` (a bare
+       string, not dict/AgentRequest).
+    2. Assert 422.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/console/chat
+    """
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/console/chat"),
+        content='"just-a-string"',
+        headers={"Content-Type": "application/json"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 422, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# mcp-oauth start
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_mcp_oauth_start_returns_auth_url(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/mcp/oauth/start/{client_key}
+      with explicit ``auth_endpoint`` and ``token_endpoint`` returns
+      200 and an ``auth_url`` without making any network calls
+      (PKCE flow is computed locally).
+
+    Test flow:
+    1. Create agent.
+    2. POST oauth/start with explicit mock endpoints.
+    3. Assert 200 and response contains ``auth_url`` and ``session_id``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/mcp/oauth/start/{client_key}
+    """
+    agent_id = "integ_misc_oauth_start_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(
+                agent_id,
+                "/mcp/oauth/start/integ-mock-mcp-client",
+            ),
+            json={
+                "url": "http://localhost:19999/mcp",
+                "auth_endpoint": "http://localhost:19999/authorize",
+                "token_endpoint": "http://localhost:19999/token",
+                "scope": "read",
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        payload = resp.json()
+        assert "auth_url" in payload
+        assert "session_id" in payload
+        assert "localhost:19999/authorize" in payload["auth_url"]
+    finally:
+        _delete_agent_quietly(app_server, agent_id)

--- a/tests/integration/test_agent_scoped_routing.py
+++ b/tests/integration/test_agent_scoped_routing.py
@@ -1,0 +1,774 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for agent-scoped URL routing.
+
+Verifies that ``/api/agents/{agentId}/...`` paths route correctly to
+the same handlers as global ``/api/...`` paths (alias endpoints) and
+that real agent-scoped endpoints resolve agent context properly.
+
+Covers 13 P0 endpoints across five domains:
+
+  - **plugins** (alias): install / upload / uninstall + real install
+  - **console/inbox** (alias): seed → list → mark-read → delete
+  - **workspace** (real): upload invalid / valid zip
+  - **mcp-oauth** (real): revoke unknown client
+  - **workspace/transcribe** (alias): disabled, unsupported extension
+  - **workspace/transcription-provider-type** (alias): roundtrip, invalid
+  - **skills/hub** (alias): cancel unknown task
+"""
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_HTTP_TIMEOUT = 15.0
+_PLUGIN_HTTP_TIMEOUT = 30.0
+_LOADER_READY_TIMEOUT = 20.0
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_OFFICIAL_PLUGINS_DIR = _REPO_ROOT / "plugins"
+_AGENT_SCOPED_PREFIX = "/api/agents"
+
+
+# ------------------------------------------------------------------ #
+# helpers
+# ------------------------------------------------------------------ #
+
+
+def _scoped(agent_id: str, path: str) -> str:
+    """Build an agent-scoped URL."""
+    return f"{_AGENT_SCOPED_PREFIX}/{agent_id}{path}"
+
+
+def _wait_until_plugin_loader_ready(
+    app_server,
+    *,
+    timeout: float = _LOADER_READY_TIMEOUT,
+) -> None:
+    """Poll POST /api/plugins/install with an invalid source until the
+    plugin loader is initialised (503 → 400 transition)."""
+    deadline = time.time() + timeout
+    last_status = None
+    last_detail = ""
+    while time.time() < deadline:
+        resp = app_server.api_request(
+            "POST",
+            "/api/plugins/install",
+            json={
+                "source": "/tmp/integ-agent-scoped-probe-not-a-path",
+                "force": False,
+            },
+            timeout=5.0,
+        )
+        last_status = resp.status_code
+        try:
+            last_detail = resp.json().get("detail", "")
+        except ValueError:
+            last_detail = resp.text[:200]
+        if resp.status_code == 400 and "Path not found" in last_detail:
+            return
+        if resp.status_code == 503:
+            time.sleep(0.5)
+            continue
+        return
+    raise AssertionError(
+        f"plugin_loader not ready in {timeout}s, "
+        f"last status={last_status} detail={last_detail!r}",
+    )
+
+
+def _delete_plugin_quietly(app_server, plugin_id: str) -> None:
+    """Best-effort plugin delete for finally blocks."""
+    try:
+        _wait_until_plugin_loader_ready(app_server)
+        app_server.api_request(
+            "DELETE",
+            f"/api/plugins/{plugin_id}",
+            timeout=_PLUGIN_HTTP_TIMEOUT,
+        )
+    except (AssertionError, Exception):
+        pass
+
+
+def _inbox_path(working_dir: Path) -> Path:
+    return working_dir / "inbox_events.json"
+
+
+def _trace_dir(working_dir: Path) -> Path:
+    return working_dir / "inbox_traces"
+
+
+def _seed_inbox_events(
+    working_dir: Path,
+    events: list[dict[str, Any]],
+) -> None:
+    path = _inbox_path(working_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(events, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _clean_inbox(working_dir: Path) -> None:
+    path = _inbox_path(working_dir)
+    if path.exists():
+        path.unlink()
+    directory = _trace_dir(working_dir)
+    if directory.exists():
+        shutil.rmtree(directory)
+
+
+def _make_event(
+    *,
+    event_id: str,
+    agent_id: str = "default",
+    source_type: str = "cron",
+    event_type: str = "cron_executed",
+    status: str = "completed",
+    severity: str = "info",
+    title: str = "scoped routing event",
+    read: bool = False,
+    created_at: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": event_id,
+        "agent_id": agent_id,
+        "source_type": source_type,
+        "source_id": "",
+        "event_type": event_type,
+        "status": status,
+        "severity": severity,
+        "title": title,
+        "body": "",
+        "payload": {},
+        "read": read,
+        "created_at": (created_at if created_at is not None else time.time()),
+    }
+
+
+def _build_workspace_zip(files: dict[str, str]) -> bytes:
+    """Build an in-memory zip containing the given path→content map."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _create_agent(app_server, agent_id: str) -> None:
+    resp = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": f"Agent {agent_id}",
+            "description": "",
+        },
+    )
+    assert resp.status_code == 201, app_server.logs_tail()
+
+
+def _delete_agent_quietly(app_server, agent_id: str) -> None:
+    try:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+    except Exception:
+        pass
+
+
+# ------------------------------------------------------------------ #
+# plugins — alias endpoints (handler ignores agentId)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_install_invalid_source(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/plugins/install with a
+      non-existent local path returns 400 ``Path not found``, proving
+      the agent-scoped URL reaches the install handler.
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. POST agent-scoped plugins/install with a bogus local path.
+    3. Assert 400 and detail contains ``Path not found``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/plugins/install
+    """
+    _wait_until_plugin_loader_ready(app_server)
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/plugins/install"),
+        json={
+            "source": "/tmp/integ-no-such-plugin-path",
+            "force": False,
+        },
+        timeout=_PLUGIN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert "Path not found" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_upload_non_zip_rejected(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/plugins/upload with a
+      non-zip filename is rejected with 400 ``Only .zip archives``.
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. POST agent-scoped plugins/upload with a plain-text file named
+       ``test.txt``.
+    3. Assert 400 and detail mentions ``.zip``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/plugins/upload
+    """
+    _wait_until_plugin_loader_ready(app_server)
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/plugins/upload"),
+        files={"file": ("test.txt", b"not a zip", "text/plain")},
+        timeout=_PLUGIN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert ".zip" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_uninstall_unknown(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /api/agents/{agentId}/plugins/{plugin_id} with
+      an unknown plugin returns 404 ``not loaded``.
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. DELETE agent-scoped plugins/<nonexistent_id>.
+    3. Assert 404 and detail mentions ``not loaded``.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/plugins/{plugin_id}
+    """
+    _wait_until_plugin_loader_ready(app_server)
+    resp = app_server.api_request(
+        "DELETE",
+        _scoped("default", "/plugins/integ-nonexistent-plugin"),
+        timeout=_PLUGIN_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert "not loaded" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_plugins_install_real_via_agent_scoped(app_server) -> None:
+    """Test purpose:
+    - Verify a real plugin (bundled ``cloudpaw``) can be installed and
+      uninstalled through the agent-scoped path. This is the happy-path
+      proof that the agent-scoped routing delivers to the full install
+      pipeline (hot-load → list → unload).
+
+    Test flow:
+    1. Wait for plugin loader readiness.
+    2. POST /api/agents/default/plugins/install with the local
+       cloudpaw bundle source.
+    3. Assert 200, ``id == "cloudpaw"``, ``loaded == True``.
+    4. GET /api/agents/default/plugins — assert cloudpaw in list.
+    5. DELETE /api/agents/default/plugins/cloudpaw — assert 200.
+    6. finally: best-effort cleanup.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/plugins/install
+    - GET  /api/agents/{agentId}/plugins
+    - DELETE /api/agents/{agentId}/plugins/{plugin_id}
+    """
+    plugin_id = "cloudpaw"
+    source_path = _OFFICIAL_PLUGINS_DIR / "bundle" / "cloudpaw"
+    assert source_path.is_dir(), f"missing source: {source_path}"
+
+    try:
+        _wait_until_plugin_loader_ready(app_server)
+        deadline = time.time() + _LOADER_READY_TIMEOUT
+        resp = None
+        while True:
+            resp = app_server.api_request(
+                "POST",
+                _scoped("default", "/plugins/install"),
+                json={"source": str(source_path), "force": False},
+                timeout=_PLUGIN_HTTP_TIMEOUT,
+            )
+            if resp.status_code != 503 or time.time() >= deadline:
+                break
+            time.sleep(0.5)
+        assert resp.status_code == 200, (
+            f"install via agent-scoped: {resp.status_code} | "
+            f"{resp.text} | logs: {app_server.logs_tail()}"
+        )
+        payload = resp.json()
+        assert payload.get("id") == plugin_id
+        assert payload.get("loaded") is True
+
+        list_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/plugins"),
+            timeout=_PLUGIN_HTTP_TIMEOUT,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        items = list_resp.json()
+        if isinstance(items, dict):
+            items = items.get("plugins", [])
+        loaded_ids = {
+            str(it["id"])
+            for it in items
+            if isinstance(it, dict) and "id" in it
+        }
+        assert plugin_id in loaded_ids
+
+        _wait_until_plugin_loader_ready(app_server)
+        del_resp = app_server.api_request(
+            "DELETE",
+            _scoped("default", f"/plugins/{plugin_id}"),
+            timeout=_PLUGIN_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+    finally:
+        _delete_plugin_quietly(app_server, plugin_id)
+
+
+# ------------------------------------------------------------------ #
+# console/inbox — alias endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_inbox_seed_list_read_delete_lifecycle(app_server) -> None:
+    """Test purpose:
+    - Verify the console inbox CRUD lifecycle works through agent-scoped
+      paths: seed data → list → mark-read → delete. Covers the three
+      inbox endpoints that are P0 under agent-scoped routing.
+
+    Test flow:
+    1. Seed 3 unread events into inbox_events.json.
+    2. GET /api/agents/default/console/inbox/events — assert 3 events.
+    3. POST /api/agents/default/console/inbox/read with 2 event ids —
+       assert ``updated == 2``.
+    4. GET events again — assert 2 read + 1 unread.
+    5. DELETE /api/agents/default/console/inbox/events/{id} for the
+       remaining unread event — assert ``deleted == True``.
+    6. GET events — assert 2 remaining.
+    7. Cleanup: wipe inbox state.
+
+    API endpoints:
+    - GET    /api/agents/{agentId}/console/inbox/events
+    - POST   /api/agents/{agentId}/console/inbox/read
+    - DELETE /api/agents/{agentId}/console/inbox/events/{event_id}
+    """
+    events = [
+        _make_event(event_id="scoped-inbox-01"),
+        _make_event(event_id="scoped-inbox-02"),
+        _make_event(event_id="scoped-inbox-03"),
+    ]
+    _seed_inbox_events(app_server.working_dir, events)
+
+    try:
+        list_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/console/inbox/events"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        listed = list_resp.json().get("events")
+        assert len(listed) == 3
+
+        mark_resp = app_server.api_request(
+            "POST",
+            _scoped("default", "/console/inbox/read"),
+            json={
+                "event_ids": ["scoped-inbox-01", "scoped-inbox-02"],
+                "all": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert mark_resp.status_code == 200, app_server.logs_tail()
+        assert mark_resp.json().get("updated") == 2
+
+        verify_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/console/inbox/events"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert verify_resp.status_code == 200, app_server.logs_tail()
+        read_map = {e["id"]: e["read"] for e in verify_resp.json()["events"]}
+        assert read_map["scoped-inbox-01"] is True
+        assert read_map["scoped-inbox-02"] is True
+        assert read_map["scoped-inbox-03"] is False
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            _scoped("default", "/console/inbox/events/scoped-inbox-03"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("deleted") is True
+
+        final_resp = app_server.api_request(
+            "GET",
+            _scoped("default", "/console/inbox/events"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert final_resp.status_code == 200, app_server.logs_tail()
+        remaining = {e["id"] for e in final_resp.json()["events"]}
+        assert remaining == {"scoped-inbox-01", "scoped-inbox-02"}
+    finally:
+        _clean_inbox(app_server.working_dir)
+
+
+# ------------------------------------------------------------------ #
+# workspace — real agent-scoped endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_workspace_upload_invalid_content_type(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/upload with a
+      non-zip content type is rejected with 400.
+
+    Test flow:
+    1. Create a test agent.
+    2. POST workspace/upload with content-type ``text/plain``.
+    3. Assert 400 and detail mentions ``zip``.
+    4. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/upload
+    """
+    agent_id = "integ_ws_upload_bad_ct_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/workspace/upload"),
+            files={
+                "file": (
+                    "bad.zip",
+                    b"not a zip",
+                    "text/plain",
+                ),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 400, app_server.logs_tail()
+        assert "zip" in resp.json().get("detail", "").lower()
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_workspace_upload_valid_zip_merges(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/upload with a valid
+      zip returns ``{"success": true}`` and the files are merged into
+      the agent workspace. This is the happy-path coverage for the real
+      agent-scoped workspace upload.
+
+    Test flow:
+    1. Create a test agent.
+    2. Build a zip containing ``test_marker.txt``.
+    3. POST workspace/upload with ``application/zip``.
+    4. Assert 200 and ``success == True``.
+    5. Delete test agent.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/upload
+    """
+    agent_id = "integ_ws_upload_ok_01"
+    _create_agent(app_server, agent_id)
+    try:
+        zip_bytes = _build_workspace_zip(
+            {
+                "test_marker.txt": "agent-scoped upload test",
+            },
+        )
+        resp = app_server.api_request(
+            "POST",
+            _scoped(agent_id, "/workspace/upload"),
+            files={
+                "file": (
+                    "workspace.zip",
+                    zip_bytes,
+                    "application/zip",
+                ),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        assert resp.json().get("success") is True
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# mcp-oauth — real agent-scoped endpoint
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_mcp_oauth_revoke_unknown_client(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /api/agents/{agentId}/mcp/oauth/{client_key} with
+      a non-existent client returns 404. The handler calls
+      ``get_agent_for_request`` (real agent-scoped), then checks
+      ``agent.config.mcp.clients``.
+
+    Test flow:
+    1. Create a test agent (fresh agent has mcp=None).
+    2. DELETE agent-scoped mcp/oauth/<bogus_key>.
+    3. Assert 404 and detail mentions ``not found``.
+    4. Delete test agent.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/mcp/oauth/{client_key}
+    """
+    agent_id = "integ_mcp_oauth_revoke_01"
+    _create_agent(app_server, agent_id)
+    try:
+        resp = app_server.api_request(
+            "DELETE",
+            _scoped(agent_id, "/mcp/oauth/no-such-client"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+        assert "not found" in resp.json().get("detail", "").lower()
+    finally:
+        _delete_agent_quietly(app_server, agent_id)
+
+
+# ------------------------------------------------------------------ #
+# workspace/transcribe — alias endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcribe_disabled_returns_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/transcribe returns
+      400 with code ``TRANSCRIPTION_DISABLED`` when the provider is
+      set to ``disabled`` (the default).
+
+    Test flow:
+    1. POST agent-scoped workspace/transcribe with a dummy audio file.
+    2. Assert 400 and detail.code == ``TRANSCRIPTION_DISABLED``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/transcribe
+    """
+    resp = app_server.api_request(
+        "POST",
+        _scoped("default", "/workspace/transcribe"),
+        files={
+            "file": ("test.webm", b"\x00" * 16, "audio/webm"),
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    detail = resp.json().get("detail", {})
+    assert detail.get("code") == "TRANSCRIPTION_DISABLED"
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcribe_unsupported_extension(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/workspace/transcribe with an
+      unsupported file extension returns 400 ``UNSUPPORTED_FILE_TYPE``.
+      Requires transcription to be enabled first (otherwise the
+      disabled check fires before the extension check).
+
+    Test flow:
+    1. PUT transcription-provider-type to ``whisper_api`` (enable).
+    2. POST workspace/transcribe with ``test.txt`` file.
+    3. Assert 400 and detail.code == ``UNSUPPORTED_FILE_TYPE``.
+    4. PUT transcription-provider-type back to ``disabled`` (restore).
+
+    API endpoints:
+    - POST /api/agents/{agentId}/workspace/transcribe
+    - PUT  /api/agents/{agentId}/workspace/transcription-provider-type
+    """
+    enable_resp = app_server.api_request(
+        "PUT",
+        _scoped("default", "/workspace/transcription-provider-type"),
+        json={"transcription_provider_type": "whisper_api"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert enable_resp.status_code == 200, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "POST",
+            _scoped("default", "/workspace/transcribe"),
+            files={
+                "file": ("test.txt", b"hello", "text/plain"),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 400, app_server.logs_tail()
+        detail = resp.json().get("detail", {})
+        assert detail.get("code") == "UNSUPPORTED_FILE_TYPE"
+    finally:
+        app_server.api_request(
+            "PUT",
+            _scoped(
+                "default",
+                "/workspace/transcription-provider-type",
+            ),
+            json={"transcription_provider_type": "disabled"},
+            timeout=_HTTP_TIMEOUT,
+        )
+
+
+# ------------------------------------------------------------------ #
+# workspace/transcription-provider-type — alias endpoints
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcription_provider_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify GET/PUT /api/agents/{agentId}/workspace/transcription-
+      provider-type forms a consistent roundtrip. This is the
+      happy-path coverage for the transcription provider setting
+      through agent-scoped routing.
+
+    Test flow:
+    1. GET agent-scoped transcription-provider-type — record baseline.
+    2. PUT ``whisper_api``.
+    3. GET — assert ``whisper_api``.
+    4. PUT back to baseline (``disabled``).
+    5. GET — assert baseline restored.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/workspace/transcription-provider-type
+    - PUT /api/agents/{agentId}/workspace/transcription-provider-type
+    """
+    base_path = "/workspace/transcription-provider-type"
+
+    baseline_resp = app_server.api_request(
+        "GET",
+        _scoped("default", base_path),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert baseline_resp.status_code == 200, app_server.logs_tail()
+    baseline = baseline_resp.json().get("transcription_provider_type")
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            _scoped("default", base_path),
+            json={"transcription_provider_type": "whisper_api"},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert (
+            put_resp.json().get("transcription_provider_type") == "whisper_api"
+        )
+
+        get_resp = app_server.api_request(
+            "GET",
+            _scoped("default", base_path),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert (
+            get_resp.json().get("transcription_provider_type") == "whisper_api"
+        )
+    finally:
+        app_server.api_request(
+            "PUT",
+            _scoped("default", base_path),
+            json={
+                "transcription_provider_type": baseline or "disabled",
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+
+    restore_resp = app_server.api_request(
+        "GET",
+        _scoped("default", base_path),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert restore_resp.status_code == 200, app_server.logs_tail()
+    assert restore_resp.json().get("transcription_provider_type") == (
+        baseline or "disabled"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_transcription_provider_invalid(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /api/agents/{agentId}/workspace/transcription-
+      provider-type with an invalid value returns 400 and enumerates
+      the allowed values.
+
+    Test flow:
+    1. PUT agent-scoped transcription-provider-type with ``"foobar"``.
+    2. Assert 400 and detail mentions ``Invalid``.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/workspace/transcription-provider-type
+    """
+    resp = app_server.api_request(
+        "PUT",
+        _scoped("default", "/workspace/transcription-provider-type"),
+        json={"transcription_provider_type": "foobar"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert "Invalid" in resp.json().get("detail", "")
+
+
+# ------------------------------------------------------------------ #
+# skills/hub — alias endpoint
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_hub_install_cancel_unknown_task(app_server) -> None:
+    """Test purpose:
+    - Verify POST /api/agents/{agentId}/skills/hub/install/cancel/
+      {task_id} with a non-existent task id returns 404.
+
+    Test flow:
+    1. POST agent-scoped skills/hub/install/cancel/<bogus_id>.
+    2. Assert 404 and detail == ``install task not found``.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/skills/hub/install/cancel/{task_id}
+    """
+    resp = app_server.api_request(
+        "POST",
+        _scoped(
+            "default",
+            "/skills/hub/install/cancel/integ-no-such-task",
+        ),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+    assert resp.json().get("detail") == "install task not found"

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -23,6 +23,7 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
 _PLUGIN_HTTP_TIMEOUT = 30.0
@@ -159,15 +160,19 @@ def _wait_until_plugin_loader_ready(
     last_status = None
     last_detail = ""
     while time.time() < deadline:
-        resp = app_server.api_request(
-            "POST",
-            "/api/plugins/install",
-            json={
-                "source": "/tmp/integ-loader-readiness-probe-not-a-path",
-                "force": False,
-            },
-            timeout=5.0,
-        )
+        try:
+            resp = app_server.api_request(
+                "POST",
+                "/api/plugins/install",
+                json={
+                    "source": "/tmp/integ-loader-readiness-probe-not-a-path",
+                    "force": False,
+                },
+                timeout=5.0,
+            )
+        except httpx.TimeoutException:
+            time.sleep(0.5)
+            continue
         last_status = resp.status_code
         try:
             last_detail = resp.json().get("detail", "")
@@ -199,12 +204,18 @@ def _install_local_official_plugin(
     resp = None
     while True:
         _wait_until_plugin_loader_ready(app_server)
-        resp = app_server.api_request(
-            "POST",
-            "/api/plugins/install",
-            json={"source": str(source_path), "force": False},
-            timeout=_PLUGIN_HTTP_TIMEOUT,
-        )
+        try:
+            resp = app_server.api_request(
+                "POST",
+                "/api/plugins/install",
+                json={"source": str(source_path), "force": False},
+                timeout=_PLUGIN_HTTP_TIMEOUT,
+            )
+        except httpx.TimeoutException:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.5)
+            continue
         if resp.status_code != 503 or time.time() >= deadline:
             break
         time.sleep(0.5)
@@ -240,11 +251,17 @@ def _upload_plugin_zip(
     deadline = time.time() + _LOADER_READY_TIMEOUT
     while True:
         _wait_until_plugin_loader_ready(app_server)
-        resp = app_server.api_request(
-            "POST",
-            "/api/plugins/upload",
-            **kwargs,
-        )
+        try:
+            resp = app_server.api_request(
+                "POST",
+                "/api/plugins/upload",
+                **kwargs,
+            )
+        except httpx.TimeoutException:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.5)
+            continue
         if resp.status_code != 503 or time.time() >= deadline:
             return resp
         time.sleep(0.5)

--- a/tests/integration/test_skills_agent_scoped.py
+++ b/tests/integration/test_skills_agent_scoped.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
-"""HTTP smoke tests for agent-scoped /api/agents/{id}/skills endpoints."""
+"""Integration tests for agent-scoped /api/agents/{id}/skills endpoints.
+
+Covers active-skill CRUD (create, save, upload, channels, config, tags)
+and their error branches, all through ``/api/agents/{agentId}/skills/*``.
+"""
 from __future__ import annotations
+
+import io
+import zipfile
 
 import pytest
 
@@ -338,3 +345,705 @@ def test_agent_scoped_skills_disable_enable_roundtrip(app_server) -> None:
     finally:
         app_server.api_request("DELETE", f"{base}/{skill_name}")
         app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+# ------------------------------------------------------------------ #
+# helpers for the new cases below
+# ------------------------------------------------------------------ #
+
+
+def _build_skill_zip(skills: dict[str, str]) -> bytes:
+    """Build a zip containing one SKILL.md per skill name."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in skills.items():
+            zf.writestr(f"{name}/SKILL.md", content)
+    return buf.getvalue()
+
+
+def _create_agent_and_skill(
+    app_server,
+    agent_id: str,
+    skill_name: str,
+    *,
+    enable: bool = False,
+    description: str = "active skill test",
+):
+    """Create agent + one workspace skill; asserts internally."""
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": f"Agent {agent_id}",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    create_skill = app_server.api_request(
+        "POST",
+        f"/api/agents/{agent_id}/skills",
+        json={
+            "name": skill_name,
+            "content": _skill_md(skill_name, description),
+            "enable": enable,
+        },
+    )
+    assert create_skill.status_code == 200, app_server.logs_tail()
+
+
+def _cleanup_agent_skill(app_server, agent_id: str, *skill_names: str):
+    for sn in skill_names:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/{sn}",
+        )
+    app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+# ------------------------------------------------------------------ #
+# save — full lifecycle
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_config_channels_tags_lifecycle(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify PUT /save updates content, then PUT channels/config/tags
+      each persist and are readable back. This is the comprehensive
+      happy-path across all four mutation endpoints for active skills.
+
+    Test flow:
+    1. Create agent + skill.
+    2. PUT /skills/save with new content.
+    3. PUT /{name}/channels with ``["dingtalk"]``.
+    4. PUT /{name}/config with ``{"llm_model": "qwen-max"}``.
+    5. PUT /{name}/tags with ``["automation"]``.
+    6. GET /{name}/config — assert ``llm_model``.
+    7. Cleanup.
+
+    API endpoints:
+    - PUT  /api/agents/{agentId}/skills/save
+    - PUT  /api/agents/{agentId}/skills/{skill_name}/channels
+    - PUT  /api/agents/{agentId}/skills/{skill_name}/config
+    - PUT  /api/agents/{agentId}/skills/{skill_name}/tags
+    - GET  /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_save_full_01"
+    skill_name = "integ-active-full-01"
+    base = f"/api/agents/{agent_id}/skills"
+    _create_agent_and_skill(app_server, agent_id, skill_name)
+
+    try:
+        save_resp = app_server.api_request(
+            "PUT",
+            f"{base}/save",
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "updated content"),
+            },
+        )
+        assert save_resp.status_code == 200, app_server.logs_tail()
+        assert save_resp.json().get("success") is True
+
+        ch_resp = app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/channels",
+            json=["dingtalk"],
+        )
+        assert ch_resp.status_code == 200, app_server.logs_tail()
+        assert ch_resp.json().get("channels") == ["dingtalk"]
+
+        cfg_resp = app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/config",
+            json={"config": {"llm_model": "qwen-max"}},
+        )
+        assert cfg_resp.status_code == 200, app_server.logs_tail()
+        assert cfg_resp.json().get("updated") is True
+
+        tags_resp = app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/tags",
+            json=["automation"],
+        )
+        assert tags_resp.status_code == 200, app_server.logs_tail()
+        assert tags_resp.json()["tags"] == ["automation"]
+
+        get_cfg = app_server.api_request(
+            "GET",
+            f"{base}/{skill_name}/config",
+        )
+        assert get_cfg.status_code == 200, app_server.logs_tail()
+        assert get_cfg.json()["config"]["llm_model"] == "qwen-max"
+    finally:
+        _cleanup_agent_skill(app_server, agent_id, skill_name)
+
+
+# ------------------------------------------------------------------ #
+# save — error branches
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /skills/save returns 404 when the skill does not
+      exist in the workspace.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/save
+    """
+    agent_id = "integ_active_save_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Save miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/save",
+            json={
+                "name": "integ-nosuch-skill-01",
+                "content": _skill_md("nosuch", "missing"),
+            },
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_conflict_409(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /skills/save returns 409 when attempting a rename
+      that collides with an existing skill.
+
+    Test flow:
+    1. Create agent + skill ``a`` + skill ``b``.
+    2. PUT /save with ``source_name="a"`` and ``name="b"`` (rename
+       a → b), ``overwrite=False``.
+    3. Assert 409 and detail.reason == ``conflict``.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/save
+    """
+    agent_id = "integ_active_save_conflict_01"
+    skill_a = "integ-active-conf-a"
+    skill_b = "integ-active-conf-b"
+
+    _create_agent_and_skill(
+        app_server,
+        agent_id,
+        skill_a,
+    )
+    create_b = app_server.api_request(
+        "POST",
+        f"/api/agents/{agent_id}/skills",
+        json={
+            "name": skill_b,
+            "content": _skill_md(skill_b, "target"),
+            "enable": False,
+        },
+    )
+    assert create_b.status_code == 200, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/save",
+            json={
+                "name": skill_b,
+                "source_name": skill_a,
+                "content": _skill_md(skill_b, "renamed"),
+                "overwrite": False,
+            },
+        )
+        assert resp.status_code == 409, app_server.logs_tail()
+        assert resp.json().get("detail", {}).get("reason") == "conflict"
+    finally:
+        _cleanup_agent_skill(
+            app_server,
+            agent_id,
+            skill_a,
+            skill_b,
+        )
+
+
+# ------------------------------------------------------------------ #
+# upload zip
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_upload_zip(app_server) -> None:
+    """Test purpose:
+    - Verify POST /skills/upload with a valid skill zip imports the
+      skill into the agent workspace. Happy-path coverage.
+
+    Test flow:
+    1. Create agent.
+    2. Build zip with skill ``integ-active-zip-01``.
+    3. POST /skills/upload.
+    4. Assert 200 and count >= 1.
+    5. GET /skills — assert the skill appears.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/skills/upload
+    - GET  /api/agents/{agentId}/skills
+    """
+    agent_id = "integ_active_upload_zip_01"
+    skill_name = "integ-active-zip-01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Upload zip agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        zip_bytes = _build_skill_zip(
+            {
+                skill_name: _skill_md(skill_name, "zip upload test"),
+            },
+        )
+        upload_resp = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills/upload",
+            files={
+                "file": (
+                    "skills.zip",
+                    zip_bytes,
+                    "application/zip",
+                ),
+            },
+            data={"enable": "false"},
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("count", 0) >= 1
+
+        list_resp = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/skills",
+        )
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        names = {item["name"] for item in list_resp.json()}
+        assert skill_name in names
+    finally:
+        _cleanup_agent_skill(app_server, agent_id, skill_name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_upload_zip_bad_archive(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify POST /skills/upload with non-zip content-type returns
+      400.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/skills/upload
+    """
+    agent_id = "integ_active_upload_bad_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Upload bad agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills/upload",
+            files={
+                "file": (
+                    "bad.txt",
+                    b"not a zip",
+                    "text/plain",
+                ),
+            },
+        )
+        assert resp.status_code == 400, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+# ------------------------------------------------------------------ #
+# channels / config / tags — error branches
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_channels_missing_404(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify PUT /{name}/channels returns 404 for a non-existent
+      skill.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/{skill_name}/channels
+    """
+    agent_id = "integ_active_ch_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Channels miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/channels",
+            json=["dingtalk"],
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_config_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /{name}/config returns 404 for a non-existent skill.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_cfg_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Config miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/config",
+            json={"config": {"k": "v"}},
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_config_delete_clears(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify DELETE /{name}/config clears config and GET returns
+      empty. Happy-path for config deletion.
+
+    Test flow:
+    1. Create agent + skill + PUT config.
+    2. DELETE config — assert ``cleared=True``.
+    3. GET config — assert empty.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/skills/{skill_name}/config
+    - GET    /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_cfg_del_01"
+    skill_name = "integ-active-cfg-del-01"
+    base = f"/api/agents/{agent_id}/skills"
+    _create_agent_and_skill(app_server, agent_id, skill_name)
+
+    try:
+        app_server.api_request(
+            "PUT",
+            f"{base}/{skill_name}/config",
+            json={"config": {"temperature": 0.7}},
+        )
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{base}/{skill_name}/config",
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("cleared") is True
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"{base}/{skill_name}/config",
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert get_resp.json()["config"] == {}
+    finally:
+        _cleanup_agent_skill(app_server, agent_id, skill_name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_config_delete_missing_404(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify DELETE /{name}/config returns 404 for a non-existent
+      skill.
+
+    API endpoints:
+    - DELETE /api/agents/{agentId}/skills/{skill_name}/config
+    """
+    agent_id = "integ_active_cfg_del_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Config del miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/config",
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_tags_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /{name}/tags returns 404 for a non-existent skill.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/{skill_name}/tags
+    """
+    agent_id = "integ_active_tags_miss_01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Tags miss agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        resp = app_server.api_request(
+            "PUT",
+            f"/api/agents/{agent_id}/skills/nosuch-skill/tags",
+            json=["test-tag"],
+        )
+        assert resp.status_code == 404, app_server.logs_tail()
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}",
+        )
+
+
+# ------------------------------------------------------------------ #
+# workspace → pool roundtrip
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_workspace_to_pool_roundtrip(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify a skill can be created in a workspace, uploaded to the
+      pool, downloaded back into a second workspace, forming a
+      complete workspace → pool → workspace roundtrip.
+
+    Test flow:
+    1. Create agent_a + skill.
+    2. POST /pool/upload from agent_a's workspace.
+    3. Create agent_b.
+    4. POST /pool/download targeting agent_b.
+    5. GET agent_b's skills — assert the skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/upload
+    - POST /api/skills/pool/download
+    - GET  /api/agents/{agentId}/skills
+    """
+    agent_a = "integ_ws2pool_a_01"
+    agent_b = "integ_ws2pool_b_01"
+    skill_name = "integ-ws2pool-roundtrip-01"
+
+    _create_agent_and_skill(
+        app_server,
+        agent_a,
+        skill_name,
+        description="roundtrip source",
+    )
+
+    try:
+        upload_resp = app_server.api_request(
+            "POST",
+            "/api/skills/pool/upload",
+            json={
+                "workspace_id": agent_a,
+                "skill_name": skill_name,
+                "overwrite": False,
+            },
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("success") is True
+
+        create_b = app_server.api_request(
+            "POST",
+            "/api/agents",
+            json={
+                "id": agent_b,
+                "name": "Roundtrip target",
+                "description": "",
+            },
+        )
+        assert create_b.status_code == 201, app_server.logs_tail()
+
+        dl_resp = app_server.api_request(
+            "POST",
+            "/api/skills/pool/download",
+            json={
+                "skill_name": skill_name,
+                "targets": [{"workspace_id": agent_b}],
+                "overwrite": False,
+            },
+        )
+        assert dl_resp.status_code == 200, app_server.logs_tail()
+        assert len(dl_resp.json().get("downloaded", [])) == 1
+
+        ws_skills = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_b}/skills",
+        )
+        assert ws_skills.status_code == 200, app_server.logs_tail()
+        ws_names = {item["name"] for item in ws_skills.json()}
+        assert skill_name in ws_names
+    finally:
+        try:
+            app_server.api_request(
+                "DELETE",
+                f"/api/skills/pool/{skill_name}",
+            )
+        except Exception:
+            pass
+        _cleanup_agent_skill(app_server, agent_a, skill_name)
+        _cleanup_agent_skill(app_server, agent_b, skill_name)
+
+
+# ------------------------------------------------------------------ #
+# save rename preserves content
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_agent_scoped_skills_save_rename_preserves(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify PUT /skills/save with ``source_name`` != ``name``
+      performs a rename and the new name appears in the listing
+      while the old name is gone. Happy-path for rename flow.
+
+    Test flow:
+    1. Create agent + skill ``old-name``.
+    2. PUT /save with ``source_name="old-name"``, ``name="new-name"``.
+    3. GET skills — assert ``new-name`` present, ``old-name`` absent.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/skills/save
+    - GET /api/agents/{agentId}/skills
+    """
+    agent_id = "integ_active_rename_01"
+    old_name = "integ-active-rename-old"
+    new_name = "integ-active-rename-new"
+    base = f"/api/agents/{agent_id}/skills"
+
+    _create_agent_and_skill(
+        app_server,
+        agent_id,
+        old_name,
+        description="rename source",
+    )
+
+    try:
+        save_resp = app_server.api_request(
+            "PUT",
+            f"{base}/save",
+            json={
+                "name": new_name,
+                "source_name": old_name,
+                "content": _skill_md(new_name, "renamed skill"),
+                "overwrite": False,
+            },
+        )
+        assert save_resp.status_code == 200, app_server.logs_tail()
+        assert save_resp.json().get("success") is True
+
+        list_resp = app_server.api_request("GET", base)
+        assert list_resp.status_code == 200, app_server.logs_tail()
+        names = {item["name"] for item in list_resp.json()}
+        assert new_name in names
+        assert old_name not in names
+    finally:
+        _cleanup_agent_skill(
+            app_server,
+            agent_id,
+            old_name,
+            new_name,
+        )

--- a/tests/integration/test_skills_pool.py
+++ b/tests/integration/test_skills_pool.py
@@ -1,0 +1,845 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for skill pool CRUD endpoints.
+
+Pool endpoints (``/api/skills/pool/*``) use ``SkillPoolService()`` — a
+global singleton that ignores the ``agentId`` path parameter when
+reached via agent-scoped routing.  Tests here hit the global
+``/api/skills/pool/*`` paths directly.
+
+Agent-scoped routing coverage for pool URLs is in
+``test_agent_scoped_routing.py``.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from typing import Any
+
+import pytest
+
+_HTTP_TIMEOUT = 15.0
+_POOL_BASE = "/api/skills/pool"
+
+
+# ------------------------------------------------------------------ #
+# helpers
+# ------------------------------------------------------------------ #
+
+
+def _skill_md(name: str, description: str) -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        "---\n\n"
+        "# Pool Integration Skill\n"
+        "This skill is created by pool integration tests.\n"
+    )
+
+
+def _create_pool_skill(
+    app_server,
+    name: str,
+    *,
+    description: str = "pool test skill",
+) -> dict[str, Any]:
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/create",
+        json={
+            "name": name,
+            "content": _skill_md(name, description),
+            "enable": False,
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    return resp.json()
+
+
+def _delete_pool_skill_quietly(app_server, name: str) -> None:
+    try:
+        app_server.api_request(
+            "DELETE",
+            f"{_POOL_BASE}/{name}",
+            timeout=_HTTP_TIMEOUT,
+        )
+    except Exception:
+        pass
+
+
+def _list_pool_skill_names(app_server) -> set[str]:
+    resp = app_server.api_request(
+        "GET",
+        _POOL_BASE,
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    return {item["name"] for item in resp.json()}
+
+
+def _build_skill_zip(skills: dict[str, str]) -> bytes:
+    """Build a zip containing one SKILL.md per skill name."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in skills.items():
+            zf.writestr(f"{name}/SKILL.md", content)
+    return buf.getvalue()
+
+
+# ------------------------------------------------------------------ #
+# lifecycle
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_skill_lifecycle(app_server) -> None:
+    """Test purpose:
+    - Verify the create → list → get-config → delete lifecycle for a
+      pool skill. This is the primary happy-path CRUD coverage.
+
+    Test flow:
+    1. POST /pool/create with a new skill.
+    2. GET /pool — assert the skill appears.
+    3. GET /pool/{name}/config — assert empty config.
+    4. DELETE /pool/{name} — assert ``deleted=True``.
+    5. GET /pool — assert the skill is gone.
+
+    API endpoints:
+    - POST /api/skills/pool/create
+    - GET  /api/skills/pool
+    - GET  /api/skills/pool/{skill_name}/config
+    - DELETE /api/skills/pool/{skill_name}
+    """
+    name = "integ-pool-lifecycle-01"
+    try:
+        result = _create_pool_skill(app_server, name)
+        assert result.get("created") is True
+
+        assert name in _list_pool_skill_names(app_server)
+
+        config_resp = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert config_resp.status_code == 200, app_server.logs_tail()
+        assert config_resp.json().get("config") == {}
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{_POOL_BASE}/{name}",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("deleted") is True
+
+        assert name not in _list_pool_skill_names(app_server)
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_skill_duplicate_409(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/create with an existing name returns 409 and
+      includes a ``suggested_name``.
+
+    Test flow:
+    1. Create pool skill ``integ-pool-dup-01``.
+    2. POST /pool/create with the same name.
+    3. Assert 409 and detail.reason == ``conflict``.
+
+    API endpoints:
+    - POST /api/skills/pool/create
+    """
+    name = "integ-pool-dup-01"
+    try:
+        _create_pool_skill(app_server, name)
+
+        dup_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/create",
+            json={
+                "name": name,
+                "content": _skill_md(name, "duplicate"),
+                "enable": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert dup_resp.status_code == 409, app_server.logs_tail()
+        detail = dup_resp.json().get("detail", {})
+        assert detail.get("reason") == "conflict"
+        assert "suggested_name" in detail
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+# ------------------------------------------------------------------ #
+# save
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_save_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /pool/save on a non-existent pool skill returns 404.
+
+    Test flow:
+    1. PUT /pool/save with a name that does not exist.
+    2. Assert 404.
+
+    API endpoints:
+    - PUT /api/skills/pool/save
+    """
+    resp = app_server.api_request(
+        "PUT",
+        f"{_POOL_BASE}/save",
+        json={
+            "name": "integ-pool-nosuch-01",
+            "content": _skill_md("nosuch", "missing"),
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# delete
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_delete_missing_409(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /pool/{name} for a non-existent skill returns 409
+      ``cannot be deleted``.
+
+    Test flow:
+    1. DELETE /pool/<nonexistent>.
+    2. Assert 409.
+
+    API endpoints:
+    - DELETE /api/skills/pool/{skill_name}
+    """
+    resp = app_server.api_request(
+        "DELETE",
+        f"{_POOL_BASE}/integ-pool-gone-01",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 409, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# config
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_config_put_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /pool/{name}/config returns 404 when the skill does
+      not exist.
+
+    API endpoints:
+    - PUT /api/skills/pool/{skill_name}/config
+    """
+    resp = app_server.api_request(
+        "PUT",
+        f"{_POOL_BASE}/integ-pool-cfg-miss-01/config",
+        json={"config": {"key": "value"}},
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_config_delete_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify DELETE /pool/{name}/config returns 404 when the skill
+      does not exist.
+
+    API endpoints:
+    - DELETE /api/skills/pool/{skill_name}/config
+    """
+    resp = app_server.api_request(
+        "DELETE",
+        f"{_POOL_BASE}/integ-pool-cfg-del-miss-01/config",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_config_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify PUT → GET → DELETE config roundtrip on a pool skill.
+      This is the happy-path coverage for the pool config endpoints.
+
+    Test flow:
+    1. Create pool skill.
+    2. PUT config with ``{"llm_model": "qwen-max"}``.
+    3. GET config — assert value matches.
+    4. DELETE config — assert ``cleared=True``.
+    5. GET config — assert empty.
+
+    API endpoints:
+    - PUT    /api/skills/pool/{skill_name}/config
+    - GET    /api/skills/pool/{skill_name}/config
+    - DELETE /api/skills/pool/{skill_name}/config
+    """
+    name = "integ-pool-cfg-rt-01"
+    try:
+        _create_pool_skill(app_server, name)
+
+        put_resp = app_server.api_request(
+            "PUT",
+            f"{_POOL_BASE}/{name}/config",
+            json={"config": {"llm_model": "qwen-max"}},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert put_resp.json().get("updated") is True
+
+        get_resp = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert get_resp.status_code == 200, app_server.logs_tail()
+        assert get_resp.json()["config"]["llm_model"] == "qwen-max"
+
+        del_resp = app_server.api_request(
+            "DELETE",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert del_resp.status_code == 200, app_server.logs_tail()
+        assert del_resp.json().get("cleared") is True
+
+        empty_resp = app_server.api_request(
+            "GET",
+            f"{_POOL_BASE}/{name}/config",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert empty_resp.status_code == 200, app_server.logs_tail()
+        assert empty_resp.json()["config"] == {}
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+# ------------------------------------------------------------------ #
+# tags
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_tags_put_missing_404(app_server) -> None:
+    """Test purpose:
+    - Verify PUT /pool/{name}/tags returns 404 when the skill does
+      not exist.
+
+    API endpoints:
+    - PUT /api/skills/pool/{skill_name}/tags
+    """
+    resp = app_server.api_request(
+        "PUT",
+        f"{_POOL_BASE}/integ-pool-tags-miss-01/tags",
+        json=["automation"],
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 404, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# batch-delete
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_batch_delete_partial(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/batch-delete with a mix of existing and
+      non-existent names returns per-skill results (success for
+      existing, failure for missing).
+
+    Test flow:
+    1. Create pool skill ``integ-pool-bd-a``.
+    2. POST batch-delete with ``["integ-pool-bd-a", "integ-pool-bd-ghost"]``.
+    3. Assert ``integ-pool-bd-a`` succeeds, ``integ-pool-bd-ghost`` fails.
+
+    API endpoints:
+    - POST /api/skills/pool/batch-delete
+    """
+    name = "integ-pool-bd-a"
+    ghost = "integ-pool-bd-ghost"
+    try:
+        _create_pool_skill(app_server, name)
+
+        resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/batch-delete",
+            json=[name, ghost],
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        results = resp.json().get("results", {})
+        assert results[name]["success"] is True
+        assert results[ghost]["success"] is False
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_batch_delete_all_success(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/batch-delete succeeds for all names when all
+      skills exist. This is the normal-flow batch cleanup scenario.
+
+    Test flow:
+    1. Create 3 pool skills.
+    2. POST batch-delete with all 3 names.
+    3. Assert all 3 succeed.
+    4. GET /pool — assert none remain.
+
+    API endpoints:
+    - POST /api/skills/pool/batch-delete
+    - GET  /api/skills/pool
+    """
+    names = [
+        "integ-pool-bd-all-a",
+        "integ-pool-bd-all-b",
+        "integ-pool-bd-all-c",
+    ]
+    try:
+        for n in names:
+            _create_pool_skill(app_server, n)
+
+        resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/batch-delete",
+            json=names,
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        results = resp.json().get("results", {})
+        for n in names:
+            assert results[n]["success"] is True
+
+        remaining = _list_pool_skill_names(app_server)
+        for n in names:
+            assert n not in remaining
+    finally:
+        for n in names:
+            _delete_pool_skill_quietly(app_server, n)
+
+
+# ------------------------------------------------------------------ #
+# upload-zip
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_upload_zip_valid(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/upload-zip with a valid skill zip imports the
+      skill into the pool. This is the happy-path for zip ingestion.
+
+    Test flow:
+    1. Build a zip with a single skill ``integ-pool-zip-01``.
+    2. POST /pool/upload-zip.
+    3. Assert 200 and ``count >= 1``.
+    4. GET /pool — assert the skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/upload-zip
+    - GET  /api/skills/pool
+    """
+    name = "integ-pool-zip-01"
+    zip_bytes = _build_skill_zip(
+        {
+            name: _skill_md(name, "zip-imported pool skill"),
+        },
+    )
+    try:
+        resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/upload-zip",
+            files={
+                "file": (
+                    "skills.zip",
+                    zip_bytes,
+                    "application/zip",
+                ),
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert resp.status_code == 200, app_server.logs_tail()
+        payload = resp.json()
+        assert payload.get("count", 0) >= 1
+
+        assert name in _list_pool_skill_names(app_server)
+    finally:
+        _delete_pool_skill_quietly(app_server, name)
+
+
+# ------------------------------------------------------------------ #
+# upload from workspace
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_upload_from_workspace(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/upload copies a workspace skill into the pool.
+      Requires a pre-existing workspace skill as input.
+
+    Test flow:
+    1. Create agent + workspace skill via ``POST /api/agents/{id}/skills``.
+    2. POST /pool/upload with ``workspace_id`` and ``skill_name``.
+    3. Assert 200 and ``success=True``.
+    4. GET /pool — assert skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/upload
+    - GET  /api/skills/pool
+    """
+    agent_id = "integ_pool_upload_ws_01"
+    skill_name = "integ-pool-from-ws-01"
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Pool upload source",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        create_skill = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills",
+            json={
+                "name": skill_name,
+                "content": _skill_md(skill_name, "source for pool"),
+                "enable": False,
+            },
+        )
+        assert create_skill.status_code == 200, app_server.logs_tail()
+
+        upload_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/upload",
+            json={
+                "workspace_id": agent_id,
+                "skill_name": skill_name,
+                "overwrite": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert upload_resp.status_code == 200, app_server.logs_tail()
+        assert upload_resp.json().get("success") is True
+
+        assert skill_name in _list_pool_skill_names(app_server)
+    finally:
+        _delete_pool_skill_quietly(app_server, skill_name)
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/{skill_name}",
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+
+
+# ------------------------------------------------------------------ #
+# download
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_download_no_targets_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/download with an empty targets list returns
+      400 ``No workspace targets provided``.
+
+    API endpoints:
+    - POST /api/skills/pool/download
+    """
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/download",
+        json={
+            "skill_name": "integ-pool-dl-notar-01",
+            "targets": [],
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+    assert "No workspace targets" in resp.json().get("detail", "")
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_download_to_workspace(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/download copies a pool skill into a workspace.
+      End-to-end happy path: create pool skill → create agent →
+      download → verify in workspace.
+
+    Test flow:
+    1. Create pool skill ``integ-pool-dl-01``.
+    2. Create agent.
+    3. POST /pool/download targeting that agent.
+    4. Assert 200 and ``downloaded`` list has 1 entry.
+    5. GET /api/agents/{id}/skills — assert the skill appears.
+
+    API endpoints:
+    - POST /api/skills/pool/download
+    - GET  /api/agents/{agentId}/skills
+    """
+    pool_name = "integ-pool-dl-01"
+    agent_id = "integ_pool_dl_agent_01"
+
+    try:
+        _create_pool_skill(app_server, pool_name)
+
+        create_agent = app_server.api_request(
+            "POST",
+            "/api/agents",
+            json={
+                "id": agent_id,
+                "name": "Download target",
+                "description": "",
+            },
+        )
+        assert create_agent.status_code == 201, app_server.logs_tail()
+
+        dl_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/download",
+            json={
+                "skill_name": pool_name,
+                "targets": [{"workspace_id": agent_id}],
+                "overwrite": False,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert dl_resp.status_code == 200, app_server.logs_tail()
+        downloaded = dl_resp.json().get("downloaded", [])
+        assert len(downloaded) == 1
+        assert downloaded[0]["workspace_id"] == agent_id
+
+        ws_skills = app_server.api_request(
+            "GET",
+            f"/api/agents/{agent_id}/skills",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert ws_skills.status_code == 200, app_server.logs_tail()
+        ws_names = {item["name"] for item in ws_skills.json()}
+        assert pool_name in ws_names
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/{pool_name}",
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")
+        _delete_pool_skill_quietly(app_server, pool_name)
+
+
+# ------------------------------------------------------------------ #
+# import-builtin + update-builtin
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_import_builtin_and_update(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/import-builtin imports a builtin skill into
+      the pool, and POST /pool/{name}/update-builtin refreshes it.
+      Uses ``file_reader-zh`` (smallest builtin).
+
+    Test flow:
+    1. POST /pool/import-builtin with ``skill_names=["file_reader-zh"]``.
+    2. Assert 200 and ``imported`` list is non-empty.
+    3. GET /pool — assert ``file_reader-zh`` appears.
+    4. POST /pool/file_reader-zh/update-builtin.
+    5. Assert 200.
+
+    API endpoints:
+    - POST /api/skills/pool/import-builtin
+    - POST /api/skills/pool/{skill_name}/update-builtin
+    - GET  /api/skills/pool
+    """
+    source = "file_reader-zh"
+    pool_name = "file_reader"
+    try:
+        import_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/import-builtin",
+            json={
+                "skill_names": [source],
+                "overwrite_conflicts": True,
+            },
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert import_resp.status_code == 200, app_server.logs_tail()
+        payload = import_resp.json()
+        total = len(payload.get("imported", [])) + len(
+            payload.get("updated", []),
+        )
+        assert total >= 1
+
+        assert pool_name in _list_pool_skill_names(app_server)
+
+        update_resp = app_server.api_request(
+            "POST",
+            f"{_POOL_BASE}/{pool_name}/update-builtin",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert update_resp.status_code == 200, app_server.logs_tail()
+    finally:
+        _delete_pool_skill_quietly(app_server, pool_name)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_update_builtin_missing_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/{name}/update-builtin for a non-existent
+      skill returns 400.
+
+    API endpoints:
+    - POST /api/skills/pool/{skill_name}/update-builtin
+    """
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/integ-pool-nobuiltin-01/update-builtin",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# import from hub
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_pool_import_hub_invalid_400(app_server) -> None:
+    """Test purpose:
+    - Verify POST /pool/import with an invalid ``bundle_url`` returns
+      400. The handler validates the URL before attempting to fetch.
+
+    API endpoints:
+    - POST /api/skills/pool/import
+    """
+    resp = app_server.api_request(
+        "POST",
+        f"{_POOL_BASE}/import",
+        json={
+            "bundle_url": "not-a-valid-url",
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 400, app_server.logs_tail()
+
+
+# ------------------------------------------------------------------ #
+# hub install start → poll → complete
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_hub_install_start_poll_complete(app_server) -> None:
+    """Test purpose:
+    - Verify the async hub install pipeline: start → status poll →
+      terminal state. Uses the ``file_reader-zh`` skill from the
+      upstream repo (smallest builtin, ~1.6 KB).
+
+    Test flow:
+    1. Create agent.
+    2. POST /skills/hub/install/start with the upstream
+       ``file_reader-zh`` GitHub URL.
+    3. Assert 200 and response contains ``task_id``.
+    4. Poll GET /skills/hub/install/status/{task_id} until terminal.
+    5. Assert status is ``completed`` or ``failed`` (network-dependent).
+    6. Cleanup: delete agent + workspace skill.
+
+    API endpoints:
+    - POST /api/skills/hub/install/start
+    - GET  /api/skills/hub/install/status/{task_id}
+    """
+    agent_id = "integ_hub_install_poll_01"
+    skill_url = (
+        "https://github.com/agentscope-ai/QwenPaw"
+        "/tree/main/src/qwenpaw/agents/skills/file_reader-zh"
+    )
+    create_agent = app_server.api_request(
+        "POST",
+        "/api/agents",
+        json={
+            "id": agent_id,
+            "name": "Hub install poll agent",
+            "description": "",
+        },
+    )
+    assert create_agent.status_code == 201, app_server.logs_tail()
+
+    try:
+        start_resp = app_server.api_request(
+            "POST",
+            f"/api/agents/{agent_id}/skills/hub/install/start",
+            json={
+                "bundle_url": skill_url,
+                "enable": False,
+            },
+            timeout=30.0,
+        )
+        assert start_resp.status_code == 200, app_server.logs_tail()
+        task_id = start_resp.json().get("task_id")
+        assert task_id
+
+        import time
+
+        terminal = {"completed", "failed", "cancelled"}
+        deadline = time.time() + 60
+        last_status = None
+        while time.time() < deadline:
+            status_resp = app_server.api_request(
+                "GET",
+                f"/api/agents/{agent_id}/skills"
+                f"/hub/install/status/{task_id}",
+                timeout=_HTTP_TIMEOUT,
+            )
+            assert status_resp.status_code == 200, app_server.logs_tail()
+            last_status = status_resp.json().get("status")
+            if last_status in terminal:
+                break
+            time.sleep(1.0)
+
+        assert (
+            last_status in terminal
+        ), f"task {task_id} stuck at {last_status}"
+    finally:
+        app_server.api_request(
+            "DELETE",
+            f"/api/agents/{agent_id}/skills/file_reader-zh",
+        )
+        app_server.api_request("DELETE", f"/api/agents/{agent_id}")

--- a/tests/unit/agents/context/test_light_context_manager.py
+++ b/tests/unit/agents/context/test_light_context_manager.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for LightContextManager automation memory handling."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from agentscope.message import Msg
+
+from qwenpaw.agents.context.light_context_manager import (
+    LightContextManager,
+    _should_skip_automation_memory,
+)
+
+
+def _agent_with_source(source: str):
+    return SimpleNamespace(_request_context={"source": source})
+
+
+@pytest.mark.parametrize("source", ["cron", "heartbeat", "CRON"])
+def test_should_skip_automation_memory_for_system_sources(source):
+    assert _should_skip_automation_memory(_agent_with_source(source)) is True
+
+
+@pytest.mark.parametrize("source", ["", "console", "user"])
+def test_should_not_skip_automation_memory_for_user_sources(source):
+    assert _should_skip_automation_memory(_agent_with_source(source)) is False
+
+
+@pytest.mark.asyncio
+async def test_post_reply_skips_auto_memory_for_cron_source(tmp_path):
+    manager = LightContextManager(str(tmp_path), "default")
+    memory_manager = SimpleNamespace(auto_memory=AsyncMock())
+    memory = SimpleNamespace(
+        content=[(Msg("user", "cron task input", "user"), None)],
+    )
+    agent = SimpleNamespace(
+        memory_manager=memory_manager,
+        memory=memory,
+        _request_context={"source": "cron"},
+    )
+
+    await manager.post_reply(agent, {}, None)
+
+    memory_manager.auto_memory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_reply_keeps_auto_memory_for_user_source(tmp_path):
+    manager = LightContextManager(str(tmp_path), "default")
+    memory_manager = SimpleNamespace(auto_memory=AsyncMock())
+    user_msg = Msg("user", "normal user input", "user")
+    memory = SimpleNamespace(content=[(user_msg, None)])
+    agent = SimpleNamespace(
+        memory_manager=memory_manager,
+        memory=memory,
+        _request_context={"source": "user"},
+    )
+
+    await manager.post_reply(agent, {}, None)
+
+    memory_manager.auto_memory.assert_awaited_once_with(
+        all_messages=[user_msg],
+    )

--- a/tests/unit/cli/test_desktop_cmd.py
+++ b/tests/unit/cli/test_desktop_cmd.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the legacy pywebview desktop bridge."""
+
+import io
+import types
+import urllib.request
+
+from qwenpaw.cli import desktop_cmd
+
+
+class _Response(io.BytesIO):
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+def test_save_file_passes_headers_to_download_request(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    destination = tmp_path / "backup.zip"
+    monkeypatch.setattr(
+        desktop_cmd,
+        "webview",
+        types.SimpleNamespace(
+            SAVE_DIALOG=1,
+            windows=[
+                types.SimpleNamespace(
+                    create_file_dialog=lambda *_args, **_kwargs: str(
+                        destination,
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    captured_url = ""
+    captured_headers: dict[str, str] = {}
+
+    def fake_urlopen(request: urllib.request.Request) -> _Response:
+        nonlocal captured_headers, captured_url
+        captured_url = request.full_url
+        captured_headers = {
+            key.lower(): value for key, value in request.header_items()
+        }
+        return _Response(b"zip")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    saved = desktop_cmd.WebViewAPI().save_file(
+        "http://127.0.0.1:43123/api/backups/abc/export",
+        "backup.zip",
+        {"Authorization": "Bearer tok", "X-Agent-Id": "agent-a"},
+    )
+
+    assert saved is True
+    assert destination.read_bytes() == b"zip"
+    assert captured_url == "http://127.0.0.1:43123/api/backups/abc/export"
+    assert captured_headers["authorization"] == "Bearer tok"
+    assert captured_headers["x-agent-id"] == "agent-a"

--- a/tests/unit/providers/test_mimo_provider.py
+++ b/tests/unit/providers/test_mimo_provider.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
+"""Tests for the Xiaomi MiMo Token Plan built-in provider."""
+from __future__ import annotations
+
+import pytest
+
+import qwenpaw.providers.provider_manager as provider_manager_module
+from qwenpaw.providers.openai_provider import OpenAIProvider
+from qwenpaw.providers.provider_manager import (
+    PROVIDER_MIMO_TOKENPLAN,
+    MIMO_TOKENPLAN_MODELS,
+    ProviderManager,
+)
+
+
+def test_mimo_provider_is_openai_compatible() -> None:
+    """MiMo Token Plan provider should be an OpenAIProvider instance."""
+    assert isinstance(PROVIDER_MIMO_TOKENPLAN, OpenAIProvider)
+
+
+def test_mimo_provider_config() -> None:
+    """Verify MiMo Token Plan provider configuration defaults."""
+    assert PROVIDER_MIMO_TOKENPLAN.id == "mimo-tokenplan"
+    assert PROVIDER_MIMO_TOKENPLAN.name == "Xiaomi MiMo Token Plan"
+    assert (
+        PROVIDER_MIMO_TOKENPLAN.base_url
+        == "https://token-plan-cn.xiaomimimo.com/v1"
+    )
+    assert PROVIDER_MIMO_TOKENPLAN.freeze_url is True
+    assert PROVIDER_MIMO_TOKENPLAN.api_key_prefix == ""
+
+
+def test_mimo_models_list() -> None:
+    """Verify MiMo Token Plan model definitions."""
+    model_ids = [m.id for m in MIMO_TOKENPLAN_MODELS]
+    assert "mimo-v2.5-pro" in model_ids
+    assert "mimo-v2.5" in model_ids
+    assert len(MIMO_TOKENPLAN_MODELS) == 2
+
+
+def test_mimo_models_attributes() -> None:
+    """Verify MiMo Token Plan model attributes."""
+    for model in MIMO_TOKENPLAN_MODELS:
+        if model.id == "mimo-v2.5":
+            assert model.supports_image is True
+            assert model.supports_video is True
+        else:
+            assert model.supports_image is False
+            assert model.supports_video is False
+        assert model.probe_source == "documentation"
+
+
+@pytest.fixture
+def isolated_secret_dir(monkeypatch, tmp_path):
+    secret_dir = tmp_path / ".qwenpaw.secret"
+    monkeypatch.setattr(provider_manager_module, "SECRET_DIR", secret_dir)
+    return secret_dir
+
+
+def test_mimo_registered_in_provider_manager(
+    isolated_secret_dir,
+) -> None:
+    """MiMo Token Plan provider should be registered as a built-in provider."""
+    manager = ProviderManager()
+
+    provider = manager.get_provider("mimo-tokenplan")
+    assert provider is not None
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.base_url == "https://token-plan-cn.xiaomimimo.com/v1"
+    assert provider.name == "Xiaomi MiMo Token Plan"
+
+
+def test_mimo_has_expected_models(isolated_secret_dir) -> None:
+    """MiMo Token Plan provider should include built-in models."""
+    manager = ProviderManager()
+    provider = manager.get_provider("mimo-tokenplan")
+
+    assert provider is not None
+    assert provider.has_model("mimo-v2.5-pro")
+    assert provider.has_model("mimo-v2.5")
+
+
+def test_mimo_provider_list_includes_mimo(isolated_secret_dir) -> None:
+    """ProviderManager should list MiMo Token Plan in available providers."""
+    manager = ProviderManager()
+    # Verify the provider exists in builtin_providers
+    assert "mimo-tokenplan" in manager.builtin_providers
+    assert manager.get_provider("mimo-tokenplan") is not None


### PR DESCRIPTION
## Summary

- 13 agent-scoped routing tests — inbox, plugins, MCP OAuth, workspace upload/transcribe, hub install cancel
- 35 skills contract tests — pool CRUD/lifecycle (18) + agent-scoped skills CRUD/batch/save/upload (17)
- 7 agent-scoped misc tests — tools list/config, heartbeat run, console chat SSE, MCP OAuth PKCE

All hermetic, zero external dependencies. Integration total: 162 → 217 cases.

## New files

- `tests/integration/test_agent_scoped_routing.py`
- `tests/integration/test_skills_pool.py`
- `tests/integration/test_skills_agent_scoped.py` (expanded from 0 → 17 cases)
- `tests/integration/test_agent_scoped_misc.py`

## Test plan

- [x] Fork CI 4-platform matrix all green
- [x] Zero regressions on existing 162 cases
- [x] Pre-commit checks pass