### PR TITLE
fix(file_io): use aiofiles for non-blocking file writes

### DIFF
--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+import aiofiles
 from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
 
@@ -232,8 +233,8 @@ async def write_file(
     encoding = _get_encoding_for_file(file_path)
 
     try:
-        with open(file_path, "w", encoding=encoding) as file:
-            file.write(content)
+        async with aiofiles.open(file_path, "w", encoding=encoding) as file:
+            await file.write(content)
         return ToolResponse(
             content=[
                 TextBlock(
@@ -374,8 +375,8 @@ async def append_file(
     encoding = _get_encoding_for_file(file_path)
 
     try:
-        with open(file_path, "a", encoding=encoding) as file:
-            file.write(content)
+        async with aiofiles.open(file_path, "a", encoding=encoding) as file:
+            await file.write(content)
         return ToolResponse(
             content=[
                 TextBlock(


### PR DESCRIPTION
## Description

Replace blocking `open()` calls in `write_file` and `append_file` with `aiofiles.open()` so file writes no longer block the event loop.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
