### PR TITLE
Add lifecycle events for background subagents

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -43,6 +43,7 @@ from .tools import (
     delegate_external_agent,
     chat_with_agent,
     check_agent_task,
+    wait_subagent_events,
     spawn_subagent,
     submit_to_agent,
     desktop_screenshot,
@@ -302,6 +303,7 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
             "chat_with_agent": chat_with_agent,
             "submit_to_agent": submit_to_agent,
             "check_agent_task": check_agent_task,
+            "wait_subagent_events": wait_subagent_events,
             "spawn_subagent": spawn_subagent,
             # Register only when the `make-skill` skill is enabled.
             **(

--- a/src/qwenpaw/agents/skills/multi_agent_collaboration-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/multi_agent_collaboration-en/SKILL.md
@@ -33,6 +33,7 @@ If the **user explicitly asks a specific agent to participate/assist/answer**, y
 3. **Check agents before invoking -- do not guess IDs**
 4. **When context continuation is needed, you must pass `--session-id`**
 5. **Do not call back the source agent**
+6. **If you start a background subagent with the built-in `spawn_subagent(background=True)`, prefer `wait_subagent_events(task_ids=[...])` for results; do not run frequent `check_agent_task` polling loops**
 
 ---
 
@@ -144,6 +145,22 @@ qwenpaw agents chat \
 6. Wait a reasonable time (30-60 seconds) before querying status
 7. Use --background --task-id to query results
 ```
+
+For tool-level `spawn_subagent(background=True)`, the background subagent sends
+completion, failure, cancellation, or timeout events back to the current parent
+session. After recording the returned task_id, use:
+
+```python
+wait_subagent_events(task_ids=["<task_id>"])
+```
+
+Multiple background subagents can be waited on together:
+
+```python
+wait_subagent_events(task_ids=["<task_id_1>", "<task_id_2>"])
+```
+
+Use `check_agent_task` only as a manual fallback when events are unavailable.
 
 ---
 

--- a/src/qwenpaw/agents/skills/multi_agent_collaboration-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/multi_agent_collaboration-zh/SKILL.md
@@ -33,6 +33,7 @@ metadata:
 3. **调用前先查 agent，不要猜 ID**
 4. **需要上下文续聊时，必须传 `--session-id`**
 5. **不要回调消息来源 agent**
+6. **如果使用内置 `spawn_subagent(background=True)` 启动后台子 agent，优先用 `wait_subagent_events(task_ids=[...])` 等待结果；不要围绕 `check_agent_task` 高频轮询**
 
 ---
 
@@ -144,6 +145,20 @@ qwenpaw agents chat \
 6. 等待合理时间（30-60秒）后查询状态
 7. 使用 --background --task-id 查询结果
 ```
+
+如果是工具层的 `spawn_subagent(background=True)`，后台子 agent 会把完成/失败/取消/超时事件发回当前父会话。记录返回的 task_id 后，使用：
+
+```python
+wait_subagent_events(task_ids=["<task_id>"])
+```
+
+多个后台子 agent 可以一起等待：
+
+```python
+wait_subagent_events(task_ids=["<task_id_1>", "<task_id_2>"])
+```
+
+`check_agent_task` 只作为手动排查或事件不可用时的兜底。
 
 ---
 

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -27,6 +27,7 @@ from .agent_management import (
     chat_with_agent,
     submit_to_agent,
     check_agent_task,
+    wait_subagent_events,
     spawn_subagent,
 )
 from .delegate_external_agent import delegate_external_agent
@@ -59,5 +60,6 @@ __all__ = [
     "chat_with_agent",
     "submit_to_agent",
     "check_agent_task",
+    "wait_subagent_events",
     "spawn_subagent",
 ]

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -19,6 +19,7 @@ from ...utils.http import trust_env_for_url
 
 DEFAULT_AGENT_API_BASE_URL = "http://127.0.0.1:8088"
 DEFAULT_AGENT_API_TIMEOUT = 30.0
+MAX_BACKGROUND_SUBAGENTS_PER_PARENT = 5
 
 
 def resolve_agent_api_base_url(base_url: Optional[str] = None) -> str:
@@ -360,21 +361,34 @@ def format_agent_chat_text(
 def format_background_submission_text(
     task_result: Dict[str, Any],
     session_id: str,
+    *,
+    prefer_events: bool = False,
 ) -> str:
     """Format background submission result as plain text."""
     task_id = task_result.get("task_id")
     if not task_id:
         return "ERROR: No task_id returned from server"
 
-    return "\n".join(
-        [
-            f"[TASK_ID: {task_id}]",
-            f"[SESSION: {session_id}]",
-            "",
-            "Task submitted successfully.",
+    lines = [
+        f"[TASK_ID: {task_id}]",
+        f"[SESSION: {session_id}]",
+        "",
+        "Task submitted successfully.",
+    ]
+    if prefer_events:
+        lines.extend(
+            [
+                "Wait for completion with: "
+                f"wait_subagent_events(task_ids=['{task_id}'])",
+                "Fallback status check: "
+                f"check_agent_task(task_id='{task_id}')",
+            ],
+        )
+    else:
+        lines.append(
             "Check status with: check_agent_task(" f"task_id='{task_id}')",
-        ],
-    )
+        )
+    return "\n".join(lines)
 
 
 def format_background_status_text(
@@ -608,7 +622,10 @@ async def check_agent_task(
     This tool queries a previously submitted background task by its task ID.
     If the task is still in progress, it returns the current lifecycle state.
     If the task has finished, it returns either the final agent response or a
-    failure message.
+    failure message. For background tasks created by ``spawn_subagent``, prefer
+    ``wait_subagent_events`` because spawned subagents publish completion events
+    back to the parent session. Use this tool as a manual fallback or for
+    background tasks that are not linked to the current parent session.
 
     Args:
         task_id (`str`):
@@ -638,6 +655,195 @@ async def check_agent_task(
     )
 
 
+def _normalize_task_ids(task_ids: Optional[list[str]]) -> Optional[set[str]]:
+    if not task_ids:
+        return None
+    normalized = {
+        normalize_id(str(task_id))
+        for task_id in task_ids
+        if normalize_id(str(task_id))
+    }
+    return normalized or None
+
+
+def _check_background_subagent_capacity(parent_session_id: str) -> str:
+    if not parent_session_id:
+        return ""
+
+    from ...app.runner.subagent_events import get_subagent_event_registry
+
+    running = get_subagent_event_registry().linked_running_count(
+        parent_session_id,
+    )
+    if running < MAX_BACKGROUND_SUBAGENTS_PER_PARENT:
+        return ""
+    return (
+        "ERROR: background subagent limit reached for the current parent "
+        f"session ({running}/{MAX_BACKGROUND_SUBAGENTS_PER_PARENT} running). "
+        "Wait for existing subagents with wait_subagent_events(...) or stop "
+        "them before spawning more."
+    )
+
+
+def _format_subagent_event(event: dict[str, Any]) -> str:
+    task_id = event.get("task_id", "")
+    status = event.get("status", "unknown")
+    child_session_id = event.get("child_session_id", "")
+    lines = [
+        f"[TASK_ID: {task_id}]",
+        f"[STATUS: {status}]",
+    ]
+    if child_session_id:
+        lines.append(f"[SESSION: {child_session_id}]")
+    lines.append("")
+
+    if status == "completed":
+        lines.append("Task completed.")
+        result = event.get("result")
+        if isinstance(result, dict):
+            lines.append("")
+            lines.append(
+                format_agent_chat_text(
+                    result,
+                    session_id=child_session_id or None,
+                ),
+            )
+        elif result:
+            lines.append("")
+            lines.append(str(result))
+    elif status in {"failed", "cancelled", "timed_out"}:
+        lines.append(f"Task {status}.")
+        error = event.get("error")
+        if error:
+            lines.append("")
+            lines.append(f"Error: {error}")
+    else:
+        lines.append(_json_text(event))
+    return "\n".join(lines)
+
+
+def _format_running_subagent_summary(
+    parent_session_id: str,
+    task_ids: Optional[set[str]],
+) -> str:
+    from ...app.runner.subagent_events import get_subagent_event_registry
+
+    now = time.time()
+    records = get_subagent_event_registry().get_records_for_parent(
+        parent_session_id,
+    )
+    lines = []
+    for record in records:
+        if task_ids and record.task_id not in task_ids:
+            continue
+        if record.status not in {"submitted", "running"}:
+            continue
+        last_seen = (
+            record.last_heartbeat_at
+            or record.started_at
+            or record.created_at
+        )
+        heartbeat_age = max(0, int(now - last_seen))
+        lines.append(
+            f"- {record.task_id}: {record.status}, "
+            f"last heartbeat {heartbeat_age}s ago",
+        )
+    if not lines:
+        return ""
+    return "Running linked subagents:\n" + "\n".join(lines)
+
+
+async def wait_subagent_events(
+    task_ids: Optional[list[str]] = None,
+    timeout: int = 60,
+    wait_for_all: bool = True,
+) -> ToolResponse:
+    """Wait for background subagent completion events.
+
+    This is the event-driven counterpart to ``check_agent_task``. It waits on
+    the parent session's subagent event inbox and returns completed, failed,
+    cancelled, or timed-out child results. Use ``check_agent_task`` only as a
+    fallback manual status inspection tool. After starting one or more
+    background subagents with ``spawn_subagent(background=True)``, call this
+    tool with their task IDs instead of repeatedly polling status.
+
+    Args:
+        task_ids: Optional list of background task IDs to wait for. When
+            omitted, returns the next available terminal subagent event for
+            the current parent session.
+        timeout: Maximum wait time in seconds.
+        wait_for_all: When task_ids is provided, wait until all listed tasks
+            have terminal events or timeout.
+    """
+    from ...app.agent_context import get_current_session_id
+    from ...app.runner.subagent_events import (
+        TERMINAL_STATUSES,
+        get_subagent_event_registry,
+    )
+
+    parent_session_id = get_current_session_id() or ""
+    if not parent_session_id:
+        return _tool_text_response(
+            "ERROR: unable to resolve current parent session ID",
+        )
+
+    wanted = _normalize_task_ids(task_ids)
+    deadline = time.monotonic() + max(0, timeout)
+    registry = get_subagent_event_registry()
+    collected: list[dict[str, Any]] = []
+    completed_task_ids: set[str] = set()
+
+    while True:
+        events = registry.drain_events(
+            parent_session_id,
+            task_ids=wanted,
+            terminal_only=True,
+        )
+        for event in events:
+            data = event.to_dict()
+            collected.append(data)
+            if data.get("status") in TERMINAL_STATUSES:
+                completed_task_ids.add(data.get("task_id", ""))
+
+        if collected:
+            if not wanted or not wait_for_all:
+                break
+            if wanted.issubset(completed_task_ids):
+                break
+
+        if time.monotonic() >= deadline:
+            break
+        await asyncio.sleep(0.5)
+
+    if not collected:
+        running_summary = _format_running_subagent_summary(
+            parent_session_id,
+            wanted,
+        )
+        if running_summary:
+            return _tool_text_response(
+                "No terminal subagent events received before timeout.\n\n"
+                + running_summary,
+            )
+        return _tool_text_response(
+            "No terminal subagent events received before timeout.",
+        )
+
+    parts = []
+    for index, event in enumerate(collected, 1):
+        if len(collected) > 1:
+            parts.append(f"## Subagent Event {index}")
+            parts.append("")
+        parts.append(_format_subagent_event(event))
+        parts.append("")
+
+    if wanted and not wanted.issubset(completed_task_ids):
+        pending = sorted(wanted - completed_task_ids)
+        parts.append("Pending task IDs: " + ", ".join(pending))
+
+    return _tool_text_response("\n".join(parts).rstrip())
+
+
 def _generate_subagent_session_id() -> str:
     """Generate a short session ID for a spawned subagent."""
     return f"sub-{str(uuid4())[:8]}"
@@ -658,6 +864,12 @@ async def spawn_subagent(
     Unlike ``chat_with_agent`` (which calls a *different* agent),
     this tool targets the same agent identity and workspace.
 
+    Background subagents are linked to the current parent session. When a
+    linked background subagent finishes, fails, times out, or is cancelled, it
+    publishes a terminal event to the parent session. To collect results for
+    one or more background subagents, call ``wait_subagent_events`` with the
+    returned task IDs. Avoid tight loops around ``check_agent_task``.
+
     Args:
         task: Description of the sub-task to perform.
         fork: If True, the subagent inherits parent session state.
@@ -666,8 +878,11 @@ async def spawn_subagent(
             back to workspace; no worktree if not a git repo).
             If False (default), starts with a fresh empty session.
         background: If True, submit as background task and return
-            immediately with a task_id. Use check_agent_task(task_id)
-            to poll status and retrieve the result.
+            immediately with a task_id. Use
+            ``wait_subagent_events(task_ids=[...])`` as the primary way to
+            receive completion events. Use ``check_agent_task(task_id)`` only
+            as a manual fallback. A parent session can have at most
+            5 running/submitted background subagents at once.
         timeout: Foreground wait timeout in seconds (default 600).
 
     Returns:
@@ -711,6 +926,15 @@ async def spawn_subagent(
     }
 
     if background:
+        from ...app.agent_context import get_current_session_id
+
+        parent_session_id = get_current_session_id() or ""
+        capacity_error = _check_background_subagent_capacity(
+            parent_session_id,
+        )
+        if capacity_error:
+            return _tool_text_response(capacity_error)
+
         result = await asyncio.to_thread(
             submit_agent_chat_task,
             None,
@@ -718,10 +942,35 @@ async def spawn_subagent(
             current_agent_id,
             int(DEFAULT_AGENT_API_TIMEOUT),
         )
+        task_id = result.get("task_id")
+        if task_id:
+            from ...app.agent_context import (
+                get_current_channel,
+                get_current_user_id,
+            )
+            from ...app.runner.subagent_events import (
+                SubagentTaskRecord,
+                get_subagent_event_registry,
+            )
+
+            get_subagent_event_registry().register_task(
+                SubagentTaskRecord(
+                    task_id=task_id,
+                    parent_agent_id=current_agent_id,
+                    parent_session_id=parent_session_id,
+                    child_agent_id=current_agent_id,
+                    child_session_id=subagent_session_id,
+                    task=task,
+                    user_id=get_current_user_id() or "",
+                    channel=get_current_channel() or "",
+                    fork=False,
+                ),
+            )
         return _tool_text_response(
             format_background_submission_text(
                 result,
                 subagent_session_id,
+                prefer_events=True,
             ),
         )
 
@@ -835,6 +1084,13 @@ async def _spawn_forked_subagent(
     user_id = get_current_user_id() or ""
     channel = get_current_channel() or ""
 
+    if background:
+        capacity_error = _check_background_subagent_capacity(
+            parent_session_id,
+        )
+        if capacity_error:
+            return _tool_text_response(capacity_error)
+
     fork_result = await _call_fork_api(
         agent_id=current_agent_id,
         parent_session_id=parent_session_id,
@@ -879,9 +1135,30 @@ async def _spawn_forked_subagent(
             current_agent_id,
             int(DEFAULT_AGENT_API_TIMEOUT),
         )
+        task_id = result.get("task_id")
+        if task_id:
+            from ...app.runner.subagent_events import (
+                SubagentTaskRecord,
+                get_subagent_event_registry,
+            )
+
+            get_subagent_event_registry().register_task(
+                SubagentTaskRecord(
+                    task_id=task_id,
+                    parent_agent_id=current_agent_id,
+                    parent_session_id=parent_session_id,
+                    child_agent_id=current_agent_id,
+                    child_session_id=fork_session_id,
+                    task=task,
+                    user_id=user_id,
+                    channel=channel,
+                    fork=True,
+                ),
+            )
         submission_text = format_background_submission_text(
             result,
             fork_session_id,
+            prefer_events=True,
         )
         if worktree_path:
             submission_text += (

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -53,6 +53,11 @@ from .migration import (
     ensure_qa_agent_exists,
 )
 from .channels.registry import register_custom_channel_routes
+from .runner.subagent_events import get_subagent_event_registry
+from .runner.subagent_cancel import (
+    cancel_linked_subagents,
+    set_subagent_task_cancel_callback,
+)
 
 # Apply log level on load so reload child process gets same level as CLI.
 logger = setup_logger(os.environ.get(LOG_LEVEL_ENV, "info"))
@@ -206,10 +211,138 @@ class DynamicMultiAgentRunner:
         return None
 
 
+class QwenPawAgentApp(AgentApp):
+    """AgentApp with QwenPaw background subagent lifecycle events."""
+
+    SUBAGENT_HEARTBEAT_INTERVAL = 30.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._stream_task_handles = {}
+
+    async def cancel_stream_task(self, task_id: str) -> bool:
+        """Cancel an in-memory stream task by AgentApp task_id."""
+        task = self._stream_task_handles.get(task_id)
+        if task is None or task.done():
+            return False
+        task.cancel()
+        return True
+
+    async def execute_stream_query_task(
+        self,
+        task_id,
+        stream_func,
+        request,
+        queue,
+        timeout=None,
+    ):
+        start_time = time.time()
+        registry = get_subagent_event_registry()
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            self._stream_task_handles[task_id] = current_task
+        heartbeat_task = None
+
+        async def publish_periodic_heartbeat():
+            while True:
+                await asyncio.sleep(self.SUBAGENT_HEARTBEAT_INTERVAL)
+                registry.publish_event(
+                    task_id,
+                    "subagent.heartbeat",
+                    "running",
+                )
+
+        async def stream_with_heartbeat(request_payload):
+            async for item in stream_func(request_payload):
+                registry.publish_event(
+                    task_id,
+                    "subagent.heartbeat",
+                    "running",
+                )
+                yield item
+
+        try:
+            heartbeat_task = asyncio.create_task(publish_periodic_heartbeat())
+            result = await super().execute_stream_query_task(
+                task_id=task_id,
+                stream_func=stream_with_heartbeat,
+                request=request,
+                queue=queue,
+                timeout=timeout,
+            )
+            registry.publish_terminal(
+                task_id,
+                status="completed",
+                result=result,
+                elapsed_time=time.time() - start_time,
+            )
+            return result
+        except asyncio.TimeoutError:
+            registry.publish_terminal(
+                task_id,
+                status="timed_out",
+                error=f"Task exceeded timeout of {timeout}s",
+                elapsed_time=time.time() - start_time,
+            )
+            raise
+        except asyncio.CancelledError:
+            parent_session_id = getattr(request, "session_id", "") or ""
+            if parent_session_id:
+                try:
+                    cancelled_children = await cancel_linked_subagents(
+                        parent_session_id,
+                    )
+                    if cancelled_children:
+                        logger.info(
+                            "Cancelled %s linked subagent task(s) for "
+                            "parent_session=%s",
+                            cancelled_children,
+                            parent_session_id,
+                        )
+                except Exception:
+                    logger.debug(
+                        "Failed to cancel linked subagents for "
+                        "parent_session=%s",
+                        parent_session_id,
+                        exc_info=True,
+                    )
+            active_task = getattr(self, "active_tasks", {}).get(task_id)
+            if active_task is not None:
+                active_task.update(
+                    {
+                        "status": "failed",
+                        "error": "Task was cancelled",
+                        "error_type": "CancelledError",
+                        "failed_at": time.time(),
+                    },
+                )
+            registry.publish_terminal(
+                task_id,
+                status="cancelled",
+                error="Task was cancelled",
+                elapsed_time=time.time() - start_time,
+            )
+            raise
+        except Exception as exc:
+            registry.publish_terminal(
+                task_id,
+                status="failed",
+                error=str(exc),
+                elapsed_time=time.time() - start_time,
+            )
+            raise
+        finally:
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await heartbeat_task
+            self._stream_task_handles.pop(task_id, None)
+
+
 # Use dynamic runner for AgentApp
 runner = DynamicMultiAgentRunner()
 
-agent_app = AgentApp(
+agent_app = QwenPawAgentApp(
     app_name="QwenPaw",
     app_description="A helpful assistant with background task support",
     runner=runner,
@@ -217,6 +350,32 @@ agent_app = AgentApp(
     stream_task_queue="stream_query",
     stream_task_timeout=1800,
 )
+
+set_subagent_task_cancel_callback(agent_app.cancel_stream_task)
+
+
+async def _subagent_stale_watchdog(
+    *,
+    interval: float = 30.0,
+    stale_after: float = 120.0,
+) -> None:
+    registry = get_subagent_event_registry()
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            stale_events = registry.mark_stale_tasks(stale_after)
+            for event in stale_events:
+                logger.warning(
+                    "Background subagent task marked stale: task_id=%s "
+                    "parent_session=%s",
+                    event.task_id,
+                    event.parent_session_id,
+                )
+        except Exception:
+            logger.debug(
+                "Subagent stale watchdog iteration failed",
+                exc_info=True,
+            )
 
 
 @asynccontextmanager
@@ -465,10 +624,16 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             )
 
     _bg_task = asyncio.create_task(_background_startup())
+    _subagent_watchdog_task = asyncio.create_task(_subagent_stale_watchdog())
 
     try:
         yield
     finally:
+        if not _subagent_watchdog_task.done():
+            _subagent_watchdog_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await _subagent_watchdog_task
+
         # Cancel background startup if still in progress
         if not _bg_task.done():
             _bg_task.cancel()

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -17,6 +17,7 @@ from starlette.responses import StreamingResponse
 from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
 from ...utils.logging import LOG_FILE_PATH
 from ..agent_context import get_agent_for_request
+from ..runner.subagent_cancel import cancel_linked_subagents
 from ..runner.title_generator import generate_and_update_title
 from ..utils import check_upload_size
 
@@ -236,6 +237,17 @@ async def post_console_chat_stop(
     """Stop the running chat. Only stops when called."""
     logger.debug("[STOP API] Received stop request for chat_id=%s", chat_id)
     workspace = await get_agent_for_request(request)
+    cancelled_subagents = 0
+    cancelled_sessions = set()
+
+    async def cancel_once(session_id: str) -> int:
+        if not session_id or session_id in cancelled_sessions:
+            return 0
+        cancelled_sessions.add(session_id)
+        return await cancel_linked_subagents(session_id)
+
+    cancelled_subagents += await cancel_once(chat_id)
+    resolved_chat_id = None
 
     # Try to stop with the provided chat_id first
     logger.debug(
@@ -266,11 +278,22 @@ async def post_console_chat_stop(
                     resolved_chat_id,
                 )
 
+    chat_manager = getattr(workspace.runner, "_chat_manager", None)
+    if chat_manager:
+        chat_spec = await chat_manager.get_chat(resolved_chat_id or chat_id)
+        if chat_spec is not None:
+            cancelled_subagents += await cancel_once(chat_spec.session_id)
+
     logger.debug(
-        "[STOP API] task_tracker.request_stop returned: stopped=%s",
+        "[STOP API] task_tracker.request_stop returned: stopped=%s "
+        "cancelled_subagents=%s",
         stopped,
+        cancelled_subagents,
     )
-    return {"stopped": stopped}
+    return {
+        "stopped": stopped,
+        "cancelled_subagents": cancelled_subagents,
+    }
 
 
 @router.post("/upload", response_model=dict, summary="Upload file for chat")

--- a/src/qwenpaw/app/runner/control_commands/stop_handler.py
+++ b/src/qwenpaw/app/runner/control_commands/stop_handler.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from .base import BaseControlCommandHandler, ControlContext
+from ..subagent_cancel import cancel_linked_subagents
 
 logger = logging.getLogger(__name__)
 
@@ -56,11 +57,20 @@ class StopCommandHandler(BaseControlCommandHandler):
             channel_id,
         )
 
+        cancelled_subagents = await cancel_linked_subagents(target_session_id)
+
         if chat_id is None:
             logger.warning(
                 f"/stop: No active chat found for "
                 f"session={target_session_id[:30]} channel={channel_id}",
             )
+            if cancelled_subagents:
+                return (
+                    f"**Task Stopped**\n\n"
+                    f"Session `{target_session_id[:40]}`: "
+                    f"{cancelled_subagents} linked subagent task(s) "
+                    f"cancelled."
+                )
             return (
                 f"**No Active Task**\n\n"
                 f"No running task found for session "
@@ -75,9 +85,10 @@ class StopCommandHandler(BaseControlCommandHandler):
             20,
         )
 
-        if stopped or cleared > 0:
+        if stopped or cleared > 0 or cancelled_subagents > 0:
             logger.info(
                 f"/stop: stopped={stopped} cleared={cleared} "
+                f"cancelled_subagents={cancelled_subagents} "
                 f"chat_id={chat_id} session={target_session_id[:30]}",
             )
             status_parts = []
@@ -85,6 +96,10 @@ class StopCommandHandler(BaseControlCommandHandler):
                 status_parts.append("running task stopped")
             if cleared > 0:
                 status_parts.append(f"{cleared} queued message(s) cleared")
+            if cancelled_subagents > 0:
+                status_parts.append(
+                    f"{cancelled_subagents} linked subagent task(s) cancelled",
+                )
             status_text = " and ".join(status_parts)
             return (
                 f"**Task Stopped**\n\n"

--- a/src/qwenpaw/app/runner/subagent_cancel.py
+++ b/src/qwenpaw/app/runner/subagent_cancel.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Cancellation bridge for linked background subagents."""
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Optional
+
+from .subagent_events import get_subagent_event_registry
+
+logger = logging.getLogger(__name__)
+
+_cancel_task_callback: Optional[Callable[[str], Awaitable[bool]]] = None
+
+
+def set_subagent_task_cancel_callback(
+    callback: Callable[[str], Awaitable[bool]],
+) -> None:
+    """Register the runtime-specific task cancellation function."""
+    global _cancel_task_callback
+    _cancel_task_callback = callback
+
+
+async def cancel_linked_subagents(parent_session_id: str) -> int:
+    """Cancel all linked running subagents for a parent session."""
+    if not parent_session_id:
+        return 0
+    if _cancel_task_callback is None:
+        logger.debug(
+            "No subagent task cancel callback registered; session=%s",
+            parent_session_id[:30],
+        )
+        return 0
+
+    registry = get_subagent_event_registry()
+    task_ids = registry.linked_running_task_ids(parent_session_id)
+    cancelled = 0
+    for task_id in task_ids:
+        try:
+            if await _cancel_task_callback(task_id):
+                cancelled += 1
+        except Exception:
+            logger.debug(
+                "Failed to cancel linked subagent task_id=%s",
+                task_id,
+                exc_info=True,
+            )
+    return cancelled
+

--- a/src/qwenpaw/app/runner/subagent_events.py
+++ b/src/qwenpaw/app/runner/subagent_events.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""In-process event bridge for background subagent tasks."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Any, Optional
+
+
+TERMINAL_STATUSES = {"completed", "failed", "cancelled", "timed_out", "stale"}
+
+
+@dataclass
+class SubagentTaskRecord:
+    """Parent-child metadata for a background subagent task."""
+
+    task_id: str
+    parent_agent_id: str
+    parent_session_id: str
+    child_agent_id: str
+    child_session_id: str
+    task: str = ""
+    user_id: str = ""
+    channel: str = ""
+    fork: bool = False
+    status: str = "submitted"
+    created_at: float = field(default_factory=time.time)
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    last_heartbeat_at: Optional[float] = None
+    result: Any = None
+    error: Optional[str] = None
+
+
+@dataclass
+class SubagentTaskEvent:
+    """Event delivered to the parent session."""
+
+    event_id: int
+    event_type: str
+    task_id: str
+    parent_agent_id: str
+    parent_session_id: str
+    child_agent_id: str
+    child_session_id: str
+    status: str
+    created_at: float
+    task: str = ""
+    result: Any = None
+    error: Optional[str] = None
+    elapsed_time: Optional[float] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "task_id": self.task_id,
+            "parent_agent_id": self.parent_agent_id,
+            "parent_session_id": self.parent_session_id,
+            "child_agent_id": self.child_agent_id,
+            "child_session_id": self.child_session_id,
+            "status": self.status,
+            "created_at": self.created_at,
+            "task": self.task,
+            "result": self.result,
+            "error": self.error,
+            "elapsed_time": self.elapsed_time,
+        }
+
+
+class SubagentEventRegistry:
+    """Small in-memory registry shared by tools and AgentApp task runner.
+
+    AgentApp starts background tasks before the tool response reaches the
+    caller, so a very fast task may finish before spawn_subagent can register
+    its parent-child relation. Pending terminal results are cached by task_id
+    and flushed when the relation is registered.
+    """
+
+    def __init__(
+        self,
+        max_events_per_session: int = 200,
+        max_pending_terminal: int = 200,
+        max_records: int = 1000,
+    ) -> None:
+        self._lock = RLock()
+        self._records: dict[str, SubagentTaskRecord] = {}
+        self._events_by_parent: dict[str, list[SubagentTaskEvent]] = {}
+        self._pending_terminal: dict[str, dict[str, Any]] = {}
+        self._event_id = 0
+        self._max_events_per_session = max(10, max_events_per_session)
+        self._max_pending_terminal = max(10, max_pending_terminal)
+        self._max_records = max(10, max_records)
+
+    def register_task(self, record: SubagentTaskRecord) -> None:
+        pending: Optional[dict[str, Any]]
+        with self._lock:
+            self._records[record.task_id] = record
+            self._prune_records_locked()
+            pending = self._pending_terminal.pop(record.task_id, None)
+        self.publish_event(record.task_id, "subagent.started", "running")
+        if pending:
+            self.publish_terminal(
+                record.task_id,
+                status=pending["status"],
+                result=pending.get("result"),
+                error=pending.get("error"),
+                elapsed_time=pending.get("elapsed_time"),
+            )
+
+    def publish_terminal(
+        self,
+        task_id: str,
+        *,
+        status: str,
+        result: Any = None,
+        error: Optional[str] = None,
+        elapsed_time: Optional[float] = None,
+    ) -> None:
+        event_type = f"subagent.{status}"
+        with self._lock:
+            record = self._records.get(task_id)
+            if record is None:
+                self._pending_terminal[task_id] = {
+                    "status": status,
+                    "result": result,
+                    "error": error,
+                    "elapsed_time": elapsed_time,
+                    "created_at": time.time(),
+                }
+                if len(self._pending_terminal) > self._max_pending_terminal:
+                    oldest = min(
+                        self._pending_terminal,
+                        key=lambda tid: self._pending_terminal[tid].get(
+                            "created_at",
+                            0,
+                        ),
+                    )
+                    self._pending_terminal.pop(oldest, None)
+                return
+            record.status = status
+            record.finished_at = time.time()
+            record.result = result
+            record.error = error
+            self._prune_records_locked()
+        self.publish_event(
+            task_id,
+            event_type,
+            status,
+            result=result,
+            error=error,
+            elapsed_time=elapsed_time,
+        )
+
+    def publish_event(
+        self,
+        task_id: str,
+        event_type: str,
+        status: str,
+        *,
+        result: Any = None,
+        error: Optional[str] = None,
+        elapsed_time: Optional[float] = None,
+    ) -> Optional[SubagentTaskEvent]:
+        with self._lock:
+            record = self._records.get(task_id)
+            if record is None:
+                return None
+            if status == "running" and record.started_at is None:
+                record.started_at = time.time()
+            record.status = status
+            if status == "running":
+                record.last_heartbeat_at = time.time()
+
+            self._event_id += 1
+            event = SubagentTaskEvent(
+                event_id=self._event_id,
+                event_type=event_type,
+                task_id=task_id,
+                parent_agent_id=record.parent_agent_id,
+                parent_session_id=record.parent_session_id,
+                child_agent_id=record.child_agent_id,
+                child_session_id=record.child_session_id,
+                status=status,
+                created_at=time.time(),
+                task=record.task,
+                result=result,
+                error=error,
+                elapsed_time=elapsed_time,
+            )
+            events = self._events_by_parent.setdefault(
+                record.parent_session_id,
+                [],
+            )
+            events.append(event)
+            if len(events) > self._max_events_per_session:
+                del events[: len(events) - self._max_events_per_session]
+            return event
+
+    def _prune_records_locked(self) -> None:
+        """Keep terminal task metadata bounded without dropping live tasks."""
+        overflow = len(self._records) - self._max_records
+        if overflow <= 0:
+            return
+        terminal_records = [
+            record
+            for record in self._records.values()
+            if record.status in TERMINAL_STATUSES
+        ]
+        terminal_records.sort(
+            key=lambda record: record.finished_at or record.created_at,
+        )
+        for record in terminal_records[:overflow]:
+            self._records.pop(record.task_id, None)
+
+    def drain_events(
+        self,
+        parent_session_id: str,
+        *,
+        task_ids: Optional[set[str]] = None,
+        terminal_only: bool = False,
+    ) -> list[SubagentTaskEvent]:
+        with self._lock:
+            events = self._events_by_parent.get(parent_session_id, [])
+            if not events:
+                return []
+            matched: list[SubagentTaskEvent] = []
+            remaining: list[SubagentTaskEvent] = []
+            for event in events:
+                if task_ids and event.task_id not in task_ids:
+                    remaining.append(event)
+                    continue
+                if terminal_only and event.status not in TERMINAL_STATUSES:
+                    remaining.append(event)
+                    continue
+                matched.append(event)
+            self._events_by_parent[parent_session_id] = remaining
+            return matched
+
+    def get_records_for_parent(
+        self,
+        parent_session_id: str,
+    ) -> list[SubagentTaskRecord]:
+        with self._lock:
+            return [
+                record
+                for record in self._records.values()
+                if record.parent_session_id == parent_session_id
+            ]
+
+    def linked_running_task_ids(self, parent_session_id: str) -> list[str]:
+        with self._lock:
+            return [
+                record.task_id
+                for record in self._records.values()
+                if record.parent_session_id == parent_session_id
+                and record.status in {"submitted", "running"}
+            ]
+
+    def linked_running_count(self, parent_session_id: str) -> int:
+        return len(self.linked_running_task_ids(parent_session_id))
+
+    def mark_stale_tasks(self, stale_after: float) -> list[SubagentTaskEvent]:
+        """Mark quiet running tasks as stale and publish terminal events."""
+        now = time.time()
+        stale_task_ids: list[str] = []
+        with self._lock:
+            for task_id, record in self._records.items():
+                if record.status not in {"submitted", "running"}:
+                    continue
+                last_seen = (
+                    record.last_heartbeat_at
+                    or record.started_at
+                    or record.created_at
+                )
+                if now - last_seen >= stale_after:
+                    stale_task_ids.append(task_id)
+
+        events: list[SubagentTaskEvent] = []
+        for task_id in stale_task_ids:
+            self.publish_terminal(
+                task_id,
+                status="stale",
+                error=(
+                    "Background subagent produced no heartbeat for "
+                    f"{int(stale_after)}s"
+                ),
+            )
+            with self._lock:
+                parent = self._records.get(task_id)
+                if parent:
+                    session_events = self._events_by_parent.get(
+                        parent.parent_session_id,
+                        [],
+                    )
+                    if session_events:
+                        events.append(session_events[-1])
+        return events
+
+
+_REGISTRY = SubagentEventRegistry()
+
+
+def get_subagent_event_registry() -> SubagentEventRegistry:
+    return _REGISTRY

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1533,8 +1533,20 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
         "check_agent_task": BuiltinToolConfig(
             name="check_agent_task",
             enabled=True,
-            description="Check the status of a background agent task",
+            description=(
+                "Check background task status; for spawned subagents prefer "
+                "wait_subagent_events"
+            ),
             icon="⏳",
+        ),
+        "wait_subagent_events": BuiltinToolConfig(
+            name="wait_subagent_events",
+            enabled=True,
+            description=(
+                "Wait for background subagent completion events without "
+                "frequent status polling"
+            ),
+            icon="📬",
         ),
         "spawn_subagent": BuiltinToolConfig(
             name="spawn_subagent",
@@ -1659,6 +1671,7 @@ def build_local_agent_tools_config() -> ToolsConfig:
             "chat_with_agent",
             "submit_to_agent",
             "check_agent_task",
+            "wait_subagent_events",
             "execute_shell_command",
             "read_file",
             "write_file",

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -278,6 +278,104 @@ async def test_check_agent_task_formats_finished_background_result(
     assert "Background reply" in text
 
 
+async def test_wait_subagent_events_formats_completed_event(monkeypatch):
+    from qwenpaw.app.runner.subagent_events import (
+        SubagentEventRegistry,
+        SubagentTaskRecord,
+    )
+
+    registry = SubagentEventRegistry()
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-1",
+            parent_agent_id="default",
+            parent_session_id="parent-1",
+            child_agent_id="default",
+            child_session_id="child-1",
+        ),
+    )
+    registry.publish_terminal(
+        "task-1",
+        status="completed",
+        result={
+            "output": [
+                {
+                    "content": [
+                        {"type": "text", "text": "Subagent done"},
+                    ],
+                },
+            ],
+        },
+    )
+
+    monkeypatch.setattr(
+        "qwenpaw.app.agent_context.get_current_session_id",
+        lambda: "parent-1",
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.runner.subagent_events.get_subagent_event_registry",
+        lambda: registry,
+    )
+
+    response = await agent_management.wait_subagent_events(
+        task_ids=["task-1"],
+        timeout=0,
+    )
+
+    text = response.content[0].get("text", "")
+    assert "[TASK_ID: task-1]" in text
+    assert "[STATUS: completed]" in text
+    assert "Subagent done" in text
+
+
+async def test_spawn_subagent_background_registers_event_relation(
+    monkeypatch,
+):
+    from qwenpaw.app.runner.subagent_events import SubagentEventRegistry
+
+    registry = SubagentEventRegistry()
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        lambda *_args, **_kwargs: {
+            "task_id": "task-1",
+            "status": "submitted",
+        },
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.agent_context.get_current_agent_id",
+        lambda: "default",
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.agent_context.get_current_session_id",
+        lambda: "parent-1",
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.agent_context.get_current_user_id",
+        lambda: "user-1",
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.agent_context.get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        "qwenpaw.app.runner.subagent_events.get_subagent_event_registry",
+        lambda: registry,
+    )
+
+    response = await agent_management.spawn_subagent(
+        task="do work",
+        background=True,
+    )
+
+    text = response.content[0].get("text", "")
+    assert "wait_subagent_events" in text
+    records = registry.get_records_for_parent("parent-1")
+    assert len(records) == 1
+    assert records[0].task_id == "task-1"
+    assert records[0].child_session_id.startswith("sub-")
+
+
 async def test_chat_with_agent_uses_to_thread_for_final_mode(monkeypatch):
     monkeypatch.setattr(
         agent_management,

--- a/tests/unit/app/test_subagent_cancel.py
+++ b/tests/unit/app/test_subagent_cancel.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+
+from qwenpaw.app.runner import subagent_cancel
+from qwenpaw.app.runner.subagent_events import (
+    SubagentTaskRecord,
+    get_subagent_event_registry,
+)
+
+
+def test_cancel_linked_subagents_cancels_all_running_children(monkeypatch):
+    registry = get_subagent_event_registry()
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-1",
+            parent_agent_id="default",
+            parent_session_id="parent-cancel",
+            child_agent_id="default",
+            child_session_id="child-1",
+        ),
+    )
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-2",
+            parent_agent_id="default",
+            parent_session_id="parent-cancel",
+            child_agent_id="default",
+            child_session_id="child-2",
+        ),
+    )
+    cancelled = []
+
+    async def fake_cancel(task_id: str) -> bool:
+        cancelled.append(task_id)
+        return True
+
+    monkeypatch.setattr(subagent_cancel, "_cancel_task_callback", fake_cancel)
+
+    count = asyncio.run(
+        subagent_cancel.cancel_linked_subagents("parent-cancel"),
+    )
+
+    assert count == 2
+    assert cancelled == ["task-1", "task-2"]

--- a/tests/unit/app/test_subagent_events.py
+++ b/tests/unit/app/test_subagent_events.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from qwenpaw.app.runner.subagent_events import (
+    SubagentEventRegistry,
+    SubagentTaskRecord,
+)
+
+
+def test_register_task_publishes_started_event():
+    registry = SubagentEventRegistry()
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-1",
+            parent_agent_id="agent-a",
+            parent_session_id="parent-1",
+            child_agent_id="agent-a",
+            child_session_id="child-1",
+            task="do work",
+        ),
+    )
+
+    events = registry.drain_events("parent-1")
+
+    assert len(events) == 1
+    assert events[0].event_type == "subagent.started"
+    assert events[0].status == "running"
+    assert events[0].task_id == "task-1"
+
+
+def test_pending_terminal_event_flushes_after_registration():
+    registry = SubagentEventRegistry()
+    registry.publish_terminal(
+        "task-fast",
+        status="completed",
+        result={"output": []},
+        elapsed_time=0.01,
+    )
+
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-fast",
+            parent_agent_id="agent-a",
+            parent_session_id="parent-1",
+            child_agent_id="agent-a",
+            child_session_id="child-1",
+            task="fast work",
+        ),
+    )
+
+    terminal = registry.drain_events("parent-1", terminal_only=True)
+
+    assert len(terminal) == 1
+    assert terminal[0].event_type == "subagent.completed"
+    assert terminal[0].status == "completed"
+    assert terminal[0].result == {"output": []}
+
+
+def test_drain_events_keeps_unmatched_tasks():
+    registry = SubagentEventRegistry()
+    for task_id in ("task-1", "task-2"):
+        registry.register_task(
+            SubagentTaskRecord(
+                task_id=task_id,
+                parent_agent_id="agent-a",
+                parent_session_id="parent-1",
+                child_agent_id="agent-a",
+                child_session_id=f"child-{task_id}",
+            ),
+        )
+        registry.publish_terminal(task_id, status="completed", result={})
+
+    first = registry.drain_events(
+        "parent-1",
+        task_ids={"task-1"},
+        terminal_only=True,
+    )
+    second = registry.drain_events(
+        "parent-1",
+        task_ids={"task-2"},
+        terminal_only=True,
+    )
+
+    assert [event.task_id for event in first] == ["task-1"]
+    assert [event.task_id for event in second] == ["task-2"]
+
+
+def test_heartbeat_updates_running_task_last_seen():
+    registry = SubagentEventRegistry()
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-heartbeat",
+            parent_agent_id="agent-a",
+            parent_session_id="parent-1",
+            child_agent_id="agent-a",
+            child_session_id="child-1",
+        ),
+    )
+    record = registry.get_records_for_parent("parent-1")[0]
+    initial_heartbeat = record.last_heartbeat_at
+
+    event = registry.publish_event(
+        "task-heartbeat",
+        "subagent.heartbeat",
+        "running",
+    )
+
+    assert event is not None
+    assert record.last_heartbeat_at is not None
+    assert record.last_heartbeat_at >= initial_heartbeat
+
+
+def test_linked_running_count_ignores_terminal_tasks():
+    registry = SubagentEventRegistry()
+    for task_id in ("task-running", "task-done"):
+        registry.register_task(
+            SubagentTaskRecord(
+                task_id=task_id,
+                parent_agent_id="agent-a",
+                parent_session_id="parent-1",
+                child_agent_id="agent-a",
+                child_session_id=f"child-{task_id}",
+            ),
+        )
+
+    registry.publish_terminal("task-done", status="completed", result={})
+
+    assert registry.linked_running_count("parent-1") == 1
+
+
+def test_mark_stale_tasks_publishes_stale_terminal_event():
+    registry = SubagentEventRegistry()
+    registry.register_task(
+        SubagentTaskRecord(
+            task_id="task-stale",
+            parent_agent_id="agent-a",
+            parent_session_id="parent-1",
+            child_agent_id="agent-a",
+            child_session_id="child-1",
+        ),
+    )
+
+    stale_events = registry.mark_stale_tasks(stale_after=0)
+    terminal = registry.drain_events("parent-1", terminal_only=True)
+
+    assert len(stale_events) == 1
+    assert len(terminal) == 1
+    assert terminal[0].event_type == "subagent.stale"
+    assert terminal[0].status == "stale"


### PR DESCRIPTION
## Description

This PR improves `spawn_subagent(background=True)` by adding parent-child lifecycle tracking, completion events, heartbeat detection, and cancellation propagation.

This targets #4873, where starting two subagent tasks as background tasks can cause the parent agent to repeatedly call `check_agent_task(...)` until the tasks finish, and Feishu cannot effectively interrupt/cancel the running background subagents.

After this change, a background subagent is linked to its parent session. When the child finishes, fails, is cancelled, times out, or becomes stale, it publishes an event back to the parent session. The parent agent can use `wait_subagent_events(...)` to wait for child results instead of busy polling.

**Related Issue:** 
Fixes #4873


## Key Design

### 1. Parent-child registry
Added an in-process registry for background subagents:
```text
src/qwenpaw/app/runner/subagent_events.py
```
Terminal states:
```text
completed, failed, cancelled, timed_out, stale
```
The registry also keeps a small event inbox per parent session, so child completion events can be delivered back to the parent agent.

### 2. Event-based wait tool
Added a new tool:
```python
wait_subagent_events(task_ids=None, timeout=60, wait_for_all=True)
```

Defined in:

```text
src/qwenpaw/agents/tools/agent_management.py
```

Usage pattern:

```text
spawn_subagent(background=True)
  -> returns task_id
  -> wait_subagent_events(task_ids=[task_id])
```

`check_agent_task(...)` is still available as a fallback/manual status inspection tool, but background subagents now prefer `wait_subagent_events(...)`.

### 3. Heartbeat and stale detection

Added heartbeat handling in the AgentApp runtime wrapper:

```text
src/qwenpaw/app/_app.py
```

Current constants:

```python
SUBAGENT_HEARTBEAT_INTERVAL = 30.0
SUBAGENT_STALE_CHECK_INTERVAL = 30.0
SUBAGENT_STALE_AFTER_SECONDS = 120.0
```

Behavior:

- child task heartbeat is maintained by the runtime layer
- watchdog checks stale tasks periodically
- if a running child has no heartbeat for 120s, it is marked as `stale`

### 4. Parent stop cancels linked subagents

Added a cancellation bridge:

```text
src/qwenpaw/app/runner/subagent_cancel.py
```

When the parent task/session is stopped, linked running background subagents are cancelled.

Updated stop paths:

```text
src/qwenpaw/app/runner/control_commands/stop_handler.py
src/qwenpaw/app/routers/console.py
src/qwenpaw/app/_app.py
```

This covers:

- Feishu `/stop`
- console stop
- parent task cancellation inside AgentApp

### 5. Background subagent limit

Added a per-parent-session limit:

```python
MAX_BACKGROUND_SUBAGENTS_PER_PARENT = 5
```

This prevents one parent agent from spawning unlimited running background subagents.

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [x] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Start QwenPaw with this branch.
2. From Feishu or Console, ask the agent to start two `spawn_subagent(background=True)` tasks.
3. Confirm the parent agent receives task IDs and uses `wait_subagent_events(task_ids=[...])`.
4. Confirm the parent agent does not repeatedly call `check_agent_task(...)` in a tight loop.
5. Let both child tasks finish and confirm their terminal events/results are returned to the parent session.
6. Start background subagents again, then stop the parent task from Feishu or Console.
7. Confirm linked running background subagents are cancelled.

## Local Verification Evidence

```bash
./scripts/check-channels.sh --changed
# ✅ No channel changes detected
```
Manual verification:

```text
- QwenPaw starts normally with this branch.
- Reproduced #4873 before the fix: two background subagents can trigger repeated check_agent_task(...) polling.
- Verified after the fix: parent agent can wait through wait_subagent_events(...), receive child terminal events, and avoid tight polling.
- Verified stop behavior: stopping the parent task cancels linked running background subagents.
```

## Additional Notes

This PR is intended as a lightweight first version for #4873. It keeps the implementation in-process and does not introduce persistent storage or a distributed event bus.