### PR TITLE
fix(mcp): alias-rewrite tool names rejected by OpenAI-style regex

### DIFF
--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from contextlib import AsyncExitStack
 from datetime import timedelta
 from typing import Any, Literal
@@ -28,7 +29,81 @@ from mcp.client.stdio import StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 
-from agentscope.mcp import StatefulClientBase
+from agentscope.mcp import MCPToolFunction, StatefulClientBase
+
+# OpenAI / Anthropic tool-call APIs reject any tools[].name that contains
+# characters outside this set. MCP, by contrast, allows '.', '/', ':' etc.,
+# so we have to sanitize before forwarding to the model and route back to the
+# original name on dispatch. Keep the regex identical to OpenAI's published
+# constraint to fail-fast against the strictest validator we know of.
+_TOOL_NAME_ALLOWED = re.compile(r"^[a-zA-Z0-9_-]+$")
+_TOOL_NAME_REPLACE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _sanitize_tool_name(raw: str, taken: set[str]) -> str:
+    """Map *raw* to a name matching ``^[a-zA-Z0-9_-]+$``, avoiding *taken*.
+
+    Returns *raw* unchanged when it is already valid AND not already in use.
+    Otherwise replaces every disallowed character with ``_`` and, if the
+    result collides with anything in *taken* (e.g. a real upstream tool that
+    happens to share the same sanitized form), appends ``_2``, ``_3``…
+    until unique. The empty-string edge case is mapped to ``_``.
+    """
+    if _TOOL_NAME_ALLOWED.match(raw) and raw not in taken:
+        return raw
+    base = _TOOL_NAME_REPLACE.sub("_", raw) or "_"
+    candidate = base
+    suffix = 2
+    while candidate in taken:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+class _SessionAliasProxy:
+    """Wrap a ``ClientSession`` to translate sanitized tool names back to
+    the real MCP names on ``call_tool``.
+
+    The toolkit dispatch path (``MCPToolFunction.__call__``) calls
+    ``self.session.call_tool(self.name, ...)`` directly on the underlying
+    ``mcp.ClientSession``, bypassing any ``call_tool`` override on this
+    client. Wrapping the session at the point we hand it to
+    ``MCPToolFunction`` is the only place the translation can happen
+    without forking ``MCPToolFunction`` itself. All other session
+    attributes are forwarded as-is via ``__getattr__``.
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        alias_to_real: dict[str, str],
+    ) -> None:
+        # Snapshot the mapping by reference; the client rebinds
+        # ``_name_alias_to_real`` to a fresh dict on reconnect, so this
+        # proxy keeps routing in-flight functions through the mapping
+        # that was current when the function was constructed.
+        self._session = session
+        self._alias_to_real = alias_to_real
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        real_name = self._alias_to_real.get(name, name)
+        # Forward ``arguments`` as keyword to match how
+        # ``MCPToolFunction.__call__`` invokes this method (and how the
+        # underlying ``ClientSession.call_tool`` is normally called).
+        return await self._session.call_tool(
+            real_name,
+            arguments=arguments,
+            **kwargs,
+        )
+
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +182,7 @@ class _MCPClientMixin:
     is_connected: bool
     _oauth_required: bool
     _cached_tools: Any
+    _name_alias_to_real: dict[str, str]
     _stop_event: asyncio.Event
     _reload_event: asyncio.Event
     _ready_event: asyncio.Event
@@ -170,6 +246,7 @@ class _MCPClientMixin:
                     self.session = None
                     self.is_connected = False
                     self._cached_tools = None
+                    self._name_alias_to_real = {}
 
                     if self._reload_event.is_set():
                         logger.info(f"Reloading MCP client: {self.name}")
@@ -199,6 +276,7 @@ class _MCPClientMixin:
                 self.session = None
                 self.is_connected = False
                 self._cached_tools = None
+                self._name_alias_to_real = {}
                 self._ready_event.clear()
                 await asyncio.sleep(1)
 
@@ -296,8 +374,17 @@ class _MCPClientMixin:
     async def list_tools(self):
         """Return all tools available from the MCP server.
 
+        MCP allows tool names with characters (``.``, ``/``, ``:``…) that
+        OpenAI- and Anthropic-style tool-call APIs reject. To stay compatible
+        without losing the ability to dispatch back to the real tool, this
+        method rewrites each non-conformant ``tool.name`` to a sanitized
+        alias and stores the alias→real mapping on the client. Subsequent
+        :meth:`call_tool` lookups consult that mapping. Tools whose names are
+        already valid pass through untouched, with no mapping entry.
+
         Returns:
-            List of available MCP tools
+            List of MCP tools whose names are guaranteed to match
+            ``^[a-zA-Z0-9_-]+$``.
 
         Raises:
             RuntimeError: If not connected
@@ -310,14 +397,44 @@ class _MCPClientMixin:
             self._handle_transport_error(exc)
             raise
 
-        self._cached_tools = res.tools
-        return res.tools
+        rewritten: list = []
+        alias_to_real: dict[str, str] = {}
+        # Reserve the set of safe names already taken so collisions
+        # (e.g. upstream exposes both ``a.b`` and ``a_b``) get a suffix.
+        taken: set[str] = {
+            t.name for t in res.tools if _TOOL_NAME_ALLOWED.match(t.name)
+        }
+        for tool in res.tools:
+            if _TOOL_NAME_ALLOWED.match(tool.name):
+                rewritten.append(tool)
+                continue
+            safe = _sanitize_tool_name(tool.name, taken)
+            taken.add(safe)
+            alias_to_real[safe] = tool.name
+            rewritten.append(tool.model_copy(update={"name": safe}))
+            logger.info(
+                "MCP client '%s': renamed tool '%s' -> '%s' for "
+                "model-side compatibility.",
+                self.name,
+                tool.name,
+                safe,
+            )
+
+        self._cached_tools = rewritten
+        self._name_alias_to_real = alias_to_real
+        return rewritten
 
     async def call_tool(self, name: str, arguments: dict | None = None):
-        """Call a tool on the MCP server.
+        """Call a tool on the MCP server with its real MCP name.
+
+        Note: this is a pure pass-through and does NOT translate sanitized
+        aliases. Sanitization-aware dispatch lives on
+        :meth:`get_callable_function` (which is what agentscope's toolkit
+        actually invokes). Callers reaching this method directly should
+        pass the real MCP tool name.
 
         Args:
-            name: Tool name
+            name: The real MCP tool name (as returned by the server).
             arguments: Tool arguments (optional)
 
         Returns:
@@ -333,6 +450,53 @@ class _MCPClientMixin:
         except Exception as exc:
             self._handle_transport_error(exc)
             raise
+
+    async def get_callable_function(
+        self,
+        func_name: str,
+        wrap_tool_result: bool = True,
+        execution_timeout: float | None = None,
+    ) -> MCPToolFunction:
+        """Build the ``MCPToolFunction`` agentscope dispatches through, with
+        a session that translates sanitized names back to MCP-real names.
+
+        The agentscope toolkit reads ``mcp_tool.name`` from our
+        :meth:`list_tools` (already sanitized) and passes it here as
+        ``func_name``. Without intervention, ``MCPToolFunction.__call__``
+        would dispatch the sanitized name to a server that only knows the
+        real name, returning "Unknown tool".
+
+        We construct ``MCPToolFunction`` ourselves rather than delegating
+        to the inherited implementation so the proxy is wired in at
+        construction time — the returned function then exposes the
+        sanitized ``name`` (correct for the model) and dispatches the real
+        MCP name (correct for the server) without any post-hoc mutation.
+        """
+        self._validate_connection()
+
+        if self._cached_tools is None:
+            await self.list_tools()
+
+        target_tool = next(
+            (t for t in self._cached_tools if t.name == func_name),
+            None,
+        )
+        if target_tool is None:
+            raise ValueError(
+                f"Tool '{func_name}' not found in MCP server '{self.name}'",
+            )
+
+        session: Any = self.session
+        if self._name_alias_to_real:
+            session = _SessionAliasProxy(session, self._name_alias_to_real)
+
+        return MCPToolFunction(
+            mcp_name=self.name,
+            tool=target_tool,
+            wrap_tool_result=wrap_tool_result,
+            session=session,
+            timeout=execution_timeout,
+        )
 
     async def close(self, ignore_errors: bool = True) -> None:
         """Close the MCP client and stop its background lifecycle task.
@@ -433,6 +597,7 @@ class _MCPClientMixin:
         )
         self.is_connected = False
         self._cached_tools = None
+        self._name_alias_to_real = {}
         # session is left as-is; see docstring above.
         if not self._stop_event.is_set():
             self._reload_event.set()
@@ -535,6 +700,7 @@ class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
 
         # Tool cache
         self._cached_tools = None
+        self._name_alias_to_real: dict[str, str] = {}
 
     async def _setup_transport(
         self,
@@ -622,6 +788,7 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
 
         # Tool cache
         self._cached_tools = None
+        self._name_alias_to_real: dict[str, str] = {}
 
     async def _setup_transport(
         self,


### PR DESCRIPTION
## Summary

OpenAI / Anthropic tool-call APIs validate `tools[].name` against `^[a-zA-Z0-9_-]+$`, but MCP allows `.`, `/`, `:` etc. Tools like `pat.batch_plan` caused the entire request to be rejected before any tool was even called.

This patch rewrites non-conformant names to a sanitized alias on `list_tools()` and translates the alias back to the real MCP name on dispatch.

## Changes

- `_sanitize_tool_name(raw, taken)`: regex-replace disallowed chars with `_`; on collision (`a.b` and `a_b` both → `a_b`) append `_2`, `_3`…
- `_MCPClientMixin.list_tools()`: rewrite invalid names via `Tool.model_copy`, build `_name_alias_to_real`. Already-valid names pass through untouched.
- `_SessionAliasProxy`: thin wrapper around `mcp.ClientSession`; translates sanitized → real on `call_tool`, forwards everything else via `__getattr__`.
- `_MCPClientMixin.get_callable_function()`: construct `MCPToolFunction` directly with the proxied session, so the function exposes the sanitized name (model side) but dispatches the real name (server side).
- `_MCPClientMixin.call_tool()`: pure pass-through; sanitization-aware dispatch lives on `get_callable_function`, not here.
- Alias map is rebound (not mutated in place) on reconnect / transport error, so in-flight `MCPToolFunction` instances keep routing through the snapshot they captured at construction.

## Known caveats

- The MCP settings UI now shows sanitized names (e.g. `pat_batch_plan` instead of `pat.batch_plan`). Functional but mildly confusing; can be fixed in a follow-up by reverse-translating in the router.

## Maintenance note

`_MCPClientMixin.get_callable_function` reimplements `StatefulClientBase.get_callable_function` so the session proxy can be wired in at construction time (no post-hoc attribute mutation). When bumping `agentscope` past 1.0.20, diff the upstream method against ours to confirm they remain functionally equivalent modulo session wrapping.
