### PR TITLE
fix: enable LaTeX math formula rendering (#4756)

### DIFF
--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -28,6 +28,7 @@
         "dayjs": "^1.11.13",
         "i18next": "^25.8.4",
         "jszip": "^3.10.1",
+        "katex": "^0.17.0",
         "lucide-react": "^0.562.0",
         "mermaid": "^11.12.2",
         "pretty-bytes": "^7.1.0",
@@ -10978,6 +10979,31 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
+      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/less": {

--- a/console/package.json
+++ b/console/package.json
@@ -40,6 +40,7 @@
     "dayjs": "^1.11.13",
     "i18next": "^25.8.4",
     "jszip": "^3.10.1",
+    "katex": "^0.17.0",
     "lucide-react": "^0.562.0",
     "mermaid": "^11.12.2",
     "pretty-bytes": "^7.1.0",

--- a/console/src/components/MarkdownCopy/MarkdownCopy.tsx
+++ b/console/src/components/MarkdownCopy/MarkdownCopy.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { Button, Switch, Input } from "@agentscope-ai/design";
 import { CopyOutlined } from "@ant-design/icons";
 import { XMarkdown } from "@ant-design/x-markdown";
+import Latex from "@ant-design/x-markdown/plugins/Latex";
 import { useTranslation } from "react-i18next";
 import type { CSSProperties } from "react";
 import { useAppMessage } from "../../hooks/useAppMessage";
@@ -180,9 +181,19 @@ export function MarkdownCopy({
             content={markdownContent}
             {...defaultMarkdownViewerProps}
             components={mermaidComponents}
+            config={{ extensions: Latex() }}
             dompurifyConfig={{
-              ADD_TAGS: ["pre", "code"],
-              ADD_ATTR: ["data-block", "data-state", "data-lang", "class"],
+              ADD_TAGS: ["pre", "code", "math", "annotation", "semantics"],
+              ADD_ATTR: [
+                "data-block",
+                "data-state",
+                "data-lang",
+                "class",
+                "style",
+                "aria-hidden",
+                "xmlns",
+                "encoding",
+              ],
             }}
           />
         </div>

--- a/console/src/pages/Agent/Workspace/components/FileEditor.tsx
+++ b/console/src/pages/Agent/Workspace/components/FileEditor.tsx
@@ -3,6 +3,7 @@ import { Button, Card, Input, Switch } from "@agentscope-ai/design";
 import { CopyOutlined, UndoOutlined, SaveOutlined } from "@ant-design/icons";
 import type { MarkdownFile } from "../../../../api/types";
 import { XMarkdown } from "@ant-design/x-markdown";
+import Latex from "@ant-design/x-markdown/plugins/Latex";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
 import { stripFrontmatter } from "../../../../utils/markdown";
@@ -123,13 +124,24 @@ export const FileEditor: React.FC<FileEditorProps> = ({
                   content={markdownContent}
                   className={styles.markdownViewer}
                   components={mermaidComponents}
+                  config={{ extensions: Latex() }}
                   dompurifyConfig={{
-                    ADD_TAGS: ["pre", "code"],
+                    ADD_TAGS: [
+                      "pre",
+                      "code",
+                      "math",
+                      "annotation",
+                      "semantics",
+                    ],
                     ADD_ATTR: [
                       "data-block",
                       "data-state",
                       "data-lang",
                       "class",
+                      "style",
+                      "aria-hidden",
+                      "xmlns",
+                      "encoding",
                     ],
                   }}
                 />


### PR DESCRIPTION

Fixes #4756 

Install KaTeX dependencies — Supplement the peer dependency required for the @ant-design/x-markdown LaTeX plugin.

console/src/components/MarkdownCopy/MarkdownCopy.tsx — Import the LaTeX plugin, enable LaTeX rendering via config={{ extensions: Latex() }}, and update dompurifyConfig to allow KaTeX to generate HTML tags (math, annotation, semantics) and attributes (style, aria-hidden, xmlns, encoding).

console/src/pages/Agent/Workspace/components/FileEditor.tsx — Same as above.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
