### PR TITLE
feat(console): implement customizable column order in sessions page

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1191,6 +1191,17 @@
     "batchDeleteButton": "Batch Delete",
     "filterUserId": "Filter by User ID",
     "filterChannel": "Filter by Channel",
+    "columnOrder": "Column Order",
+    "columns": {
+      "id": "ID",
+      "name": "Name",
+      "sessionId": "SessionID",
+      "userId": "UserID",
+      "channel": "Channel",
+      "createdAt": "CreatedAt",
+      "updatedAt": "UpdatedAt",
+      "action": "Action"
+    },
     "allChannels": "All Channels",
     "totalItems": "Total {{count}} items",
     "selectedItems": "Selected {{count}} items",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1040,6 +1040,17 @@
     "batchDeleteButton": "批量删除",
     "filterUserId": "按用户ID筛选",
     "filterChannel": "按频道筛选",
+    "columnOrder": "表头顺序",
+    "columns": {
+      "id": "ID",
+      "name": "名称",
+      "sessionId": "SessionID",
+      "userId": "UserID",
+      "channel": "频道",
+      "createdAt": "创建时间",
+      "updatedAt": "更新时间",
+      "action": "操作"
+    },
     "allChannels": "全部频道",
     "totalItems": "共 {{count}} 项",
     "selectedItems": "已选 {{count}} 项",

--- a/console/src/pages/Control/Sessions/components/columns.tsx
+++ b/console/src/pages/Control/Sessions/components/columns.tsx
@@ -1,16 +1,37 @@
 import { Button, Tag } from "@agentscope-ai/design";
-import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import type { ColumnsType } from "antd/es/table";
 import { formatTime, type Session } from "./constants";
 import { CHANNEL_COLORS } from "../../../../constants/channel";
 import styles from "../index.module.less";
 
+export type SessionColumnKey =
+  | "id"
+  | "name"
+  | "session_id"
+  | "user_id"
+  | "channel"
+  | "created_at"
+  | "updated_at"
+  | "action";
+
+export const DEFAULT_SESSION_COLUMN_ORDER: SessionColumnKey[] = [
+  "id",
+  "name",
+  "session_id",
+  "user_id",
+  "channel",
+  "created_at",
+  "updated_at",
+  "action",
+];
+
 interface ColumnHandlers {
   onEdit: (session: Session) => void;
   onDelete: (sessionId: string) => void;
   onView: (session: Session) => void;
   t: TFunction;
+  columnOrder?: SessionColumnKey[];
 }
 
 /** Normalize ISO string to UTC for consistent sorting across mixed timezone formats. */
@@ -24,35 +45,33 @@ const toUTCTime = (ts: string | null | undefined): number => {
 export const createColumns = (
   handlers: ColumnHandlers,
 ): ColumnsType<Session> => {
-  const { t } = useTranslation();
-
-  return [
-    {
-      title: "ID",
+  const columnsByKey: Record<SessionColumnKey, ColumnsType<Session>[number]> = {
+    id: {
+      title: handlers.t("sessions.columns.id"),
       dataIndex: "id",
       key: "id",
       width: 250,
     },
-    {
-      title: "Name",
+    name: {
+      title: handlers.t("sessions.columns.name"),
       dataIndex: "name",
       key: "name",
       width: 200,
     },
-    {
-      title: "SessionID",
+    session_id: {
+      title: handlers.t("sessions.columns.sessionId"),
       dataIndex: "session_id",
       key: "session_id",
       width: 180,
     },
-    {
-      title: "UserID",
+    user_id: {
+      title: handlers.t("sessions.columns.userId"),
       dataIndex: "user_id",
       key: "user_id",
       width: 150,
     },
-    {
-      title: "Channel",
+    channel: {
+      title: handlers.t("sessions.columns.channel"),
       dataIndex: "channel",
       key: "channel",
       width: 120,
@@ -60,8 +79,8 @@ export const createColumns = (
         <Tag color={CHANNEL_COLORS[channel] || "default"}>{channel}</Tag>
       ),
     },
-    {
-      title: "CreatedAt",
+    created_at: {
+      title: handlers.t("sessions.columns.createdAt"),
       dataIndex: "created_at",
       key: "created_at",
       width: 180,
@@ -69,8 +88,8 @@ export const createColumns = (
       sorter: (a: Session, b: Session) =>
         toUTCTime(a.created_at) - toUTCTime(b.created_at),
     },
-    {
-      title: "UpdatedAt",
+    updated_at: {
+      title: handlers.t("sessions.columns.updatedAt"),
       dataIndex: "updated_at",
       key: "updated_at",
       width: 180,
@@ -79,8 +98,8 @@ export const createColumns = (
         toUTCTime(a.updated_at) - toUTCTime(b.updated_at),
       defaultSortOrder: "descend",
     },
-    {
-      title: "Action",
+    action: {
+      title: handlers.t("sessions.columns.action"),
       key: "action",
       width: 180,
       fixed: "right",
@@ -91,7 +110,7 @@ export const createColumns = (
             size="small"
             onClick={() => handlers.onEdit(record)}
           >
-            {t("common.edit")}
+            {handlers.t("common.edit")}
           </Button>
           <Button
             type="link"
@@ -99,7 +118,7 @@ export const createColumns = (
             style={{ color: "#52c41a" }}
             onClick={() => handlers.onView(record)}
           >
-            {t("common.view")}
+            {handlers.t("common.view")}
           </Button>
           <Button
             type="link"
@@ -107,10 +126,25 @@ export const createColumns = (
             danger
             onClick={() => handlers.onDelete(record.id)}
           >
-            {t("common.delete")}
+            {handlers.t("common.delete")}
           </Button>
         </div>
       ),
     },
-  ];
+  };
+
+  const order = handlers.columnOrder?.length
+    ? handlers.columnOrder
+    : DEFAULT_SESSION_COLUMN_ORDER;
+
+  return order
+    .map((key, index) => {
+      const column = columnsByKey[key];
+      if (key !== "action") return column;
+      return {
+        ...column,
+        fixed: index === order.length - 1 ? ("right" as const) : undefined,
+      };
+    })
+    .filter(Boolean);
 };

--- a/console/src/pages/Control/Sessions/components/columns.tsx
+++ b/console/src/pages/Control/Sessions/components/columns.tsx
@@ -137,14 +137,5 @@ export const createColumns = (
     ? handlers.columnOrder
     : DEFAULT_SESSION_COLUMN_ORDER;
 
-  return order
-    .map((key, index) => {
-      const column = columnsByKey[key];
-      if (key !== "action") return column;
-      return {
-        ...column,
-        fixed: index === order.length - 1 ? ("right" as const) : undefined,
-      };
-    })
-    .filter(Boolean);
+  return order.map((key) => columnsByKey[key]).filter(Boolean);
 };

--- a/console/src/pages/Control/Sessions/components/index.ts
+++ b/console/src/pages/Control/Sessions/components/index.ts
@@ -1,4 +1,8 @@
-export { createColumns } from "./columns";
+export {
+  createColumns,
+  DEFAULT_SESSION_COLUMN_ORDER,
+  type SessionColumnKey,
+} from "./columns";
 export { FilterBar } from "./FilterBar";
 export { SessionDrawer } from "./SessionDrawer";
 export { formatTime, type Session } from "./constants";

--- a/console/src/pages/Control/Sessions/index.module.less
+++ b/console/src/pages/Control/Sessions/index.module.less
@@ -90,6 +90,59 @@
   gap: 8px;
 }
 
+.columnOrderList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.columnOrderItem {
+  display: grid;
+  grid-template-columns: 32px 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 6px 8px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.02);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.columnOrderItem:active {
+  cursor: grabbing;
+}
+
+.columnOrderItemDragging {
+  opacity: 0.72;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.16);
+}
+
+.columnOrderIndex {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+  text-align: center;
+}
+
+.columnOrderDragIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(0, 0, 0, 0.35);
+  font-size: 16px;
+}
+
+.columnOrderLabel {
+  min-width: 0;
+  overflow: hidden;
+  color: rgba(0, 0, 0, 0.88);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ─── Dark mode ─────────────────────────────────────────────────────────────── */
 :global(.dark-mode) {
   .sessionsPage {
@@ -127,6 +180,28 @@
   .selectedRow:hover > td {
     background-color: rgba(97, 92, 237, 0.2) !important;
   }
+
+  .columnOrderItem {
+    border-color: rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .columnOrderItemDragging {
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  }
+
+  .columnOrderIndex {
+    color: rgba(255, 255, 255, 0.35);
+  }
+
+  .columnOrderDragIcon {
+    color: rgba(255, 255, 255, 0.35);
+  }
+
+  .columnOrderLabel {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
   :global(.sessions-filter-input) {
     :global(.qwenpaw-input),
     :global(.ant-input) {

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -1,18 +1,102 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { useNavigate } from "react-router-dom";
 import { Card, Form, Modal, Table, Button } from "@agentscope-ai/design";
 import { useAppMessage } from "../../../hooks/useAppMessage";
 import { useTranslation } from "react-i18next";
+import { MenuOutlined, SettingOutlined } from "@ant-design/icons";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import {
   createColumns,
+  DEFAULT_SESSION_COLUMN_ORDER,
   FilterBar,
   SessionDrawer,
   type Session,
+  type SessionColumnKey,
 } from "./components";
 import { useSessions } from "./useSessions";
 import api from "../../../api";
 import { PageHeader } from "@/components/PageHeader";
 import styles from "./index.module.less";
+
+const SESSION_COLUMN_ORDER_STORAGE_KEY = "qwenpaw.sessions.columnOrder";
+
+const normalizeColumnOrder = (order: unknown): SessionColumnKey[] => {
+  const validKeys = new Set<SessionColumnKey>(DEFAULT_SESSION_COLUMN_ORDER);
+  const customOrder = Array.isArray(order) ? order : [];
+  const normalized = customOrder.filter(
+    (key): key is SessionColumnKey =>
+      typeof key === "string" && validKeys.has(key as SessionColumnKey),
+  );
+
+  DEFAULT_SESSION_COLUMN_ORDER.forEach((key) => {
+    if (!normalized.includes(key)) normalized.push(key);
+  });
+
+  return normalized;
+};
+
+interface SortableColumnOrderItemProps {
+  columnKey: SessionColumnKey;
+  index: number;
+  label: string;
+}
+
+function SortableColumnOrderItem({
+  columnKey,
+  index,
+  label,
+}: SortableColumnOrderItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: columnKey });
+
+  const itemStyle: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        styles.columnOrderItem,
+        isDragging ? styles.columnOrderItemDragging : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      style={itemStyle}
+      {...attributes}
+      {...listeners}
+    >
+      <span className={styles.columnOrderIndex}>{index + 1}</span>
+      <span className={styles.columnOrderDragIcon} aria-hidden="true">
+        <MenuOutlined />
+      </span>
+      <span className={styles.columnOrderLabel}>{label}</span>
+    </div>
+  );
+}
 
 function SessionsPage() {
   const { t } = useTranslation();
@@ -36,8 +120,39 @@ function SessionsPage() {
   const [filterUserId, setFilterUserId] = useState<string>("");
   const [filterChannel, setFilterChannel] = useState<string>("");
   const [availableChannels, setAvailableChannels] = useState<string[]>([]);
+  const [columnOrder, setColumnOrder] = useState<SessionColumnKey[]>(
+    DEFAULT_SESSION_COLUMN_ORDER,
+  );
+  const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
+  const [draftColumnOrder, setDraftColumnOrder] = useState<SessionColumnKey[]>(
+    DEFAULT_SESSION_COLUMN_ORDER,
+  );
+  const columnOrderSensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
 
   const { message } = useAppMessage();
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(
+        SESSION_COLUMN_ORDER_STORAGE_KEY,
+      );
+      if (!stored) return;
+
+      const normalized = normalizeColumnOrder(JSON.parse(stored));
+      setColumnOrder(normalized);
+      setDraftColumnOrder(normalized);
+    } catch (error) {
+      console.error("❌ Failed to load session column order:", error);
+      window.localStorage.removeItem(SESSION_COLUMN_ORDER_STORAGE_KEY);
+    }
+  }, []);
 
   useEffect(() => {
     const fetchChannelTypes = async () => {
@@ -139,12 +254,60 @@ function SessionsPage() {
     }
   };
 
+  const handleOpenColumnSettings = () => {
+    setDraftColumnOrder(columnOrder);
+    setColumnSettingsOpen(true);
+  };
+
+  const handleColumnDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+
+    setDraftColumnOrder((current) => {
+      const activeKey = active.id as SessionColumnKey;
+      const overKey = over.id as SessionColumnKey;
+      const oldIndex = current.indexOf(activeKey);
+      const newIndex = current.indexOf(overKey);
+
+      if (oldIndex < 0 || newIndex < 0) {
+        return current;
+      }
+
+      return arrayMove(current, oldIndex, newIndex);
+    });
+  };
+
+  const handleSaveColumnOrder = () => {
+    const normalized = normalizeColumnOrder(draftColumnOrder);
+    setColumnOrder(normalized);
+    window.localStorage.setItem(
+      SESSION_COLUMN_ORDER_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+    setColumnSettingsOpen(false);
+  };
+
+  const handleResetColumnOrder = () => {
+    setDraftColumnOrder(DEFAULT_SESSION_COLUMN_ORDER);
+  };
+
   const columns = createColumns({
     onEdit: handleEdit,
     onDelete: handleDelete,
     onView: handleView,
     t,
+    columnOrder,
   });
+
+  const columnLabels: Record<SessionColumnKey, string> = {
+    id: t("sessions.columns.id"),
+    name: t("sessions.columns.name"),
+    session_id: t("sessions.columns.sessionId"),
+    user_id: t("sessions.columns.userId"),
+    channel: t("sessions.columns.channel"),
+    created_at: t("sessions.columns.createdAt"),
+    updated_at: t("sessions.columns.updatedAt"),
+    action: t("sessions.columns.action"),
+  };
 
   const rowSelection = {
     fixed: true,
@@ -168,6 +331,12 @@ function SessionsPage() {
               onUserIdChange={setFilterUserId}
               onChannelChange={setFilterChannel}
             />
+            <Button
+              icon={<SettingOutlined />}
+              onClick={handleOpenColumnSettings}
+            >
+              {t("sessions.columnOrder")}
+            </Button>
             {selectedRowKeys.length > 0 && (
               <Button type="primary" danger onClick={handleBatchDelete}>
                 {t("sessions.batchDeleteButton")} ({selectedRowKeys.length})
@@ -203,6 +372,49 @@ function SessionsPage() {
         onClose={handleDrawerClose}
         onSubmit={handleSubmit}
       />
+
+      <Modal
+        title={t("sessions.columnOrder")}
+        open={columnSettingsOpen}
+        onOk={handleSaveColumnOrder}
+        onCancel={() => setColumnSettingsOpen(false)}
+        okText={t("common.save")}
+        cancelText={t("common.cancel")}
+        width={420}
+        footer={[
+          <Button key="reset" onClick={handleResetColumnOrder}>
+            {t("common.reset")}
+          </Button>,
+          <Button key="cancel" onClick={() => setColumnSettingsOpen(false)}>
+            {t("common.cancel")}
+          </Button>,
+          <Button key="save" type="primary" onClick={handleSaveColumnOrder}>
+            {t("common.save")}
+          </Button>,
+        ]}
+      >
+        <DndContext
+          sensors={columnOrderSensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleColumnDragEnd}
+        >
+          <SortableContext
+            items={draftColumnOrder}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className={styles.columnOrderList}>
+              {draftColumnOrder.map((key, index) => (
+                <SortableColumnOrderItem
+                  key={key}
+                  columnKey={key}
+                  index={index}
+                  label={columnLabels[key]}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </Modal>
     </div>
   );
 }

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -35,6 +35,10 @@ import { PageHeader } from "@/components/PageHeader";
 import styles from "./index.module.less";
 
 const SESSION_COLUMN_ORDER_STORAGE_KEY = "qwenpaw.sessions.columnOrder";
+const FIXED_SESSION_COLUMN_KEY: SessionColumnKey = "action";
+const CONFIGURABLE_SESSION_COLUMN_ORDER = DEFAULT_SESSION_COLUMN_ORDER.filter(
+  (key) => key !== FIXED_SESSION_COLUMN_KEY,
+);
 
 const normalizeColumnOrder = (order: unknown): SessionColumnKey[] => {
   const validKeys = new Set<SessionColumnKey>(DEFAULT_SESSION_COLUMN_ORDER);
@@ -45,6 +49,25 @@ const normalizeColumnOrder = (order: unknown): SessionColumnKey[] => {
   );
 
   DEFAULT_SESSION_COLUMN_ORDER.forEach((key) => {
+    if (!normalized.includes(key)) normalized.push(key);
+  });
+
+  return normalized;
+};
+
+const normalizeConfigurableColumnOrder = (
+  order: unknown,
+): SessionColumnKey[] => {
+  const validKeys = new Set<SessionColumnKey>(
+    CONFIGURABLE_SESSION_COLUMN_ORDER,
+  );
+  const customOrder = Array.isArray(order) ? order : [];
+  const normalized = customOrder.filter(
+    (key): key is SessionColumnKey =>
+      typeof key === "string" && validKeys.has(key as SessionColumnKey),
+  );
+
+  CONFIGURABLE_SESSION_COLUMN_ORDER.forEach((key) => {
     if (!normalized.includes(key)) normalized.push(key);
   });
 
@@ -125,7 +148,7 @@ function SessionsPage() {
   );
   const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
   const [draftColumnOrder, setDraftColumnOrder] = useState<SessionColumnKey[]>(
-    DEFAULT_SESSION_COLUMN_ORDER,
+    CONFIGURABLE_SESSION_COLUMN_ORDER,
   );
   const columnOrderSensors = useSensors(
     useSensor(PointerSensor, {
@@ -147,7 +170,7 @@ function SessionsPage() {
 
       const normalized = normalizeColumnOrder(JSON.parse(stored));
       setColumnOrder(normalized);
-      setDraftColumnOrder(normalized);
+      setDraftColumnOrder(normalizeConfigurableColumnOrder(normalized));
     } catch (error) {
       console.error("❌ Failed to load session column order:", error);
       window.localStorage.removeItem(SESSION_COLUMN_ORDER_STORAGE_KEY);
@@ -255,7 +278,7 @@ function SessionsPage() {
   };
 
   const handleOpenColumnSettings = () => {
-    setDraftColumnOrder(columnOrder);
+    setDraftColumnOrder(normalizeConfigurableColumnOrder(columnOrder));
     setColumnSettingsOpen(true);
   };
 
@@ -277,7 +300,10 @@ function SessionsPage() {
   };
 
   const handleSaveColumnOrder = () => {
-    const normalized = normalizeColumnOrder(draftColumnOrder);
+    const normalized = [
+      ...normalizeConfigurableColumnOrder(draftColumnOrder),
+      FIXED_SESSION_COLUMN_KEY,
+    ];
     setColumnOrder(normalized);
     window.localStorage.setItem(
       SESSION_COLUMN_ORDER_STORAGE_KEY,
@@ -287,7 +313,7 @@ function SessionsPage() {
   };
 
   const handleResetColumnOrder = () => {
-    setDraftColumnOrder(DEFAULT_SESSION_COLUMN_ORDER);
+    setDraftColumnOrder(CONFIGURABLE_SESSION_COLUMN_ORDER);
   };
 
   const columns = createColumns({


### PR DESCRIPTION
feat(console): implement customizable column order in sessions page

## Description

[Describe what this PR does and why]

**Related Issue:** #4770 
**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

<img width="2438" height="962" alt="53fe88c885140c8ca77ba0a744e7edba" src="https://github.com/user-attachments/assets/e7750f44-4404-4e93-9cef-b69ccda3c05d" />

<img width="2470" height="1414" alt="e0638f3ad3ed04283e3d3b23f019c33a" src="https://github.com/user-attachments/assets/78114cc1-79c8-4df2-b450-765e74e938c6" />

