### PR TITLE
fix(security): restrict file preview to WORKING_DIR and block sensiti…

### DIFF
--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -4,7 +4,34 @@ from urllib.parse import unquote
 from fastapi import APIRouter, HTTPException
 from starlette.responses import FileResponse
 
+from qwenpaw.constant import WORKING_DIR
+from qwenpaw.security.tool_guard.guardians.file_guardian import (
+    FilePathToolGuardian,
+    _normalize_path,
+)
+
 router = APIRouter(prefix="/files", tags=["files"])
+
+_ALLOWED_ROOT: Path = WORKING_DIR.resolve()
+
+# Reuse the FileGuard sensitive path detection for the preview endpoint.
+_file_guardian = FilePathToolGuardian()
+
+
+def _is_path_allowed(path: Path) -> bool:
+    """Check *path* is under WORKING_DIR and not sensitive."""
+    resolved = path.resolve()
+    # 1. Must be under WORKING_DIR.
+    if not (
+        resolved == _ALLOWED_ROOT or resolved.is_relative_to(_ALLOWED_ROOT)
+    ):
+        return False
+    # 2. Must not be a FileGuard-sensitive path.
+    normalized = _normalize_path(str(resolved))
+    # pylint: disable-next=protected-access
+    if _file_guardian._is_sensitive(normalized):
+        return False
+    return True
 
 
 @router.api_route(
@@ -27,10 +54,12 @@ async def preview_file(
     ):
         normalized = normalized[1:]
 
-    path = Path(normalized)
+    path = Path(normalized).expanduser()
     if not path.is_absolute():
         path = Path("/" + normalized)
     path = path.resolve()
+    if not _is_path_allowed(path):
+        raise HTTPException(status_code=403, detail="Forbidden")
     if not path.is_file():
         raise HTTPException(status_code=404, detail="Not found")
     return FileResponse(path, filename=path.name)


### PR DESCRIPTION
…ve paths

The /files/preview endpoint previously served any file on the filesystem without path restrictions. Add WORKING_DIR boundary check, FileGuard sensitive-path deny list, and tilde (~) expansion to prevent path traversal and sensitive file exposure.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
