### PR TITLE
fix(channels): fix Yuanbao streaming replies silently dropped when streaming_enabled=True (#4979)

### DIFF
--- a/src/qwenpaw/app/channels/yuanbao/channel.py
+++ b/src/qwenpaw/app/channels/yuanbao/channel.py
@@ -1392,6 +1392,61 @@ class YuanbaoChannel(BaseChannel):
             logger.error("yuanbao: failed to send media: %s", exc)
 
     # ------------------------------------------------------------------
+    # Streaming support
+    # ------------------------------------------------------------------
+
+    async def on_streaming_end(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Send accumulated text via WebSocket when streaming ends."""
+        if stream_type != "message":
+            return
+        if not accumulated_text or not accumulated_text.strip():
+            return
+        await self.send(to_handle, accumulated_text, send_meta)
+
+    async def _on_stream_msg_end(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        msg_id_to_stream_type: Dict[str, str],
+        streaming_buffers: Dict[str, str],
+    ) -> bool:
+        """Override: return False when buffer is empty so non-streaming
+        send() runs."""
+        stream_type = self._resolve_stream_type(event)
+        msg_id = getattr(event, "id", None)
+        if msg_id:
+            msg_id_to_stream_type.pop(msg_id, None)
+        if stream_type not in self._STREAMABLE_TYPES:
+            return False
+        if stream_type not in streaming_buffers:
+            return False
+        if stream_type == "reasoning" and self._filter_thinking:
+            streaming_buffers.pop(stream_type, None)
+            return True
+        accumulated = streaming_buffers.pop(stream_type, "")
+        if not accumulated.strip():
+            return False
+        await self.on_streaming_end(
+            request,
+            to_handle,
+            event,
+            send_meta,
+            stream_type,
+            accumulated_text=accumulated,
+        )
+        return True
+
+    # ------------------------------------------------------------------
     # Reconnect / cleanup / stop
     # ------------------------------------------------------------------
 

--- a/tests/unit/channels/test_yuanbao.py
+++ b/tests/unit/channels/test_yuanbao.py
@@ -1048,3 +1048,149 @@ class TestCleanup:
         connected_channel._media_session = None
         await connected_channel._cleanup_session()
         assert connected_channel._media_session is None
+
+
+# =============================================================================
+# P0: Streaming Support Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestStreamingSupport:
+    """P0: on_streaming_end and _on_stream_msg_end override tests."""
+
+    async def test_on_streaming_end_sends_message_text(
+        self,
+        connected_channel,
+    ):
+        """on_streaming_end should send accumulated text via send()."""
+        connected_channel._session_map["sess"] = {
+            "chat_type": "c2c",
+            "sender_id": "user_1",
+        }
+        with patch.object(
+            connected_channel,
+            "send",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await connected_channel.on_streaming_end(
+                request=MagicMock(),
+                to_handle="sess",
+                event=MagicMock(),
+                send_meta={"session_id": "sess"},
+                stream_type="message",
+                accumulated_text="Hello from streaming!",
+            )
+        mock_send.assert_called_once_with(
+            "sess",
+            "Hello from streaming!",
+            {"session_id": "sess"},
+        )
+
+    async def test_on_streaming_end_skips_non_message_type(
+        self,
+        connected_channel,
+    ):
+        """on_streaming_end should ignore reasoning type."""
+        with patch.object(
+            connected_channel,
+            "send",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await connected_channel.on_streaming_end(
+                request=MagicMock(),
+                to_handle="sess",
+                event=MagicMock(),
+                send_meta={},
+                stream_type="reasoning",
+                accumulated_text="thinking...",
+            )
+        mock_send.assert_not_called()
+
+    async def test_on_streaming_end_skips_empty_text(self, connected_channel):
+        """on_streaming_end should skip empty accumulated text."""
+        with patch.object(
+            connected_channel,
+            "send",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await connected_channel.on_streaming_end(
+                request=MagicMock(),
+                to_handle="sess",
+                event=MagicMock(),
+                send_meta={},
+                stream_type="message",
+                accumulated_text="",
+            )
+        mock_send.assert_not_called()
+
+    async def test_on_stream_msg_end_returns_true_with_text(
+        self,
+        connected_channel,
+    ):
+        """_on_stream_msg_end should return True when buffer has text."""
+        event = MagicMock()
+        event.type = MagicMock(value="message")
+        event.id = "msg_1"
+
+        streaming_buffers = {"message": "Hello world"}
+        msg_id_to_stream_type = {"msg_1": "message"}
+
+        with patch.object(
+            connected_channel,
+            "on_streaming_end",
+            new_callable=AsyncMock,
+        ):
+            result = await connected_channel._on_stream_msg_end(
+                request=MagicMock(),
+                to_handle="sess",
+                event=event,
+                send_meta={},
+                msg_id_to_stream_type=msg_id_to_stream_type,
+                streaming_buffers=streaming_buffers,
+            )
+        assert result is True
+        assert "message" not in streaming_buffers
+
+    async def test_on_stream_msg_end_returns_false_empty_buffer(
+        self,
+        connected_channel,
+    ):
+        """_on_stream_msg_end should return False when buffer is empty,
+        allowing non-streaming send() fallback."""
+        event = MagicMock()
+        event.type = MagicMock(value="message")
+        event.id = "msg_2"
+
+        streaming_buffers = {"message": ""}
+        msg_id_to_stream_type = {"msg_2": "message"}
+
+        result = await connected_channel._on_stream_msg_end(
+            request=MagicMock(),
+            to_handle="sess",
+            event=event,
+            send_meta={},
+            msg_id_to_stream_type=msg_id_to_stream_type,
+            streaming_buffers=streaming_buffers,
+        )
+        assert result is False
+
+    async def test_on_stream_msg_end_returns_false_no_buffer(
+        self,
+        connected_channel,
+    ):
+        """_on_stream_msg_end returns False when stream_type
+        not in buffer."""
+        event = MagicMock()
+        event.type = MagicMock(value="message")
+        event.id = "msg_3"
+
+        result = await connected_channel._on_stream_msg_end(
+            request=MagicMock(),
+            to_handle="sess",
+            event=event,
+            send_meta={},
+            msg_id_to_stream_type={},
+            streaming_buffers={},
+        )
+        assert result is False


### PR DESCRIPTION
 fix(channels): fix Yuanbao streaming replies silently dropped when streaming_enabled=True (#4979)

## Description

Override `on_streaming_end` to send accumulated text via WebSocket and
`_on_stream_msg_end` to return False when the streaming buffer is empty,
allowing the non-streaming send() fallback path to execute.

**Related Issue:** Fixes #4979

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
