### PR TITLE
fix(channels): store connectId from AuthBindRsp for connection tracking (#4978) 

### DIFF
--- a/src/qwenpaw/app/channels/yuanbao/channel.py
+++ b/src/qwenpaw/app/channels/yuanbao/channel.py
@@ -162,8 +162,9 @@ class YuanbaoChannel(BaseChannel):
         self._reconnect_attempts = 0
         self._stopping = False
 
-        # Bot identity (resolved during sign-token)
+        # Connection identity (resolved during AuthBind)
         self._bot_id: str = ""
+        self._connect_id: str = ""
 
         # Session tracking for reply routing (short_id → raw ids)
         self._session_map: Dict[str, Dict[str, Any]] = {}
@@ -323,7 +324,10 @@ class YuanbaoChannel(BaseChannel):
         return {
             "channel": self.channel,
             "status": "healthy",
-            "detail": f"Connected as bot={self._bot_id}",
+            "detail": (
+                f"Connected as bot={self._bot_id}"
+                f" connectId={self._connect_id}"
+            ),
         }
 
     async def start(self) -> None:
@@ -401,8 +405,6 @@ class YuanbaoChannel(BaseChannel):
         self._heartbeat_ack_received = True
         self._heartbeat_timeout_count = 0
 
-        logger.info("yuanbao: authenticated as bot=%s ✅", self._bot_id)
-
         # Start heartbeat and receive loops
         self._heartbeat_task = asyncio.create_task(
             self._heartbeat_loop(),
@@ -459,10 +461,11 @@ class YuanbaoChannel(BaseChannel):
 
         code = rsp.get("code", status_code)
         if code in (0, AUTH_ALREADY_CODE):
-            connect_id = rsp.get("connectId", "")
+            self._connect_id = rsp.get("connectId", "")
             logger.info(
-                "yuanbao: auth success connectId=%s",
-                connect_id,
+                "yuanbao: auth success bot=%s connectId=%s",
+                self._bot_id,
+                self._connect_id,
             )
             return True
 
@@ -617,6 +620,8 @@ class YuanbaoChannel(BaseChannel):
 
         if cmd == CMD_AUTH_BIND:
             rsp = decode_auth_bind_rsp(data)
+            if rsp:
+                self._connect_id = rsp.get("connectId", "") or self._connect_id
             status = head.get("status", 0)
             if status != 0 and status in AUTH_FAILED_CODES:
                 logger.warning(
@@ -1430,6 +1435,8 @@ class YuanbaoChannel(BaseChannel):
         self._reconnect_task = asyncio.create_task(_reconnect())
 
     async def _cleanup_session(self) -> None:
+        self._connect_id = ""
+
         if self._ws:
             try:
                 await self._ws.close()

--- a/tests/unit/channels/test_yuanbao.py
+++ b/tests/unit/channels/test_yuanbao.py
@@ -58,7 +58,9 @@ def connected_channel(yuanbao_channel):
     """Channel with mocked connected state."""
     yuanbao_channel._connected = True
     yuanbao_channel._bot_id = "test_bot_id"
+    yuanbao_channel._connect_id = "8c41af0b7aec4074a0bbe2478d175516"
     yuanbao_channel._ws = MagicMock()
+    yuanbao_channel._ws.closed = False
     yuanbao_channel._ws.send_bytes = AsyncMock()
     yuanbao_channel._ws.close = AsyncMock()
     yuanbao_channel._session = MagicMock()
@@ -120,6 +122,7 @@ class TestYuanbaoChannelInit:
         assert yuanbao_channel._connected is False
         assert yuanbao_channel._reconnect_attempts == 0
         assert yuanbao_channel._bot_id == ""
+        assert yuanbao_channel._connect_id == ""
         assert isinstance(yuanbao_channel._session_map, dict)
         assert yuanbao_channel._token_manager is None
 
@@ -1048,3 +1051,199 @@ class TestCleanup:
         connected_channel._media_session = None
         await connected_channel._cleanup_session()
         assert connected_channel._media_session is None
+
+    async def test_cleanup_resets_connect_id(self, connected_channel):
+        """_cleanup_session should reset _connect_id."""
+        connected_channel._media_session = None
+        assert connected_channel._connect_id != ""
+        await connected_channel._cleanup_session()
+        assert connected_channel._connect_id == ""
+
+
+# =============================================================================
+# P2: Health Check Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestHealthCheck:
+    """P2: health_check tests including connectId reporting."""
+
+    async def test_health_check_healthy_includes_connect_id(
+        self,
+        connected_channel,
+    ):
+        """Healthy status should include connectId."""
+        result = await connected_channel.health_check()
+        assert result["status"] == "healthy"
+        assert "8c41af0b7aec4074a0bbe2478d175516" in result["detail"]
+        assert "connectId=" in result["detail"]
+
+    async def test_health_check_unhealthy_no_connect_id(
+        self,
+        yuanbao_channel,
+    ):
+        """Unhealthy status should not reference connectId."""
+        result = await yuanbao_channel.health_check()
+        assert result["status"] == "unhealthy"
+        assert "connectId=" not in result["detail"]
+
+    async def test_health_check_disabled(self, yuanbao_channel):
+        """Disabled channel should return disabled status."""
+        yuanbao_channel.enabled = False
+        result = await yuanbao_channel.health_check()
+        assert result["status"] == "disabled"
+
+
+# =============================================================================
+# P2: Auth Response connectId Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestAuthResponseConnectId:
+    """P2: Tests for _connect_id storage during auth handshake."""
+
+    async def test_wait_for_auth_response_stores_connect_id(
+        self,
+        connected_channel,
+    ):
+        """_wait_for_auth_response should store connectId on success."""
+        from qwenpaw.app.channels.yuanbao.codec import (
+            encode_conn_msg,
+            encode_pb,
+        )
+
+        auth_rsp_data = encode_pb(
+            "trpc.yuanbao.conn_common.AuthBindRsp",
+            {"code": 0, "message": "ok"},
+        )
+        conn_raw = encode_conn_msg(
+            {
+                "cmdType": 1,
+                "cmd": "auth-bind",
+                "seqNo": 1,
+                "msgId": "test",
+                "module": "conn_access",
+                "status": 0,
+            },
+            auth_rsp_data,
+        )
+
+        ws_msg = MagicMock()
+        ws_msg.type = 2  # WSMsgType.BINARY
+        ws_msg.data = conn_raw
+
+        connected_channel._ws.receive = AsyncMock(return_value=ws_msg)
+        connected_channel._connect_id = ""
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.decode_auth_bind_rsp",
+        ) as mock_decode:
+            mock_decode.return_value = {
+                "code": 0,
+                "message": "ok",
+                "connectId": "abc123def456",
+            }
+            result = await connected_channel._wait_for_auth_response()
+
+        assert result is True
+        assert connected_channel._connect_id == "abc123def456"
+
+    async def test_wait_for_auth_response_no_connect_id(
+        self,
+        connected_channel,
+    ):
+        """Auth success without connectId should leave _connect_id empty."""
+        from qwenpaw.app.channels.yuanbao.codec import (
+            encode_conn_msg,
+            encode_pb,
+        )
+
+        auth_rsp_data = encode_pb(
+            "trpc.yuanbao.conn_common.AuthBindRsp",
+            {"code": 0, "message": "ok"},
+        )
+        conn_raw = encode_conn_msg(
+            {
+                "cmdType": 1,
+                "cmd": "auth-bind",
+                "seqNo": 1,
+                "msgId": "test",
+                "module": "conn_access",
+                "status": 0,
+            },
+            auth_rsp_data,
+        )
+
+        ws_msg = MagicMock()
+        ws_msg.type = 2
+        ws_msg.data = conn_raw
+
+        connected_channel._ws.receive = AsyncMock(return_value=ws_msg)
+        connected_channel._connect_id = ""
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.decode_auth_bind_rsp",
+        ) as mock_decode:
+            mock_decode.return_value = {
+                "code": 0,
+                "message": "ok",
+            }
+            result = await connected_channel._wait_for_auth_response()
+
+        assert result is True
+        assert connected_channel._connect_id == ""
+
+    async def test_handle_response_auth_bind_updates_connect_id(
+        self,
+        connected_channel,
+    ):
+        """_handle_response for auth-bind should update _connect_id."""
+        connected_channel._connect_id = ""
+        head = {
+            "cmdType": 1,
+            "cmd": "auth-bind",
+            "seqNo": 1,
+            "msgId": "test",
+            "module": "conn_access",
+            "status": 0,
+        }
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.decode_auth_bind_rsp",
+        ) as mock_decode:
+            mock_decode.return_value = {
+                "code": 0,
+                "message": "ok",
+                "connectId": "new_conn_id_999",
+            }
+            await connected_channel._handle_response(head, b"\x00")
+
+        assert connected_channel._connect_id == "new_conn_id_999"
+
+    async def test_handle_response_auth_bind_preserves_existing(
+        self,
+        connected_channel,
+    ):
+        """If rsp has no connectId, existing _connect_id should be kept."""
+        connected_channel._connect_id = "existing_id"
+        head = {
+            "cmdType": 1,
+            "cmd": "auth-bind",
+            "seqNo": 1,
+            "msgId": "test",
+            "module": "conn_access",
+            "status": 0,
+        }
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.decode_auth_bind_rsp",
+        ) as mock_decode:
+            mock_decode.return_value = {
+                "code": 0,
+                "message": "ok",
+            }
+            await connected_channel._handle_response(head, b"\x00")
+
+        assert connected_channel._connect_id == "existing_id"


### PR DESCRIPTION
fix(channels): store connectId from AuthBindRsp for connection tracking (#4978) 

## Description

 Changes                                                                                                                                                                                                          
   
 channel.py — Core fix                                                                                                                                                                                            
                  
  1. Added _connect_id instance variable — alongside _bot_id, initialized to empty string                                                                                                                          
  2. _wait_for_auth_response() — stores connectId in self._connect_id on auth success instead of discarding it after logging; log now includes both bot and connectId
  3. _handle_response() — extracts connectId from decoded CMD_AUTH_BIND push messages and updates self._connect_id; preserves existing value if absent in response                                                 
  4. health_check() — includes connectId= in healthy detail string for observability                                                                                                                               
  5. _cleanup_session() — resets _connect_id to empty on disconnect to prevent stale values                                                                                                                        
                                                                                                                                                                                                                   
 test_yuanbao.py — Test coverage                                                                                                                                                                                  
                                                                                                                                                                                                                   
  1. Fixture update — connected_channel adds _connect_id and _ws.closed = False                                                                                                                                    
  2. Init assertion — verifies _connect_id starts empty
  3. TestCleanup::test_cleanup_resets_connect_id — cleanup resets connectId                                                                                                                                        
  4. TestHealthCheck (3 tests) — healthy includes connectId, unhealthy excludes it, disabled status                                                                                                                
  5. TestAuthResponseConnectId (4 tests) — stores connectId on auth success, empty when absent, _handle_response updates it, preserves existing when missing

**Related Issue:** Fixes #4978

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
