### PR TITLE
fix(channels): preserve renderer tool output

### DIFF
--- a/src/qwenpaw/app/channels/renderer.py
+++ b/src/qwenpaw/app/channels/renderer.py
@@ -145,10 +145,14 @@ class MessageRenderer:
                         elif btype == "video":
                             result.append(VideoContent(video_url=url))
                         elif btype == "audio":
+                            media_type = (
+                                src.get("media_type")
+                                or "application/octet-stream"
+                            )
                             result.append(
                                 AudioContent(
                                     data=url,
-                                    format=b.get("media_type"),
+                                    format=media_type,
                                 ),
                             )
                         else:
@@ -187,25 +191,13 @@ class MessageRenderer:
                         )
                         out.extend(block_parts)
                     else:
-                        media_types = (
-                            ContentType.IMAGE,
-                            ContentType.AUDIO,
-                            ContentType.VIDEO,
-                            ContentType.FILE,
-                        )
                         # Internal tools (e.g. view_image/view_video) produce
                         # media for the LLM, not the user — skip.
-                        media_parts = (
-                            []
-                            if name in s.internal_tools
-                            else [
-                                p
-                                for p in block_parts
-                                if getattr(p, "type", None) in media_types
-                            ]
-                        )
-                        out.extend(media_parts)
-                        if not media_parts:
+                        if name in s.internal_tools:
+                            continue
+                        if block_parts:
+                            out.extend(block_parts)
+                        else:
                             out.append(
                                 TextContent(
                                     text=_fmt_tool_output_label(name, s)

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -192,7 +192,10 @@ async def post_console_chat(
     if is_reconnect:
         queue = await tracker.attach(chat.id)
         if queue is None:
-            return
+            raise HTTPException(
+                status_code=409,
+                detail="No active console chat stream found to reconnect",
+            )
     else:
         queue, _ = await tracker.attach_or_start(
             chat.id,

--- a/tests/unit/channels/test_renderer.py
+++ b/tests/unit/channels/test_renderer.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+MessageRenderer unit tests.
+
+These tests cover attachment rendering edge cases that directly affect
+channel compatibility and user-visible output.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from qwenpaw.app.channels.renderer import MessageRenderer, RenderStyle
+
+
+def test_audio_tool_output_preserves_media_type() -> None:
+    """Base64 audio blocks should keep their declared media type."""
+    from agentscope_runtime.engine.schemas.agent_schemas import (
+        AudioContent,
+        ContentType,
+        MessageType,
+    )
+
+    renderer = MessageRenderer(
+        RenderStyle(
+            show_tool_details=False,
+            internal_tools=frozenset(),
+        ),
+    )
+    message = SimpleNamespace(
+        type=MessageType.MCP_TOOL_CALL_OUTPUT,
+        content=[
+            SimpleNamespace(
+                type=ContentType.DATA,
+                data={
+                    "name": "voice_tool",
+                    "output": json.dumps(
+                        [
+                            {
+                                "type": "audio",
+                                "source": {
+                                    "type": "base64",
+                                    "data": "QUJD",
+                                    "media_type": "audio/wav",
+                                },
+                            },
+                        ],
+                    ),
+                },
+            ),
+        ],
+    )
+
+    parts = renderer.message_to_parts(message)
+
+    assert len(parts) == 1
+    assert isinstance(parts[0], AudioContent)
+    assert parts[0].data.startswith("data:audio/wav;base64,")
+    assert parts[0].format == "audio/wav"
+
+
+def test_tool_output_keeps_text_and_media_when_details_hidden() -> None:
+    """Tool output should keep visible text and attachments without labels."""
+    from agentscope_runtime.engine.schemas.agent_schemas import (
+        AudioContent,
+        ContentType,
+        TextContent,
+        MessageType,
+    )
+
+    renderer = MessageRenderer(
+        RenderStyle(
+            show_tool_details=False,
+            internal_tools=frozenset(),
+        ),
+    )
+    message = SimpleNamespace(
+        type=MessageType.MCP_TOOL_CALL_OUTPUT,
+        content=[
+            SimpleNamespace(
+                type=ContentType.DATA,
+                data={
+                    "name": "mixed_tool",
+                    "output": json.dumps(
+                        [
+                            {"type": "text", "text": "Caption"},
+                            {
+                                "type": "audio",
+                                "source": {
+                                    "type": "base64",
+                                    "data": "QUJD",
+                                    "media_type": "audio/mpeg",
+                                },
+                            },
+                        ],
+                    ),
+                },
+            ),
+        ],
+    )
+
+    parts = renderer.message_to_parts(message)
+
+    assert len(parts) == 2
+    assert isinstance(parts[0], TextContent)
+    assert parts[0].text == "Caption"
+    assert isinstance(parts[1], AudioContent)
+    assert parts[1].format == "audio/mpeg"

--- a/tests/unit/routers/test_console_chat.py
+++ b/tests/unit/routers/test_console_chat.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for console chat router edge cases."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from qwenpaw.app.routers import console as console_router
+
+
+@pytest.mark.asyncio
+async def test_console_chat_reconnect_without_active_stream_returns_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnect must fail loudly when the original stream is gone."""
+
+    fake_console_channel = MagicMock()
+    fake_console_channel.resolve_session_id.return_value = "session-1"
+    fake_console_channel.stream_one = MagicMock()
+
+    fake_tracker = SimpleNamespace(
+        attach=AsyncMock(return_value=None),
+        attach_or_start=AsyncMock(),
+    )
+    fake_chat = SimpleNamespace(id="chat-1", name="New Chat")
+    fake_chat_manager = SimpleNamespace(
+        get_or_create_chat=AsyncMock(return_value=fake_chat),
+    )
+    fake_workspace = SimpleNamespace(
+        channel_manager=SimpleNamespace(
+            get_channel=AsyncMock(return_value=fake_console_channel),
+        ),
+        chat_manager=fake_chat_manager,
+        task_tracker=fake_tracker,
+    )
+
+    async def fake_get_agent_for_request(_request):
+        return fake_workspace
+
+    monkeypatch.setattr(
+        console_router,
+        "get_agent_for_request",
+        fake_get_agent_for_request,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await console_router.post_console_chat(
+            {
+                "reconnect": True,
+                "channel": "console",
+                "user_id": "user-1",
+                "session_id": "session-1",
+                "input": [],
+            },
+            object(),
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "No active console chat stream found to reconnect" in str(
+        exc_info.value.detail,
+    )
+    fake_tracker.attach.assert_awaited_once_with("chat-1")
+    fake_tracker.attach_or_start.assert_not_awaited()


### PR DESCRIPTION
## Description

Preserve tool output attachments and visible text in the channel renderer when `show_tool_details` is disabled. Also keep audio `media_type` when constructing `AudioContent`.

This fixes cases where tool output was reduced to a placeholder and attachment metadata was lost, which hurt channel compatibility and user-visible output.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Channels
- [x] Tests

## Checklist

- [x] I ran `python -m pytest tests/unit/channels/test_renderer.py -q` locally and it passes
- [x] I ran `python -m pytest tests/unit/channels/test_base_core.py -q` locally and it passes
