### PR TITLE
WIP: Plugin extension infrastructure (agentscope 2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ e2e/reports/
 e2e/data/
 e2e/.pytest_cache/
 e2e/__pycache__/
+
+# knowledge-base related
+graphify-out/

--- a/console/package-lock.json
+++ b/console/package-lock.json
@@ -8,7 +8,7 @@
       "name": "qwenpaw-console",
       "version": "0.0.0",
       "dependencies": {
-        "@agentscope-ai/chat": "^1.1.64-beta.1779961389231",
+        "@agentscope-ai/chat": "1.1.68-beta.1780475996648",
         "@agentscope-ai/design": "^1.0.14",
         "@agentscope-ai/icons": "^1.0.67",
         "@ant-design/icons": "^5.0.1",
@@ -76,9 +76,9 @@
       "license": "MIT"
     },
     "node_modules/@agentscope-ai/chat": {
-      "version": "1.1.64-beta.1779961389231",
-      "resolved": "https://registry.npmjs.org/@agentscope-ai/chat/-/chat-1.1.64-beta.1779961389231.tgz",
-      "integrity": "sha512-FnCPqhgw1WZ59M2G6LMXIKMC2+Q8xgOMyf3ZwHJcvaecMNM5c958i4e8aF60rDQ4/PXJiruF1IpIWBTOUFt8Tw==",
+      "version": "1.1.68-beta.1780475996648",
+      "resolved": "https://registry.npmjs.org/@agentscope-ai/chat/-/chat-1.1.68-beta.1780475996648.tgz",
+      "integrity": "sha512-V80ilDvB+jcZq1b8M6SUYdfqFDLOEcO08/YDrt1DTkRu8OtbE2wBE1F0IM5DC4N/1/1OkTrlTI0IypdayWRDtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentscope-ai/icons": "^1.0.32",

--- a/console/package.json
+++ b/console/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "NODE_OPTIONS=--max-old-space-size=4096 vitest run --coverage"
   },
   "dependencies": {
-    "@agentscope-ai/chat": "^1.1.64-beta.1779961389231",
+    "@agentscope-ai/chat": "1.1.68-beta.1780475996648",
     "@agentscope-ai/design": "^1.0.14",
     "@agentscope-ai/icons": "^1.0.67",
     "@ant-design/icons": "^5.0.1",

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -21,6 +21,7 @@ import {
 } from "./constants";
 import { useTheme } from "../contexts/ThemeContext";
 import { useState, useEffect } from "react";
+import { Slot } from "../plugins/registry/Slot";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -166,11 +167,19 @@ export default function Header() {
     <>
       <AntHeader className={styles.header}>
         <div className={styles.logoWrapper}>
-          <img
-            src={isDark ? "/logo-dark.svg" : "/logo-light.svg"}
-            alt="QwenPaw"
-            className={styles.logoImg}
-          />
+          {/*
+            Slot lets a plugin replace the brand logo (e.g. a per-agent
+            branding override). When no plugin registers a replacement —
+            or when the registered render returns null — the host default
+            <img> below paints.
+          */}
+          <Slot name="header.logo" kind="replace">
+            <img
+              src={isDark ? "/logo-dark.svg" : "/logo-light.svg"}
+              alt="QwenPaw"
+              className={styles.logoImg}
+            />
+          </Slot>
           <div className={styles.logoDivider} />
           {version && (
             <Badge
@@ -191,7 +200,9 @@ export default function Header() {
             </Badge>
           )}
         </div>
+        <Slot name="header.left" kind="fill" />
         <Space size="middle">
+          <Slot name="header.right" kind="fill" />
           <Dropdown
             menu={{
               items: [

--- a/console/src/layouts/MainLayout/index.tsx
+++ b/console/src/layouts/MainLayout/index.tsx
@@ -1,121 +1,49 @@
-import { Suspense } from "react";
+import { Suspense, useMemo } from "react";
 import { Layout, Spin } from "antd";
-import { Routes, Route, useLocation, Navigate } from "react-router-dom";
+import { Routes, Route, useLocation, matchPath } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Sidebar from "../Sidebar";
 import Header from "../Header";
 import ConsolePollService from "../../components/ConsolePollService";
 import { ChunkErrorBoundary } from "../../components/ChunkErrorBoundary";
-import { lazyImportWithRetry } from "../../utils/lazyWithRetry";
-import { usePlugins } from "../../plugins/PluginContext";
-import { useCodingMode } from "../../stores/codingModeStore";
 import { useSyncCodingMode } from "../../stores/useSyncCodingMode";
 import styles from "../index.module.less";
-
-// Chat is eagerly loaded (default landing page)
-import Chat from "../../pages/Chat";
-// Coding Mode IDE page
-import CodingPage from "../../pages/Coding";
-
-// All other pages are lazily loaded with automatic retry on chunk failure
-const ChannelsPage = lazyImportWithRetry("../../pages/Control/Channels");
-const SessionsPage = lazyImportWithRetry("../../pages/Control/Sessions");
-const InboxPage = lazyImportWithRetry("../../pages/Inbox");
-const CronJobsPage = lazyImportWithRetry("../../pages/Control/CronJobs");
-const HeartbeatPage = lazyImportWithRetry("../../pages/Control/Heartbeat");
-const AgentConfigPage = lazyImportWithRetry("../../pages/Agent/Config");
-const SkillsPage = lazyImportWithRetry("../../pages/Agent/Skills");
-const SkillPoolPage = lazyImportWithRetry("../../pages/Settings/SkillPool");
-const MarketPage = lazyImportWithRetry("../../pages/Settings/Market");
-const ToolsPage = lazyImportWithRetry("../../pages/Agent/Tools");
-const WorkspacePage = lazyImportWithRetry("../../pages/Agent/Workspace");
-const MCPPage = lazyImportWithRetry("../../pages/Agent/MCP");
-const ACPPage = lazyImportWithRetry("../../pages/Agent/ACP");
-const ModelsPage = lazyImportWithRetry("../../pages/Settings/Models");
-const EnvironmentsPage = lazyImportWithRetry(
-  "../../pages/Settings/Environments",
-);
-const SecurityPage = lazyImportWithRetry("../../pages/Settings/Security");
-const TokenUsagePage = lazyImportWithRetry("../../pages/Settings/TokenUsage");
-const AgentStatsPage = lazyImportWithRetry("../../pages/Settings/AgentStats");
-const VoiceTranscriptionPage = lazyImportWithRetry(
-  "../../pages/Settings/VoiceTranscription",
-);
-const AgentsPage = lazyImportWithRetry("../../pages/Settings/Agents");
-const DebugPage = lazyImportWithRetry("../../pages/Settings/Debug");
-const BackupsPage = lazyImportWithRetry("../../pages/Settings/Backups");
-const PluginManagerPage = lazyImportWithRetry(
-  "../../pages/Settings/PluginManager",
-);
+import { useRoutes } from "../../plugins/registry/hooks";
+import { Slot } from "../../plugins/registry/Slot";
 
 const { Content } = Layout;
 
-// Route "/" lands here. Waits for useSyncCodingMode to populate the store
-// from the backend before deciding where to send the user — otherwise we
-// would flash /chat first and the toggle button would desync with the
-// rendered page.
-function DefaultRedirect() {
-  const { t } = useTranslation();
-  const { codingMode, initialized } = useCodingMode();
-  if (!initialized) {
-    return (
-      <Spin
-        tip={t("common.loading")}
-        style={{ display: "block", margin: "20vh auto" }}
-      />
-    );
+/**
+ * Find the registered route whose path pattern matches the current URL.
+ * Falls back to "core.chat" so the sidebar always has a sensible
+ * highlight, mirroring the old `pathToKey` default.
+ */
+function pickSelectedKey(
+  currentPath: string,
+  routes: ReturnType<typeof useRoutes>,
+): string {
+  for (const r of routes) {
+    if (matchPath({ path: r.path, end: r.path === "/" }, currentPath)) {
+      return r.id;
+    }
   }
-  return <Navigate to={codingMode ? "/coding" : "/chat"} replace />;
+  return "core.chat";
 }
-
-const pathToKey: Record<string, string> = {
-  "/chat": "chat",
-  "/coding": "chat",
-  "/channels": "channels",
-  "/sessions": "sessions",
-  "/inbox": "inbox",
-  "/cron-jobs": "cron-jobs",
-  "/heartbeat": "heartbeat",
-  "/skills": "skills",
-  "/skill-pool": "skill-pool",
-  "/market": "market",
-  "/tools": "tools",
-  "/mcp": "mcp",
-  "/acp": "acp",
-  "/workspace": "workspace",
-  "/agents": "agents",
-  "/models": "models",
-  "/environments": "environments",
-  "/agent-config": "agent-config",
-  "/security": "security",
-  "/token-usage": "token-usage",
-  "/agent-stats": "agent-stats",
-  "/voice-transcription": "voice-transcription",
-  "/debug": "debug",
-  "/backups": "backups",
-  "/plugin-manager": "plugin-manager",
-};
 
 export default function MainLayout() {
   const { t } = useTranslation();
   const location = useLocation();
   const currentPath = location.pathname;
-  const { pluginRoutes } = usePlugins();
+  const routes = useRoutes();
 
   // Backend is the source of truth for Coding Mode state — refill the
   // in-memory store every time the selected agent changes.
   useSyncCodingMode();
 
-  // Resolve selected key: check static routes first, then plugin routes
-  let selectedKey = pathToKey[currentPath] || "";
-  if (!selectedKey) {
-    const matchedPlugin = pluginRoutes.find(
-      (route) => currentPath === route.path,
-    );
-    selectedKey = matchedPlugin
-      ? matchedPlugin.path.replace(/^\//, "")
-      : "chat";
-  }
+  const selectedKey = useMemo(
+    () => pickSelectedKey(currentPath, routes),
+    [currentPath, routes],
+  );
 
   return (
     <Layout className={styles.mainLayout}>
@@ -124,6 +52,7 @@ export default function MainLayout() {
         <Sidebar selectedKey={selectedKey} />
         <Content className="page-container">
           <ConsolePollService />
+          <Slot name="content.statusBar" kind="fill" />
           <div className="page-content">
             <ChunkErrorBoundary resetKey={currentPath}>
               <Suspense
@@ -135,47 +64,8 @@ export default function MainLayout() {
                 }
               >
                 <Routes>
-                  <Route path="/" element={<DefaultRedirect />} />
-                  <Route path="/chat/*" element={<Chat />} />
-                  <Route path="/coding" element={<CodingPage />} />
-                  <Route path="/channels" element={<ChannelsPage />} />
-                  <Route path="/sessions" element={<SessionsPage />} />
-                  <Route path="/inbox" element={<InboxPage />} />
-                  <Route path="/cron-jobs" element={<CronJobsPage />} />
-                  <Route path="/heartbeat" element={<HeartbeatPage />} />
-                  <Route path="/skills" element={<SkillsPage />} />
-                  <Route path="/skill-pool" element={<SkillPoolPage />} />
-                  <Route path="/market" element={<MarketPage />} />
-                  <Route path="/tools" element={<ToolsPage />} />
-                  <Route path="/mcp" element={<MCPPage />} />
-                  <Route path="/acp" element={<ACPPage />} />
-                  <Route path="/ACP" element={<Navigate to="/acp" replace />} />
-                  <Route path="/workspace" element={<WorkspacePage />} />
-                  <Route path="/agents" element={<AgentsPage />} />
-                  <Route path="/models" element={<ModelsPage />} />
-                  <Route path="/environments" element={<EnvironmentsPage />} />
-                  <Route path="/agent-config" element={<AgentConfigPage />} />
-                  <Route path="/security" element={<SecurityPage />} />
-                  <Route path="/token-usage" element={<TokenUsagePage />} />
-                  <Route path="/agent-stats" element={<AgentStatsPage />} />
-                  <Route
-                    path="/voice-transcription"
-                    element={<VoiceTranscriptionPage />}
-                  />
-                  <Route path="/debug" element={<DebugPage />} />
-                  <Route path="/backups" element={<BackupsPage />} />
-                  <Route
-                    path="/plugin-manager"
-                    element={<PluginManagerPage />}
-                  />
-
-                  {/* Plugin routes — dynamically injected at runtime */}
-                  {pluginRoutes.map((route) => (
-                    <Route
-                      key={route.path}
-                      path={route.path}
-                      element={<route.component />}
-                    />
+                  {routes.map((r) => (
+                    <Route key={r.id} path={r.path} element={<r.Component />} />
                   ))}
                 </Routes>
               </Suspense>
@@ -183,6 +73,7 @@ export default function MainLayout() {
           </div>
         </Content>
       </Layout>
+      <Slot name="overlay.global" kind="fill" />
     </Layout>
   );
 }

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -1,57 +1,35 @@
-import {
-  Layout,
-  Menu,
-  Button,
-  Modal,
-  Input,
-  Form,
-  Tooltip,
-  Badge,
-  type MenuProps,
-} from "antd";
-import { useState, useEffect } from "react";
+import { Layout, Menu, Button, Modal, Input, Form, Tooltip, Badge } from "antd";
+import { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "../hooks/useAppMessage";
 import AgentSelector from "../components/AgentSelector";
 import {
   SparkChatTabFill,
-  SparkWifiLine,
-  SparkUserGroupLine,
-  SparkDateLine,
-  SparkVoiceChat01Line,
-  SparkMagicWandLine,
-  SparkLocalFileLine,
-  SparkModePlazaLine,
-  SparkInternetLine,
-  SparkModifyLine,
-  SparkBrowseLine,
-  SparkMcpMcpLine,
-  SparkScanLine,
-  SparkToolLine,
-  SparkDataLine,
-  SparkMicLine,
-  SparkAgentLine,
   SparkExitFullscreenLine,
   SparkSearchUserLine,
   SparkMenuExpandLine,
   SparkMenuFoldLine,
-  SparkOtherLine,
-  SparkBarChartLine,
-  SparkDebugLine,
-  SparkSaveLine,
   SparkEmailLine,
-  SparkCardLine,
 } from "@agentscope-ai/icons";
-import { Package } from "lucide-react";
 import { clearAuthToken } from "../api/config";
 import { authApi } from "../api/modules/auth";
 import api from "../api";
-import { usePlugins } from "../plugins/PluginContext";
 import { useCodingMode } from "../stores/codingModeStore";
 import styles from "./index.module.less";
 import { useTheme } from "../contexts/ThemeContext";
-import { KEY_TO_PATH, DEFAULT_OPEN_KEYS } from "./constants";
+import { useMenuItems, useRoutes } from "../plugins/registry/hooks";
+import { Slot } from "../plugins/registry/Slot";
+import {
+  deriveOpenKeys,
+  findMenuItem,
+  flattenMenu,
+  renderIcon,
+  routeIdToPath,
+  toAntdItems,
+} from "./registry/adapter";
+import type { MenuItem } from "../plugins/registry/types";
+import type { ReactNode } from "react";
 
 // ── Layout ────────────────────────────────────────────────────────────────
 
@@ -70,6 +48,7 @@ const INBOX_BADGE_POLLING_MS = 6000;
 // ── Types ─────────────────────────────────────────────────────────────────
 
 interface SidebarProps {
+  /** Route id of the currently active page (e.g. "core.workspace"). */
   selectedKey: string;
 }
 
@@ -80,7 +59,6 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
   const { isDark } = useTheme();
-  const { pluginRoutes } = usePlugins();
   // When coding mode is on, the sidebar "Chat" entry should land on /coding
   // (FileTree + Editor + Chat panel) rather than the bare Chat page.
   const { codingMode } = useCodingMode();
@@ -92,6 +70,11 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [isMobile, setIsMobile] = useState(isMobileSidebarViewport);
   const [hasInboxUnread, setHasInboxUnread] = useState(false);
+
+  // Menu + route snapshots from registry (builtin + plugin registrations merged).
+  const agentMenu = useMenuItems("primary.agentScoped");
+  const settingsMenu = useMenuItems("primary.settings");
+  const routes = useRoutes();
 
   // ── Effects ──────────────────────────────────────────────────────────────
 
@@ -150,12 +133,82 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     return () => window.clearInterval(timer);
   }, []);
 
-  const inboxLabel = collapsed ? null : (
-    <Badge dot={hasInboxUnread} color="rgba(255, 157, 77, 1)" offset={[5, 7]}>
-      <span>{t("nav.inbox")}</span>
-    </Badge>
+  // ── Adapter: convert MenuItem trees to antd, with inbox badge decoration.
+
+  /** Wrap the inbox label with the unread-Badge while keeping all other labels intact. */
+  const decorateLabel = (item: MenuItem, label: ReactNode): ReactNode => {
+    if (item.id !== "core.inbox" || label == null) return label;
+    return (
+      <Badge dot={hasInboxUnread} color="rgba(255, 157, 77, 1)" offset={[5, 7]}>
+        <span>{label}</span>
+      </Badge>
+    );
+  };
+
+  const agentMenuItems = useMemo(
+    () => toAntdItems(agentMenu, { collapsed, decorateLabel }),
+    // hasInboxUnread closure inside decorateLabel — listed as dep explicitly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [agentMenu, collapsed, hasInboxUnread],
   );
+
+  const settingsMenuItems = useMemo(
+    () => toAntdItems(settingsMenu, { collapsed }),
+    [settingsMenu, collapsed],
+  );
+
+  const openKeys = useMemo(
+    () => [...deriveOpenKeys(agentMenu), ...deriveOpenKeys(settingsMenu)],
+    [agentMenu, settingsMenu],
+  );
+
+  const collapsedNavItems = useMemo(() => {
+    // Sticky chat is its own carve-out (lives outside menu data — see builtinMenu.ts).
+    const stickyChat = {
+      key: "core.chat",
+      icon: <SparkChatTabFill size={18} />,
+      path: chatPath,
+      label: t("nav.chat"),
+    };
+    // Inbox in collapsed mode shows a dot overlay on its icon (kept Sidebar-local
+    // for the same reason as decorateLabel: live state isn't menu data).
+    const decorateInboxIcon = (icon: ReactNode): ReactNode => (
+      <span style={{ position: "relative", display: "inline-flex" }}>
+        {icon ?? <SparkEmailLine size={18} />}
+        {hasInboxUnread && (
+          <span
+            style={{
+              position: "absolute",
+              top: -1,
+              right: -3,
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: "rgba(255, 157, 77, 1)",
+            }}
+          />
+        )}
+      </span>
+    );
+    const flat = [
+      stickyChat,
+      ...flattenMenu(agentMenu, routes, 18),
+      ...flattenMenu(settingsMenu, routes, 18),
+    ];
+    return flat.map((entry) =>
+      entry.key === "core.inbox"
+        ? { ...entry, icon: decorateInboxIcon(entry.icon) }
+        : entry,
+    );
+  }, [agentMenu, settingsMenu, routes, chatPath, t, hasInboxUnread]);
+
   // ── Handlers ──────────────────────────────────────────────────────────────
+
+  const handleMenuClick = (key: string, allItems: MenuItem[]) => {
+    const item = findMenuItem(allItems, key);
+    const path = routeIdToPath(item?.route, routes);
+    if (path) navigate(path);
+  };
 
   const handleUpdateProfile = async (values: {
     currentPassword: string;
@@ -210,332 +263,14 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     }
   };
 
-  // ── Collapsed nav items (all leaf pages) ──────────────────────────────
-
-  const collapsedNavItems = [
-    {
-      key: "chat",
-      icon: <SparkChatTabFill size={18} />,
-      path: chatPath,
-      label: t("nav.chat"),
-    },
-    {
-      key: "inbox",
-      icon: (
-        <span style={{ position: "relative", display: "inline-flex" }}>
-          <SparkEmailLine size={18} />
-          {hasInboxUnread && (
-            <span
-              style={{
-                position: "absolute",
-                top: -1,
-                right: -3,
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                background: "rgba(255, 157, 77, 1)",
-              }}
-            />
-          )}
-        </span>
-      ),
-      path: "/inbox",
-      label: t("nav.inbox"),
-    },
-    {
-      key: "channels",
-      icon: <SparkWifiLine size={18} />,
-      path: "/channels",
-      label: t("nav.channels"),
-    },
-    {
-      key: "sessions",
-      icon: <SparkUserGroupLine size={18} />,
-      path: "/sessions",
-      label: t("nav.sessions"),
-    },
-    {
-      key: "cron-jobs",
-      icon: <SparkDateLine size={18} />,
-      path: "/cron-jobs",
-      label: t("nav.cronJobs"),
-    },
-    {
-      key: "heartbeat",
-      icon: <SparkVoiceChat01Line size={18} />,
-      path: "/heartbeat",
-      label: t("nav.heartbeat"),
-    },
-    {
-      key: "workspace",
-      icon: <SparkLocalFileLine size={18} />,
-      path: "/workspace",
-      label: t("nav.workspace"),
-    },
-    {
-      key: "skills",
-      icon: <SparkMagicWandLine size={18} />,
-      path: "/skills",
-      label: t("nav.skills"),
-    },
-    {
-      key: "skill-pool",
-      icon: <SparkOtherLine size={18} />,
-      path: "/skill-pool",
-      label: t("nav.skillPool", "Skill Pool"),
-    },
-    {
-      key: "tools",
-      icon: <SparkToolLine size={18} />,
-      path: "/tools",
-      label: t("nav.tools"),
-    },
-    {
-      key: "mcp",
-      icon: <SparkMcpMcpLine size={18} />,
-      path: "/mcp",
-      label: t("nav.mcp"),
-    },
-    {
-      key: "acp",
-      icon: <SparkScanLine size={18} />,
-      path: "/acp",
-      label: t("nav.acp"),
-    },
-    {
-      key: "agent-config",
-      icon: <SparkModifyLine size={18} />,
-      path: "/agent-config",
-      label: t("nav.agentConfig"),
-    },
-    {
-      key: "agent-stats",
-      icon: <SparkBarChartLine size={18} />,
-      path: "/agent-stats",
-      label: t("nav.agentStats"),
-    },
-    {
-      key: "agents",
-      icon: <SparkAgentLine size={18} />,
-      path: "/agents",
-      label: t("nav.agents"),
-    },
-    {
-      key: "models",
-      icon: <SparkModePlazaLine size={18} />,
-      path: "/models",
-      label: t("nav.models"),
-    },
-    {
-      key: "environments",
-      icon: <SparkInternetLine size={18} />,
-      path: "/environments",
-      label: t("nav.environments"),
-    },
-    {
-      key: "security",
-      icon: <SparkBrowseLine size={18} />,
-      path: "/security",
-      label: t("nav.security"),
-    },
-    {
-      key: "token-usage",
-      icon: <SparkDataLine size={18} />,
-      path: "/token-usage",
-      label: t("nav.tokenUsage"),
-    },
-    {
-      key: "backups",
-      icon: <SparkSaveLine size={18} />,
-      path: "/backups",
-      label: t("nav.backups"),
-    },
-    {
-      key: "voice-transcription",
-      icon: <SparkMicLine size={18} />,
-      path: "/voice-transcription",
-      label: t("nav.voiceTranscription"),
-    },
-    {
-      key: "debug",
-      icon: <SparkDebugLine size={18} />,
-      path: "/debug",
-      label: t("nav.debug", "Debug"),
-    },
-    {
-      key: "plugin-manager",
-      icon: <Package size={18} />,
-      path: "/plugin-manager",
-      label: t("nav.pluginManager", "Plugin Manager"),
-    },
-    // Append plugin nav items dynamically
-    ...pluginRoutes.map((route) => ({
-      key: route.path.replace(/^\//, ""),
-      icon: <span style={{ fontSize: 18 }}>{route.icon}</span>,
-      path: route.path,
-      label: route.label,
-    })),
-  ];
-
-  // ── Menu items — agent-scoped (Chat + Control + Workspace) ──────────────
-
-  const agentMenuItems: MenuProps["items"] = [
-    {
-      key: "inbox",
-      label: inboxLabel,
-      icon: <SparkEmailLine size={16} />,
-    },
-    {
-      key: "control-group",
-      label: collapsed ? null : t("nav.control"),
-      children: [
-        {
-          key: "channels",
-          label: collapsed ? null : t("nav.channels"),
-          icon: <SparkWifiLine size={16} />,
-        },
-        {
-          key: "sessions",
-          label: collapsed ? null : t("nav.sessions"),
-          icon: <SparkUserGroupLine size={16} />,
-        },
-        {
-          key: "cron-jobs",
-          label: collapsed ? null : t("nav.cronJobs"),
-          icon: <SparkDateLine size={16} />,
-        },
-        {
-          key: "heartbeat",
-          label: collapsed ? null : t("nav.heartbeat"),
-          icon: <SparkVoiceChat01Line size={16} />,
-        },
-      ],
-    },
-    {
-      key: "agent-group",
-      label: collapsed ? null : t("nav.agent"),
-      children: [
-        {
-          key: "workspace",
-          label: collapsed ? null : t("nav.workspace"),
-          icon: <SparkLocalFileLine size={16} />,
-        },
-        {
-          key: "skills",
-          label: collapsed ? null : t("nav.skills"),
-          icon: <SparkMagicWandLine size={16} />,
-        },
-        {
-          key: "tools",
-          label: collapsed ? null : t("nav.tools"),
-          icon: <SparkToolLine size={16} />,
-        },
-        {
-          key: "mcp",
-          label: collapsed ? null : t("nav.mcp"),
-          icon: <SparkMcpMcpLine size={16} />,
-        },
-        {
-          key: "acp",
-          label: collapsed ? null : t("nav.acp"),
-          icon: <SparkScanLine size={16} />,
-        },
-        {
-          key: "agent-config",
-          label: collapsed ? null : t("nav.agentConfig"),
-          icon: <SparkModifyLine size={16} />,
-        },
-        {
-          key: "agent-stats",
-          label: collapsed ? null : t("nav.agentStats"),
-          icon: <SparkBarChartLine size={16} />,
-        },
-      ],
-    },
-  ];
-
-  // ── Menu items — global settings ──────────────────────────────────────
-
-  const settingsMenuItems: MenuProps["items"] = [
-    {
-      key: "settings-group",
-      label: collapsed ? null : t("nav.settings"),
-      children: [
-        {
-          key: "agents",
-          label: collapsed ? null : t("nav.agents"),
-          icon: <SparkAgentLine size={16} />,
-        },
-        {
-          key: "models",
-          label: collapsed ? null : t("nav.models"),
-          icon: <SparkModePlazaLine size={16} />,
-        },
-        {
-          key: "skill-pool",
-          label: collapsed ? null : t("nav.skillPool", "Skill Pool"),
-          icon: <SparkOtherLine size={16} />,
-        },
-        {
-          key: "market",
-          label: collapsed ? null : t("nav.market", "Skill Market"),
-          icon: <SparkCardLine size={16} />,
-        },
-        {
-          key: "environments",
-          label: collapsed ? null : t("nav.environments"),
-          icon: <SparkInternetLine size={16} />,
-        },
-        {
-          key: "security",
-          label: collapsed ? null : t("nav.security"),
-          icon: <SparkBrowseLine size={16} />,
-        },
-        {
-          key: "token-usage",
-          label: collapsed ? null : t("nav.tokenUsage"),
-          icon: <SparkDataLine size={16} />,
-        },
-        {
-          key: "backups",
-          label: collapsed ? null : t("nav.backups"),
-          icon: <SparkSaveLine size={16} />,
-        },
-        {
-          key: "voice-transcription",
-          label: collapsed ? null : t("nav.voiceTranscription"),
-          icon: <SparkMicLine size={16} />,
-        },
-        {
-          key: "debug",
-          label: collapsed ? null : t("nav.debug", "Debug"),
-          icon: <SparkDebugLine size={16} />,
-        },
-        {
-          key: "plugin-manager",
-          label: collapsed ? null : t("nav.pluginManager", "Plugin Manager"),
-          icon: <Package size={16} />,
-        },
-      ],
-    },
-  ];
-
-  // Append plugin menu items as a group (only when there are plugins)
-  if (pluginRoutes.length > 0) {
-    settingsMenuItems.push({
-      key: "plugins-group",
-      label: collapsed ? null : t("nav.plugins"),
-      children: pluginRoutes.map((route) => ({
-        key: route.path.replace(/^\//, ""),
-        label: collapsed ? null : route.label,
-        icon: <span style={{ fontSize: 16 }}>{route.icon}</span>,
-      })),
-    } as any);
-  }
-
   // ── Render ────────────────────────────────────────────────────────────────
 
   const siderWidth = collapsed ? (isMobile ? 56 : 72) : 240;
+  // Sticky chat is active when on /chat* or /coding routes.
+  const isChatActive =
+    selectedKey === "core.chat" || selectedKey === "core.coding";
+  // `renderIcon` retained for tree-shaking awareness.
+  void renderIcon;
 
   return (
     <Sider
@@ -547,7 +282,10 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
       {collapsed ? (
         <nav className={styles.collapsedNav}>
           {collapsedNavItems.map((item) => {
-            const isActive = selectedKey === item.key;
+            const isActive =
+              item.key === "core.chat"
+                ? isChatActive
+                : selectedKey === item.key;
             return (
               <Tooltip
                 key={item.key}
@@ -579,9 +317,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
               {/* Chat entry — sticky together with agent selector */}
               <button
                 className={`${styles.stickyChatButton}${
-                  selectedKey === "chat"
-                    ? ` ${styles.stickyChatButtonActive}`
-                    : ""
+                  isChatActive ? ` ${styles.stickyChatButtonActive}` : ""
                 }`}
                 onClick={() => navigate(chatPath)}
               >
@@ -589,14 +325,12 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                 <span>{t("nav.chat")}</span>
               </button>
             </div>
+            <Slot name="sider.top" kind="fill" />
             <Menu
               mode="inline"
               selectedKeys={[selectedKey]}
-              openKeys={DEFAULT_OPEN_KEYS}
-              onClick={({ key }) => {
-                const path = KEY_TO_PATH[String(key)];
-                if (path) navigate(path);
-              }}
+              openKeys={openKeys}
+              onClick={({ key }) => handleMenuClick(String(key), agentMenu)}
               items={agentMenuItems}
               theme={isDark ? "dark" : "light"}
               className={styles.sideMenu}
@@ -607,18 +341,13 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
           <Menu
             mode="inline"
             selectedKeys={[selectedKey]}
-            openKeys={[
-              ...DEFAULT_OPEN_KEYS,
-              ...(pluginRoutes.length > 0 ? ["plugins-group"] : []),
-            ]}
-            onClick={({ key }) => {
-              const path = KEY_TO_PATH[String(key)] ?? `/${String(key)}`;
-              navigate(path);
-            }}
+            openKeys={openKeys}
+            onClick={({ key }) => handleMenuClick(String(key), settingsMenu)}
             items={settingsMenuItems}
             theme={isDark ? "dark" : "light"}
             className={styles.sideMenu}
           />
+          <Slot name="sider.bottom" kind="fill" />
         </>
       )}
 

--- a/console/src/layouts/constants.ts
+++ b/console/src/layouts/constants.ts
@@ -8,66 +8,6 @@ export const GITHUB_URL = "https://github.com/agentscope-ai/QwenPaw" as const;
 
 export const ONE_HOUR_MS = 60 * 60 * 1000;
 
-// ── Navigation ────────────────────────────────────────────────────────────
-
-export const DEFAULT_OPEN_KEYS = [
-  "chat-group",
-  "control-group",
-  "agent-group",
-  "settings-group",
-];
-
-export const KEY_TO_PATH: Record<string, string> = {
-  chat: "/chat",
-  channels: "/channels",
-  sessions: "/sessions",
-  inbox: "/inbox",
-  "cron-jobs": "/cron-jobs",
-  heartbeat: "/heartbeat",
-  skills: "/skills",
-  "skill-pool": "/skill-pool",
-  market: "/market",
-  tools: "/tools",
-  mcp: "/mcp",
-  acp: "/acp",
-  workspace: "/workspace",
-  agents: "/agents",
-  models: "/models",
-  environments: "/environments",
-  "agent-config": "/agent-config",
-  security: "/security",
-  "token-usage": "/token-usage",
-  "agent-stats": "/agent-stats",
-  "voice-transcription": "/voice-transcription",
-  debug: "/debug",
-  backups: "/backups",
-  "plugin-manager": "/plugin-manager",
-};
-
-export const KEY_TO_LABEL: Record<string, string> = {
-  chat: "nav.chat",
-  channels: "nav.channels",
-  sessions: "nav.sessions",
-  inbox: "nav.inbox",
-  "cron-jobs": "nav.cronJobs",
-  heartbeat: "nav.heartbeat",
-  skills: "nav.skills",
-  "skill-pool": "nav.skillPool",
-  market: "nav.market",
-  tools: "nav.tools",
-  mcp: "nav.mcp",
-  acp: "nav.acp",
-  "agent-config": "nav.agentConfig",
-  workspace: "nav.workspace",
-  models: "nav.models",
-  environments: "nav.environments",
-  security: "nav.security",
-  "token-usage": "nav.tokenUsage",
-  agents: "nav.agents",
-  debug: "nav.debug",
-  backups: "nav.backups",
-};
-
 // ── URL helpers ───────────────────────────────────────────────────────────
 
 export const getWebsiteLang = (lang: string): string =>

--- a/console/src/layouts/registry/adapter.tsx
+++ b/console/src/layouts/registry/adapter.tsx
@@ -1,0 +1,164 @@
+/**
+ * registry/adapter.tsx — bridge MenuItem (registry shape) → antd Menu items.
+ *
+ * MenuItem stores neutral data: id, label-as-fn, icon-as-component-or-node,
+ * route-id (logical), etc. Sidebar consumes via these helpers to:
+ *   - resolve labels/icons into ReactNodes for antd
+ *   - look up the URL path from route id (router-driven, no constants table)
+ *   - flatten the tree for collapsed mode
+ *   - apply Sidebar-local decorations (e.g. inbox unread Badge)
+ */
+import type { CSSProperties, ReactNode } from "react";
+import { createElement, isValidElement } from "react";
+import type { MenuProps } from "antd";
+import type { MenuItem } from "../../plugins/registry/types";
+
+/** ReactNode + the resolved navigation path for a leaf item (or undefined for groups). */
+export interface FlatMenuEntry {
+  key: string;
+  icon: ReactNode;
+  label: ReactNode;
+  path: string;
+}
+
+/** Treat MenuItem.icon (Component or Node) as ReactNode with a given size. */
+export function renderIcon(icon: MenuItem["icon"], size: number): ReactNode {
+  if (icon == null) return null;
+  if (isValidElement(icon)) return icon;
+  // Component-like: plain function components AND React-internal wrappers
+  // (forwardRef / memo / lazy — these are OBJECTS carrying a `$$typeof`
+  // symbol, NOT functions; lucide-react + most Spark icons are forwardRef).
+  // Anything with `$$typeof` is safe to pass to React.createElement as the
+  // first argument.
+  if (
+    typeof icon === "function" ||
+    (typeof icon === "object" &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (icon as any).$$typeof !== undefined)
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return createElement(icon as React.ComponentType<any>, { size });
+  }
+  // Primitive ReactNode (string emoji, number, etc.) — wrap in span at right size.
+  const style: CSSProperties = { fontSize: size };
+  return <span style={style}>{icon as ReactNode}</span>;
+}
+
+export function resolveLabel(label: MenuItem["label"]): ReactNode {
+  return typeof label === "function" ? label() : label;
+}
+
+export interface RouteRef {
+  id: string;
+  path: string;
+}
+
+/** Look up the path for a route id; falls back to `/<id>` so old behaviour is preserved. */
+export function routeIdToPath(
+  routeId: string | undefined,
+  routes: RouteRef[],
+): string | undefined {
+  if (!routeId) return undefined;
+  const r = routes.find((x) => x.id === routeId);
+  return r?.path;
+}
+
+interface ToAntdOpts {
+  collapsed: boolean;
+  iconSize?: number;
+  /** Optional Sidebar-local decoration. e.g. wrap inbox label with unread Badge. */
+  decorateLabel?: (item: MenuItem, label: ReactNode) => ReactNode;
+}
+
+type ItemWithChildren = MenuItem & { __children?: MenuItem[] };
+
+/**
+ * Convert a tree of MenuItems (snapshot output) into the antd Menu `items` shape.
+ * Top-level items with isGroup or with __children render as expandable groups.
+ */
+export function toAntdItems(
+  items: MenuItem[],
+  opts: ToAntdOpts,
+): MenuProps["items"] {
+  const { collapsed, iconSize = 16, decorateLabel } = opts;
+  return items
+    .filter((i) => i.visible?.() !== false)
+    .map((rawItem) => {
+      const i = rawItem as ItemWithChildren;
+      const baseLabel = collapsed ? null : resolveLabel(i.label);
+      const decorated = decorateLabel ? decorateLabel(i, baseLabel) : baseLabel;
+      const node: NonNullable<MenuProps["items"]>[number] = {
+        key: i.id,
+        label: decorated,
+        icon: renderIcon(i.icon, iconSize),
+      };
+      if (i.__children && i.__children.length > 0) {
+        // antd expects `children` on submenu / group items
+        const visibleChildren = i.__children.filter(
+          (c) => c.visible?.() !== false,
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (node as any).children = toAntdItems(visibleChildren, opts);
+      }
+      return node;
+    });
+}
+
+/**
+ * Flatten a menu tree into a leaf-only list (for the collapsed icon-nav).
+ * Group items are skipped; their children are recursed into.
+ */
+export function flattenMenu(
+  items: MenuItem[],
+  routes: RouteRef[],
+  iconSize: number,
+): FlatMenuEntry[] {
+  const out: FlatMenuEntry[] = [];
+  const walk = (arr: MenuItem[]) => {
+    for (const rawItem of arr) {
+      const i = rawItem as ItemWithChildren;
+      if (i.visible?.() === false) continue;
+      if (i.divider) continue;
+      if (i.isGroup || (i.__children && i.__children.length > 0)) {
+        walk(i.__children ?? []);
+        continue;
+      }
+      const path = routeIdToPath(i.route, routes);
+      if (!path) continue;
+      out.push({
+        key: i.id,
+        icon: renderIcon(i.icon, iconSize),
+        label: resolveLabel(i.label),
+        path,
+      });
+    }
+  };
+  walk(items);
+  return out;
+}
+
+/** Walk a tree to find the MenuItem whose id matches. */
+export function findMenuItem(
+  items: MenuItem[],
+  id: string,
+): MenuItem | undefined {
+  for (const rawItem of items) {
+    const i = rawItem as ItemWithChildren;
+    if (i.id === id) return i;
+    if (i.__children) {
+      const hit = findMenuItem(i.__children, id);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}
+
+/** Derive openKeys: all top-level items marked isGroup or that have children. */
+export function deriveOpenKeys(items: MenuItem[]): string[] {
+  return items
+    .filter((i) => {
+      const item = i as ItemWithChildren;
+      return item.isGroup || (item.__children && item.__children.length > 0);
+    })
+    .map((i) => i.id);
+}

--- a/console/src/layouts/registry/builtinMenu.ts
+++ b/console/src/layouts/registry/builtinMenu.ts
@@ -1,0 +1,295 @@
+/**
+ * builtinMenu.ts — host's built-in sidebar menu entries as data.
+ *
+ * Importing this module self-registers all builtins into menuRegistry, so the
+ * Sidebar's `useMenuItems()` snapshot returns them on first render. Plugins
+ * register via `QwenPaw.menu.add(...)` which lands in the same registry, so
+ * Sidebar treats core + plugin items uniformly.
+ *
+ * ── Naming convention ──────────────────────────────────────────────────────
+ *  Group ids: `core.<name>-group` (e.g. core.control-group)
+ *  Item ids:  `core.<key>`        (e.g. core.workspace)
+ *  Plugin items use their own prefix (e.g. cloudpaw.a2a) — no clash possible.
+ *
+ * ── Sticky chat button carve-out ───────────────────────────────────────────
+ *  `core.chat` is NOT in this data. The sticky chat button lives outside the
+ *  antd <Menu> (rendered next to AgentSelector with bespoke styling); see
+ *  Sidebar.tsx. We don't model it as menu data because it has zero antd-Menu
+ *  semantics in common with the rest of the sidebar entries.
+ *
+ * ── Order convention ───────────────────────────────────────────────────────
+ *  Within each group, items use order = 10/20/30/… in their natural sequence
+ *  so plugins can insert with order 15/25 without colliding.
+ */
+import {
+  SparkAgentLine,
+  SparkBarChartLine,
+  SparkBrowseLine,
+  SparkCardLine,
+  SparkDataLine,
+  SparkDateLine,
+  SparkDebugLine,
+  SparkEmailLine,
+  SparkInternetLine,
+  SparkLocalFileLine,
+  SparkMagicWandLine,
+  SparkMcpMcpLine,
+  SparkMicLine,
+  SparkModePlazaLine,
+  SparkModifyLine,
+  SparkOtherLine,
+  SparkSaveLine,
+  SparkScanLine,
+  SparkToolLine,
+  SparkUserGroupLine,
+  SparkVoiceChat01Line,
+  SparkWifiLine,
+} from "@agentscope-ai/icons";
+import { Package } from "lucide-react";
+import i18next from "i18next";
+import { menuRegistry } from "../../plugins/registry/store";
+import type { MenuItem } from "../../plugins/registry/types";
+
+/** Translate a nav key. Falls back to defaultValue when i18n hasn't loaded. */
+const navLabel = (key: string, defaultValue?: string) => (): string =>
+  i18next.t(key, defaultValue ?? key);
+
+export const BUILTIN_MENU: MenuItem[] = [
+  // ── Agent-scoped (Sidebar Menu #1) ───────────────────────────────────────
+  {
+    id: "core.inbox",
+    location: "primary.agentScoped",
+    label: navLabel("nav.inbox"),
+    icon: SparkEmailLine,
+    route: "core.inbox",
+    order: 10,
+  },
+
+  // control-group
+  {
+    id: "core.control-group",
+    location: "primary.agentScoped",
+    label: navLabel("nav.control"),
+    isGroup: true,
+    order: 20,
+  },
+  {
+    id: "core.channels",
+    location: "primary.agentScoped",
+    parentId: "core.control-group",
+    label: navLabel("nav.channels"),
+    icon: SparkWifiLine,
+    route: "core.channels",
+    order: 10,
+  },
+  {
+    id: "core.sessions",
+    location: "primary.agentScoped",
+    parentId: "core.control-group",
+    label: navLabel("nav.sessions"),
+    icon: SparkUserGroupLine,
+    route: "core.sessions",
+    order: 20,
+  },
+  {
+    id: "core.cron-jobs",
+    location: "primary.agentScoped",
+    parentId: "core.control-group",
+    label: navLabel("nav.cronJobs"),
+    icon: SparkDateLine,
+    route: "core.cron-jobs",
+    order: 30,
+  },
+  {
+    id: "core.heartbeat",
+    location: "primary.agentScoped",
+    parentId: "core.control-group",
+    label: navLabel("nav.heartbeat"),
+    icon: SparkVoiceChat01Line,
+    route: "core.heartbeat",
+    order: 40,
+  },
+
+  // agent-group
+  {
+    id: "core.agent-group",
+    location: "primary.agentScoped",
+    label: navLabel("nav.agent"),
+    isGroup: true,
+    order: 30,
+  },
+  {
+    id: "core.workspace",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.workspace"),
+    icon: SparkLocalFileLine,
+    route: "core.workspace",
+    order: 10,
+  },
+  {
+    id: "core.skills",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.skills"),
+    icon: SparkMagicWandLine,
+    route: "core.skills",
+    order: 20,
+  },
+  {
+    id: "core.tools",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.tools"),
+    icon: SparkToolLine,
+    route: "core.tools",
+    order: 30,
+  },
+  {
+    id: "core.mcp",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.mcp"),
+    icon: SparkMcpMcpLine,
+    route: "core.mcp",
+    order: 40,
+  },
+  {
+    id: "core.acp",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.acp"),
+    icon: SparkScanLine,
+    route: "core.acp",
+    order: 50,
+  },
+  {
+    id: "core.agent-config",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.agentConfig"),
+    icon: SparkModifyLine,
+    route: "core.agent-config",
+    order: 60,
+  },
+  {
+    id: "core.agent-stats",
+    location: "primary.agentScoped",
+    parentId: "core.agent-group",
+    label: navLabel("nav.agentStats"),
+    icon: SparkBarChartLine,
+    route: "core.agent-stats",
+    order: 70,
+  },
+
+  // ── Settings (Sidebar Menu #2) ───────────────────────────────────────────
+  {
+    id: "core.settings-group",
+    location: "primary.settings",
+    label: navLabel("nav.settings"),
+    isGroup: true,
+    order: 10,
+  },
+  {
+    id: "core.agents",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.agents"),
+    icon: SparkAgentLine,
+    route: "core.agents",
+    order: 10,
+  },
+  {
+    id: "core.models",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.models"),
+    icon: SparkModePlazaLine,
+    route: "core.models",
+    order: 20,
+  },
+  {
+    id: "core.skill-pool",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.skillPool", "Skill Pool"),
+    icon: SparkOtherLine,
+    route: "core.skill-pool",
+    order: 30,
+  },
+  {
+    id: "core.market",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.market", "Skill Market"),
+    icon: SparkCardLine,
+    route: "core.market",
+    order: 40,
+  },
+  {
+    id: "core.environments",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.environments"),
+    icon: SparkInternetLine,
+    route: "core.environments",
+    order: 50,
+  },
+  {
+    id: "core.security",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.security"),
+    icon: SparkBrowseLine,
+    route: "core.security",
+    order: 60,
+  },
+  {
+    id: "core.token-usage",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.tokenUsage"),
+    icon: SparkDataLine,
+    route: "core.token-usage",
+    order: 70,
+  },
+  {
+    id: "core.backups",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.backups"),
+    icon: SparkSaveLine,
+    route: "core.backups",
+    order: 80,
+  },
+  {
+    id: "core.voice-transcription",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.voiceTranscription"),
+    icon: SparkMicLine,
+    route: "core.voice-transcription",
+    order: 90,
+  },
+  {
+    id: "core.debug",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.debug", "Debug"),
+    icon: SparkDebugLine,
+    route: "core.debug",
+    order: 100,
+  },
+  {
+    id: "core.plugin-manager",
+    location: "primary.settings",
+    parentId: "core.settings-group",
+    label: navLabel("nav.pluginManager", "Plugin Manager"),
+    icon: Package,
+    route: "core.plugin-manager",
+    order: 110,
+  },
+];
+
+// Self-register at module load. main.tsx imports this file as a side-effect.
+menuRegistry.addBuiltin(BUILTIN_MENU);

--- a/console/src/layouts/registry/builtinRoutes.tsx
+++ b/console/src/layouts/registry/builtinRoutes.tsx
@@ -1,0 +1,132 @@
+/**
+ * builtinRoutes.ts — host's built-in routes as data.
+ *
+ * Importing self-registers all builtins into routeRegistry. MainLayout's
+ * `useRoutes()` snapshot returns them. Plugin routes are registered via
+ * `QwenPaw.route.add(...)` into the same registry and treated uniformly.
+ *
+ * Lazy components use `lazyImportWithRetry` inline; eager pages (Chat,
+ * CodingPage) are passed as ComponentType directly. The `/` redirect is a
+ * named route with a tiny DefaultRedirect component so routeRegistry has a
+ * single uniform shape.
+ *
+ * Naming convention mirrors builtinMenu: `core.<key>`.
+ */
+import { Suspense } from "react";
+import { Navigate } from "react-router-dom";
+import { Spin } from "antd";
+import { useTranslation } from "react-i18next";
+import { lazyImportWithRetry } from "../../utils/lazyWithRetry";
+import { useCodingMode } from "../../stores/codingModeStore";
+import { routeRegistry } from "../../plugins/registry/store";
+import type { Route } from "../../plugins/registry/types";
+
+// Eager pages
+import Chat from "../../pages/Chat";
+import CodingPage from "../../pages/Coding";
+
+// Lazy pages
+const ChannelsPage = lazyImportWithRetry("../../pages/Control/Channels");
+const SessionsPage = lazyImportWithRetry("../../pages/Control/Sessions");
+const InboxPage = lazyImportWithRetry("../../pages/Inbox");
+const CronJobsPage = lazyImportWithRetry("../../pages/Control/CronJobs");
+const HeartbeatPage = lazyImportWithRetry("../../pages/Control/Heartbeat");
+const AgentConfigPage = lazyImportWithRetry("../../pages/Agent/Config");
+const SkillsPage = lazyImportWithRetry("../../pages/Agent/Skills");
+const SkillPoolPage = lazyImportWithRetry("../../pages/Settings/SkillPool");
+const MarketPage = lazyImportWithRetry("../../pages/Settings/Market");
+const ToolsPage = lazyImportWithRetry("../../pages/Agent/Tools");
+const WorkspacePage = lazyImportWithRetry("../../pages/Agent/Workspace");
+const MCPPage = lazyImportWithRetry("../../pages/Agent/MCP");
+const ACPPage = lazyImportWithRetry("../../pages/Agent/ACP");
+const ModelsPage = lazyImportWithRetry("../../pages/Settings/Models");
+const EnvironmentsPage = lazyImportWithRetry(
+  "../../pages/Settings/Environments",
+);
+const SecurityPage = lazyImportWithRetry("../../pages/Settings/Security");
+const TokenUsagePage = lazyImportWithRetry("../../pages/Settings/TokenUsage");
+const AgentStatsPage = lazyImportWithRetry("../../pages/Settings/AgentStats");
+const VoiceTranscriptionPage = lazyImportWithRetry(
+  "../../pages/Settings/VoiceTranscription",
+);
+const AgentsPage = lazyImportWithRetry("../../pages/Settings/Agents");
+const DebugPage = lazyImportWithRetry("../../pages/Settings/Debug");
+const BackupsPage = lazyImportWithRetry("../../pages/Settings/Backups");
+const PluginManagerPage = lazyImportWithRetry(
+  "../../pages/Settings/PluginManager",
+);
+
+/**
+ * "/" lands here. Waits for useSyncCodingMode to populate the store before
+ * deciding between /coding and /chat — see MainLayout.tsx history for why.
+ */
+function DefaultRedirect() {
+  const { t } = useTranslation();
+  const { codingMode, initialized } = useCodingMode();
+  if (!initialized) {
+    return (
+      <Spin
+        tip={t("common.loading")}
+        style={{ display: "block", margin: "20vh auto" }}
+      />
+    );
+  }
+  return <Navigate to={codingMode ? "/coding" : "/chat"} replace />;
+}
+
+/** Synonym for /acp. Kept for plugins / external links that reference uppercase. */
+function ACPRedirect() {
+  return <Navigate to="/acp" replace />;
+}
+
+export const BUILTIN_ROUTES: Route[] = [
+  { id: "core.root", path: "/", component: DefaultRedirect },
+  { id: "core.chat", path: "/chat/*", component: Chat },
+  { id: "core.coding", path: "/coding", component: CodingPage },
+  { id: "core.channels", path: "/channels", component: ChannelsPage },
+  { id: "core.sessions", path: "/sessions", component: SessionsPage },
+  { id: "core.inbox", path: "/inbox", component: InboxPage },
+  { id: "core.cron-jobs", path: "/cron-jobs", component: CronJobsPage },
+  { id: "core.heartbeat", path: "/heartbeat", component: HeartbeatPage },
+  { id: "core.skills", path: "/skills", component: SkillsPage },
+  { id: "core.skill-pool", path: "/skill-pool", component: SkillPoolPage },
+  { id: "core.market", path: "/market", component: MarketPage },
+  { id: "core.tools", path: "/tools", component: ToolsPage },
+  { id: "core.mcp", path: "/mcp", component: MCPPage },
+  { id: "core.acp", path: "/acp", component: ACPPage },
+  { id: "core.acp-alias", path: "/ACP", component: ACPRedirect },
+  { id: "core.workspace", path: "/workspace", component: WorkspacePage },
+  { id: "core.agents", path: "/agents", component: AgentsPage },
+  { id: "core.models", path: "/models", component: ModelsPage },
+  {
+    id: "core.environments",
+    path: "/environments",
+    component: EnvironmentsPage,
+  },
+  {
+    id: "core.agent-config",
+    path: "/agent-config",
+    component: AgentConfigPage,
+  },
+  { id: "core.security", path: "/security", component: SecurityPage },
+  { id: "core.token-usage", path: "/token-usage", component: TokenUsagePage },
+  { id: "core.agent-stats", path: "/agent-stats", component: AgentStatsPage },
+  {
+    id: "core.voice-transcription",
+    path: "/voice-transcription",
+    component: VoiceTranscriptionPage,
+  },
+  { id: "core.debug", path: "/debug", component: DebugPage },
+  { id: "core.backups", path: "/backups", component: BackupsPage },
+  {
+    id: "core.plugin-manager",
+    path: "/plugin-manager",
+    component: PluginManagerPage,
+  },
+];
+
+routeRegistry.addBuiltin(BUILTIN_ROUTES);
+
+// Suspense imported above is used by lazyImportWithRetry consumers; ref keeps
+// TS from tree-shaking the import in older bundler configs.
+void Suspense;

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -2,15 +2,27 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./i18n";
 import { installHostExternals } from "./plugins/hostExternals";
-import { registerHostModulesEager } from "./plugins/dynamicModuleRegistry";
+import { installHostSdk } from "./plugins/hostSdk/install";
+import { registerHostModulesDynamic } from "./plugins/dynamicModuleRegistry";
+// Bare side-effect imports: each file self-registers its data into
+// menuRegistry / routeRegistry so consumers' first render sees them.
+import "./layouts/registry/builtinMenu";
+import "./layouts/registry/builtinRoutes.tsx";
 
 // Expose host dependencies (React, antd, etc.) on window
 // so that plugin UI modules can use them without bundling their own copies.
 installHostExternals();
 
-// Dynamic module registration - no generated files needed!
-// Automatically discovers all modules in src/pages at build time
-registerHostModulesEager();
+// Attach window.QwenPaw.chat (Chat customization), extend
+// window.QwenPaw.host with hooks + fetch, attach window.QwenPaw.audit.
+installHostSdk();
+
+// Dynamic module registration — fire-and-forget. Pages register into
+// `moduleRegistry` as they are lazy-loaded; this background pass pre-warms
+// the registry so `window.QwenPaw.modules.<page>` is populated soon after
+// startup without blocking the first paint (eager mode used to synchronously
+// pull all 233 page modules + transitive deps into the main thread).
+void registerHostModulesDynamic();
 
 if (typeof window !== "undefined") {
   const originalError = console.error;

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -1,0 +1,184 @@
+/**
+ * pages/Chat/HostBubbles.tsx — host-side wrappers around the vendor's
+ * AgentScopeRuntime{Request,Response}Card components.
+ *
+ * Why wrappers:
+ * - Plugin extensions (chat.request.render / prepend / append and the
+ *   response equivalents) need a render seam SDK doesn't expose.
+ * - We register HostRequestCard / HostResponseCard into options.cards so the
+ *   SDK Cards dispatcher invokes them instead of the vendor defaults.
+ * - The wrapper itself subscribes to the chat extension registry via hooks,
+ *   so it re-renders when plugins register/dispose — no need to rebuild the
+ *   parent useMemo (and avoid re-mounting bubbles on every plugin change).
+ *
+ * The vendor's Card components are deep-imported because they're not in the
+ * package's top-level exports. If the SDK reorganizes its internal paths,
+ * update the two import statements below.
+ */
+import React from "react";
+// eslint-disable-next-line import/no-unresolved
+import VendorRequestCardOriginal from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Request/Card";
+// eslint-disable-next-line import/no-unresolved
+import VendorResponseCardOriginal from "@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Card";
+// Vendor `.d.ts` doesn't yet describe the contentPrepend/contentAppend
+// slots we added in the patched .js (Response/Card.js + Request/Card.js).
+// Loosen the prop type so TS doesn't reject the passthrough; runtime
+// behaviour is unchanged.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const VendorRequestCard = VendorRequestCardOriginal as React.ComponentType<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const VendorResponseCard =
+  VendorResponseCardOriginal as React.ComponentType<any>;
+import {
+  useChatScalarSnapshot,
+  useChatListSnapshot,
+} from "../../plugins/registry/useChatExtensions";
+import { ChatScalar, ChatList } from "../../plugins/registry/slotKeys";
+import { PluginSlotBoundary } from "../../plugins/registry/PluginSlotBoundary";
+import type {
+  ChatRequestData,
+  ChatResponseData,
+} from "../../plugins/registry/types";
+
+function sortByOrder<T extends { item: { order?: number } }>(arr: T[]): T[] {
+  return arr
+    .slice()
+    .sort((a, b) => (a.item.order ?? 100) - (b.item.order ?? 100));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyCardProps = any;
+
+export function HostRequestCard(props: { data: ChatRequestData }) {
+  const extScalar = useChatScalarSnapshot();
+  const extLists = useChatListSnapshot();
+
+  const renderEntry = extScalar[ChatScalar.requestRender];
+  const renderFn = renderEntry?.value;
+  const prependList = sortByOrder(extLists[ChatList.requestPrepend]);
+  const appendList = sortByOrder(extLists[ChatList.requestAppend]);
+
+  // prepend/append routed through vendor's contentPrepend/contentAppend
+  // slot so actions stay last. Mirrors HostResponseCard.
+  const contentPrepend =
+    prependList.length === 0 ? null : (
+      <>
+        {prependList.map((e) => (
+          <PluginSlotBoundary
+            key={e.item.id}
+            slot={ChatList.requestPrepend}
+            pluginId={e.pluginId}
+          >
+            {e.item.render({ data: props.data })}
+          </PluginSlotBoundary>
+        ))}
+      </>
+    );
+  const contentAppend =
+    appendList.length === 0 ? null : (
+      <>
+        {appendList.map((e) => (
+          <PluginSlotBoundary
+            key={e.item.id}
+            slot={ChatList.requestAppend}
+            pluginId={e.pluginId}
+          >
+            {e.item.render({ data: props.data })}
+          </PluginSlotBoundary>
+        ))}
+      </>
+    );
+
+  const fallback = () => (
+    <VendorRequestCard
+      data={props.data as AnyCardProps}
+      contentPrepend={contentPrepend as AnyCardProps}
+      contentAppend={contentAppend as AnyCardProps}
+    />
+  );
+
+  if (renderFn) {
+    return (
+      <PluginSlotBoundary
+        slot={ChatScalar.requestRender}
+        pluginId={renderEntry!.pluginId}
+        fallback={fallback()}
+      >
+        {renderFn({ data: props.data, fallback })}
+      </PluginSlotBoundary>
+    );
+  }
+  return fallback();
+}
+
+export function HostResponseCard(props: {
+  data: ChatResponseData;
+  isLast?: boolean;
+}) {
+  const extScalar = useChatScalarSnapshot();
+  const extLists = useChatListSnapshot();
+
+  const renderEntry = extScalar[ChatScalar.responseRender];
+  const renderFn = renderEntry?.value;
+  const prependList = sortByOrder(extLists[ChatList.responsePrepend]);
+  const appendList = sortByOrder(extLists[ChatList.responseAppend]);
+
+  // prepend/append are routed through vendor's contentPrepend/contentAppend
+  // slot so they land BETWEEN messages and Actions — actions always last.
+  // Vendor change: see Response/Card.js DefaultResponseRender, which now
+  // reads props.contentPrepend / props.contentAppend.
+  const contentPrepend =
+    prependList.length === 0 ? null : (
+      <>
+        {prependList.map((e) => (
+          <PluginSlotBoundary
+            key={e.item.id}
+            slot={ChatList.responsePrepend}
+            pluginId={e.pluginId}
+          >
+            {e.item.render({ data: props.data, isLast: props.isLast })}
+          </PluginSlotBoundary>
+        ))}
+      </>
+    );
+  const contentAppend =
+    appendList.length === 0 ? null : (
+      <>
+        {appendList.map((e) => (
+          <PluginSlotBoundary
+            key={e.item.id}
+            slot={ChatList.responseAppend}
+            pluginId={e.pluginId}
+          >
+            {e.item.render({ data: props.data, isLast: props.isLast })}
+          </PluginSlotBoundary>
+        ))}
+      </>
+    );
+
+  const fallback = () => (
+    <VendorResponseCard
+      data={props.data as AnyCardProps}
+      isLast={props.isLast}
+      contentPrepend={contentPrepend as AnyCardProps}
+      contentAppend={contentAppend as AnyCardProps}
+    />
+  );
+
+  if (renderFn) {
+    return (
+      <PluginSlotBoundary
+        slot={ChatScalar.responseRender}
+        pluginId={renderEntry!.pluginId}
+        fallback={fallback()}
+      >
+        {renderFn({
+          data: props.data,
+          isLast: props.isLast,
+          fallback,
+        })}
+      </PluginSlotBoundary>
+    );
+  }
+  return fallback();
+}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -33,6 +33,17 @@ import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { planApi } from "../../api/modules/plan";
+import {
+  useChatScalarSnapshot,
+  useChatListSnapshot,
+} from "../../plugins/registry/useChatExtensions";
+import { PluginSlotBoundary } from "../../plugins/registry/PluginSlotBoundary";
+import {
+  resolveLocalized,
+  type WelcomeRenderProps,
+} from "../../plugins/registry/types";
+import { ChatScalar, ChatList } from "../../plugins/registry/slotKeys";
+import { HostRequestCard, HostResponseCard } from "./HostBubbles";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -662,7 +673,7 @@ const timestampStyle: React.CSSProperties = {
 };
 
 export default function ChatPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { isDark } = useTheme();
@@ -682,6 +693,8 @@ export default function ChatPage() {
   const [showModelPrompt, setShowModelPrompt] = useState(false);
   const { selectedAgent } = useAgentStore();
   const { toolRenderConfig } = usePlugins();
+  const extScalar = useChatScalarSnapshot();
+  const extLists = useChatListSnapshot();
   const [refreshKey, setRefreshKey] = useState(0);
   const runtimeLoadingBridgeRef = useRef<RuntimeLoadingBridgeApi | null>(null);
   const { message } = useAppMessage();
@@ -1223,14 +1236,196 @@ export default function ChatPage() {
       return true;
     };
 
+    // ── Resolve plugin extension snapshots ────────────────────────────────
+    const locale = i18n.language;
+    const extGreeting = resolveLocalized(
+      extScalar[ChatScalar.welcomeGreeting]?.value,
+      locale,
+    );
+    const extDescription = resolveLocalized(
+      extScalar[ChatScalar.welcomeDescription]?.value,
+      locale,
+    );
+    const extAvatar = resolveLocalized(
+      extScalar[ChatScalar.welcomeAvatar]?.value,
+      locale,
+    );
+    const extNick = resolveLocalized(
+      extScalar[ChatScalar.welcomeNick]?.value,
+      locale,
+    );
+    const extPrompts = resolveLocalized(
+      extScalar[ChatScalar.welcomePrompts]?.value,
+      locale,
+    );
+    const extLeftTitle = resolveLocalized(
+      extScalar[ChatScalar.headerLeftTitle]?.value,
+      locale,
+    );
+    const extLeftLogo = resolveLocalized(
+      extScalar[ChatScalar.headerLeftLogo]?.value,
+      locale,
+    );
+    const extColorPrimary = extScalar[ChatScalar.themeColorPrimary]?.value;
+    const extPlaceholder = resolveLocalized(
+      extScalar[ChatScalar.senderPlaceholder]?.value,
+      locale,
+    );
+    const extDisclaimer = resolveLocalized(
+      extScalar[ChatScalar.senderDisclaimer]?.value,
+      locale,
+    );
+
+    // Whole-section render overrides (plugin can fully replace welcome / leftHeader)
+    const extWelcomeRenderEntry = extScalar[ChatScalar.welcomeRender];
+    const extWelcomeRender = extWelcomeRenderEntry?.value;
+    const extLeftHeaderRenderEntry =
+      extScalar[ChatScalar.headerLeftHeaderRender];
+    const extLeftHeaderRender = extLeftHeaderRenderEntry?.value;
+
+    const wrappedWelcomeRender = extWelcomeRender
+      ? (props: WelcomeRenderProps) => (
+          <PluginSlotBoundary
+            slot={ChatScalar.welcomeRender}
+            pluginId={extWelcomeRenderEntry!.pluginId}
+          >
+            {extWelcomeRender(props)}
+          </PluginSlotBoundary>
+        )
+      : undefined;
+
+    const sortByOrder = <T extends { item: { order?: number } }>(arr: T[]) =>
+      arr.slice().sort((a, b) => (a.item.order ?? 100) - (b.item.order ?? 100));
+
+    const pluginRightHeader = sortByOrder(extLists[ChatList.rightHeader]).map(
+      (e) => (
+        <PluginSlotBoundary
+          key={e.item.id}
+          slot={ChatList.rightHeader}
+          pluginId={e.pluginId}
+        >
+          {e.item.node}
+        </PluginSlotBoundary>
+      ),
+    );
+    const pluginSenderPrefix = sortByOrder(extLists[ChatList.senderPrefix]).map(
+      (e) => (
+        <PluginSlotBoundary
+          key={e.item.id}
+          slot={ChatList.senderPrefix}
+          pluginId={e.pluginId}
+        >
+          {e.item.node}
+        </PluginSlotBoundary>
+      ),
+    );
+    const pluginSuggestions = extLists[ChatList.senderSuggestions].flatMap(
+      (e) => {
+        const resolved = resolveLocalized(e.item.items, locale) ?? [];
+        return resolved.map((s) => ({ label: s.label, value: s.value }));
+      },
+    );
+
+    const wrapActionSpec = (
+      pluginId: string,
+      slot: string,
+      spec: { id: string; icon?: any; render?: any; onClick?: any },
+    ) => ({
+      icon: spec.icon,
+      render: spec.render
+        ? (ctx: { data: unknown }) => (
+            <PluginSlotBoundary slot={slot} pluginId={pluginId}>
+              {spec.render!(ctx)}
+            </PluginSlotBoundary>
+          )
+        : undefined,
+      onClick: spec.onClick
+        ? (ctx: { data: unknown }) => {
+            try {
+              spec.onClick!(ctx);
+            } catch (err) {
+              console.error(
+                `[plugin:${pluginId}] action ${spec.id} onClick threw:`,
+                err,
+              );
+            }
+          }
+        : undefined,
+    });
+
+    const pluginActions = extLists[ChatList.actions].map((e) =>
+      wrapActionSpec(e.pluginId, ChatList.actions, e.item.item),
+    );
+    const pluginRequestActions = extLists[ChatList.requestActions].map((e) =>
+      wrapActionSpec(e.pluginId, ChatList.requestActions, e.item.item),
+    );
+
+    const wrapToolFC = (
+      pluginId: string,
+      toolName: string,
+      FC: React.FC<any>,
+    ) => {
+      const Wrapped: React.FC<any> = (props) => (
+        <PluginSlotBoundary
+          slot={`customToolRender:${toolName}`}
+          pluginId={pluginId}
+        >
+          <FC {...props} />
+        </PluginSlotBoundary>
+      );
+      return Wrapped;
+    };
+    const pluginToolRenderers: Record<string, React.FC<any>> = {};
+    for (const e of extLists[ChatList.customToolRender]) {
+      pluginToolRenderers[e.item.toolName] = wrapToolFC(
+        e.pluginId,
+        e.item.toolName,
+        e.item.render,
+      );
+    }
+    const mergedToolRenderers: Record<string, React.FC<any>> = {
+      ...toolRenderConfig,
+      ...pluginToolRenderers,
+    };
+
+    const pluginCards: Record<string, React.FC<any>> = {};
+    for (const e of extLists[ChatList.cards]) {
+      pluginCards[e.item.cardName] = wrapToolFC(
+        e.pluginId,
+        e.item.cardName,
+        e.item.render,
+      );
+    }
+
+    const baseSuggestions = commandSuggestions.map((item) => ({
+      label: renderSuggestionLabel(item.command, item.description),
+      value: item.value,
+    }));
+
+    // leftHeader: whole-section render wins, otherwise partial merge {logo, title}.
+    const mergedLeftHeader: any =
+      extLeftHeaderRender !== undefined ? (
+        <PluginSlotBoundary
+          slot={ChatScalar.headerLeftHeaderRender}
+          pluginId={extLeftHeaderRenderEntry!.pluginId}
+        >
+          {extLeftHeaderRender}
+        </PluginSlotBoundary>
+      ) : (
+        {
+          ...defaultConfig.theme.leftHeader,
+          ...(extLeftTitle !== undefined ? { title: extLeftTitle } : {}),
+          ...(extLeftLogo !== undefined ? { logo: extLeftLogo } : {}),
+        }
+      );
+
     return {
       ...i18nConfig,
       theme: {
         ...defaultConfig.theme,
         darkMode: isDark,
-        leftHeader: {
-          ...defaultConfig.theme.leftHeader,
-        },
+        ...(extColorPrimary ? { colorPrimary: extColorPrimary } : {}),
+        leftHeader: mergedLeftHeader,
         rightHeader: (
           <>
             <ChatSessionInitializer />
@@ -1239,24 +1434,38 @@ export default function ChatPage() {
             <span style={{ flex: 1 }} />
             <ModelSelector />
             <ChatActionGroup planEnabled={planEnabled} />
+            {pluginRightHeader}
           </>
         ),
       },
       welcome: {
         ...i18nConfig.welcome,
-        nick: "QwenPaw",
-        avatar: "/qwenpaw.png",
+        nick: extNick ?? "QwenPaw",
+        avatar: extAvatar ?? "/qwenpaw.png",
+        ...(extGreeting !== undefined ? { greeting: extGreeting } : {}),
+        ...(extDescription !== undefined
+          ? { description: extDescription }
+          : {}),
+        ...(extPrompts !== undefined ? { prompts: extPrompts } : {}),
+        // SDK uses `render` if present and ignores the other fields.
+        ...(wrappedWelcomeRender ? { render: wrappedWelcomeRender } : {}),
       },
       sender: {
         ...(i18nConfig as any)?.sender,
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: whisperChecked && !whisperEnabled,
-        prefix: whisperEnabled ? (
-          <WhisperSpeechButton
-            ref={whisperSpeechRef}
-            onTranscription={handleWhisperTranscription}
-          />
-        ) : undefined,
+        prefix:
+          whisperEnabled || pluginSenderPrefix.length > 0 ? (
+            <>
+              {whisperEnabled ? (
+                <WhisperSpeechButton
+                  ref={whisperSpeechRef}
+                  onTranscription={handleWhisperTranscription}
+                />
+              ) : null}
+              {pluginSenderPrefix}
+            </>
+          ) : undefined,
         attachments: {
           multiple: true,
           trigger: function (props: any) {
@@ -1277,11 +1486,9 @@ export default function ChatPage() {
           },
           customRequest: handleFileUpload,
         },
-        placeholder: t("chat.inputPlaceholder"),
-        suggestions: commandSuggestions.map((item) => ({
-          label: renderSuggestionLabel(item.command, item.description),
-          value: item.value,
-        })),
+        placeholder: extPlaceholder ?? t("chat.inputPlaceholder"),
+        ...(extDisclaimer !== undefined ? { disclaimer: extDisclaimer } : {}),
+        suggestions: [...baseSuggestions, ...pluginSuggestions],
       },
       session: {
         multiple: true,
@@ -1336,7 +1543,17 @@ export default function ChatPage() {
         },
       },
       customToolRenderConfig:
-        Object.keys(toolRenderConfig).length > 0 ? toolRenderConfig : undefined,
+        Object.keys(mergedToolRenderers).length > 0
+          ? mergedToolRenderers
+          : undefined,
+      cards: {
+        // Host wrappers that delegate to vendor defaults when no plugin
+        // request/response render/prepend/append is registered — and
+        // compose plugin slots otherwise.
+        AgentScopeRuntimeRequestCard: HostRequestCard,
+        AgentScopeRuntimeResponseCard: HostResponseCard,
+        ...pluginCards,
+      },
       actions: {
         list: [
           {
@@ -1362,6 +1579,7 @@ export default function ChatPage() {
               );
             },
           },
+          ...pluginActions,
         ],
         replace: true,
       },
@@ -1390,6 +1608,7 @@ export default function ChatPage() {
               }
             },
           },
+          ...pluginRequestActions,
         ],
       },
     } as unknown as IAgentScopeRuntimeWebUIOptions;
@@ -1398,9 +1617,12 @@ export default function ChatPage() {
     copyResponse,
     handleFileUpload,
     t,
+    i18n.language,
     isDark,
     multimodalCaps,
     toolRenderConfig,
+    extScalar,
+    extLists,
     scheduleHistoryClear,
     planEnabled,
     onFileCardClick,

--- a/console/src/plugins/PluginContext.tsx
+++ b/console/src/plugins/PluginContext.tsx
@@ -12,6 +12,25 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 import { pluginSystem } from "./hostExternals";
 import { loadAllPlugins } from "./usePluginLoader";
 import type { PluginRouteDeclaration } from "./hostExternals";
+import {
+  routeRegistry,
+  subscribe as registrySubscribe,
+} from "./registry/store";
+
+/** Derive the legacy PluginRouteDeclaration[] shape from routeRegistry. */
+function derivePluginRoutes(): PluginRouteDeclaration[] {
+  // Include both legacy (registerRoutes shim) routes and any new route.add
+  // registrations from a plugin source. Built-in `core.*` routes are excluded.
+  return routeRegistry
+    .snapshot()
+    .filter((r) => r.source !== "core")
+    .map((r) => ({
+      path: r.path,
+      component: r.Component,
+      label: r.id,
+      icon: "",
+    }));
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Context shape
@@ -49,16 +68,20 @@ export function PluginProvider({ children }: { children: React.ReactNode }) {
     Record<string, React.FC<any>>
   >(pluginSystem.getToolRenderConfig());
   const [pluginRoutes, setPluginRoutes] = useState<PluginRouteDeclaration[]>(
-    pluginSystem.getRoutes(),
+    derivePluginRoutes(),
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Re-sync state whenever any plugin registers new capabilities
-    const unsub = pluginSystem.subscribe(() => {
+    // Re-sync state whenever any plugin registers new capabilities — both
+    // the legacy pluginSystem (toolRenderers) and the new registry
+    // (routes via shim + direct route.add) notify on change.
+    const unsubA = pluginSystem.subscribe(() => {
       setToolRenderConfig(pluginSystem.getToolRenderConfig());
-      setPluginRoutes(pluginSystem.getRoutes());
+    });
+    const unsubB = registrySubscribe(() => {
+      setPluginRoutes(derivePluginRoutes());
     });
 
     // Load all installed plugins (non-fatal: one bad plugin won’t block others)
@@ -67,7 +90,10 @@ export function PluginProvider({ children }: { children: React.ReactNode }) {
       setLoading(false);
     });
 
-    return unsub;
+    return () => {
+      unsubA();
+      unsubB();
+    };
   }, []);
 
   return (

--- a/console/src/plugins/dynamicModuleRegistry.ts
+++ b/console/src/plugins/dynamicModuleRegistry.ts
@@ -44,26 +44,28 @@ export async function registerHostModulesDynamic(): Promise<void> {
     } module(s) for registration`,
   );
 
-  // Register modules
-  let registeredCount = 0;
-  for (const [path, importFn] of Object.entries(modules)) {
-    try {
-      // Convert absolute path to module key
-      // "../pages/Agent/Config/index.tsx" -> "Agent/Config/index"
+  // Register modules in parallel so dev-mode background warm-up doesn't serialize
+  // 233 import requests through Vite's transform pipeline.
+  const results = await Promise.allSettled(
+    Object.entries(modules).map(async ([path, importFn]) => {
       const moduleKey = path
         .replace(/^\.\.\/pages\//, "")
         .replace(/\.(ts|tsx)$/, "");
-
-      // Lazy load the module
       const module = await importFn();
-
-      // Check if module has exports
       if (module && Object.keys(module).length > 0) {
         moduleRegistry.register(moduleKey, module);
-        registeredCount++;
+        return true;
       }
-    } catch (error) {
-      console.warn(`[patchable] Failed to register module: ${path}`, error);
+      return false;
+    }),
+  );
+
+  const registeredCount = results.filter(
+    (r) => r.status === "fulfilled" && r.value,
+  ).length;
+  for (const r of results) {
+    if (r.status === "rejected") {
+      console.warn("[patchable] Failed to register module:", r.reason);
     }
   }
 

--- a/console/src/plugins/hostExternals.ts
+++ b/console/src/plugins/hostExternals.ts
@@ -13,6 +13,23 @@ import ReactDOM from "react-dom";
 import * as antd from "antd";
 import * as antdIcons from "@ant-design/icons";
 import { getApiUrl, getApiToken } from "../api/config";
+import {
+  buildAuditNamespace,
+  buildMenuNamespace,
+  buildRouteNamespace,
+  buildSlotNamespace,
+  type QwenPawAuditNamespace,
+  type QwenPawMenuNamespace,
+  type QwenPawRouteNamespace,
+  type QwenPawSlotNamespace,
+} from "./registry/sdk";
+import { menuRegistry, routeRegistry } from "./registry/store";
+import type {
+  HostAgentInfo,
+  HostSessionInfo,
+  HostThemeMode,
+  QwenPawChatNamespace,
+} from "./types/qwenpaw";
 
 declare const VITE_API_BASE_URL: string;
 
@@ -29,6 +46,14 @@ export interface HostExternals {
   apiBaseUrl: string;
   getApiUrl: typeof getApiUrl;
   getApiToken: typeof getApiToken;
+  // ── Hooks + helpers attached later by installHostSdk() ─────────────────────
+  useTheme?: () => HostThemeMode;
+  useLocale?: () => string;
+  useSelectedAgent?: () => HostAgentInfo;
+  useCurrentSession?: () => HostSessionInfo | null;
+  getSelectedAgentId?: () => string;
+  getCurrentSessionId?: () => string | null;
+  fetch?: (path: string, init?: RequestInit) => Promise<Response>;
 }
 
 export interface PluginRouteDeclaration {
@@ -130,13 +155,23 @@ export interface WindowNamespace {
    * Plugins can access and modify module exports to monkey-patch host functions.
    */
   modules: Record<string, Record<string, unknown>>;
-  /** Register page routes for a plugin. */
+  /** Register page routes for a plugin. Translates to menu.add + route.add. */
   registerRoutes?: (pluginId: string, routes: PluginRouteDeclaration[]) => void;
   /** Register tool-call renderers for a plugin. */
   registerToolRender?: (
     pluginId: string,
     renderers: Record<string, React.FC<any>>,
   ) => void;
+  /** Console-wide plugin Menu API. Attached by installHostExternals(). */
+  menu?: QwenPawMenuNamespace;
+  /** Console-wide plugin Route API. */
+  route?: QwenPawRouteNamespace;
+  /** Console-wide plugin Slot API (header.left, sider.bottom, …). */
+  slot?: QwenPawSlotNamespace;
+  /** Chat-surface customization API. Attached by installHostSdk(). */
+  chat?: QwenPawChatNamespace;
+  /** Override audit log (debug). Attached by installHostExternals(). */
+  audit?: QwenPawAuditNamespace;
 }
 
 declare global {
@@ -148,6 +183,29 @@ declare global {
 // ─────────────────────────────────────────────────────────────────────────────
 // Install (call once in main.tsx)
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Synthesize the `plugins-group` parent menu the first time a legacy
+ * `registerRoutes` call lands. Idempotent via menuRegistry snapshot check —
+ * if a plugin (or test) has already created `plugins-group` (via the new API
+ * or a prior synthesis call), we skip. No mutable module flag, so behaviour
+ * is correct under test reset / hot reload.
+ */
+function ensurePluginsGroup(): void {
+  const exists = menuRegistry
+    .snapshot("primary.settings")
+    .some((i) => i.id === "plugins-group");
+  if (exists) return;
+  menuRegistry.addBuiltin([
+    {
+      id: "plugins-group",
+      location: "primary.settings",
+      label: "Plugins",
+      isGroup: true,
+      order: 999,
+    },
+  ]);
+}
 
 export function installHostExternals(): void {
   const apiBaseUrl =
@@ -169,11 +227,47 @@ export function installHostExternals(): void {
     };
   }
 
+  // ── Console-wide extension API ─────────────────────────────────────────
+  if (!window.QwenPaw.menu) window.QwenPaw.menu = buildMenuNamespace();
+  if (!window.QwenPaw.route) window.QwenPaw.route = buildRouteNamespace();
+  if (!window.QwenPaw.slot) window.QwenPaw.slot = buildSlotNamespace();
+  if (!window.QwenPaw.audit) window.QwenPaw.audit = buildAuditNamespace();
+
+  // ── Back-compat shim ───────────────────────────────────────────────────
+  // Legacy registerRoutes(pluginId, routes[]) fans out to:
+  //   1. route.add with id = `legacy:<pluginId>:<path>`
+  //   2. menu.add under the synthesized `plugins-group` (settings location).
+  // Visual output matches the pre-refactor Sidebar plugins-group rendering.
   if (!window.QwenPaw.registerRoutes) {
     window.QwenPaw.registerRoutes = (pluginId, routes) => {
+      ensurePluginsGroup();
+      for (const r of routes) {
+        const id = `legacy:${pluginId}:${r.path.replace(/^\//, "")}`;
+        routeRegistry.add(pluginId, {
+          id,
+          path: r.path,
+          component: r.component,
+        });
+        menuRegistry.add(pluginId, {
+          id,
+          location: "primary.settings",
+          parentId: "plugins-group",
+          label: r.label,
+          // Emoji string in original API → wrap to match prior Sidebar font-size styling.
+          icon: React.createElement(
+            "span",
+            { style: { fontSize: 16 } },
+            r.icon,
+          ),
+          route: id,
+          order: r.priority ?? 0,
+        });
+      }
+      // Keep the legacy pluginSystem in sync so usePlugins().pluginRoutes still works
+      // for any consumer that has not migrated yet (e.g. the chat-extension branch).
       pluginSystem.addRoutes(pluginId, routes);
       console.info(
-        `[plugin:${pluginId}] registerRoutes → ${routes.length} route(s)`,
+        `[plugin:${pluginId}] registerRoutes → ${routes.length} route(s) (translated to menu+route)`,
       );
     };
   }

--- a/console/src/plugins/hostSdk/fetch.ts
+++ b/console/src/plugins/hostSdk/fetch.ts
@@ -1,0 +1,20 @@
+/**
+ * hostSdk/fetch.ts — auth-aware fetch wrapper for plugins.
+ *
+ * Reuses `buildAuthHeaders()` which already injects `Authorization`
+ * and `X-Agent-Id` from the agent store. Plugin callers pass an API path
+ * (e.g. "/console/chat") and get back a normal Response.
+ */
+import { getApiUrl } from "../../api/config";
+import { buildAuthHeaders } from "../../api/authHeaders";
+
+export async function hostFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    ...buildAuthHeaders(),
+    ...((init?.headers as Record<string, string>) ?? {}),
+  };
+  return fetch(getApiUrl(path), { ...init, headers });
+}

--- a/console/src/plugins/hostSdk/hooks.ts
+++ b/console/src/plugins/hostSdk/hooks.ts
@@ -1,0 +1,52 @@
+/**
+ * hostSdk/hooks.ts — React hooks exposed on `window.QwenPaw.host.*`.
+ *
+ * These are thin wrappers over existing host contexts. Plugin components
+ * call them while rendering INSIDE the host React tree, so all underlying
+ * providers (Theme, i18n, agent store, chat session context) are guaranteed
+ * to be mounted.
+ */
+import { useTranslation } from "react-i18next";
+import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
+import { useTheme as useThemeCtx } from "../../contexts/ThemeContext";
+import { useAgentStore } from "../../stores/agentStore";
+
+export type HostThemeMode = "light" | "dark";
+
+export interface HostAgentInfo {
+  id: string;
+}
+
+export interface HostSessionInfo {
+  id: string;
+}
+
+export function useHostTheme(): HostThemeMode {
+  return useThemeCtx().isDark ? "dark" : "light";
+}
+
+export function useHostLocale(): string {
+  return useTranslation().i18n.language;
+}
+
+export function useHostSelectedAgent(): HostAgentInfo {
+  const id = useAgentStore((s) => s.selectedAgent) ?? "default";
+  return { id };
+}
+
+export function useHostCurrentSession(): HostSessionInfo | null {
+  const state = useChatAnywhereSessionsState();
+  return state?.currentSessionId ? { id: state.currentSessionId } : null;
+}
+
+export function getSelectedAgentId(): string {
+  return useAgentStore.getState().selectedAgent ?? "default";
+}
+
+export function getCurrentSessionId(): string | null {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as unknown as { currentSessionId?: string }).currentSessionId ??
+    null
+  );
+}

--- a/console/src/plugins/hostSdk/install.test.ts
+++ b/console/src/plugins/hostSdk/install.test.ts
@@ -1,0 +1,229 @@
+/**
+ * install.test.ts — validates the public window.QwenPaw.chat API surface.
+ *
+ * Focuses on the sugar/wiring layer in install.ts; the underlying registry
+ * mechanics (LIFO, audit, disposeAll) are covered by chatExtensions.test.ts.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import type React from "react";
+import { installHostSdk } from "./install";
+import { installHostExternals } from "../hostExternals";
+import { chatExtensions } from "../registry/chatExtensions";
+import { auditStore } from "../registry/audit";
+
+beforeEach(() => {
+  // Reset the window.QwenPaw namespace before each test so installHostSdk
+  // attaches fresh references.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).QwenPaw = undefined;
+  installHostExternals();
+  installHostSdk();
+  chatExtensions.__resetForTests();
+  auditStore.clear();
+});
+
+describe("window.QwenPaw.chat.welcome", () => {
+  it("set(partial) writes multiple scalar fields", () => {
+    window.QwenPaw.chat!.welcome.set("p1", {
+      greeting: "Hi",
+      avatar: "/a.png",
+    });
+    const snap = chatExtensions.getScalarSnapshot();
+    expect(snap["welcome.greeting"]?.value).toBe("Hi");
+    expect(snap["welcome.avatar"]?.value).toBe("/a.png");
+    expect(snap["welcome.nick"]).toBeUndefined();
+  });
+
+  it("set() returns a Disposable that reverts every field it wrote", () => {
+    const d = window.QwenPaw.chat!.welcome.set("p1", {
+      greeting: "Hi",
+      avatar: "/a.png",
+    });
+    d.dispose();
+    const snap = chatExtensions.getScalarSnapshot();
+    expect(snap["welcome.greeting"]).toBeUndefined();
+    expect(snap["welcome.avatar"]).toBeUndefined();
+  });
+
+  it("set() from different plugins on different fields coexist (no overwrite)", () => {
+    window.QwenPaw.chat!.welcome.set("p1", { greeting: "P1 hi" });
+    window.QwenPaw.chat!.welcome.set("p2", { avatar: "/p2.png" });
+    const snap = chatExtensions.getScalarSnapshot();
+    expect(snap["welcome.greeting"]?.pluginId).toBe("p1");
+    expect(snap["welcome.avatar"]?.pluginId).toBe("p2");
+  });
+
+  it("render(node) writes a welcome.render scalar", () => {
+    window.QwenPaw.chat!.welcome.render("p1", "<plain node>");
+    const entry = chatExtensions.getScalarSnapshot()["welcome.render"];
+    expect(entry?.pluginId).toBe("p1");
+    expect(typeof entry?.value).toBe("function");
+  });
+
+  it("render(fn) keeps the fn as-is", () => {
+    const fn = () => null as never;
+    window.QwenPaw.chat!.welcome.render("p1", fn);
+    expect(chatExtensions.getScalarSnapshot()["welcome.render"]?.value).toBe(
+      fn,
+    );
+  });
+});
+
+describe("window.QwenPaw.chat.leftHeader", () => {
+  it("set(partial) writes header.leftLogo / header.leftTitle", () => {
+    window.QwenPaw.chat!.leftHeader.set("p1", {
+      title: "MyApp",
+      logo: "/logo.png",
+    });
+    const snap = chatExtensions.getScalarSnapshot();
+    expect(snap["header.leftTitle"]?.value).toBe("MyApp");
+    expect(snap["header.leftLogo"]?.value).toBe("/logo.png");
+  });
+
+  it("render(node) writes header.leftHeader.render scalar", () => {
+    window.QwenPaw.chat!.leftHeader.render("p1", "<custom>");
+    expect(
+      chatExtensions.getScalarSnapshot()["header.leftHeader.render"]?.value,
+    ).toBe("<custom>");
+  });
+});
+
+describe("window.QwenPaw.chat.theme / sender", () => {
+  it("theme.set(partial) writes theme.colorPrimary", () => {
+    window.QwenPaw.chat!.theme.set("p1", { colorPrimary: "#123456" });
+    expect(
+      chatExtensions.getScalarSnapshot()["theme.colorPrimary"]?.value,
+    ).toBe("#123456");
+  });
+
+  it("sender.set(partial) writes placeholder and disclaimer", () => {
+    window.QwenPaw.chat!.sender.set("p1", {
+      placeholder: "Ask anything",
+      disclaimer: "Beta",
+    });
+    const snap = chatExtensions.getScalarSnapshot();
+    expect(snap["sender.placeholder"]?.value).toBe("Ask anything");
+    expect(snap["sender.disclaimer"]?.value).toBe("Beta");
+  });
+
+  it("sender.addPrefix appends to sender.prefix list", () => {
+    window.QwenPaw.chat!.sender.addPrefix("p1", "<icon>");
+    const list = chatExtensions.getListSnapshot()["sender.prefix"];
+    expect(list).toHaveLength(1);
+    expect(list[0].pluginId).toBe("p1");
+  });
+});
+
+describe("window.QwenPaw.chat.rightHeader / actions", () => {
+  it("rightHeader.add appends, never replaces", () => {
+    window.QwenPaw.chat!.rightHeader.add("p1", "btn1", { order: 200 });
+    window.QwenPaw.chat!.rightHeader.add("p2", "btn2", { order: 300 });
+    const list = chatExtensions.getListSnapshot()["header.rightHeader"];
+    expect(list.map((e) => e.pluginId)).toEqual(["p1", "p2"]);
+  });
+
+  it("actions.add and requestActions.add are separate lists", () => {
+    window.QwenPaw.chat!.actions.add("p1", { id: "a1", onClick: () => {} });
+    window.QwenPaw.chat!.requestActions.add("p1", {
+      id: "r1",
+      onClick: () => {},
+    });
+    const snap = chatExtensions.getListSnapshot();
+    expect(snap.actions.map((e) => e.item.id)).toEqual(["a1"]);
+    expect(snap.requestActions.map((e) => e.item.id)).toEqual(["r1"]);
+  });
+});
+
+describe("window.QwenPaw.host.* hooks attached", () => {
+  it("attaches the four hooks + fetch + imperative getters", () => {
+    expect(typeof window.QwenPaw.host.useTheme).toBe("function");
+    expect(typeof window.QwenPaw.host.useLocale).toBe("function");
+    expect(typeof window.QwenPaw.host.useSelectedAgent).toBe("function");
+    expect(typeof window.QwenPaw.host.useCurrentSession).toBe("function");
+    expect(typeof window.QwenPaw.host.getSelectedAgentId).toBe("function");
+    expect(typeof window.QwenPaw.host.getCurrentSessionId).toBe("function");
+    expect(typeof window.QwenPaw.host.fetch).toBe("function");
+  });
+});
+
+describe("window.QwenPaw.audit", () => {
+  it("overrides() returns the audit ring buffer", () => {
+    window.QwenPaw.chat!.welcome.set("p1", { greeting: "Hi" });
+    const records = window.QwenPaw.audit!.overrides();
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.some((r) => r.field === "welcome.greeting")).toBe(true);
+  });
+});
+
+describe("window.QwenPaw.chat.request / response", () => {
+  it("request.render writes a request.render scalar", () => {
+    const fn = ({ fallback }: { fallback: () => React.ReactElement }) =>
+      fallback();
+    window.QwenPaw.chat!.request.render("p1", fn);
+    expect(chatExtensions.getScalarSnapshot()["request.render"]?.value).toBe(
+      fn,
+    );
+  });
+
+  it("response.render writes a response.render scalar", () => {
+    const fn = ({ fallback }: { fallback: () => React.ReactElement }) =>
+      fallback();
+    window.QwenPaw.chat!.response.render("p1", fn);
+    expect(chatExtensions.getScalarSnapshot()["response.render"]?.value).toBe(
+      fn,
+    );
+  });
+
+  it("request.prepend / append append to their respective lists", () => {
+    const r1 = () => null;
+    const r2 = () => null;
+    window.QwenPaw.chat!.request.prepend("p1", r1, { id: "p1.pre" });
+    window.QwenPaw.chat!.request.append("p1", r2, { id: "p1.post" });
+
+    const snap = chatExtensions.getListSnapshot();
+    expect(snap["request.prepend"].map((e) => e.item.id)).toEqual(["p1.pre"]);
+    expect(snap["request.append"].map((e) => e.item.id)).toEqual(["p1.post"]);
+  });
+
+  it("response.prepend / append from multiple plugins coexist", () => {
+    window.QwenPaw.chat!.response.prepend("p1", () => null, { id: "a" });
+    window.QwenPaw.chat!.response.prepend("p2", () => null, { id: "b" });
+    expect(
+      chatExtensions
+        .getListSnapshot()
+        ["response.prepend"].map((e) => e.pluginId),
+    ).toEqual(["p1", "p2"]);
+  });
+
+  it("returned Disposables actually clean up the slots", () => {
+    const d = window.QwenPaw.chat!.request.prepend("p1", () => null, {
+      id: "x",
+    });
+    expect(chatExtensions.getListSnapshot()["request.prepend"]).toHaveLength(1);
+    d.dispose();
+    expect(chatExtensions.getListSnapshot()["request.prepend"]).toHaveLength(0);
+  });
+});
+
+describe("disposeAll", () => {
+  it("clears every registration from the named plugin", () => {
+    window.QwenPaw.chat!.welcome.set("p1", { greeting: "Hi", avatar: "/x" });
+    window.QwenPaw.chat!.actions.add("p1", {
+      id: "p1.a",
+      onClick: () => {},
+    });
+    window.QwenPaw.chat!.actions.add("p2", {
+      id: "p2.a",
+      onClick: () => {},
+    });
+
+    window.QwenPaw.chat!.disposeAll("p1");
+
+    const snap = chatExtensions.getScalarSnapshot();
+    expect(snap["welcome.greeting"]).toBeUndefined();
+    expect(snap["welcome.avatar"]).toBeUndefined();
+    expect(
+      chatExtensions.getListSnapshot().actions.map((e) => e.item.id),
+    ).toEqual(["p2.a"]);
+  });
+});

--- a/console/src/plugins/hostSdk/install.ts
+++ b/console/src/plugins/hostSdk/install.ts
@@ -1,0 +1,364 @@
+/**
+ * hostSdk/install.ts — attach `window.QwenPaw.chat`, `window.QwenPaw.host.*`
+ * (hooks + fetch), and `window.QwenPaw.audit` to the global namespace.
+ *
+ * Call AFTER `installHostExternals()` from main.tsx.
+ *
+ * Public chat API (3 verbs to cover all intents):
+ *   - set(pluginId, partial)  → shallow-merge specific option fields
+ *   - render(pluginId, node)  → whole-section replacement (welcome / leftHeader)
+ *   - add(pluginId, item)     → append to additive lists (rightHeader / sender.prefix / actions / …)
+ */
+import type React from "react";
+import { chatExtensions } from "../registry/chatExtensions";
+import { auditStore } from "../registry/audit";
+import { pluginSystem } from "../hostExternals";
+import { combineDisposables } from "../registry/types";
+import { ChatScalar } from "../registry/slotKeys";
+import type {
+  ChatActionSpec,
+  ChatNodeItem,
+  ChatRequestRenderFn,
+  ChatRequestSlotFn,
+  ChatResponseRenderFn,
+  ChatResponseSlotFn,
+  ChatScalarField,
+  ChatScalarValues,
+  ChatSlotItem,
+  ChatSuggestionsItem,
+  Disposable,
+  OverrideRecord,
+  WelcomeRenderFn,
+  WelcomeRenderProps,
+} from "../registry/types";
+import {
+  useHostTheme,
+  useHostLocale,
+  useHostSelectedAgent,
+  useHostCurrentSession,
+  getSelectedAgentId,
+  getCurrentSessionId,
+} from "./hooks";
+import { hostFetch } from "./fetch";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin-facing API surface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type WelcomeRenderValue = WelcomeRenderFn | React.ReactNode;
+
+interface WelcomePartial {
+  greeting?: ChatScalarValues["welcome.greeting"];
+  description?: ChatScalarValues["welcome.description"];
+  avatar?: ChatScalarValues["welcome.avatar"];
+  nick?: ChatScalarValues["welcome.nick"];
+  prompts?: ChatScalarValues["welcome.prompts"];
+}
+
+interface LeftHeaderPartial {
+  logo?: ChatScalarValues["header.leftLogo"];
+  title?: ChatScalarValues["header.leftTitle"];
+}
+
+interface ThemePartial {
+  colorPrimary?: ChatScalarValues["theme.colorPrimary"];
+}
+
+interface SenderPartial {
+  placeholder?: ChatScalarValues["sender.placeholder"];
+  disclaimer?: ChatScalarValues["sender.disclaimer"];
+}
+
+export interface QwenPawChatNamespace {
+  welcome: {
+    set(pluginId: string, partial: WelcomePartial): Disposable;
+    render(pluginId: string, value: WelcomeRenderValue): Disposable;
+  };
+  theme: {
+    set(pluginId: string, partial: ThemePartial): Disposable;
+  };
+  leftHeader: {
+    set(pluginId: string, partial: LeftHeaderPartial): Disposable;
+    render(pluginId: string, node: React.ReactNode): Disposable;
+  };
+  rightHeader: {
+    add(
+      pluginId: string,
+      node: React.ReactNode,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+  };
+  sender: {
+    set(pluginId: string, partial: SenderPartial): Disposable;
+    addPrefix(
+      pluginId: string,
+      node: React.ReactNode,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+    addSuggestion(
+      pluginId: string,
+      item: { id?: string; items: ChatSuggestionsItem["items"] },
+    ): Disposable;
+  };
+  actions: { add(pluginId: string, spec: ChatActionSpec): Disposable };
+  requestActions: { add(pluginId: string, spec: ChatActionSpec): Disposable };
+  request: {
+    /** Whole-bubble replacement for the user request card. Wins over host default; prepend/append still render around it. */
+    render(pluginId: string, fn: ChatRequestRenderFn): Disposable;
+    /** Append a custom component above the user bubble. Returning null skips this bubble. */
+    prepend(
+      pluginId: string,
+      fn: ChatRequestSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+    /** Append a custom component below the user bubble. */
+    append(
+      pluginId: string,
+      fn: ChatRequestSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+  };
+  response: {
+    /** Whole-bubble replacement for the assistant response card. */
+    render(pluginId: string, fn: ChatResponseRenderFn): Disposable;
+    /** Append a custom component above the AI bubble. */
+    prepend(
+      pluginId: string,
+      fn: ChatResponseSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+    /** Append a custom component below the AI bubble. */
+    append(
+      pluginId: string,
+      fn: ChatResponseSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+  };
+  toolRender(
+    pluginId: string,
+    toolName: string,
+    render: React.FC<Record<string, unknown>>,
+  ): Disposable;
+  card(
+    pluginId: string,
+    cardName: string,
+    render: React.FC<Record<string, unknown>>,
+  ): Disposable;
+  disposeAll(pluginId: string): void;
+}
+
+export interface QwenPawAuditNamespace {
+  overrides(): OverrideRecord[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Apply a `set(partial)` call by fanning out to setScalar() per field.
+ * Returns a combined Disposable that reverts every field this call wrote.
+ * Fields are stored independently in their own LIFO stacks, so different
+ * fields from different plugins coexist without overwriting each other.
+ */
+function applyPartial<T extends object>(
+  pluginId: string,
+  partial: T,
+  fieldMap: Record<keyof T, ChatScalarField>,
+): Disposable {
+  const disposables: Disposable[] = [];
+  for (const k of Object.keys(partial) as Array<keyof T>) {
+    const value = (partial as Record<keyof T, unknown>)[k];
+    if (value === undefined) continue;
+    const field = fieldMap[k];
+    // The runtime carries the typed value through to setScalar — but TS
+    // can't see the structural mapping, so we cast at the boundary.
+    disposables.push(
+      chatExtensions.setScalar(
+        pluginId,
+        field,
+        value as unknown as ChatScalarValues[typeof field],
+      ),
+    );
+  }
+  return combineDisposables(...disposables);
+}
+
+/** Normalize a plugin-supplied welcome.render value into the SDK's fn shape. */
+function normalizeWelcomeRender(value: WelcomeRenderValue): WelcomeRenderFn {
+  if (typeof value === "function") {
+    return value as WelcomeRenderFn;
+  }
+  // Plain ReactNode → wrap into a fn that ignores SDK props and renders the node verbatim.
+  const node = value;
+  return ((_props: WelcomeRenderProps) =>
+    node as unknown as React.ReactElement) as WelcomeRenderFn;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Build the namespace
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeChatNamespace(): QwenPawChatNamespace {
+  let anonSeq = 0;
+  const anonId = (kind: string) => {
+    anonSeq += 1;
+    return `${kind}.anon.${anonSeq}`;
+  };
+
+  const welcomeFieldMap: Record<keyof WelcomePartial, ChatScalarField> = {
+    greeting: ChatScalar.welcomeGreeting,
+    description: ChatScalar.welcomeDescription,
+    avatar: ChatScalar.welcomeAvatar,
+    nick: ChatScalar.welcomeNick,
+    prompts: ChatScalar.welcomePrompts,
+  };
+
+  const leftHeaderFieldMap: Record<keyof LeftHeaderPartial, ChatScalarField> = {
+    logo: ChatScalar.headerLeftLogo,
+    title: ChatScalar.headerLeftTitle,
+  };
+
+  const themeFieldMap: Record<keyof ThemePartial, ChatScalarField> = {
+    colorPrimary: ChatScalar.themeColorPrimary,
+  };
+
+  const senderFieldMap: Record<keyof SenderPartial, ChatScalarField> = {
+    placeholder: ChatScalar.senderPlaceholder,
+    disclaimer: ChatScalar.senderDisclaimer,
+  };
+
+  return {
+    welcome: {
+      set: (pid, partial) => applyPartial(pid, partial, welcomeFieldMap),
+      render: (pid, value) =>
+        chatExtensions.setScalar(
+          pid,
+          ChatScalar.welcomeRender,
+          normalizeWelcomeRender(value),
+        ),
+    },
+    theme: {
+      set: (pid, partial) => applyPartial(pid, partial, themeFieldMap),
+    },
+    leftHeader: {
+      set: (pid, partial) => applyPartial(pid, partial, leftHeaderFieldMap),
+      render: (pid, node) =>
+        chatExtensions.setScalar(pid, ChatScalar.headerLeftHeaderRender, node),
+    },
+    rightHeader: {
+      add: (pid, node, opts) => {
+        const item: ChatNodeItem = {
+          id: opts?.id ?? anonId(`${pid}.rightHeader`),
+          node,
+          order: opts?.order,
+        };
+        return chatExtensions.addRightHeader(pid, item);
+      },
+    },
+    sender: {
+      set: (pid, partial) => applyPartial(pid, partial, senderFieldMap),
+      addPrefix: (pid, node, opts) => {
+        const item: ChatNodeItem = {
+          id: opts?.id ?? anonId(`${pid}.senderPrefix`),
+          node,
+          order: opts?.order,
+        };
+        return chatExtensions.addSenderPrefix(pid, item);
+      },
+      addSuggestion: (pid, { id, items }) => {
+        const sug: ChatSuggestionsItem = {
+          id: id ?? anonId(`${pid}.suggestion`),
+          items,
+        };
+        return chatExtensions.addSenderSuggestions(pid, sug);
+      },
+    },
+    actions: { add: (pid, action) => chatExtensions.addAction(pid, action) },
+    requestActions: {
+      add: (pid, action) => chatExtensions.addRequestAction(pid, action),
+    },
+    request: {
+      render: (pid, fn) =>
+        chatExtensions.setScalar(pid, ChatScalar.requestRender, fn),
+      prepend: (pid, fn, opts) => {
+        const item: ChatSlotItem<ChatRequestSlotFn> = {
+          id: opts?.id ?? anonId(`${pid}.request.prepend`),
+          render: fn,
+          order: opts?.order,
+        };
+        return chatExtensions.addRequestPrepend(pid, item);
+      },
+      append: (pid, fn, opts) => {
+        const item: ChatSlotItem<ChatRequestSlotFn> = {
+          id: opts?.id ?? anonId(`${pid}.request.append`),
+          render: fn,
+          order: opts?.order,
+        };
+        return chatExtensions.addRequestAppend(pid, item);
+      },
+    },
+    response: {
+      render: (pid, fn) =>
+        chatExtensions.setScalar(pid, ChatScalar.responseRender, fn),
+      prepend: (pid, fn, opts) => {
+        const item: ChatSlotItem<ChatResponseSlotFn> = {
+          id: opts?.id ?? anonId(`${pid}.response.prepend`),
+          render: fn,
+          order: opts?.order,
+        };
+        return chatExtensions.addResponsePrepend(pid, item);
+      },
+      append: (pid, fn, opts) => {
+        const item: ChatSlotItem<ChatResponseSlotFn> = {
+          id: opts?.id ?? anonId(`${pid}.response.append`),
+          render: fn,
+          order: opts?.order,
+        };
+        return chatExtensions.addResponseAppend(pid, item);
+      },
+    },
+    toolRender: (pid, toolName, render) => {
+      // Mirror to existing pluginSystem.toolRenderers so the old
+      // `usePlugins().toolRenderConfig` path keeps producing the same map.
+      pluginSystem.addToolRenderers(pid, { [toolName]: render });
+      return chatExtensions.addToolRender(pid, toolName, render);
+    },
+    card: (pid, cardName, render) =>
+      chatExtensions.addCard(pid, cardName, render),
+    disposeAll: (pid) => chatExtensions.disposeAll(pid),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Install
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function installHostSdk(): void {
+  if (typeof window === "undefined") return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ns = (window.QwenPaw as any) ?? ((window as any).QwenPaw = {});
+
+  if (!ns.chat) {
+    ns.chat = makeChatNamespace();
+  }
+
+  if (!ns.audit) {
+    const auditNamespace: QwenPawAuditNamespace = {
+      overrides: () => auditStore.overrides(),
+    };
+    ns.audit = auditNamespace;
+  }
+
+  // Extend window.QwenPaw.host with hooks + fetch.
+  // hostExternals.ts attaches host first; we add new fields without
+  // overwriting React / antd / antdIcons / getApiUrl / getApiToken.
+  const host = ns.host ?? (ns.host = {});
+  if (!host.useTheme) host.useTheme = useHostTheme;
+  if (!host.useLocale) host.useLocale = useHostLocale;
+  if (!host.useSelectedAgent) host.useSelectedAgent = useHostSelectedAgent;
+  if (!host.useCurrentSession) host.useCurrentSession = useHostCurrentSession;
+  if (!host.getSelectedAgentId) host.getSelectedAgentId = getSelectedAgentId;
+  if (!host.getCurrentSessionId) host.getCurrentSessionId = getCurrentSessionId;
+  if (!host.fetch) host.fetch = hostFetch;
+}

--- a/console/src/plugins/registry/PluginSlotBoundary.tsx
+++ b/console/src/plugins/registry/PluginSlotBoundary.tsx
@@ -1,0 +1,45 @@
+/**
+ * registry/PluginSlotBoundary.tsx — error boundary for plugin-contributed JSX.
+ *
+ * A plugin throwing inside its component should never tear down the host
+ * Chat tree. This boundary catches the error, writes it to the audit log,
+ * and renders an optional fallback (default: render nothing).
+ */
+import React from "react";
+import { auditStore } from "./audit";
+
+interface Props {
+  pluginId: string;
+  slot: string;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface State {
+  errored: boolean;
+}
+
+export class PluginSlotBoundary extends React.Component<Props, State> {
+  state: State = { errored: false };
+
+  static getDerivedStateFromError(): State {
+    return { errored: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    auditStore.record({
+      kind: "chat.error",
+      field: this.props.slot,
+      pluginId: this.props.pluginId,
+      detail: error.message,
+      timestamp: Date.now(),
+    });
+  }
+
+  render(): React.ReactNode {
+    if (this.state.errored) {
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}

--- a/console/src/plugins/registry/Slot.tsx
+++ b/console/src/plugins/registry/Slot.tsx
@@ -1,0 +1,107 @@
+/**
+ * registry/Slot.tsx — <Slot name kind children?> layout fill point.
+ *
+ * - kind="fill": renders `children` (host default) first, then all plugin fills
+ *   sorted by topo + order. Multiple plugins compose.
+ * - kind="replace": renders the latest plugin replace if any, else `children`.
+ *
+ * Every plugin-provided render is wrapped in <SlotErrorBoundary> so a single
+ * crash logs to audit and degrades to null instead of taking down the whole
+ * layout.
+ */
+import React from "react";
+import { useSyncExternalStore } from "react";
+import { slotRegistry, subscribe } from "./store";
+import type { SlotKind, SlotName } from "./types";
+import { auditStore } from "./audit";
+
+interface SlotProps {
+  name: SlotName;
+  kind: SlotKind;
+  /** Host's own content for this slot. Always rendered for fill, used as fallback for replace. */
+  children?: React.ReactNode;
+}
+
+export function Slot({ name, kind, children }: SlotProps) {
+  const entries = useSyncExternalStore(subscribe, () =>
+    slotRegistry.snapshot(name),
+  );
+
+  if (kind === "replace") {
+    const replaceEntry = entries.find((e) => e.kind === "replace");
+    if (!replaceEntry) return <>{children}</>;
+    // Pass `children` (host default) into the plugin render so an
+    // agent-/route-aware plugin can `return defaultContent` to opt out
+    // of replacement on a per-render basis — mirrors fallback() in
+    // chat.{request,response}.render.
+    //
+    // Also fall back to children when the render itself yields null/
+    // undefined (e.g. a plugin that returns null instead of taking the
+    // defaultContent path). Either way the slot still paints.
+    const rendered = replaceEntry.render(children);
+    if (rendered == null) return <>{children}</>;
+    return (
+      <SlotErrorBoundary slot={name} pluginId={replaceEntry.source}>
+        {rendered}
+      </SlotErrorBoundary>
+    );
+  }
+
+  // fill mode
+  const visibleFills = entries.filter((e) => e.kind === "fill");
+  return (
+    <>
+      {children}
+      {visibleFills.map((e) => (
+        <SlotErrorBoundary
+          key={e.registrationId}
+          slot={name}
+          pluginId={e.source}
+        >
+          {e.render()}
+        </SlotErrorBoundary>
+      ))}
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SlotErrorBoundary
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface BoundaryProps {
+  slot: string;
+  pluginId: string;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface BoundaryState {
+  errored: boolean;
+}
+
+export class SlotErrorBoundary extends React.Component<
+  BoundaryProps,
+  BoundaryState
+> {
+  state: BoundaryState = { errored: false };
+
+  static getDerivedStateFromError(): BoundaryState {
+    return { errored: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    auditStore.record({
+      kind: "slot.error",
+      targetId: this.props.slot,
+      pluginId: this.props.pluginId,
+      detail: error.message,
+      timestamp: Date.now(),
+    });
+  }
+
+  render(): React.ReactNode {
+    if (this.state.errored) return this.props.fallback ?? null;
+    return this.props.children;
+  }
+}

--- a/console/src/plugins/registry/__tests__/Slot.test.tsx
+++ b/console/src/plugins/registry/__tests__/Slot.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Slot.test.tsx — <Slot> component + SlotErrorBoundary.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { Slot } from "../Slot";
+import { slotRegistry } from "../store";
+import { auditStore } from "../audit";
+
+beforeEach(() => {
+  slotRegistry.__resetForTests();
+  auditStore.clear();
+});
+
+describe("<Slot kind='fill'>", () => {
+  it("renders children (host default) when no fills", () => {
+    const { getByTestId } = render(
+      <Slot name="x" kind="fill">
+        <span data-testid="default">D</span>
+      </Slot>,
+    );
+    expect(getByTestId("default")).toBeInTheDocument();
+  });
+
+  it("renders children then plugin fills in order", () => {
+    slotRegistry.fill("p1", "x", () => <span data-testid="p1">P1</span>, {
+      order: 100,
+    });
+    slotRegistry.fill("p2", "x", () => <span data-testid="p2">P2</span>, {
+      order: 200,
+    });
+    const { getByTestId, container } = render(
+      <Slot name="x" kind="fill">
+        <span data-testid="default">D</span>
+      </Slot>,
+    );
+    expect(getByTestId("default")).toBeInTheDocument();
+    expect(getByTestId("p1")).toBeInTheDocument();
+    expect(getByTestId("p2")).toBeInTheDocument();
+    const texts = Array.from(container.querySelectorAll("span")).map(
+      (e) => e.textContent,
+    );
+    expect(texts).toEqual(["D", "P1", "P2"]);
+  });
+
+  it("re-renders when a fill is added after mount", () => {
+    const { container } = render(<Slot name="x" kind="fill" />);
+    expect(container.textContent).toBe("");
+    act(() => {
+      slotRegistry.fill("p1", "x", () => <span>P1</span>);
+    });
+    expect(container.textContent).toBe("P1");
+  });
+});
+
+describe("<Slot kind='replace'>", () => {
+  it("renders children when no replace", () => {
+    const { getByTestId } = render(
+      <Slot name="x" kind="replace">
+        <span data-testid="default">D</span>
+      </Slot>,
+    );
+    expect(getByTestId("default")).toBeInTheDocument();
+  });
+
+  it("plugin replace overrides children", () => {
+    slotRegistry.replace("p1", "x", () => <span data-testid="plugin">P</span>);
+    const { getByTestId, queryByTestId } = render(
+      <Slot name="x" kind="replace">
+        <span data-testid="default">D</span>
+      </Slot>,
+    );
+    expect(getByTestId("plugin")).toBeInTheDocument();
+    expect(queryByTestId("default")).not.toBeInTheDocument();
+  });
+});
+
+describe("SlotErrorBoundary", () => {
+  function Boom(): never {
+    throw new Error("plugin boom");
+  }
+
+  it("catches throwing plugin render + writes audit + falls back", () => {
+    slotRegistry.fill("evil", "x", () => <Boom />, { id: "evil.boom" });
+    const { container } = render(
+      <Slot name="x" kind="fill">
+        <span data-testid="default">D</span>
+      </Slot>,
+    );
+    // Default still rendered; plugin output replaced by null (fallback).
+    expect(container.textContent).toBe("D");
+    expect(
+      auditStore
+        .overrides()
+        .some((r) => r.kind === "slot.error" && r.pluginId === "evil"),
+    ).toBe(true);
+  });
+});

--- a/console/src/plugins/registry/__tests__/hostExternals.compat.test.tsx
+++ b/console/src/plugins/registry/__tests__/hostExternals.compat.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * hostExternals.compat.test.tsx — back-compat shim for legacy registerRoutes.
+ *
+ * Verifies that a call shaped like CloudPaw's existing one:
+ *   window.QwenPaw.registerRoutes("cloudpaw", [{ path: "/a2a", ... }])
+ *
+ * translates into both:
+ *   - routeRegistry entry under id `legacy:cloudpaw:a2a`
+ *   - menuRegistry entry under parentId `plugins-group` in primary.settings
+ *
+ * And that the synthesized `plugins-group` parent exists.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { installHostExternals } from "../../hostExternals";
+import { menuRegistry, routeRegistry } from "../store";
+import { auditStore } from "../audit";
+
+function freshInstall() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).QwenPaw = undefined;
+  menuRegistry.__resetForTests();
+  routeRegistry.__resetForTests();
+  auditStore.clear();
+  installHostExternals();
+}
+
+const Comp = () => null;
+
+beforeEach(() => {
+  freshInstall();
+});
+
+describe("legacy registerRoutes shim", () => {
+  it("attaches window.QwenPaw.{menu, route, slot, audit}", () => {
+    expect(typeof window.QwenPaw.menu?.add).toBe("function");
+    expect(typeof window.QwenPaw.route?.add).toBe("function");
+    expect(typeof window.QwenPaw.slot?.fill).toBe("function");
+    expect(typeof window.QwenPaw.audit?.overrides).toBe("function");
+  });
+
+  it("translates CloudPaw-shape registerRoutes into menu+route", () => {
+    window.QwenPaw.registerRoutes!("cloudpaw", [
+      {
+        path: "/a2a",
+        component: Comp,
+        label: "A2A",
+        icon: "🔗",
+        priority: 10,
+      },
+    ]);
+
+    const route = routeRegistry
+      .snapshot()
+      .find((r) => r.id === "legacy:cloudpaw:a2a");
+    expect(route?.path).toBe("/a2a");
+
+    const settings = menuRegistry.snapshot("primary.settings");
+    const pluginsGroup = settings.find((i) => i.id === "plugins-group") as
+      | { __children?: Array<{ id: string }> }
+      | undefined;
+    expect(pluginsGroup).toBeTruthy();
+    expect(pluginsGroup?.__children?.map((c) => c.id)).toContain(
+      "legacy:cloudpaw:a2a",
+    );
+  });
+
+  it("multiple legacy registers share the synthesized plugins-group", () => {
+    window.QwenPaw.registerRoutes!("p1", [
+      { path: "/p1", component: Comp, label: "P1", icon: "1" },
+    ]);
+    window.QwenPaw.registerRoutes!("p2", [
+      { path: "/p2", component: Comp, label: "P2", icon: "2" },
+    ]);
+
+    const settings = menuRegistry.snapshot("primary.settings");
+    const groups = settings.filter((i) => i.id === "plugins-group");
+    expect(groups).toHaveLength(1);
+    const kids = (groups[0] as { __children?: Array<{ id: string }> })
+      .__children;
+    expect(kids?.map((c) => c.id)).toEqual(
+      expect.arrayContaining(["legacy:p1:p1", "legacy:p2:p2"]),
+    );
+  });
+
+  it("new QwenPaw.menu.add coexists with legacy in plugins-group", () => {
+    window.QwenPaw.registerRoutes!("cloudpaw", [
+      { path: "/a2a", component: Comp, label: "A2A", icon: "🔗" },
+    ]);
+    window.QwenPaw.menu!.add("newPlugin", {
+      id: "newPlugin.foo",
+      location: "primary.agentScoped",
+      parentId: "core.agent-group",
+      label: "Foo",
+    });
+
+    const settings = menuRegistry.snapshot("primary.settings");
+    const pluginsGroup = settings.find((i) => i.id === "plugins-group") as
+      | { __children?: Array<{ id: string }> }
+      | undefined;
+    expect(pluginsGroup?.__children?.map((c) => c.id)).toContain(
+      "legacy:cloudpaw:a2a",
+    );
+    // newPlugin lives in primary.agentScoped, not settings
+    expect(settings.find((i) => i.id === "newPlugin.foo")).toBeUndefined();
+  });
+
+  it("legacy registerToolRender still writes to pluginSystem", async () => {
+    const { pluginSystem } = await import("../../hostExternals");
+    const RenderFC = () => null;
+    window.QwenPaw.registerToolRender!("p1", { my_tool: RenderFC });
+    expect(pluginSystem.getToolRenderConfig().my_tool).toBe(RenderFC);
+  });
+});

--- a/console/src/plugins/registry/__tests__/menu.test.ts
+++ b/console/src/plugins/registry/__tests__/menu.test.ts
@@ -1,0 +1,159 @@
+/**
+ * menu.test.ts — MenuRegistry behaviour.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { menuRegistry } from "../store";
+import { auditStore } from "../audit";
+
+beforeEach(() => {
+  menuRegistry.__resetForTests();
+  auditStore.clear();
+});
+
+describe("menuRegistry.add", () => {
+  it("adds an item that appears in snapshot", () => {
+    menuRegistry.add("p1", {
+      id: "p1.foo",
+      location: "primary.settings",
+      label: "Foo",
+    });
+    const items = menuRegistry.snapshot("primary.settings");
+    expect(items.map((i) => i.id)).toContain("p1.foo");
+  });
+
+  it("default location is primary.settings", () => {
+    menuRegistry.add("p1", { id: "p1.bar", label: "Bar" });
+    expect(
+      menuRegistry.snapshot("primary.settings").map((i) => i.id),
+    ).toContain("p1.bar");
+  });
+
+  it("duplicate id is rejected with conflict audit", () => {
+    menuRegistry.add("p1", { id: "x", label: "A" });
+    menuRegistry.add("p2", { id: "x", label: "B" });
+    const items = menuRegistry.snapshot("primary.settings");
+    expect(items.filter((i) => i.id === "x")).toHaveLength(1);
+    expect(
+      auditStore
+        .overrides()
+        .some((r) => r.kind === "menu.conflict" && r.pluginId === "p2"),
+    ).toBe(true);
+  });
+
+  it("filters items where visible() returns false", () => {
+    menuRegistry.add("p1", {
+      id: "shown",
+      label: "S",
+      visible: () => true,
+    });
+    menuRegistry.add("p1", {
+      id: "hidden",
+      label: "H",
+      visible: () => false,
+    });
+    const items = menuRegistry.snapshot("primary.settings").map((i) => i.id);
+    expect(items).toContain("shown");
+    expect(items).not.toContain("hidden");
+  });
+});
+
+describe("menuRegistry.replace", () => {
+  it("later writer wins, audit records supersede", () => {
+    menuRegistry.add("p1", { id: "x", label: "from P1" });
+    menuRegistry.replace("p2", "x", { id: "x", label: "from P2" });
+    const item = menuRegistry
+      .snapshot("primary.settings")
+      .find((i) => i.id === "x");
+    expect(item?.label).toBe("from P2");
+    expect(
+      auditStore
+        .overrides()
+        .some(
+          (r) =>
+            r.kind === "menu.replace" &&
+            r.pluginId === "p2" &&
+            r.supersededPluginId === "p1",
+        ),
+    ).toBe(true);
+  });
+
+  it("disposing winner falls back to prior (LIFO)", () => {
+    menuRegistry.add("p1", { id: "x", label: "P1" });
+    const d = menuRegistry.replace("p2", "x", { id: "x", label: "P2" });
+    d.dispose();
+    const item = menuRegistry
+      .snapshot("primary.settings")
+      .find((i) => i.id === "x");
+    expect(item?.label).toBe("P1");
+  });
+});
+
+describe("menuRegistry topology (before/after/order)", () => {
+  it("respects before/after constraints", () => {
+    menuRegistry.add("core", { id: "a", label: "A", order: 10 });
+    menuRegistry.add("core", { id: "b", label: "B", order: 20 });
+    menuRegistry.add("p1", { id: "c", label: "C", before: "b" });
+    const ids = menuRegistry.snapshot("primary.settings").map((i) => i.id);
+    const a = ids.indexOf("a"),
+      b = ids.indexOf("b"),
+      c = ids.indexOf("c");
+    expect(c).toBeLessThan(b);
+    expect(a).toBeLessThan(b);
+  });
+
+  it("falls back to order on a cycle", () => {
+    menuRegistry.add("core", { id: "a", label: "A", before: "b", order: 1 });
+    menuRegistry.add("core", { id: "b", label: "B", before: "a", order: 2 });
+    const ids = menuRegistry.snapshot("primary.settings").map((i) => i.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("b");
+  });
+
+  it("builds parent/child tree via parentId", () => {
+    menuRegistry.add("core", {
+      id: "g",
+      label: "Group",
+      isGroup: true,
+    });
+    menuRegistry.add("core", {
+      id: "child1",
+      label: "C1",
+      parentId: "g",
+    });
+    menuRegistry.add("core", {
+      id: "child2",
+      label: "C2",
+      parentId: "g",
+    });
+    const items = menuRegistry.snapshot("primary.settings");
+    const group = items.find((i) => i.id === "g") as MenuItem & {
+      __children?: MenuItem[];
+    };
+    expect(group?.__children?.map((c) => c.id)).toEqual(["child1", "child2"]);
+    // children should NOT also appear at top level
+    expect(items.map((i) => i.id)).not.toContain("child1");
+  });
+});
+
+describe("menuRegistry locations", () => {
+  it("separates agentScoped vs settings buckets", () => {
+    menuRegistry.add("core", {
+      id: "a",
+      location: "primary.agentScoped",
+      label: "A",
+    });
+    menuRegistry.add("core", {
+      id: "s",
+      location: "primary.settings",
+      label: "S",
+    });
+    expect(
+      menuRegistry.snapshot("primary.agentScoped").map((i) => i.id),
+    ).toEqual(["a"]);
+    expect(menuRegistry.snapshot("primary.settings").map((i) => i.id)).toEqual([
+      "s",
+    ]);
+  });
+});
+
+import type { MenuItem } from "../types";

--- a/console/src/plugins/registry/__tests__/routes.test.tsx
+++ b/console/src/plugins/registry/__tests__/routes.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * routes.test.tsx — RouteRegistry behaviour.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { routeRegistry } from "../store";
+import { auditStore } from "../audit";
+
+const Base = () => <div data-testid="base">base</div>;
+const PluginPage = () => <div data-testid="plugin">plugin</div>;
+
+beforeEach(() => {
+  routeRegistry.__resetForTests();
+  auditStore.clear();
+});
+
+describe("routeRegistry.add", () => {
+  it("registers and snapshots", () => {
+    routeRegistry.add("core", { id: "r1", path: "/r1", component: Base });
+    const snap = routeRegistry.snapshot();
+    expect(snap.map((r) => r.id)).toContain("r1");
+  });
+
+  it("rejects duplicate id with conflict audit", () => {
+    routeRegistry.add("core", { id: "r1", path: "/a", component: Base });
+    routeRegistry.add("p1", { id: "r1", path: "/b", component: Base });
+    expect(routeRegistry.snapshot().filter((r) => r.id === "r1")).toHaveLength(
+      1,
+    );
+    expect(
+      auditStore.overrides().some((r) => r.kind === "route.conflict"),
+    ).toBe(true);
+  });
+
+  it("rejects duplicate path with conflict audit", () => {
+    routeRegistry.add("core", { id: "r1", path: "/x", component: Base });
+    routeRegistry.add("p1", { id: "r2", path: "/x", component: Base });
+    expect(routeRegistry.snapshot().map((r) => r.path)).toEqual(["/x"]);
+    expect(
+      auditStore
+        .overrides()
+        .some((r) => r.kind === "route.conflict" && r.targetId === "r2"),
+    ).toBe(true);
+  });
+});
+
+describe("routeRegistry.replace", () => {
+  it("LIFO winner; rendered Component reflects override", () => {
+    routeRegistry.add("core", { id: "p", path: "/p", component: Base });
+    routeRegistry.replace("p1", "p", PluginPage);
+    const Comp = routeRegistry.snapshot().find((r) => r.id === "p")?.Component!;
+    expect(Comp).toBeTruthy();
+    const { getByTestId } = render(<Comp />);
+    expect(getByTestId("plugin")).toBeInTheDocument();
+  });
+
+  it("dispose restores base", () => {
+    routeRegistry.add("core", { id: "p", path: "/p", component: Base });
+    const d = routeRegistry.replace("p1", "p", PluginPage);
+    d.dispose();
+    const Comp = routeRegistry.snapshot().find((r) => r.id === "p")?.Component!;
+    const { getByTestId } = render(<Comp />);
+    expect(getByTestId("base")).toBeInTheDocument();
+  });
+});
+
+describe("routeRegistry.wrap — onion composition", () => {
+  it("later wrap is outermost", () => {
+    routeRegistry.add("core", { id: "p", path: "/p", component: Base });
+    routeRegistry.wrap("p1", "p", (Inner) => () => (
+      <div data-testid="outer-p1">
+        <Inner />
+      </div>
+    ));
+    routeRegistry.wrap("p2", "p", (Inner) => () => (
+      <div data-testid="outer-p2">
+        <Inner />
+      </div>
+    ));
+    const Comp = routeRegistry.snapshot().find((r) => r.id === "p")?.Component!;
+    const { getByTestId, container } = render(<Comp />);
+    // p2 should wrap p1 (p2 is last registered → outermost)
+    const outerP2 = getByTestId("outer-p2");
+    const outerP1 = getByTestId("outer-p1");
+    expect(outerP2.contains(outerP1)).toBe(true);
+    expect(container.querySelector("[data-testid='base']")).toBeInTheDocument();
+  });
+
+  it("replace + wrap: wrap sees the override, not the base", () => {
+    routeRegistry.add("core", { id: "p", path: "/p", component: Base });
+    routeRegistry.replace("p1", "p", PluginPage);
+    routeRegistry.wrap("p2", "p", (Inner) => () => (
+      <div data-testid="wrap">
+        <Inner />
+      </div>
+    ));
+    const Comp = routeRegistry.snapshot().find((r) => r.id === "p")?.Component!;
+    const { queryByTestId } = render(<Comp />);
+    expect(queryByTestId("wrap")).toBeInTheDocument();
+    expect(queryByTestId("plugin")).toBeInTheDocument();
+    expect(queryByTestId("base")).not.toBeInTheDocument();
+  });
+
+  it("disposing wrap removes it from chain", () => {
+    routeRegistry.add("core", { id: "p", path: "/p", component: Base });
+    const d = routeRegistry.wrap("p1", "p", (Inner) => () => (
+      <div data-testid="wrap">
+        <Inner />
+      </div>
+    ));
+    d.dispose();
+    const Comp = routeRegistry.snapshot().find((r) => r.id === "p")?.Component!;
+    const { queryByTestId } = render(<Comp />);
+    expect(queryByTestId("wrap")).not.toBeInTheDocument();
+    expect(queryByTestId("base")).toBeInTheDocument();
+  });
+});

--- a/console/src/plugins/registry/__tests__/slot.test.ts
+++ b/console/src/plugins/registry/__tests__/slot.test.ts
@@ -1,0 +1,111 @@
+/**
+ * slot.test.ts — SlotRegistry pure behaviour (no React render).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { slotRegistry } from "../store";
+import { auditStore } from "../audit";
+
+beforeEach(() => {
+  slotRegistry.__resetForTests();
+  auditStore.clear();
+});
+
+describe("slotRegistry.fill", () => {
+  it("appends fills in registration order when no order opts", () => {
+    slotRegistry.fill("p1", "x", () => null, { id: "a" });
+    slotRegistry.fill("p2", "x", () => null, { id: "b" });
+    expect(slotRegistry.snapshot("x").map((e) => e.opts.id)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("sorts by order ascending", () => {
+    slotRegistry.fill("p1", "x", () => null, { id: "a", order: 30 });
+    slotRegistry.fill("p2", "x", () => null, { id: "b", order: 10 });
+    slotRegistry.fill("p3", "x", () => null, { id: "c", order: 20 });
+    expect(slotRegistry.snapshot("x").map((e) => e.opts.id)).toEqual([
+      "b",
+      "c",
+      "a",
+    ]);
+  });
+
+  it("respects before/after constraints", () => {
+    slotRegistry.fill("p1", "x", () => null, { id: "a" });
+    slotRegistry.fill("p2", "x", () => null, { id: "b" });
+    slotRegistry.fill("p3", "x", () => null, { id: "z", before: "a" });
+    const ids = slotRegistry.snapshot("x").map((e) => e.opts.id);
+    expect(ids.indexOf("z")).toBeLessThan(ids.indexOf("a"));
+  });
+
+  it("filters by visible()", () => {
+    slotRegistry.fill("p1", "x", () => null, {
+      id: "shown",
+      visible: () => true,
+    });
+    slotRegistry.fill("p2", "x", () => null, {
+      id: "hidden",
+      visible: () => false,
+    });
+    expect(slotRegistry.snapshot("x").map((e) => e.opts.id)).toEqual(["shown"]);
+  });
+
+  it("dispose removes only the targeted fill", () => {
+    slotRegistry.fill("p1", "x", () => null, { id: "a" });
+    const d = slotRegistry.fill("p2", "x", () => null, { id: "b" });
+    slotRegistry.fill("p3", "x", () => null, { id: "c" });
+    d.dispose();
+    expect(slotRegistry.snapshot("x").map((e) => e.opts.id)).toEqual([
+      "a",
+      "c",
+    ]);
+  });
+});
+
+describe("slotRegistry.replace", () => {
+  it("replace wins over fills", () => {
+    slotRegistry.fill("p1", "x", () => null, { id: "fill1" });
+    slotRegistry.fill("p2", "x", () => null, { id: "fill2" });
+    slotRegistry.replace("p3", "x", () => null, { id: "rep" });
+    const snap = slotRegistry.snapshot("x");
+    expect(snap).toHaveLength(1);
+    expect(snap[0].kind).toBe("replace");
+    expect(snap[0].opts.id).toBe("rep");
+  });
+
+  it("last replace wins among multiple replacers", () => {
+    slotRegistry.replace("p1", "x", () => null, { id: "r1" });
+    slotRegistry.replace("p2", "x", () => null, { id: "r2" });
+    const snap = slotRegistry.snapshot("x");
+    expect(snap).toHaveLength(1);
+    expect(snap[0].opts.id).toBe("r2");
+  });
+
+  it("disposing the replace reveals fills again", () => {
+    slotRegistry.fill("p1", "x", () => null, { id: "f" });
+    const d = slotRegistry.replace("p2", "x", () => null, { id: "r" });
+    d.dispose();
+    const snap = slotRegistry.snapshot("x");
+    expect(snap.map((e) => e.opts.id)).toEqual(["f"]);
+  });
+});
+
+describe("slotRegistry audit", () => {
+  it("records replace + fill kinds", () => {
+    slotRegistry.fill("p1", "x", () => null, {});
+    slotRegistry.replace("p2", "x", () => null, {});
+    const kinds = auditStore.overrides().map((r) => r.kind);
+    expect(kinds).toContain("slot.fill");
+    expect(kinds).toContain("slot.replace");
+  });
+});
+
+describe("slotRegistry.snapshotAll", () => {
+  it("lists all registered slots across names", () => {
+    slotRegistry.fill("p1", "a", () => null, { id: "1" });
+    slotRegistry.replace("p2", "b", () => null, { id: "2" });
+    const all = slotRegistry.snapshotAll();
+    expect(all.map((s) => `${s.name}:${s.id}`).sort()).toEqual(["a:1", "b:2"]);
+  });
+});

--- a/console/src/plugins/registry/audit.ts
+++ b/console/src/plugins/registry/audit.ts
@@ -1,0 +1,65 @@
+/**
+ * registry/audit.ts — single override log shared by all QwenPaw registries
+ * (console-wide menu/route/slot + chat extensions).
+ *
+ * Ring buffer (default 500 entries). Plugin authors can read via
+ * `window.QwenPaw.audit.overrides()` for debugging / change attribution.
+ *
+ * OverrideRecord carries two interchangeable id fields:
+ *   - `targetId` — preferred by console-wide registries (menuId / routeId / slotName)
+ *   - `field`    — preferred by chat-extension registries (scalar / list field name)
+ * Either works; this store normalises printing so consumers see consistent output.
+ */
+import type { OverrideRecord } from "./types";
+
+const DEFAULT_CAP = 500;
+
+function idOf(rec: OverrideRecord): string {
+  return rec.targetId ?? rec.field ?? "";
+}
+
+class AuditStore {
+  private buf: OverrideRecord[] = [];
+  private readonly cap: number;
+
+  constructor(cap = DEFAULT_CAP) {
+    this.cap = cap;
+  }
+
+  record(rec: OverrideRecord): void {
+    this.buf.push(rec);
+    if (this.buf.length > this.cap) {
+      this.buf.splice(0, this.buf.length - this.cap);
+    }
+    const id = idOf(rec);
+    if (
+      rec.kind === "menu.conflict" ||
+      rec.kind === "route.conflict" ||
+      rec.kind === "slot.error" ||
+      rec.kind === "chat.error"
+    ) {
+      console.warn(
+        `[QwenPaw audit] ${rec.kind} ${id} by ${rec.pluginId}` +
+          (rec.detail ? `: ${rec.detail}` : ""),
+      );
+    } else {
+      console.info(
+        `[QwenPaw audit] ${rec.kind} ${id} by ${rec.pluginId}` +
+          (rec.supersededPluginId
+            ? ` (superseded ${rec.supersededPluginId})`
+            : ""),
+      );
+    }
+  }
+
+  /** Return a copy — callers can sort/filter without mutating internal state. */
+  overrides(): OverrideRecord[] {
+    return this.buf.slice();
+  }
+
+  clear(): void {
+    this.buf = [];
+  }
+}
+
+export const auditStore = new AuditStore();

--- a/console/src/plugins/registry/chatExtensions.test.ts
+++ b/console/src/plugins/registry/chatExtensions.test.ts
@@ -1,0 +1,149 @@
+/**
+ * chatExtensions.test.ts — pure registry behaviour (no React).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { chatExtensions } from "./chatExtensions";
+import { auditStore } from "./audit";
+
+beforeEach(() => {
+  chatExtensions.__resetForTests();
+  auditStore.clear();
+});
+
+describe("chatExtensions.setScalar", () => {
+  it("returns the most-recently-registered value", () => {
+    chatExtensions.setScalar("p1", "welcome.greeting", "Hi from P1");
+    expect(chatExtensions.getScalarSnapshot()["welcome.greeting"]).toEqual({
+      pluginId: "p1",
+      value: "Hi from P1",
+    });
+  });
+
+  it("later writer wins and audit captures the supersede", () => {
+    chatExtensions.setScalar("p1", "welcome.greeting", "Hi P1");
+    chatExtensions.setScalar("p2", "welcome.greeting", "Hi P2");
+    expect(
+      chatExtensions.getScalarSnapshot()["welcome.greeting"]?.pluginId,
+    ).toBe("p2");
+    const records = auditStore.overrides();
+    expect(
+      records.some(
+        (r) =>
+          r.kind === "chat.scalar.superseded" &&
+          r.pluginId === "p1" &&
+          r.supersededPluginId === "p2",
+      ),
+    ).toBe(true);
+  });
+
+  it("disposing the winner falls back to the prior entry (LIFO)", () => {
+    chatExtensions.setScalar("p1", "welcome.greeting", "Hi P1");
+    const d2 = chatExtensions.setScalar("p2", "welcome.greeting", "Hi P2");
+    d2.dispose();
+    expect(
+      chatExtensions.getScalarSnapshot()["welcome.greeting"]?.pluginId,
+    ).toBe("p1");
+  });
+
+  it("disposing a non-winner does not affect the current winner", () => {
+    const d1 = chatExtensions.setScalar("p1", "welcome.greeting", "Hi P1");
+    chatExtensions.setScalar("p2", "welcome.greeting", "Hi P2");
+    d1.dispose();
+    expect(
+      chatExtensions.getScalarSnapshot()["welcome.greeting"]?.pluginId,
+    ).toBe("p2");
+  });
+
+  it("idempotent dispose() — second call is a no-op", () => {
+    const d = chatExtensions.setScalar("p1", "welcome.greeting", "Hi");
+    d.dispose();
+    d.dispose();
+    expect(
+      chatExtensions.getScalarSnapshot()["welcome.greeting"],
+    ).toBeUndefined();
+  });
+});
+
+describe("chatExtensions additive lists", () => {
+  it("addAction items appear in registration order", () => {
+    chatExtensions.addAction("p1", {
+      id: "p1.share",
+      onClick: () => {},
+    });
+    chatExtensions.addAction("p2", {
+      id: "p2.bookmark",
+      onClick: () => {},
+    });
+    const snap = chatExtensions.getListSnapshot().actions;
+    expect(snap.map((e) => e.item.id)).toEqual(["p1.share", "p2.bookmark"]);
+  });
+
+  it("dispose removes only the targeted entry", () => {
+    chatExtensions.addAction("p1", { id: "a", onClick: () => {} });
+    const d = chatExtensions.addAction("p2", {
+      id: "b",
+      onClick: () => {},
+    });
+    chatExtensions.addAction("p3", { id: "c", onClick: () => {} });
+    d.dispose();
+    const snap = chatExtensions.getListSnapshot().actions;
+    expect(snap.map((e) => e.item.id)).toEqual(["a", "c"]);
+  });
+
+  it("addRightHeader items survive snapshot reads as stable references", () => {
+    chatExtensions.addRightHeader("p1", { id: "p1.btn", node: "X" });
+    const a = chatExtensions.getListSnapshot()["header.rightHeader"];
+    const b = chatExtensions.getListSnapshot()["header.rightHeader"];
+    expect(a).toBe(b);
+  });
+});
+
+describe("chatExtensions.disposeAll", () => {
+  it("removes every registration from a single plugin", () => {
+    chatExtensions.setScalar("p1", "welcome.greeting", "Hi P1");
+    chatExtensions.setScalar("p1", "welcome.nick", "P1");
+    chatExtensions.setScalar("p2", "welcome.greeting", "Hi P2");
+    chatExtensions.addAction("p1", {
+      id: "p1.act",
+      onClick: () => {},
+    });
+    chatExtensions.addAction("p2", {
+      id: "p2.act",
+      onClick: () => {},
+    });
+
+    chatExtensions.disposeAll("p1");
+
+    const scalar = chatExtensions.getScalarSnapshot();
+    expect(scalar["welcome.greeting"]?.pluginId).toBe("p2");
+    expect(scalar["welcome.nick"]).toBeUndefined();
+
+    const actions = chatExtensions
+      .getListSnapshot()
+      .actions.map((e) => e.item.id);
+    expect(actions).toEqual(["p2.act"]);
+  });
+});
+
+describe("chatExtensions subscriptions", () => {
+  it("notifies subscribers on add and dispose", () => {
+    let count = 0;
+    const off = chatExtensions.subscribe(() => {
+      count += 1;
+    });
+    const d = chatExtensions.setScalar("p", "welcome.greeting", "x");
+    d.dispose();
+    off();
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("audit store ring buffer", () => {
+  it("returns a copy each call (no internal-mutation hazard)", () => {
+    chatExtensions.setScalar("p", "welcome.greeting", "x");
+    const a = auditStore.overrides();
+    const b = auditStore.overrides();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});

--- a/console/src/plugins/registry/chatExtensions.ts
+++ b/console/src/plugins/registry/chatExtensions.ts
@@ -1,0 +1,495 @@
+/**
+ * registry/chatExtensions.ts — singleton store for plugin-contributed Chat customizations.
+ *
+ * Two storage shapes:
+ *
+ *   1. Scalar fields (last-writer-wins):
+ *      - Each ChatScalarField has its own LIFO stack of registrations.
+ *      - `setScalar` pushes a new entry to the top of the stack.
+ *      - The returned Disposable removes ONLY that specific entry (by stable
+ *        registrationId), so disposing a superseded registration is a no-op for
+ *        the current winner, and disposing the current winner falls back to the
+ *        previous entry in the stack.
+ *
+ *   2. Additive lists (header.rightHeader, sender.prefix, actions, …):
+ *      - Each list holds entries in registration order.
+ *      - Consumers (ChatPage useMemo) stable-sort by `order` then registration time.
+ *
+ * The registry notifies subscribers on every mutation. ChatPage consumes via
+ * `useChatExtensions.ts` which uses `useSyncExternalStore`.
+ */
+import type {
+  ChatActionItem,
+  ChatActionSpec,
+  ChatCardItem,
+  ChatListField,
+  ChatNodeItem,
+  ChatRequestSlotFn,
+  ChatResponseSlotFn,
+  ChatScalarField,
+  ChatScalarValues,
+  ChatSlotItem,
+  ChatSuggestionsItem,
+  ChatToolRendererItem,
+  Disposable,
+  Localized,
+} from "./types";
+import { auditStore } from "./audit";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal entry shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ScalarEntry<F extends ChatScalarField> {
+  registrationId: string;
+  pluginId: string;
+  field: F;
+  value: ChatScalarValues[F];
+  registeredAt: number;
+}
+
+interface ListEntry<T> {
+  registrationId: string;
+  pluginId: string;
+  item: T;
+  registeredAt: number;
+}
+
+/** Public read shape consumed by ChatPage hooks (one winner per scalar field). */
+export interface ChatScalarSnapshot {
+  "welcome.greeting"?: {
+    pluginId: string;
+    value: ChatScalarValues["welcome.greeting"];
+  };
+  "welcome.description"?: {
+    pluginId: string;
+    value: ChatScalarValues["welcome.description"];
+  };
+  "welcome.avatar"?: {
+    pluginId: string;
+    value: ChatScalarValues["welcome.avatar"];
+  };
+  "welcome.nick"?: {
+    pluginId: string;
+    value: ChatScalarValues["welcome.nick"];
+  };
+  "welcome.prompts"?: {
+    pluginId: string;
+    value: ChatScalarValues["welcome.prompts"];
+  };
+  "welcome.render"?: {
+    pluginId: string;
+    value: ChatScalarValues["welcome.render"];
+  };
+  "header.leftTitle"?: {
+    pluginId: string;
+    value: ChatScalarValues["header.leftTitle"];
+  };
+  "header.leftLogo"?: {
+    pluginId: string;
+    value: ChatScalarValues["header.leftLogo"];
+  };
+  "header.leftHeader.render"?: {
+    pluginId: string;
+    value: ChatScalarValues["header.leftHeader.render"];
+  };
+  "theme.colorPrimary"?: {
+    pluginId: string;
+    value: ChatScalarValues["theme.colorPrimary"];
+  };
+  "sender.placeholder"?: {
+    pluginId: string;
+    value: ChatScalarValues["sender.placeholder"];
+  };
+  "sender.disclaimer"?: {
+    pluginId: string;
+    value: ChatScalarValues["sender.disclaimer"];
+  };
+  "request.render"?: {
+    pluginId: string;
+    value: ChatScalarValues["request.render"];
+  };
+  "response.render"?: {
+    pluginId: string;
+    value: ChatScalarValues["response.render"];
+  };
+}
+
+export interface ChatListSnapshot {
+  "header.rightHeader": ListEntry<ChatNodeItem>[];
+  "sender.prefix": ListEntry<ChatNodeItem>[];
+  "sender.suggestions": ListEntry<ChatSuggestionsItem>[];
+  actions: ListEntry<ChatActionItem>[];
+  requestActions: ListEntry<ChatActionItem>[];
+  cards: ListEntry<ChatCardItem>[];
+  customToolRender: ListEntry<ChatToolRendererItem>[];
+  "request.prepend": ListEntry<ChatSlotItem<ChatRequestSlotFn>>[];
+  "request.append": ListEntry<ChatSlotItem<ChatRequestSlotFn>>[];
+  "response.prepend": ListEntry<ChatSlotItem<ChatResponseSlotFn>>[];
+  "response.append": ListEntry<ChatSlotItem<ChatResponseSlotFn>>[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ChatExtensionsRegistry {
+  // Each scalar field: a stack; top entry is the winner.
+  private scalarStacks = new Map<
+    ChatScalarField,
+    ScalarEntry<ChatScalarField>[]
+  >();
+  // Each list field: append-only array.
+  private listMaps: ChatListSnapshot = {
+    "header.rightHeader": [],
+    "sender.prefix": [],
+    "sender.suggestions": [],
+    actions: [],
+    requestActions: [],
+    cards: [],
+    customToolRender: [],
+    "request.prepend": [],
+    "request.append": [],
+    "response.prepend": [],
+    "response.append": [],
+  };
+
+  private listeners = new Set<() => void>();
+
+  // Memoized snapshots — recreated only when state changes, so
+  // useSyncExternalStore consumers don't see new refs on every read.
+  private scalarSnapshot: ChatScalarSnapshot = {};
+  private listSnapshot: ChatListSnapshot = { ...this.listMaps };
+  private seq = 0;
+
+  // ── Scalar ────────────────────────────────────────────────────────────────
+
+  setScalar<F extends ChatScalarField>(
+    pluginId: string,
+    field: F,
+    value: ChatScalarValues[F],
+  ): Disposable {
+    const stack = (this.scalarStacks.get(field) ?? []) as ScalarEntry<F>[];
+    const prevTop = stack[stack.length - 1];
+    const entry: ScalarEntry<F> = {
+      registrationId: this.nextId(),
+      pluginId,
+      field,
+      value,
+      registeredAt: Date.now(),
+    };
+    stack.push(entry);
+    this.scalarStacks.set(field, stack as ScalarEntry<ChatScalarField>[]);
+
+    auditStore.record({
+      kind: "chat.scalar.set",
+      field,
+      pluginId,
+      supersededPluginId: prevTop?.pluginId,
+      timestamp: entry.registeredAt,
+    });
+    if (prevTop && prevTop.pluginId !== pluginId) {
+      auditStore.record({
+        kind: "chat.scalar.superseded",
+        field,
+        pluginId: prevTop.pluginId,
+        supersededPluginId: pluginId,
+        timestamp: entry.registeredAt,
+      });
+    }
+
+    this.rebuildScalarSnapshot();
+    this.notify();
+
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const cur = (this.scalarStacks.get(field) ?? []) as ScalarEntry<F>[];
+        const idx = cur.findIndex(
+          (e) => e.registrationId === entry.registrationId,
+        );
+        if (idx < 0) return;
+        cur.splice(idx, 1);
+        this.scalarStacks.set(field, cur as ScalarEntry<ChatScalarField>[]);
+        auditStore.record({
+          kind: "chat.scalar.dispose",
+          field,
+          pluginId,
+          timestamp: Date.now(),
+        });
+        this.rebuildScalarSnapshot();
+        this.notify();
+      },
+    };
+  }
+
+  // ── Additive lists ────────────────────────────────────────────────────────
+
+  addRightHeader(pluginId: string, item: ChatNodeItem): Disposable {
+    return this.addToList("header.rightHeader", pluginId, item);
+  }
+
+  addSenderPrefix(pluginId: string, item: ChatNodeItem): Disposable {
+    return this.addToList("sender.prefix", pluginId, item);
+  }
+
+  addSenderSuggestions(
+    pluginId: string,
+    item: ChatSuggestionsItem,
+  ): Disposable {
+    return this.addToList("sender.suggestions", pluginId, item);
+  }
+
+  addAction(pluginId: string, spec: ChatActionSpec): Disposable {
+    return this.addToList("actions", pluginId, {
+      id: spec.id,
+      pluginId,
+      item: spec,
+    });
+  }
+
+  addRequestAction(pluginId: string, spec: ChatActionSpec): Disposable {
+    return this.addToList("requestActions", pluginId, {
+      id: spec.id,
+      pluginId,
+      item: spec,
+    });
+  }
+
+  addToolRender(
+    pluginId: string,
+    toolName: string,
+    render: ChatToolRendererItem["render"],
+  ): Disposable {
+    return this.addToList("customToolRender", pluginId, {
+      id: `${pluginId}:${toolName}`,
+      toolName,
+      render,
+    });
+  }
+
+  addCard(
+    pluginId: string,
+    cardName: string,
+    render: ChatCardItem["render"],
+  ): Disposable {
+    return this.addToList("cards", pluginId, {
+      id: `${pluginId}:${cardName}`,
+      cardName,
+      render,
+    });
+  }
+
+  addRequestPrepend(
+    pluginId: string,
+    item: ChatSlotItem<ChatRequestSlotFn>,
+  ): Disposable {
+    return this.addToList("request.prepend", pluginId, item);
+  }
+
+  addRequestAppend(
+    pluginId: string,
+    item: ChatSlotItem<ChatRequestSlotFn>,
+  ): Disposable {
+    return this.addToList("request.append", pluginId, item);
+  }
+
+  addResponsePrepend(
+    pluginId: string,
+    item: ChatSlotItem<ChatResponseSlotFn>,
+  ): Disposable {
+    return this.addToList("response.prepend", pluginId, item);
+  }
+
+  addResponseAppend(
+    pluginId: string,
+    item: ChatSlotItem<ChatResponseSlotFn>,
+  ): Disposable {
+    return this.addToList("response.append", pluginId, item);
+  }
+
+  private addToList<F extends ChatListField>(
+    field: F,
+    pluginId: string,
+    item: ChatListSnapshot[F][number]["item"],
+  ): Disposable {
+    const registrationId = this.nextId();
+    const registeredAt = Date.now();
+    const entry: ListEntry<typeof item> = {
+      registrationId,
+      pluginId,
+      item,
+      registeredAt,
+    };
+    (this.listMaps[field] as ListEntry<typeof item>[]).push(entry);
+
+    auditStore.record({
+      kind: "chat.list.add",
+      field,
+      pluginId,
+      detail: this.itemDescription(field, item),
+      timestamp: registeredAt,
+    });
+
+    this.rebuildListSnapshot(field);
+    this.notify();
+
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const arr = this.listMaps[field] as ListEntry<typeof item>[];
+        const idx = arr.findIndex((e) => e.registrationId === registrationId);
+        if (idx < 0) return;
+        arr.splice(idx, 1);
+        auditStore.record({
+          kind: "chat.list.dispose",
+          field,
+          pluginId,
+          timestamp: Date.now(),
+        });
+        this.rebuildListSnapshot(field);
+        this.notify();
+      },
+    };
+  }
+
+  // ── Bulk dispose for plugin unload (future) ───────────────────────────────
+
+  disposeAll(pluginId: string): void {
+    let mutated = false;
+
+    for (const [field, stack] of this.scalarStacks) {
+      const filtered = stack.filter((e) => e.pluginId !== pluginId);
+      if (filtered.length !== stack.length) {
+        this.scalarStacks.set(field, filtered);
+        mutated = true;
+      }
+    }
+
+    for (const field of Object.keys(this.listMaps) as ChatListField[]) {
+      const arr = this.listMaps[field] as ListEntry<unknown>[];
+      const filtered = arr.filter((e) => e.pluginId !== pluginId);
+      if (filtered.length !== arr.length) {
+        (this.listMaps as unknown as Record<string, ListEntry<unknown>[]>)[
+          field
+        ] = filtered;
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      this.rebuildScalarSnapshot();
+      for (const field of Object.keys(this.listMaps) as ChatListField[]) {
+        this.rebuildListSnapshot(field);
+      }
+      this.notify();
+    }
+  }
+
+  // ── Read API (snapshots are stable refs between mutations) ────────────────
+
+  getScalarSnapshot(): ChatScalarSnapshot {
+    return this.scalarSnapshot;
+  }
+
+  getListSnapshot(): ChatListSnapshot {
+    return this.listSnapshot;
+  }
+
+  // ── Subscription ──────────────────────────────────────────────────────────
+
+  subscribe(cb: () => void): () => void {
+    this.listeners.add(cb);
+    return () => this.listeners.delete(cb);
+  }
+
+  // ── Test helper ───────────────────────────────────────────────────────────
+
+  /** Reset all state. Tests only. */
+  __resetForTests(): void {
+    this.scalarStacks.clear();
+    for (const f of Object.keys(this.listMaps) as ChatListField[]) {
+      (this.listMaps as unknown as Record<string, ListEntry<unknown>[]>)[f] =
+        [];
+    }
+    this.rebuildScalarSnapshot();
+    for (const f of Object.keys(this.listMaps) as ChatListField[]) {
+      this.rebuildListSnapshot(f);
+    }
+    this.listeners.clear();
+    this.seq = 0;
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────────────
+
+  private nextId(): string {
+    this.seq += 1;
+    return `r${this.seq}`;
+  }
+
+  private rebuildScalarSnapshot(): void {
+    const next: ChatScalarSnapshot = {};
+    for (const [field, stack] of this.scalarStacks) {
+      const top = stack[stack.length - 1];
+      if (top) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (next as any)[field] = { pluginId: top.pluginId, value: top.value };
+      }
+    }
+    this.scalarSnapshot = next;
+  }
+
+  private rebuildListSnapshot(field: ChatListField): void {
+    // Always rebuild the full snapshot object so consumers can compare by ref.
+    this.listSnapshot = {
+      "header.rightHeader": this.listMaps["header.rightHeader"].slice(),
+      "sender.prefix": this.listMaps["sender.prefix"].slice(),
+      "sender.suggestions": this.listMaps["sender.suggestions"].slice(),
+      actions: this.listMaps.actions.slice(),
+      requestActions: this.listMaps.requestActions.slice(),
+      cards: this.listMaps.cards.slice(),
+      customToolRender: this.listMaps.customToolRender.slice(),
+      "request.prepend": this.listMaps["request.prepend"].slice(),
+      "request.append": this.listMaps["request.append"].slice(),
+      "response.prepend": this.listMaps["response.prepend"].slice(),
+      "response.append": this.listMaps["response.append"].slice(),
+    };
+    void field;
+  }
+
+  private notify(): void {
+    for (const fn of this.listeners) {
+      try {
+        fn();
+      } catch (err) {
+        console.warn("[QwenPaw] chatExtensions listener threw:", err);
+      }
+    }
+  }
+
+  private itemDescription(field: ChatListField, item: unknown): string {
+    if (field === "actions" || field === "requestActions") {
+      const a = item as ChatActionItem;
+      return a?.id ?? "(no id)";
+    }
+    if (field === "customToolRender") {
+      return (item as ChatToolRendererItem).toolName;
+    }
+    if (field === "cards") {
+      return (item as ChatCardItem).cardName;
+    }
+    if (field === "sender.suggestions") {
+      return (item as ChatSuggestionsItem).id;
+    }
+    return (item as ChatNodeItem).id ?? "(no id)";
+  }
+}
+
+// Suppress noisy unused-locale type warning when value resolution happens in consumers.
+export type { Localized };
+
+export const chatExtensions = new ChatExtensionsRegistry();

--- a/console/src/plugins/registry/hooks.ts
+++ b/console/src/plugins/registry/hooks.ts
@@ -1,0 +1,25 @@
+/**
+ * registry/hooks.ts — React subscriptions for Menu / Route / Slot registries.
+ *
+ * All hooks use useSyncExternalStore against the shared notify bus, so any
+ * registration triggers a single render pass for the affected consumers.
+ */
+import { useSyncExternalStore } from "react";
+import { menuRegistry, routeRegistry, slotRegistry, subscribe } from "./store";
+import type { MenuItem, MenuLocation, SlotName } from "./types";
+
+export function useMenuItems(location: MenuLocation): MenuItem[] {
+  return useSyncExternalStore(subscribe, () => menuRegistry.snapshot(location));
+}
+
+export function useAllMenuItems(): MenuItem[] {
+  return useSyncExternalStore(subscribe, () => menuRegistry.snapshot());
+}
+
+export function useRoutes(): ReturnType<typeof routeRegistry.snapshot> {
+  return useSyncExternalStore(subscribe, () => routeRegistry.snapshot());
+}
+
+export function useSlotEntries(name: SlotName) {
+  return useSyncExternalStore(subscribe, () => slotRegistry.snapshot(name));
+}

--- a/console/src/plugins/registry/sdk.ts
+++ b/console/src/plugins/registry/sdk.ts
@@ -1,0 +1,125 @@
+/**
+ * registry/sdk.ts — public plugin API factory.
+ *
+ * `buildPluginSdk()` returns an object suitable for attaching to
+ * `window.QwenPaw.{menu, route, slot, audit}`. All plugin-facing methods take
+ * `pluginId` as their first argument (mirrors existing
+ * `registerRoutes("cloudpaw", …)` style — no async "currentPlugin" magic).
+ *
+ * Wired by `hostExternals.ts → installHostExternals()` in Commit 3.
+ */
+import type {
+  Disposable,
+  MenuItem,
+  OverrideRecord,
+  Route,
+  RouteWrapper,
+  SlotInfo,
+  SlotName,
+  SlotOpts,
+  SlotRenderer,
+} from "./types";
+import { menuRegistry, routeRegistry, slotRegistry } from "./store";
+import { auditStore } from "./audit";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin-facing namespaces
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface QwenPawMenuNamespace {
+  add(pluginId: string, item: MenuItem | MenuItem[]): Disposable;
+  replace(pluginId: string, targetId: string, item: MenuItem): Disposable;
+  remove(targetId: string): void;
+  snapshot(location?: Parameters<typeof menuRegistry.snapshot>[0]): MenuItem[];
+}
+
+export interface QwenPawRouteNamespace {
+  add(pluginId: string, route: Route | Route[]): Disposable;
+  replace(
+    pluginId: string,
+    targetId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    component: React.ComponentType<any>,
+  ): Disposable;
+  wrap(pluginId: string, targetId: string, wrapper: RouteWrapper): Disposable;
+  remove(targetId: string): void;
+}
+
+export interface QwenPawSlotNamespace {
+  fill(
+    pluginId: string,
+    name: SlotName,
+    render: SlotRenderer,
+    opts?: SlotOpts,
+  ): Disposable;
+  replace(
+    pluginId: string,
+    name: SlotName,
+    render: SlotRenderer,
+    opts?: SlotOpts,
+  ): Disposable;
+  snapshot(): SlotInfo[];
+}
+
+export interface QwenPawAuditNamespace {
+  overrides(): OverrideRecord[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { combineDisposables } from "./types";
+
+function asArray<T>(x: T | T[]): T[] {
+  return Array.isArray(x) ? x : [x];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factories
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildMenuNamespace(): QwenPawMenuNamespace {
+  return {
+    add: (pluginId, item) => {
+      const items = asArray(item);
+      const ds = items.map((i) => menuRegistry.add(pluginId, i));
+      return combineDisposables(...ds);
+    },
+    replace: (pluginId, targetId, item) =>
+      menuRegistry.replace(pluginId, targetId, item),
+    remove: (targetId) => menuRegistry.remove(targetId),
+    snapshot: (location) => menuRegistry.snapshot(location),
+  };
+}
+
+export function buildRouteNamespace(): QwenPawRouteNamespace {
+  return {
+    add: (pluginId, route) => {
+      const routes = asArray(route);
+      const ds = routes.map((r) => routeRegistry.add(pluginId, r));
+      return combineDisposables(...ds);
+    },
+    replace: (pluginId, targetId, component) =>
+      routeRegistry.replace(pluginId, targetId, component),
+    wrap: (pluginId, targetId, wrapper) =>
+      routeRegistry.wrap(pluginId, targetId, wrapper),
+    remove: (targetId) => routeRegistry.remove(targetId),
+  };
+}
+
+export function buildSlotNamespace(): QwenPawSlotNamespace {
+  return {
+    fill: (pluginId, name, render, opts) =>
+      slotRegistry.fill(pluginId, name, render, opts),
+    replace: (pluginId, name, render, opts) =>
+      slotRegistry.replace(pluginId, name, render, opts),
+    snapshot: () => slotRegistry.snapshotAll(),
+  };
+}
+
+export function buildAuditNamespace(): QwenPawAuditNamespace {
+  return {
+    overrides: () => auditStore.overrides(),
+  };
+}

--- a/console/src/plugins/registry/slotKeys.ts
+++ b/console/src/plugins/registry/slotKeys.ts
@@ -1,0 +1,57 @@
+/**
+ * registry/slotKeys.ts — single source of truth for chat slot field names.
+ *
+ * All string literals used as keys into chatExtensions (setScalar / addToList /
+ * snapshot / audit) live here. The `ChatScalarField` / `ChatListField` union
+ * types are derived from these objects, so adding a new slot is one entry.
+ *
+ * ── How to add a new slot ────────────────────────────────────────────────────
+ * 1. Add the entry to `ChatScalar` or `ChatList` below.
+ * 2. Add the corresponding value-type to `ChatScalarValues` in types.ts.
+ * 3. Add the snapshot entry to `ChatScalarSnapshot` (scalar) or
+ *    `ChatListSnapshot` (list) in chatExtensions.ts. TypeScript will flag
+ *    mismatches in chatExtensions.ts at compile time.
+ * 4. Expose via the plugin API in hostSdk/install.ts.
+ * 5. Read & merge in pages/Chat/index.tsx options useMemo.
+ *
+ * Field strings follow `domain.field` dotted naming so they read naturally
+ * in audit logs and developer tools (e.g. `welcome.greeting`, not `wg`).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+/** Scalar (last-writer-wins) slot keys. */
+export const ChatScalar = {
+  welcomeGreeting: "welcome.greeting",
+  welcomeDescription: "welcome.description",
+  welcomeAvatar: "welcome.avatar",
+  welcomeNick: "welcome.nick",
+  welcomePrompts: "welcome.prompts",
+  welcomeRender: "welcome.render",
+  headerLeftTitle: "header.leftTitle",
+  headerLeftLogo: "header.leftLogo",
+  headerLeftHeaderRender: "header.leftHeader.render",
+  themeColorPrimary: "theme.colorPrimary",
+  senderPlaceholder: "sender.placeholder",
+  senderDisclaimer: "sender.disclaimer",
+  requestRender: "request.render",
+  responseRender: "response.render",
+} as const;
+
+export type ChatScalarField = (typeof ChatScalar)[keyof typeof ChatScalar];
+
+/** Additive list slot keys. */
+export const ChatList = {
+  rightHeader: "header.rightHeader",
+  senderPrefix: "sender.prefix",
+  senderSuggestions: "sender.suggestions",
+  actions: "actions",
+  requestActions: "requestActions",
+  cards: "cards",
+  customToolRender: "customToolRender",
+  requestPrepend: "request.prepend",
+  requestAppend: "request.append",
+  responsePrepend: "response.prepend",
+  responseAppend: "response.append",
+} as const;
+
+export type ChatListField = (typeof ChatList)[keyof typeof ChatList];

--- a/console/src/plugins/registry/store.ts
+++ b/console/src/plugins/registry/store.ts
@@ -1,0 +1,751 @@
+/**
+ * registry/store.ts — Menu / Route / Slot singletons backed by a shared notify bus.
+ *
+ * Three sub-registries share one subscriber set (`notify`) so a single
+ * `useSyncExternalStore` subscription wakes up consumers of any of them.
+ * Snapshot methods return memoized stable refs between mutations to keep
+ * downstream useMemo deps quiet.
+ *
+ * Conflict policy:
+ *   - menu.add of duplicate id → no-op + audit "menu.conflict" + warn.
+ *   - route.add of duplicate id OR path → no-op + audit "route.conflict".
+ *   - menu.replace / route.replace → LIFO stack; dispose pops to prior winner.
+ *   - route.wrap → list, reduceRight composition (last-registered wraps outermost).
+ *   - slot.replace → LIFO winner among entries with kind="replace"; fills are
+ *     skipped entirely when a replace is active.
+ */
+import type {
+  Disposable,
+  MenuItem,
+  MenuLocation,
+  Route,
+  RouteWrapper,
+  SlotInfo,
+  SlotKind,
+  SlotName,
+  SlotOpts,
+  SlotRenderer,
+} from "./types";
+import { auditStore } from "./audit";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared notify bus
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  for (const fn of listeners) {
+    try {
+      fn();
+    } catch (err) {
+      console.warn("[QwenPaw registry] subscriber threw:", err);
+    }
+  }
+}
+
+export function subscribe(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+let seq = 0;
+const nextId = () => {
+  seq += 1;
+  return `r${seq}`;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MenuRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MenuEntry {
+  source: string;
+  item: MenuItem;
+  registrationId: string;
+  registeredAt: number;
+}
+
+class MenuRegistryImpl {
+  // Single source: each id has a STACK of entries (replace pushes, dispose pops).
+  private stacks = new Map<string, MenuEntry[]>();
+  private snapshots = new Map<MenuLocation | "*", MenuItem[]>();
+  private allSnapshot: MenuItem[] = [];
+
+  /** Used by builtinMenu.ts at module-load time. source = "core". */
+  addBuiltin(items: MenuItem[]): void {
+    for (const item of items) {
+      this.addInternal("core", item, /*isReplace*/ false, /*silent*/ true);
+    }
+    this.invalidate();
+    notify();
+  }
+
+  add(source: string, item: MenuItem): Disposable {
+    return this.addInternal(source, item, false, false);
+  }
+
+  replace(source: string, targetId: string, item: MenuItem): Disposable {
+    const stack = this.stacks.get(targetId);
+    if (!stack || stack.length === 0) {
+      // No prior — treat as add. Audit as conflict so reviewer notices.
+      auditStore.record({
+        kind: "menu.conflict",
+        targetId,
+        pluginId: source,
+        detail: "replace target not found; falling back to add",
+        timestamp: Date.now(),
+      });
+      return this.addInternal(source, { ...item, id: targetId }, false, false);
+    }
+    return this.addInternal(source, { ...item, id: targetId }, true, false);
+  }
+
+  remove(targetId: string): void {
+    if (this.stacks.delete(targetId)) {
+      this.invalidate();
+      notify();
+    }
+  }
+
+  snapshot(location?: MenuLocation): MenuItem[] {
+    if (!location) {
+      return this.allSnapshot;
+    }
+    const cached = this.snapshots.get(location);
+    if (cached) return cached;
+    const built = this.buildSnapshot(location);
+    this.snapshots.set(location, built);
+    return built;
+  }
+
+  /** Test-only. */
+  __resetForTests(): void {
+    this.stacks.clear();
+    this.invalidate();
+  }
+
+  private addInternal(
+    source: string,
+    item: MenuItem,
+    isReplace: boolean,
+    silent: boolean,
+  ): Disposable {
+    const existing = this.stacks.get(item.id);
+    if (existing && existing.length > 0 && !isReplace) {
+      auditStore.record({
+        kind: "menu.conflict",
+        targetId: item.id,
+        pluginId: source,
+        supersededPluginId: existing[existing.length - 1].source,
+        detail: "duplicate id; call replace() to override",
+        timestamp: Date.now(),
+      });
+      return { dispose: () => {} };
+    }
+    const entry: MenuEntry = {
+      source,
+      item,
+      registrationId: nextId(),
+      registeredAt: Date.now(),
+    };
+    const stack = existing ?? [];
+    const prevTop = stack[stack.length - 1];
+    stack.push(entry);
+    this.stacks.set(item.id, stack);
+
+    if (!silent) {
+      auditStore.record({
+        kind: isReplace ? "menu.replace" : "menu.add",
+        targetId: item.id,
+        pluginId: source,
+        supersededPluginId: prevTop?.source,
+        timestamp: entry.registeredAt,
+      });
+      this.invalidate();
+      notify();
+    }
+
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const cur = this.stacks.get(item.id);
+        if (!cur) return;
+        const idx = cur.findIndex(
+          (e) => e.registrationId === entry.registrationId,
+        );
+        if (idx < 0) return;
+        cur.splice(idx, 1);
+        if (cur.length === 0) {
+          this.stacks.delete(item.id);
+        }
+        auditStore.record({
+          kind: "menu.dispose",
+          targetId: item.id,
+          pluginId: source,
+          timestamp: Date.now(),
+        });
+        this.invalidate();
+        notify();
+      },
+    };
+  }
+
+  private invalidate(): void {
+    this.snapshots.clear();
+    this.allSnapshot = this.collectWinners();
+  }
+
+  private collectWinners(): MenuItem[] {
+    const winners: MenuItem[] = [];
+    for (const stack of this.stacks.values()) {
+      const top = stack[stack.length - 1];
+      if (top) winners.push(top.item);
+    }
+    return winners;
+  }
+
+  private buildSnapshot(location: MenuLocation): MenuItem[] {
+    const winners = this.allSnapshot;
+    const inBucket = winners.filter(
+      (i) => (i.location ?? "primary.settings") === location,
+    );
+    const visible = inBucket.filter((i) => i.visible?.() !== false);
+    return sortAndTree(visible);
+  }
+}
+
+/**
+ * Topo-sort by before/after with order tiebreak, then group children under
+ * their parentId. Returns the top-level items (parents); children live inside
+ * each parent under a `__children` ad-hoc field which the Sidebar adapter
+ * unpacks. We attach via a wrapped item rather than mutating to keep
+ * snapshot refs stable.
+ */
+function sortAndTree(items: MenuItem[]): MenuItem[] {
+  const sorted = topoSort(items);
+  const byId = new Map(sorted.map((i) => [i.id, i] as const));
+  const childrenOf = new Map<string, MenuItem[]>();
+  const topLevel: MenuItem[] = [];
+
+  for (const item of sorted) {
+    if (item.parentId && byId.has(item.parentId)) {
+      const arr = childrenOf.get(item.parentId) ?? [];
+      arr.push(item);
+      childrenOf.set(item.parentId, arr);
+    } else {
+      topLevel.push(item);
+    }
+  }
+
+  return topLevel.map((parent) => {
+    const kids = childrenOf.get(parent.id);
+    if (!kids) return parent;
+    // Attach via a wrapper symbol so antd adapter can pull children out.
+    return Object.assign({}, parent, { __children: kids } as Partial<MenuItem>);
+  });
+}
+
+/**
+ * Kahn's algorithm over before/after constraints. Ties broken by
+ * `order` (numeric ascending, missing = Infinity) then by stable input order.
+ */
+function topoSort(items: MenuItem[]): MenuItem[] {
+  const byId = new Map(items.map((i) => [i.id, i] as const));
+  const adj = new Map<string, Set<string>>(); // id → ids that must come AFTER it
+  const indeg = new Map<string, number>();
+  for (const i of items) {
+    adj.set(i.id, new Set());
+    indeg.set(i.id, 0);
+  }
+  for (const i of items) {
+    if (i.before && byId.has(i.before)) {
+      adj.get(i.id)!.add(i.before);
+      indeg.set(i.before, (indeg.get(i.before) ?? 0) + 1);
+    }
+    if (i.after && byId.has(i.after)) {
+      adj.get(i.after)!.add(i.id);
+      indeg.set(i.id, (indeg.get(i.id) ?? 0) + 1);
+    }
+  }
+  const ready: MenuItem[] = items.filter((i) => (indeg.get(i.id) ?? 0) === 0);
+  ready.sort(byOrder);
+  const out: MenuItem[] = [];
+  while (ready.length > 0) {
+    const next = ready.shift()!;
+    out.push(next);
+    for (const childId of adj.get(next.id) ?? []) {
+      const d = (indeg.get(childId) ?? 0) - 1;
+      indeg.set(childId, d);
+      if (d === 0) {
+        const child = byId.get(childId);
+        if (child) {
+          ready.push(child);
+          ready.sort(byOrder);
+        }
+      }
+    }
+  }
+  // Cycle? Append remaining by order as fallback.
+  if (out.length < items.length) {
+    const remaining = items.filter((i) => !out.includes(i)).sort(byOrder);
+    out.push(...remaining);
+  }
+  return out;
+}
+
+function byOrder(a: { order?: number }, b: { order?: number }): number {
+  return (a.order ?? Infinity) - (b.order ?? Infinity);
+}
+
+export const menuRegistry = new MenuRegistryImpl();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RouteRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RouteEntry {
+  source: string;
+  route: Route;
+  registrationId: string;
+}
+
+interface RouteOverrideEntry {
+  source: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: React.ComponentType<any>;
+  registrationId: string;
+}
+
+interface RouteWrapEntry {
+  source: string;
+  wrapper: RouteWrapper;
+  registrationId: string;
+}
+
+interface ResolvedRoute {
+  id: string;
+  path: string;
+  source: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Component: React.ComponentType<any>;
+}
+
+class RouteRegistryImpl {
+  private bases = new Map<string, RouteEntry>();
+  private overrides = new Map<string, RouteOverrideEntry[]>(); // stack
+  private wraps = new Map<string, RouteWrapEntry[]>(); // order = registration order
+  private resolvedSnapshot: ResolvedRoute[] = [];
+
+  /** Used by builtinRoutes.ts. source = "core". */
+  addBuiltin(routes: Route[]): void {
+    for (const r of routes) {
+      this.addInternal("core", r, /*silent*/ true);
+    }
+    this.invalidate();
+    notify();
+  }
+
+  add(source: string, route: Route): Disposable {
+    return this.addInternal(source, route, false);
+  }
+
+  replace(
+    source: string,
+    targetId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    component: React.ComponentType<any>,
+  ): Disposable {
+    const stack = this.overrides.get(targetId) ?? [];
+    const entry: RouteOverrideEntry = {
+      source,
+      component,
+      registrationId: nextId(),
+    };
+    const prev = stack[stack.length - 1];
+    stack.push(entry);
+    this.overrides.set(targetId, stack);
+    auditStore.record({
+      kind: "route.replace",
+      targetId,
+      pluginId: source,
+      supersededPluginId: prev?.source,
+      timestamp: Date.now(),
+    });
+    this.invalidate();
+    notify();
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const cur = this.overrides.get(targetId) ?? [];
+        const idx = cur.findIndex(
+          (e) => e.registrationId === entry.registrationId,
+        );
+        if (idx < 0) return;
+        cur.splice(idx, 1);
+        if (cur.length === 0) this.overrides.delete(targetId);
+        auditStore.record({
+          kind: "route.dispose",
+          targetId,
+          pluginId: source,
+          timestamp: Date.now(),
+        });
+        this.invalidate();
+        notify();
+      },
+    };
+  }
+
+  wrap(source: string, targetId: string, wrapper: RouteWrapper): Disposable {
+    const list = this.wraps.get(targetId) ?? [];
+    const entry: RouteWrapEntry = {
+      source,
+      wrapper,
+      registrationId: nextId(),
+    };
+    list.push(entry);
+    this.wraps.set(targetId, list);
+    auditStore.record({
+      kind: "route.wrap",
+      targetId,
+      pluginId: source,
+      timestamp: Date.now(),
+    });
+    this.invalidate();
+    notify();
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const cur = this.wraps.get(targetId) ?? [];
+        const idx = cur.findIndex(
+          (e) => e.registrationId === entry.registrationId,
+        );
+        if (idx < 0) return;
+        cur.splice(idx, 1);
+        if (cur.length === 0) this.wraps.delete(targetId);
+        auditStore.record({
+          kind: "route.dispose",
+          targetId,
+          pluginId: source,
+          timestamp: Date.now(),
+        });
+        this.invalidate();
+        notify();
+      },
+    };
+  }
+
+  remove(targetId: string): void {
+    const changed =
+      this.bases.delete(targetId) ||
+      this.overrides.delete(targetId) ||
+      this.wraps.delete(targetId);
+    if (changed) {
+      this.invalidate();
+      notify();
+    }
+  }
+
+  snapshot(): ResolvedRoute[] {
+    return this.resolvedSnapshot;
+  }
+
+  /** Test-only. */
+  __resetForTests(): void {
+    this.bases.clear();
+    this.overrides.clear();
+    this.wraps.clear();
+    this.invalidate();
+  }
+
+  private addInternal(
+    source: string,
+    route: Route,
+    silent: boolean,
+  ): Disposable {
+    if (this.bases.has(route.id)) {
+      auditStore.record({
+        kind: "route.conflict",
+        targetId: route.id,
+        pluginId: source,
+        detail: "duplicate route id; ignored",
+        timestamp: Date.now(),
+      });
+      return { dispose: () => {} };
+    }
+    // Path-uniqueness check across all bases
+    for (const existing of this.bases.values()) {
+      if (existing.route.path === route.path) {
+        auditStore.record({
+          kind: "route.conflict",
+          targetId: route.id,
+          pluginId: source,
+          detail: `path ${route.path} already registered by ${existing.source} (${existing.route.id})`,
+          timestamp: Date.now(),
+        });
+        return { dispose: () => {} };
+      }
+    }
+    const entry: RouteEntry = {
+      source,
+      route,
+      registrationId: nextId(),
+    };
+    this.bases.set(route.id, entry);
+    if (!silent) {
+      auditStore.record({
+        kind: "route.add",
+        targetId: route.id,
+        pluginId: source,
+        timestamp: Date.now(),
+      });
+      this.invalidate();
+      notify();
+    }
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const cur = this.bases.get(route.id);
+        if (!cur || cur.registrationId !== entry.registrationId) return;
+        this.bases.delete(route.id);
+        auditStore.record({
+          kind: "route.dispose",
+          targetId: route.id,
+          pluginId: source,
+          timestamp: Date.now(),
+        });
+        this.invalidate();
+        notify();
+      },
+    };
+  }
+
+  private invalidate(): void {
+    this.resolvedSnapshot = this.resolveAll();
+  }
+
+  private resolveAll(): ResolvedRoute[] {
+    const out: ResolvedRoute[] = [];
+    for (const entry of this.bases.values()) {
+      const overrideStack = this.overrides.get(entry.route.id);
+      const overrideTop = overrideStack?.[overrideStack.length - 1];
+      const base = overrideTop?.component ?? entry.route.component;
+      const wraps = this.wraps.get(entry.route.id) ?? [];
+      // reduce (left→right): first wrap is applied first (innermost), each
+      // subsequent wrap wraps the previous result — last-registered ends up
+      // outermost. Matches "later wrap takes the outside" per the doc.
+      const Component = wraps.reduce<
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        React.ComponentType<any>
+      >((Inner, w) => w.wrapper(Inner), base);
+      out.push({
+        id: entry.route.id,
+        path: entry.route.path,
+        source: overrideTop?.source ?? entry.source,
+        Component,
+      });
+    }
+    return out;
+  }
+}
+
+export const routeRegistry = new RouteRegistryImpl();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SlotRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SlotEntry {
+  source: string;
+  kind: SlotKind;
+  render: SlotRenderer;
+  opts: SlotOpts;
+  registrationId: string;
+  registeredAt: number;
+}
+
+class SlotRegistryImpl {
+  private slots = new Map<SlotName, SlotEntry[]>();
+  private snapshots = new Map<SlotName, SlotEntry[]>();
+
+  fill(
+    source: string,
+    name: SlotName,
+    render: SlotRenderer,
+    opts: SlotOpts = {},
+  ): Disposable {
+    return this.addInternal(source, name, "fill", render, opts);
+  }
+
+  replace(
+    source: string,
+    name: SlotName,
+    render: SlotRenderer,
+    opts: SlotOpts = {},
+  ): Disposable {
+    return this.addInternal(source, name, "replace", render, opts);
+  }
+
+  snapshot(name: SlotName): SlotEntry[] {
+    const cached = this.snapshots.get(name);
+    if (cached) return cached;
+    const built = this.buildSnapshot(name);
+    this.snapshots.set(name, built);
+    return built;
+  }
+
+  /** Debug: every registered slot across the registry. */
+  snapshotAll(): SlotInfo[] {
+    const out: SlotInfo[] = [];
+    for (const [name, entries] of this.slots) {
+      for (const e of entries) {
+        out.push({
+          name,
+          kind: e.kind,
+          source: e.source,
+          id: e.opts.id,
+          order: e.opts.order,
+        });
+      }
+    }
+    return out;
+  }
+
+  /** Test-only. */
+  __resetForTests(): void {
+    this.slots.clear();
+    this.snapshots.clear();
+  }
+
+  private addInternal(
+    source: string,
+    name: SlotName,
+    kind: SlotKind,
+    render: SlotRenderer,
+    opts: SlotOpts,
+  ): Disposable {
+    const entry: SlotEntry = {
+      source,
+      kind,
+      render,
+      opts,
+      registrationId: nextId(),
+      registeredAt: Date.now(),
+    };
+    const arr = this.slots.get(name) ?? [];
+    const priorReplace = arr.find((e) => e.kind === "replace");
+    arr.push(entry);
+    this.slots.set(name, arr);
+    auditStore.record({
+      kind: kind === "replace" ? "slot.replace" : "slot.fill",
+      targetId: name,
+      pluginId: source,
+      supersededPluginId: kind === "replace" ? priorReplace?.source : undefined,
+      detail: opts.id,
+      timestamp: entry.registeredAt,
+    });
+    this.snapshots.delete(name);
+    notify();
+    let disposed = false;
+    return {
+      dispose: () => {
+        if (disposed) return;
+        disposed = true;
+        const cur = this.slots.get(name) ?? [];
+        const idx = cur.findIndex(
+          (e) => e.registrationId === entry.registrationId,
+        );
+        if (idx < 0) return;
+        cur.splice(idx, 1);
+        if (cur.length === 0) this.slots.delete(name);
+        this.snapshots.delete(name);
+        auditStore.record({
+          kind: "slot.dispose",
+          targetId: name,
+          pluginId: source,
+          timestamp: Date.now(),
+        });
+        notify();
+      },
+    };
+  }
+
+  private buildSnapshot(name: SlotName): SlotEntry[] {
+    const entries = (this.slots.get(name) ?? []).filter(
+      (e) => e.opts.visible?.() !== false,
+    );
+    const replaceEntries = entries.filter((e) => e.kind === "replace");
+    if (replaceEntries.length > 0) {
+      // Only the LAST replace wins; fills are dropped.
+      return [replaceEntries[replaceEntries.length - 1]];
+    }
+    return sortFillEntries(entries);
+  }
+}
+
+function sortFillEntries(entries: SlotEntry[]): SlotEntry[] {
+  // Topo sort by before/after on opts.id, with order/registeredAt tiebreak.
+  const byId = new Map<string, SlotEntry>();
+  for (const e of entries) {
+    if (e.opts.id) byId.set(e.opts.id, e);
+  }
+  const adj = new Map<string, Set<string>>();
+  const indeg = new Map<string, number>();
+  const sentinel = (e: SlotEntry) => e.registrationId;
+  for (const e of entries) {
+    adj.set(sentinel(e), new Set());
+    indeg.set(sentinel(e), 0);
+  }
+  for (const e of entries) {
+    if (e.opts.before && byId.has(e.opts.before)) {
+      const targetSentinel = sentinel(byId.get(e.opts.before)!);
+      adj.get(sentinel(e))!.add(targetSentinel);
+      indeg.set(targetSentinel, (indeg.get(targetSentinel) ?? 0) + 1);
+    }
+    if (e.opts.after && byId.has(e.opts.after)) {
+      const targetSentinel = sentinel(byId.get(e.opts.after)!);
+      adj.get(targetSentinel)!.add(sentinel(e));
+      indeg.set(sentinel(e), (indeg.get(sentinel(e)) ?? 0) + 1);
+    }
+  }
+  const compare = (a: SlotEntry, b: SlotEntry) => {
+    const o = (a.opts.order ?? Infinity) - (b.opts.order ?? Infinity);
+    return o !== 0 ? o : a.registeredAt - b.registeredAt;
+  };
+  const ready = entries.filter((e) => (indeg.get(sentinel(e)) ?? 0) === 0);
+  ready.sort(compare);
+  const out: SlotEntry[] = [];
+  const bySentinel = new Map(entries.map((e) => [sentinel(e), e] as const));
+  while (ready.length > 0) {
+    const next = ready.shift()!;
+    out.push(next);
+    for (const child of adj.get(sentinel(next)) ?? []) {
+      const d = (indeg.get(child) ?? 0) - 1;
+      indeg.set(child, d);
+      if (d === 0) {
+        const childEntry = bySentinel.get(child);
+        if (childEntry) {
+          ready.push(childEntry);
+          ready.sort(compare);
+        }
+      }
+    }
+  }
+  if (out.length < entries.length) {
+    const remaining = entries.filter((e) => !out.includes(e)).sort(compare);
+    out.push(...remaining);
+  }
+  return out;
+}
+
+export const slotRegistry = new SlotRegistryImpl();
+export type { SlotEntry };

--- a/console/src/plugins/registry/types.ts
+++ b/console/src/plugins/registry/types.ts
@@ -1,0 +1,349 @@
+/**
+ * registry/types.ts — public shapes for the QwenPaw plugin extension registries.
+ *
+ * Three console-wide concepts:
+ *   - Menu  → sidebar entries with location/parentId/before/after/order
+ *   - Route → pages with add/replace/wrap
+ *   - Slot  → named layout fill points (header.left, sider.bottom, …)
+ *
+ * Plus the chat-surface customization shapes consumed by chatExtensions:
+ *   - Localized<T> for i18n-aware values
+ *   - Welcome / Request / Response render + slot fn signatures
+ *   - ChatScalarValues + supporting card/action item shapes
+ *
+ * Plugin-facing API surface lives in:
+ *   - sdk.ts                  (console-wide: menu/route/slot/audit)
+ *   - hostSdk/install.ts      (chat: chat.welcome/leftHeader/sender/...)
+ *
+ * Both surfaces share the single audit log in `./audit.ts`.
+ */
+import type React from "react";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Disposable
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface Disposable {
+  dispose(): void;
+}
+
+/** Combine multiple Disposables into one. Errors per-dispose are swallowed + logged. */
+export function combineDisposables(...d: Disposable[]): Disposable {
+  return {
+    dispose() {
+      for (const it of d) {
+        try {
+          it.dispose();
+        } catch (err) {
+          console.warn("[QwenPaw] Disposable threw on dispose:", err);
+        }
+      }
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Localized<T> — accept either a raw value or a `(locale) => value` callback.
+// The registry stores the raw shape verbatim; the consumer (ChatPage useMemo)
+// resolves the function form using the active i18n locale.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type Localized<T> = T | ((locale: string) => T);
+
+export function resolveLocalized<T>(
+  value: Localized<T> | undefined,
+  locale: string,
+): T | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "function"
+    ? (value as (l: string) => T)(locale)
+    : value;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Menu (console-wide)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type MenuLocation =
+  | "primary.agentScoped" // Sidebar Menu #1 (agent-bound entries: inbox, control, agent-group)
+  | "primary.settings" //   Sidebar Menu #2 (global settings + plugins-group)
+  | "userMenu"; //          Reserved for future avatar-dropdown items
+
+export interface MenuItem {
+  /** Globally unique id, e.g. "core.workspace" / "cloudpaw.a2a". */
+  id: string;
+  /** Which Sidebar bucket. Defaults to "primary.settings". */
+  location?: MenuLocation;
+  /**
+   * If set, this item is a CHILD of the named parent (groups: "core.control-group",
+   * "core.agent-group", "core.settings-group", "plugins-group", …).
+   * Items without parentId render at top level within their location bucket.
+   */
+  parentId?: string;
+  /** Relative-position constraint: render before the item with this id. */
+  before?: string;
+  /** Relative-position constraint: render after the item with this id. */
+  after?: string;
+  /** Numeric fallback when before/after can't disambiguate. Lower renders first. */
+  order?: number;
+  /**
+   * Display label. String for static, function for i18n + dynamic decoration
+   * (e.g. unread badge). Adapter wraps `null` returns in a Fragment.
+   */
+  label: string | (() => React.ReactNode);
+  /**
+   * Icon. ComponentType for SDK / lucide icons (rendered with size=16); ReactNode for
+   * plain emoji/img. We accept `ComponentType<any>` to allow any icon library
+   * (Spark, lucide, antd) whose props accept a `size` field even if typed loosely.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon?: React.ComponentType<any> | React.ReactNode;
+  /** Route id to navigate to when clicked. If absent, item is non-interactive (group header / divider). */
+  route?: string;
+  /** Hide this entry when callback returns false. Defaults to always visible. */
+  visible?: () => boolean;
+  /** Render as group header (children appear nested under it). */
+  isGroup?: boolean;
+  /** Render as horizontal divider. id is still required for de-dup. */
+  divider?: boolean;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Route (console-wide)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A registered route entry (added via builtinRoutes or QwenPaw.route.add). */
+export interface Route {
+  /** Stable id, e.g. "core.chat" / "cloudpaw.a2a". */
+  id: string;
+  /** URL path. Supports react-router patterns, including "/chat/*". */
+  path: string;
+  /** Lazy or eager component. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: React.ComponentType<any>;
+}
+
+/**
+ * Onion-style wrapper. Receives the inner component (current resolved render)
+ * and returns the new component to render. Multiple wraps compose;
+ * later-registered wrappers wrap the outside (see resolveRoute in store.ts).
+ */
+export type RouteWrapper = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Inner: React.ComponentType<any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => React.ComponentType<any>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slot (console-wide)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A free-form name like "header.left" / "sider.bottom". Host curates the list. */
+export type SlotName = string;
+
+export type SlotKind = "fill" | "replace";
+
+export interface SlotOpts {
+  /** Stable id for this fill; lets other fills target with before/after. */
+  id?: string;
+  /** Numeric fallback. Lower renders first. */
+  order?: number;
+  /** Render only when this returns true. */
+  visible?: () => boolean;
+  /** Render strictly before another fill (same slot). fill-mode only. */
+  before?: string;
+  /** Render strictly after another fill (same slot). fill-mode only. */
+  after?: string;
+}
+
+/**
+ * Slot render function. Receives the host's default content for this slot
+ * (i.e. the `children` passed to the <Slot> JSX element) so a
+ * conditional plugin can `return defaultContent` to opt out of replacement
+ * in some scenarios without having to re-implement the default itself.
+ * Plugins that always replace can ignore the parameter.
+ */
+export type SlotRenderer = (
+  defaultContent?: React.ReactNode,
+) => React.ReactNode;
+
+export interface SlotInfo {
+  name: SlotName;
+  kind: SlotKind;
+  source: string;
+  id?: string;
+  order?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chat scalar fields (last-writer-wins) — consumed by chatExtensions registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * SDK's welcome.render signature — receives the resolved welcome props plus
+ * `onSubmit` and returns the entire welcome surface. Plugins may also pass a
+ * plain `React.ReactNode`; install.ts wraps it into a fn before storage.
+ */
+export interface WelcomeRenderProps {
+  greeting?: React.ReactNode;
+  description?: React.ReactNode;
+  avatar?: string | React.ReactNode;
+  prompts?: Array<{ label?: React.ReactNode; value: string }>;
+  onSubmit: (data: { query: string; fileList?: unknown[] }) => void;
+}
+
+export type WelcomeRenderFn = (props: WelcomeRenderProps) => React.ReactElement;
+
+/**
+ * Plugin-facing data shapes for request/response cards.
+ * Kept loose (`unknown`-ish records) to avoid leaking vendor types — plugin
+ * authors who want strong typing can cast inside their handlers.
+ */
+export type ChatRequestData = Record<string, unknown>;
+export type ChatResponseData = Record<string, unknown>;
+
+export type ChatRequestRenderFn = (ctx: {
+  data: ChatRequestData;
+  fallback: () => React.ReactElement;
+}) => React.ReactNode;
+
+export type ChatResponseRenderFn = (ctx: {
+  data: ChatResponseData;
+  isLast?: boolean;
+  fallback: () => React.ReactElement;
+}) => React.ReactNode;
+
+export type ChatRequestSlotFn = (ctx: {
+  data: ChatRequestData;
+}) => React.ReactNode;
+export type ChatResponseSlotFn = (ctx: {
+  data: ChatResponseData;
+  isLast?: boolean;
+}) => React.ReactNode;
+
+export interface ChatSlotItem<F> {
+  id: string;
+  render: F;
+  order?: number;
+}
+
+// Chat scalar / list field name unions are defined in `./slotKeys.ts` for
+// single-source-of-truth ergonomics; re-exported here for caller convenience.
+export type { ChatScalarField, ChatListField } from "./slotKeys";
+import type { ChatScalarField, ChatListField } from "./slotKeys";
+
+export interface ChatScalarValues {
+  "welcome.greeting"?: Localized<React.ReactNode>;
+  "welcome.description"?: Localized<React.ReactNode>;
+  "welcome.avatar"?: Localized<string | React.ReactNode>;
+  "welcome.nick"?: Localized<string | React.ReactNode>;
+  "welcome.prompts"?: Localized<
+    Array<{ label?: React.ReactNode; value: string }>
+  >;
+  /** Whole-section override of the welcome panel. Wins over the partial fields above. */
+  "welcome.render"?: WelcomeRenderFn;
+  "header.leftTitle"?: Localized<React.ReactNode>;
+  "header.leftLogo"?: Localized<string | React.ReactNode>;
+  /** Whole-section override of theme.leftHeader. Wins over leftTitle/leftLogo. */
+  "header.leftHeader.render"?: React.ReactNode;
+  "theme.colorPrimary"?: string;
+  "sender.placeholder"?: Localized<string>;
+  "sender.disclaimer"?: Localized<React.ReactNode>;
+  /** Whole-bubble replacement for user requests. Wins over additive prepend/append slots. */
+  "request.render"?: ChatRequestRenderFn;
+  /** Whole-bubble replacement for assistant responses. */
+  "response.render"?: ChatResponseRenderFn;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chat list item shapes (additive) — consumed by chatExtensions registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ChatNodeItem {
+  id: string;
+  node: React.ReactNode;
+  order?: number;
+}
+
+export interface ChatSuggestionsItem {
+  id: string;
+  items: Localized<Array<{ label?: React.ReactNode; value: string }>>;
+}
+
+/**
+ * Loose shape matching `IAgentScopeRuntimeWebUIActionsOptions.list[number]`
+ * but kept host-owned to avoid leaking the vendor type to plugins.
+ */
+export interface ChatActionSpec {
+  id: string;
+  icon?: React.ReactElement;
+  /** Either `render` or `onClick`; `render` wins if both supplied (SDK behaviour). */
+  render?: (ctx: { data: unknown }) => React.ReactElement;
+  onClick?: (ctx: { data: unknown }) => void;
+}
+
+export interface ChatActionItem {
+  id: string;
+  pluginId: string;
+  item: ChatActionSpec;
+}
+
+export interface ChatToolRendererItem {
+  id: string;
+  toolName: string;
+  render: React.FC<
+    { result: unknown; sessionId: string; messageId: string } & Record<
+      string,
+      unknown
+    >
+  >;
+}
+
+export interface ChatCardItem {
+  id: string;
+  cardName: string;
+  render: React.FC<Record<string, unknown>>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit — unified across console + chat registries
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AuditKind =
+  // Console-wide registry events
+  | "menu.add"
+  | "menu.replace"
+  | "menu.dispose"
+  | "menu.conflict"
+  | "route.add"
+  | "route.replace"
+  | "route.wrap"
+  | "route.dispose"
+  | "route.conflict"
+  | "slot.fill"
+  | "slot.replace"
+  | "slot.dispose"
+  | "slot.error"
+  // Chat surface registry events
+  | "chat.scalar.set"
+  | "chat.scalar.superseded"
+  | "chat.scalar.dispose"
+  | "chat.list.add"
+  | "chat.list.dispose"
+  | "chat.error";
+
+export interface OverrideRecord {
+  kind: AuditKind;
+  /** What was acted on: menuId / routeId / slotName / scalar field / list field / etc. */
+  field?: ChatScalarField | ChatListField | string;
+  /**
+   * Compat alias for `field` used by the console-wide registries.
+   * Kept so consumers reading either name continue to work.
+   */
+  targetId?: string;
+  pluginId: string;
+  supersededPluginId?: string;
+  /** Free-form details (conflict reason, error message, slot id, …). */
+  detail?: string;
+  timestamp: number;
+}

--- a/console/src/plugins/registry/useChatExtensions.test.tsx
+++ b/console/src/plugins/registry/useChatExtensions.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * useChatExtensions.test.tsx — React-side integration of the registry.
+ *
+ * Renders a tiny component that consumes the hooks, then mutates the
+ * registry and asserts the component re-renders with new values.
+ * Avoids the heavy ChatPage mock setup (worker-crash-prone).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { chatExtensions } from "./chatExtensions";
+import { auditStore } from "./audit";
+import {
+  useChatScalarSnapshot,
+  useChatListSnapshot,
+} from "./useChatExtensions";
+import { PluginSlotBoundary } from "./PluginSlotBoundary";
+import { resolveLocalized } from "./types";
+
+beforeEach(() => {
+  chatExtensions.__resetForTests();
+  auditStore.clear();
+});
+
+function Probe() {
+  const scalar = useChatScalarSnapshot();
+  const lists = useChatListSnapshot();
+  return (
+    <div>
+      <span data-testid="greeting">
+        {String(
+          resolveLocalized(scalar["welcome.greeting"]?.value, "en") ?? "",
+        )}
+      </span>
+      <span data-testid="nick">
+        {String(resolveLocalized(scalar["welcome.nick"]?.value, "en") ?? "")}
+      </span>
+      <span data-testid="rightHeader-count">
+        {String(lists["header.rightHeader"].length)}
+      </span>
+      <span data-testid="actions-count">{String(lists.actions.length)}</span>
+    </div>
+  );
+}
+
+describe("useChatExtensions hooks", () => {
+  it("re-renders Probe when a plugin sets a scalar", () => {
+    render(<Probe />);
+    expect(screen.getByTestId("greeting").textContent).toBe("");
+
+    act(() => {
+      chatExtensions.setScalar("p1", "welcome.greeting", "Hello P1");
+    });
+
+    expect(screen.getByTestId("greeting").textContent).toBe("Hello P1");
+  });
+
+  it("last-writer-wins propagates to the Probe", () => {
+    render(<Probe />);
+    act(() => {
+      chatExtensions.setScalar("p1", "welcome.greeting", "P1");
+      chatExtensions.setScalar("p2", "welcome.greeting", "P2");
+    });
+    expect(screen.getByTestId("greeting").textContent).toBe("P2");
+  });
+
+  it("dispose() of the winner falls back to the prior", () => {
+    let disposeP2!: () => void;
+    render(<Probe />);
+    act(() => {
+      chatExtensions.setScalar("p1", "welcome.greeting", "P1");
+      const d = chatExtensions.setScalar("p2", "welcome.greeting", "P2");
+      disposeP2 = () => d.dispose();
+    });
+    expect(screen.getByTestId("greeting").textContent).toBe("P2");
+    act(() => disposeP2());
+    expect(screen.getByTestId("greeting").textContent).toBe("P1");
+  });
+
+  it("additive list mutations propagate", () => {
+    render(<Probe />);
+    expect(screen.getByTestId("actions-count").textContent).toBe("0");
+    act(() => {
+      chatExtensions.addAction("p1", { id: "a1", onClick: () => {} });
+      chatExtensions.addAction("p2", { id: "a2", onClick: () => {} });
+    });
+    expect(screen.getByTestId("actions-count").textContent).toBe("2");
+  });
+});
+
+describe("PluginSlotBoundary", () => {
+  function Boom(): never {
+    throw new Error("kaboom");
+  }
+
+  it("renders children when they don't throw", () => {
+    render(
+      <PluginSlotBoundary slot="test" pluginId="p1">
+        <span data-testid="child">ok</span>
+      </PluginSlotBoundary>,
+    );
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("renders fallback and writes audit when child throws", () => {
+    render(
+      <PluginSlotBoundary
+        slot="header.rightHeader"
+        pluginId="evil"
+        fallback={<span data-testid="fb">fallback</span>}
+      >
+        <Boom />
+      </PluginSlotBoundary>,
+    );
+    expect(screen.getByTestId("fb")).toBeInTheDocument();
+    expect(
+      auditStore
+        .overrides()
+        .some(
+          (r) =>
+            r.kind === "chat.error" &&
+            r.pluginId === "evil" &&
+            r.field === "header.rightHeader",
+        ),
+    ).toBe(true);
+  });
+});

--- a/console/src/plugins/registry/useChatExtensions.ts
+++ b/console/src/plugins/registry/useChatExtensions.ts
@@ -1,0 +1,30 @@
+/**
+ * registry/useChatExtensions.ts — React subscriptions for the chat extension registry.
+ *
+ * Wraps `useSyncExternalStore` so ChatPage re-renders whenever a plugin
+ * registers/disposes. Snapshots are stable refs between mutations
+ * (the registry replaces them only on change), so the useMemo
+ * dep chain in ChatPage doesn't fire spuriously.
+ */
+import { useSyncExternalStore } from "react";
+import {
+  chatExtensions,
+  type ChatListSnapshot,
+  type ChatScalarSnapshot,
+} from "./chatExtensions";
+
+function subscribe(cb: () => void): () => void {
+  return chatExtensions.subscribe(cb);
+}
+
+export function useChatScalarSnapshot(): ChatScalarSnapshot {
+  return useSyncExternalStore(subscribe, () =>
+    chatExtensions.getScalarSnapshot(),
+  );
+}
+
+export function useChatListSnapshot(): ChatListSnapshot {
+  return useSyncExternalStore(subscribe, () =>
+    chatExtensions.getListSnapshot(),
+  );
+}

--- a/console/src/plugins/types/qwenpaw.d.ts
+++ b/console/src/plugins/types/qwenpaw.d.ts
@@ -1,0 +1,269 @@
+/**
+ * plugins/types/qwenpaw.d.ts — stable public contract for plugin authors.
+ *
+ * Plugin TS projects (cloudpaw, qwenpaw-pet, …) should COPY this file into
+ * their own `qwenpaw-host.d.ts` and uncomment the `declare global` block at
+ * the bottom. We intentionally do NOT re-export `IAgentScopeRuntimeWebUIOptions`
+ * so the public surface stays stable across vendor upgrades.
+ *
+ * Inside the host, the global `Window.QwenPaw` is declared in
+ * `console/src/plugins/hostExternals.ts` — keep that the single source
+ * of truth to avoid duplicate-declaration conflicts.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Three verbs cover every chat customization intent:
+ *   set(pluginId, partial)  → shallow-merge specific option fields
+ *   render(pluginId, node)  → whole-section replacement (welcome / leftHeader)
+ *   add(pluginId, item)     → append to additive lists
+ * ─────────────────────────────────────────────────────────────────────────
+ */
+import type React from "react";
+
+export type Localized<T> = T | ((locale: string) => T);
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export type HostThemeMode = "light" | "dark";
+
+export interface HostAgentInfo {
+  id: string;
+}
+
+export interface HostSessionInfo {
+  id: string;
+}
+
+export interface ChatPromptItem {
+  label?: React.ReactNode;
+  value: string;
+}
+
+export interface ChatSuggestionItem {
+  label?: React.ReactNode;
+  value: string;
+}
+
+export interface ChatActionSpec {
+  /** Stable id, used for dispose tracking and deduplication. */
+  id: string;
+  icon?: React.ReactElement;
+  /** Either `render` or `onClick` (render wins if both supplied). */
+  render?: (ctx: { data: unknown }) => React.ReactElement;
+  onClick?: (ctx: { data: unknown }) => void;
+}
+
+export interface OverrideRecord {
+  kind: string;
+  field: string;
+  pluginId: string;
+  supersededPluginId?: string;
+  detail?: string;
+  timestamp: number;
+}
+
+export interface WelcomeRenderProps {
+  greeting?: React.ReactNode;
+  description?: React.ReactNode;
+  avatar?: string | React.ReactNode;
+  prompts?: ChatPromptItem[];
+  onSubmit: (data: { query: string; fileList?: unknown[] }) => void;
+}
+
+/** Plugin-supplied welcome render: either a fn (receives SDK props) or a plain node. */
+export type WelcomeRenderValue =
+  | ((props: WelcomeRenderProps) => React.ReactElement)
+  | React.ReactNode;
+
+/** Opaque request/response data. Plugin authors can cast if they need strong typing. */
+export type ChatRequestData = Record<string, unknown>;
+export type ChatResponseData = Record<string, unknown>;
+
+export type ChatRequestRenderFn = (ctx: {
+  data: ChatRequestData;
+  fallback: () => React.ReactElement;
+}) => React.ReactNode;
+
+export type ChatResponseRenderFn = (ctx: {
+  data: ChatResponseData;
+  isLast?: boolean;
+  fallback: () => React.ReactElement;
+}) => React.ReactNode;
+
+export type ChatRequestSlotFn = (ctx: {
+  data: ChatRequestData;
+}) => React.ReactNode;
+export type ChatResponseSlotFn = (ctx: {
+  data: ChatResponseData;
+  isLast?: boolean;
+}) => React.ReactNode;
+
+export interface QwenPawChatNamespace {
+  welcome: {
+    set(
+      pluginId: string,
+      partial: Partial<{
+        greeting: Localized<React.ReactNode>;
+        description: Localized<React.ReactNode>;
+        avatar: Localized<string | React.ReactNode>;
+        nick: Localized<string | React.ReactNode>;
+        prompts: Localized<ChatPromptItem[]>;
+      }>,
+    ): Disposable;
+    /** Whole-section replacement. Wins over set() fields. */
+    render(pluginId: string, value: WelcomeRenderValue): Disposable;
+  };
+  theme: {
+    set(
+      pluginId: string,
+      partial: Partial<{ colorPrimary: string }>,
+    ): Disposable;
+  };
+  leftHeader: {
+    set(
+      pluginId: string,
+      partial: Partial<{
+        logo: Localized<string | React.ReactNode>;
+        title: Localized<React.ReactNode>;
+      }>,
+    ): Disposable;
+    /** Whole-section replacement. Wins over set() fields. */
+    render(pluginId: string, node: React.ReactNode): Disposable;
+  };
+  rightHeader: {
+    /** Append-only — host's default header controls (session/model/history) always render. */
+    add(
+      pluginId: string,
+      node: React.ReactNode,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+  };
+  sender: {
+    set(
+      pluginId: string,
+      partial: Partial<{
+        placeholder: Localized<string>;
+        disclaimer: Localized<React.ReactNode>;
+      }>,
+    ): Disposable;
+    addPrefix(
+      pluginId: string,
+      node: React.ReactNode,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+    addSuggestion(
+      pluginId: string,
+      item: { id?: string; items: Localized<ChatSuggestionItem[]> },
+    ): Disposable;
+  };
+  actions: { add(pluginId: string, spec: ChatActionSpec): Disposable };
+  requestActions: { add(pluginId: string, spec: ChatActionSpec): Disposable };
+  request: {
+    /** Whole-bubble replacement for the user request card. */
+    render(pluginId: string, fn: ChatRequestRenderFn): Disposable;
+    /** Insert a custom component above the user bubble. Returning null skips this bubble. */
+    prepend(
+      pluginId: string,
+      fn: ChatRequestSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+    /** Insert a custom component below the user bubble. */
+    append(
+      pluginId: string,
+      fn: ChatRequestSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+  };
+  response: {
+    /** Whole-bubble replacement for the assistant response card. */
+    render(pluginId: string, fn: ChatResponseRenderFn): Disposable;
+    /** Insert a custom component above the AI bubble. */
+    prepend(
+      pluginId: string,
+      fn: ChatResponseSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+    /** Insert a custom component below the AI bubble. */
+    append(
+      pluginId: string,
+      fn: ChatResponseSlotFn,
+      opts?: { id?: string; order?: number },
+    ): Disposable;
+  };
+  toolRender(
+    pluginId: string,
+    toolName: string,
+    render: React.FC<Record<string, unknown>>,
+  ): Disposable;
+  card(
+    pluginId: string,
+    cardName: string,
+    render: React.FC<Record<string, unknown>>,
+  ): Disposable;
+  /** Tear down every registration from this plugin. Useful for future hot-unload. */
+  disposeAll(pluginId: string): void;
+}
+
+export interface QwenPawHostNamespace {
+  // ── Shared dependencies (attached by hostExternals.ts) ────────────────────
+  React: typeof React;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ReactDOM: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  antd: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  antdIcons: any;
+  apiBaseUrl: string;
+  getApiUrl(path: string): string;
+  getApiToken(): string | null;
+
+  // ── Hooks (call only inside plugin-supplied React components) ─────────────
+  useTheme(): HostThemeMode;
+  useLocale(): string;
+  useSelectedAgent(): HostAgentInfo;
+  useCurrentSession(): HostSessionInfo | null;
+
+  // ── Imperative getters (safe outside React render) ────────────────────────
+  getSelectedAgentId(): string;
+  getCurrentSessionId(): string | null;
+
+  /** Auth-aware fetch. Automatically injects `Authorization` and `X-Agent-Id`. */
+  fetch(path: string, init?: RequestInit): Promise<Response>;
+}
+
+export interface QwenPawAuditNamespace {
+  overrides(): OverrideRecord[];
+}
+
+export interface PluginRouteDeclaration {
+  path: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component: React.ComponentType<any>;
+  label: string;
+  icon?: string;
+  priority?: number;
+}
+
+export interface QwenPawWindowNamespace {
+  host: QwenPawHostNamespace;
+  chat: QwenPawChatNamespace;
+  audit: QwenPawAuditNamespace;
+  modules: Record<string, Record<string, unknown>>;
+  registerRoutes?(pluginId: string, routes: PluginRouteDeclaration[]): void;
+  registerToolRender?(
+    pluginId: string,
+    renderers: Record<string, React.FC<Record<string, unknown>>>,
+  ): void;
+}
+
+// Plugin projects: uncomment this in your own qwenpaw-host.d.ts to type
+// `window.QwenPaw.*` accesses in plugin code.
+//
+// declare global {
+//   interface Window {
+//     QwenPaw: QwenPawWindowNamespace;
+//   }
+// }
+
+export {};

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -46,6 +46,12 @@ export default defineConfig(({ mode }) => {
     server: {
       host: "0.0.0.0",
       port: 5173,
+      proxy: {
+        "/api": {
+          target: "http://localhost:8088",
+          changeOrigin: false,
+        },
+      },
     },
     test: {
       globals: true,

--- a/plugins/package-lock.json
+++ b/plugins/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugins",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary

🚧 **WIP — Do not merge**

Same plugin extension infrastructure as #4997, targeting the `dev/agentscope2.0` branch.

- **Menu/Route/Slot Registry**: Plugins register sidebar menus, route pages, and UI slots via `QwenPaw.menu.add` / `route.add` / `slot.fill`
- **Chat Extension API**: Plugins can extend the chat interface — welcome, rightHeader, actions, response.append, request.render, sender suggestions, etc.
- **Host SDK**: Provides fetch proxy and React hooks for plugins
- **Data-driven Layouts**: Built-in menus and routes refactored from hardcoded to data-driven, unified with plugin registry consumption
- **Audit API**: `QwenPaw.audit.overrides()` to inspect all registered extensions

## Changes (40 files)

- `console/src/plugins/registry/` — Registry core (store, types, chatExtensions, Slot, hooks, audit)
- `console/src/plugins/hostSdk/` — Host SDK (fetch proxy, hooks, install)
- `console/src/layouts/registry/` — Built-in menu/route data + adapter
- `console/src/pages/Chat/HostBubbles.tsx` — Chat bubble extension rendering
- Full unit test coverage (8 files, 76 cases)

## Test plan

- [x] Unit tests pass (76/76)
- [x] Page loads correctly, zero JS errors
- [x] window.QwenPaw API fully mounted (menu/route/slot/audit/chat)
- [x] All 17 chat extension APIs return valid Disposable objects
- [ ] Plugin loading pipeline e2e verification
- [ ] Compatibility check with existing plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)