### PR TITLE
feat(mcp): add per-server tool whitelisting with frontend toggle UI

### DIFF
--- a/console/src/api/modules/mcp.ts
+++ b/console/src/api/modules/mcp.ts
@@ -62,6 +62,15 @@ export const mcpApi = {
     request<MCPToolInfo[]>(`/mcp/tools/${encodeURIComponent(clientKey)}`),
 
   /**
+   * Update tool whitelist for an MCP client
+   */
+  updateMCPToolWhitelist: (clientKey: string, tools: string[] | null) =>
+    request<MCPToolInfo[]>(`/mcp/tools/${encodeURIComponent(clientKey)}`, {
+      method: "PUT",
+      body: JSON.stringify({ tools }),
+    }),
+
+  /**
    * Start an OAuth 2.1 PKCE flow for a remote MCP client.
    * Returns the authorization URL to open in a popup.
    */

--- a/console/src/api/types/mcp.ts
+++ b/console/src/api/types/mcp.ts
@@ -36,6 +36,8 @@ export interface MCPClientInfo {
   env: Record<string, string>;
   /** Working directory for stdio command */
   cwd: string;
+  /** Tool whitelist (null means all tools enabled) */
+  tools: string[] | null;
   /** OAuth status (null if OAuth not configured) */
   oauth_status: MCPClientOAuthStatus | null;
 }
@@ -99,6 +101,8 @@ export interface MCPToolInfo {
   name: string;
   /** Tool description */
   description: string;
+  /** Whether this tool is enabled (passes the whitelist) */
+  enabled: boolean;
   /** JSON Schema for the tool's input parameters */
   input_schema: Record<string, unknown>;
 }

--- a/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
@@ -6,6 +6,7 @@ import {
   Input,
   Empty,
   Tag,
+  Switch,
 } from "@agentscope-ai/design";
 import { Spin } from "antd";
 import type { MCPClientInfo, MCPToolInfo } from "../../../../api/types";
@@ -19,6 +20,7 @@ import {
 } from "@ant-design/icons";
 import { ShieldCheck, ShieldAlert, ShieldX, KeyRound } from "lucide-react";
 import api from "../../../../api";
+import { useAppMessage } from "../../../../hooks/useAppMessage";
 import { MCPOAuthSection } from "./MCPOAuthSection";
 import styles from "../index.module.less";
 
@@ -51,6 +53,7 @@ export const MCPClientCard = React.memo(function MCPClientCard({
   onRefresh,
 }: MCPClientCardProps) {
   const { t } = useTranslation();
+  const { message } = useAppMessage();
   const { isDark } = useTheme();
   const [isHovered, setIsHovered] = useState(false);
   const [jsonModalOpen, setJsonModalOpen] = useState(false);
@@ -59,6 +62,8 @@ export const MCPClientCard = React.memo(function MCPClientCard({
   const [tools, setTools] = useState<MCPToolInfo[]>([]);
   const [toolsLoading, setToolsLoading] = useState(false);
   const [toolsError, setToolsError] = useState<string | null>(null);
+  const [toolsSaving, setToolsSaving] = useState(false);
+  const [toolToggles, setToolToggles] = useState<Record<string, boolean>>({});
   const [editedJson, setEditedJson] = useState("");
   const [isEditing, setIsEditing] = useState(false);
   const [oauthModalOpen, setOauthModalOpen] = useState(false);
@@ -127,9 +132,15 @@ export const MCPClientCard = React.memo(function MCPClientCard({
       setToolsLoading(true);
       setToolsError(null);
       setTools([]);
+      setToolToggles({});
       try {
         const data = await api.listMCPTools(client.key);
         setTools(data);
+        const toggles: Record<string, boolean> = {};
+        data.forEach((tool) => {
+          toggles[tool.name] = tool.enabled;
+        });
+        setToolToggles(toggles);
       } catch (err: any) {
         const msg = err?.message || "";
         if (msg.includes("connecting") || msg.includes("not ready")) {
@@ -143,6 +154,34 @@ export const MCPClientCard = React.memo(function MCPClientCard({
     },
     [client.key, t],
   );
+
+  const handleToolToggle = useCallback((toolName: string, checked: boolean) => {
+    setToolToggles((prev) => ({ ...prev, [toolName]: checked }));
+  }, []);
+
+  const handleSaveToolWhitelist = useCallback(async () => {
+    setToolsSaving(true);
+    try {
+      const allEnabled = Object.values(toolToggles).every((v) => v);
+      const enabledTools = allEnabled
+        ? null
+        : Object.entries(toolToggles)
+            .filter(([, enabled]) => enabled)
+            .map(([name]) => name);
+      const data = await api.updateMCPToolWhitelist(client.key, enabledTools);
+      setTools(data);
+      const toggles: Record<string, boolean> = {};
+      data.forEach((tool) => {
+        toggles[tool.name] = tool.enabled;
+      });
+      setToolToggles(toggles);
+      onRefresh?.();
+    } catch (err: any) {
+      message.error(err?.message || t("mcp.toolsSaveError", "Failed to save tool settings"));
+    } finally {
+      setToolsSaving(false);
+    }
+  }, [client.key, toolToggles, onRefresh, message, t]);
 
   const clientJson = JSON.stringify(client, null, 2);
 
@@ -303,9 +342,18 @@ export const MCPClientCard = React.memo(function MCPClientCard({
         onCancel={() => setToolsModalOpen(false)}
         footer={
           <div style={{ textAlign: "right" }}>
-            <Button onClick={() => setToolsModalOpen(false)}>
+            <Button onClick={() => setToolsModalOpen(false)} style={{ marginRight: 8 }}>
               {t("common.close")}
             </Button>
+            {tools.length > 0 && (
+              <Button
+                type="primary"
+                onClick={handleSaveToolWhitelist}
+                loading={toolsSaving}
+              >
+                {t("common.save")}
+              </Button>
+            )}
           </div>
         }
         width={700}
@@ -323,7 +371,14 @@ export const MCPClientCard = React.memo(function MCPClientCard({
             {tools.map((tool) => (
               <div key={tool.name} className={styles.toolItem}>
                 <div className={styles.toolHeader}>
-                  <Tag color="blue">{tool.name}</Tag>
+                  <Switch
+                    size="small"
+                    checked={toolToggles[tool.name] ?? tool.enabled}
+                    onChange={(checked) => handleToolToggle(tool.name, checked)}
+                  />
+                  <Tag color={toolToggles[tool.name] ?? tool.enabled ? "blue" : "default"}>
+                    {tool.name}
+                  </Tag>
                 </div>
                 {tool.description && (
                   <p className={styles.toolDescription}>{tool.description}</p>

--- a/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
+++ b/console/src/pages/Agent/MCP/components/MCPClientCard.tsx
@@ -177,7 +177,9 @@ export const MCPClientCard = React.memo(function MCPClientCard({
       setToolToggles(toggles);
       onRefresh?.();
     } catch (err: any) {
-      message.error(err?.message || t("mcp.toolsSaveError", "Failed to save tool settings"));
+      message.error(
+        err?.message || t("mcp.toolsSaveError", "Failed to save tool settings"),
+      );
     } finally {
       setToolsSaving(false);
     }
@@ -342,7 +344,10 @@ export const MCPClientCard = React.memo(function MCPClientCard({
         onCancel={() => setToolsModalOpen(false)}
         footer={
           <div style={{ textAlign: "right" }}>
-            <Button onClick={() => setToolsModalOpen(false)} style={{ marginRight: 8 }}>
+            <Button
+              onClick={() => setToolsModalOpen(false)}
+              style={{ marginRight: 8 }}
+            >
               {t("common.close")}
             </Button>
             {tools.length > 0 && (
@@ -376,7 +381,13 @@ export const MCPClientCard = React.memo(function MCPClientCard({
                     checked={toolToggles[tool.name] ?? tool.enabled}
                     onChange={(checked) => handleToolToggle(tool.name, checked)}
                   />
-                  <Tag color={toolToggles[tool.name] ?? tool.enabled ? "blue" : "default"}>
+                  <Tag
+                    color={
+                      toolToggles[tool.name] ?? tool.enabled
+                        ? "blue"
+                        : "default"
+                    }
+                  >
                     {tool.name}
                   </Tag>
                 </div>

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -256,6 +256,12 @@ class MCPClientManager:
             "cwd": client_config.cwd or None,
         }
 
+        whitelist = (
+            set(client_config.tools)
+            if client_config.tools is not None
+            else None
+        )
+
         if client_config.transport == "stdio":
             client = StdIOStatefulClient(
                 name=client_config.name,
@@ -263,6 +269,7 @@ class MCPClientManager:
                 args=client_config.args,
                 env=client_config.env,
                 cwd=client_config.cwd or None,
+                tool_whitelist=whitelist,
             )
             setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
             return client
@@ -281,6 +288,7 @@ class MCPClientManager:
             transport=client_config.transport,
             url=client_config.url,
             headers=headers or None,
+            tool_whitelist=whitelist,
         )
         setattr(client, "_qwenpaw_rebuild_info", rebuild_info)
         return client

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -183,6 +183,7 @@ class _MCPClientMixin:
     _oauth_required: bool
     _cached_tools: Any
     _name_alias_to_real: dict[str, str]
+    _tool_whitelist: set[str] | None
     _stop_event: asyncio.Event
     _reload_event: asyncio.Event
     _ready_event: asyncio.Event
@@ -371,20 +372,48 @@ class _MCPClientMixin:
     # Public API
     # ------------------------------------------------------------------
 
-    async def list_tools(self):
-        """Return all tools available from the MCP server.
+    def _sanitize_server_tools(
+        self,
+        raw_tools: list,
+    ) -> tuple[list, dict[str, str]]:
+        """Sanitize tool names for model-side compatibility.
 
-        MCP allows tool names with characters (``.``, ``/``, ``:``…) that
-        OpenAI- and Anthropic-style tool-call APIs reject. To stay compatible
-        without losing the ability to dispatch back to the real tool, this
-        method rewrites each non-conformant ``tool.name`` to a sanitized
-        alias and stores the alias→real mapping on the client. Subsequent
-        :meth:`call_tool` lookups consult that mapping. Tools whose names are
-        already valid pass through untouched, with no mapping entry.
+        Returns ``(sanitized_tools, alias_to_real)`` where
+        ``alias_to_real`` maps each rewritten name back to the original
+        MCP name (only for tools that were actually renamed).
+        """
+        sanitized: list = []
+        alias_to_real: dict[str, str] = {}
+        taken: set[str] = {
+            t.name for t in raw_tools if _TOOL_NAME_ALLOWED.match(t.name)
+        }
+        for tool in raw_tools:
+            if _TOOL_NAME_ALLOWED.match(tool.name):
+                sanitized.append(tool)
+                continue
+            safe = _sanitize_tool_name(tool.name, taken)
+            taken.add(safe)
+            alias_to_real[safe] = tool.name
+            sanitized.append(tool.model_copy(update={"name": safe}))
+            logger.info(
+                "MCP client '%s': renamed tool '%s' -> '%s' for "
+                "model-side compatibility.",
+                self.name,
+                tool.name,
+                safe,
+            )
+        return sanitized, alias_to_real
+
+    async def list_tools(self):
+        """Return whitelisted tools from the MCP server.
+
+        Applies name sanitization (so all names match
+        ``^[a-zA-Z0-9_-]+$``) and then filters by ``_tool_whitelist``.
+        The whitelist stores **sanitized** names (the same names the
+        frontend and model see).
 
         Returns:
-            List of MCP tools whose names are guaranteed to match
-            ``^[a-zA-Z0-9_-]+$``.
+            List of MCP tools after sanitization and whitelist filtering.
 
         Raises:
             RuntimeError: If not connected
@@ -397,32 +426,37 @@ class _MCPClientMixin:
             self._handle_transport_error(exc)
             raise
 
-        rewritten: list = []
-        alias_to_real: dict[str, str] = {}
-        # Reserve the set of safe names already taken so collisions
-        # (e.g. upstream exposes both ``a.b`` and ``a_b``) get a suffix.
-        taken: set[str] = {
-            t.name for t in res.tools if _TOOL_NAME_ALLOWED.match(t.name)
-        }
-        for tool in res.tools:
-            if _TOOL_NAME_ALLOWED.match(tool.name):
-                rewritten.append(tool)
-                continue
-            safe = _sanitize_tool_name(tool.name, taken)
-            taken.add(safe)
-            alias_to_real[safe] = tool.name
-            rewritten.append(tool.model_copy(update={"name": safe}))
-            logger.info(
-                "MCP client '%s': renamed tool '%s' -> '%s' for "
-                "model-side compatibility.",
-                self.name,
-                tool.name,
-                safe,
-            )
+        rewritten, alias_to_real = self._sanitize_server_tools(res.tools)
+
+        # Whitelist stores sanitized names (what the frontend displays).
+        whitelist = getattr(self, "_tool_whitelist", None)
+        if whitelist is not None:
+            rewritten = [t for t in rewritten if t.name in whitelist]
+            alias_to_real = {
+                k: v for k, v in alias_to_real.items() if k in whitelist
+            }
 
         self._cached_tools = rewritten
         self._name_alias_to_real = alias_to_real
         return rewritten
+
+    async def list_all_tools(self):
+        """Return all tools from the MCP server, ignoring the whitelist.
+
+        Used by management APIs to show available tools so users can
+        configure which ones to enable. Applies name sanitization but
+        skips whitelist filtering.
+        """
+        self._validate_connection()
+
+        try:
+            res = await self.session.list_tools()
+        except Exception as exc:
+            self._handle_transport_error(exc)
+            raise
+
+        sanitized, _ = self._sanitize_server_tools(res.tools)
+        return sanitized
 
     async def call_tool(self, name: str, arguments: dict | None = None):
         """Call a tool on the MCP server with its real MCP name.
@@ -653,6 +687,7 @@ class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
             "replace",
         ] = "strict",
         read_timeout_seconds: float = 60 * 5,
+        tool_whitelist: set[str] | None = None,
     ) -> None:
         """Initialize the StdIO MCP client.
 
@@ -665,6 +700,8 @@ class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
             encoding: The text encoding used when sending/receiving messages
             encoding_error_handler: The text encoding error handler
             read_timeout_seconds: The read timeout seconds
+            tool_whitelist: Only expose these tools (sanitized names).
+                None means expose all.
 
         Raises:
             TypeError: If name or command is not a string
@@ -698,9 +735,10 @@ class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
         self.session: ClientSession | None = None
         self.is_connected = False
 
-        # Tool cache
+        # Tool cache and whitelist
         self._cached_tools = None
         self._name_alias_to_real: dict[str, str] = {}
+        self._tool_whitelist = tool_whitelist
 
     async def _setup_transport(
         self,
@@ -735,6 +773,7 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
         headers: dict[str, str] | None = None,
         timeout: float = 30,
         sse_read_timeout: float = 60 * 5,
+        tool_whitelist: set[str] | None = None,
         **client_kwargs: Any,
     ) -> None:
         """Initialize the HTTP MCP client.
@@ -746,6 +785,8 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
             headers: Additional headers to include in the HTTP request
             timeout: The timeout for the HTTP request in seconds
             sse_read_timeout: The timeout for reading SSE in seconds
+            tool_whitelist: Only expose these tools (sanitized names).
+                None means expose all.
             **client_kwargs: Additional keyword arguments for the client
 
         Raises:
@@ -786,9 +827,10 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
         self.session: ClientSession | None = None
         self.is_connected = False
 
-        # Tool cache
+        # Tool cache and whitelist
         self._cached_tools = None
         self._name_alias_to_real: dict[str, str] = {}
+        self._tool_whitelist = tool_whitelist
 
     async def _setup_transport(
         self,

--- a/src/qwenpaw/app/mcp/watcher.py
+++ b/src/qwenpaw/app/mcp/watcher.py
@@ -255,7 +255,10 @@ class MCPConfigWatcher:
 
         # Client enabled: check if config changed
         if old_cfg != new_cfg:
-            await self._reload_single_client(key, new_cfg)
+            if self._only_tools_changed(old_cfg, new_cfg):
+                await self._hot_patch_whitelist(key, new_cfg)
+            else:
+                await self._reload_single_client(key, new_cfg)
 
     async def _reload_single_client(self, key: str, new_cfg) -> None:
         """Reload a single client with retry tracking."""
@@ -314,6 +317,31 @@ class MCPConfigWatcher:
                 f"client '{key}' "
                 f"(attempt {new_count}/{self._max_retries})",
             )
+
+    @staticmethod
+    def _only_tools_changed(old_cfg, new_cfg) -> bool:
+        """Return True if only the ``tools`` field differs between configs."""
+        old_dump = old_cfg.model_dump(mode="json")
+        new_dump = new_cfg.model_dump(mode="json")
+        old_dump.pop("tools", None)
+        new_dump.pop("tools", None)
+        return old_dump == new_dump
+
+    async def _hot_patch_whitelist(self, key: str, new_cfg) -> None:
+        """Update running client's tool whitelist without reconnecting."""
+        client = await self._mcp_manager.get_client(key)
+        if client is None:
+            return
+        new_whitelist = (
+            set(new_cfg.tools) if new_cfg.tools is not None else None
+        )
+        # pylint: disable=protected-access
+        client._tool_whitelist = new_whitelist
+        client._cached_tools = None
+        logger.debug(
+            "MCPConfigWatcher: hot-patched tool whitelist for '%s'",
+            key,
+        )
 
     async def _handle_client_removal(self, key: str) -> None:
         """Handle removal of a client from config."""

--- a/src/qwenpaw/app/routers/mcp.py
+++ b/src/qwenpaw/app/routers/mcp.py
@@ -61,6 +61,11 @@ class MCPClientInfo(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
+    tools: Optional[List[str]] = Field(
+        default=None,
+        description="Tool whitelist. Only listed tools will be loaded. "
+        "None means load all tools.",
+    )
     oauth_status: Optional[MCPClientOAuthStatus] = Field(
         default=None,
         description="OAuth token status (None if OAuth not configured)",
@@ -104,6 +109,11 @@ class MCPClientCreateRequest(BaseModel):
         default="",
         description="Working directory for stdio MCP command",
     )
+    tools: Optional[List[str]] = Field(
+        default=None,
+        description="Tool whitelist. Only listed tools will be loaded. "
+        "None means load all tools.",
+    )
 
 
 class MCPClientUpdateRequest(BaseModel):
@@ -142,6 +152,11 @@ class MCPClientUpdateRequest(BaseModel):
     cwd: Optional[str] = Field(
         None,
         description="Working directory for stdio MCP command",
+    )
+    tools: Optional[List[str]] = Field(
+        None,
+        description="Tool whitelist (omit field to leave unchanged). "
+        "Use PUT /mcp/tools/{key} to set or clear the whitelist.",
     )
 
 
@@ -237,6 +252,7 @@ def _build_client_info(key: str, client: MCPClientConfig) -> MCPClientInfo:
         args=client.args,
         env=masked_env,
         cwd=client.cwd,
+        tools=client.tools,
         oauth_status=_build_oauth_status(client),
     )
 
@@ -261,6 +277,10 @@ class MCPToolInfo(BaseModel):
 
     name: str = Field(..., description="Tool name")
     description: str = Field(default="", description="Tool description")
+    enabled: bool = Field(
+        default=True,
+        description="Whether this tool is enabled (passes the whitelist)",
+    )
     input_schema: Dict[str, Any] = Field(
         default_factory=dict,
         description="JSON Schema for the tool's input parameters",
@@ -308,7 +328,7 @@ async def list_mcp_tools(
         )
 
     try:
-        tools = await client.list_tools()
+        tools = await client.list_all_tools()
     except Exception as e:
         logger.warning(
             f"Failed to list tools for MCP client '{client_key}': {e}",
@@ -318,10 +338,94 @@ async def list_mcp_tools(
             detail=f"Failed to query tools from MCP server: {e}",
         ) from e
 
+    whitelist = client_config.tools
+    whitelist_set = set(whitelist) if whitelist is not None else None
+
     return [
         MCPToolInfo(
             name=t.name,
             description=getattr(t, "description", "") or "",
+            enabled=whitelist_set is None or t.name in whitelist_set,
+            input_schema=getattr(t, "inputSchema", {}) or {},
+        )
+        for t in tools
+    ]
+
+
+class MCPToolWhitelistRequest(BaseModel):
+    """Request body for updating tool whitelist."""
+
+    tools: Optional[List[str]] = Field(
+        default=None,
+        description="List of tool names to enable. "
+        "None means enable all tools (remove whitelist).",
+    )
+
+
+@router.put(
+    "/tools/{client_key:path}",
+    response_model=List[MCPToolInfo],
+    summary="Update tool whitelist for an MCP client",
+)
+async def update_mcp_tool_whitelist(
+    request: Request,
+    client_key: str = Path(...),
+    body: MCPToolWhitelistRequest = Body(...),
+) -> List[MCPToolInfo]:
+    """Update which tools are enabled for an MCP client.
+
+    Pass a list of tool names to enable only those tools (whitelist),
+    or None to remove the whitelist and enable all tools.
+    Returns the updated tool list with enabled status.
+    """
+    from ..agent_context import get_agent_for_request
+    from ...config.config import save_agent_config
+
+    agent = await get_agent_for_request(request)
+
+    mcp_config = agent.config.mcp
+    if mcp_config is None or client_key not in (mcp_config.clients or {}):
+        raise HTTPException(404, detail=f"MCP client '{client_key}' not found")
+
+    client_config = mcp_config.clients[client_key]
+    client_config.tools = body.tools
+    save_agent_config(agent.agent_id, agent.config)
+
+    # Hot-patch the running client's whitelist without a full reconnect.
+    # The config watcher will also detect this change and call
+    # _hot_patch_whitelist ~2s later — that's intentionally idempotent.
+    # We patch here for immediate effect.
+    mcp_manager = agent.mcp_manager
+    if mcp_manager is None:
+        raise HTTPException(
+            503,
+            detail="Tool whitelist saved, but MCP manager is not ready. "
+            "Changes will take effect once the server connects.",
+        )
+
+    client = await mcp_manager.get_client(client_key)
+    if client is None or not getattr(client, "is_connected", False):
+        raise HTTPException(
+            503,
+            detail="Tool whitelist saved, but MCP server is not connected. "
+            "Changes will take effect once the server reconnects.",
+        )
+
+    new_whitelist = set(body.tools) if body.tools is not None else None
+    # pylint: disable=protected-access
+    client._tool_whitelist = new_whitelist
+    client._cached_tools = None
+
+    try:
+        tools = await client.list_all_tools()
+    except Exception:
+        return []
+
+    return [
+        MCPToolInfo(
+            name=t.name,
+            description=getattr(t, "description", "") or "",
+            enabled=new_whitelist is None or t.name in new_whitelist,
             input_schema=getattr(t, "inputSchema", {}) or {},
         )
         for t in tools
@@ -391,6 +495,7 @@ async def create_mcp_client(
         args=client.args,
         env=client.env,
         cwd=client.cwd,
+        tools=client.tools,
     )
 
     # Add to agent's config and save

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1303,6 +1303,11 @@ class MCPClientConfig(BaseModel):
     args: List[str] = Field(default_factory=list)
     env: Dict[str, str] = Field(default_factory=dict)
     cwd: str = ""
+    tools: Optional[List[str]] = Field(
+        default=None,
+        description="Tool whitelist. Only listed tools will be loaded. "
+        "None means load all tools from the server.",
+    )
     oauth: Optional[MCPOAuthConfig] = None
 
     @model_validator(mode="before")


### PR DESCRIPTION
## Description

Allow users to selectively enable/disable individual tools from an MCP server. Tools can be toggled via switches in the tools modal on MCP client cards. The whitelist is persisted in config and hot-patched at runtime without reconnecting. Backend adds `PUT /mcp/tools/{key}` endpoint, `list_all_tools()` for management, and `_tool_whitelist` filtering in `list_tools()`. Includes tool name sanitization deduplication, proper `None` vs `[]` semantics, and constructor-based whitelist injection.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
