### PR TITLE
Add uninstall hooks and expose skill provider API

### DIFF
--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -124,6 +124,16 @@ class MultiAgentManager:
                 f"Workspace created and started: {agent_id} "
                 f"({elapsed:.3f}s)",
             )
+
+            # Fire workspace_created hooks so plugins can provision
+            # skills / config into the newly created workspace.
+            await self._fire_workspace_created_hooks(
+                {
+                    "agent_id": agent_id,
+                    "workspace_dir": str(agent_ref.workspace_dir),
+                },
+            )
+
             return instance
         except Exception as e:
             logger.error(f"Failed to start workspace {agent_id}: {e}")
@@ -134,6 +144,45 @@ class MultiAgentManager:
             async with self._lock:
                 self._pending_starts.pop(agent_id, None)
             event.set()
+
+    @staticmethod
+    async def _fire_workspace_created_hooks(workspace_info: dict) -> None:
+        """Invoke all registered workspace_created hooks.
+
+        Supports both sync and async callbacks:
+        - Async callbacks are awaited directly.
+        - Sync callbacks are offloaded to a thread via
+          ``asyncio.to_thread`` so they never block the event loop.
+
+        Errors in individual hooks are logged but do not prevent
+        subsequent hooks from running.
+
+        Args:
+            workspace_info: Dict with at least ``agent_id`` and
+                ``workspace_dir`` keys.
+        """
+        try:
+            from ..plugins.registry import PluginRegistry
+
+            hooks = PluginRegistry().get_workspace_created_hooks()
+        except Exception:
+            # Plugin system not initialised yet — nothing to do.
+            return
+
+        for hook in hooks:
+            try:
+                callback = hook.callback
+                if asyncio.iscoroutinefunction(callback):
+                    await callback(workspace_info)
+                else:
+                    await asyncio.to_thread(callback, workspace_info)
+            except Exception as exc:
+                logger.error(
+                    f"Error in workspace_created hook "
+                    f"'{hook.hook_name}' for plugin "
+                    f"'{hook.plugin_id}': {exc}",
+                    exc_info=True,
+                )
 
     async def _graceful_stop_old_instance(
         self,

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -175,7 +175,12 @@ class MultiAgentManager:
                 if asyncio.iscoroutinefunction(callback):
                     await callback(workspace_info)
                 else:
-                    await asyncio.to_thread(callback, workspace_info)
+                    result = await asyncio.to_thread(callback, workspace_info)
+                    if asyncio.iscoroutine(result) or hasattr(
+                        result,
+                        "__await__",
+                    ):
+                        await result
             except Exception as exc:
                 logger.error(
                     f"Error in workspace_created hook "

--- a/src/qwenpaw/cli/plugin_commands.py
+++ b/src/qwenpaw/cli/plugin_commands.py
@@ -18,6 +18,10 @@ from typing import Optional
 
 import click
 
+from qwenpaw.plugins.validation import (
+    validate_plugin_module as _validate_plugin_module,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -607,30 +611,7 @@ def install(source: str, force: bool):
     try:
         backend_entry = manifest.get("entry", {}).get("backend")
         if backend_entry:
-            backend_path = source_path / backend_entry
-            if not backend_path.exists():
-                raise FileNotFoundError(
-                    f"Backend entry point not found: {backend_entry}",
-                )
-
-            import importlib.util
-
-            spec = importlib.util.spec_from_file_location(
-                f"_plugin_validation_{plugin_id}",
-                backend_path,
-            )
-            if spec and spec.loader:
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-
-                has_plugin_class = hasattr(module, "Plugin")
-                has_plugin_instance = hasattr(module, "plugin")
-
-                if not (has_plugin_class or has_plugin_instance):
-                    raise AttributeError(
-                        "Plugin module must export a 'Plugin' class "
-                        "or 'plugin' instance",
-                    )
+            _validate_plugin_module(plugin_id, source_path, backend_entry)
 
         click.echo("Plugin validation successful")
     except Exception as e:
@@ -891,13 +872,7 @@ def validate(path: str):
         entry = manifest.get("entry", {})
         backend_entry = entry.get("backend")
         if backend_entry:
-            backend_path = plugin_path / backend_entry
-            if not backend_path.exists():
-                click.echo(
-                    f"❌ Backend entry not found: {backend_entry}",
-                    err=True,
-                )
-                return
+            _validate_plugin_module(manifest["id"], plugin_path, backend_entry)
 
         frontend_entry = entry.get("frontend")
         if frontend_entry:
@@ -915,4 +890,4 @@ def validate(path: str):
     except json.JSONDecodeError as e:
         click.echo(f"❌ Invalid JSON in plugin.json: {e}", err=True)
     except Exception as e:
-        click.echo(f"❌ Validation error: {e}", err=True)
+        click.echo(f"❌ Validation failed: {e}", err=True)

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -2,6 +2,7 @@
 """Plugin API for plugin developers."""
 
 import logging
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type
 
 logger = logging.getLogger(__name__)
@@ -186,6 +187,85 @@ class PluginApi:
             logger.info(
                 f"Plugin '{self.plugin_id}' registered shutdown hook "
                 f"'{hook_name}' (priority={priority})",
+            )
+
+    def register_uninstall_hook(
+        self,
+        hook_name: str,
+        callback: Callable,
+        priority: int = 100,
+    ):
+        """Register an uninstall hook.
+
+        Unlike shutdown hooks (which run on every app shutdown),
+        uninstall hooks run **only** when the plugin is explicitly
+        unloaded or removed via ``PluginLoader.unload_plugin()``.
+
+        Use these for one-time cleanup on uninstall — e.g. removing
+        workspace skills, clearing manifest entries, or undoing
+        monkey-patches applied during startup.
+
+        The callback receives keyword arguments:
+            - ``plugin_id`` (str): The plugin being uninstalled.
+            - ``delete_files`` (bool): Whether files are being deleted.
+
+        Args:
+            hook_name: Unique hook identifier
+            callback: Async or sync function to call on uninstall.
+            priority: Execution priority (lower = earlier, default=100)
+
+        Example:
+            >>> api.register_uninstall_hook(
+            ...     hook_name="cleanup_skills",
+            ...     callback=self.on_uninstall,
+            ... )
+        """
+        if self._registry:
+            self._registry.register_uninstall_hook(
+                plugin_id=self.plugin_id,
+                hook_name=hook_name,
+                callback=callback,
+                priority=priority,
+            )
+            logger.info(
+                f"Plugin '{self.plugin_id}' registered uninstall hook "
+                f"'{hook_name}' (priority={priority})",
+            )
+
+    def register_workspace_created_hook(
+        self,
+        hook_name: str,
+        callback: Callable,
+        priority: int = 100,
+    ):
+        """Register a hook that fires when a new workspace is created.
+
+        The callback receives a single ``workspace_info`` dict with at
+        least ``agent_id`` (str) and ``workspace_dir`` (str) keys.
+
+        Args:
+            hook_name: Unique hook identifier
+            callback: Sync or async function to call on workspace creation.
+                Signature: ``(workspace_info: dict) -> None``
+            priority: Execution priority (lower = earlier, default=100)
+
+        Example:
+            >>> api.register_workspace_created_hook(
+            ...     hook_name="provision_new_workspace",
+            ...     callback=self.on_workspace_created,
+            ... )
+        """
+        if self._registry:
+            self._registry.register_workspace_created_hook(
+                plugin_id=self.plugin_id,
+                hook_name=hook_name,
+                callback=callback,
+                priority=priority,
+            )
+            logger.info(
+                f"Plugin '{self.plugin_id}' registered "
+                f"workspace_created hook '{hook_name}' "
+                f"(priority={priority})",
             )
 
     def register_http_router(
@@ -398,3 +478,303 @@ class PluginApi:
             f"Plugin '{self.plugin_id}' scheduled tool "
             f"'{tool_name}' for registration on startup",
         )
+
+    def register_skill_provider(
+        self,
+        skills_dir: Path,
+        *,
+        enabled_by_default: bool = True,
+        channels: Optional[List[str]] = None,
+    ) -> None:
+        """Register a plugin as a skill provider.
+
+        Copies the plugin's skills into the workspace skill directory,
+        reconciles the workspace manifest, and applies the plugin's
+        default enable/channel strategy.  On uninstall, skills sourced
+        from this plugin are automatically cleaned up.
+
+        Skills are also automatically installed into workspaces created
+        after the server starts, via a ``workspace_created`` hook.
+
+        The host handles:
+        - Copying the skill directory into the workspace.
+        - Reconciling the workspace skill manifest.
+        - Applying the default enabled/channels strategy.
+        - Cleaning up manifest entries on uninstall (by ``source``).
+
+        Args:
+            skills_dir: Path to the directory containing the plugin's
+                skill sub-directories (each with a ``SKILL.md``).
+            enabled_by_default: Whether the skills should be enabled
+                immediately after installation. Default: True.
+            channels: List of channel names the skills apply to, or
+                ``["all"]`` for all channels. Default: ``["all"]``.
+
+        Example:
+            >>> from pathlib import Path
+            >>> PLUGIN_DIR = Path(__file__).parent
+            >>> api.register_skill_provider(
+            ...     skills_dir=PLUGIN_DIR / "skills",
+            ...     enabled_by_default=True,
+            ...     channels=["all"],
+            ... )
+        """
+        skills_dir = Path(skills_dir)
+        resolved_channels = channels or ["all"]
+        source_tag = f"plugin:{self.plugin_id}"
+
+        def _install_skills():
+            self._do_install_skills(
+                skills_dir,
+                source_tag,
+                enabled_by_default,
+                resolved_channels,
+            )
+
+        def _uninstall_skills(plugin_id: str, delete_files: bool = False):
+            """Remove skills sourced from this plugin on uninstall."""
+            _ = delete_files  # unused but part of uninstall hook contract
+            self._do_uninstall_skills(plugin_id, source_tag)
+
+        def _on_workspace_created(workspace_info: dict):
+            """Install plugin skills into a newly created workspace."""
+            self._install_skills_into_workspace(
+                workspace_info,
+                skills_dir,
+                source_tag,
+                enabled_by_default,
+                resolved_channels,
+            )
+
+        # Register skill installation on startup
+        self.register_startup_hook(
+            hook_name=f"install_skills_{self.plugin_id}",
+            callback=_install_skills,
+            priority=80,
+        )
+
+        # Register hook to provision newly created workspaces
+        self.register_workspace_created_hook(
+            hook_name=f"provision_skills_{self.plugin_id}",
+            callback=_on_workspace_created,
+            priority=80,
+        )
+
+        # Register cleanup on uninstall
+        self.register_uninstall_hook(
+            hook_name=f"uninstall_skills_{self.plugin_id}",
+            callback=_uninstall_skills,
+        )
+
+    def _get_skill_names(self, skills_dir: Path) -> List[str]:
+        """Return sub-directory names that contain a SKILL.md file."""
+        if not skills_dir.exists() or not skills_dir.is_dir():
+            logger.warning(
+                f"Plugin '{self.plugin_id}' skills_dir "
+                f"does not exist: {skills_dir}",
+            )
+            return []
+        return [
+            d.name
+            for d in skills_dir.iterdir()
+            if d.is_dir() and (d / "SKILL.md").exists()
+        ]
+
+    def _install_skills_into_workspace(
+        self,
+        workspace_info: dict,
+        skills_dir: Path,
+        source_tag: str,
+        enabled_by_default: bool,
+        resolved_channels: List[str],
+    ) -> None:
+        """Copy plugin skills into a single workspace and update its manifest.
+
+        This is the shared implementation used by both the startup hook
+        (for all existing workspaces) and the workspace_created hook
+        (for newly created workspaces).
+        """
+        try:
+            from ..agents.skill_system.store import (
+                copy_skill_dir,
+                get_workspace_skills_dir,
+                get_workspace_skill_manifest_path,
+                default_workspace_manifest,
+                mutate_json,
+            )
+            from ..agents.skill_system.registry import (
+                reconcile_workspace_manifest,
+            )
+
+            skill_names = self._get_skill_names(skills_dir)
+            if not skill_names:
+                return
+
+            workspace_dir = Path(workspace_info["workspace_dir"])
+            ws_skills_dir = get_workspace_skills_dir(workspace_dir)
+            ws_skills_dir.mkdir(parents=True, exist_ok=True)
+
+            for skill_name in skill_names:
+                copy_skill_dir(
+                    skills_dir / skill_name,
+                    ws_skills_dir / skill_name,
+                )
+
+            reconcile_workspace_manifest(workspace_dir)
+
+            manifest_path = get_workspace_skill_manifest_path(
+                workspace_dir,
+            )
+
+            def _apply_defaults(
+                payload,
+                _names=tuple(skill_names),
+                _src=source_tag,
+                _enabled=enabled_by_default,
+                _channels=tuple(resolved_channels),
+            ):
+                skills = payload.setdefault("skills", {})
+                for name in _names:
+                    entry = skills.get(name)
+                    if entry is None:
+                        continue
+                    entry["source"] = _src
+                    entry["enabled"] = _enabled
+                    entry["channels"] = _channels
+                return payload
+
+            mutate_json(
+                manifest_path,
+                default_workspace_manifest(),
+                _apply_defaults,
+            )
+
+            logger.debug(
+                f"Plugin '{self.plugin_id}' installed "
+                f"{len(skill_names)} skill(s) into workspace "
+                f"'{workspace_info.get('agent_id', '?')}'",
+            )
+        except Exception as exc:
+            logger.error(
+                f"Failed to install skills for plugin "
+                f"'{self.plugin_id}' into workspace "
+                f"'{workspace_info.get('agent_id', '?')}': {exc}",
+                exc_info=True,
+            )
+
+    def _do_install_skills(
+        self,
+        skills_dir: Path,
+        source_tag: str,
+        enabled_by_default: bool,
+        resolved_channels: List[str],
+    ) -> None:
+        """Copy plugin skills into all existing workspaces."""
+        try:
+            from ..agents.skill_system.registry import list_workspaces
+
+            skill_names = self._get_skill_names(skills_dir)
+            if not skill_names:
+                return
+
+            workspaces = list_workspaces()
+            for workspace_info in workspaces:
+                self._install_skills_into_workspace(
+                    workspace_info,
+                    skills_dir,
+                    source_tag,
+                    enabled_by_default,
+                    resolved_channels,
+                )
+
+            logger.info(
+                f"Plugin '{self.plugin_id}' installed "
+                f"{len(skill_names)} skill(s) into "
+                f"{len(workspaces)} workspace(s)",
+            )
+        except Exception as exc:
+            logger.error(
+                f"Failed to install skills for plugin "
+                f"'{self.plugin_id}': {exc}",
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _do_uninstall_skills(plugin_id: str, source_tag: str) -> None:
+        """Remove skills sourced from a plugin across all workspaces."""
+        try:
+            import shutil
+
+            from ..agents.skill_system.store import (
+                get_workspace_skills_dir,
+                get_workspace_skill_manifest_path,
+                default_workspace_manifest,
+                mutate_json,
+            )
+            from ..agents.skill_system.registry import (
+                list_workspaces,
+            )
+
+            workspaces = list_workspaces()
+            for workspace_info in workspaces:
+                workspace_dir = Path(workspace_info["workspace_dir"])
+                ws_skills_dir = get_workspace_skills_dir(workspace_dir)
+                manifest_path = get_workspace_skill_manifest_path(
+                    workspace_dir,
+                )
+
+                # NOTE: The closure captures loop variables via default args.
+                # This is safe because mutate_json is called synchronously
+                # immediately below.  If mutate_json ever becomes async or
+                # deferred, these must be refactored to explicit arguments.
+                def _remove_plugin_skills(
+                    payload,
+                    _ws_skills=ws_skills_dir,
+                    _tag=source_tag,
+                    _agent_id=workspace_info["agent_id"],
+                ):
+                    skills = payload.setdefault("skills", {})
+                    to_remove = [
+                        name
+                        for name, entry in skills.items()
+                        if entry.get("source") == _tag
+                    ]
+                    for name in to_remove:
+                        skills.pop(name, None)
+                        skill_dir = _ws_skills / name
+                        if skill_dir.exists():
+                            try:
+                                shutil.rmtree(skill_dir)
+                            except OSError as rmtree_exc:
+                                logger.warning(
+                                    "Failed to fully remove skill "
+                                    "directory %s: %s",
+                                    skill_dir,
+                                    rmtree_exc,
+                                )
+                    if to_remove:
+                        logger.info(
+                            "Removed skills %s from workspace '%s'",
+                            to_remove,
+                            _agent_id,
+                        )
+                    return payload
+
+                mutate_json(
+                    manifest_path,
+                    default_workspace_manifest(),
+                    _remove_plugin_skills,
+                )
+
+            logger.info(
+                "Plugin '%s' skills cleaned up from %d workspace(s)",
+                plugin_id,
+                len(workspaces),
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to uninstall skills for plugin '%s': %s",
+                plugin_id,
+                exc,
+                exc_info=True,
+            )

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -566,6 +566,41 @@ class PluginApi:
             callback=_uninstall_skills,
         )
 
+    def unregister_skill_provider(self) -> None:
+        """Unregister this plugin as a skill provider.
+
+        Removes the startup, workspace_created, and uninstall hooks
+        that were registered by ``register_skill_provider()``, and
+        cleans up skills sourced from this plugin across all existing
+        workspaces.
+
+        This allows plugins to dynamically disable their skill
+        provider without requiring a full plugin uninstall.
+
+        Example:
+            >>> api.unregister_skill_provider()
+        """
+        source_tag = f"plugin:{self.plugin_id}"
+        hook_names = [
+            f"install_skills_{self.plugin_id}",
+            f"provision_skills_{self.plugin_id}",
+            f"uninstall_skills_{self.plugin_id}",
+        ]
+
+        # Remove the hooks from registry
+        if self._registry:
+            self._registry.remove_hooks_by_name(
+                self.plugin_id,
+                hook_names,
+            )
+
+        # Clean up already-installed skills
+        self._do_uninstall_skills(self.plugin_id, source_tag)
+
+        logger.info(
+            f"Plugin '{self.plugin_id}' unregistered as skill provider",
+        )
+
     def _get_skill_names(self, skills_dir: Path) -> List[str]:
         """Return sub-directory names that contain a SKILL.md file."""
         if not skills_dir.exists() or not skills_dir.is_dir():
@@ -638,9 +673,10 @@ class PluginApi:
                     entry = skills.get(name)
                     if entry is None:
                         continue
+                    if entry.get("source") != _src:
+                        entry["enabled"] = _enabled
+                        entry["channels"] = list(_channels)
                     entry["source"] = _src
-                    entry["enabled"] = _enabled
-                    entry["channels"] = _channels
                 return payload
 
             mutate_json(

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -576,6 +576,29 @@ class PluginLoader:
                     f"for plugin '{plugin_id}': {exc}",
                 )
 
+        # Execute uninstall hooks (only run on explicit unload/remove)
+        uninstall_hooks = [
+            h
+            for h in self.registry.get_uninstall_hooks()
+            if h.plugin_id == plugin_id
+        ]
+        for hook in uninstall_hooks:
+            try:
+                result = hook.callback(
+                    plugin_id=plugin_id,
+                    delete_files=delete_files,
+                )
+                if inspect.iscoroutine(result) or inspect.isawaitable(
+                    result,
+                ):
+                    await result
+            except Exception as exc:
+                logger.error(
+                    f"Error in uninstall hook '{hook.hook_name}' "
+                    f"for plugin '{plugin_id}': {exc}",
+                    exc_info=True,
+                )
+
         # Remove Python module and all sub-modules so the next import
         # gets a fresh copy (e.g. plugin_foo.utils must not be reused).
         module_name = f"plugin_{plugin_id.replace('-', '_')}"

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -118,6 +118,8 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         self._providers: Dict[str, ProviderRegistration] = {}
         self._startup_hooks: List[HookRegistration] = []
         self._shutdown_hooks: List[HookRegistration] = []
+        self._uninstall_hooks: List[HookRegistration] = []
+        self._workspace_created_hooks: List[HookRegistration] = []
         self._control_commands: List[ControlCommandRegistration] = []
         self._runtime_helpers = None
         self._plugin_manifests: Dict[str, Dict[str, Any]] = {}
@@ -396,6 +398,90 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         """
         return self._shutdown_hooks.copy()
 
+    def register_uninstall_hook(
+        self,
+        plugin_id: str,
+        hook_name: str,
+        callback: Callable,
+        priority: int = 100,
+    ):
+        """Register an uninstall hook.
+
+        Unlike shutdown hooks (which run on every app shutdown),
+        uninstall hooks run only when a plugin is explicitly unloaded
+        or removed.  Use these for cleanup that should happen once on
+        uninstall — e.g. removing workspace skills, clearing manifest
+        entries, or undoing monkey-patches.
+
+        Args:
+            plugin_id: Plugin identifier
+            hook_name: Hook name
+            callback: Callback function (sync or async).
+                Receives keyword arguments:
+                ``plugin_id``, ``delete_files`` (bool).
+            priority: Priority (lower = earlier execution)
+        """
+        hook = HookRegistration(
+            plugin_id=plugin_id,
+            hook_name=hook_name,
+            callback=callback,
+            priority=priority,
+        )
+        self._uninstall_hooks.append(hook)
+        self._uninstall_hooks.sort(key=lambda h: h.priority)
+        logger.info(
+            f"Registered uninstall hook '{hook_name}' from plugin "
+            f"'{plugin_id}' (priority={priority})",
+        )
+
+    def get_uninstall_hooks(self) -> List[HookRegistration]:
+        """Get all uninstall hooks sorted by priority.
+
+        Returns:
+            List of HookRegistration
+        """
+        return self._uninstall_hooks.copy()
+
+    def register_workspace_created_hook(
+        self,
+        plugin_id: str,
+        hook_name: str,
+        callback: Callable,
+        priority: int = 100,
+    ):
+        """Register a hook that fires when a new workspace is created.
+
+        The callback receives a single ``workspace_info`` dict with at
+        least ``agent_id`` and ``workspace_dir`` keys.
+
+        Args:
+            plugin_id: Plugin identifier
+            hook_name: Hook name
+            callback: Sync or async callback function.
+                Signature: ``(workspace_info: dict) -> None``
+            priority: Priority (lower = earlier execution)
+        """
+        hook = HookRegistration(
+            plugin_id=plugin_id,
+            hook_name=hook_name,
+            callback=callback,
+            priority=priority,
+        )
+        self._workspace_created_hooks.append(hook)
+        self._workspace_created_hooks.sort(key=lambda h: h.priority)
+        logger.info(
+            f"Registered workspace_created hook '{hook_name}' from plugin "
+            f"'{plugin_id}' (priority={priority})",
+        )
+
+    def get_workspace_created_hooks(self) -> List[HookRegistration]:
+        """Get all workspace-created hooks sorted by priority.
+
+        Returns:
+            List of HookRegistration
+        """
+        return self._workspace_created_hooks.copy()
+
     def register_control_command(
         self,
         plugin_id: str,
@@ -494,6 +580,14 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         ]
         self._shutdown_hooks = [
             h for h in self._shutdown_hooks if h.plugin_id != plugin_id
+        ]
+        self._uninstall_hooks = [
+            h for h in self._uninstall_hooks if h.plugin_id != plugin_id
+        ]
+        self._workspace_created_hooks = [
+            h
+            for h in self._workspace_created_hooks
+            if h.plugin_id != plugin_id
         ]
         self._control_commands = [
             c for c in self._control_commands if c.plugin_id != plugin_id

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -482,6 +482,39 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         """
         return self._workspace_created_hooks.copy()
 
+    def remove_hooks_by_name(
+        self,
+        plugin_id: str,
+        hook_names: List[str],
+    ) -> None:
+        """Remove specific hooks registered by a plugin.
+
+        Removes hooks matching the given ``hook_names`` from all hook
+        lists (startup, shutdown, uninstall, workspace_created).
+
+        Args:
+            plugin_id: Plugin identifier that owns the hooks.
+            hook_names: Hook names to remove.
+        """
+        names_set = set(hook_names)
+
+        def _filter(hooks: list) -> list:
+            return [
+                h
+                for h in hooks
+                if not (h.plugin_id == plugin_id and h.hook_name in names_set)
+            ]
+
+        self._startup_hooks = _filter(self._startup_hooks)
+        self._shutdown_hooks = _filter(self._shutdown_hooks)
+        self._uninstall_hooks = _filter(self._uninstall_hooks)
+        self._workspace_created_hooks = _filter(
+            self._workspace_created_hooks,
+        )
+        logger.info(
+            f"Removed hooks {hook_names} for plugin '{plugin_id}'",
+        )
+
     def register_control_command(
         self,
         plugin_id: str,

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Plugin module-loading validation utilities.
+
+This module provides the core validation logic used by both the CLI
+``plugin install`` and ``plugin validate`` commands. It replicates
+the module-loading semantics of PluginLoader.load_plugin so that
+plugins are validated under the same conditions they will run in.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def validate_plugin_module(
+    plugin_id: str,
+    plugin_path: Path,
+    backend_entry: str,
+) -> None:
+    """Validate a plugin module can be imported with relative imports.
+
+    This replicates the module-loading semantics of PluginLoader.load_plugin:
+    - Sanitizes plugin_id (replace '-' with '_') for a valid Python identifier
+    - Registers in sys.modules BEFORE exec_module
+    - Cleans up all ephemeral modules in finally
+
+    Args:
+        plugin_id: The plugin identifier (may contain hyphens).
+        plugin_path: Path to the plugin directory.
+        backend_entry: Relative path to the backend entry file.
+
+    Raises:
+        FileNotFoundError: If the backend entry file doesn't exist.
+        ImportError: If the module cannot be loaded (e.g. broken imports).
+        AttributeError: If the module exports neither Plugin class nor plugin
+            instance.
+    """
+    backend_path = plugin_path / backend_entry
+    if not backend_path.exists():
+        raise FileNotFoundError(
+            f"Backend entry point not found: {backend_entry}",
+        )
+
+    safe_id = plugin_id.replace("-", "_")
+    module_name = f"_plugin_validation_{safe_id}"
+    plugin_dir_str = str(plugin_path)
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        backend_path,
+        submodule_search_locations=[plugin_dir_str],
+    )
+    if not (spec and spec.loader):
+        raise ImportError(
+            f"Cannot create module spec for {backend_entry}",
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec_module so that
+    # relative imports can resolve the parent package.
+    sys.modules[module_name] = module
+    module.__package__ = module_name
+    module.__path__ = [plugin_dir_str]
+    try:
+        spec.loader.exec_module(module)
+
+        has_plugin_class = hasattr(module, "Plugin")
+        has_plugin_instance = hasattr(module, "plugin")
+        if not (has_plugin_class or has_plugin_instance):
+            raise AttributeError(
+                "Plugin module must export a 'Plugin' class "
+                "or 'plugin' instance",
+            )
+    finally:
+        # Clean up ephemeral validation modules to avoid
+        # leaking into the process on repeated installs.
+        prefix = module_name + "."
+        for key in list(sys.modules):
+            if key == module_name or key.startswith(prefix):
+                sys.modules.pop(key, None)

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -64,12 +64,9 @@ def validate_plugin_module(
     try:
         spec.loader.exec_module(module)
 
-        has_plugin_class = hasattr(module, "Plugin")
-        has_plugin_instance = hasattr(module, "plugin")
-        if not (has_plugin_class or has_plugin_instance):
+        if not hasattr(module, "plugin"):
             raise AttributeError(
-                "Plugin module must export a 'Plugin' class "
-                "or 'plugin' instance",
+                "Plugin module must export a 'plugin' instance",
             )
     finally:
         # Clean up ephemeral validation modules to avoid

--- a/tests/unit/plugins/test_plugin_api_extensions.py
+++ b/tests/unit/plugins/test_plugin_api_extensions.py
@@ -1,0 +1,762 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access,import-outside-toplevel
+"""Unit tests for plugin API extensions: #8, #10, #16.
+
+Tests cover:
+- #8: register_uninstall_hook and its execution during unload_plugin
+- #10: Plugin validator uses submodule_search_locations for relative imports
+- #16: register_skill_provider API contract
+"""
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fresh_registry():
+    """Create a fresh PluginRegistry (bypass singleton for test isolation).
+
+    .. warning::
+        This fixture is NOT safe for parallel test execution (e.g.
+        ``pytest-xdist``).  It mutates the class-level ``_instance``
+        attribute without locking.  Only use with sequential test runs.
+    """
+    from qwenpaw.plugins.registry import PluginRegistry
+
+    # Force a new instance by clearing the singleton
+    old_instance = PluginRegistry._instance
+    PluginRegistry._instance = None
+    registry = PluginRegistry()
+    yield registry
+    # Restore
+    PluginRegistry._instance = old_instance
+
+
+@pytest.fixture()
+def plugin_api(fresh_registry):
+    """Create a PluginApi instance with a fresh registry."""
+    from qwenpaw.plugins.api import PluginApi
+
+    api = PluginApi("test-plugin", config={}, manifest={"id": "test-plugin"})
+    api.set_registry(fresh_registry)
+    return api
+
+
+# ---------------------------------------------------------------------------
+# #8: register_uninstall_hook
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallHook:
+    """Tests for register_uninstall_hook (requirement #8)."""
+
+    def test_register_uninstall_hook_stores_in_registry(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """Uninstall hooks are stored in registry after registration."""
+        callback = MagicMock()
+        plugin_api.register_uninstall_hook(
+            hook_name="test_cleanup",
+            callback=callback,
+            priority=50,
+        )
+
+        hooks = fresh_registry.get_uninstall_hooks()
+        assert len(hooks) == 1
+        assert hooks[0].plugin_id == "test-plugin"
+        assert hooks[0].hook_name == "test_cleanup"
+        assert hooks[0].callback is callback
+        assert hooks[0].priority == 50
+
+    def test_uninstall_hooks_sorted_by_priority(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """Multiple uninstall hooks are sorted by priority."""
+        plugin_api.register_uninstall_hook(
+            hook_name="low_priority",
+            callback=MagicMock(),
+            priority=200,
+        )
+        plugin_api.register_uninstall_hook(
+            hook_name="high_priority",
+            callback=MagicMock(),
+            priority=10,
+        )
+
+        hooks = fresh_registry.get_uninstall_hooks()
+        assert hooks[0].hook_name == "high_priority"
+        assert hooks[1].hook_name == "low_priority"
+
+    def test_uninstall_hooks_cleaned_on_unregister(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """Uninstall hooks are removed when plugin is unregistered."""
+        plugin_api.register_uninstall_hook(
+            hook_name="cleanup",
+            callback=MagicMock(),
+        )
+        assert len(fresh_registry.get_uninstall_hooks()) == 1
+
+        fresh_registry.unregister_plugin("test-plugin")
+        assert len(fresh_registry.get_uninstall_hooks()) == 0
+
+    @pytest.mark.asyncio
+    async def test_unload_plugin_calls_uninstall_hooks(self, fresh_registry):
+        """PluginLoader.unload_plugin executes uninstall hooks."""
+        from qwenpaw.plugins.loader import PluginLoader
+        from qwenpaw.plugins.architecture import (
+            PluginManifest,
+            PluginRecord,
+            PluginEntryPoints,
+        )
+
+        loader = PluginLoader(plugin_dirs=[])
+        loader.registry = fresh_registry
+
+        # Create a fake loaded plugin record
+        manifest = PluginManifest(
+            id="test-plugin",
+            name="Test",
+            version="1.0.0",
+            entry=PluginEntryPoints(backend="plugin.py"),
+        )
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=Path("/fake"),
+            enabled=True,
+            instance=None,
+        )
+        loader._loaded_plugins["test-plugin"] = record
+
+        # Register an uninstall hook
+        hook_called_with: Dict[str, Any] = {}
+
+        def uninstall_callback(plugin_id: str, delete_files: bool):
+            hook_called_with["plugin_id"] = plugin_id
+            hook_called_with["delete_files"] = delete_files
+
+        fresh_registry.register_uninstall_hook(
+            plugin_id="test-plugin",
+            hook_name="test_cleanup",
+            callback=uninstall_callback,
+        )
+
+        await loader.unload_plugin("test-plugin", delete_files=True)
+
+        assert hook_called_with["plugin_id"] == "test-plugin"
+        assert hook_called_with["delete_files"] is True
+
+    @pytest.mark.asyncio
+    async def test_uninstall_hook_async_callback(self, fresh_registry):
+        """Async uninstall hook callbacks are properly awaited."""
+        from qwenpaw.plugins.loader import PluginLoader
+        from qwenpaw.plugins.architecture import (
+            PluginManifest,
+            PluginRecord,
+            PluginEntryPoints,
+        )
+
+        loader = PluginLoader(plugin_dirs=[])
+        loader.registry = fresh_registry
+
+        manifest = PluginManifest(
+            id="async-plugin",
+            name="Async",
+            version="1.0.0",
+            entry=PluginEntryPoints(backend="plugin.py"),
+        )
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=Path("/fake"),
+            enabled=True,
+            instance=None,
+        )
+        loader._loaded_plugins["async-plugin"] = record
+
+        async_called = []
+
+        async def async_cleanup(plugin_id: str, **_kwargs):
+            async_called.append(plugin_id)
+
+        fresh_registry.register_uninstall_hook(
+            plugin_id="async-plugin",
+            hook_name="async_cleanup",
+            callback=async_cleanup,
+        )
+
+        await loader.unload_plugin("async-plugin")
+        assert "async-plugin" in async_called
+
+    @pytest.mark.asyncio
+    async def test_uninstall_hook_error_isolated(self, fresh_registry):
+        """Errors in uninstall hooks don't crash the unload flow."""
+        from qwenpaw.plugins.loader import PluginLoader
+        from qwenpaw.plugins.architecture import (
+            PluginManifest,
+            PluginRecord,
+            PluginEntryPoints,
+        )
+
+        loader = PluginLoader(plugin_dirs=[])
+        loader.registry = fresh_registry
+
+        manifest = PluginManifest(
+            id="err-plugin",
+            name="Err",
+            version="1.0.0",
+            entry=PluginEntryPoints(backend="plugin.py"),
+        )
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=Path("/fake"),
+            enabled=True,
+            instance=None,
+        )
+        loader._loaded_plugins["err-plugin"] = record
+
+        def bad_hook(**_kwargs):
+            raise RuntimeError("hook failed")
+
+        fresh_registry.register_uninstall_hook(
+            plugin_id="err-plugin",
+            hook_name="bad_hook",
+            callback=bad_hook,
+        )
+
+        # Should not raise
+        await loader.unload_plugin("err-plugin")
+        assert "err-plugin" not in loader._loaded_plugins
+
+
+# ---------------------------------------------------------------------------
+# #10: Plugin validator relative import fix
+# ---------------------------------------------------------------------------
+
+
+class TestPluginValidatorImports:
+    """Tests for plugin validator import resolution (requirement #10)."""
+
+    def test_validator_sets_submodule_search_locations(self):
+        """CLI install validator uses submodule_search_locations."""
+        # Create a temp plugin with relative import
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir)
+
+            # Create plugin.json
+            import json
+
+            manifest = {
+                "id": "import-test",
+                "name": "Import Test",
+                "version": "1.0.0",
+                "entry": {"backend": "plugin.py"},
+            }
+            (plugin_dir / "plugin.json").write_text(
+                json.dumps(manifest),
+                encoding="utf-8",
+            )
+
+            # Create a helper module
+            (plugin_dir / "constants.py").write_text(
+                "PLUGIN_NAME = 'import-test'\n",
+                encoding="utf-8",
+            )
+
+            # Create plugin.py that uses relative import
+            (plugin_dir / "plugin.py").write_text(
+                "from .constants import PLUGIN_NAME\n"
+                "\n"
+                "class Plugin:\n"
+                "    pass\n"
+                "\n"
+                "plugin = Plugin()\n",
+                encoding="utf-8",
+            )
+
+            # Simulate validation with correct submodule_search_locations
+            backend_path = plugin_dir / "plugin.py"
+            module_name = "_plugin_validation_import_test"
+            plugin_dir_str = str(plugin_dir)
+
+            spec = importlib.util.spec_from_file_location(
+                module_name,
+                backend_path,
+                submodule_search_locations=[plugin_dir_str],
+            )
+            assert spec is not None
+            assert spec.loader is not None
+
+            module = importlib.util.module_from_spec(spec)
+            module.__package__ = module_name
+            module.__path__ = [plugin_dir_str]
+
+            # Register sub-module mapping so relative imports resolve
+            sys.modules[module_name] = module
+            # Also register the constants sub-module path
+            constants_spec = importlib.util.spec_from_file_location(
+                f"{module_name}.constants",
+                plugin_dir / "constants.py",
+            )
+            constants_module = importlib.util.module_from_spec(constants_spec)
+            sys.modules[f"{module_name}.constants"] = constants_module
+            constants_spec.loader.exec_module(constants_module)
+
+            try:
+                spec.loader.exec_module(module)
+                assert hasattr(module, "plugin")
+                assert hasattr(module, "PLUGIN_NAME")
+            finally:
+                sys.modules.pop(module_name, None)
+                sys.modules.pop(f"{module_name}.constants", None)
+
+    def test_validator_without_search_locations_fails(self):
+        """Without submodule_search_locations, relative imports fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir)
+
+            (plugin_dir / "constants.py").write_text(
+                "PLUGIN_NAME = 'test'\n",
+                encoding="utf-8",
+            )
+            (plugin_dir / "plugin.py").write_text(
+                "from .constants import PLUGIN_NAME\n",
+                encoding="utf-8",
+            )
+
+            backend_path = plugin_dir / "plugin.py"
+            module_name = "_plugin_validation_no_locations"
+
+            # Without submodule_search_locations — should fail
+            spec = importlib.util.spec_from_file_location(
+                module_name,
+                backend_path,
+            )
+            module = importlib.util.module_from_spec(spec)
+            # Don't set __package__ or __path__
+
+            sys.modules[module_name] = module
+            try:
+                with pytest.raises(ImportError):
+                    spec.loader.exec_module(module)
+            finally:
+                sys.modules.pop(module_name, None)
+
+    def test_cli_validate_path_with_relative_import(self):
+        """Exercise the actual CLI validation code path.
+
+        Calls validate_plugin_module (the real implementation used by
+        both 'install' and 'validate' commands) to prove that relative
+        imports work end-to-end, including sys.modules registration
+        before exec_module, cleanup in finally, and sanitized module
+        name from plugin_id with hyphens.
+        """
+        from qwenpaw.plugins.validation import validate_plugin_module
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir) / "my-datapaw"
+            plugin_dir.mkdir()
+
+            (plugin_dir / "helpers.py").write_text(
+                "HELPER_VALUE = 42\n",
+                encoding="utf-8",
+            )
+            (plugin_dir / "plugin.py").write_text(
+                "from .helpers import HELPER_VALUE\n"
+                "\n"
+                "class Plugin:\n"
+                "    pass\n"
+                "\n"
+                "plugin = Plugin()\n",
+                encoding="utf-8",
+            )
+
+            # Should succeed without raising
+            validate_plugin_module("my-datapaw", plugin_dir, "plugin.py")
+
+            # Verify sys.modules was cleaned up (no leaking)
+            leaked = [
+                k
+                for k in sys.modules
+                if k.startswith("_plugin_validation_my_datapaw")
+            ]
+            assert leaked == [], f"Leaked modules: {leaked}"
+
+    def test_cli_validate_cleans_sys_modules_on_error(self):
+        """sys.modules cleanup happens even when validation fails."""
+        from qwenpaw.plugins.validation import validate_plugin_module
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            plugin_dir = Path(tmpdir) / "bad-plugin"
+            plugin_dir.mkdir()
+
+            # Plugin that imports a non-existent module
+            (plugin_dir / "plugin.py").write_text(
+                "from .nonexistent import MISSING\n",
+                encoding="utf-8",
+            )
+
+            with pytest.raises(ImportError):
+                validate_plugin_module(
+                    "bad-plugin",
+                    plugin_dir,
+                    "plugin.py",
+                )
+
+            # Verify cleanup still happened
+            leaked = [
+                k
+                for k in sys.modules
+                if k.startswith("_plugin_validation_bad_plugin")
+            ]
+            assert leaked == [], f"Leaked modules: {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# #16: register_skill_provider
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterSkillProvider:
+    """Tests for register_skill_provider API (requirement #16)."""
+
+    def test_register_skill_provider_registers_hooks(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """register_skill_provider registers startup and uninstall hooks."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir)
+            # Create a fake skill
+            skill_dir = skills_dir / "my-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: My Skill\n---\nDo something.",
+                encoding="utf-8",
+            )
+
+            plugin_api.register_skill_provider(
+                skills_dir=skills_dir,
+                enabled_by_default=True,
+                channels=["all"],
+            )
+
+        # Check startup hook registered
+        startup_hooks = fresh_registry.get_startup_hooks()
+        startup_names = [h.hook_name for h in startup_hooks]
+        assert "install_skills_test-plugin" in startup_names
+
+        # Check uninstall hook registered
+        uninstall_hooks = fresh_registry.get_uninstall_hooks()
+        uninstall_names = [h.hook_name for h in uninstall_hooks]
+        assert "uninstall_skills_test-plugin" in uninstall_names
+
+    def test_register_skill_provider_default_channels(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """Default channels is ['all'] when not specified."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir)
+            skill_dir = skills_dir / "default-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: Default\n---\nHello.",
+                encoding="utf-8",
+            )
+
+            plugin_api.register_skill_provider(skills_dir=skills_dir)
+
+        # Verify startup hook is registered (integration correctness)
+        hooks = fresh_registry.get_startup_hooks()
+        assert any(h.hook_name == "install_skills_test-plugin" for h in hooks)
+
+    def test_register_skill_provider_source_tag(self, plugin_api):
+        """Source tag follows 'plugin:{id}' convention."""
+        # Verify internal source_tag format
+        expected_tag = "plugin:test-plugin"
+        assert expected_tag == f"plugin:{plugin_api.plugin_id}"
+
+    def test_register_skill_provider_registers_workspace_created_hook(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """register_skill_provider also registers a workspace_created hook."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_dir = Path(tmpdir)
+            skill_dir = skills_dir / "auto-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: Auto Skill\n---\nAuto.",
+                encoding="utf-8",
+            )
+
+            plugin_api.register_skill_provider(
+                skills_dir=skills_dir,
+                enabled_by_default=True,
+                channels=["all"],
+            )
+
+        hooks = fresh_registry.get_workspace_created_hooks()
+        hook_names = [h.hook_name for h in hooks]
+        assert "provision_skills_test-plugin" in hook_names
+
+
+# ---------------------------------------------------------------------------
+# workspace_created hook infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceCreatedHook:
+    """Tests for workspace_created hook registration and dispatch."""
+
+    def test_register_workspace_created_hook_stores_in_registry(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """workspace_created hooks are stored in registry."""
+        callback = MagicMock()
+        plugin_api.register_workspace_created_hook(
+            hook_name="on_ws_created",
+            callback=callback,
+            priority=50,
+        )
+
+        hooks = fresh_registry.get_workspace_created_hooks()
+        assert len(hooks) == 1
+        assert hooks[0].plugin_id == "test-plugin"
+        assert hooks[0].hook_name == "on_ws_created"
+        assert hooks[0].callback is callback
+        assert hooks[0].priority == 50
+
+
+# ---------------------------------------------------------------------------
+# _fire_workspace_created_hooks: sync / async dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestFireWorkspaceCreatedHooks:
+    """Tests for async _fire_workspace_created_hooks dispatch logic."""
+
+    @pytest.mark.asyncio
+    async def test_sync_callback_offloaded_to_thread(
+        self,
+        plugin_api,
+    ):
+        """Sync callbacks are executed via asyncio.to_thread (non-blocking)."""
+        invoked_with = {}
+
+        def sync_hook(workspace_info: dict) -> None:
+            invoked_with.update(workspace_info)
+
+        plugin_api.register_workspace_created_hook(
+            hook_name="sync_hook",
+            callback=sync_hook,
+        )
+
+        from qwenpaw.app.multi_agent_manager import MultiAgentManager
+
+        await MultiAgentManager._fire_workspace_created_hooks(
+            {"agent_id": "a1", "workspace_dir": "/tmp/ws"},
+        )
+
+        assert invoked_with == {
+            "agent_id": "a1",
+            "workspace_dir": "/tmp/ws",
+        }
+
+    @pytest.mark.asyncio
+    async def test_async_callback_awaited(
+        self,
+        plugin_api,
+    ):
+        """Async callbacks are directly awaited."""
+        invoked_with = {}
+
+        async def async_hook(workspace_info: dict) -> None:
+            invoked_with.update(workspace_info)
+
+        plugin_api.register_workspace_created_hook(
+            hook_name="async_hook",
+            callback=async_hook,
+        )
+
+        from qwenpaw.app.multi_agent_manager import MultiAgentManager
+
+        await MultiAgentManager._fire_workspace_created_hooks(
+            {"agent_id": "a2", "workspace_dir": "/tmp/ws2"},
+        )
+
+        assert invoked_with == {
+            "agent_id": "a2",
+            "workspace_dir": "/tmp/ws2",
+        }
+
+    @pytest.mark.asyncio
+    async def test_hook_error_does_not_block_subsequent_hooks(
+        self,
+        plugin_api,
+    ):
+        """A failing hook does not prevent later hooks from running."""
+        results = []
+
+        def failing_hook(_info: dict) -> None:
+            raise RuntimeError("boom")
+
+        def good_hook(_info: dict) -> None:
+            results.append("ok")
+
+        plugin_api.register_workspace_created_hook(
+            hook_name="fail_first",
+            callback=failing_hook,
+            priority=10,
+        )
+        plugin_api.register_workspace_created_hook(
+            hook_name="succeed_second",
+            callback=good_hook,
+            priority=20,
+        )
+
+        from qwenpaw.app.multi_agent_manager import MultiAgentManager
+
+        await MultiAgentManager._fire_workspace_created_hooks(
+            {"agent_id": "a3", "workspace_dir": "/tmp/ws3"},
+        )
+
+        assert results == ["ok"]
+
+    def test_workspace_created_hooks_sorted_by_priority(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """Multiple workspace_created hooks are sorted by priority."""
+        plugin_api.register_workspace_created_hook(
+            hook_name="low_prio",
+            callback=MagicMock(),
+            priority=200,
+        )
+        plugin_api.register_workspace_created_hook(
+            hook_name="high_prio",
+            callback=MagicMock(),
+            priority=10,
+        )
+
+        hooks = fresh_registry.get_workspace_created_hooks()
+        assert hooks[0].hook_name == "high_prio"
+        assert hooks[1].hook_name == "low_prio"
+
+    def test_workspace_created_hooks_cleaned_on_unregister(
+        self,
+        plugin_api,
+        fresh_registry,
+    ):
+        """workspace_created hooks are removed when plugin is unregistered."""
+        plugin_api.register_workspace_created_hook(
+            hook_name="provision",
+            callback=MagicMock(),
+        )
+        assert len(fresh_registry.get_workspace_created_hooks()) == 1
+
+        fresh_registry.unregister_plugin("test-plugin")
+        assert len(fresh_registry.get_workspace_created_hooks()) == 0
+
+    @pytest.mark.asyncio
+    async def test_fire_workspace_created_hooks_calls_callbacks(
+        self,
+        fresh_registry,
+    ):
+        """_fire_workspace_created_hooks invokes registered callbacks."""
+        from qwenpaw.plugins.api import PluginApi
+        from qwenpaw.app.multi_agent_manager import MultiAgentManager
+
+        api = PluginApi(
+            "hook-plugin",
+            config={},
+            manifest={"id": "hook-plugin"},
+        )
+        api.set_registry(fresh_registry)
+
+        received_info: Dict[str, Any] = {}
+
+        def on_created(workspace_info):
+            received_info.update(workspace_info)
+
+        api.register_workspace_created_hook(
+            hook_name="test_hook",
+            callback=on_created,
+        )
+
+        workspace_info = {
+            "agent_id": "agent-42",
+            "workspace_dir": "/tmp/ws/agent-42",
+        }
+        await MultiAgentManager._fire_workspace_created_hooks(workspace_info)
+
+        assert received_info["agent_id"] == "agent-42"
+        assert received_info["workspace_dir"] == "/tmp/ws/agent-42"
+
+    @pytest.mark.asyncio
+    async def test_fire_workspace_created_hooks_error_isolation(
+        self,
+        fresh_registry,
+    ):
+        """Errors in one hook don't prevent subsequent hooks from running."""
+        from qwenpaw.plugins.api import PluginApi
+        from qwenpaw.app.multi_agent_manager import MultiAgentManager
+
+        api = PluginApi(
+            "err-plugin",
+            config={},
+            manifest={"id": "err-plugin"},
+        )
+        api.set_registry(fresh_registry)
+
+        second_called = []
+
+        def bad_hook(workspace_info):
+            raise RuntimeError("boom")
+
+        def good_hook(workspace_info):
+            second_called.append(workspace_info["agent_id"])
+
+        api.register_workspace_created_hook(
+            hook_name="bad",
+            callback=bad_hook,
+            priority=10,
+        )
+        api.register_workspace_created_hook(
+            hook_name="good",
+            callback=good_hook,
+            priority=20,
+        )
+
+        # Should not raise
+        await MultiAgentManager._fire_workspace_created_hooks(
+            {
+                "agent_id": "ws-1",
+                "workspace_dir": "/tmp/ws-1",
+            },
+        )
+
+        assert "ws-1" in second_called

--- a/tests/unit/plugins/test_plugin_api_extensions.py
+++ b/tests/unit/plugins/test_plugin_api_extensions.py
@@ -11,11 +11,29 @@ Tests cover:
 import importlib.util
 import sys
 import tempfile
+import types
 from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock
 
 import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub missing agentscope 2.0 modules so MultiAgentManager can be imported
+# in environments where agentscope 2.0 is not installed.
+# ---------------------------------------------------------------------------
+_AGENTSCOPE_STUBS = [
+    "agentscope.state",
+]
+
+for _mod_name in _AGENTSCOPE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        # Provide placeholder attributes that downstream imports expect.
+        # type: ignore[attr-defined]
+        _stub.AgentState = type("AgentState", (), {})
+        sys.modules[_mod_name] = _stub
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Cherry-pick PR #4794 to `dev/agentscope2.0`

Cherry-pick of #4794 (merged into `main`) to `dev/agentscope2.0` branch, as requested in #4794 comments.

**Original PR**: #4794

---

### Changes

- **Uninstall hooks**: Added `on_uninstall` lifecycle hook to the plugin API, allowing plugins to perform cleanup (remove config entries, stop subprocesses, etc.) before being removed.
- **Validation refactor**: Extracted validation logic into `src/qwenpaw/plugins/validation.py`; tightened offline validation to require a `plugin` instance (matching runtime loader behavior).
- **Skill provider API**: Exposed `register_skill_provider()` and `unregister_skill_provider()` in the plugin API, enabling plugins to programmatically manage skill provider registration.
- **Preserve user settings**: Skill provider defaults (enabled/channels) are now applied only on first install; subsequent startups preserve user edits.
- **Async hook safety**: `_fire_workspace_created_hooks` now correctly handles callbacks that return awaitables (e.g. `functools.partial` wrapping async functions).
- **Windows test fix**: Fixed `test_plugin_api_extensions` failures on Windows caused by path separator differences.

### Files Changed

| File | Change |
|------|--------|
| `src/qwenpaw/plugins/api.py` | Add `register_skill_provider()`, `unregister_skill_provider()`, skill lifecycle hooks |
| `src/qwenpaw/plugins/validation.py` | **New** — Extracted offline plugin validation with `plugin` instance check |
| `src/qwenpaw/plugins/registry.py` | Add `remove_hooks_by_name()`, uninstall/workspace_created hook storage |
| `src/qwenpaw/plugins/loader.py` | Fire uninstall hooks during `unload_plugin()` |
| `src/qwenpaw/cli/plugin_commands.py` | Use shared `validate_plugin_module()` for CLI validation |
| `src/qwenpaw/app/multi_agent_manager.py` | Async-safe `_fire_workspace_created_hooks` with awaitable handling |
| `tests/unit/plugins/test_plugin_api_extensions.py` | **New** — Unit tests for hooks, validation, and skill provider API |