### PR TITLE
fix(onebot): graceful degradation on port conflict during reload

### DIFF
--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -245,7 +245,11 @@ class OneBotChannel(BaseChannel):
         await self._stop_ws_server()
 
     async def _start_ws_server(self) -> None:
-        """Create and start the aiohttp WebSocket server."""
+        """Create and start the aiohttp WebSocket server.
+
+        On port conflict (e.g. during reload), defers to watchdog
+        for automatic recovery instead of blocking.
+        """
         self._app = web.Application()
         self._app.router.add_get("/ws", self._handle_ws_connection)
         self._app.router.add_get("/ws/", self._handle_ws_connection)
@@ -256,12 +260,29 @@ class OneBotChannel(BaseChannel):
             self._ws_host,
             self._ws_port,
         )
-        await self._site.start()
-        logger.info(
-            "onebot: reverse WS server listening on %s:%s",
-            self._ws_host,
-            self._ws_port,
-        )
+        try:
+            await self._site.start()
+            logger.info(
+                "onebot: reverse WS server listening on %s:%s",
+                self._ws_host,
+                self._ws_port,
+            )
+        except OSError:
+            logger.warning(
+                "onebot: port %s:%s in use, watchdog will retry "
+                "once the old instance releases it",
+                self._ws_host,
+                self._ws_port,
+            )
+            # Clean up the failed attempt so watchdog sees
+            # _site as None and triggers a restart.
+            self._site = None
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
+            self._runner = None
+            self._app = None
 
     async def _stop_ws_server(self) -> None:
         """Tear down the WebSocket server and clean up connections."""

--- a/tests/unit/channels/test_onebot_channel.py
+++ b/tests/unit/channels/test_onebot_channel.py
@@ -842,3 +842,81 @@ class TestPreviewText:
 
     def test_empty_parts(self):
         assert OneBotChannel._preview_text([]) == "<non-text>"
+
+
+# ===================================================================
+# Port bind retry during _start_ws_server
+# ===================================================================
+
+
+class TestPortBindGracefulDegradation:
+    """Tests for graceful degradation when port is in use."""
+
+    async def test_port_conflict_does_not_raise(self):
+        """_start_ws_server should not raise on OSError (port in use).
+
+        It should clean up and leave _site as None so the watchdog
+        can retry later.
+        """
+        ch = _make_channel(ws_port=0)
+
+        from unittest.mock import patch
+        from aiohttp.web import TCPSite
+
+        async def always_fail(self_site):
+            raise OSError(98, "address already in use")
+
+        with patch.object(TCPSite, "start", always_fail):
+            # Should NOT raise
+            await ch._start_ws_server()
+
+        # State should be cleaned up for watchdog recovery
+        assert ch._site is None
+        assert ch._runner is None
+        assert ch._app is None
+
+    async def test_watchdog_recovers_after_port_conflict(self):
+        """Watchdog should recover the server after initial port conflict."""
+        ch = _make_channel(ws_port=0)
+        ch._watchdog_interval = 0.05
+
+        from unittest.mock import patch
+        from aiohttp.web import TCPSite
+
+        fail_count = 1
+        original_tcp_start = TCPSite.start
+
+        async def mock_site_start(self_site):
+            nonlocal fail_count
+            if fail_count > 0:
+                fail_count -= 1
+                raise OSError(98, "address already in use")
+            return await original_tcp_start(self_site)
+
+        with patch.object(TCPSite, "start", mock_site_start):
+            await ch.start()
+            # Initial start failed, _site is None
+            assert ch._site is None
+
+        # Watchdog should recover (no patch, real start succeeds)
+        await asyncio.sleep(0.3)
+        assert ch._site is not None
+
+        await ch.stop()
+
+    async def test_non_oserror_still_raises(self):
+        """Non-OSError exceptions should propagate normally."""
+        ch = _make_channel(ws_port=0)
+
+        from unittest.mock import patch
+        from aiohttp.web import TCPSite
+
+        async def fail_with_runtime_error(self_site):
+            raise RuntimeError("unexpected error")
+
+        with patch.object(TCPSite, "start", fail_with_runtime_error):
+            try:
+                await ch._start_ws_server()
+                assert False, "Should have raised RuntimeError"
+            except RuntimeError:
+                pass


### PR DESCRIPTION
## Description

During zero-downtime agent reload, the new workspace starts before the old one stops. The OneBot WebSocket server would fail to bind the port (OSError: address already in use) and raise an exception, which prevented the watchdog from being created — leaving the channel permanently dead.

Now _start_ws_server() catches OSError, cleans up the failed attempt, and lets start() proceed to create the watchdog task. The watchdog automatically retries and recovers once the old instance releases the port.

**Related Issue:** Fixes #4926 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
