### PR TITLE
fix: coding mode session switch failure and header overflow (#4987)

### DIFF
--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
@@ -4,14 +4,13 @@
   line-height: 22px;
   color: var(--colorText, rgba(0, 0, 0, 0.88));
   max-width: 240px;
+  min-width: 0;
+  flex-shrink: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Dark mode */
-:global(.dark-mode) {
-  .chatName {
-    color: rgba(255, 255, 255, 0.95);
-  }
+.chatNameCoding {
+  max-width: 100px;
 }

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
@@ -1,13 +1,19 @@
 import React from "react";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
+import { useCodingMode } from "../../../../stores/codingModeStore";
 import styles from "./index.module.less";
 
 const ChatHeaderTitle: React.FC = () => {
   const { sessions, currentSessionId } = useChatAnywhereSessionsState();
+  const { codingMode } = useCodingMode();
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const chatName = currentSession?.name || "New Chat";
 
-  return <span className={styles.chatName}>{chatName}</span>;
+  const className = codingMode
+    ? `${styles.chatName} ${styles.chatNameCoding}`
+    : styles.chatName;
+
+  return <span className={className}>{chatName}</span>;
 };
 
 export default ChatHeaderTitle;

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from "react-i18next";
 import type { ChatStatus } from "../../../../api/types/chat";
 import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
+import { useCodingMode } from "../../../../stores/codingModeStore";
 import ChatSessionItem from "../ChatSessionItem";
 import { getChannelLabel } from "../../../Control/Channels/components";
 import {
@@ -148,6 +149,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   const navigate = useNavigate();
   const { sessions, currentSessionId, setCurrentSessionId, setSessions } =
     useChatAnywhereSessionsState();
+  const { codingMode } = useCodingMode();
 
   const { createSession } = useChatAnywhereSessions();
 
@@ -294,9 +296,15 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       sessionApi
         .preloadSession(sessionId)
         .then(({ realId }) => {
-          const targetUrl = `/chat/${realId || sessionId}`;
-          sessionApi.lastNavigatedChatId = realId || sessionId;
-          navigate(targetUrl, { replace: true });
+          // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
+          // The redirect effect in ChatPage would immediately navigate back
+          // to /coding before session data loads, causing the switch to fail.
+          // Instead, just set the session directly — the UI stays on /coding.
+          if (!codingMode) {
+            const targetUrl = `/chat/${realId || sessionId}`;
+            sessionApi.lastNavigatedChatId = realId || sessionId;
+            navigate(targetUrl, { replace: true });
+          }
           // Now set currentSessionId — the library's getSession will hit cache.
           setCurrentSessionId(sessionId);
         })
@@ -318,7 +326,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           setSwitchingSessionId(null);
         });
     },
-    [currentSessionId, setCurrentSessionId, navigate],
+    [currentSessionId, setCurrentSessionId, navigate, codingMode],
   );
 
   /** Delete a session: call deleteChat API then refresh the list */

--- a/console/src/pages/Coding/index.module.less
+++ b/console/src/pages/Coding/index.module.less
@@ -240,3 +240,9 @@
     }
   }
 }
+
+// Issue #4987: Tighten chat header padding in coding mode
+// so action buttons remain visible in the narrower panel.
+.root :global(.qwenpaw-chat-anywhere-layout-right-header) {
+  padding: 0 10px;
+}


### PR DESCRIPTION
- In coding mode, handleSessionClick skips URL navigation and directly switches sessions via setCurrentSessionId, remaining on the /coding route.
- Limit chat header title max-width to 100px in coding mode so action buttons remain visible in the narrower panel
- Reduce chat header padding to 0 10px in coding mode layout

Fixes #4987

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
