### PR TITLE
test(console): M1 — Agent page + API modules unit tests + coverage ratchet

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -46,10 +46,8 @@ jobs:
       - name: Run unit tests
         run: npm run test:run
 
-      - name: Generate coverage report
+      - name: Coverage ratchet (blocks PR on regression)
         run: npm run test:coverage
-        # 当前阶段仅报告，不卡 PR（覆盖率基线建立中）
-        continue-on-error: true
 
       - name: Upload coverage report
         if: always()

--- a/console/src/api/modules/agent.test.ts
+++ b/console/src/api/modules/agent.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../request", () => ({
+  request: vi.fn(),
+}));
+
+import { agentApi } from "./agent";
+import { request } from "../request";
+
+describe("agentApi", () => {
+  beforeEach(() => {
+    vi.mocked(request).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("agentRoot calls GET /agent/", async () => {
+    vi.mocked(request).mockResolvedValue({ status: "ok" });
+    const result = await agentApi.agentRoot();
+    expect(request).toHaveBeenCalledWith("/agent/");
+    expect(result).toEqual({ status: "ok" });
+  });
+
+  it("healthCheck calls GET /agent/health", async () => {
+    vi.mocked(request).mockResolvedValue({ healthy: true });
+    const result = await agentApi.healthCheck();
+    expect(request).toHaveBeenCalledWith("/agent/health");
+    expect(result).toEqual({ healthy: true });
+  });
+
+  it("agentApi sends POST to /agent/process with body", async () => {
+    const body = { message: "hello", session_id: "s1" };
+    await agentApi.agentApi(body as any);
+    expect(request).toHaveBeenCalledWith("/agent/process", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  });
+
+  it("getProcessStatus calls GET /agent/admin/status", async () => {
+    vi.mocked(request).mockResolvedValue({ running: true });
+    const result = await agentApi.getProcessStatus();
+    expect(request).toHaveBeenCalledWith("/agent/admin/status");
+    expect(result).toEqual({ running: true });
+  });
+
+  it("shutdown sends POST to /agent/admin/shutdown", async () => {
+    await agentApi.shutdown();
+    expect(request).toHaveBeenCalledWith("/agent/admin/shutdown", {
+      method: "POST",
+    });
+  });
+
+  it("getAgentRunningConfig calls GET /agent/running-config", async () => {
+    const config = { agents: [] };
+    vi.mocked(request).mockResolvedValue(config);
+    const result = await agentApi.getAgentRunningConfig();
+    expect(request).toHaveBeenCalledWith("/workspace/running-config");
+    expect(result).toEqual(config);
+  });
+
+  it("updateAgentRunningConfig sends PUT with config body", async () => {
+    const config = { agents: [{ name: "test" }] } as any;
+    vi.mocked(request).mockResolvedValue(config);
+    const result = await agentApi.updateAgentRunningConfig(config);
+    expect(request).toHaveBeenCalledWith("/workspace/running-config", {
+      method: "PUT",
+      body: JSON.stringify(config),
+    });
+    expect(result).toEqual(config);
+  });
+
+  it("updateAgentLanguage sends PUT with language in body", async () => {
+    vi.mocked(request).mockResolvedValue({
+      language: "zh",
+      copied_files: ["a.txt"],
+    });
+    const result = await agentApi.updateAgentLanguage("zh");
+    expect(request).toHaveBeenCalledWith("/workspace/language", {
+      method: "PUT",
+      body: JSON.stringify({ language: "zh" }),
+    });
+    expect(result).toEqual({ language: "zh", copied_files: ["a.txt"] });
+  });
+
+  it("updateAudioMode sends PUT with audio_mode in body", async () => {
+    await agentApi.updateAudioMode("push_to_talk");
+    expect(request).toHaveBeenCalledWith("/workspace/audio-mode", {
+      method: "PUT",
+      body: JSON.stringify({ audio_mode: "push_to_talk" }),
+    });
+  });
+
+  it("getLocalWhisperStatus calls GET /agent/local-whisper-status", async () => {
+    const status = {
+      available: true,
+      ffmpeg_installed: true,
+      whisper_installed: true,
+    };
+    vi.mocked(request).mockResolvedValue(status);
+    const result = await agentApi.getLocalWhisperStatus();
+    expect(request).toHaveBeenCalledWith("/workspace/local-whisper-status");
+    expect(result).toEqual(status);
+  });
+
+  it("updateTranscriptionProvider sends PUT with provider_id", async () => {
+    await agentApi.updateTranscriptionProvider("openai");
+    expect(request).toHaveBeenCalledWith("/workspace/transcription-provider", {
+      method: "PUT",
+      body: JSON.stringify({ provider_id: "openai" }),
+    });
+  });
+});

--- a/console/src/api/modules/cronjob.test.ts
+++ b/console/src/api/modules/cronjob.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../request", () => ({
+  request: vi.fn(),
+}));
+
+import { cronJobApi } from "./cronjob";
+import { request } from "../request";
+
+describe("cronJobApi", () => {
+  beforeEach(() => {
+    vi.mocked(request).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("listCronJobs calls GET /cron/jobs", async () => {
+    const jobs = [{ id: "job-1", name: "backup" }];
+    vi.mocked(request).mockResolvedValue(jobs);
+    const result = await cronJobApi.listCronJobs();
+    expect(request).toHaveBeenCalledWith("/cron/jobs");
+    expect(result).toEqual(jobs);
+  });
+
+  it("createCronJob sends POST to /cron/jobs with spec body", async () => {
+    const spec = { name: "cleanup", cron_expression: "0 * * * *" } as any;
+    const created = { ...spec, id: "job-2" };
+    vi.mocked(request).mockResolvedValue(created);
+    const result = await cronJobApi.createCronJob(spec);
+    expect(request).toHaveBeenCalledWith("/cron/jobs", {
+      method: "POST",
+      body: JSON.stringify(spec),
+    });
+    expect(result).toEqual(created);
+  });
+
+  it("getCronJob calls GET with encoded jobId", async () => {
+    const job = { id: "job/special", name: "test" };
+    vi.mocked(request).mockResolvedValue(job);
+    const result = await cronJobApi.getCronJob("job/special");
+    expect(request).toHaveBeenCalledWith(
+      `/cron/jobs/${encodeURIComponent("job/special")}`,
+    );
+    expect(result).toEqual(job);
+  });
+
+  it("replaceCronJob sends PUT with encoded jobId and spec body", async () => {
+    const spec = { name: "updated", cron_expression: "*/5 * * * *" } as any;
+    await cronJobApi.replaceCronJob("job-1", spec);
+    expect(request).toHaveBeenCalledWith(`/cron/jobs/${encodeURIComponent("job-1")}`, {
+      method: "PUT",
+      body: JSON.stringify(spec),
+    });
+  });
+
+  it("deleteCronJob sends DELETE with encoded jobId", async () => {
+    await cronJobApi.deleteCronJob("job-1");
+    expect(request).toHaveBeenCalledWith(`/cron/jobs/${encodeURIComponent("job-1")}`, {
+      method: "DELETE",
+    });
+  });
+
+  it("pauseCronJob sends POST to /pause endpoint", async () => {
+    await cronJobApi.pauseCronJob("job-1");
+    expect(request).toHaveBeenCalledWith(
+      `/cron/jobs/${encodeURIComponent("job-1")}/pause`,
+      { method: "POST" },
+    );
+  });
+
+  it("resumeCronJob sends POST to /resume endpoint", async () => {
+    await cronJobApi.resumeCronJob("job-1");
+    expect(request).toHaveBeenCalledWith(
+      `/cron/jobs/${encodeURIComponent("job-1")}/resume`,
+      { method: "POST" },
+    );
+  });
+
+  it("runCronJob sends POST to /run endpoint", async () => {
+    await cronJobApi.runCronJob("job-1");
+    expect(request).toHaveBeenCalledWith(
+      `/cron/jobs/${encodeURIComponent("job-1")}/run`,
+      { method: "POST" },
+    );
+  });
+});

--- a/console/src/api/modules/cronjob.test.ts
+++ b/console/src/api/modules/cronjob.test.ts
@@ -49,17 +49,23 @@ describe("cronJobApi", () => {
   it("replaceCronJob sends PUT with encoded jobId and spec body", async () => {
     const spec = { name: "updated", cron_expression: "*/5 * * * *" } as any;
     await cronJobApi.replaceCronJob("job-1", spec);
-    expect(request).toHaveBeenCalledWith(`/cron/jobs/${encodeURIComponent("job-1")}`, {
-      method: "PUT",
-      body: JSON.stringify(spec),
-    });
+    expect(request).toHaveBeenCalledWith(
+      `/cron/jobs/${encodeURIComponent("job-1")}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(spec),
+      },
+    );
   });
 
   it("deleteCronJob sends DELETE with encoded jobId", async () => {
     await cronJobApi.deleteCronJob("job-1");
-    expect(request).toHaveBeenCalledWith(`/cron/jobs/${encodeURIComponent("job-1")}`, {
-      method: "DELETE",
-    });
+    expect(request).toHaveBeenCalledWith(
+      `/cron/jobs/${encodeURIComponent("job-1")}`,
+      {
+        method: "DELETE",
+      },
+    );
   });
 
   it("pauseCronJob sends POST to /pause endpoint", async () => {

--- a/console/src/api/modules/security.test.ts
+++ b/console/src/api/modules/security.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../request", () => ({
+  request: vi.fn(),
+}));
+
+import { securityApi } from "./security";
+import type { ToolGuardConfig, SkillScannerConfig } from "./security";
+import { request } from "../request";
+
+describe("securityApi", () => {
+  beforeEach(() => {
+    vi.mocked(request).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getToolGuard calls GET /config/security/tool-guard", async () => {
+    const config: ToolGuardConfig = {
+      enabled: true,
+      guarded_tools: null,
+      denied_tools: [],
+      custom_rules: [],
+      disabled_rules: [],
+    };
+    vi.mocked(request).mockResolvedValue(config);
+    const result = await securityApi.getToolGuard();
+    expect(request).toHaveBeenCalledWith("/config/security/tool-guard");
+    expect(result).toEqual(config);
+  });
+
+  it("updateToolGuard sends PUT with config body", async () => {
+    const config: ToolGuardConfig = {
+      enabled: false,
+      guarded_tools: ["shell"],
+      denied_tools: ["rm"],
+      custom_rules: [],
+      disabled_rules: ["rule-1"],
+    };
+    vi.mocked(request).mockResolvedValue(config);
+    const result = await securityApi.updateToolGuard(config);
+    expect(request).toHaveBeenCalledWith("/config/security/tool-guard", {
+      method: "PUT",
+      body: JSON.stringify(config),
+    });
+    expect(result).toEqual(config);
+  });
+
+  it("getBuiltinRules calls GET /config/security/tool-guard/builtin-rules", async () => {
+    const rules = [{ id: "r1", tools: [], params: [], category: "security", severity: "high", patterns: [], exclude_patterns: [], description: "test", remediation: "fix" }];
+    vi.mocked(request).mockResolvedValue(rules);
+    const result = await securityApi.getBuiltinRules();
+    expect(request).toHaveBeenCalledWith("/config/security/tool-guard/builtin-rules");
+    expect(result).toEqual(rules);
+  });
+
+  it("updateFileGuard sends PUT with body", async () => {
+    const body = { enabled: true, paths: ["/secret"] };
+    vi.mocked(request).mockResolvedValue({ enabled: true, paths: ["/secret"] });
+    const result = await securityApi.updateFileGuard(body);
+    expect(request).toHaveBeenCalledWith("/config/security/file-guard", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+    expect(result).toEqual({ enabled: true, paths: ["/secret"] });
+  });
+
+  it("getSkillScanner calls GET /config/security/skill-scanner", async () => {
+    const config: SkillScannerConfig = { mode: "block", timeout: 30, whitelist: [] };
+    vi.mocked(request).mockResolvedValue(config);
+    const result = await securityApi.getSkillScanner();
+    expect(request).toHaveBeenCalledWith("/config/security/skill-scanner");
+    expect(result).toEqual(config);
+  });
+
+  it("clearBlockedHistory sends DELETE to blocked-history endpoint", async () => {
+    vi.mocked(request).mockResolvedValue({ cleared: true });
+    const result = await securityApi.clearBlockedHistory();
+    expect(request).toHaveBeenCalledWith(
+      "/config/security/skill-scanner/blocked-history",
+      { method: "DELETE" },
+    );
+    expect(result).toEqual({ cleared: true });
+  });
+
+  it("addToWhitelist sends POST with skill_name and content_hash", async () => {
+    vi.mocked(request).mockResolvedValue({ whitelisted: true, skill_name: "my-skill" });
+    const result = await securityApi.addToWhitelist("my-skill", "abc123");
+    expect(request).toHaveBeenCalledWith(
+      "/config/security/skill-scanner/whitelist",
+      {
+        method: "POST",
+        body: JSON.stringify({ skill_name: "my-skill", content_hash: "abc123" }),
+      },
+    );
+    expect(result).toEqual({ whitelisted: true, skill_name: "my-skill" });
+  });
+
+  it("removeFromWhitelist sends DELETE with encoded skill name", async () => {
+    vi.mocked(request).mockResolvedValue({ removed: true, skill_name: "my/skill" });
+    const result = await securityApi.removeFromWhitelist("my/skill");
+    expect(request).toHaveBeenCalledWith(
+      `/config/security/skill-scanner/whitelist/${encodeURIComponent("my/skill")}`,
+      { method: "DELETE" },
+    );
+    expect(result).toEqual({ removed: true, skill_name: "my/skill" });
+  });
+});

--- a/console/src/api/modules/security.test.ts
+++ b/console/src/api/modules/security.test.ts
@@ -24,6 +24,8 @@ describe("securityApi", () => {
       denied_tools: [],
       custom_rules: [],
       disabled_rules: [],
+      auto_denied_rules: [],
+      shell_evasion_checks: {},
     };
     vi.mocked(request).mockResolvedValue(config);
     const result = await securityApi.getToolGuard();
@@ -38,6 +40,8 @@ describe("securityApi", () => {
       denied_tools: ["rm"],
       custom_rules: [],
       disabled_rules: ["rule-1"],
+      auto_denied_rules: ["dangerous-cmd"],
+      shell_evasion_checks: { bash: true },
     };
     vi.mocked(request).mockResolvedValue(config);
     const result = await securityApi.updateToolGuard(config);
@@ -49,10 +53,24 @@ describe("securityApi", () => {
   });
 
   it("getBuiltinRules calls GET /config/security/tool-guard/builtin-rules", async () => {
-    const rules = [{ id: "r1", tools: [], params: [], category: "security", severity: "high", patterns: [], exclude_patterns: [], description: "test", remediation: "fix" }];
+    const rules = [
+      {
+        id: "r1",
+        tools: [],
+        params: [],
+        category: "security",
+        severity: "high",
+        patterns: [],
+        exclude_patterns: [],
+        description: "test",
+        remediation: "fix",
+      },
+    ];
     vi.mocked(request).mockResolvedValue(rules);
     const result = await securityApi.getBuiltinRules();
-    expect(request).toHaveBeenCalledWith("/config/security/tool-guard/builtin-rules");
+    expect(request).toHaveBeenCalledWith(
+      "/config/security/tool-guard/builtin-rules",
+    );
     expect(result).toEqual(rules);
   });
 
@@ -68,7 +86,11 @@ describe("securityApi", () => {
   });
 
   it("getSkillScanner calls GET /config/security/skill-scanner", async () => {
-    const config: SkillScannerConfig = { mode: "block", timeout: 30, whitelist: [] };
+    const config: SkillScannerConfig = {
+      mode: "block",
+      timeout: 30,
+      whitelist: [],
+    };
     vi.mocked(request).mockResolvedValue(config);
     const result = await securityApi.getSkillScanner();
     expect(request).toHaveBeenCalledWith("/config/security/skill-scanner");
@@ -86,23 +108,34 @@ describe("securityApi", () => {
   });
 
   it("addToWhitelist sends POST with skill_name and content_hash", async () => {
-    vi.mocked(request).mockResolvedValue({ whitelisted: true, skill_name: "my-skill" });
+    vi.mocked(request).mockResolvedValue({
+      whitelisted: true,
+      skill_name: "my-skill",
+    });
     const result = await securityApi.addToWhitelist("my-skill", "abc123");
     expect(request).toHaveBeenCalledWith(
       "/config/security/skill-scanner/whitelist",
       {
         method: "POST",
-        body: JSON.stringify({ skill_name: "my-skill", content_hash: "abc123" }),
+        body: JSON.stringify({
+          skill_name: "my-skill",
+          content_hash: "abc123",
+        }),
       },
     );
     expect(result).toEqual({ whitelisted: true, skill_name: "my-skill" });
   });
 
   it("removeFromWhitelist sends DELETE with encoded skill name", async () => {
-    vi.mocked(request).mockResolvedValue({ removed: true, skill_name: "my/skill" });
+    vi.mocked(request).mockResolvedValue({
+      removed: true,
+      skill_name: "my/skill",
+    });
     const result = await securityApi.removeFromWhitelist("my/skill");
     expect(request).toHaveBeenCalledWith(
-      `/config/security/skill-scanner/whitelist/${encodeURIComponent("my/skill")}`,
+      `/config/security/skill-scanner/whitelist/${encodeURIComponent(
+        "my/skill",
+      )}`,
       { method: "DELETE" },
     );
     expect(result).toEqual({ removed: true, skill_name: "my/skill" });

--- a/console/src/api/modules/skill.test.ts
+++ b/console/src/api/modules/skill.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../request", () => ({ request: vi.fn() }));
+vi.mock("../config", () => ({
+  getApiUrl: (path: string) => `/api${path}`,
+}));
+vi.mock("../authHeaders", () => ({
+  buildAuthHeaders: vi.fn(() => ({})),
+}));
+
+import { request } from "../request";
+import { skillApi, invalidateSkillCache } from "./skill";
+
+// ---------------------------------------------------------------------------
+// listSkills — caching + header pass-through
+// ---------------------------------------------------------------------------
+describe("skillApi.listSkills", () => {
+  beforeEach(() => {
+    invalidateSkillCache();
+    vi.mocked(request).mockResolvedValue([]);
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /skills without agent header when no agentId", async () => {
+    await skillApi.listSkills();
+    expect(request).toHaveBeenCalledWith("/skills", {});
+  });
+
+  it("passes X-Agent-Id header when agentId is provided", async () => {
+    await skillApi.listSkills("agent-1");
+    const opts = vi.mocked(request).mock.calls[0][1] as RequestInit;
+    const headers = opts.headers as Headers;
+    expect(headers.get("X-Agent-Id")).toBe("agent-1");
+  });
+
+  it("returns cached value on second call within TTL", async () => {
+    vi.mocked(request).mockResolvedValue([{ name: "s1" }]);
+    const first = await skillApi.listSkills();
+    const second = await skillApi.listSkills();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+
+  it("calls request again after cache is invalidated", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.listSkills();
+    invalidateSkillCache();
+    await skillApi.listSkills();
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires cache after TTL", async () => {
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(1000);
+    vi.mocked(request).mockResolvedValue([{ name: "s1" }]);
+    await skillApi.listSkills();
+
+    // Advance past 30s TTL
+    nowSpy.mockReturnValue(32000);
+    await skillApi.listSkills();
+    expect(request).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listSkillWorkspaces — caching
+// ---------------------------------------------------------------------------
+describe("skillApi.listSkillWorkspaces", () => {
+  beforeEach(() => {
+    invalidateSkillCache();
+    vi.mocked(request).mockResolvedValue([]);
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /skills/workspaces", async () => {
+    await skillApi.listSkillWorkspaces();
+    expect(request).toHaveBeenCalledWith("/skills/workspaces");
+  });
+
+  it("returns cached value on second call", async () => {
+    vi.mocked(request).mockResolvedValue([{ id: "ws1" }]);
+    await skillApi.listSkillWorkspaces();
+    await skillApi.listSkillWorkspaces();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listSkillPoolSkills — caching + array validation
+// ---------------------------------------------------------------------------
+describe("skillApi.listSkillPoolSkills", () => {
+  beforeEach(() => {
+    invalidateSkillCache();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /skills/pool and returns data", async () => {
+    vi.mocked(request).mockResolvedValue([{ name: "pool-skill" }]);
+    const result = await skillApi.listSkillPoolSkills();
+    expect(request).toHaveBeenCalledWith("/skills/pool");
+    expect(result).toEqual([{ name: "pool-skill" }]);
+  });
+
+  it("throws when response is not an array", async () => {
+    vi.mocked(request).mockResolvedValue({ not: "an array" });
+    await expect(skillApi.listSkillPoolSkills()).rejects.toThrow(
+      "Expected array from /skills/pool but got object",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshSkills — POST + cache update
+// ---------------------------------------------------------------------------
+describe("skillApi.refreshSkills", () => {
+  beforeEach(() => {
+    invalidateSkillCache();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST to /skills/refresh", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.refreshSkills();
+    expect(request).toHaveBeenCalledWith(
+      "/skills/refresh",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("passes X-Agent-Id header when agentId provided", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.refreshSkills("agent-2");
+    const opts = vi.mocked(request).mock.calls[0][1] as RequestInit;
+    const headers = opts.headers as Headers;
+    expect(headers.get("X-Agent-Id")).toBe("agent-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchHubSkills — query params
+// ---------------------------------------------------------------------------
+describe("skillApi.searchHubSkills", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("encodes query and passes limit", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.searchHubSkills("hello world", 10);
+    expect(request).toHaveBeenCalledWith(
+      "/skills/hub/search?q=hello%20world&limit=10",
+    );
+  });
+
+  it("uses default limit of 20", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.searchHubSkills("test");
+    expect(request).toHaveBeenCalledWith(
+      "/skills/hub/search?q=test&limit=20",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSkill — POST with body
+// ---------------------------------------------------------------------------
+describe("skillApi.createSkill", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST with name, content, config and enable", async () => {
+    vi.mocked(request).mockResolvedValue({ created: true, name: "myskill" });
+    await skillApi.createSkill("myskill", "# content", { key: "val" }, true);
+    expect(request).toHaveBeenCalledWith("/skills", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "myskill",
+        content: "# content",
+        config: { key: "val" },
+        enable: true,
+      }),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enableSkill / disableSkill — POST to encoded path
+// ---------------------------------------------------------------------------
+describe("skillApi.enableSkill", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST to /skills/<encoded>/enable", async () => {
+    vi.mocked(request).mockResolvedValue(undefined);
+    await skillApi.enableSkill("my skill");
+    expect(request).toHaveBeenCalledWith("/skills/my%20skill/enable", {
+      method: "POST",
+    });
+  });
+});
+
+describe("skillApi.disableSkill", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST to /skills/<encoded>/disable", async () => {
+    vi.mocked(request).mockResolvedValue(undefined);
+    await skillApi.disableSkill("special/skill");
+    expect(request).toHaveBeenCalledWith(
+      "/skills/special%2Fskill/disable",
+      { method: "POST" },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteSkill — DELETE to encoded path
+// ---------------------------------------------------------------------------
+describe("skillApi.deleteSkill", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends DELETE to /skills/<encoded>", async () => {
+    vi.mocked(request).mockResolvedValue({ deleted: true });
+    const result = await skillApi.deleteSkill("rm-me");
+    expect(request).toHaveBeenCalledWith("/skills/rm-me", {
+      method: "DELETE",
+    });
+    expect(result).toEqual({ deleted: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// invalidateSkillCache — targeted invalidation
+// ---------------------------------------------------------------------------
+describe("invalidateSkillCache", () => {
+  beforeEach(() => {
+    invalidateSkillCache(); // start clean
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("clears all skill cache when no options given", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.listSkills();
+    await skillApi.listSkillWorkspaces();
+    invalidateSkillCache();
+    // Both should need fresh fetch
+    await skillApi.listSkills();
+    await skillApi.listSkillWorkspaces();
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+
+  it("clears only workspace cache with workspaces option", async () => {
+    vi.mocked(request).mockResolvedValue([]);
+    await skillApi.listSkills();
+    await skillApi.listSkillWorkspaces();
+    invalidateSkillCache({ workspaces: true });
+    // listSkills still cached, listSkillWorkspaces refetches
+    await skillApi.listSkills();
+    await skillApi.listSkillWorkspaces();
+    // 2 initial + 1 workspace refetch = 3
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// batchEnableSkills — POST with array body
+// ---------------------------------------------------------------------------
+describe("skillApi.batchEnableSkills", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST to /skills/batch-enable with skill names", async () => {
+    vi.mocked(request).mockResolvedValue(undefined);
+    await skillApi.batchEnableSkills(["skill-a", "skill-b"]);
+    expect(request).toHaveBeenCalledWith("/skills/batch-enable", {
+      method: "POST",
+      body: JSON.stringify(["skill-a", "skill-b"]),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// batchDeleteSkills — POST with array body
+// ---------------------------------------------------------------------------
+describe("skillApi.batchDeleteSkills", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST to /skills/batch-delete with skill names", async () => {
+    vi.mocked(request).mockResolvedValue({
+      results: { "skill-a": { success: true } },
+    });
+    const result = await skillApi.batchDeleteSkills(["skill-a"]);
+    expect(request).toHaveBeenCalledWith("/skills/batch-delete", {
+      method: "POST",
+      body: JSON.stringify(["skill-a"]),
+    });
+    expect(result).toEqual({ results: { "skill-a": { success: true } } });
+  });
+});

--- a/console/src/api/modules/skill.test.ts
+++ b/console/src/api/modules/skill.test.ts
@@ -154,9 +154,7 @@ describe("skillApi.searchHubSkills", () => {
   it("uses default limit of 20", async () => {
     vi.mocked(request).mockResolvedValue([]);
     await skillApi.searchHubSkills("test");
-    expect(request).toHaveBeenCalledWith(
-      "/skills/hub/search?q=test&limit=20",
-    );
+    expect(request).toHaveBeenCalledWith("/skills/hub/search?q=test&limit=20");
   });
 });
 
@@ -202,10 +200,9 @@ describe("skillApi.disableSkill", () => {
   it("sends POST to /skills/<encoded>/disable", async () => {
     vi.mocked(request).mockResolvedValue(undefined);
     await skillApi.disableSkill("special/skill");
-    expect(request).toHaveBeenCalledWith(
-      "/skills/special%2Fskill/disable",
-      { method: "POST" },
-    );
+    expect(request).toHaveBeenCalledWith("/skills/special%2Fskill/disable", {
+      method: "POST",
+    });
   });
 });
 

--- a/console/src/api/modules/workspace.test.ts
+++ b/console/src/api/modules/workspace.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
 vi.mock("@tauri-apps/plugin-dialog", () => ({ save: vi.fn() }));
@@ -10,7 +10,9 @@ vi.mock("../authHeaders", () => ({
   buildAuthHeaders: vi.fn(() => ({})),
 }));
 vi.mock("../../stores/codeFileCacheStore", () => ({
-  useCodeFileCacheStore: { getState: () => ({ get: () => null, set: vi.fn(), invalidate: vi.fn() }) },
+  useCodeFileCacheStore: {
+    getState: () => ({ get: () => null, set: vi.fn(), invalidate: vi.fn() }),
+  },
 }));
 vi.mock("../../utils/downloadFileFromUrl", () => ({
   downloadFileFromUrl: vi.fn(),
@@ -32,7 +34,9 @@ describe("workspaceApi.listFiles", () => {
 
     expect(request).toHaveBeenCalledWith("/workspace/files");
     expect(result[0]).toHaveProperty("updated_at");
-    expect(result[0].updated_at).toBe(new Date("2024-01-15T10:00:00Z").getTime());
+    expect(result[0].updated_at).toBe(
+      new Date("2024-01-15T10:00:00Z").getTime(),
+    );
   });
 });
 

--- a/console/src/api/modules/workspace.test.ts
+++ b/console/src/api/modules/workspace.test.ts
@@ -81,14 +81,20 @@ describe("workspaceApi.downloadWorkspace", () => {
 });
 
 describe("workspaceApi.uploadFile", () => {
-  afterEach(() => vi.clearAllMocks());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
 
   it("sends POST with FormData to /workspace/upload", async () => {
     const mockFile = new File(["content"], "test.txt", { type: "text/plain" });
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ success: true, message: "ok" }),
-    } as unknown as Response);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, message: "ok" }),
+      } as unknown as Response),
+    );
 
     const result = await workspaceApi.uploadFile(mockFile);
 
@@ -101,12 +107,15 @@ describe("workspaceApi.uploadFile", () => {
 
   it("throws on upload failure", async () => {
     const mockFile = new File(["x"], "bad.txt");
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 413,
-      statusText: "Payload Too Large",
-      text: () => Promise.resolve("File too big"),
-    } as unknown as Response);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 413,
+        statusText: "Payload Too Large",
+        text: () => Promise.resolve("File too big"),
+      } as unknown as Response),
+    );
 
     await expect(workspaceApi.uploadFile(mockFile)).rejects.toThrow(
       "Upload failed: 413 Payload Too Large - File too big",

--- a/console/src/api/modules/workspace.test.ts
+++ b/console/src/api/modules/workspace.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ save: vi.fn() }));
+vi.mock("../request", () => ({ request: vi.fn() }));
+vi.mock("../config", () => ({
+  getApiUrl: (path: string) => `/api${path}`,
+}));
+vi.mock("../authHeaders", () => ({
+  buildAuthHeaders: vi.fn(() => ({})),
+}));
+vi.mock("../../stores/codeFileCacheStore", () => ({
+  useCodeFileCacheStore: { getState: () => ({ get: () => null, set: vi.fn(), invalidate: vi.fn() }) },
+}));
+vi.mock("../../utils/downloadFileFromUrl", () => ({
+  downloadFileFromUrl: vi.fn(),
+}));
+
+import { request } from "../request";
+import { workspaceApi } from "./workspace";
+import { downloadFileFromUrl } from "../../utils/downloadFileFromUrl";
+
+describe("workspaceApi.listFiles", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /workspace/files and transforms modified_time", async () => {
+    vi.mocked(request).mockResolvedValue([
+      { filename: "note.md", modified_time: "2024-01-15T10:00:00Z" },
+    ]);
+
+    const result = await workspaceApi.listFiles();
+
+    expect(request).toHaveBeenCalledWith("/workspace/files");
+    expect(result[0]).toHaveProperty("updated_at");
+    expect(result[0].updated_at).toBe(new Date("2024-01-15T10:00:00Z").getTime());
+  });
+});
+
+describe("workspaceApi.loadFile", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /workspace/files/<encoded> with filename", async () => {
+    vi.mocked(request).mockResolvedValue({ content: "hello" });
+    await workspaceApi.loadFile("my file.md");
+    expect(request).toHaveBeenCalledWith("/workspace/files/my%20file.md");
+  });
+});
+
+describe("workspaceApi.saveFile", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends PUT with content body to encoded path", async () => {
+    vi.mocked(request).mockResolvedValue({});
+    await workspaceApi.saveFile("doc.md", "# Title");
+    expect(request).toHaveBeenCalledWith("/workspace/files/doc.md", {
+      method: "PUT",
+      body: JSON.stringify({ content: "# Title" }),
+    });
+  });
+});
+
+describe("workspaceApi.downloadWorkspace", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls downloadFileFromUrl with correct URL and options", async () => {
+    vi.mocked(downloadFileFromUrl).mockResolvedValue(undefined);
+    await workspaceApi.downloadWorkspace();
+    expect(downloadFileFromUrl).toHaveBeenCalledWith(
+      "/api/workspace/download",
+      expect.stringContaining("qwenpaw_workspace_"),
+      expect.objectContaining({
+        errorMessage: "Workspace download failed",
+        preferResponseFilename: true,
+      }),
+    );
+  });
+});
+
+describe("workspaceApi.uploadFile", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends POST with FormData to /workspace/upload", async () => {
+    const mockFile = new File(["content"], "test.txt", { type: "text/plain" });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, message: "ok" }),
+    } as unknown as Response);
+
+    const result = await workspaceApi.uploadFile(mockFile);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/workspace/upload",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(result).toEqual({ success: true, message: "ok" });
+  });
+
+  it("throws on upload failure", async () => {
+    const mockFile = new File(["x"], "bad.txt");
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 413,
+      statusText: "Payload Too Large",
+      text: () => Promise.resolve("File too big"),
+    } as unknown as Response);
+
+    await expect(workspaceApi.uploadFile(mockFile)).rejects.toThrow(
+      "Upload failed: 413 Payload Too Large - File too big",
+    );
+  });
+});
+
+describe("workspaceApi.listDailyMemory", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("strips .md suffix to produce date field", async () => {
+    vi.mocked(request).mockResolvedValue([
+      { filename: "2024-06-01.md", modified_time: "2024-06-01T12:00:00Z" },
+    ]);
+
+    const result = await workspaceApi.listDailyMemory();
+
+    expect(request).toHaveBeenCalledWith("/workspace/memory");
+    expect(result[0].date).toBe("2024-06-01");
+  });
+});
+
+describe("workspaceApi.loadDailyMemory", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /workspace/memory/<date>.md", async () => {
+    vi.mocked(request).mockResolvedValue({ content: "memory" });
+    await workspaceApi.loadDailyMemory("2024-06-01");
+    expect(request).toHaveBeenCalledWith("/workspace/memory/2024-06-01.md");
+  });
+});
+
+describe("workspaceApi.saveDailyMemory", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends PUT to /workspace/memory/<date>.md with content", async () => {
+    vi.mocked(request).mockResolvedValue({});
+    await workspaceApi.saveDailyMemory("2024-06-01", "today");
+    expect(request).toHaveBeenCalledWith("/workspace/memory/2024-06-01.md", {
+      method: "PUT",
+      body: JSON.stringify({ content: "today" }),
+    });
+  });
+});
+
+describe("workspaceApi.getSystemPromptFiles", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("calls /workspace/system-prompt-files", async () => {
+    vi.mocked(request).mockResolvedValue(["file1.md"]);
+    const result = await workspaceApi.getSystemPromptFiles();
+    expect(request).toHaveBeenCalledWith("/workspace/system-prompt-files");
+    expect(result).toEqual(["file1.md"]);
+  });
+});
+
+describe("workspaceApi.setSystemPromptFiles", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("sends PUT with JSON array of filenames", async () => {
+    vi.mocked(request).mockResolvedValue(["a.md", "b.md"]);
+    await workspaceApi.setSystemPromptFiles(["a.md", "b.md"]);
+    expect(request).toHaveBeenCalledWith("/workspace/system-prompt-files", {
+      method: "PUT",
+      body: JSON.stringify(["a.md", "b.md"]),
+    });
+  });
+});

--- a/console/src/pages/Agent/Config/components/SliderWithValue.test.tsx
+++ b/console/src/pages/Agent/Config/components/SliderWithValue.test.tsx
@@ -28,7 +28,7 @@ describe("SliderWithValue", () => {
     expect(container).toBeTruthy();
   });
 
-  it("displays formatted value: integer for >= 1, two decimals for < 1", () => {
+  it("displays formatted value: toString for >= 1, two decimals for < 1", () => {
     const { rerender } = renderWithProviders(
       <SliderWithValue value={0.75} min={0} max={2} step={0.01} />,
     );
@@ -36,6 +36,10 @@ describe("SliderWithValue", () => {
 
     rerender(<SliderWithValue value={2} min={0} max={2} step={0.01} />);
     expect(screen.getByText("2")).toBeInTheDocument();
+
+    // toString preserves decimals (does not truncate to integer)
+    rerender(<SliderWithValue value={1.5} min={0} max={2} step={0.01} />);
+    expect(screen.getByText("1.5")).toBeInTheDocument();
   });
 
   it("calls onChange when slider value changes", () => {

--- a/console/src/pages/Agent/Config/components/SliderWithValue.test.tsx
+++ b/console/src/pages/Agent/Config/components/SliderWithValue.test.tsx
@@ -41,7 +41,13 @@ describe("SliderWithValue", () => {
   it("calls onChange when slider value changes", () => {
     const handleChange = vi.fn();
     renderWithProviders(
-      <SliderWithValue value={0.5} min={0} max={1} step={0.01} onChange={handleChange} />,
+      <SliderWithValue
+        value={0.5}
+        min={0}
+        max={1}
+        step={0.01}
+        onChange={handleChange}
+      />,
     );
 
     const slider = screen.getByTestId("slider");

--- a/console/src/pages/Agent/Config/components/SliderWithValue.test.tsx
+++ b/console/src/pages/Agent/Config/components/SliderWithValue.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "@/test/common_setup";
+import { SliderWithValue } from "./SliderWithValue";
+
+// Mock the Slider component from @agentscope-ai/design
+vi.mock("@agentscope-ai/design", async () => {
+  const actual = await vi.importActual("@agentscope-ai/design");
+  return {
+    ...actual,
+    Slider: ({ value, onChange, ...props }: any) => (
+      <input
+        type="range"
+        data-testid="slider"
+        value={value ?? 0}
+        onChange={(e) => onChange?.(Number(e.target.value))}
+        {...props}
+      />
+    ),
+  };
+});
+
+describe("SliderWithValue", () => {
+  it("renders without crashing", () => {
+    const { container } = renderWithProviders(
+      <SliderWithValue value={0.5} min={0} max={1} step={0.01} />,
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it("displays formatted value: integer for >= 1, two decimals for < 1", () => {
+    const { rerender } = renderWithProviders(
+      <SliderWithValue value={0.75} min={0} max={2} step={0.01} />,
+    );
+    expect(screen.getByText("0.75")).toBeInTheDocument();
+
+    rerender(<SliderWithValue value={2} min={0} max={2} step={0.01} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("calls onChange when slider value changes", () => {
+    const handleChange = vi.fn();
+    renderWithProviders(
+      <SliderWithValue value={0.5} min={0} max={1} step={0.01} onChange={handleChange} />,
+    );
+
+    const slider = screen.getByTestId("slider");
+    fireEvent.change(slider, { target: { value: "0.8" } });
+    expect(handleChange).toHaveBeenCalledWith(0.8);
+  });
+});

--- a/console/src/pages/Agent/Skills/useSkillFilter.test.ts
+++ b/console/src/pages/Agent/Skills/useSkillFilter.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSkillFilter } from "./useSkillFilter";
+import { SKILL_TAG_FILTER_PREFIX } from "@/constants/skill";
+
+interface TestSkill {
+  name: string;
+  description?: string;
+  tags?: string[];
+}
+
+const mockSkills: TestSkill[] = [
+  { name: "CodeGen", description: "Generates code from prompts", tags: ["ai", "code"] },
+  { name: "Translator", description: "Translates between languages", tags: ["ai", "language"] },
+  { name: "Formatter", description: "Formats source files", tags: ["code", "tools"] },
+  { name: "Linter", description: "Checks code quality", tags: ["code", "quality"] },
+];
+
+function tagFilter(tag: string) {
+  return `${SKILL_TAG_FILTER_PREFIX}${tag}`;
+}
+
+describe("useSkillFilter", () => {
+  it("returns all skills when no filter is applied", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+    expect(result.current.filteredSkills).toEqual(mockSkills);
+  });
+
+  it("filters by name case-insensitively", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+
+    act(() => {
+      result.current.setSearchQuery("codegen");
+    });
+
+    expect(result.current.filteredSkills).toHaveLength(1);
+    expect(result.current.filteredSkills[0].name).toBe("CodeGen");
+  });
+
+  it("filters by description", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+
+    act(() => {
+      result.current.setSearchQuery("translates");
+    });
+
+    expect(result.current.filteredSkills).toHaveLength(1);
+    expect(result.current.filteredSkills[0].name).toBe("Translator");
+  });
+
+  it("filters by tags using exact match", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+
+    act(() => {
+      result.current.setSearchTags([tagFilter("language")]);
+    });
+
+    expect(result.current.filteredSkills).toHaveLength(1);
+    expect(result.current.filteredSkills[0].name).toBe("Translator");
+  });
+
+  it("combines search query and tag filter", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+
+    act(() => {
+      result.current.setSearchQuery("code");
+    });
+    act(() => {
+      result.current.setSearchTags([tagFilter("ai")]);
+    });
+
+    // "code" matches CodeGen (name) and Linter (description), tag "ai" narrows to CodeGen only
+    expect(result.current.filteredSkills).toHaveLength(1);
+    expect(result.current.filteredSkills[0].name).toBe("CodeGen");
+  });
+
+  it("collects unique sorted tags from all skills", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+    expect(result.current.allTags).toEqual(["ai", "code", "language", "quality", "tools"]);
+  });
+
+  it("re-filters skills when searchQuery is updated", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+
+    act(() => {
+      result.current.setSearchQuery("formatter");
+    });
+    expect(result.current.filteredSkills).toHaveLength(1);
+
+    act(() => {
+      result.current.setSearchQuery("linter");
+    });
+    expect(result.current.filteredSkills).toHaveLength(1);
+    expect(result.current.filteredSkills[0].name).toBe("Linter");
+  });
+
+  it("returns all skills when query is cleared back to empty", () => {
+    const { result } = renderHook(() => useSkillFilter(mockSkills));
+
+    act(() => {
+      result.current.setSearchQuery("codegen");
+    });
+    expect(result.current.filteredSkills).toHaveLength(1);
+
+    act(() => {
+      result.current.setSearchQuery("");
+    });
+    expect(result.current.filteredSkills).toEqual(mockSkills);
+  });
+});

--- a/console/src/pages/Agent/Skills/useSkillFilter.test.ts
+++ b/console/src/pages/Agent/Skills/useSkillFilter.test.ts
@@ -10,10 +10,26 @@ interface TestSkill {
 }
 
 const mockSkills: TestSkill[] = [
-  { name: "CodeGen", description: "Generates code from prompts", tags: ["ai", "code"] },
-  { name: "Translator", description: "Translates between languages", tags: ["ai", "language"] },
-  { name: "Formatter", description: "Formats source files", tags: ["code", "tools"] },
-  { name: "Linter", description: "Checks code quality", tags: ["code", "quality"] },
+  {
+    name: "CodeGen",
+    description: "Generates code from prompts",
+    tags: ["ai", "code"],
+  },
+  {
+    name: "Translator",
+    description: "Translates between languages",
+    tags: ["ai", "language"],
+  },
+  {
+    name: "Formatter",
+    description: "Formats source files",
+    tags: ["code", "tools"],
+  },
+  {
+    name: "Linter",
+    description: "Checks code quality",
+    tags: ["code", "quality"],
+  },
 ];
 
 function tagFilter(tag: string) {
@@ -76,7 +92,13 @@ describe("useSkillFilter", () => {
 
   it("collects unique sorted tags from all skills", () => {
     const { result } = renderHook(() => useSkillFilter(mockSkills));
-    expect(result.current.allTags).toEqual(["ai", "code", "language", "quality", "tools"]);
+    expect(result.current.allTags).toEqual([
+      "ai",
+      "code",
+      "language",
+      "quality",
+      "tools",
+    ]);
   });
 
   it("re-filters skills when searchQuery is updated", () => {

--- a/console/src/pages/Agent/Workspace/components/utils.test.ts
+++ b/console/src/pages/Agent/Workspace/components/utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
+
+import { formatTimeAgo, isDailyMemoryFile } from "./utils";
+
+describe("formatTimeAgo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a relative time string for a recent timestamp", () => {
+    const fiveMinutesAgo = new Date("2024-06-01T11:55:00Z").getTime();
+    const result = formatTimeAgo(fiveMinutesAgo);
+    expect(result).toBe("5 minutes ago");
+  });
+
+  it("returns a relative time string for a string timestamp", () => {
+    const result = formatTimeAgo("2024-06-01T11:00:00Z");
+    expect(result).toBe("an hour ago");
+  });
+});
+
+describe("isDailyMemoryFile", () => {
+  it("returns true for a valid daily memory filename like '2024-01-15.md'", () => {
+    expect(isDailyMemoryFile("2024-01-15.md")).toBe(true);
+  });
+
+  it("returns false for a non-date filename like 'notes.md'", () => {
+    expect(isDailyMemoryFile("notes.md")).toBe(false);
+  });
+
+  it("returns false for single-digit month/day like '2024-1-5.md'", () => {
+    expect(isDailyMemoryFile("2024-1-5.md")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isDailyMemoryFile("")).toBe(false);
+  });
+});

--- a/console/src/test/tauri-mock.ts
+++ b/console/src/test/tauri-mock.ts
@@ -1,2 +1,9 @@
-export const invoke = () => Promise.resolve(undefined);
-export const save = () => Promise.resolve(null);
+import { vi } from "vitest";
+
+export const invoke = vi.fn<(...args: unknown[]) => Promise<unknown>>(() =>
+  Promise.resolve(undefined),
+);
+export const isTauri = vi.fn<() => boolean>(() => false);
+export const save = vi.fn<() => Promise<string | null>>(() =>
+  Promise.resolve(null),
+);

--- a/console/src/test/tauri-mock.ts
+++ b/console/src/test/tauri-mock.ts
@@ -1,0 +1,2 @@
+export const invoke = () => Promise.resolve(undefined);
+export const save = () => Promise.resolve(null);

--- a/console/src/utils/openExternalLink.test.ts
+++ b/console/src/utils/openExternalLink.test.ts
@@ -1,19 +1,23 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const tauriMocks = vi.hoisted(() => ({
-  invoke: vi.fn(),
-  isTauri: vi.fn(() => false),
-}));
-const dialogMocks = vi.hoisted(() => ({
-  save: vi.fn(),
-}));
+// The vite.config.ts aliases @tauri-apps/api/core and @tauri-apps/plugin-dialog
+// to src/test/tauri-mock.ts, which exports vi.fn() instances we can control directly.
+import { invoke, isTauri, save } from "../test/tauri-mock";
 
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: tauriMocks.invoke,
-  isTauri: tauriMocks.isTauri,
+vi.mock("../request", () => ({
+  request: vi.fn(),
 }));
-vi.mock("@tauri-apps/plugin-dialog", () => ({
-  save: dialogMocks.save,
+vi.mock("../config", () => ({
+  getApiUrl: (path: string) => `/api${path}`,
+}));
+vi.mock("../authHeaders", () => ({
+  buildAuthHeaders: vi.fn(() => ({})),
+}));
+vi.mock("../../stores/codeFileCacheStore", () => ({
+  useCodeFileCacheStore: {
+    getState: () => ({ get: () => null, set: vi.fn(), invalidate: vi.fn() }),
+  },
 }));
 
 import {
@@ -27,10 +31,10 @@ describe("openExternalLink", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
-    tauriMocks.invoke.mockReset();
-    tauriMocks.isTauri.mockReturnValue(false);
-    tauriMocks.invoke.mockResolvedValue(undefined);
-    dialogMocks.save.mockReset();
+    invoke.mockReset();
+    isTauri.mockReturnValue(false);
+    invoke.mockResolvedValue(undefined);
+    save.mockReset();
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
     Object.defineProperty(URL, "createObjectURL", {
@@ -63,14 +67,14 @@ describe("openExternalLink", () => {
         open_external_link: openExternal,
       },
     };
-    tauriMocks.isTauri.mockReturnValue(true);
+    isTauri.mockReturnValue(true);
 
     openExternalLink("https://github.com/agentscope-ai/QwenPaw");
 
     expect(openExternal).toHaveBeenCalledWith(
       "https://github.com/agentscope-ai/QwenPaw",
     );
-    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
     expect(windowOpen).not.toHaveBeenCalled();
   });
 
@@ -96,36 +100,36 @@ describe("openExternalLink", () => {
     openExternalLink("javascript:alert(1)");
     openExternalLink("#");
 
-    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
     expect(windowOpen).not.toHaveBeenCalled();
   });
 
   it("rejects ambiguous HTTP links without slashes before opening", () => {
-    tauriMocks.isTauri.mockReturnValue(true);
+    isTauri.mockReturnValue(true);
 
     openExternalLink("http:example.com");
 
-    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
     expect(windowOpen).not.toHaveBeenCalled();
   });
 
   it("uses the Tauri external link command for supported non-HTTP schemes", () => {
-    tauriMocks.isTauri.mockReturnValue(true);
+    isTauri.mockReturnValue(true);
 
     openExternalLink("mailto:support@example.com");
 
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+    expect(invoke).toHaveBeenCalledWith("open_external_link", {
       url: "mailto:support@example.com",
     });
     expect(windowOpen).not.toHaveBeenCalled();
   });
 
   it("uses the Tauri external link command in the Tauri desktop app", () => {
-    tauriMocks.isTauri.mockReturnValue(true);
+    isTauri.mockReturnValue(true);
 
     openExternalLink("https://qwenpaw.agentscope.io/docs/intro?lang=zh");
 
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+    expect(invoke).toHaveBeenCalledWith("open_external_link", {
       url: "https://qwenpaw.agentscope.io/docs/intro?lang=zh",
     });
     expect(windowOpen).not.toHaveBeenCalled();
@@ -138,15 +142,15 @@ describe("openExternalLink", () => {
 
     openExternalLink("https://github.com/agentscope-ai/QwenPaw");
 
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+    expect(invoke).toHaveBeenCalledWith("open_external_link", {
       url: "https://github.com/agentscope-ai/QwenPaw",
     });
     expect(windowOpen).not.toHaveBeenCalled();
   });
 
   it("logs Tauri external link failures without falling back to window.open", async () => {
-    tauriMocks.isTauri.mockReturnValue(true);
-    tauriMocks.invoke.mockRejectedValue(new Error("permission denied"));
+    isTauri.mockReturnValue(true);
+    invoke.mockRejectedValue(new Error("permission denied"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     openExternalLink("https://github.com/agentscope-ai/QwenPaw");
@@ -175,7 +179,7 @@ describe("openExternalLink", () => {
 
     openExternalLink("https://github.com/agentscope-ai/QwenPaw");
 
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+    expect(invoke).toHaveBeenCalledWith("open_external_link", {
       url: "https://github.com/agentscope-ai/QwenPaw",
     });
     expect(fetchMock).not.toHaveBeenCalled();
@@ -208,18 +212,18 @@ describe("openExternalLink", () => {
   });
 
   it("resolves relative links before passing them to desktop bridges", () => {
-    tauriMocks.isTauri.mockReturnValue(true);
+    isTauri.mockReturnValue(true);
 
     openExternalLink("/docs/faq");
 
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("open_external_link", {
+    expect(invoke).toHaveBeenCalledWith("open_external_link", {
       url: "http://localhost:3000/docs/faq",
     });
   });
 
   it("downloads Tauri files with headers through the native backend command", async () => {
-    tauriMocks.isTauri.mockReturnValue(true);
-    dialogMocks.save.mockResolvedValue("C:\\Downloads\\server.zip");
+    isTauri.mockReturnValue(true);
+    save.mockResolvedValue("C:\\Downloads\\server.zip");
     localStorage.setItem("qwenpaw_auth_token", "tok");
 
     await expect(
@@ -229,24 +233,22 @@ describe("openExternalLink", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(dialogMocks.save).toHaveBeenCalledWith({
+    expect(save).toHaveBeenCalledWith({
       defaultPath: "workspace.zip",
     });
-    expect(tauriMocks.invoke).toHaveBeenCalledWith("download_backend_file", {
+    expect(invoke).toHaveBeenCalledWith("download_backend_file", {
       request: {
         url: "http://localhost:3000/api/workspace/download",
         filePath: "C:\\Downloads\\server.zip",
         headers: { "X-Agent-Id": "agent-a" },
       },
     });
-    expect(dialogMocks.save.mock.invocationCallOrder[0]).toBeLessThan(
-      tauriMocks.invoke.mock.invocationCallOrder[0],
+    expect(save.mock.invocationCallOrder[0]).toBeLessThan(
+      invoke.mock.invocationCallOrder[0],
     );
     expect(fetchMock).not.toHaveBeenCalled();
     expect(
-      tauriMocks.invoke.mock.calls.some(
-        ([command]) => command === "open_external_link",
-      ),
+      invoke.mock.calls.some(([command]) => command === "open_external_link"),
     ).toBe(false);
   });
 
@@ -275,7 +277,7 @@ describe("openExternalLink", () => {
       { Authorization: "Bearer tok" },
     );
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(dialogMocks.save).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
   });
 
   it("keeps legacy pywebview downloads backward-compatible without headers", async () => {
@@ -297,8 +299,8 @@ describe("openExternalLink", () => {
   });
 
   it("sanitizes Tauri save dialog filenames for Windows", async () => {
-    tauriMocks.isTauri.mockReturnValue(true);
-    dialogMocks.save.mockResolvedValue("C:\\Downloads\\backup.zip");
+    isTauri.mockReturnValue(true);
+    save.mockResolvedValue("C:\\Downloads\\backup.zip");
 
     await expect(
       downloadFileFromUrl(
@@ -307,10 +309,10 @@ describe("openExternalLink", () => {
       ),
     ).resolves.toBeUndefined();
 
-    expect(dialogMocks.save).toHaveBeenCalledWith({
+    expect(save).toHaveBeenCalledWith({
       defaultPath: "Backup 2026-05-22 14_13.zip",
     });
-    expect(tauriMocks.invoke).toHaveBeenCalledWith(
+    expect(invoke).toHaveBeenCalledWith(
       "download_backend_file",
       expect.objectContaining({
         request: expect.objectContaining({
@@ -322,8 +324,8 @@ describe("openExternalLink", () => {
   });
 
   it("reports Tauri download cancellation before starting the native download", async () => {
-    tauriMocks.isTauri.mockReturnValue(true);
-    dialogMocks.save.mockResolvedValue(null);
+    isTauri.mockReturnValue(true);
+    save.mockResolvedValue(null);
     fetchMock.mockResolvedValue(new Response("zip"));
 
     await expect(
@@ -333,16 +335,16 @@ describe("openExternalLink", () => {
     ).rejects.toBeInstanceOf(DownloadCancelledError);
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(tauriMocks.invoke).not.toHaveBeenCalledWith(
+    expect(invoke).not.toHaveBeenCalledWith(
       "download_backend_file",
       expect.anything(),
     );
   });
 
   it("surfaces Tauri native download failures with the caller's message", async () => {
-    tauriMocks.isTauri.mockReturnValue(true);
-    dialogMocks.save.mockResolvedValue("C:\\Downloads\\server.zip");
-    tauriMocks.invoke.mockRejectedValue(new Error("HTTP 500"));
+    isTauri.mockReturnValue(true);
+    save.mockResolvedValue("C:\\Downloads\\server.zip");
+    invoke.mockRejectedValue(new Error("HTTP 500"));
 
     await expect(
       downloadFileFromUrl("/api/workspace/download", "workspace.zip", {
@@ -369,15 +371,15 @@ describe("openExternalLink", () => {
   });
 
   it("rejects non-HTTP URLs before selecting a download runtime", async () => {
-    tauriMocks.isTauri.mockReturnValue(true);
-    dialogMocks.save.mockResolvedValue("C:\\Downloads\\mail.zip");
+    isTauri.mockReturnValue(true);
+    save.mockResolvedValue("C:\\Downloads\\mail.zip");
 
     await expect(
       downloadFileFromUrl("mailto:support@example.com", "mail.zip"),
     ).rejects.toThrow("Download URL is invalid");
 
-    expect(dialogMocks.save).not.toHaveBeenCalled();
-    expect(tauriMocks.invoke).not.toHaveBeenCalledWith(
+    expect(save).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalledWith(
       "download_backend_file",
       expect.anything(),
     );
@@ -390,7 +392,7 @@ describe("openExternalLink", () => {
     ).rejects.toThrow("Download URL is invalid");
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(tauriMocks.invoke).not.toHaveBeenCalledWith(
+    expect(invoke).not.toHaveBeenCalledWith(
       "download_backend_file",
       expect.anything(),
     );

--- a/console/src/utils/openExternalLink.test.ts
+++ b/console/src/utils/openExternalLink.test.ts
@@ -5,21 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // to src/test/tauri-mock.ts, which exports vi.fn() instances we can control directly.
 import { invoke, isTauri, save } from "../test/tauri-mock";
 
-vi.mock("../request", () => ({
-  request: vi.fn(),
-}));
-vi.mock("../config", () => ({
-  getApiUrl: (path: string) => `/api${path}`,
-}));
-vi.mock("../authHeaders", () => ({
-  buildAuthHeaders: vi.fn(() => ({})),
-}));
-vi.mock("../../stores/codeFileCacheStore", () => ({
-  useCodeFileCacheStore: {
-    getState: () => ({ get: () => null, set: vi.fn(), invalidate: vi.fn() }),
-  },
-}));
-
 import {
   DownloadCancelledError,
   downloadFileFromUrl,

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -70,6 +70,14 @@ export default defineConfig(({ mode }) => {
           __dirname,
           "src/test/icons-mock.ts",
         ),
+        "@tauri-apps/api/core": path.resolve(
+          __dirname,
+          "src/test/tauri-mock.ts",
+        ),
+        "@tauri-apps/plugin-dialog": path.resolve(
+          __dirname,
+          "src/test/tauri-mock.ts",
+        ),
       },
       exclude: [
         "**/node_modules/**",
@@ -83,7 +91,7 @@ export default defineConfig(({ mode }) => {
       ],
       coverage: {
         provider: "v8",
-        reporter: ["text", "html", "json", "lcov"],
+        reporter: ["text", "html", "json", "json-summary", "lcov"],
         include: ["src/**/*.{ts,tsx}"],
         exclude: [
           "src/test/**",
@@ -92,8 +100,12 @@ export default defineConfig(({ mode }) => {
           "src/main.tsx",
           "src/vite-env.d.ts",
         ],
-        // 第一阶段：记录基线，不强制卡点
-        // 后续稳定后可开启：thresholds: { statements: 60, functions: 60 }
+        thresholds: {
+          statements: 5,
+          branches: 4,
+          functions: 3,
+          lines: 5,
+        },
       },
     },
     optimizeDeps: {


### PR DESCRIPTION
## Summary

Add 76 new Vitest unit tests for M1 milestone (Agent page + core API modules) and enable a coverage ratchet in CI to prevent regression.

## Type of Change

- [ ] Bug fix
- [x] Feature (test infrastructure + coverage enforcement)
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Problem / Motivation

The Agent page and core API modules had zero test coverage. Without a coverage ratchet, any PR could silently decrease coverage. This blocks the team's goal of reaching 25% statement coverage by M3.

## Proposed Solution

### New test files (8, 76 tests total):
| File | Tests | Coverage target |
| --- | --- | --- |
| api/modules/agent.test.ts | 11 | Agent CRUD, config, language, audio |
| api/modules/cronjob.test.ts | 8 | CronJob CRUD, pause/resume/run |
| api/modules/security.test.ts | 8 | Tool guard, file guard, skill scanner |
| api/modules/skill.test.ts | 21 | Skill CRUD, cache, hub search, batch ops |
| api/modules/workspace.test.ts | 11 | Files, memory, download/upload |
| Agent/Skills/useSkillFilter.test.ts | 8 | Filter by name, description, tags |
| Agent/Workspace/components/utils.test.ts | 6 | formatTimeAgo, isDailyMemoryFile |
| Agent/Config/components/SliderWithValue.test.tsx | 3 | Render, format, onChange |

### Coverage ratchet:
- Enabled thresholds in vite.config.ts (statements 5%, branches 4%, functions 3%, lines 5%)
- Removed continue-on-error from CI coverage step so PRs that lower coverage will be blocked
- Added json-summary reporter for machine-readable coverage output
- Added tauri-mock.ts to resolve @tauri-apps/* imports in test env

## Alternatives Considered

- Hook tests (useMCP, useTools, useAgentConfig) deferred — they need a custom wrapper for async fetch-on-mount patterns. Will address in M1 follow-up.
- Higher thresholds considered but set conservatively at current baseline.

## Checklist

- [x] Run and pass pre-commit run --all-files
- [x] Run and pass relevant tests (76 new tests all green)
- [ ] Update documentation if needed (N/A)

## Testing

```bash
cd console
npx vitest run src/api/modules/agent.test.ts src/api/modules/cronjob.test.ts \
  src/api/modules/security.test.ts src/api/modules/skill.test.ts \
  src/api/modules/workspace.test.ts \
  src/pages/Agent/Config/components/SliderWithValue.test.tsx \
  src/pages/Agent/Skills/useSkillFilter.test.ts \
  src/pages/Agent/Workspace/components/utils.test.ts
# Test Files  8 passed (8)
#       Tests  76 passed (76)
```

## Local Verification Evidence

```
pre-commit run --all-files
# All hooks passed (yaml, detect-private-key, trailing-whitespace)

npx vitest run (new files only)
# Test Files  8 passed (8)
# Tests  76 passed (76)
# Duration  3.11s
```

## Additional Context

- Part of the Frontend Testing (Vitest) Plan: https://yuque.antfin.com/kb41g4/kg7h1z/hnth08b4l7ewpqb0
- Resolves #5005

## Willing to Contribute

- [x] I am willing to open a PR for this feature (after discussion).