### PR TITLE
fix(mcp): prevent subprocess accumulation across restarts (#4834)

### DIFF
--- a/deploy/config/supervisord.conf.template
+++ b/deploy/config/supervisord.conf.template
@@ -16,6 +16,7 @@ command=qwenpaw app --host 0.0.0.0 --port ${QWENPAW_PORT}
 autostart=true
 autorestart=true
 priority=30
+stopwaitsecs=30
 stderr_logfile=/var/log/app.err.log
 stdout_logfile=/var/log/app.out.log
 environment=DISPLAY=":1",PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/usr/bin/chromium",QWENPAW_RUNNING_IN_CONTAINER="1"

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -151,21 +151,48 @@ class MCPClientManager:
                 logger.warning(f"Error closing MCP client '{key}': {e}")
 
     async def close_all(self) -> None:
-        """Close all MCP clients.
+        """Close all MCP clients concurrently.
 
-        Called during application shutdown.
+        Called during application shutdown.  All clients are
+        closed in parallel via ``asyncio.gather`` with a 30 s
+        overall timeout so one hung client cannot block the rest.
         """
         async with self._lock:
             clients_snapshot = list(self._clients.items())
             self._clients.clear()
 
-        logger.debug("Closing all MCP clients")
-        for key, client in clients_snapshot:
-            if client is not None:
-                try:
-                    await client.close()
-                except Exception as e:
-                    logger.warning(f"Error closing MCP client '{key}': {e}")
+        if not clients_snapshot:
+            return
+
+        logger.debug(
+            f"Closing {len(clients_snapshot)} MCP client(s)",
+        )
+
+        async def _close_one(key: str, client) -> None:
+            try:
+                await client.close()
+            except Exception as e:
+                logger.warning(
+                    f"Error closing MCP client '{key}': {e}",
+                )
+
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *(
+                        _close_one(k, c)
+                        for k, c in clients_snapshot
+                        if c is not None
+                    ),
+                    return_exceptions=True,
+                ),
+                timeout=30.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "MCP close_all timed out after 30s; "
+                "some clients may not have shut down cleanly",
+            )
 
     async def _add_client(
         self,

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -194,6 +194,13 @@ class MCPClientManager:
                 "some clients may not have shut down cleanly",
             )
 
+        # Final sweep: kill any stdio subprocesses that survived
+        # graceful teardown (include_active=True covers the case
+        # where the gather timed out before all clients closed).
+        from .stateful_client import kill_orphaned_mcp_children
+
+        await kill_orphaned_mcp_children(include_active=True)
+
     async def _add_client(
         self,
         key: str,

--- a/src/qwenpaw/app/mcp/manager.py
+++ b/src/qwenpaw/app/mcp/manager.py
@@ -194,12 +194,13 @@ class MCPClientManager:
                 "some clients may not have shut down cleanly",
             )
 
-        # Final sweep: kill any stdio subprocesses that survived
-        # graceful teardown (include_active=True covers the case
-        # where the gather timed out before all clients closed).
+        # Reap orphans only — PIDs that survived their client's
+        # close().  Do NOT use include_active=True here because
+        # another manager (e.g. new workspace after reload) may
+        # have already registered fresh PIDs in the global table.
         from .stateful_client import kill_orphaned_mcp_children
 
-        await kill_orphaned_mcp_children(include_active=True)
+        await kill_orphaned_mcp_children(include_active=False)
 
     async def _add_client(
         self,

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
+import signal
+import time
 from contextlib import AsyncExitStack
 from datetime import timedelta
 from typing import Any, Literal
@@ -155,6 +158,109 @@ def _is_401_error(exc: BaseException) -> bool:
     return False
 
 
+# Timeout for ``close()`` to wait for the lifecycle task before
+# cancelling and force-killing child processes.
+_CLOSE_TIMEOUT = 15.0
+
+# Graceful period between SIGTERM and SIGKILL when force-killing
+# orphaned MCP subprocesses.
+_FORCE_KILL_GRACE = 2.0
+
+
+def _snapshot_child_pids() -> set[int]:
+    """Return PIDs of current child processes.
+
+    Uses ``/proc`` on Linux, falls back to ``psutil``,
+    then returns an empty set on unsupported platforms.
+    """
+    my_pid = os.getpid()
+    try:
+        children_path = f"/proc/{my_pid}/task/{my_pid}/children"
+        with open(
+            children_path,
+            encoding="utf-8",
+        ) as fh:
+            return {int(p) for p in fh.read().split() if p.strip()}
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+    try:
+        import psutil  # type: ignore[import-untyped]
+
+        return {c.pid for c in psutil.Process(my_pid).children()}
+    except Exception:
+        pass
+    return set()
+
+
+def _pid_exists(pid: int) -> bool:
+    """Check whether *pid* is alive (cross-platform)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
+
+
+def _force_kill_pids(
+    pids: set[int],
+    client_name: str,
+) -> None:
+    """SIGTERM then SIGKILL orphaned MCP child PIDs.
+
+    Uses ``os.killpg`` when a process-group ID can be
+    obtained (POSIX); falls back to ``os.kill`` per-PID.
+    """
+    if not pids:
+        return
+
+    _sigterm = signal.SIGTERM
+    _sigkill = getattr(signal, "SIGKILL", _sigterm)
+    _killpg = getattr(os, "killpg", None)
+
+    def _send(pid: int, sig: int) -> None:
+        if _killpg is not None:
+            try:
+                pgid = os.getpgid(pid)
+                _killpg(pgid, sig)
+                return
+            except (
+                ProcessLookupError,
+                PermissionError,
+                OSError,
+            ):
+                pass
+        try:
+            os.kill(pid, sig)
+        except (
+            ProcessLookupError,
+            PermissionError,
+            OSError,
+        ):
+            pass
+
+    for pid in pids:
+        _send(pid, _sigterm)
+        logger.debug(
+            "Sent SIGTERM to MCP child %d (%s)",
+            pid,
+            client_name,
+        )
+
+    time.sleep(_FORCE_KILL_GRACE)
+
+    for pid in pids:
+        if not _pid_exists(pid):
+            continue
+        _send(pid, _sigkill)
+        logger.warning(
+            "Force-killed MCP child %d (%s) after SIGTERM timeout",
+            pid,
+            client_name,
+        )
+
+
 class _MCPClientMixin:
     """Mixin providing shared tool-call and lifecycle logic for both clients.
 
@@ -187,6 +293,7 @@ class _MCPClientMixin:
     _reload_event: asyncio.Event
     _ready_event: asyncio.Event
     _lifecycle_task: asyncio.Task | None
+    _child_pids: set[int]
 
     # ------------------------------------------------------------------
     # Transport hook (implemented by each concrete subclass)
@@ -210,6 +317,28 @@ class _MCPClientMixin:
     # Lifecycle
     # ------------------------------------------------------------------
 
+    def _force_kill_children(self) -> None:
+        """Force-kill any tracked child PIDs that survived
+        the graceful ``AsyncExitStack`` teardown.
+
+        Safe to call from any context (sync).  No-op when
+        ``_child_pids`` is empty or on non-stdio clients.
+        """
+        pids = getattr(self, "_child_pids", None)
+        if not pids:
+            return
+        alive = {p for p in pids if _pid_exists(p)}
+        if alive:
+            logger.warning(
+                "MCP client '%s': %d child process(es) "
+                "survived teardown, force-killing: %s",
+                self.name,
+                len(alive),
+                alive,
+            )
+            _force_kill_pids(alive, self.name)
+        self._child_pids = set()
+
     async def _run_lifecycle(self) -> None:  # noqa: C901
         """Run MCP client lifecycle in a dedicated task.
 
@@ -219,58 +348,70 @@ class _MCPClientMixin:
         """
         while not self._stop_event.is_set():
             try:
-                logger.debug(f"Connecting MCP client: {self.name}")
+                logger.debug(
+                    f"Connecting MCP client: {self.name}",
+                )
 
                 async with AsyncExitStack() as stack:
                     read_stream, write_stream = await self._setup_transport(
                         stack,
                     )
 
-                    self.session = ClientSession(read_stream, write_stream)
-                    await stack.enter_async_context(self.session)
+                    self.session = ClientSession(
+                        read_stream,
+                        write_stream,
+                    )
+                    await stack.enter_async_context(
+                        self.session,
+                    )
                     await self.session.initialize()
 
                     self.is_connected = True
                     self._ready_event.set()
-                    logger.info(f"MCP client connected: {self.name}")
+                    logger.info(
+                        f"MCP client connected: {self.name}",
+                    )
 
-                    # Wait for a reload or stop signal (0.1 s poll).
+                    # Wait for a reload or stop signal.
                     while (
                         not self._reload_event.is_set()
                         and not self._stop_event.is_set()
                     ):
                         await asyncio.sleep(0.1)
 
-                    # Clear state before the context manager exits and
-                    # tears down the transport / subprocess.
+                    # Clear state before the context manager
+                    # exits and tears down the transport.
                     self.session = None
                     self.is_connected = False
                     self._cached_tools = None
                     self._name_alias_to_real = {}
 
                     if self._reload_event.is_set():
-                        logger.info(f"Reloading MCP client: {self.name}")
+                        logger.info(
+                            f"Reloading MCP client: " f"{self.name}",
+                        )
                         self._reload_event.clear()
                         self._ready_event.clear()
                     else:
-                        logger.info(f"Stopping MCP client: {self.name}")
+                        logger.info(
+                            f"Stopping MCP client: " f"{self.name}",
+                        )
 
-                # AsyncExitStack exits here in THIS task — no cross-task issue.
+                # AsyncExitStack exits here in THIS task.
 
             except Exception as e:
-                # 401 means the server requires OAuth; fail fast and signal
-                # connect() so it can raise instead of returning silently.
                 if _is_401_error(e):
                     logger.info(
-                        f"MCP client '{self.name}': server requires OAuth "
-                        "(HTTP 401). Authorize via the UI to connect.",
+                        f"MCP client '{self.name}': server "
+                        "requires OAuth (HTTP 401). "
+                        "Authorize via the UI to connect.",
                     )
                     self._oauth_required = True
                     self._stop_event.set()
                     self._ready_event.set()
                     return
                 logger.error(
-                    f"Error in MCP client lifecycle for {self.name}: {e}",
+                    "Error in MCP client lifecycle " f"for {self.name}: {e}",
                     exc_info=True,
                 )
                 self.session = None
@@ -279,8 +420,15 @@ class _MCPClientMixin:
                 self._name_alias_to_real = {}
                 self._ready_event.clear()
                 await asyncio.sleep(1)
+            finally:
+                # After each iteration (whether clean exit,
+                # reload, or exception), kill any orphaned
+                # child processes the SDK failed to reap.
+                self._force_kill_children()
 
-        logger.info(f"MCP client lifecycle task exited: {self.name}")
+        logger.info(
+            f"MCP client lifecycle task exited: " f"{self.name}",
+        )
 
     async def connect(self, timeout: float = 30.0) -> None:
         """Connect to the MCP server.
@@ -499,53 +647,64 @@ class _MCPClientMixin:
         )
 
     async def close(self, ignore_errors: bool = True) -> None:
-        """Close the MCP client and stop its background lifecycle task.
+        """Close the MCP client and stop its lifecycle task.
 
-        Unlike the old guard (``if not self.is_connected: return``), this
-        method always attempts to stop the lifecycle task when one is still
-        running.  The old guard was a bug: when the client is in a reconnect
-        loop (``is_connected=False`` but the task is alive and will spawn a
-        new subprocess the moment it wakes from ``asyncio.sleep``), skipping
-        the stop leaked the eventual subprocess permanently.
+        Waits up to ``_CLOSE_TIMEOUT`` seconds for the lifecycle
+        task to finish.  If it doesn't, the task is cancelled
+        and any surviving child processes are force-killed.
 
         Args:
-            ignore_errors: When ``True`` (default), exceptions during cleanup
-                are logged but not re-raised.
+            ignore_errors: When ``True`` (default), exceptions
+                during cleanup are logged but not re-raised.
 
         Raises:
-            RuntimeError: If not connected and no task is running, and
-                ``ignore_errors`` is ``False``.
+            RuntimeError: If not connected and no task running,
+                and ``ignore_errors`` is ``False``.
         """
-        has_task = self._lifecycle_task is not None and not (
-            self._lifecycle_task.done()
+        has_task = (
+            self._lifecycle_task is not None
+            and not self._lifecycle_task.done()
         )
 
         if not self.is_connected and not has_task:
             if not ignore_errors:
                 raise RuntimeError(
-                    f"MCP client '{self.name}' is not connected. "
-                    f"Call connect() before closing.",
+                    f"MCP client '{self.name}' is not "
+                    "connected. Call connect() first.",
                 )
             return
 
         try:
-            # Signal stop and wait for the lifecycle task to finish.  This
-            # must happen even when is_connected is False (reconnect loop).
             self._stop_event.set()
             if self._lifecycle_task:
-                await self._lifecycle_task
+                try:
+                    await asyncio.wait_for(
+                        self._lifecycle_task,
+                        timeout=_CLOSE_TIMEOUT,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "MCP client '%s' close timed out "
+                        "after %.0fs, cancelling task",
+                        self.name,
+                        _CLOSE_TIMEOUT,
+                    )
+                    self._lifecycle_task.cancel()
+                    try:
+                        await self._lifecycle_task
+                    except (
+                        asyncio.CancelledError,
+                        Exception,
+                    ):
+                        pass
+                    self._force_kill_children()
         except Exception as e:
             if not ignore_errors:
                 raise
             logger.warning(
-                f"Error closing MCP client '{self.name}': {e}",
+                f"Error closing MCP client " f"'{self.name}': {e}",
             )
         finally:
-            # Clear the reference unconditionally — including when the current
-            # coroutine is cancelled (CancelledError is BaseException, not
-            # Exception, so it bypasses the except block above).  _stop_event
-            # is already set at this point, so the task will exit on its next
-            # iteration even if we don't hold the reference.
             self._lifecycle_task = None
 
     # ------------------------------------------------------------------
@@ -702,18 +861,30 @@ class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
         self._cached_tools = None
         self._name_alias_to_real: dict[str, str] = {}
 
+        # PID tracking for force-kill fallback
+        self._child_pids: set[int] = set()
+
     async def _setup_transport(
         self,
         stack: AsyncExitStack,
     ) -> tuple[Any, Any]:
-        # Local import: stdio_client pulls in anyio's subprocess machinery;
-        # deferring it here keeps module import time fast and avoids pulling
-        # platform-specific code at import time for users who only use HTTP.
         from mcp.client.stdio import stdio_client
+
+        pids_before = _snapshot_child_pids()
 
         context = await stack.enter_async_context(
             stdio_client(self.server_params),
         )
+
+        new_pids = _snapshot_child_pids() - pids_before
+        if new_pids:
+            self._child_pids = new_pids
+            logger.debug(
+                "MCP client '%s': tracked child PID(s) %s",
+                self.name,
+                new_pids,
+            )
+
         return context[0], context[1]
 
 
@@ -789,6 +960,9 @@ class HttpStatefulClient(_MCPClientMixin, StatefulClientBase):
         # Tool cache
         self._cached_tools = None
         self._name_alias_to_real: dict[str, str] = {}
+
+        # No stdio children for HTTP clients
+        self._child_pids: set[int] = set()
 
     async def _setup_transport(
         self,

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -225,8 +225,9 @@ async def _force_kill_pids(
         if _killpg is not None:
             try:
                 pgid = os.getpgid(pid)
-                _killpg(pgid, sig)
-                return
+                if pgid == pid:
+                    _killpg(pgid, sig)
+                    return
             except (
                 ProcessLookupError,
                 PermissionError,
@@ -698,8 +699,12 @@ class _MCPClientMixin:
                     )
                     self._lifecycle_task.cancel()
                     try:
-                        await self._lifecycle_task
+                        await asyncio.wait_for(
+                            self._lifecycle_task,
+                            timeout=1.0,
+                        )
                     except (
+                        asyncio.TimeoutError,
                         asyncio.CancelledError,
                         Exception,
                     ):

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -227,11 +227,19 @@ def _register_stdio_pids(
     pids: set[int],
     server_name: str,
 ) -> None:
-    """Register newly spawned stdio PIDs and their PGIDs."""
+    """Register newly spawned stdio PIDs and their PGIDs.
+
+    Only stores pgid when pgid == pid (child is its own
+    process-group leader, guaranteed by start_new_session).
+    Skips storage otherwise to prevent killpg from hitting
+    the main application's process group.
+    """
     pgids: Dict[int, int] = {}
     for pid in pids:
         try:
-            pgids[pid] = os.getpgid(pid)
+            pgid = os.getpgid(pid)
+            if pgid == pid:
+                pgids[pid] = pgid
         except (AttributeError, ProcessLookupError, OSError):
             pass
     with _stdio_lock:

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -21,9 +21,10 @@ import logging
 import os
 import re
 import signal
+import threading
 from contextlib import AsyncExitStack
 from datetime import timedelta
-from typing import Any, Literal
+from typing import Any, Dict, Literal
 
 import httpx
 from mcp import ClientSession
@@ -165,6 +166,26 @@ _CLOSE_TIMEOUT = 15.0
 # orphaned MCP subprocesses.
 _FORCE_KILL_GRACE = 2.0
 
+# ----------------------------------------------------------------
+# Global PID registry for stdio MCP subprocesses.
+#
+# All StdIOStatefulClient instances share this registry so that
+# concurrent connections cannot mis-attribute PIDs.  A PID is
+# registered at spawn time and removed on normal teardown.  If
+# teardown fails, the PID is moved to _orphan_stdio_pids for
+# deferred cleanup by kill_orphaned_mcp_children().
+# ----------------------------------------------------------------
+_stdio_lock = threading.Lock()
+
+# pid -> server_name (active stdio children)
+_stdio_pids: Dict[int, str] = {}
+
+# pid -> pgid (captured at spawn time while child is alive)
+_stdio_pgids: Dict[int, int] = {}
+
+# PIDs that survived their session teardown (SDK cleanup failed).
+_orphan_stdio_pids: set = set()
+
 
 def _snapshot_child_pids() -> set[int]:
     """Return PIDs of current child processes.
@@ -202,17 +223,85 @@ def _pid_exists(pid: int) -> bool:
         return False
 
 
-async def _force_kill_pids(
+def _register_stdio_pids(
     pids: set[int],
-    client_name: str,
+    server_name: str,
 ) -> None:
-    """SIGTERM then SIGKILL orphaned MCP child PIDs.
+    """Register newly spawned stdio PIDs and their PGIDs."""
+    pgids: Dict[int, int] = {}
+    for pid in pids:
+        try:
+            pgids[pid] = os.getpgid(pid)
+        except (AttributeError, ProcessLookupError, OSError):
+            pass
+    with _stdio_lock:
+        for pid in pids:
+            _stdio_pids[pid] = server_name
+        _stdio_pgids.update(pgids)
 
-    Uses ``os.killpg`` when a process-group ID can be
-    obtained (POSIX); falls back to ``os.kill`` per-PID.
-    On Windows, SIGTERM already calls TerminateProcess
-    (hard kill), so SIGKILL escalation is skipped.
+
+def _unregister_stdio_pids(pids: set[int]) -> None:
+    """Unregister PIDs on normal teardown.
+
+    If any PID is still alive, move it to orphan set instead
+    of dropping it silently.
     """
+    if not pids:
+        return
+    _killpg = getattr(os, "killpg", None)
+    with _stdio_lock:
+        for pid in pids:
+            _stdio_pids.pop(pid, None)
+        for pid in pids:
+            pid_alive = _pid_exists(pid)
+            pgroup_alive = False
+            pgid = _stdio_pgids.get(pid)
+            if not pid_alive and pgid is not None and _killpg is not None:
+                try:
+                    _killpg(pgid, 0)
+                    pgroup_alive = True
+                except (
+                    ProcessLookupError,
+                    PermissionError,
+                    OSError,
+                ):
+                    pass
+            if pid_alive or pgroup_alive:
+                _orphan_stdio_pids.add(pid)
+            else:
+                _stdio_pgids.pop(pid, None)
+
+
+async def kill_orphaned_mcp_children(
+    include_active: bool = False,
+) -> None:
+    """Reap orphaned MCP stdio subprocesses.
+
+    Sends SIGTERM, waits ``_FORCE_KILL_GRACE`` seconds, then
+    escalates to SIGKILL for survivors.  Uses the spawn-time
+    pgid so reparented grandchildren are also reaped.
+
+    On Windows, SIGTERM is TerminateProcess (hard kill), so
+    the SIGKILL phase is skipped.
+
+    Args:
+        include_active: If True, also kills all PIDs in the
+            active registry (for final shutdown only).
+    """
+    with _stdio_lock:
+        pids: Dict[int, str] = {}
+        for opid in _orphan_stdio_pids:
+            pids[opid] = "orphan"
+        _orphan_stdio_pids.clear()
+        if include_active:
+            pids.update(dict(_stdio_pids))
+            _stdio_pids.clear()
+        pgids: Dict[int, int] = {
+            pid: _stdio_pgids[pid] for pid in pids if pid in _stdio_pgids
+        }
+        for pid in pgids:
+            _stdio_pgids.pop(pid, None)
+
     if not pids:
         return
 
@@ -222,12 +311,11 @@ async def _force_kill_pids(
     _is_win = os.name == "nt"
 
     def _send(pid: int, sig: int) -> None:
-        if _killpg is not None:
+        pgid = pgids.get(pid)
+        if pgid is not None and _killpg is not None:
             try:
-                pgid = os.getpgid(pid)
-                if pgid == pid:
-                    _killpg(pgid, sig)
-                    return
+                _killpg(pgid, sig)
+                return
             except (
                 ProcessLookupError,
                 PermissionError,
@@ -243,29 +331,28 @@ async def _force_kill_pids(
         ):
             pass
 
-    for pid in pids:
+    for pid, name in pids.items():
         _send(pid, _sigterm)
         logger.debug(
-            "Sent SIGTERM to MCP child %d (%s)",
+            "Sent SIGTERM to orphaned MCP process %d (%s)",
             pid,
-            client_name,
+            name,
         )
 
-    # On Windows, SIGTERM is TerminateProcess (immediate),
-    # no need to wait and escalate to SIGKILL.
+    # On Windows, SIGTERM is TerminateProcess (immediate).
     if _is_win or _sigkill is None:
         return
 
     await asyncio.sleep(_FORCE_KILL_GRACE)
 
-    for pid in pids:
+    for pid, name in pids.items():
         if not _pid_exists(pid):
             continue
         _send(pid, _sigkill)
         logger.warning(
-            "Force-killed MCP child %d (%s) after SIGTERM timeout",
+            "Force-killed MCP process %d (%s) after SIGTERM",
             pid,
-            client_name,
+            name,
         )
 
 
@@ -325,27 +412,19 @@ class _MCPClientMixin:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def _force_kill_children(self) -> None:
-        """Force-kill any tracked child PIDs that survived
-        the graceful ``AsyncExitStack`` teardown.
+    async def _mark_and_reap_orphans(self) -> None:
+        """Mark tracked child PIDs as orphans if still alive,
+        then reap all orphans.
 
-        No-op when ``_child_pids`` is empty or on non-stdio
-        clients.
+        Called after each lifecycle iteration and on close
+        timeout.  No-op for non-stdio clients.
         """
         pids = getattr(self, "_child_pids", None)
         if not pids:
             return
-        alive = {p for p in pids if _pid_exists(p)}
-        if alive:
-            logger.warning(
-                "MCP client '%s': %d child process(es) "
-                "survived teardown, force-killing: %s",
-                self.name,
-                len(alive),
-                alive,
-            )
-            await _force_kill_pids(alive, self.name)
+        _unregister_stdio_pids(pids)
         self._child_pids = set()
+        await kill_orphaned_mcp_children()
 
     async def _run_lifecycle(self) -> None:  # noqa: C901
         """Run MCP client lifecycle in a dedicated task.
@@ -432,7 +511,7 @@ class _MCPClientMixin:
                 # After each iteration (whether clean exit,
                 # reload, or exception), kill any orphaned
                 # child processes the SDK failed to reap.
-                await self._force_kill_children()
+                await self._mark_and_reap_orphans()
 
         logger.info(
             f"MCP client lifecycle task exited: " f"{self.name}",
@@ -709,7 +788,7 @@ class _MCPClientMixin:
                         Exception,
                     ):
                         pass
-                    await self._force_kill_children()
+                    await self._mark_and_reap_orphans()
         except Exception as e:
             if not ignore_errors:
                 raise
@@ -891,6 +970,7 @@ class StdIOStatefulClient(_MCPClientMixin, StatefulClientBase):
         new_pids = _snapshot_child_pids() - pids_before
         if new_pids:
             self._child_pids = new_pids
+            _register_stdio_pids(new_pids, self.name)
             logger.debug(
                 "MCP client '%s': tracked child PID(s) %s",
                 self.name,

--- a/src/qwenpaw/app/mcp/stateful_client.py
+++ b/src/qwenpaw/app/mcp/stateful_client.py
@@ -21,7 +21,6 @@ import logging
 import os
 import re
 import signal
-import time
 from contextlib import AsyncExitStack
 from datetime import timedelta
 from typing import Any, Literal
@@ -203,7 +202,7 @@ def _pid_exists(pid: int) -> bool:
         return False
 
 
-def _force_kill_pids(
+async def _force_kill_pids(
     pids: set[int],
     client_name: str,
 ) -> None:
@@ -211,13 +210,16 @@ def _force_kill_pids(
 
     Uses ``os.killpg`` when a process-group ID can be
     obtained (POSIX); falls back to ``os.kill`` per-PID.
+    On Windows, SIGTERM already calls TerminateProcess
+    (hard kill), so SIGKILL escalation is skipped.
     """
     if not pids:
         return
 
     _sigterm = signal.SIGTERM
-    _sigkill = getattr(signal, "SIGKILL", _sigterm)
+    _sigkill = getattr(signal, "SIGKILL", None)
     _killpg = getattr(os, "killpg", None)
+    _is_win = os.name == "nt"
 
     def _send(pid: int, sig: int) -> None:
         if _killpg is not None:
@@ -248,7 +250,12 @@ def _force_kill_pids(
             client_name,
         )
 
-    time.sleep(_FORCE_KILL_GRACE)
+    # On Windows, SIGTERM is TerminateProcess (immediate),
+    # no need to wait and escalate to SIGKILL.
+    if _is_win or _sigkill is None:
+        return
+
+    await asyncio.sleep(_FORCE_KILL_GRACE)
 
     for pid in pids:
         if not _pid_exists(pid):
@@ -317,12 +324,12 @@ class _MCPClientMixin:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def _force_kill_children(self) -> None:
+    async def _force_kill_children(self) -> None:
         """Force-kill any tracked child PIDs that survived
         the graceful ``AsyncExitStack`` teardown.
 
-        Safe to call from any context (sync).  No-op when
-        ``_child_pids`` is empty or on non-stdio clients.
+        No-op when ``_child_pids`` is empty or on non-stdio
+        clients.
         """
         pids = getattr(self, "_child_pids", None)
         if not pids:
@@ -336,7 +343,7 @@ class _MCPClientMixin:
                 len(alive),
                 alive,
             )
-            _force_kill_pids(alive, self.name)
+            await _force_kill_pids(alive, self.name)
         self._child_pids = set()
 
     async def _run_lifecycle(self) -> None:  # noqa: C901
@@ -424,7 +431,7 @@ class _MCPClientMixin:
                 # After each iteration (whether clean exit,
                 # reload, or exception), kill any orphaned
                 # child processes the SDK failed to reap.
-                self._force_kill_children()
+                await self._force_kill_children()
 
         logger.info(
             f"MCP client lifecycle task exited: " f"{self.name}",
@@ -697,7 +704,7 @@ class _MCPClientMixin:
                         Exception,
                     ):
                         pass
-                    self._force_kill_children()
+                    await self._force_kill_children()
         except Exception as e:
             if not ignore_errors:
                 raise


### PR DESCRIPTION
## Description

Fix MCP server subprocess accumulation across Docker restarts. When QwenPaw restarts (via `docker restart` or supervisor), MCP stdio subprocesses survive because the MCP SDK spawns them with `start_new_session=True` (separate process group). If the graceful shutdown path hangs or times out, these orphaned processes accumulate indefinitely, causing slow console loading and memory waste (reported: 8.3GB to 9.8GB growth).

This PR adds three layers of defense:

1. **PID tracking + force-kill** in `StdIOStatefulClient`: snapshot child PIDs before/after `stdio_client` context entry, SIGTERM then SIGKILL any survivors on close.
2. **Close timeout + concurrent shutdown** in `MCPClientManager`: `close()` now has a 15s timeout with task cancellation fallback; `close_all()` runs all clients concurrently via `asyncio.gather` with a 30s overall timeout.
3. **Supervisor stop grace period**: `stopwaitsecs=30` gives the app enough time for graceful MCP cleanup before supervisord escalates to SIGKILL.

**Related Issue:** Fixes #4834

**Security Considerations:** Force-kill only targets PIDs that were spawned as children of the current process (tracked via `/proc` or `psutil`). No privilege escalation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. **Reproduce the leak** (Docker environment with multiple MCP stdio clients):
   - Start QwenPaw with 3+ MCP stdio clients configured
   - Run `ps aux | grep -c mcp` to count MCP processes
   - Run `docker restart <container>` 3 times
   - Verify MCP process count stays constant (no accumulation)

2. **Graceful shutdown**:
   - Start QwenPaw, wait for MCP clients to connect
   - Stop the app (`kill -TERM <pid>`)
   - Verify all MCP child processes are cleaned up within 15s

3. **Hung client resilience**:
   - Configure an MCP server that ignores SIGTERM (e.g., traps the signal)
   - Restart QwenPaw
   - Verify the hung process is SIGKILL'd after the 2s grace period

4. **Config hot-reload**:
   - Change an MCP client config while the app is running
   - Verify the old MCP process is killed and the new one starts

## Local Verification Evidence

```bash
pre-commit run --file src/qwenpaw/app/mcp/stateful_client.py src/qwenpaw/app/mcp/manager.py deploy/config/supervisord.conf.template
# All checks passed (ast, trailing-comma, mypy, black, flake8, pylint)

pytest tests/unit/ -x -q
# 497 passed, 1 failed (pre-existing unrelated failure in test_agent_status.py)
```

## Additional Notes

- The PID tracking pattern mirrors the existing implementation in `sub_repo/hermes-agent/tools/mcp_tool.py` (`_snapshot_child_pids` / `_kill_orphaned_mcp_children`), adapted for the async `StdIOStatefulClient` lifecycle.
- On Linux, child PIDs are read from `/proc/<pid>/children`; on other platforms, `psutil` is used as a fallback (returns empty set if unavailable).
- The `_force_kill_pids()` helper uses `os.killpg()` first (to kill the entire process group created by `start_new_session=True`), falling back to `os.kill()` if the process group kill fails.
- `close_all()` timeout (30s) aligns with the new `stopwaitsecs=30` in supervisord, ensuring the app has the full window for cleanup before SIGKILL.
