### PR TITLE
fix: resolve /compact and auto-compaction ignoring model's max_input_length when active_model is unset

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -316,6 +316,17 @@ async def create_agent(
         request.language or config.agents.language or "en",
     )
 
+    active_model = request.active_model
+    if not active_model or not active_model.provider_id:
+        try:
+            from ...providers import ProviderManager
+
+            global_model = ProviderManager.get_instance().get_active_model()
+            if global_model and global_model.provider_id:
+                active_model = global_model
+        except Exception:
+            pass
+
     agent_config = AgentProfileConfig(
         id=new_id,
         name=request.name,
@@ -326,7 +337,7 @@ async def create_agent(
         mcp=MCPConfig(),
         heartbeat=HeartbeatConfig(),
         tools=ToolsConfig(),
-        active_model=request.active_model,
+        active_model=active_model,
     )
 
     _initialize_agent_workspace(

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -667,6 +667,24 @@ async def set_active_model(
             if "provider" in lower_msg and "not found" in lower_msg:
                 raise HTTPException(status_code=404, detail=message) from exc
             raise HTTPException(status_code=400, detail=message) from exc
+
+        # Sync to active agent if its active_model is unset (#4937)
+        try:
+            workspace = await get_agent_for_request(request)
+            agent_config = load_agent_config(workspace.agent_id)
+            if (
+                not agent_config.active_model
+                or not agent_config.active_model.provider_id
+            ):
+                agent_config.active_model = ModelSlotConfig(
+                    provider_id=body.provider_id,
+                    model=body.model,
+                )
+                save_agent_config(workspace.agent_id, agent_config)
+                schedule_agent_reload(request, workspace.agent_id)
+        except Exception:
+            pass
+
         return ActiveModelsInfo(active_llm=manager.get_active_model())
 
     if not body.agent_id:

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Optional, Union, Dict, List, Literal, Any, Set
@@ -32,6 +33,8 @@ from ..constant import (
     LLM_RATE_LIMIT_PAUSE,
     WORKING_DIR,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ============================================================================
@@ -2169,6 +2172,19 @@ def migrate_legacy_config_to_multi_agent() -> bool:
     default_workspace = Path(f"{WORKING_DIR}/workspaces/default").expanduser()
     default_workspace.mkdir(parents=True, exist_ok=True)
 
+    # Inherit the global active model so the new agent.json has a valid
+    # active_model pointer from the start (fixes #4937).
+    try:
+        from ..providers import ProviderManager
+
+        global_active_model = ProviderManager.get_instance().get_active_model()
+    except Exception:
+        global_active_model = None
+        logger.info(
+            "Could not resolve global active model during migration; "
+            "agent will be created without active_model.",
+        )
+
     # Create default agent configuration from legacy settings
     default_agent_config = AgentProfileConfig(
         id="default",
@@ -2199,6 +2215,7 @@ def migrate_legacy_config_to_multi_agent() -> bool:
         ),
         tools=config.tools if config.tools else None,
         security=config.security if config.security else None,
+        active_model=global_active_model,
     )
 
     # Save default agent configuration to workspace
@@ -2305,4 +2322,10 @@ def get_model_max_input_length(
                     return model_info.max_input_length
         except Exception:
             pass
+    logger.debug(
+        "Could not resolve max_input_length for agent '%s' "
+        "(active_model=%s), falling back to 128K default.",
+        getattr(agent_config, "id", "?"),
+        agent_config.active_model,
+    )
     return 128 * 1024


### PR DESCRIPTION
## Description

When `agent.json` lacks an `active_model` field, `get_model_max_input_length()` silently falls back to the 128K default instead of using the configured model's context window. This affects both the `/compact` command and automatic context compaction triggered by `pre_reasoning`, causing them to compress against 128K regardless of the actual model
setting.

Root cause: several code paths create `agent.json` without populating `active_model` — legacy migration, agent creation, and global-scope model switching. The field is `Optional` with `default=None` and serialized with `exclude_none=True`, so it simply disappears from disk.

This PR ensures `active_model` is consistently populated:
- Legacy migration now inherits the global active model
- Agent creation falls back to the global model when none is specified
- Global-scope model switching syncs to the active agent's config when its `active_model` is unset
- Added debug logging when `max_input_length` resolution falls back to 128K

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
