### PR TITLE
[codex] Guard agent workspace restore targets

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -28,6 +28,10 @@ from ...config.config import (
     validate_agent_id,
 )
 from ...config.utils import load_config, save_config
+from ...config.workspace_paths import (
+    WorkspacePathValidationError,
+    validate_agent_workspace_path,
+)
 from ...agents.utils import copy_workspace_md_files, normalize_agent_language
 from ...agents.skill_system import SkillPoolService, get_workspace_skills_dir
 from ..multi_agent_manager import MultiAgentManager
@@ -303,6 +307,10 @@ async def create_agent(
     workspace_dir = Path(
         request.workspace_dir or f"{WORKING_DIR}/workspaces/{new_id}",
     ).expanduser()
+    try:
+        workspace_dir = validate_agent_workspace_path(workspace_dir)
+    except WorkspacePathValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
     from ...config.config import (

--- a/src/qwenpaw/backup/_ops/restore.py
+++ b/src/qwenpaw/backup/_ops/restore.py
@@ -29,6 +29,7 @@ from .._utils.safe_swap import (
 )
 from .._utils.signing import resolve_signature_action, sign_trusted_backup
 from ..models import BackupMeta, BackupValidationError, RestoreBackupRequest
+from ...config.workspace_paths import WorkspacePathValidationError
 from ...config.config import AgentProfileRef
 from ...config.utils import load_config, save_config
 from ...constant import CONFIG_FILE, SECRET_DIR, WORKING_DIR
@@ -161,11 +162,18 @@ def _plan_agent_destinations(
             # Will be skipped in the staging loop; no need to plan a dst.
             continue
         ref = config_before.agents.profiles.get(aid)
-        dst, is_new = resolve_workspace_dst(
-            aid,
-            ref,
-            req.default_workspace_dir,
-        )
+        try:
+            dst, is_new = resolve_workspace_dst(
+                aid,
+                ref,
+                req.default_workspace_dir,
+            )
+        except WorkspacePathValidationError as exc:
+            raise BackupValidationError(
+                "invalid_workspace_restore_target",
+                str(exc),
+                exc.details,
+            ) from exc
 
         # Conflict: two agents in the same restore batch resolve to the
         # same dir.

--- a/src/qwenpaw/backup/_ops/restore_helpers.py
+++ b/src/qwenpaw/backup/_ops/restore_helpers.py
@@ -18,6 +18,10 @@ from pathlib import Path
 
 from .._utils.constants import PREFIX_SECRETS, PREFIX_WORKSPACES
 from ..models import BackupMeta, RestoreBackupRequest
+from ...config.workspace_paths import (
+    WorkspacePathValidationError,
+    validate_agent_workspace_path,
+)
 from ...constant import BACKUP_DIR, SECRET_DIR, WORKING_DIR
 
 logger = logging.getLogger(__name__)
@@ -87,10 +91,16 @@ def resolve_workspace_dst(
     All returned paths are fully resolved (absolute, symlinks expanded) so
     that ``str(dst)`` is always canonical regardless of which branch is taken.
     """
+    if aid in {"", ".", ".."} or "/" in aid or "\\" in aid:
+        raise WorkspacePathValidationError(
+            f"Backup agent ID {aid!r} is not a safe workspace directory name.",
+            path=Path(aid),
+        )
+
     if ref is not None:
         dst = Path(ref.workspace_dir).expanduser()
         if dst.exists():
-            return dst.resolve(), False
+            return validate_agent_workspace_path(dst), False
         # Existing agent in config but local path is absent (cross-machine
         # restore or manually deleted directory) – fall through to defaults.
 
@@ -99,14 +109,7 @@ def resolve_workspace_dst(
     else:
         dst = Path(WORKING_DIR) / "workspaces" / aid
 
-    # Resolve even when the directory does not yet exist so that the returned
-    # path string is always in fully-qualified, canonical form.
-    try:
-        return dst.resolve(), ref is None
-    except OSError:
-        # resolve() can fail on some platforms when parts of the path don't
-        # exist; fall back to absolute path without symlink expansion.
-        return dst.absolute(), ref is None
+    return validate_agent_workspace_path(dst), ref is None
 
 
 def rewrite_agent_workspace_dir(dst: Path, aid: str) -> None:

--- a/src/qwenpaw/cli/agents_cmd.py
+++ b/src/qwenpaw/cli/agents_cmd.py
@@ -22,6 +22,10 @@ from ..config.config import (
     generate_short_agent_id,
     save_agent_config,
 )
+from ..config.workspace_paths import (
+    WorkspacePathValidationError,
+    validate_agent_workspace_path,
+)
 from ..constant import WORKING_DIR
 from ..config.config import ModelSlotConfig
 from ..providers.provider_manager import ProviderManager
@@ -336,8 +340,13 @@ def _build_agent_workspace_dir(
         workspace_dir = workspace_dir.strip() or None
 
     if workspace_dir is not None:
-        return Path(workspace_dir).expanduser()
-    return (WORKING_DIR / "workspaces" / agent_id).expanduser()
+        path = Path(workspace_dir).expanduser()
+    else:
+        path = (WORKING_DIR / "workspaces" / agent_id).expanduser()
+    try:
+        return validate_agent_workspace_path(path)
+    except WorkspacePathValidationError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _normalize_optional_text(value: Optional[str]) -> Optional[str]:

--- a/src/qwenpaw/config/workspace_paths.py
+++ b/src/qwenpaw/config/workspace_paths.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Validation helpers for agent workspace paths."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..constant import (
+    BACKUP_DIR,
+    CUSTOM_CHANNELS_DIR,
+    PLUGINS_DIR,
+    SECRET_DIR,
+    WORKING_DIR,
+)
+
+
+class WorkspacePathValidationError(ValueError):
+    """Raised when an agent workspace path targets an unsafe location."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path,
+        protected_name: str | None = None,
+        protected_dir: Path | None = None,
+    ) -> None:
+        self.path = str(path)
+        self.protected_name = protected_name
+        self.protected_dir = str(protected_dir) if protected_dir else None
+        details: dict[str, str] = {"path": self.path}
+        if protected_name is not None:
+            details["protected_name"] = protected_name
+        if protected_dir is not None:
+            details["protected_dir"] = str(protected_dir)
+        self.details = details
+        super().__init__(message)
+
+
+def resolve_workspace_path(path: Path | str) -> Path:
+    """Return an absolute, expanded workspace path for validation."""
+    expanded = Path(path).expanduser()
+    try:
+        return expanded.resolve()
+    except OSError:
+        return expanded.absolute()
+
+
+def _is_same_or_child(path: Path, parent: Path) -> bool:
+    return path == parent or path.is_relative_to(parent)
+
+
+def _protected_agent_workspace_dirs() -> tuple[tuple[str, Path], ...]:
+    return (
+        ("custom_channels", CUSTOM_CHANNELS_DIR),
+        ("plugins", PLUGINS_DIR),
+        ("secrets", SECRET_DIR),
+        ("backups", BACKUP_DIR),
+        ("skill_pool", WORKING_DIR / "skill_pool"),
+    )
+
+
+def validate_agent_workspace_path(path: Path | str) -> Path:
+    """Validate and return a resolved agent workspace path.
+
+    Agent workspaces may live outside ``WORKING_DIR/workspaces`` when users
+    choose a custom location, but they must not overlap with directories that
+    QwenPaw treats as executable extension roots or app-managed storage.
+    """
+    resolved = resolve_workspace_path(path)
+    resolved_working_dir = resolve_workspace_path(WORKING_DIR)
+    if resolved == resolved_working_dir:
+        raise WorkspacePathValidationError(
+            "Agent workspace cannot be the QwenPaw working directory itself. "
+            "Choose a dedicated agent workspace directory.",
+            path=resolved,
+            protected_name="working_dir",
+            protected_dir=resolved_working_dir,
+        )
+
+    for name, protected_dir in _protected_agent_workspace_dirs():
+        resolved_protected = resolve_workspace_path(protected_dir)
+        if _is_same_or_child(resolved, resolved_protected):
+            raise WorkspacePathValidationError(
+                f"Agent workspace cannot be inside QwenPaw {name} "
+                f"directory: {resolved_protected}. Choose a dedicated "
+                "agent workspace directory.",
+                path=resolved,
+                protected_name=name,
+                protected_dir=resolved_protected,
+            )
+
+    return resolved

--- a/tests/unit/app/test_agents_ordering.py
+++ b/tests/unit/app/test_agents_ordering.py
@@ -11,6 +11,7 @@ from qwenpaw.config.config import (
     AgentProfileRef,
     Config,
 )
+from qwenpaw.config import workspace_paths
 from qwenpaw.app.routers import agents as agents_router
 
 
@@ -170,6 +171,45 @@ async def test_create_agent_appends_new_id_to_order(monkeypatch, tmp_path):
     )
 
     assert config.agents.agent_order == ["alpha", "default", "beta"]
+
+
+@pytest.mark.asyncio
+async def test_create_agent_rejects_managed_workspace_dir(
+    monkeypatch,
+    tmp_path,
+):
+    """New agents should not be created inside app-managed directories."""
+    working_dir = tmp_path / "working"
+    custom_channels_dir = working_dir / "custom_channels"
+    config = _build_config(["default"])
+
+    monkeypatch.setattr(workspace_paths, "WORKING_DIR", working_dir)
+    monkeypatch.setattr(
+        workspace_paths,
+        "CUSTOM_CHANNELS_DIR",
+        custom_channels_dir,
+    )
+    monkeypatch.setattr(workspace_paths, "PLUGINS_DIR", working_dir / "plugins")
+    monkeypatch.setattr(workspace_paths, "SECRET_DIR", working_dir / ".secret")
+    monkeypatch.setattr(
+        workspace_paths,
+        "BACKUP_DIR",
+        working_dir / ".backups",
+    )
+    monkeypatch.setattr(agents_router, "load_config", lambda: config)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await agents_router.create_agent(
+            agents_router.CreateAgentRequest(
+                id="unsafe",
+                name="Unsafe",
+                workspace_dir=str(custom_channels_dir / "unsafe"),
+            ),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "custom_channels" in exc_info.value.detail
+    assert not (custom_channels_dir / "unsafe").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/backup/test_restore_targets.py
+++ b/tests/unit/backup/test_restore_targets.py
@@ -4,11 +4,36 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from qwenpaw.backup._ops import restore
 from qwenpaw.backup.models import BackupValidationError
+from qwenpaw.config import workspace_paths
+
+
+def _empty_config() -> SimpleNamespace:
+    return SimpleNamespace(agents=SimpleNamespace(profiles={}))
+
+
+def _patch_managed_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    working_dir: Path,
+) -> None:
+    monkeypatch.setattr(workspace_paths, "WORKING_DIR", working_dir)
+    monkeypatch.setattr(
+        workspace_paths,
+        "CUSTOM_CHANNELS_DIR",
+        working_dir / "custom_channels",
+    )
+    monkeypatch.setattr(workspace_paths, "PLUGINS_DIR", working_dir / "plugins")
+    monkeypatch.setattr(workspace_paths, "SECRET_DIR", working_dir / ".secret")
+    monkeypatch.setattr(
+        workspace_paths,
+        "BACKUP_DIR",
+        working_dir / ".backups",
+    )
 
 
 def test_busy_restore_target_reports_user_actionable_error(
@@ -42,3 +67,66 @@ def test_busy_restore_target_reports_user_actionable_error(
     assert exc_info.value.details["locked_paths"] == [
         str(target / "browser"),
     ]
+
+
+def test_plan_agent_destinations_allows_custom_workspace_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_managed_dirs(monkeypatch, tmp_path / "working")
+    default_workspace_dir = tmp_path / "agent_workspaces"
+
+    dst_map = restore._plan_agent_destinations(
+        ["pocpkg"],
+        {"pocpkg"},
+        _empty_config(),
+        restore.RestoreBackupRequest(
+            agent_ids=["pocpkg"],
+            default_workspace_dir=str(default_workspace_dir),
+        ),
+    )
+
+    assert dst_map["pocpkg"] == (
+        (default_workspace_dir / "pocpkg").resolve(),
+        True,
+    )
+
+
+def test_plan_agent_destinations_rejects_custom_channels_target(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    working_dir = tmp_path / "working"
+    _patch_managed_dirs(monkeypatch, working_dir)
+
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore._plan_agent_destinations(
+            ["pocpkg"],
+            {"pocpkg"},
+            _empty_config(),
+            restore.RestoreBackupRequest(
+                agent_ids=["pocpkg"],
+                default_workspace_dir=str(working_dir / "custom_channels"),
+            ),
+        )
+
+    assert exc_info.value.code == "invalid_workspace_restore_target"
+    assert exc_info.value.details["protected_name"] == "custom_channels"
+
+
+def test_plan_agent_destinations_rejects_traversal_agent_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_managed_dirs(monkeypatch, tmp_path / "working")
+
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore._plan_agent_destinations(
+            [".."],
+            {".."},
+            _empty_config(),
+            restore.RestoreBackupRequest(agent_ids=[".."]),
+        )
+
+    assert exc_info.value.code == "invalid_workspace_restore_target"
+    assert "not a safe workspace directory name" in exc_info.value.message

--- a/tests/unit/config/test_workspace_paths.py
+++ b/tests/unit/config/test_workspace_paths.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent workspace path validation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.config import workspace_paths
+
+
+def _patch_managed_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    working_dir: Path,
+) -> None:
+    monkeypatch.setattr(workspace_paths, "WORKING_DIR", working_dir)
+    monkeypatch.setattr(
+        workspace_paths,
+        "CUSTOM_CHANNELS_DIR",
+        working_dir / "custom_channels",
+    )
+    monkeypatch.setattr(workspace_paths, "PLUGINS_DIR", working_dir / "plugins")
+    monkeypatch.setattr(workspace_paths, "SECRET_DIR", working_dir / ".secret")
+    monkeypatch.setattr(
+        workspace_paths,
+        "BACKUP_DIR",
+        working_dir / ".backups",
+    )
+
+
+def test_validate_agent_workspace_path_allows_external_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    working_dir = tmp_path / "working"
+    _patch_managed_dirs(monkeypatch, working_dir)
+
+    workspace = tmp_path / "custom_agents" / "research"
+
+    assert workspace_paths.validate_agent_workspace_path(
+        workspace,
+    ) == workspace.resolve()
+
+
+@pytest.mark.parametrize(
+    ("protected_name", "relative_path"),
+    [
+        ("custom_channels", "custom_channels/poc"),
+        ("plugins", "plugins/poc"),
+        ("secrets", ".secret/poc"),
+        ("backups", ".backups/poc"),
+        ("skill_pool", "skill_pool/poc"),
+    ],
+)
+def test_validate_agent_workspace_path_rejects_managed_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    protected_name: str,
+    relative_path: str,
+) -> None:
+    working_dir = tmp_path / "working"
+    _patch_managed_dirs(monkeypatch, working_dir)
+
+    with pytest.raises(
+        workspace_paths.WorkspacePathValidationError,
+    ) as exc_info:
+        workspace_paths.validate_agent_workspace_path(
+            working_dir / relative_path,
+        )
+
+    assert exc_info.value.protected_name == protected_name
+
+
+def test_validate_agent_workspace_path_rejects_working_dir_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    working_dir = tmp_path / "working"
+    _patch_managed_dirs(monkeypatch, working_dir)
+
+    with pytest.raises(
+        workspace_paths.WorkspacePathValidationError,
+    ) as exc_info:
+        workspace_paths.validate_agent_workspace_path(working_dir)
+
+    assert exc_info.value.protected_name == "working_dir"


### PR DESCRIPTION
## Description

Adds shared validation for agent workspace paths so backups and agent creation can still use custom workspace locations, but cannot place agent workspaces inside QwenPaw-managed directories such as `custom_channels`, `plugins`, `secrets`, `backups`, or `skill_pool`.

This closes the backup-restore path where `default_workspace_dir` could target `custom_channels`, causing restored `__init__.py` files to be imported during custom channel discovery.

**Related Issue:** Relates to security triage; no public issue number.

**Security Considerations:** Prevents agent workspace restore/creation from writing into executable extension roots or app-managed storage while preserving user-selected external workspace roots.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `python -m pytest tests/unit/config/test_workspace_paths.py tests/unit/backup/test_restore_targets.py tests/unit/app/test_agents_ordering.py tests/unit/cli/test_cli_agents.py`
- `python -m py_compile src/qwenpaw/config/workspace_paths.py src/qwenpaw/backup/_ops/restore_helpers.py src/qwenpaw/backup/_ops/restore.py src/qwenpaw/app/routers/agents.py src/qwenpaw/cli/agents_cmd.py tests/unit/config/test_workspace_paths.py tests/unit/backup/test_restore_targets.py tests/unit/app/test_agents_ordering.py`
- `git diff --check`

## Local Verification Evidence

```bash
python -m pytest tests/unit/config/test_workspace_paths.py tests/unit/backup/test_restore_targets.py tests/unit/app/test_agents_ordering.py tests/unit/cli/test_cli_agents.py
# 36 passed, 1 warning

python -m py_compile src/qwenpaw/config/workspace_paths.py src/qwenpaw/backup/_ops/restore_helpers.py src/qwenpaw/backup/_ops/restore.py src/qwenpaw/app/routers/agents.py src/qwenpaw/cli/agents_cmd.py tests/unit/config/test_workspace_paths.py tests/unit/backup/test_restore_targets.py tests/unit/app/test_agents_ordering.py
# passed

git diff --check
# passed
```

## Additional Notes

Custom workspace roots remain supported. The new guard only rejects final agent workspace paths that equal or live under QwenPaw-managed directories, plus unsafe backup agent IDs such as `..` that would make restore targets escape the intended child directory.
