### PR TITLE
feat(plugins): add Plugin Market tab with AgentScope Platform integration

### DIFF
--- a/console/src/api/modules/pluginMarket.ts
+++ b/console/src/api/modules/pluginMarket.ts
@@ -70,5 +70,5 @@ export async function fetchMarketPlugins(
 export function buildMarketDownloadUrl(entry: MarketPluginEntry): string {
   const id = entry.id.startsWith("@") ? entry.id.slice(1) : entry.id;
   const [owner, name] = id.split("/");
-  return `https://platform-pre.agentscope.io/plugins/${owner}/${name}/archive/zip/master`;
+  return `https://platform.agentscope.io/plugins/${owner}/${name}/archive/zip/master`;
 }

--- a/console/src/api/modules/pluginMarket.ts
+++ b/console/src/api/modules/pluginMarket.ts
@@ -15,6 +15,7 @@ export interface MarketPluginEntry {
   logo_url: string | null;
   downloads: number;
   view_count: number;
+  details_url: string | null;
   locales: Record<string, MarketPluginLocale>;
 }
 

--- a/console/src/api/modules/pluginMarket.ts
+++ b/console/src/api/modules/pluginMarket.ts
@@ -1,0 +1,70 @@
+import { getApiUrl } from "../config";
+import { buildAuthHeaders } from "../authHeaders";
+
+export interface MarketPluginLocale {
+  description: string;
+  category: string;
+}
+
+export interface MarketPluginEntry {
+  id: string;
+  display_name: string;
+  developer: string;
+  owner: string;
+  version: string;
+  logo_url: string | null;
+  downloads: number;
+  view_count: number;
+  locales: Record<string, MarketPluginLocale>;
+}
+
+interface MarketPluginListResponse {
+  success: boolean;
+  message: string;
+  data: {
+    total: number;
+    plugins: MarketPluginEntry[];
+  };
+}
+
+export interface FetchMarketPluginsParams {
+  search?: string;
+  category?: string;
+  page_number: number;
+  page_size: number;
+}
+
+export async function fetchMarketPlugins(
+  params: FetchMarketPluginsParams,
+): Promise<{ total: number; plugins: MarketPluginEntry[] }> {
+  const url = new URL(getApiUrl("/plugins/market/search"), window.location.origin);
+  url.searchParams.set("page_number", String(params.page_number));
+  url.searchParams.set("page_size", String(params.page_size));
+  if (params.search) url.searchParams.set("search", params.search);
+  if (params.category) url.searchParams.set("category", params.category);
+
+  const response = await fetch(url.toString(), {
+    headers: buildAuthHeaders(),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(
+      (body as { detail?: string; message?: string }).detail ??
+        (body as { message?: string }).message ??
+        `Failed to fetch market plugins (${response.status})`,
+    );
+  }
+
+  const json: MarketPluginListResponse = await response.json();
+  if (!json.success) {
+    throw new Error(json.message || "Failed to fetch market plugins");
+  }
+
+  return json.data;
+}
+
+export function buildMarketDownloadUrl(entry: MarketPluginEntry): string {
+  const id = entry.id.startsWith("@") ? entry.id.slice(1) : entry.id;
+  const [owner, name] = id.split("/");
+  return `https://platform-pre.agentscope.io/plugins/${owner}/${name}/archive/zip/master`;
+}

--- a/console/src/api/modules/pluginMarket.ts
+++ b/console/src/api/modules/pluginMarket.ts
@@ -37,7 +37,10 @@ export interface FetchMarketPluginsParams {
 export async function fetchMarketPlugins(
   params: FetchMarketPluginsParams,
 ): Promise<{ total: number; plugins: MarketPluginEntry[] }> {
-  const url = new URL(getApiUrl("/plugins/market/search"), window.location.origin);
+  const url = new URL(
+    getApiUrl("/plugins/market/search"),
+    window.location.origin,
+  );
   url.searchParams.set("page_number", String(params.page_number));
   url.searchParams.set("page_size", String(params.page_size));
   if (params.search) url.searchParams.set("search", params.search);

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2269,6 +2269,7 @@
     "installed": "Installed Plugins",
     "noPlugins": "No plugins installed yet",
     "installBtn": "Install Plugin",
+    "publishBtn": "Publish Plugin",
     "installTitle": "Install Plugin",
     "dropPrimary": "Drop folder or ZIP here",
     "dropSecondary": "or click to browse a ZIP file",
@@ -2313,6 +2314,10 @@
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
     "marketSearch": "Search plugins...",
+    "marketAll": "All",
+    "marketCategory": "Filter by category",
+    "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
+    "marketDetails": "Details",
     "marketDownloads": "Downloads",
     "marketDeveloper": "Developer"
   },

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2313,6 +2313,7 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketUnavailable": "Plugin Market is currently under maintenance, please try again later",
     "marketSearch": "Search plugins...",
     "marketAll": "All",
     "marketCategory": "Filter by category",

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2308,7 +2308,13 @@
     "kindBundle": "Bundle",
     "kindTool": "Tool",
     "filterByName": "Filter by name",
-    "filterByKind": "Filter by kind"
+    "filterByKind": "Filter by kind",
+    "marketTitle": "Plugin Market",
+    "marketEmpty": "No plugins found in market",
+    "marketLoadFailed": "Failed to load plugin market",
+    "marketSearch": "Search plugins...",
+    "marketDownloads": "Downloads",
+    "marketDeveloper": "Developer"
   },
   "codingMode": {
     "title": "Coding Mode",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -698,7 +698,11 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketAll": "All",
     "marketSearch": "Search plugins...",
+    "marketCategory": "Filter by category",
+    "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
+    "marketDetails": "Details",
     "marketDownloads": "Downloads",
     "marketDeveloper": "Developer"
   },

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -698,6 +698,7 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketUnavailable": "Plugin Market is currently under maintenance, please try again later",
     "marketAll": "All",
     "marketSearch": "Search plugins...",
     "marketCategory": "Filter by category",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -694,7 +694,13 @@
     "kindBundle": "Bundel",
     "kindTool": "Alat",
     "filterByName": "Filter berdasarkan nama",
-    "filterByKind": "Filter berdasarkan jenis"
+    "filterByKind": "Filter berdasarkan jenis",
+    "marketTitle": "Plugin Market",
+    "marketEmpty": "No plugins found in market",
+    "marketLoadFailed": "Failed to load plugin market",
+    "marketSearch": "Search plugins...",
+    "marketDownloads": "Downloads",
+    "marketDeveloper": "Developer"
   },
   "debug": {
     "title": "Debug",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2131,7 +2131,11 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketAll": "All",
     "marketSearch": "Search plugins...",
+    "marketCategory": "Filter by category",
+    "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
+    "marketDetails": "Details",
     "marketDownloads": "Downloads",
     "marketDeveloper": "Developer"
   },

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2131,6 +2131,7 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketUnavailable": "Plugin Market is currently under maintenance, please try again later",
     "marketAll": "All",
     "marketSearch": "Search plugins...",
     "marketCategory": "Filter by category",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2127,7 +2127,13 @@
     "kindBundle": "バンドル",
     "kindTool": "ツール",
     "filterByName": "名前で絞り込み",
-    "filterByKind": "タグで絞り込み"
+    "filterByKind": "タグで絞り込み",
+    "marketTitle": "Plugin Market",
+    "marketEmpty": "No plugins found in market",
+    "marketLoadFailed": "Failed to load plugin market",
+    "marketSearch": "Search plugins...",
+    "marketDownloads": "Downloads",
+    "marketDeveloper": "Developer"
   },
   "plan": {
     "title": "プラン",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2162,7 +2162,13 @@
     "kindBundle": "Pacote",
     "kindTool": "Ferramenta",
     "filterByName": "Filtrar por nome",
-    "filterByKind": "Filtrar por tipo"
+    "filterByKind": "Filtrar por tipo",
+    "marketTitle": "Plugin Market",
+    "marketEmpty": "No plugins found in market",
+    "marketLoadFailed": "Failed to load plugin market",
+    "marketSearch": "Search plugins...",
+    "marketDownloads": "Downloads",
+    "marketDeveloper": "Developer"
   },
   "plan": {
     "title": "Plan",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2166,7 +2166,11 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketAll": "All",
     "marketSearch": "Search plugins...",
+    "marketCategory": "Filter by category",
+    "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
+    "marketDetails": "Details",
     "marketDownloads": "Downloads",
     "marketDeveloper": "Developer"
   },

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2166,6 +2166,7 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketUnavailable": "Plugin Market is currently under maintenance, please try again later",
     "marketAll": "All",
     "marketSearch": "Search plugins...",
     "marketCategory": "Filter by category",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2146,7 +2146,11 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketAll": "All",
     "marketSearch": "Search plugins...",
+    "marketCategory": "Filter by category",
+    "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
+    "marketDetails": "Details",
     "marketDownloads": "Downloads",
     "marketDeveloper": "Developer"
   },

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2142,7 +2142,13 @@
     "kindBundle": "Пакет",
     "kindTool": "Инструмент",
     "filterByName": "Фильтр по имени",
-    "filterByKind": "Фильтр по типу"
+    "filterByKind": "Фильтр по типу",
+    "marketTitle": "Plugin Market",
+    "marketEmpty": "No plugins found in market",
+    "marketLoadFailed": "Failed to load plugin market",
+    "marketSearch": "Search plugins...",
+    "marketDownloads": "Downloads",
+    "marketDeveloper": "Developer"
   },
   "plan": {
     "title": "План",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2146,6 +2146,7 @@
     "marketTitle": "Plugin Market",
     "marketEmpty": "No plugins found in market",
     "marketLoadFailed": "Failed to load plugin market",
+    "marketUnavailable": "Plugin Market is currently under maintenance, please try again later",
     "marketAll": "All",
     "marketSearch": "Search plugins...",
     "marketCategory": "Filter by category",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2322,6 +2322,7 @@
     "marketTitle": "插件市场",
     "marketEmpty": "暂无市场插件",
     "marketLoadFailed": "加载插件市场失败",
+    "marketUnavailable": "插件市场正在维护中，请稍后再试",
     "marketSearch": "搜索插件...",
     "marketAll": "全部",
     "marketCategory": "按类别筛选",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2317,7 +2317,13 @@
     "kindBundle": "插件包",
     "kindTool": "工具",
     "filterByName": "按名称筛选",
-    "filterByKind": "按标签筛选"
+    "filterByKind": "按标签筛选",
+    "marketTitle": "插件市场",
+    "marketEmpty": "暂无市场插件",
+    "marketLoadFailed": "加载插件市场失败",
+    "marketSearch": "搜索插件...",
+    "marketDownloads": "下载量",
+    "marketDeveloper": "开发者"
   },
   "codingMode": {
     "title": "编程模式",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2278,6 +2278,7 @@
     "installed": "已安装插件",
     "noPlugins": "暂无已安装插件",
     "installBtn": "安装插件",
+    "publishBtn": "发布插件",
     "installTitle": "安装插件",
     "dropPrimary": "拖入文件夹或 ZIP 文件",
     "dropSecondary": "或点击选择 ZIP 文件",
@@ -2322,6 +2323,10 @@
     "marketEmpty": "暂无市场插件",
     "marketLoadFailed": "加载插件市场失败",
     "marketSearch": "搜索插件...",
+    "marketAll": "全部",
+    "marketCategory": "按类别筛选",
+    "marketSearchResult": "\"{{keyword}}\" 相关插件共搜索到 {{count}} 个结果",
+    "marketDetails": "详情",
     "marketDownloads": "下载量",
     "marketDeveloper": "开发者"
   },

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.module.less
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.module.less
@@ -1,0 +1,58 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.toolbarRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.categoryTabs {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.categoryTab {
+  position: relative;
+  padding: 6px 0;
+  font-size: 14px;
+  color: var(--ant-color-text-secondary);
+  cursor: pointer;
+  transition: color 0.2s;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--ant-color-text);
+  }
+}
+
+.categoryTabActive {
+  color: var(--ant-color-text);
+  font-weight: 500;
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--ant-color-primary, #1890ff);
+    border-radius: 1px;
+  }
+}
+
+.searchHint {
+  font-size: 13px;
+  color: var(--ant-color-text-secondary);
+  white-space: nowrap;
+}

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -142,7 +142,7 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
         <Alert
           type="warning"
           showIcon
-          message={error}
+          message={<span style={{ fontSize: 15 }}>{error}</span>}
           style={{ marginBottom: 12 }}
         />
       )}

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Alert,
+  Button,
+  Input,
+  Pagination,
+  Spin,
+  Tag,
+  Typography,
+} from "antd";
+import { Download, Package, RefreshCw } from "lucide-react";
+import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
+import { useMarketPlugins } from "../hooks/useMarketPlugins";
+import styles from "./OfficialPluginList.module.less";
+
+const { Text } = Typography;
+
+function pickLocalizedDescription(
+  entry: MarketPluginEntry,
+  language: string,
+): string {
+  const locales = entry.locales;
+  if (!locales || Object.keys(locales).length === 0) return "";
+
+  if (locales[language]) return locales[language].description;
+
+  const prefix = language.split("-")[0].toLowerCase();
+  for (const key of Object.keys(locales)) {
+    if (key.toLowerCase().startsWith(prefix)) {
+      return locales[key].description;
+    }
+  }
+
+  if (locales.en) return locales.en.description;
+
+  const first = Object.values(locales)[0];
+  return first?.description ?? "";
+}
+
+interface MarketPluginListProps {
+  onInstalled: () => void;
+}
+
+export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
+  const { t, i18n } = useTranslation();
+  const [searchInput, setSearchInput] = useState("");
+
+  const {
+    loading,
+    error,
+    plugins,
+    total,
+    page,
+    pageSize,
+    installingId,
+    loadPlugins,
+    handleSearch,
+    handlePageChange,
+    handleInstall,
+  } = useMarketPlugins({ onInstalled });
+
+  return (
+    <div className={styles.catalogSection}>
+      <div className={styles.catalogToolbar}>
+        <div className={styles.catalogFilters}>
+          <Input.Search
+            placeholder={t("pluginManager.marketSearch")}
+            allowClear
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onSearch={(val) => handleSearch(val)}
+            style={{ width: 280 }}
+          />
+        </div>
+        <Button
+          type="default"
+          size="small"
+          icon={<RefreshCw size={14} />}
+          onClick={() => void loadPlugins(page, searchInput)}
+          disabled={loading}
+        >
+          {t("pluginManager.catalogRefresh")}
+        </Button>
+      </div>
+
+      {error && (
+        <Alert
+          type="warning"
+          showIcon
+          message={error}
+          style={{ marginBottom: 12 }}
+        />
+      )}
+
+      <Spin spinning={loading}>
+        {!loading && plugins.length === 0 && !error && (
+          <Text type="secondary">{t("pluginManager.marketEmpty")}</Text>
+        )}
+        <div className={styles.catalogList}>
+          {plugins.map((entry) => (
+            <div className={styles.catalogRow} key={entry.id}>
+              <div className={styles.catalogIcon}>
+                {entry.logo_url ? (
+                  <img
+                    src={entry.logo_url}
+                    alt=""
+                    style={{
+                      width: 24,
+                      height: 24,
+                      borderRadius: 4,
+                      objectFit: "contain",
+                    }}
+                  />
+                ) : (
+                  <Package size={18} />
+                )}
+              </div>
+              <div className={styles.catalogInfo}>
+                <div className={styles.catalogNameRow}>
+                  <Text strong>{entry.display_name}</Text>
+                  {entry.locales?.[
+                    i18n.language.split("-")[0]
+                  ]?.category && (
+                    <Tag color="blue" style={{ margin: 0, fontSize: 11 }}>
+                      {
+                        entry.locales[i18n.language.split("-")[0]]
+                          .category
+                      }
+                    </Tag>
+                  )}
+                </div>
+                {entry.locales && (
+                  <div className={styles.catalogDescription}>
+                    {pickLocalizedDescription(entry, i18n.language)}
+                  </div>
+                )}
+                <div className={styles.catalogMeta}>
+                  v{entry.version}
+                  {entry.developer
+                    ? ` · ${t("pluginManager.marketDeveloper")}: ${entry.developer}`
+                    : ""}
+                  {entry.downloads != null
+                    ? ` · ${t("pluginManager.marketDownloads")}: ${entry.downloads}`
+                    : ""}
+                </div>
+              </div>
+              <div className={styles.catalogActions}>
+                <Button
+                  type="primary"
+                  size="small"
+                  icon={<Download size={14} />}
+                  loading={installingId === entry.id}
+                  disabled={
+                    installingId !== null && installingId !== entry.id
+                  }
+                  onClick={() => void handleInstall(entry)}
+                >
+                  {t("pluginManager.catalogInstall")}
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {total > pageSize && (
+          <div style={{ marginTop: 16, textAlign: "center" }}>
+            <Pagination
+              current={page}
+              pageSize={pageSize}
+              total={total}
+              onChange={handlePageChange}
+              showSizeChanger={false}
+              size="small"
+            />
+          </div>
+        )}
+      </Spin>
+    </div>
+  );
+}

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -1,12 +1,22 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Button, Input, Pagination, Spin, Tag, Typography } from "antd";
-import { Download, Package, RefreshCw } from "lucide-react";
+import { Download, ExternalLink, Package, RefreshCw } from "lucide-react";
 import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
 import { useMarketPlugins } from "../hooks/useMarketPlugins";
 import styles from "./OfficialPluginList.module.less";
+import marketStyles from "./MarketPluginList.module.less";
 
 const { Text } = Typography;
+
+const PLUGIN_CATEGORIES = [
+  { code: "agent-tool", zh: "Agent 工具", en: "Agent Tool" },
+  { code: "provider", zh: "模型接入", en: "Provider" },
+  { code: "command", zh: "Slash 命令", en: "Slash Command" },
+  { code: "hook", zh: "生命周期 Hook", en: "Lifecycle Hook" },
+  { code: "frontend", zh: "UI 扩展", en: "UI Extension" },
+  { code: "general", zh: "通用插件", en: "General" },
+];
 
 function pickLocalizedDescription(
   entry: MarketPluginEntry,
@@ -37,6 +47,7 @@ interface MarketPluginListProps {
 export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
   const { t, i18n } = useTranslation();
   const [searchInput, setSearchInput] = useState("");
+  const [activeSearch, setActiveSearch] = useState("");
 
   const {
     loading,
@@ -45,35 +56,86 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
     total,
     page,
     pageSize,
+    category,
     installingId,
     loadPlugins,
     handleSearch,
+    handleCategoryChange,
     handlePageChange,
     handleInstall,
   } = useMarketPlugins({ onInstalled });
 
+  const lang = i18n.language.split("-")[0].toLowerCase();
+
+  const isSearchMode = !!activeSearch;
+
+  const onSearch = (val: string) => {
+    setActiveSearch(val);
+    handleSearch(val);
+    if (val) handleCategoryChange(undefined);
+  };
+
+  const onCategoryClick = (code: string | null) => {
+    handleCategoryChange(code || undefined);
+  };
+
   return (
     <div className={styles.catalogSection}>
-      <div className={styles.catalogToolbar}>
-        <div className={styles.catalogFilters}>
+      <div className={marketStyles.toolbar}>
+        {!isSearchMode ? (
+          <div className={marketStyles.categoryTabs}>
+            <span
+              className={`${marketStyles.categoryTab} ${
+                !category ? marketStyles.categoryTabActive : ""
+              }`}
+              onClick={() => onCategoryClick(null)}
+            >
+              {t("pluginManager.marketAll")}
+            </span>
+            {PLUGIN_CATEGORIES.map((cat) => (
+              <span
+                key={cat.code}
+                className={`${marketStyles.categoryTab} ${
+                  category === cat.code ? marketStyles.categoryTabActive : ""
+                }`}
+                onClick={() => onCategoryClick(cat.code)}
+              >
+                {lang === "zh" ? cat.zh : cat.en}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div className={marketStyles.searchHint}>
+            {!loading &&
+              !error &&
+              t("pluginManager.marketSearchResult", {
+                keyword: activeSearch,
+                count: total,
+              })}
+          </div>
+        )}
+        <div className={marketStyles.toolbarRight}>
           <Input.Search
             placeholder={t("pluginManager.marketSearch")}
             allowClear
             value={searchInput}
-            onChange={(e) => setSearchInput(e.target.value)}
-            onSearch={(val) => handleSearch(val)}
-            style={{ width: 280 }}
+            onChange={(e) => {
+              setSearchInput(e.target.value);
+              if (!e.target.value) onSearch("");
+            }}
+            onSearch={onSearch}
+            style={{ width: 220 }}
           />
+          <Button
+            type="default"
+            size="small"
+            icon={<RefreshCw size={14} />}
+            onClick={() => void loadPlugins(page, searchInput, category)}
+            disabled={loading}
+          >
+            {t("pluginManager.catalogRefresh")}
+          </Button>
         </div>
-        <Button
-          type="default"
-          size="small"
-          icon={<RefreshCw size={14} />}
-          onClick={() => void loadPlugins(page, searchInput)}
-          disabled={loading}
-        >
-          {t("pluginManager.catalogRefresh")}
-        </Button>
       </div>
 
       {error && (
@@ -111,9 +173,9 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
               <div className={styles.catalogInfo}>
                 <div className={styles.catalogNameRow}>
                   <Text strong>{entry.display_name}</Text>
-                  {entry.locales?.[i18n.language.split("-")[0]]?.category && (
+                  {entry.locales?.[lang]?.category && (
                     <Tag color="blue" style={{ margin: 0, fontSize: 11 }}>
-                      {entry.locales[i18n.language.split("-")[0]].category}
+                      {entry.locales[lang].category}
                     </Tag>
                   )}
                 </div>
@@ -137,6 +199,16 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
                 </div>
               </div>
               <div className={styles.catalogActions}>
+                {entry.details_url && (
+                  <Button
+                    type="default"
+                    size="small"
+                    icon={<ExternalLink size={14} />}
+                    onClick={() => window.open(entry.details_url!, "_blank")}
+                  >
+                    {t("pluginManager.marketDetails")}
+                  </Button>
+                )}
                 <Button
                   type="primary"
                   size="small"

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -58,10 +58,10 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
     pageSize,
     category,
     installingId,
-    loadPlugins,
     handleSearch,
     handleCategoryChange,
     handlePageChange,
+    handleRefresh,
     handleInstall,
   } = useMarketPlugins({ onInstalled });
 
@@ -130,7 +130,7 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
             type="default"
             size="small"
             icon={<RefreshCw size={14} />}
-            onClick={() => void loadPlugins(page, searchInput, category)}
+            onClick={handleRefresh}
             disabled={loading}
           >
             {t("pluginManager.catalogRefresh")}

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -1,14 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Input,
-  Pagination,
-  Spin,
-  Tag,
-  Typography,
-} from "antd";
+import { Alert, Button, Input, Pagination, Spin, Tag, Typography } from "antd";
 import { Download, Package, RefreshCw } from "lucide-react";
 import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
 import { useMarketPlugins } from "../hooks/useMarketPlugins";
@@ -119,14 +111,9 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
               <div className={styles.catalogInfo}>
                 <div className={styles.catalogNameRow}>
                   <Text strong>{entry.display_name}</Text>
-                  {entry.locales?.[
-                    i18n.language.split("-")[0]
-                  ]?.category && (
+                  {entry.locales?.[i18n.language.split("-")[0]]?.category && (
                     <Tag color="blue" style={{ margin: 0, fontSize: 11 }}>
-                      {
-                        entry.locales[i18n.language.split("-")[0]]
-                          .category
-                      }
+                      {entry.locales[i18n.language.split("-")[0]].category}
                     </Tag>
                   )}
                 </div>
@@ -138,10 +125,14 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
                 <div className={styles.catalogMeta}>
                   v{entry.version}
                   {entry.developer
-                    ? ` · ${t("pluginManager.marketDeveloper")}: ${entry.developer}`
+                    ? ` · ${t("pluginManager.marketDeveloper")}: ${
+                        entry.developer
+                      }`
                     : ""}
                   {entry.downloads != null
-                    ? ` · ${t("pluginManager.marketDownloads")}: ${entry.downloads}`
+                    ? ` · ${t("pluginManager.marketDownloads")}: ${
+                        entry.downloads
+                      }`
                     : ""}
                 </div>
               </div>
@@ -151,9 +142,7 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
                   size="small"
                   icon={<Download size={14} />}
                   loading={installingId === entry.id}
-                  disabled={
-                    installingId !== null && installingId !== entry.id
-                  }
+                  disabled={installingId !== null && installingId !== entry.id}
                   onClick={() => void handleInstall(entry)}
                 >
                   {t("pluginManager.catalogInstall")}

--- a/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "@/hooks/useAppMessage";
 import {
@@ -15,6 +15,9 @@ interface UseMarketPluginsOptions {
 export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
+  const tRef = useRef(t);
+  tRef.current = t;
+
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [plugins, setPlugins] = useState<MarketPluginEntry[]>([]);
@@ -39,14 +42,14 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
         setPlugins(data.plugins ?? []);
         setTotal(data.total);
       } catch {
-        setError(t("pluginManager.marketUnavailable"));
+        setError(tRef.current("pluginManager.marketUnavailable"));
         setPlugins([]);
         setTotal(0);
       } finally {
         setLoading(false);
       }
     },
-    [pageSize, t],
+    [pageSize],
   );
 
   useEffect(() => {
@@ -67,24 +70,32 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
     setPage(newPage);
   }, []);
 
+  const handleRefresh = useCallback(() => {
+    void loadPlugins(page, search, category);
+  }, [loadPlugins, page, search, category]);
+
   const handleInstall = useCallback(
     async (entry: MarketPluginEntry) => {
       setInstallingId(entry.id);
       try {
         const downloadUrl = buildMarketDownloadUrl(entry);
         const result = await installPlugin(downloadUrl, { force: true });
-        message.success(`${t("pluginManager.installSuccess")}: ${result.name}`);
+        message.success(
+          `${tRef.current("pluginManager.installSuccess")}: ${result.name}`,
+        );
         onInstalled();
         setTimeout(() => window.location.reload(), 800);
       } catch (err) {
         const msg =
-          err instanceof Error ? err.message : t("pluginManager.installFailed");
+          err instanceof Error
+            ? err.message
+            : tRef.current("pluginManager.installFailed");
         message.error(msg);
       } finally {
         setInstallingId(null);
       }
     },
-    [message, onInstalled, t],
+    [message, onInstalled],
   );
 
   return {
@@ -96,10 +107,10 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
     pageSize,
     category,
     installingId,
-    loadPlugins,
     handleSearch,
     handleCategoryChange,
     handlePageChange,
+    handleRefresh,
     handleInstall,
   };
 }

--- a/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppMessage } from "@/hooks/useAppMessage";
+import {
+  fetchMarketPlugins,
+  buildMarketDownloadUrl,
+  type MarketPluginEntry,
+} from "@/api/modules/pluginMarket";
+import { installPlugin } from "@/api/modules/plugin";
+
+interface UseMarketPluginsOptions {
+  onInstalled: () => void;
+}
+
+export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
+  const { t } = useTranslation();
+  const { message } = useAppMessage();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [plugins, setPlugins] = useState<MarketPluginEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(20);
+  const [search, setSearch] = useState("");
+  const [installingId, setInstallingId] = useState<string | null>(null);
+
+  const loadPlugins = useCallback(
+    async (pageNum: number, keyword: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchMarketPlugins({
+          page_number: pageNum,
+          page_size: pageSize,
+          search: keyword || undefined,
+        });
+        setPlugins(data.plugins ?? []);
+        setTotal(data.total);
+      } catch (err) {
+        const msg =
+          err instanceof Error
+            ? err.message
+            : t("pluginManager.marketLoadFailed");
+        setError(msg);
+        setPlugins([]);
+        setTotal(0);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [pageSize, t],
+  );
+
+  useEffect(() => {
+    void loadPlugins(page, search);
+  }, [page, search, loadPlugins]);
+
+  const handleSearch = useCallback((keyword: string) => {
+    setSearch(keyword);
+    setPage(1);
+  }, []);
+
+  const handlePageChange = useCallback((newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const handleInstall = useCallback(
+    async (entry: MarketPluginEntry) => {
+      setInstallingId(entry.id);
+      try {
+        const downloadUrl = buildMarketDownloadUrl(entry);
+        const result = await installPlugin(downloadUrl, { force: true });
+        message.success(`${t("pluginManager.installSuccess")}: ${result.name}`);
+        onInstalled();
+        setTimeout(() => window.location.reload(), 800);
+      } catch (err) {
+        const msg =
+          err instanceof Error ? err.message : t("pluginManager.installFailed");
+        message.error(msg);
+      } finally {
+        setInstallingId(null);
+      }
+    },
+    [message, onInstalled, t],
+  );
+
+  return {
+    loading,
+    error,
+    plugins,
+    total,
+    page,
+    pageSize,
+    installingId,
+    loadPlugins,
+    handleSearch,
+    handlePageChange,
+    handleInstall,
+  };
+}

--- a/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
@@ -22,10 +22,11 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   const [page, setPage] = useState(1);
   const [pageSize] = useState(20);
   const [search, setSearch] = useState("");
+  const [category, setCategory] = useState<string | undefined>(undefined);
   const [installingId, setInstallingId] = useState<string | null>(null);
 
   const loadPlugins = useCallback(
-    async (pageNum: number, keyword: string) => {
+    async (pageNum: number, keyword: string, cat?: string) => {
       setLoading(true);
       setError(null);
       try {
@@ -33,6 +34,7 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
           page_number: pageNum,
           page_size: pageSize,
           search: keyword || undefined,
+          category: cat || undefined,
         });
         setPlugins(data.plugins ?? []);
         setTotal(data.total);
@@ -52,11 +54,16 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   );
 
   useEffect(() => {
-    void loadPlugins(page, search);
-  }, [page, search, loadPlugins]);
+    void loadPlugins(page, search, category);
+  }, [page, search, category, loadPlugins]);
 
   const handleSearch = useCallback((keyword: string) => {
     setSearch(keyword);
+    setPage(1);
+  }, []);
+
+  const handleCategoryChange = useCallback((cat: string | undefined) => {
+    setCategory(cat);
     setPage(1);
   }, []);
 
@@ -91,9 +98,11 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
     total,
     page,
     pageSize,
+    category,
     installingId,
     loadPlugins,
     handleSearch,
+    handleCategoryChange,
     handlePageChange,
     handleInstall,
   };

--- a/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
@@ -38,12 +38,8 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
         });
         setPlugins(data.plugins ?? []);
         setTotal(data.total);
-      } catch (err) {
-        const msg =
-          err instanceof Error
-            ? err.message
-            : t("pluginManager.marketLoadFailed");
-        setError(msg);
+      } catch {
+        setError(t("pluginManager.marketUnavailable"));
         setPlugins([]);
         setTotal(0);
       } finally {

--- a/console/src/pages/Settings/PluginManager/index.tsx
+++ b/console/src/pages/Settings/PluginManager/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Button, Empty, Spin, Table, Tabs } from "antd";
-import { Package, Plus } from "lucide-react";
+import { ExternalLink, Package, Plus } from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { usePluginManager } from "./hooks/usePluginManager";
 import { usePluginColumns } from "./hooks/usePluginColumns";
@@ -65,13 +65,26 @@ export default function PluginManagerPage() {
         parent={t("nav.settings")}
         current={t("nav.pluginManager")}
         extra={
-          <Button
-            type="primary"
-            icon={<Plus size={16} />}
-            onClick={installModal.openModal}
-          >
-            {t("pluginManager.installBtn")}
-          </Button>
+          <>
+            <Button
+              icon={<ExternalLink size={16} />}
+              onClick={() =>
+                window.open(
+                  "https://platform-pre.agentscope.io/plugins",
+                  "_blank",
+                )
+              }
+            >
+              {t("pluginManager.publishBtn")}
+            </Button>
+            <Button
+              type="primary"
+              icon={<Plus size={16} />}
+              onClick={installModal.openModal}
+            >
+              {t("pluginManager.installBtn")}
+            </Button>
+          </>
         }
       />
 

--- a/console/src/pages/Settings/PluginManager/index.tsx
+++ b/console/src/pages/Settings/PluginManager/index.tsx
@@ -69,10 +69,7 @@ export default function PluginManagerPage() {
             <Button
               icon={<ExternalLink size={16} />}
               onClick={() =>
-                window.open(
-                  "https://platform-pre.agentscope.io/plugins",
-                  "_blank",
-                )
+                window.open("https://platform.agentscope.io/plugins", "_blank")
               }
             >
               {t("pluginManager.publishBtn")}

--- a/console/src/pages/Settings/PluginManager/index.tsx
+++ b/console/src/pages/Settings/PluginManager/index.tsx
@@ -7,6 +7,7 @@ import { usePluginColumns } from "./hooks/usePluginColumns";
 import { useInstallModal } from "./hooks/useInstallModal";
 import { InstallPluginModal } from "./components/InstallPluginModal";
 import { OfficialPluginList } from "./components/OfficialPluginList";
+import { MarketPluginList } from "./components/MarketPluginList";
 import styles from "./index.module.less";
 
 export default function PluginManagerPage() {
@@ -50,6 +51,11 @@ export default function PluginManagerPage() {
       key: "official",
       label: t("pluginManager.officialTitle"),
       children: <OfficialPluginList onInstalled={refresh} />,
+    },
+    {
+      key: "market",
+      label: t("pluginManager.marketTitle"),
+      children: <MarketPluginList onInstalled={refresh} />,
     },
   ];
 

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -885,7 +885,7 @@ async def serve_plugin_ui_file(
 
 # ── Plugin market proxy ───────────────────────────────────────────────────
 
-_PLUGIN_MARKET_BASE_URL = "https://platform-pre.agentscope.io"
+_PLUGIN_MARKET_BASE_URL = "https://platform.agentscope.io"
 _PLUGIN_MARKET_TIMEOUT = 15
 
 

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -883,6 +883,52 @@ async def serve_plugin_ui_file(
     return FileResponse(str(full_path))
 
 
+# ── Plugin market proxy ───────────────────────────────────────────────────
+
+_PLUGIN_MARKET_BASE_URL = "https://platform-pre.agentscope.io"
+_PLUGIN_MARKET_TIMEOUT = 15
+
+
+@router.get(
+    "/market/search",
+    summary="Search plugins from AgentScope Platform",
+)
+async def search_market_plugins(
+    page_number: int = 1,
+    page_size: int = 20,
+    search: Optional[str] = None,
+    category: Optional[str] = None,
+):
+    """Proxy plugin search to AgentScope Platform to avoid CORS."""
+    import httpx
+
+    params: dict = {
+        "page_number": page_number,
+        "page_size": page_size,
+    }
+    if search:
+        params["search"] = search
+    if category:
+        params["category"] = category
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=_PLUGIN_MARKET_TIMEOUT,
+        ) as client:
+            resp = await client.get(
+                f"{_PLUGIN_MARKET_BASE_URL}/openapi/v1/plugins",
+                params=params,
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as exc:
+        logger.warning("Plugin market search failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to fetch from plugin market: {exc}",
+        ) from exc
+
+
 # ── Internal async helpers ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Description

## Summary

- Add a "Plugin Market" tab to the Plugin Manager page
- Supports searching and browsing community plugins from AgentScope Platform (`platform-pre.agentscope.io`)
- Each plugin card shows name, category, description (localized), version, developer, downloads, and an install button
- Install flow reuses the existing `installPlugin()` path (POST /api/plugins/install)
- Backend proxy endpoint (`GET /api/plugins/market/search`) forwards requests to the platform API to avoid CORS issues

## Changes

**Backend** (1 file)
- `src/qwenpaw/app/routers/plugins.py` — new `GET /plugins/market/search` proxy endpoint using httpx

**Frontend** (4 new files, 7 modified)
- `console/src/api/modules/pluginMarket.ts` — API types and fetch function
- `console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts` — data hook with pagination, search, install
- `console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx` — list component with search bar, card rows, install buttons
- `console/src/pages/Settings/PluginManager/index.tsx` — add third tab
- 6 locale files — add `marketTitle`, `marketEmpty`, `marketLoadFailed`, `marketSearch`, `marketDownloads`, `marketDeveloper`

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
