### PR TITLE
fix(agents): prevent duplicated session_id in filename when user_id equals session_id (#5025) 

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -218,6 +218,7 @@ def build_agent_chat_request(
     final_text = ensure_agent_identity_prefix(text, caller_agent_id)
     request_payload = {
         "session_id": final_session_id,
+        "user_id": caller_agent_id,
         "input": [
             {
                 "role": "user",

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -235,7 +235,7 @@ class SafeJSONSession(SessionBase):
         safe_sid = sanitize_filename(session_id)
         safe_uid = sanitize_filename(user_id) if user_id else ""
 
-        if safe_uid:
+        if safe_uid and safe_uid != safe_sid:
             filename = f"{safe_uid}_{safe_sid}.json"
         else:
             filename = f"{safe_sid}.json"

--- a/tests/unit/agents/test_session.py
+++ b/tests/unit/agents/test_session.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for SafeJSONSession JSON corruption resilience."""
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,protected-access,unused-argument
 import json
 import os
 import pathlib
@@ -335,3 +335,45 @@ async def test_load_whitespace_only(sess, tmp_session_dir):
     mod = FakeModule()
     await sess.load_session_state("test:session", user_id="", memory=mod)
     assert mod.data is None
+
+
+# ── regression: issue #5025 — duplicated session_id in filename ────
+
+
+def test_save_path_no_duplicated_sid_when_user_id_differs(
+    sess,
+    tmp_session_dir,
+):
+    """When user_id differs from session_id, the filename must not duplicate.
+
+    Regression test for #5025: when inter-agent requests omitted user_id,
+    the framework defaulted user_id=session_id, producing filenames like
+    ``{sid}_{sid}.json``. Now user_id is set to the calling agent's ID.
+    """
+    sid = "Project_Director:to:Reviewer:1780928960707:eba0fdee"
+    uid = "Project_Director"
+    path = sess._get_save_path(sid, user_id=uid, channel="console")
+    basename = os.path.basename(path)
+    assert basename.startswith(f"{uid}_")
+    # The critical check: the session_id part must not repeat the user_id
+    # prefix pattern as if user_id == session_id.
+    assert (
+        basename != f"{sid.replace(':', '--')}_{sid.replace(':', '--')}.json"
+    )
+
+
+def test_save_path_user_id_equals_session_id_falls_back_to_sid_only(
+    sess,
+    tmp_session_dir,
+):
+    """When user_id equals session_id, the duplicated pattern is avoided.
+
+    Regression test for #5025: _get_save_path now detects user_id ==
+    session_id and falls back to ``{sid}.json`` instead of producing
+    ``{sid}_{sid}.json``.
+    """
+    sid = "Project_Director:to:Reviewer:1780928960707:eba0fdee"
+    path = sess._get_save_path(sid, user_id=sid, channel="console")
+    basename = os.path.basename(path)
+    safe_sid = sid.replace(":", "--")
+    assert basename == f"{safe_sid}.json"

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -86,6 +86,8 @@ def test_build_agent_chat_request_adds_identity_prefix():
     assert session_id.startswith("bot_a:to:bot_b:")
     assert prefix_added is True
     assert payload["session_id"] == session_id
+    assert payload["user_id"] == "bot_a"
+    assert payload["user_id"] != session_id
     assert payload["input"][0]["content"][0]["text"].startswith(
         "[Agent bot_a requesting] ",
     )
@@ -109,6 +111,7 @@ def test_build_agent_chat_request_discovers_calling_agent(monkeypatch):
     )
 
     assert session_id.startswith("auto_bot:to:bot_b:")
+    assert payload["user_id"] == "auto_bot"
     assert payload["input"][0]["content"][0]["text"].startswith(
         "[Agent auto_bot requesting] ",
     )
@@ -129,6 +132,7 @@ def test_build_agent_chat_request_reuses_session_id_when_provided():
 
     assert session_id == "existing-session"
     assert payload["session_id"] == "existing-session"
+    assert payload["user_id"] == "bot_a"
     assert prefix_added is True
 
 


### PR DESCRIPTION

## Description

  When inter-agent requests omitted user_id, the framework defaulted                                                                                                                                               
  user_id to session_id, producing filenames like {sid}_{sid}.json.                                                                                                                                                
  Now build_agent_chat_request explicitly sets user_id to the calling                                                                                                                                              
  agent's ID, and _get_save_path falls back to {sid}.json when                                                                                                                                                     
  user_id equals session_id.  


**Related Issue:** Fixes #5025 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
