### PR TITLE
fix(security): isolate keychain master key per install

### DIFF
--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -110,6 +110,9 @@ SECRET_DIR = (
     .resolve()
 )
 
+# Env key for overriding the OS keychain account used for the master key.
+KEYRING_ACCOUNT_ENV = "QWENPAW_KEYRING_ACCOUNT"
+
 PROJECT_NAME = "QwenPaw"
 
 # Subdirectory name inside each agent's workspace that holds cloned / imported

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -14,6 +14,7 @@ from legacy plaintext and transparently migrate on first access.
 from __future__ import annotations
 
 import base64
+import hashlib
 import logging
 import os
 import secrets
@@ -36,6 +37,48 @@ def _get_secret_dir() -> Path:
     from ..constant import SECRET_DIR
 
     return SECRET_DIR
+
+
+def _keyring_account() -> str:
+    """Return the keychain account name for the current install.
+
+    The OS keychain is a single, machine-global namespace keyed by
+    ``(service, account)``.  Because the service/account pair used to be a
+    fixed constant, *every* install on the machine read and wrote the same
+    keychain item regardless of where its ``SECRET_DIR`` lived.  A
+    development checkout pointed at a separate working dir (e.g. ``.devdata``
+    via ``QWENPAW_WORKING_DIR``) would therefore share — and silently
+    overwrite — the stable install's master key, leaving the stable install
+    unable to decrypt its own secrets.
+
+    Resolution:
+
+    1. Explicit ``QWENPAW_KEYRING_ACCOUNT`` override always wins (useful for
+       CI or for naming a dev profile deterministically).
+    2. If the install has *not* relocated its config/secrets via env
+       override, keep the historical ``master_key`` account verbatim so that
+       existing default and auto-detected legacy installs are completely
+       unaffected (no new keychain entry, no re-prompt).
+    3. Otherwise the user has explicitly opted into a separate location, so
+       derive a per-install account from the resolved ``SECRET_DIR`` path.
+       Distinct secret dirs get distinct, stable keychain items and never
+       collide.
+    """
+    explicit = EnvVarLoader.get_str("QWENPAW_KEYRING_ACCOUNT")
+    if explicit:
+        return explicit
+
+    relocated = bool(
+        EnvVarLoader.get_str("QWENPAW_WORKING_DIR")
+        or EnvVarLoader.get_str("QWENPAW_SECRET_DIR"),
+    )
+    if not relocated:
+        return _KEYRING_ACCOUNT
+
+    digest = hashlib.sha256(
+        str(_get_secret_dir()).encode("utf-8"),
+    ).hexdigest()[:16]
+    return f"{_KEYRING_ACCOUNT}:{digest}"
 
 
 # ---------------------------------------------------------------------------
@@ -129,17 +172,19 @@ def _try_keyring_get() -> Optional[str]:
     try:
         import keyring
 
+        account = _keyring_account()
+
         def _get():
             value = keyring.get_password(
                 _KEYRING_SERVICE,
-                _KEYRING_ACCOUNT,
+                account,
             )
             if value:
                 return value
             # Backward compatibility: read legacy CoPaw keyring entry.
             return keyring.get_password(
                 _KEYRING_SERVICE_LEGACY,
-                _KEYRING_ACCOUNT,
+                account,
             )
 
         result, timed_out = _call_with_timeout(_get, _KEYRING_TIMEOUT)
@@ -167,10 +212,12 @@ def _try_keyring_set(key_hex: str) -> bool:
     try:
         import keyring
 
+        account = _keyring_account()
+
         def _set():
             keyring.set_password(
                 _KEYRING_SERVICE,
-                _KEYRING_ACCOUNT,
+                account,
                 key_hex,
             )
 

--- a/src/qwenpaw/security/secret_store.py
+++ b/src/qwenpaw/security/secret_store.py
@@ -22,7 +22,7 @@ import threading
 from pathlib import Path
 from typing import Optional
 
-from ..constant import EnvVarLoader
+from ..constant import EnvVarLoader, KEYRING_ACCOUNT_ENV
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ def _keyring_account() -> str:
        Distinct secret dirs get distinct, stable keychain items and never
        collide.
     """
-    explicit = EnvVarLoader.get_str("QWENPAW_KEYRING_ACCOUNT")
+    explicit = EnvVarLoader.get_str(KEYRING_ACCOUNT_ENV)
     if explicit:
         return explicit
 

--- a/tests/unit/security/test_secret_store.py
+++ b/tests/unit/security/test_secret_store.py
@@ -173,3 +173,77 @@ class TestMasterKeyGeneration:
             key = mod._get_master_key()
 
         assert key == bytes.fromhex(key_hex)
+
+
+class TestKeyringAccountIsolation:
+    """The keychain account must isolate relocated (dev) installs from the
+    default install so they cannot overwrite each other's master key."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_relocation_env(self, monkeypatch):
+        for var in (
+            "QWENPAW_KEYRING_ACCOUNT",
+            "QWENPAW_WORKING_DIR",
+            "COPAW_WORKING_DIR",
+            "QWENPAW_SECRET_DIR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_default_install_uses_legacy_account(self, monkeypatch):
+        import qwenpaw.security.secret_store as mod
+
+        # No relocation env vars → historical account preserved verbatim so
+        # existing installs are untouched.
+        monkeypatch.setattr(
+            mod,
+            "_get_secret_dir",
+            lambda: Path("~/.qwenpaw.secret").expanduser(),
+        )
+        assert mod._keyring_account() == "master_key"
+
+    def test_explicit_override_wins(self, monkeypatch):
+        import qwenpaw.security.secret_store as mod
+
+        monkeypatch.setenv("QWENPAW_KEYRING_ACCOUNT", "dev-profile")
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", "/tmp/whatever")
+        assert mod._keyring_account() == "dev-profile"
+
+    def test_relocated_install_is_namespaced(self, monkeypatch, tmp_path):
+        import qwenpaw.security.secret_store as mod
+
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".devdata"))
+        monkeypatch.setattr(
+            mod,
+            "_get_secret_dir",
+            lambda: tmp_path / ".devdata.secret",
+        )
+        account = mod._keyring_account()
+        assert account != "master_key"
+        assert account.startswith("master_key:")
+
+    def test_distinct_secret_dirs_get_distinct_accounts(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import qwenpaw.security.secret_store as mod
+
+        monkeypatch.setenv("QWENPAW_SECRET_DIR", "set-to-mark-relocated")
+
+        monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path / "a")
+        account_a = mod._keyring_account()
+        monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path / "b")
+        account_b = mod._keyring_account()
+
+        assert account_a != account_b
+
+    def test_account_is_stable_for_same_secret_dir(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import qwenpaw.security.secret_store as mod
+
+        monkeypatch.setenv("QWENPAW_SECRET_DIR", "set-to-mark-relocated")
+        monkeypatch.setattr(mod, "_get_secret_dir", lambda: tmp_path / "x")
+        assert mod._keyring_account() == mod._keyring_account()

--- a/tests/unit/security/test_secret_store.py
+++ b/tests/unit/security/test_secret_store.py
@@ -183,9 +183,11 @@ class TestKeyringAccountIsolation:
     def _clear_relocation_env(self, monkeypatch):
         for var in (
             "QWENPAW_KEYRING_ACCOUNT",
+            "COPAW_KEYRING_ACCOUNT",
             "QWENPAW_WORKING_DIR",
             "COPAW_WORKING_DIR",
             "QWENPAW_SECRET_DIR",
+            "COPAW_SECRET_DIR",
         ):
             monkeypatch.delenv(var, raising=False)
 

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -87,16 +87,16 @@ You can customize paths and behavior via environment variables:
 
 **Path-related:**
 
-| Variable                   | Default             | Description                                                                                                 |
-| -------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `QWENPAW_WORKING_DIR`      | `~/.qwenpaw`        | Working directory root path                                                                                 |
-| `QWENPAW_SECRET_DIR`       | `~/.qwenpaw.secret` | Sensitive data directory (stores `providers.json` and `envs.json`). Docker default is `/app/working.secret` |
+| Variable                   | Default             | Description                                                                                                                                                                                                                                                                              |
+| -------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `QWENPAW_WORKING_DIR`      | `~/.qwenpaw`        | Working directory root path                                                                                                                                                                                                                                                              |
+| `QWENPAW_SECRET_DIR`       | `~/.qwenpaw.secret` | Sensitive data directory (stores `providers.json` and `envs.json`). Docker default is `/app/working.secret`                                                                                                                                                                              |
 | `QWENPAW_KEYRING_ACCOUNT`  | _(auto)_            | OS keychain account name for the master key. Defaults to `master_key`; when `QWENPAW_WORKING_DIR`/`QWENPAW_SECRET_DIR` are set (e.g. a dev checkout) it auto-derives a per-install account so a dev install never overwrites the stable install's key. Set explicitly to name a profile. |
-| `QWENPAW_CONFIG_FILE`      | `config.json`       | Config file name (relative to `QWENPAW_WORKING_DIR`)                                                        |
-| `QWENPAW_HEARTBEAT_FILE`   | `HEARTBEAT.md`      | Heartbeat file name (relative to agent workspace)                                                           |
-| `QWENPAW_JOBS_FILE`        | `jobs.json`         | Cron jobs file name (relative to agent workspace)                                                           |
-| `QWENPAW_CHATS_FILE`       | `chats.json`        | Conversation history file name (relative to agent workspace)                                                |
-| `QWENPAW_TOKEN_USAGE_FILE` | `token_usage.json`  | Token usage record file name (relative to agent workspace)                                                  |
+| `QWENPAW_CONFIG_FILE`      | `config.json`       | Config file name (relative to `QWENPAW_WORKING_DIR`)                                                                                                                                                                                                                                     |
+| `QWENPAW_HEARTBEAT_FILE`   | `HEARTBEAT.md`      | Heartbeat file name (relative to agent workspace)                                                                                                                                                                                                                                        |
+| `QWENPAW_JOBS_FILE`        | `jobs.json`         | Cron jobs file name (relative to agent workspace)                                                                                                                                                                                                                                        |
+| `QWENPAW_CHATS_FILE`       | `chats.json`        | Conversation history file name (relative to agent workspace)                                                                                                                                                                                                                             |
+| `QWENPAW_TOKEN_USAGE_FILE` | `token_usage.json`  | Token usage record file name (relative to agent workspace)                                                                                                                                                                                                                               |
 
 **Other configuration:**
 

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -91,6 +91,7 @@ You can customize paths and behavior via environment variables:
 | -------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `QWENPAW_WORKING_DIR`      | `~/.qwenpaw`        | Working directory root path                                                                                 |
 | `QWENPAW_SECRET_DIR`       | `~/.qwenpaw.secret` | Sensitive data directory (stores `providers.json` and `envs.json`). Docker default is `/app/working.secret` |
+| `QWENPAW_KEYRING_ACCOUNT`  | _(auto)_            | OS keychain account name for the master key. Defaults to `master_key`; when `QWENPAW_WORKING_DIR`/`QWENPAW_SECRET_DIR` are set (e.g. a dev checkout) it auto-derives a per-install account so a dev install never overwrites the stable install's key. Set explicitly to name a profile. |
 | `QWENPAW_CONFIG_FILE`      | `config.json`       | Config file name (relative to `QWENPAW_WORKING_DIR`)                                                        |
 | `QWENPAW_HEARTBEAT_FILE`   | `HEARTBEAT.md`      | Heartbeat file name (relative to agent workspace)                                                           |
 | `QWENPAW_JOBS_FILE`        | `jobs.json`         | Cron jobs file name (relative to agent workspace)                                                           |

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -60,6 +60,7 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
 | -------------------------- | ------------------- | ------------------------------------------------------------------------------------------- |
 | `QWENPAW_WORKING_DIR`      | `~/.qwenpaw`        | 工作目录根路径                                                                              |
 | `QWENPAW_SECRET_DIR`       | `~/.qwenpaw.secret` | 敏感数据目录（存放 `providers.json` 和 `envs.json`）。Docker 中默认为 `/app/working.secret` |
+| `QWENPAW_KEYRING_ACCOUNT`  | _(自动)_           | 主密钥在操作系统钥匙串中的账户名。默认为 `master_key`；当设置了 `QWENPAW_WORKING_DIR`/`QWENPAW_SECRET_DIR`（例如开发检出）时会自动派生为每个安装独立的账户名，使开发安装不会覆盖稳定安装的密钥。可显式设置以命名某个配置档案。 |
 | `QWENPAW_CONFIG_FILE`      | `config.json`       | 配置文件名（相对于 `QWENPAW_WORKING_DIR`）                                                  |
 | `QWENPAW_HEARTBEAT_FILE`   | `HEARTBEAT.md`      | 心跳文件名（相对于智能体工作区）                                                            |
 | `QWENPAW_JOBS_FILE`        | `jobs.json`         | 定时任务文件名（相对于智能体工作区）                                                        |

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -56,16 +56,16 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
 
 **路径相关：**
 
-| 变量                       | 默认值              | 说明                                                                                        |
-| -------------------------- | ------------------- | ------------------------------------------------------------------------------------------- |
-| `QWENPAW_WORKING_DIR`      | `~/.qwenpaw`        | 工作目录根路径                                                                              |
-| `QWENPAW_SECRET_DIR`       | `~/.qwenpaw.secret` | 敏感数据目录（存放 `providers.json` 和 `envs.json`）。Docker 中默认为 `/app/working.secret` |
-| `QWENPAW_KEYRING_ACCOUNT`  | _(自动)_           | 主密钥在操作系统钥匙串中的账户名。默认为 `master_key`；当设置了 `QWENPAW_WORKING_DIR`/`QWENPAW_SECRET_DIR`（例如开发检出）时会自动派生为每个安装独立的账户名，使开发安装不会覆盖稳定安装的密钥。可显式设置以命名某个配置档案。 |
-| `QWENPAW_CONFIG_FILE`      | `config.json`       | 配置文件名（相对于 `QWENPAW_WORKING_DIR`）                                                  |
-| `QWENPAW_HEARTBEAT_FILE`   | `HEARTBEAT.md`      | 心跳文件名（相对于智能体工作区）                                                            |
-| `QWENPAW_JOBS_FILE`        | `jobs.json`         | 定时任务文件名（相对于智能体工作区）                                                        |
-| `QWENPAW_CHATS_FILE`       | `chats.json`        | 对话历史文件名（相对于智能体工作区）                                                        |
-| `QWENPAW_TOKEN_USAGE_FILE` | `token_usage.json`  | Token 消耗记录文件名（相对于智能体工作区）                                                  |
+| 变量                       | 默认值              | 说明                                                                                                                                                                                                                           |
+| -------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `QWENPAW_WORKING_DIR`      | `~/.qwenpaw`        | 工作目录根路径                                                                                                                                                                                                                 |
+| `QWENPAW_SECRET_DIR`       | `~/.qwenpaw.secret` | 敏感数据目录（存放 `providers.json` 和 `envs.json`）。Docker 中默认为 `/app/working.secret`                                                                                                                                    |
+| `QWENPAW_KEYRING_ACCOUNT`  | _(自动)_            | 主密钥在操作系统钥匙串中的账户名。默认为 `master_key`；当设置了 `QWENPAW_WORKING_DIR`/`QWENPAW_SECRET_DIR`（例如开发检出）时会自动派生为每个安装独立的账户名，使开发安装不会覆盖稳定安装的密钥。可显式设置以命名某个配置档案。 |
+| `QWENPAW_CONFIG_FILE`      | `config.json`       | 配置文件名（相对于 `QWENPAW_WORKING_DIR`）                                                                                                                                                                                     |
+| `QWENPAW_HEARTBEAT_FILE`   | `HEARTBEAT.md`      | 心跳文件名（相对于智能体工作区）                                                                                                                                                                                               |
+| `QWENPAW_JOBS_FILE`        | `jobs.json`         | 定时任务文件名（相对于智能体工作区）                                                                                                                                                                                           |
+| `QWENPAW_CHATS_FILE`       | `chats.json`        | 对话历史文件名（相对于智能体工作区）                                                                                                                                                                                           |
+| `QWENPAW_TOKEN_USAGE_FILE` | `token_usage.json`  | Token 消耗记录文件名（相对于智能体工作区）                                                                                                                                                                                     |
 
 **其他配置：**
 


### PR DESCRIPTION
## Description

The OS keychain is a single, machine-global namespace keyed by `(service, account)`. The master-key account in `secret_store.py` was a fixed `"master_key"` constant, so **every install on the machine read and wrote the same keychain item regardless of its `SECRET_DIR`**.

A development checkout pointed at a separate working dir (e.g. `.devdata` via `QWENPAW_WORKING_DIR`) would therefore share the stable install's master key — and actively overwrite it, via the file-fallback resync in `_get_master_key` and in `reload_master_key_from_disk`. After that, the stable install can no longer decrypt its own secrets; `decrypt()` silently degrades to returning raw ciphertext, so the corruption is quiet.

This PR resolves the keychain account dynamically so a dev install and the stable install never collide:

- **`QWENPAW_KEYRING_ACCOUNT`** override always wins (CI / named dev profiles).
- Installs that have **not** relocated config/secrets via env override keep the historical `master_key` account verbatim — existing default and auto-detected legacy (`~/.copaw`) installs are completely unaffected (no new keychain entry, no re-prompt).
- Installs that opt into a separate location (`QWENPAW_WORKING_DIR` / `QWENPAW_SECRET_DIR` set) derive a **stable per-install account** from the resolved `SECRET_DIR` path.

Because the `.master_key` file on disk remains the source of truth and is written alongside every keychain entry, relocated installs that previously shared the key self-heal from their own file on next launch.

**Related Issue:** N/A

**Security Considerations:** Touches master-key handling for the encrypted secret store (`SECRET_DIR`). No change to the encryption scheme, key length, or file fallback. Default/legacy installs keep the exact same keychain `(service, account)` pair, so there is no key migration or re-prompt for existing users. Only env-relocated installs get a distinct, deterministic account derived from their secret-dir path (SHA-256, first 16 hex chars).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. **Default install** (no relocation env vars): keychain account resolves to `master_key` exactly as before — verified existing installs are untouched.
2. **Dev install** (`QWENPAW_WORKING_DIR=.../.devdata`): account resolves to `master_key:<hash>`, distinct from the stable install, so the two no longer share/overwrite each other's master key.
3. Two different secret dirs produce two different accounts; the same secret dir produces a stable account across calls.
4. `QWENPAW_KEYRING_ACCOUNT` explicit override takes precedence.

New unit tests in `tests/unit/security/test_secret_store.py` (`TestKeyringAccountIsolation`) cover all four cases.

## Local Verification Evidence

```bash
# pre-commit is not installed in the lean dev venv, so the pinned hooks were
# run directly against the changed files:

black@23.3.0 --line-length=79 --check  # 2 files would be left unchanged
flake8==6.1.0 --extend-ignore=E203     # clean
add-trailing-comma==3.1.0              # no changes
pylint                                 # no new warnings (pre-existing lazy-import/broad-except only); 9.27/10

pytest tests/unit/security/test_secret_store.py -q
# 22 passed, 1 warning in 0.11s
```

## Additional Notes

`QWENPAW_KEYRING_ACCOUNT` is documented in `website/public/docs/config.{en,zh}.md` for discoverability.
