### PR TITLE
feat(tui): bundle the terminal chat UI into `qwenpaw` (Phase 1)

### DIFF
--- a/docs/design/qwenpaw-cli-tui.md
+++ b/docs/design/qwenpaw-cli-tui.md
@@ -1,0 +1,138 @@
+# QwenPaw CLI TUI — design
+
+Status: **Phase 1 implemented** (relocation + ACP-subprocess transport).
+Audience: QwenPaw contributors extending or maintaining the terminal UI.
+
+## 1. Goal
+
+Give `qwenpaw` a first-class, interactive terminal chat experience — the same
+UX previously shipped as the standalone `paw` CLI — launched simply by running
+`qwenpaw` with no subcommand. The design must accommodate frequent future
+additions (model-provider config, skills config, memory viewer, MCP config)
+without protocol churn.
+
+## 2. Architecture: the transport seam
+
+The single most important property of this UI is that **the widgets never know
+how the agent is reached.** The UI layer consumes a small, normalized event
+union (`TuiEvent`) produced by an implementation of the `TuiTransport`
+protocol. ACP is *one* such implementation, not a UI-level dependency.
+
+```
+  widgets/ + app.py  ──consumes──►  TuiEvent (normalized union, §4.2)
+        │                                  ▲
+        │                          TuiTransport protocol (§4.1)
+        │                          ╱                    ╲
+        │            AcpTransport (Phase 1)        InProcessTransport (future)
+        │            spawn `qwenpaw acp`           drive workspace runner
+        │                  │                            in-process
+        ▼                  ▼
+   Textual App      ACP/stdio JSON-RPC ──► QwenPawACPAgent ──► Workspace.runner
+```
+
+Because the seam exists, the Phase 1 → future-transport switch is a one-line
+default change in `launch.py`, not a UI rewrite.
+
+## 3. Module layout
+
+```
+src/qwenpaw/cli/tui/
+├── __init__.py          # package doc; re-exports __version__
+├── __version__.py       # TUI version (independent of backend version)
+├── launch.py            # build transport + run app; `tui` click command
+├── app.py               # PawApp (Textual App): the whole UI/controller
+├── events.py            # TuiEvent union — the UI's stable contract (§4.2)
+├── normalize.py         # ACP session_update -> TuiEvent translation
+├── paths.py             # self-owned state dir (logs); honors PAW_STATE_DIR
+├── themes.py            # theme gallery + palette generation
+├── transport/
+│   ├── base.py          # TuiTransport protocol (§4.1)
+│   └── acp.py           # AcpTransport: spawns `qwenpaw acp`, drives ACP/stdio
+└── widgets/             # Textual widgets (messages, tool panel, status bar, …)
+```
+
+Tests live in `tests/cli/tui/` and run against a fake ACP agent
+(`tests/cli/tui/_fake_acp_agent.py`) — no heavy backend required.
+
+## 4. Contracts
+
+### 4.1 `TuiTransport` (`transport/base.py`)
+
+An async protocol that drives one conversation and yields `TuiEvent`s:
+`start`, `send`, `interrupt`, `list_sessions`, `load_session`, `events`,
+`resolve_permission`, `close`. Any object satisfying this protocol can back the
+UI. `AcpTransport` is the Phase 1 implementation.
+
+### 4.2 `TuiEvent` (`events.py`)
+
+The normalized union the UI consumes: `Connected`, `BackendWarmed`,
+`SessionTitle`, `TextDelta`, `ThoughtDelta`, `ToolCall` (+ `FileLink`),
+`PlanUpdate`, `Usage`/`TokenUsage`, `PermissionRequest`, `AvailableCommands`,
+`PushMessage`, `UserTurn`, `TurnEnded`, `TransportError`. Transports translate
+their wire format *into* this union; widgets render *from* it. New UI
+capabilities are added by extending this union plus the producing transport —
+never by leaking a wire format into the widgets.
+
+### 4.3 Extensions (server-initiated)
+
+`AcpTransport`'s client implements the ACP `ext_notification` / `ext_method`
+hooks. Proactive server pushes (`qwenpaw/push_message`) become `PushMessage`
+events. Unknown extension methods degrade gracefully (ignored). This is the
+channel for backend-initiated UI signals that don't fit the request/response
+turn model.
+
+## 5. CLI integration (`launch.py`, `cli/main.py`)
+
+- The root group is `invoke_without_command=True`; bare `qwenpaw` calls
+  `run_tui()` (the TUI), while every other entry point is an explicit
+  subcommand. `--help`/`--version` are handled by Click before the callback.
+- `qwenpaw tui [--agent | --agent-cmd | --resume]` is the explicit form.
+- The default transport command is `[sys.executable, "-m", "qwenpaw", "acp"]`,
+  so the TUI always drives the *same* install/venv it ships in — no reliance on
+  `qwenpaw` being on `PATH`. `--agent-cmd` overrides this to point at any
+  command speaking ACP over stdio (remote/dev agents).
+
+## 6. Why ACP-subprocess for Phase 1
+
+The chat loop is already exposed over ACP by `QwenPawACPAgent`
+(`agents/acp/server.py`) and is also consumed by external IDEs (Zed, etc.), so
+it is proven and maintained. Spawning it as a subprocess gives full feature
+parity (tools, memory, permissions, slash commands, model switching, session
+resume) for free, plus process isolation: a UI crash can't take down the
+backend, and the heavy backend imports don't slow UI startup. It is also fully
+testable without model keys via the fake ACP agent.
+
+The alternative — an in-process transport that drives `Workspace.runner`
+directly — is attractive for deep integration but, on the agentscope-2.0
+branch, the in-process envelope→event translation in the ACP server
+(`_EnvelopeTracker`) is minimal (text/thought/tool/usage only); a full-parity
+in-process transport would have to re-derive permissions, file links, plans,
+and command advertising from raw `stream_query` envelopes, and can't be
+verified on the lean dev setup. It is therefore deferred (see §7), behind the
+unchanged seam.
+
+## 7. Future phases & extensibility
+
+Configuration/inspection features should **not** be routed through the agent
+prompt or ACP. They become native TUI screens backed by a thin service layer
+over QwenPaw internals — additive, no wire-protocol versioning:
+
+| Future screen        | Backed directly by                               |
+| -------------------- | ------------------------------------------------ |
+| Model/provider config| `providers/provider_manager.py` + config I/O     |
+| Skills config        | `agents/skill_system/` hub                       |
+| Memory viewer        | memory managers (`agents/memory/`)               |
+| MCP config           | `config.py` `MCPConfig` + `app/mcp/manager.py`   |
+
+These pair naturally with a future `InProcessTransport`, which would give the
+screens typed, in-process access to those subsystems. Adding one is "a screen +
+a service call," and the transport seam means it can land without disturbing the
+chat UI.
+
+## 8. Testing
+
+`tests/cli/tui/` exercises normalize, the app (Textual test harness), the
+AcpTransport end-to-end against the fake ACP agent, the status bar, the welcome
+banner, and launch wiring. The suite needs only light deps
+(`textual`, `agent-client-protocol`, `click`, …) — see the project memory note
+"TUI dev/test setup" for the lean-venv recipe.

--- a/docs/design/qwenpaw-cli-tui.md
+++ b/docs/design/qwenpaw-cli-tui.md
@@ -86,11 +86,11 @@ turn model.
 - The root group is `invoke_without_command=True`; bare `qwenpaw` calls
   `run_tui()` (the TUI), while every other entry point is an explicit
   subcommand. `--help`/`--version` are handled by Click before the callback.
-- `qwenpaw tui [--agent | --agent-cmd | --resume]` is the explicit form.
-- The default transport command is `[sys.executable, "-m", "qwenpaw", "acp"]`,
-  so the TUI always drives the *same* install/venv it ships in — no reliance on
-  `qwenpaw` being on `PATH`. `--agent-cmd` overrides this to point at any
-  command speaking ACP over stdio (remote/dev agents).
+- `qwenpaw tui [--agent | --resume]` is the explicit form.
+- The transport command is `[sys.executable, "-m", "qwenpaw", "acp"]`, so the
+  TUI always drives the *same* install/venv it ships in — no reliance on
+  `qwenpaw` being on `PATH`. (`AcpTransport` still accepts a custom `command`
+  for a future remote/dev escape hatch; it is simply not exposed on the CLI.)
 
 ## 6. Why ACP-subprocess for Phase 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dependencies = [
     "huggingface_hub>=0.20.0",
     "pillow>=10.0.0",
     "agent-client-protocol>=0.9.0",
+    # Streaming-markdown terminal UI for the bundled `qwenpaw` TUI
+    # (v4+ adds the streaming Markdown widget).
+    "textual>=4.0",
     "psutil>=6.0.0",
     "openai>=2.0.0,<=2.33.0",
     # anyio 4.13.0: _deliver_cancellation busy-loop / getpid storm (QwenPaw#2632)

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -94,6 +94,7 @@ class LazyGroup(click.Group):
 
 @click.group(
     cls=LazyGroup,
+    invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
     lazy_subcommands={
         "acp": ("qwenpaw.cli.acp_cmd", "acp_cmd", ".acp_cmd"),
@@ -121,6 +122,7 @@ class LazyGroup(click.Group):
             ".providers_cmd",
         ),
         "skills": ("qwenpaw.cli.skills_cmd", "skills_group", ".skills_cmd"),
+        "tui": ("qwenpaw.cli.tui.launch", "tui_cmd", ".tui.launch"),
         "uninstall": (
             "qwenpaw.cli.uninstall_cmd",
             "uninstall_cmd",
@@ -170,3 +172,12 @@ def cli(ctx: click.Context, host: str | None, port: int | None) -> None:
     ctx.ensure_object(dict)
     ctx.obj["host"] = host
     ctx.obj["port"] = port
+
+    # Bare ``qwenpaw`` (no subcommand) opens the interactive terminal chat UI.
+    # ``--help`` is handled by Click before this callback runs, and every other
+    # entry point is an explicit subcommand, so this only fires for a bare
+    # invocation.
+    if ctx.invoked_subcommand is None:
+        from .tui.launch import run_tui
+
+        run_tui()

--- a/src/qwenpaw/cli/tui/__init__.py
+++ b/src/qwenpaw/cli/tui/__init__.py
@@ -11,7 +11,7 @@ touching any widget.
 Entry points:
 
 * bare ``qwenpaw`` (no subcommand) -> :func:`~qwenpaw.cli.tui.launch.run_tui`
-* ``qwenpaw tui [--agent ... | --agent-cmd ... | --resume ...]``
+* ``qwenpaw tui [--agent ... | --resume ...]``
 
 Originally developed as the standalone ``paw`` CLI; relocated here in Phase 1.
 """

--- a/src/qwenpaw/cli/tui/__init__.py
+++ b/src/qwenpaw/cli/tui/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""QwenPaw terminal chat UI (TUI).
+
+A Textual front-end, bundled into QwenPaw, that drives the agent over ACP by
+spawning ``qwenpaw acp`` as a subprocess. The UI layer only ever sees the
+normalized :class:`~qwenpaw.cli.tui.transport.base.TuiTransport` interface and
+the :mod:`~qwenpaw.cli.tui.events` event union, so the transport is a swappable
+seam: a future in-process transport can replace the ACP subprocess without
+touching any widget.
+
+Entry points:
+
+* bare ``qwenpaw`` (no subcommand) -> :func:`~qwenpaw.cli.tui.launch.run_tui`
+* ``qwenpaw tui [--agent ... | --agent-cmd ... | --resume ...]``
+
+Originally developed as the standalone ``paw`` CLI; relocated here in Phase 1.
+"""
+
+from __future__ import annotations
+
+from .__version__ import __version__
+
+__all__ = ["__version__"]

--- a/src/qwenpaw/cli/tui/__version__.py
+++ b/src/qwenpaw/cli/tui/__version__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+__version__ = "0.1.0"

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -235,14 +235,14 @@ class PawApp(App):
         self._apply_theme_prompt(self._theme_prompt, notify=False)
         if self._resume_session_id is not None:
             await self._mount(
-                InfoMessage("Resumed previous session — replaying history…")
+                InfoMessage("Resumed previous session — replaying history…"),
             )
         else:
             await self._mount(
                 WelcomeMessage(
                     palette_for_prompt(self._theme_prompt),
                     accent_for_prompt(self._theme_prompt),
-                )
+                ),
             )
         self._consume()
 
@@ -303,7 +303,7 @@ class PawApp(App):
     def _scroll_transcript_end(self, *, defer: bool = False) -> None:
         if defer:
             self.call_after_refresh(
-                lambda: self._transcript().scroll_end(animate=False)
+                lambda: self._transcript().scroll_end(animate=False),
             )
             return
         self._transcript().scroll_end(animate=False)
@@ -484,8 +484,8 @@ class PawApp(App):
                         "suggestions (or /resume list to browse all), "
                         "/theme <prompt> to personalize the background, "
                         "or /inspect for details. Model and provider "
-                        "commands (e.g. /model) are handled by QwenPaw."
-                    )
+                        "commands (e.g. /model) are handled by QwenPaw.",
+                    ),
                 )
             case "/resume":
                 await self._handle_resume_command(rest.strip())
@@ -506,14 +506,16 @@ class PawApp(App):
     async def _handle_theme_command(self, rest: str) -> None:
         if not rest or rest in {"gallery", "list"}:
             await self.push_screen(
-                ThemePicker(), callback=self._apply_theme_picker_result
+                ThemePicker(),
+                callback=self._apply_theme_picker_result,
             )
             return
         theme = find_theme(rest)
         self._apply_theme(theme or rest)
 
     def _apply_theme_picker_result(
-        self, result: ThemeInfo | str | None
+        self,
+        result: ThemeInfo | str | None,
     ) -> None:
         self.query_one("#prompt", PromptInput).focus()
         if result is None:
@@ -533,21 +535,21 @@ class PawApp(App):
                 InfoMessage(
                     "Finish or interrupt the current turn before resuming.",
                     level="warn",
-                )
+                ),
             )
             return
         try:
             sessions = await self._transport.list_sessions()
         except Exception as exc:  # noqa: BLE001 - surface, don't crash
             await self._mount(
-                InfoMessage(f"Could not list sessions: {exc}", level="warn")
+                InfoMessage(f"Could not list sessions: {exc}", level="warn"),
             )
             return
         # Keep the auto-suggest entries fresh from this same fetch.
         self._set_recent_sessions(sessions)
         if not sessions:
             await self._mount(
-                InfoMessage("No previous sessions yet.", level="info")
+                InfoMessage("No previous sessions yet.", level="info"),
             )
             return
 
@@ -560,7 +562,7 @@ class PawApp(App):
                     InfoMessage(
                         f"No session matches '{rest}'. Try /resume list.",
                         level="warn",
-                    )
+                    ),
                 )
                 return
             self.query_one("#prompt", PromptInput).focus()
@@ -577,7 +579,8 @@ class PawApp(App):
 
     @staticmethod
     def _resolve_session_ref(
-        ref: str, sessions: list[SessionSummary]
+        ref: str,
+        sessions: list[SessionSummary],
     ) -> str | None:
         """Map a `/resume` argument to a full session id.
 
@@ -609,7 +612,7 @@ class PawApp(App):
         # Mounted before the load so it sits above the replayed transcript;
         # the replay updates only land once load_session is awaited below.
         await self._mount(
-            InfoMessage("Resumed previous session — replaying history…")
+            InfoMessage("Resumed previous session — replaying history…"),
         )
         try:
             await self._transport.load_session(session_id)
@@ -624,7 +627,7 @@ class PawApp(App):
             attachments = _attachments_from_paste(text)
         except ValueError as exc:
             await self._mount(
-                InfoMessage(f"Could not attach paste: {exc}", level="warn")
+                InfoMessage(f"Could not attach paste: {exc}", level="warn"),
             )
             return None
         if attachments:
@@ -634,7 +637,7 @@ class PawApp(App):
                     f"Attached {len(paths)} pasted file"
                     f"{'s' if len(paths) != 1 else ''}.",
                     level="ok",
-                )
+                ),
             )
             return "\n".join(f"[attached file: {path}]" for path in paths)
         embedded = _replace_embedded_file_references(text)
@@ -645,15 +648,16 @@ class PawApp(App):
                     f"Attached {len(paths)} pasted file"
                     f"{'s' if len(paths) != 1 else ''}.",
                     level="ok",
-                )
+                ),
             )
             return replacement
         if _should_store_pasted_text(text):
             path = _store_pasted_text(text)
             await self._mount(
                 InfoMessage(
-                    f"Stored pasted text ({len(text)} characters).", level="ok"
-                )
+                    f"Stored pasted text ({len(text)} characters).",
+                    level="ok",
+                ),
             )
             return f"[pasted text: {path}]"
         return None
@@ -683,17 +687,21 @@ class PawApp(App):
         """
         variables = super().get_css_variables()
         screen, prompt_bg, chrome = palette_for_prompt(
-            getattr(self, "_theme_prompt", "") or "original"
+            getattr(self, "_theme_prompt", "") or "original",
         )
         variables.update(
             {
                 "bubble-border": mix_hex(
-                    mix_hex(screen, chrome, 0.55), "#ffffff", 0.12
+                    mix_hex(screen, chrome, 0.55),
+                    "#ffffff",
+                    0.12,
                 ),
                 "bubble-user-border": mix_hex(
-                    mix_hex(prompt_bg, chrome, 0.7), "#ffffff", 0.16
+                    mix_hex(prompt_bg, chrome, 0.7),
+                    "#ffffff",
+                    0.16,
                 ),
-            }
+            },
         )
         return variables
 
@@ -712,7 +720,8 @@ class PawApp(App):
             welcome.set_palette(colors, accent_for_prompt(prompt))
         try:
             self._theme_path().write_text(
-                json.dumps({"prompt": prompt}), encoding="utf-8"
+                json.dumps({"prompt": prompt}),
+                encoding="utf-8",
             )
         except Exception:  # noqa: BLE001
             pass
@@ -765,6 +774,7 @@ class PawApp(App):
             tok_out_approx=est > 0,
         )
 
+    # pylint: disable-next=too-many-branches, too-many-statements
     async def _dispatch(self, event) -> None:
         if isinstance(event, TextDelta):
             self._mark_backend_update()
@@ -914,7 +924,7 @@ class PawApp(App):
                     InfoMessage(
                         f"Backend warmup skipped: {event.message}",
                         level="warn",
-                    )
+                    ),
                 )
             self._status().set(state=self._current_work_state())
 
@@ -944,7 +954,7 @@ class PawApp(App):
             ):
                 self._status().set(state="error")
                 await self._mount(
-                    ErrorMessage(self._no_response_text(event.stop_reason))
+                    ErrorMessage(self._no_response_text(event.stop_reason)),
                 )
             # Hand off to the next message the user queued while we worked.
             await self._drain_queue()
@@ -986,7 +996,8 @@ class PawApp(App):
         def _resolve(option_id: str | None) -> None:
             self.run_worker(
                 self._transport.resolve_permission(
-                    event.request_id, option_id
+                    event.request_id,
+                    option_id,
                 ),
                 exclusive=False,
             )
@@ -1074,7 +1085,7 @@ def _replace_embedded_file_references(
     cursor = 0
     for ref in references:
         destination = _copy_paste_attachment(
-            _PasteAttachment(name=ref.path.name, source_path=ref.path)
+            _PasteAttachment(name=ref.path.name, source_path=ref.path),
         )
         copied.append(destination)
         chunks.append(text[cursor : ref.start])
@@ -1109,7 +1120,8 @@ def _looks_like_path_start(text: str, index: int) -> bool:
 
 
 def _longest_file_reference(
-    text: str, start: int
+    text: str,
+    start: int,
 ) -> _PasteFileReference | None:
     line_end = text.find("\n", start)
     if line_end == -1:
@@ -1178,7 +1190,9 @@ def _is_file(path: Path | None) -> bool:
 
 def _data_url_attachment(value: str) -> _PasteAttachment | None:
     match = re.fullmatch(
-        r"data:([^;,]+)?(;base64)?,(.*)", value, flags=re.DOTALL
+        r"data:([^;,]+)?(;base64)?,(.*)",
+        value,
+        flags=re.DOTALL,
     )
     if match is None:
         return None

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -1,0 +1,1241 @@
+# -*- coding: utf-8 -*-
+"""The paw terminal chat application (Textual)."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import mimetypes
+import os
+import re
+import shlex
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+from uuid import uuid4
+
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.widgets import TextArea
+
+from .__version__ import __version__
+from .events import (
+    AvailableCommands,
+    BackendWarmed,
+    Connected,
+    PermissionRequest,
+    PlanUpdate,
+    PushMessage,
+    SessionSummary,
+    SessionTitle,
+    SlashCommand,
+    TextDelta,
+    ThoughtDelta,
+    TokenUsage,
+    ToolCall,
+    TransportError,
+    TurnEnded,
+    Usage,
+    UserTurn,
+)
+from .paths import state_dir
+from .themes import (
+    THEME_GALLERY,
+    ThemeInfo,
+    accent_for_prompt,
+    find_theme,
+    mix_hex,
+    palette_for_prompt,
+)
+from .transport.base import TuiTransport
+from .widgets import (
+    ActivityLine,
+    AgentLabel,
+    AssistantMessage,
+    CommandMenu,
+    CommandSuggester,
+    ErrorMessage,
+    FileLinkBox,
+    InfoMessage,
+    PermissionModal,
+    PromptInput,
+    PushMessageBox,
+    QueuedMessage,
+    SessionPicker,
+    StatusBar,
+    ThemePicker,
+    ThoughtMessage,
+    ToolPanel,
+    UserMessage,
+    WelcomeMessage,
+)
+
+
+class PawApp(App):
+    """Streaming chat over a :class:`TuiTransport` (ACP)."""
+
+    CSS = """
+    Screen {
+        layers: base overlay;
+        background: #12202a;
+        color: $text;
+    }
+    .statusbar {
+        layer: base;
+        dock: top;
+        height: 1;
+        background: #183246 92%;
+        color: $text;
+    }
+    #transcript { padding: 1 2 4 2; background: transparent; }
+    /* Messages are transparent 'bubbles': the fill matches the static screen
+       background, so the text and bubble blend into the overall background and
+       only a subtle rounded border outlines each one. The background no longer
+       animates, so transparency is safe — there is nothing to re-blend against
+       each frame. */
+    .msg {
+        height: auto; margin-bottom: 1; padding: 0 1; color: $text;
+        background: transparent; border: round $bubble-border;
+    }
+    .msg.user, .msg.queued {
+        width: auto; max-width: 100%; border: round $bubble-user-border;
+    }
+    .msg.assistant { padding: 0; }
+    .msg.assistant > Markdown { background: transparent; padding: 0 1; }
+    .msg.assistant > Markdown > *:last-child { margin-bottom: 0; }
+    .msg.welcome {
+        margin: 1 0 2 0; padding: 1 2;
+        background: transparent; border: none;
+    }
+    /* One agent label per turn, sitting tight above the activity below it. */
+    .agentlabel { height: 1; margin: 0 0 0 1; }
+    /* Tool calls + thinking are Collapsible widgets; transparent with a
+       rounded outline like the other bubbles. */
+    .tool, .msg.thought {
+        height: auto; padding: 0; margin: 0 0 1 0;
+        background: transparent; border: round $bubble-border;
+    }
+    .tool > CollapsibleTitle, .msg.thought > CollapsibleTitle {
+        padding: 0 1; background: transparent;
+    }
+    .tool Contents, .msg.thought Contents {
+        padding: 0 1; background: transparent;
+    }
+    .msg.activity { height: auto; }
+    .tool.hidden, .msg.thought.hidden, .msg.activity.hidden {
+        display: none;
+    }
+    .msg.info { margin-bottom: 0; }
+    #prompt {
+        layer: base;
+        dock: bottom;
+        border: round #68d391;
+        background: #182433 94%;
+        height: 3;
+        max-height: 10;
+    }
+    #prompt:focus { border: round #ffcf6d; }
+    """
+
+    BINDINGS = [
+        Binding("escape", "interrupt", "Cancel/interrupt", show=True),
+        Binding("up", "recall_queued", "Edit queued", show=False),
+        # Kept functional for power users but no longer advertised in the
+        # input bar — the glyph was unfamiliar to most users.
+        Binding("ctrl+t", "toggle_tools", "Hide/show tools", show=False),
+        Binding("ctrl+i", "toggle_inspection", "Inspect", show=True),
+        Binding("ctrl+c", "quit", "Quit", show=True, priority=True),
+        Binding("ctrl+q", "quit", "Quit", show=False, priority=True),
+    ]
+
+    def __init__(
+        self,
+        transport: TuiTransport,
+        *,
+        agent: str = "default",
+        target: str | None = None,
+        resume_session_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._transport = transport
+        self._agent = agent
+        self._target = target
+        # When launched with --resume, the transport opens this session and
+        # replays its history; skip the welcome banner so the two don't mix.
+        self._resume_session_id = resume_session_id
+        self._assistant: AssistantMessage | None = None
+        self._thought: ThoughtMessage | None = None
+        self._activity: ActivityLine | None = None
+        # Whether the "qwenpaw" label has been shown for the current turn.
+        self._labeled = False
+        self._tools: dict[str, ToolPanel] = {}
+        self._tools_hidden = False
+        self._inspection_mode = False
+        self._busy = False
+        self._backend_warmed = False
+        self._awaiting_backend_update = False
+        # Per-turn flags so a turn that produces nothing the user can see (a
+        # silent backend failure, e.g. an unusable model) reports an error
+        # instead of quietly returning to "ready". ``_turn_saw_error`` avoids a
+        # duplicate "no response" message when a TransportError already showed.
+        self._turn_saw_output = False
+        self._turn_saw_error = False
+        # Messages typed while the agent is busy wait here (FIFO) and are sent
+        # automatically as each turn ends. Each entry pairs the text with its
+        # dimmed transcript widget so it can be removed when sent or recalled.
+        self._queued: list[tuple[str, QueuedMessage]] = []
+        # (tool_call_id, uri) pairs already surfaced as a FileLinkBox, so a
+        # repeated tool update doesn't mount the same link twice.
+        self._file_links_seen: set[tuple[str, str]] = set()
+        # Running token totals for the session (summed across LLM calls).
+        # ``_tok_out`` is the confirmed output total; ``_stream_chars`` counts
+        # characters streamed since the last confirmed usage, for a live
+        # (approximate) output-token estimate while a call is in flight.
+        self._tok_in = 0
+        self._tok_out = 0
+        self._stream_chars = 0
+        self._suggester = CommandSuggester()
+        self._menu = CommandMenu()
+        self._agent_commands: list[SlashCommand] = []
+        self._local_commands = _local_commands()
+        # Recent resumable sessions, surfaced as `/resume <id>` auto-suggest
+        # entries (populated from the backend once connected).
+        self._recent_sessions: list[SessionSummary] = []
+        self._session_commands: list[SlashCommand] = []
+        self._set_command_catalog()
+        # The model QwenPaw reports it is using (read-only, for the status bar
+        # and error messages). paw does not select or configure models.
+        self._model = ""
+        self._theme_prompt = self._load_theme_prompt()
+
+    # -- layout --------------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield StatusBar(tui_version=__version__)
+        yield VerticalScroll(id="transcript")
+        yield self._menu
+        yield PromptInput(
+            self._menu,
+            placeholder=(
+                "type a message  "
+                "(/ commands · enter send/queue · shift+enter newline · "
+                "paste files/long text)"
+            ),
+            id="prompt",
+            show_line_numbers=False,
+            soft_wrap=True,
+        )
+
+    async def on_mount(self) -> None:
+        self.query_one("#prompt", PromptInput).focus()
+        self._status().set(agent=self._agent)
+        self._apply_theme_prompt(self._theme_prompt, notify=False)
+        if self._resume_session_id is not None:
+            await self._mount(
+                InfoMessage("Resumed previous session — replaying history…")
+            )
+        else:
+            await self._mount(
+                WelcomeMessage(
+                    palette_for_prompt(self._theme_prompt),
+                    accent_for_prompt(self._theme_prompt),
+                )
+            )
+        self._consume()
+
+    # -- helpers -------------------------------------------------------------
+    def _status(self) -> StatusBar:
+        return self.query_one(StatusBar)
+
+    def _transcript(self) -> VerticalScroll:
+        return self.query_one("#transcript", VerticalScroll)
+
+    def _set_command_catalog(self) -> None:
+        seen: set[str] = set()
+        commands: list[SlashCommand] = []
+        for command in [
+            *self._local_commands,
+            *self._session_commands,
+            *self._agent_commands,
+        ]:
+            if command.name in seen:
+                continue
+            seen.add(command.name)
+            commands.append(command)
+        self._suggester.set_commands(commands)
+        self._menu.set_commands(commands)
+
+    # Cap for the `/resume` auto-suggest list (most recent N chats).
+    _RECENT_SESSION_LIMIT = 10
+
+    def _set_recent_sessions(self, sessions: list[SessionSummary]) -> None:
+        """Refresh the `/resume <id>` auto-suggest entries (most recent N).
+
+        Each becomes a ``resume <short-id>`` command whose description is the
+        session title, so it surfaces in the menu exactly like ``/theme <id>``.
+        """
+        self._recent_sessions = list(sessions[: self._RECENT_SESSION_LIMIT])
+        self._session_commands = [
+            SlashCommand(
+                f"resume {session.session_id[:8]}",
+                session.title or "(untitled)",
+            )
+            for session in self._recent_sessions
+        ]
+        self._set_command_catalog()
+
+    @work(group="recent-sessions", exclusive=True)
+    async def _refresh_recent_sessions(self) -> None:
+        """Pull recent sessions from the backend for the auto-suggest list."""
+        try:
+            sessions = await self._transport.list_sessions()
+        except Exception:  # noqa: BLE001 - best-effort; suggestions are extra
+            return
+        self._set_recent_sessions(sessions)
+
+    async def _mount(self, widget) -> None:
+        await self._transcript().mount(widget)
+        self._scroll_transcript_end()
+
+    def _scroll_transcript_end(self, *, defer: bool = False) -> None:
+        if defer:
+            self.call_after_refresh(
+                lambda: self._transcript().scroll_end(animate=False)
+            )
+            return
+        self._transcript().scroll_end(animate=False)
+
+    async def _ensure_activity_line(self) -> ActivityLine:
+        await self._ensure_turn_label()
+        if self._activity is None:
+            self._activity = ActivityLine()
+            self._apply_activity_visibility()
+            await self._mount(self._activity)
+        return self._activity
+
+    def _apply_activity_visibility(self) -> None:
+        for activity in self.query(ActivityLine):
+            activity.set_class(self._inspection_mode, "hidden")
+        if self._activity is not None:
+            self._activity.set_class(self._inspection_mode, "hidden")
+
+    def _apply_thought_visibility(self, thought: ThoughtMessage) -> None:
+        thought.collapsed = not self._inspection_mode
+        thought.set_class(not self._inspection_mode, "hidden")
+
+    def _apply_tool_visibility(self, panel: ToolPanel) -> None:
+        hidden = not self._inspection_mode
+        if self._inspection_mode and self._tools_hidden and panel.is_done:
+            hidden = True
+        panel.set_class(hidden, "hidden")
+
+    async def _ensure_turn_label(self) -> None:
+        """Mount the ``qwenpaw`` label once per turn, above the first piece
+        of assistant activity (thinking, a tool, or the answer)."""
+        if not self._labeled:
+            self._labeled = True
+            await self._mount(AgentLabel())
+
+    def _set_terminal_title(self, title: str) -> None:
+        """Set the terminal tab/window title via an OSC escape sequence."""
+        driver = getattr(self, "_driver", None)
+        if driver is not None:
+            try:
+                driver.write(f"\x1b]2;{title}\x07")
+            except Exception:  # noqa: BLE001 - cosmetic, never fatal
+                pass
+
+    # -- input ---------------------------------------------------------------
+    async def on_text_area_changed(self, event: TextArea.Changed) -> None:
+        if not isinstance(event.text_area, PromptInput):
+            return
+        if event.text_area.consume_programmatic_change():
+            return
+        self._menu.update_for(event.text_area.value)
+        self._resize_prompt(event.text_area.value)
+
+    def on_input_changed(self, event) -> None:
+        self._menu.update_for(event.value)
+
+    async def _submit_prompt(self) -> None:
+        prompt = self.query_one("#prompt", PromptInput)
+        text = prompt.value.strip()
+        if not text:
+            return
+        prompt.set_programmatic_value("")
+        self._resize_prompt("")
+        self._menu.display = False
+        if text.startswith("/"):
+            await self._handle_local_command(text)
+            return
+        if self._busy:
+            # Queue it; it's delivered automatically when the turn ends. The
+            # user can recall it with ↑ to edit before it's picked up.
+            widget = QueuedMessage(text)
+            await self._mount(widget)
+            self._queued.append((text, widget))
+            return
+        await self._submit(text)
+
+    async def _submit(self, text: str) -> None:
+        """Deliver one user turn now."""
+        await self._mount(UserMessage(text))
+        # Reset per-turn lane state so a fresh assistant bubble (and a single
+        # new "qwenpaw" label) is created for the reply.
+        self._assistant = None
+        self._thought = None
+        self._activity = None
+        self._labeled = False
+        self._busy = True
+        self._awaiting_backend_update = True
+        self._turn_saw_output = False
+        self._turn_saw_error = False
+        self._status().set(state=self._current_work_state())
+        try:
+            await self._transport.send(text)
+        except Exception as exc:  # noqa: BLE001
+            self._busy = False
+            self._awaiting_backend_update = False
+            self._status().set(state="ready")
+            await self._mount(ErrorMessage(str(exc)))
+            await self._drain_queue()
+
+    async def _drain_queue(self) -> None:
+        """Send the next queued message, if the agent is free to take it."""
+        if self._busy or not self._queued:
+            return
+        text, widget = self._queued.pop(0)
+        widget.remove()
+        await self._submit(text)
+
+    # -- actions -------------------------------------------------------------
+    async def action_interrupt(self) -> None:
+        if self._busy:
+            # Reflect the request immediately; the agent may take a moment to
+            # observe the cancel and end the turn (then state → ready).
+            self._status().set(state="interrupting")
+            await self._transport.interrupt()
+            return
+        # Idle: esc cancels the current input draft (and any open menu).
+        prompt = self.query_one("#prompt", PromptInput)
+        if prompt.value:
+            prompt.value = ""
+            self._menu.display = False
+
+    async def action_recall_queued(self) -> None:
+        """Pull the most recently queued message back into the input to edit.
+
+        Only when the menu is closed and the input is empty, so it never
+        clobbers text the user is mid-way through typing.
+        """
+        if self._menu.display or not self._queued:
+            return
+        prompt = self.query_one("#prompt", PromptInput)
+        if prompt.value:
+            return
+        text, widget = self._queued.pop()
+        widget.remove()
+        prompt.set_programmatic_value(text, cursor_end=True)
+
+    def action_toggle_tools(self) -> None:
+        """Hide (or reveal) every finished tool panel for a clean transcript.
+
+        Running tools stay visible; completed/failed ones are display:none'd
+        but remain mounted so toggling back restores them for inspection.
+        """
+        self._tools_hidden = not self._tools_hidden
+        hidden = 0
+        for panel in self.query(ToolPanel):
+            if panel.is_done:
+                self._apply_tool_visibility(panel)
+                hidden += 1
+        verb = "Hid" if self._tools_hidden else "Showing"
+        self.notify(f"{verb} {hidden} finished tool(s)", timeout=2)
+
+    def action_toggle_inspection(self) -> None:
+        """Switch between friendly transcript mode and deeper inspection."""
+        self._inspection_mode = not self._inspection_mode
+        for thought in self.query(ThoughtMessage):
+            thought.collapsed = not self._inspection_mode
+            thought.set_class(not self._inspection_mode, "hidden")
+        for panel in self.query(ToolPanel):
+            self._apply_tool_visibility(panel)
+        self._apply_activity_visibility()
+        self._scroll_transcript_end(defer=True)
+        mode = "inspection" if self._inspection_mode else "friendly"
+        self.notify(f"{mode} mode", timeout=2)
+
+    async def action_quit(self) -> None:
+        try:
+            await self._transport.close()
+        finally:
+            self.exit()
+
+    async def _handle_local_command(self, raw: str) -> None:
+        command, _, rest = raw.partition(" ")
+        match command:
+            case "/help":
+                await self._mount(
+                    InfoMessage(
+                        "Type /resume to pick a recent session from the "
+                        "suggestions (or /resume list to browse all), "
+                        "/theme <prompt> to personalize the background, "
+                        "or /inspect for details. Model and provider "
+                        "commands (e.g. /model) are handled by QwenPaw."
+                    )
+                )
+            case "/resume":
+                await self._handle_resume_command(rest.strip())
+            case "/theme":
+                await self._handle_theme_command(rest.strip())
+            case "/inspect":
+                self.action_toggle_inspection()
+            case _:
+                # Everything else (including QwenPaw's own slash commands such
+                # as /model and /clear) is forwarded to the agent.
+                if self._busy:
+                    widget = QueuedMessage(raw)
+                    await self._mount(widget)
+                    self._queued.append((raw, widget))
+                    return
+                await self._submit(raw)
+
+    async def _handle_theme_command(self, rest: str) -> None:
+        if not rest or rest in {"gallery", "list"}:
+            await self.push_screen(
+                ThemePicker(), callback=self._apply_theme_picker_result
+            )
+            return
+        theme = find_theme(rest)
+        self._apply_theme(theme or rest)
+
+    def _apply_theme_picker_result(
+        self, result: ThemeInfo | str | None
+    ) -> None:
+        self.query_one("#prompt", PromptInput).focus()
+        if result is None:
+            return
+        self._apply_theme(result)
+
+    def _apply_theme(self, theme: ThemeInfo | str) -> None:
+        if isinstance(theme, ThemeInfo):
+            self._apply_theme_prompt(theme.prompt)
+            self.notify(f"{theme.emoji} {theme.name}", timeout=2)
+            return
+        self._apply_theme_prompt(theme)
+
+    async def _handle_resume_command(self, rest: str = "") -> None:
+        if self._busy:
+            await self._mount(
+                InfoMessage(
+                    "Finish or interrupt the current turn before resuming.",
+                    level="warn",
+                )
+            )
+            return
+        try:
+            sessions = await self._transport.list_sessions()
+        except Exception as exc:  # noqa: BLE001 - surface, don't crash
+            await self._mount(
+                InfoMessage(f"Could not list sessions: {exc}", level="warn")
+            )
+            return
+        # Keep the auto-suggest entries fresh from this same fetch.
+        self._set_recent_sessions(sessions)
+        if not sessions:
+            await self._mount(
+                InfoMessage("No previous sessions yet.", level="info")
+            )
+            return
+
+        # `/resume <id>` (e.g. picked from the auto-suggest list) resumes
+        # directly; bare `/resume` (or `/resume list`) opens the full picker.
+        if rest and rest.lower() not in {"list", "all", "browse"}:
+            session_id = self._resolve_session_ref(rest, sessions)
+            if session_id is None:
+                await self._mount(
+                    InfoMessage(
+                        f"No session matches '{rest}'. Try /resume list.",
+                        level="warn",
+                    )
+                )
+                return
+            self.query_one("#prompt", PromptInput).focus()
+            await self._resume_session(session_id)
+            return
+
+        def _on_pick(session_id: str | None) -> None:
+            self.query_one("#prompt", PromptInput).focus()
+            if session_id is None:
+                return
+            self.run_worker(self._resume_session(session_id), exclusive=False)
+
+        await self.push_screen(SessionPicker(sessions), callback=_on_pick)
+
+    @staticmethod
+    def _resolve_session_ref(
+        ref: str, sessions: list[SessionSummary]
+    ) -> str | None:
+        """Map a `/resume` argument to a full session id.
+
+        The auto-suggest entries use a short id (first 8 chars), so match by
+        prefix first; fall back to an exact id so a full id still works.
+        """
+        for session in sessions:
+            if session.session_id == ref:
+                return session.session_id
+        for session in sessions:
+            if session.session_id.startswith(ref):
+                return session.session_id
+        return None
+
+    async def _resume_session(self, session_id: str) -> None:
+        # Wipe the current (fresh) transcript so the replayed history isn't
+        # mixed with the welcome banner, then reset all per-turn lane state.
+        await self._transcript().remove_children()
+        self._assistant = None
+        self._thought = None
+        self._activity = None
+        self._labeled = False
+        self._tools.clear()
+        self._file_links_seen.clear()
+        self._tok_in = 0
+        self._tok_out = 0
+        self._stream_chars = 0
+        self._refresh_tokens()
+        # Mounted before the load so it sits above the replayed transcript;
+        # the replay updates only land once load_session is awaited below.
+        await self._mount(
+            InfoMessage("Resumed previous session — replaying history…")
+        )
+        try:
+            await self._transport.load_session(session_id)
+        except Exception as exc:  # noqa: BLE001
+            await self._mount(ErrorMessage(f"Could not resume: {exc}"))
+            return
+        self._status().set(session=session_id)
+        self._set_terminal_title(f"QwenPaw {session_id[:8]}")
+
+    async def _handle_prompt_paste(self, text: str) -> str | None:
+        try:
+            attachments = _attachments_from_paste(text)
+        except ValueError as exc:
+            await self._mount(
+                InfoMessage(f"Could not attach paste: {exc}", level="warn")
+            )
+            return None
+        if attachments:
+            paths = [_copy_paste_attachment(item) for item in attachments]
+            await self._mount(
+                InfoMessage(
+                    f"Attached {len(paths)} pasted file"
+                    f"{'s' if len(paths) != 1 else ''}.",
+                    level="ok",
+                )
+            )
+            return "\n".join(f"[attached file: {path}]" for path in paths)
+        embedded = _replace_embedded_file_references(text)
+        if embedded is not None:
+            replacement, paths = embedded
+            await self._mount(
+                InfoMessage(
+                    f"Attached {len(paths)} pasted file"
+                    f"{'s' if len(paths) != 1 else ''}.",
+                    level="ok",
+                )
+            )
+            return replacement
+        if _should_store_pasted_text(text):
+            path = _store_pasted_text(text)
+            await self._mount(
+                InfoMessage(
+                    f"Stored pasted text ({len(text)} characters).", level="ok"
+                )
+            )
+            return f"[pasted text: {path}]"
+        return None
+
+    def _resize_prompt(self, value: str) -> None:
+        prompt = self.query_one("#prompt", PromptInput)
+        width = max(20, prompt.size.width or 80)
+        rows = _prompt_height(value, width=width)
+        prompt.styles.height = max(3, min(10, rows + 2))
+
+    def _theme_path(self) -> Path:
+        return state_dir() / "theme.json"
+
+    def _load_theme_prompt(self) -> str:
+        try:
+            data = json.loads(self._theme_path().read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            return os.getenv("PAW_BACKGROUND_PROMPT", "original")
+        return str(data.get("prompt") or "original")
+
+    def get_css_variables(self) -> dict[str, str]:
+        """Expose palette-derived bubble outline colours to the stylesheet.
+
+        Message bubbles are transparent; only their rounded border is coloured.
+        These variables keep the CSS declarative while the border tones follow
+        the active theme (re-evaluated via ``refresh_css`` on theme change).
+        """
+        variables = super().get_css_variables()
+        screen, prompt_bg, chrome = palette_for_prompt(
+            getattr(self, "_theme_prompt", "") or "original"
+        )
+        variables.update(
+            {
+                "bubble-border": mix_hex(
+                    mix_hex(screen, chrome, 0.55), "#ffffff", 0.12
+                ),
+                "bubble-user-border": mix_hex(
+                    mix_hex(prompt_bg, chrome, 0.7), "#ffffff", 0.16
+                ),
+            }
+        )
+        return variables
+
+    def _apply_theme_prompt(self, prompt: str, *, notify: bool = True) -> None:
+        self._theme_prompt = prompt
+        colors = palette_for_prompt(prompt)
+        # Re-evaluate the bubble border variables for the new palette. Done
+        # before the imperative style writes below so those stay authoritative.
+        self.refresh_css()
+        # Static background — the theme's base shade, no animation.
+        self.screen.styles.background = colors[0]
+        self._transcript().styles.background = "transparent"
+        self.query_one("#prompt", PromptInput).styles.background = colors[1]
+        self.query_one(StatusBar).styles.background = colors[2]
+        for welcome in self.query(WelcomeMessage):
+            welcome.set_palette(colors, accent_for_prompt(prompt))
+        try:
+            self._theme_path().write_text(
+                json.dumps({"prompt": prompt}), encoding="utf-8"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        if notify:
+            theme = find_theme(prompt)
+            label = f"{theme.emoji} {theme.name}" if theme else prompt
+            self.notify(f"Theme: {label}", timeout=2)
+
+    # -- event pump ----------------------------------------------------------
+    @work(exclusive=True)
+    async def _consume(self) -> None:
+        try:
+            connected = await self._transport.start()
+            self._on_connected(connected)
+            async for event in self._transport.events():
+                await self._dispatch(event)
+        except Exception as exc:  # noqa: BLE001
+            self._status().set(state="error")
+            await self._mount(ErrorMessage(f"transport: {exc}"))
+
+    def _on_connected(self, ev: Connected) -> None:
+        self._backend_warmed = not ev.warming
+        if ev.model:
+            self._model = ev.model
+        self._status().set(
+            session=ev.session_id,
+            agent=ev.agent or self._agent,
+            model=ev.model or "—",
+            qwenpaw_version=ev.qwenpaw_version or "—",
+            state="ready" if self._backend_warmed else "warming",
+        )
+        # Start with the session id; replaced by the real title once the
+        # agent reports one (see SessionTitle).
+        self._set_terminal_title(f"QwenPaw {str(ev.session_id)[:8]}")
+        # Populate the `/resume` auto-suggest list from past sessions.
+        self._refresh_recent_sessions()
+
+    # Rough bytes-per-token for the live output estimate (~4 chars/token for
+    # typical text; intentionally crude — it's marked approximate and is
+    # replaced by the exact count when the call's usage arrives).
+    _CHARS_PER_TOKEN = 4
+
+    def _refresh_tokens(self) -> None:
+        """Push token totals to the status bar, including the in-flight
+        estimate for output tokens still streaming."""
+        est = self._stream_chars // self._CHARS_PER_TOKEN
+        self._status().set(
+            tok_in=self._tok_in,
+            tok_out=self._tok_out + est,
+            tok_out_approx=est > 0,
+        )
+
+    async def _dispatch(self, event) -> None:
+        if isinstance(event, TextDelta):
+            self._mark_backend_update()
+            await self._ensure_turn_label()
+            # The visible answer beginning means thinking is done; freeze the
+            # thought lane and its activity row (otherwise the row keeps
+            # animating "thinking" while the answer streams) and drop both so
+            # reasoning that resumes later starts a fresh block.
+            if self._thought is not None:
+                self._thought.done()
+                self._thought = None
+            if self._activity is not None:
+                self._activity.done()
+                self._activity = None
+            if self._assistant is None:
+                self._assistant = AssistantMessage()
+                await self._mount(self._assistant)
+            await self._assistant.append(event.text)
+            self._scroll_transcript_end()
+            self._stream_chars += len(event.text)
+            self._refresh_tokens()
+
+        elif isinstance(event, ThoughtDelta):
+            self._mark_backend_update()
+            await self._ensure_turn_label()
+            activity = await self._ensure_activity_line()
+            activity.set_thinking()
+            # A new thinking block: any answer text after it should mount
+            # below, so close the current assistant bubble.
+            self._assistant = None
+            if self._thought is None:
+                self._thought = ThoughtMessage(live=True)
+                self._thought.add_class("hidden")
+                await self._mount(self._thought)
+                self._apply_thought_visibility(self._thought)
+            self._thought.append(event.text)
+            # Reasoning counts toward output tokens too.
+            self._stream_chars += len(event.text)
+            self._refresh_tokens()
+
+        elif isinstance(event, ToolCall):
+            self._mark_backend_update()
+            activity = await self._ensure_activity_line()
+            activity.set_tool(
+                title=event.title,
+                kind=event.kind,
+                status=event.status,
+                params=event.params,
+            )
+            panel = self._tools.get(event.tool_call_id)
+            if panel is None:
+                await self._ensure_turn_label()
+                # A new tool ends the current thinking block and closes the
+                # assistant bubble, so transcript widgets stay in the order
+                # content was produced (text → tool → text reads top-down).
+                if self._thought is not None:
+                    self._thought.done()
+                    self._thought = None
+                self._assistant = None
+                panel = ToolPanel(
+                    event.tool_call_id,
+                    event.title,
+                    event.kind,
+                    params=event.params,
+                )
+                self._tools[event.tool_call_id] = panel
+                panel.add_class("hidden")
+                await self._mount(panel)
+                self._apply_tool_visibility(panel)
+            panel.update_call(
+                title=event.title,
+                kind=event.kind,
+                status=event.status,
+                output=event.output,
+                params=event.params,
+            )
+            self._apply_tool_visibility(panel)
+            # Surface any files the tool returned (e.g. send_file_to_user) as
+            # their own clickable transcript line, since the panel collapses.
+            for link in event.links:
+                key = (event.tool_call_id, link.uri)
+                if key in self._file_links_seen:
+                    continue
+                self._file_links_seen.add(key)
+                await self._mount(FileLinkBox(link.name, link.uri))
+
+        elif isinstance(event, UserTurn):
+            # A user turn replayed from a resumed session. Close any open
+            # assistant lane so the next replayed reply starts its own bubble.
+            if self._thought is not None:
+                self._thought.done()
+                self._thought = None
+            if self._activity is not None:
+                self._activity.done()
+                self._activity = None
+            self._assistant = None
+            self._labeled = False
+            await self._mount(UserMessage(event.text))
+
+        elif isinstance(event, SessionTitle):
+            self._set_terminal_title(f"QwenPaw {event.title}")
+
+        elif isinstance(event, AvailableCommands):
+            self._agent_commands = list(event.commands)
+            self._set_command_catalog()
+
+        elif isinstance(event, PushMessage):
+            await self._mount(PushMessageBox(event.text))
+
+        elif isinstance(event, Usage):
+            self._status().set(used=event.used, size=event.size)
+
+        elif isinstance(event, TokenUsage):
+            # Exact usage for the just-finished call replaces our estimate.
+            self._tok_in += event.input_tokens
+            self._tok_out += event.output_tokens
+            self._stream_chars = 0
+            if event.model:
+                self._model = event.model
+                self._status().set(model=event.model)
+            self._refresh_tokens()
+
+        elif isinstance(event, PlanUpdate):
+            # Render the plan inline as a thought-style summary for now.
+            lines = "\n".join(
+                f"  {'✓' if e.status == 'completed' else '•'} {e.content}"
+                for e in event.entries
+            )
+            if lines:
+                box = ThoughtMessage(title="📋 plan", collapsed=False)
+                box.append(lines)
+                await self._mount(box)
+
+        elif isinstance(event, PermissionRequest):
+            self._on_permission(event)
+
+        elif isinstance(event, TransportError):
+            self._awaiting_backend_update = False
+            self._turn_saw_error = True
+            self._status().set(state="error")
+            await self._mount(ErrorMessage(event.message))
+
+        elif isinstance(event, BackendWarmed):
+            self._backend_warmed = True
+            if not event.success and event.message:
+                await self._mount(
+                    InfoMessage(
+                        f"Backend warmup skipped: {event.message}",
+                        level="warn",
+                    )
+                )
+            self._status().set(state=self._current_work_state())
+
+        elif isinstance(event, TurnEnded):
+            self._busy = False
+            self._awaiting_backend_update = False
+            if self._thought is not None:
+                self._thought.done()
+            if self._activity is not None:
+                self._activity.done()
+            self._assistant = None
+            self._thought = None
+            self._activity = None
+            self._labeled = False
+            self._tools.clear()
+            # Drop any leftover estimate (e.g. a turn with no usage report).
+            self._stream_chars = 0
+            self._refresh_tokens()
+            self._status().set(state="ready")
+            # A turn that ended without any visible output (and without an
+            # error already shown) is a silent backend failure — surface it so
+            # an unusable model doesn't just look like nothing happened.
+            if (
+                not self._turn_saw_output
+                and not self._turn_saw_error
+                and event.stop_reason != "cancelled"
+            ):
+                self._status().set(state="error")
+                await self._mount(
+                    ErrorMessage(self._no_response_text(event.stop_reason))
+                )
+            # Hand off to the next message the user queued while we worked.
+            await self._drain_queue()
+            # The just-finished exchange makes this (or a resumed) session the
+            # newest; refresh the /resume auto-suggest list to reflect it.
+            self._refresh_recent_sessions()
+
+    def _mark_backend_update(self) -> None:
+        # Reached on every text / thought / tool event, i.e. anything the user
+        # can see — so the turn produced a visible response.
+        self._turn_saw_output = True
+        if not self._awaiting_backend_update:
+            return
+        self._awaiting_backend_update = False
+        self._backend_warmed = True
+        self._status().set(state="thinking")
+
+    def _current_work_state(self) -> str:
+        if not self._busy:
+            return "ready"
+        if self._awaiting_backend_update:
+            return "waiting" if self._backend_warmed else "warming"
+        return "thinking"
+
+    def _no_response_text(self, stop_reason: str | None) -> str:
+        model = self._model or "the model"
+        extra = (
+            f" (stop reason: {stop_reason})"
+            if stop_reason and stop_reason not in {"end_turn", "stop"}
+            else ""
+        )
+        return (
+            f"No response from {model}{extra}. The model or its API key "
+            "may be misconfigured in QwenPaw — check it with `qwenpaw "
+            "doctor` or `qwenpaw models config-key`."
+        )
+
+    def _on_permission(self, event: PermissionRequest) -> None:
+        def _resolve(option_id: str | None) -> None:
+            self.run_worker(
+                self._transport.resolve_permission(
+                    event.request_id, option_id
+                ),
+                exclusive=False,
+            )
+
+        self.push_screen(PermissionModal(event), _resolve)
+
+    async def on_unmount(self) -> None:
+        await self._transport.close()
+
+
+def _local_commands() -> list[SlashCommand]:
+    """Slash commands handled by the TUI itself. Model/provider commands are
+    QwenPaw's and are forwarded to the agent, not listed here."""
+    commands = [
+        SlashCommand("help", "show QwenPaw TUI shortcuts"),
+        SlashCommand("resume", "resume a previous session"),
+        SlashCommand("theme", "open theme gallery or apply a vibe"),
+        SlashCommand("inspect", "toggle deeper thought/tool detail"),
+    ]
+    commands.extend(
+        SlashCommand(
+            f"theme {theme.id}",
+            f"{theme.emoji} {theme.name}",
+        )
+        for theme in THEME_GALLERY
+    )
+    return commands
+
+
+_LONG_PASTE_CHAR_THRESHOLD = 2000
+_LONG_PASTE_LINE_THRESHOLD = 12
+_ATTACHMENT_DIR = "attachments"
+
+
+@dataclass(frozen=True)
+class _PasteAttachment:
+    name: str
+    source_path: Path | None = None
+    data: bytes | None = None
+
+
+@dataclass(frozen=True)
+class _PasteFileReference:
+    start: int
+    end: int
+    path: Path
+
+
+def _should_store_pasted_text(text: str) -> bool:
+    if not text:
+        return False
+    return (
+        len(text) >= _LONG_PASTE_CHAR_THRESHOLD
+        or text.count("\n") + 1 >= _LONG_PASTE_LINE_THRESHOLD
+    )
+
+
+def _attachments_from_paste(text: str) -> list[_PasteAttachment]:
+    stripped = text.strip()
+    if not stripped:
+        return []
+    data_attachment = _data_url_attachment(stripped)
+    if data_attachment is not None:
+        return [data_attachment]
+    candidates = _paste_file_candidates(stripped)
+    if not candidates:
+        return []
+    attachments: list[_PasteAttachment] = []
+    for candidate in candidates:
+        path = _path_from_file_reference(candidate)
+        if not _is_file(path):
+            return []
+        attachments.append(_PasteAttachment(name=path.name, source_path=path))
+    return attachments
+
+
+def _replace_embedded_file_references(
+    text: str,
+) -> tuple[str, list[Path]] | None:
+    references = _embedded_file_references(text)
+    if not references:
+        return None
+    chunks: list[str] = []
+    copied: list[Path] = []
+    cursor = 0
+    for ref in references:
+        destination = _copy_paste_attachment(
+            _PasteAttachment(name=ref.path.name, source_path=ref.path)
+        )
+        copied.append(destination)
+        chunks.append(text[cursor : ref.start])
+        chunks.append(f"[attached file: {destination}]")
+        cursor = ref.end
+    chunks.append(text[cursor:])
+    return "".join(chunks), copied
+
+
+def _embedded_file_references(text: str) -> list[_PasteFileReference]:
+    references: list[_PasteFileReference] = []
+    index = 0
+    while index < len(text):
+        if not _looks_like_path_start(text, index):
+            index += 1
+            continue
+        reference = _longest_file_reference(text, index)
+        if reference is None:
+            index += 1
+            continue
+        references.append(reference)
+        index = reference.end
+    return references
+
+
+def _looks_like_path_start(text: str, index: int) -> bool:
+    return (
+        text[index] == "/"
+        or (text[index] == "~" and text[index : index + 2] == "~/")
+        or text.startswith("file://", index)
+    )
+
+
+def _longest_file_reference(
+    text: str, start: int
+) -> _PasteFileReference | None:
+    line_end = text.find("\n", start)
+    if line_end == -1:
+        line_end = len(text)
+    for end in range(line_end, start, -1):
+        fragment = text[start:end]
+        trimmed = fragment.rstrip(".,;:)]}")
+        trim_end = start + len(trimmed)
+        path = _path_from_text_fragment(trimmed)
+        if path is not None:
+            return _PasteFileReference(start, trim_end, path)
+    return None
+
+
+def _path_from_text_fragment(value: str) -> Path | None:
+    value = value.strip()
+    if not value:
+        return None
+    direct = _path_from_file_reference(_strip_wrapping_quotes(value))
+    if _is_file(direct):
+        return direct
+    try:
+        parts = shlex.split(value)
+    except ValueError:
+        return None
+    if len(parts) != 1:
+        return None
+    parsed = _path_from_file_reference(parts[0])
+    return parsed if _is_file(parsed) else None
+
+
+def _paste_file_candidates(text: str) -> list[str]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if len(lines) > 1:
+        return [_strip_wrapping_quotes(line) for line in lines]
+    whole = _strip_wrapping_quotes(text)
+    whole_path = _path_from_file_reference(whole)
+    if _is_file(whole_path):
+        return [whole]
+    try:
+        parts = shlex.split(text)
+    except ValueError:
+        parts = []
+    if len(parts) > 1:
+        return parts
+    return [whole]
+
+
+def _path_from_file_reference(value: str) -> Path | None:
+    if value.startswith("file://"):
+        parsed = urlparse(value)
+        if parsed.netloc and parsed.netloc not in {"localhost", "127.0.0.1"}:
+            return None
+        return Path(unquote(parsed.path)).expanduser()
+    return Path(value).expanduser()
+
+
+def _is_file(path: Path | None) -> bool:
+    if path is None:
+        return False
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
+def _data_url_attachment(value: str) -> _PasteAttachment | None:
+    match = re.fullmatch(
+        r"data:([^;,]+)?(;base64)?,(.*)", value, flags=re.DOTALL
+    )
+    if match is None:
+        return None
+    media_type = match.group(1) or "application/octet-stream"
+    if match.group(2) != ";base64":
+        raise ValueError("pasted data URLs must be base64 encoded")
+    try:
+        data = base64.b64decode(match.group(3), validate=True)
+    except binascii.Error as exc:
+        raise ValueError(f"invalid base64 data URL: {exc}") from exc
+    extension = mimetypes.guess_extension(media_type) or ".bin"
+    prefix = (
+        "pasted-image" if media_type.startswith("image/") else "pasted-file"
+    )
+    return _PasteAttachment(name=f"{prefix}{extension}", data=data)
+
+
+def _copy_paste_attachment(attachment: _PasteAttachment) -> Path:
+    destination = _unique_attachment_path(attachment.name)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if attachment.source_path is not None:
+        shutil.copy2(attachment.source_path, destination)
+    elif attachment.data is not None:
+        destination.write_bytes(attachment.data)
+    else:
+        destination.write_bytes(b"")
+    return destination
+
+
+def _store_pasted_text(text: str) -> Path:
+    destination = _unique_attachment_path("pasted-text.txt")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(text, encoding="utf-8")
+    return destination
+
+
+def _unique_attachment_path(name: str) -> Path:
+    path = Path(name)
+    suffix = path.suffix
+    stem = _safe_attachment_stem(path.stem or "pasted-file")
+    return state_dir() / _ATTACHMENT_DIR / f"{stem}-{uuid4().hex[:10]}{suffix}"
+
+
+def _safe_attachment_stem(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip(".-")
+    return normalized[:64] or "pasted-file"
+
+
+def _strip_wrapping_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _prompt_height(value: str, *, width: int) -> int:
+    rows = 1
+    usable = max(20, width - 4)
+    for line in value.splitlines() or [""]:
+        rows += max(0, (len(line) - 1) // usable)
+    return rows + value.count("\n")

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -22,7 +22,6 @@ from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.widgets import TextArea
 
-from .__version__ import __version__
 from .events import (
     AvailableCommands,
     BackendWarmed,
@@ -214,7 +213,7 @@ class PawApp(App):
 
     # -- layout --------------------------------------------------------------
     def compose(self) -> ComposeResult:
-        yield StatusBar(tui_version=__version__)
+        yield StatusBar()
         yield VerticalScroll(id="transcript")
         yield self._menu
         yield PromptInput(

--- a/src/qwenpaw/cli/tui/events.py
+++ b/src/qwenpaw/cli/tui/events.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""Normalized TUI event types.
+
+The ACP subprocess transport translates its wire format into this small union
+so the UI layer is transport-agnostic. This is the ``TuiEvent`` contract
+referenced in the design doc (§4.2/§4.3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Connected:
+    """Emitted once the transport has a live session."""
+
+    session_id: str
+    agent: str | None = None
+    model: str | None = None
+    qwenpaw_version: str | None = None
+    warming: bool = False
+
+
+@dataclass(frozen=True)
+class BackendWarmed:
+    """The backend completed its proactive first-turn warmup."""
+
+    success: bool = True
+    message: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionTitle:
+    """A human-readable title for the session (e.g. for the terminal tab)."""
+
+    title: str
+
+
+@dataclass(frozen=True)
+class TextDelta:
+    """A chunk of visible assistant text (already a delta, not cumulative)."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ThoughtDelta:
+    """A chunk of agent thinking/reasoning."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class FileLink:
+    """A file the agent surfaced (e.g. via ``send_file_to_user``).
+
+    Carried on a :class:`ToolCall` as an ACP ``resource_link`` content block;
+    the UI renders it as a clickable link that opens the file.
+    """
+
+    uri: str
+    name: str = ""
+    mime_type: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """Start or update of a tool call (keyed by ``tool_call_id``)."""
+
+    tool_call_id: str
+    title: str
+    kind: str | None = None
+    status: str | None = None  # pending | in_progress | completed | failed
+    output: str | None = None
+    params: str | None = None  # raw input parameters, rendered for display
+    links: tuple[FileLink, ...] = ()  # file/resource links in the result
+
+
+@dataclass(frozen=True)
+class PlanEntry:
+    content: str
+    status: str = "pending"
+    priority: str = "medium"
+
+
+@dataclass(frozen=True)
+class PlanUpdate:
+    """The agent's current plan/todo list."""
+
+    entries: list[PlanEntry] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Usage:
+    """Token-usage metadata for the status bar."""
+
+    used: int
+    size: int
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Incremental token counts from one LLM call.
+
+    QwenPaw reports usage per LLM invocation, so the UI sums these to show
+    the running input/output totals for the session. ``model`` is the model
+    that produced the call (the session may bind it late, e.g. via a
+    global fallback), so the UI can fill in the model name once known.
+    """
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    model: str | None = None
+
+
+@dataclass(frozen=True)
+class PermissionOption:
+    option_id: str
+    name: str
+    kind: str  # allow_once | allow_always | reject_once | reject_always
+
+
+@dataclass(frozen=True)
+class PermissionRequest:
+    """A tool is awaiting the user's approval. ``request_id`` resolves it."""
+
+    request_id: str
+    title: str
+    options: list[PermissionOption] = field(default_factory=list)
+    tool_kind: str | None = None
+
+
+@dataclass(frozen=True)
+class SlashCommand:
+    """One agent slash command, used to drive input auto-suggestions."""
+
+    name: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class AvailableCommands:
+    """The set of slash commands the agent currently advertises."""
+
+    commands: list[SlashCommand] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PushMessage:
+    """A server-initiated proactive message (ACP ext push-message)."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class UserTurn:
+    """A user message replayed from a resumed session's saved transcript.
+
+    Only emitted during ``session/load`` history replay — live user input is
+    rendered directly by the UI, not round-tripped through the transport.
+    """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    """One resumable past session, for the /resume picker."""
+
+    session_id: str
+    title: str = ""
+    cwd: str = ""
+    updated_at: str = ""
+
+
+@dataclass(frozen=True)
+class TurnEnded:
+    """The current prompt turn finished."""
+
+    stop_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class TransportError:
+    """A transport/agent error to surface in the transcript."""
+
+    message: str
+
+
+# The normalized union the UI consumes.
+TuiEvent = (
+    Connected
+    | BackendWarmed
+    | SessionTitle
+    | TextDelta
+    | ThoughtDelta
+    | ToolCall
+    | PlanUpdate
+    | Usage
+    | TokenUsage
+    | PermissionRequest
+    | AvailableCommands
+    | PushMessage
+    | UserTurn
+    | TurnEnded
+    | TransportError
+)

--- a/src/qwenpaw/cli/tui/launch.py
+++ b/src/qwenpaw/cli/tui/launch.py
@@ -4,13 +4,11 @@
 ``qwenpaw``                    open an interactive chat with the active agent
 ``qwenpaw tui``                same, with explicit options
 ``qwenpaw tui --agent NAME``   chat with a specific agent
-``qwenpaw tui --agent-cmd ..`` drive an explicit ACP agent command (remote/dev)
 ``qwenpaw tui --resume ID``    resume a previous session and continue it
 
-By default the TUI spawns ``qwenpaw acp`` using the *current* interpreter
+The TUI spawns ``qwenpaw acp`` using the *current* interpreter
 (``python -m qwenpaw acp``), so it always drives the same install/venv it ships
-in -- no reliance on ``qwenpaw`` being on ``PATH``. ``--agent-cmd`` overrides
-this to point at any command that speaks ACP over stdio.
+in -- no reliance on ``qwenpaw`` being on ``PATH``.
 
 Textual and the transport are imported lazily so ``qwenpaw --help`` and other
 subcommands stay fast.
@@ -18,7 +16,6 @@ subcommands stay fast.
 
 from __future__ import annotations
 
-import shlex
 import sys
 
 import click
@@ -27,31 +24,24 @@ import click
 def _build_transport(
     *,
     agent: str | None,
-    agent_cmd: str | None,
     resume: str | None,
 ):
     """Return ``(transport, description)`` for the requested target.
 
-    The ``--agent`` suffix is *not* appended here: :class:`AcpTransport`
-    appends ``--agent <id>`` itself when ``agent`` is set, so doing it here
-    too would double it.
+    ``command=None`` lets :class:`AcpTransport` use its default,
+    ``[sys.executable, "-m", "qwenpaw", "acp"]`` -- the same interpreter the
+    TUI is running under. The ``--agent`` suffix is *not* appended here:
+    ``AcpTransport`` appends ``--agent <id>`` itself when ``agent`` is set, so
+    doing it here too would double it.
     """
     from .transport.acp import AcpTransport
 
-    if agent_cmd:
-        command: list[str] | None = shlex.split(agent_cmd)
-        description = f"custom: {agent_cmd}"
-    else:
-        # ``None`` lets AcpTransport use its default:
-        # ``[sys.executable, "-m", "qwenpaw", "acp"]`` -- the same interpreter
-        # the TUI is running under.
-        command = None
-        description = f"qwenpaw acp ({sys.executable} -m qwenpaw acp)"
+    description = f"qwenpaw acp ({sys.executable} -m qwenpaw acp)"
 
     return (
         AcpTransport(
             agent=agent,
-            command=command,
+            command=None,
             resume_session_id=resume,
         ),
         description,
@@ -61,13 +51,11 @@ def _build_transport(
 def run_tui(
     *,
     agent: str | None = None,
-    agent_cmd: str | None = None,
     resume: str | None = None,
 ) -> None:
     """Build the transport and run the Textual app (blocking)."""
     transport, description = _build_transport(
         agent=agent,
-        agent_cmd=agent_cmd,
         resume=resume,
     )
 
@@ -91,13 +79,6 @@ def run_tui(
     help="Agent ID to chat with (defaults to the active agent).",
 )
 @click.option(
-    "--agent-cmd",
-    default=None,
-    metavar="COMMAND",
-    help="Explicit command that speaks ACP over stdio "
-    "(e.g. 'qwenpaw acp'). Overrides the default subprocess.",
-)
-@click.option(
     "--resume",
     default=None,
     metavar="SESSION_ID",
@@ -106,8 +87,7 @@ def run_tui(
 )
 def tui_cmd(
     agent: str | None,
-    agent_cmd: str | None,
     resume: str | None,
 ) -> None:
     """Open the QwenPaw terminal chat UI."""
-    run_tui(agent=agent, agent_cmd=agent_cmd, resume=resume)
+    run_tui(agent=agent, resume=resume)

--- a/src/qwenpaw/cli/tui/launch.py
+++ b/src/qwenpaw/cli/tui/launch.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Launch the QwenPaw TUI.
+
+``qwenpaw``                    open an interactive chat with the active agent
+``qwenpaw tui``                same, with explicit options
+``qwenpaw tui --agent NAME``   chat with a specific agent
+``qwenpaw tui --agent-cmd ..`` drive an explicit ACP agent command (remote/dev)
+``qwenpaw tui --resume ID``    resume a previous session and continue it
+
+By default the TUI spawns ``qwenpaw acp`` using the *current* interpreter
+(``python -m qwenpaw acp``), so it always drives the same install/venv it ships
+in -- no reliance on ``qwenpaw`` being on ``PATH``. ``--agent-cmd`` overrides
+this to point at any command that speaks ACP over stdio.
+
+Textual and the transport are imported lazily so ``qwenpaw --help`` and other
+subcommands stay fast.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+
+import click
+
+
+def _build_transport(
+    *,
+    agent: str | None,
+    agent_cmd: str | None,
+    resume: str | None,
+):
+    """Return ``(transport, description)`` for the requested target.
+
+    The ``--agent`` suffix is *not* appended here: :class:`AcpTransport`
+    appends ``--agent <id>`` itself when ``agent`` is set, so doing it here
+    too would double it.
+    """
+    from .transport.acp import AcpTransport
+
+    if agent_cmd:
+        command: list[str] | None = shlex.split(agent_cmd)
+        description = f"custom: {agent_cmd}"
+    else:
+        # ``None`` lets AcpTransport use its default:
+        # ``[sys.executable, "-m", "qwenpaw", "acp"]`` -- the same interpreter
+        # the TUI is running under.
+        command = None
+        description = f"qwenpaw acp ({sys.executable} -m qwenpaw acp)"
+
+    return (
+        AcpTransport(
+            agent=agent,
+            command=command,
+            resume_session_id=resume,
+        ),
+        description,
+    )
+
+
+def run_tui(
+    *,
+    agent: str | None = None,
+    agent_cmd: str | None = None,
+    resume: str | None = None,
+) -> None:
+    """Build the transport and run the Textual app (blocking)."""
+    transport, description = _build_transport(
+        agent=agent,
+        agent_cmd=agent_cmd,
+        resume=resume,
+    )
+
+    from .app import PawApp
+
+    PawApp(
+        transport,
+        agent=agent or "default",
+        target=description,
+        resume_session_id=resume,
+    ).run()
+
+
+@click.command(
+    "tui",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--agent",
+    default=None,
+    help="Agent ID to chat with (defaults to the active agent).",
+)
+@click.option(
+    "--agent-cmd",
+    default=None,
+    metavar="COMMAND",
+    help="Explicit command that speaks ACP over stdio "
+    "(e.g. 'qwenpaw acp'). Overrides the default subprocess.",
+)
+@click.option(
+    "--resume",
+    default=None,
+    metavar="SESSION_ID",
+    help="Resume a previous session by id (use /resume in-app to browse). "
+    "Replays that session's transcript and continues it.",
+)
+def tui_cmd(
+    agent: str | None,
+    agent_cmd: str | None,
+    resume: str | None,
+) -> None:
+    """Open the QwenPaw terminal chat UI."""
+    run_tui(agent=agent, agent_cmd=agent_cmd, resume=resume)

--- a/src/qwenpaw/cli/tui/normalize.py
+++ b/src/qwenpaw/cli/tui/normalize.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Translate ACP ``session_update`` objects into normalized ``TuiEvent``s.
+
+Kept free of Textual and of the connection runtime so it is trivially
+unit-testable (see ``tests/cli/test_tui_normalize.py``). The shapes here match
+the ``acp.schema`` types verified against ``agent-client-protocol`` 0.9.x:
+
+* ``AgentMessageChunk`` / ``AgentThoughtChunk`` carry a single content block
+  whose ``.text`` is already a *delta* (the QwenPaw ACP server emits deltas).
+* ``ToolCallStart`` / ``ToolCallProgress`` share ``tool_call_id`` so the UI can
+  find-or-update one panel.
+* ``AgentPlanUpdate`` and ``UsageUpdate`` map straight across.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .events import (
+    AvailableCommands,
+    FileLink,
+    PlanEntry,
+    PlanUpdate,
+    SessionTitle,
+    SlashCommand,
+    TextDelta,
+    ThoughtDelta,
+    TokenUsage,
+    ToolCall,
+    TransportError,
+    TuiEvent,
+    Usage,
+    UserTurn,
+)
+
+# Tool-content block types that carry a file/resource URI worth linking.
+_LINK_BLOCK_TYPES = ("resource_link", "image", "audio", "resource")
+
+# ``_meta`` key QwenPaw sets on an ``agent_message_chunk`` to mark it as an
+# error; mirrors the ACP server's ``ACP_ERROR_META_KEY``.
+_ERROR_META_KEY = "qwenpaw.error"
+
+
+def _block_text(content: Any) -> str:
+    """Pull text out of an ACP content block (object or dict)."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        return str(content.get("text", "") or "")
+    return str(getattr(content, "text", "") or "")
+
+
+def _tool_output_text(content: Any) -> str:
+    """Flatten a tool-call ``content`` list into display text."""
+    if not content:
+        return ""
+    parts: list[str] = []
+    for item in content:
+        inner = (
+            item.get("content")
+            if isinstance(item, dict)
+            else getattr(item, "content", None)
+        )
+        text = _block_text(inner)
+        if text:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _attr(obj: Any, key: str) -> Any:
+    """Read ``key`` from a dict or an attribute-style object."""
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _tool_links(content: Any) -> tuple[FileLink, ...]:
+    """Pull file/resource links out of a tool-call ``content`` list.
+
+    Recognises ACP ``resource_link`` blocks (and image/audio/resource blocks
+    that carry a ``uri``), e.g. the link QwenPaw emits for
+    ``send_file_to_user``.
+    """
+    if not content:
+        return ()
+    links: list[FileLink] = []
+    for item in content:
+        inner = _attr(item, "content")
+        if inner is None:
+            continue
+        if _attr(inner, "type") not in _LINK_BLOCK_TYPES:
+            continue
+        uri = _attr(inner, "uri")
+        if not uri:
+            continue
+        links.append(
+            FileLink(
+                uri=str(uri),
+                name=str(_attr(inner, "name") or ""),
+                mime_type=(
+                    str(_attr(inner, "mime_type"))
+                    if _attr(inner, "mime_type")
+                    else None
+                ),
+            )
+        )
+    return tuple(links)
+
+
+def _tool_input_text(raw_input: Any) -> str:
+    """Render raw tool input parameters into compact, readable display text.
+
+    ``raw_input`` is whatever the agent sent (usually a dict like
+    ``{"command": "ls -la"}``). One ``key: value`` line per parameter so the
+    actual command/path/etc. is visible in the panel.
+    """
+    if raw_input is None:
+        return ""
+    if isinstance(raw_input, str):
+        return raw_input.strip()
+    if isinstance(raw_input, dict):
+        lines: list[str] = []
+        for key, value in raw_input.items():
+            text = (
+                value
+                if isinstance(value, str)
+                else json.dumps(value, ensure_ascii=False)
+            )
+            lines.append(f"{key}: {text}")
+        return "\n".join(lines)
+    return str(raw_input)
+
+
+def normalize_update(update: Any) -> list[TuiEvent]:
+    """Convert one ACP ``session_update`` payload into zero or more events.
+
+    Accepts the typed ``acp.schema`` objects. Unknown updates yield ``[]`` so
+    the UI degrades gracefully rather than crashing on protocol additions.
+    """
+    kind = getattr(update, "session_update", None)
+
+    if kind == "agent_message_chunk":
+        meta = getattr(update, "field_meta", None)
+        # QwenPaw reports per-call token usage as an (otherwise empty)
+        # message chunk tagged with ``_meta.usage`` (inputTokens / etc.).
+        if isinstance(meta, dict) and isinstance(meta.get("usage"), dict):
+            u = meta["usage"]
+            return [
+                TokenUsage(
+                    input_tokens=int(u.get("inputTokens", 0) or 0),
+                    output_tokens=int(u.get("outputTokens", 0) or 0),
+                    total_tokens=int(u.get("totalTokens", 0) or 0),
+                    model=str(u.get("model")) if u.get("model") else None,
+                )
+            ]
+        text = _block_text(getattr(update, "content", None))
+        if not text:
+            return []
+        # QwenPaw tags failed turns via ``_meta`` so we can render them as
+        # an error instead of a normal assistant reply (see the ACP server's
+        # ``ACP_ERROR_META_KEY``). Other agents omit it → plain text.
+        if isinstance(meta, dict) and meta.get(_ERROR_META_KEY):
+            return [TransportError(text)]
+        return [TextDelta(text)]
+
+    if kind == "agent_thought_chunk":
+        text = _block_text(getattr(update, "content", None))
+        return [ThoughtDelta(text)] if text else []
+
+    if kind in ("tool_call", "tool_call_update"):
+        return [
+            ToolCall(
+                tool_call_id=getattr(update, "tool_call_id", ""),
+                # Keep an absent title empty rather than coercing to "tool":
+                # the agent only sends the real name on the *start* event, so a
+                # placeholder here would clobber it on the completion update
+                # (which carries title=None). The widget fills the fallback.
+                title=getattr(update, "title", None) or "",
+                kind=getattr(update, "kind", None),
+                status=getattr(update, "status", None),
+                output=_tool_output_text(getattr(update, "content", None))
+                or None,
+                params=_tool_input_text(getattr(update, "raw_input", None))
+                or None,
+                links=_tool_links(getattr(update, "content", None)),
+            )
+        ]
+
+    if kind == "plan":
+        entries = [
+            PlanEntry(
+                content=getattr(e, "content", "") or "",
+                status=getattr(e, "status", "pending") or "pending",
+                priority=getattr(e, "priority", "medium") or "medium",
+            )
+            for e in (getattr(update, "entries", None) or [])
+        ]
+        return [PlanUpdate(entries=entries)]
+
+    if kind == "usage_update":
+        return [
+            Usage(
+                used=int(getattr(update, "used", 0) or 0),
+                size=int(getattr(update, "size", 0) or 0),
+            )
+        ]
+
+    if kind == "available_commands_update":
+        commands = [
+            SlashCommand(
+                name=name,
+                description=getattr(c, "description", "") or "",
+            )
+            for c in (getattr(update, "available_commands", None) or [])
+            if (name := getattr(c, "name", "") or "")
+        ]
+        return [AvailableCommands(commands=commands)]
+
+    if kind == "session_info_update":
+        title = getattr(update, "title", None)
+        return [SessionTitle(str(title))] if title else []
+
+    if kind == "user_message_chunk":
+        # Emitted only while a resumed session replays its saved transcript;
+        # surface it so the prior user turns render in the rebuilt history.
+        text = _block_text(getattr(update, "content", None))
+        return [UserTurn(text)] if text else []
+
+    # current_mode / config_option: not surfaced in the chat transcript (yet).
+    return []

--- a/src/qwenpaw/cli/tui/normalize.py
+++ b/src/qwenpaw/cli/tui/normalize.py
@@ -124,7 +124,7 @@ def _tool_links(content: Any) -> tuple[FileLink, ...]:
                     if _attr(inner, "mime_type")
                     else None
                 ),
-            )
+            ),
         )
     return tuple(links)
 
@@ -153,6 +153,7 @@ def _tool_input_text(raw_input: Any) -> str:
     return str(raw_input)
 
 
+# pylint: disable-next=too-many-return-statements
 def normalize_update(update: Any) -> list[TuiEvent]:
     """Convert one ACP ``session_update`` payload into zero or more events.
 
@@ -173,7 +174,7 @@ def normalize_update(update: Any) -> list[TuiEvent]:
                     output_tokens=int(u.get("outputTokens", 0) or 0),
                     total_tokens=int(u.get("totalTokens", 0) or 0),
                     model=str(u.get("model")) if u.get("model") else None,
-                )
+                ),
             ]
         text = _block_text(getattr(update, "content", None))
         if not text:
@@ -205,7 +206,7 @@ def normalize_update(update: Any) -> list[TuiEvent]:
                 params=_tool_input_text(getattr(update, "raw_input", None))
                 or None,
                 links=_tool_links(getattr(update, "content", None)),
-            )
+            ),
         ]
 
     if kind == "plan":
@@ -224,7 +225,7 @@ def normalize_update(update: Any) -> list[TuiEvent]:
             Usage(
                 used=int(getattr(update, "used", 0) or 0),
                 size=int(getattr(update, "size", 0) or 0),
-            )
+            ),
         ]
 
     if kind == "available_commands_update":

--- a/src/qwenpaw/cli/tui/normalize.py
+++ b/src/qwenpaw/cli/tui/normalize.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from urllib.parse import urlparse
 
 from .events import (
     AvailableCommands,
@@ -36,6 +37,21 @@ from .events import (
 
 # Tool-content block types that carry a file/resource URI worth linking.
 _LINK_BLOCK_TYPES = ("resource_link", "image", "audio", "resource")
+
+
+def _is_local_file_uri(uri: str) -> bool:
+    """Whether *uri* is a local file safe to surface as a one-click link.
+
+    A clicked ``FileLink`` is handed to ``App.open_url`` (the OS handler), so a
+    buggy or hostile agent emitting an ``http(s)://`` (or other-scheme)
+    ``resource_link`` could drive a one-click browser open. QwenPaw only emits
+    local files here (e.g. ``send_file_to_user``), so restrict to ``file://``
+    and bare local paths; everything else is dropped.
+    """
+    scheme = urlparse(uri).scheme.lower()
+    # "" = bare path; a single alpha char is a Windows drive letter (C:\...).
+    return scheme in ("", "file") or (len(scheme) == 1 and scheme.isalpha())
+
 
 # ``_meta`` key QwenPaw sets on an ``agent_message_chunk`` to mark it as an
 # error; mirrors the ACP server's ``ACP_ERROR_META_KEY``.
@@ -95,6 +111,9 @@ def _tool_links(content: Any) -> tuple[FileLink, ...]:
             continue
         uri = _attr(inner, "uri")
         if not uri:
+            continue
+        if not _is_local_file_uri(str(uri)):
+            # Skip non-local schemes (e.g. http) — not safe to one-click open.
             continue
         links.append(
             FileLink(

--- a/src/qwenpaw/cli/tui/paths.py
+++ b/src/qwenpaw/cli/tui/paths.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Where paw keeps its own state (logs, etc.).
+
+Self-owned so paw never depends on QwenPaw's working dir. Honors
+``PAW_STATE_DIR`` and ``XDG_STATE_HOME``; falls back to a platform default.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def state_dir() -> Path:
+    """Return paw's state directory, creating it if needed."""
+    override = os.environ.get("PAW_STATE_DIR")
+    if override:
+        base = Path(override).expanduser()
+    elif sys.platform == "win32":
+        root = os.environ.get("LOCALAPPDATA") or "~"
+        base = Path(root).expanduser() / "paw"
+    elif sys.platform == "darwin":
+        base = Path("~/Library/Application Support/paw").expanduser()
+    else:
+        root = os.environ.get("XDG_STATE_HOME") or "~/.local/state"
+        base = Path(root).expanduser() / "paw"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def log_path(name: str = "acp.log") -> Path:
+    """Path to a log file under the state dir."""
+    return state_dir() / name

--- a/src/qwenpaw/cli/tui/themes.py
+++ b/src/qwenpaw/cli/tui/themes.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+"""Fun terminal theme gallery for QwenPaw."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ThemeInfo:
+    id: str
+    name: str
+    emoji: str
+    prompt: str
+    screen: str
+    prompt_bg: str
+    chrome: str
+    accent: str
+    text: str = "#f4fff8"
+
+    @property
+    def palette(self) -> tuple[str, str, str]:
+        return self.screen, self.prompt_bg, self.chrome
+
+
+THEME_GALLERY: tuple[ThemeInfo, ...] = (
+    ThemeInfo(
+        "original",
+        "Original",
+        "🐾",
+        "original",
+        # Warm, dark take on QwenPaw's console palette (brand orange #ff7f16).
+        "#1d1308",
+        "#2c1d0e",
+        "#5a3614",
+        "#ff7f16",
+    ),
+    ThemeInfo(
+        "funky",
+        "Funky Paw Rave",
+        "🪩",
+        "funky neon paw party",
+        "#23153d",
+        "#351f57",
+        "#53218a",
+        "#ff7ad9",
+    ),
+    ThemeInfo(
+        "cyberpunk",
+        "Cyberpunk Alley",
+        "⚡",
+        "cyberpunk tiger-paw alley with laser rain",
+        "#071b2c",
+        "#101f3c",
+        "#163857",
+        "#00f5ff",
+    ),
+    ThemeInfo(
+        "greek",
+        "Oracle Marble",
+        "🏛️",
+        "greek roman marble oracle courtyard",
+        "#1f2330",
+        "#2b3140",
+        "#3d4660",
+        "#f4d58d",
+    ),
+    ThemeInfo(
+        "zen",
+        "Zen Matcha",
+        "🍵",
+        "quiet zen garden with matcha glow",
+        "#14251d",
+        "#1c3428",
+        "#274a37",
+        "#a9f0b6",
+    ),
+    ThemeInfo(
+        "medieval",
+        "Medieval Quest",
+        "🛡️",
+        "middle age quest tavern with warm torchlight",
+        "#281b19",
+        "#38261f",
+        "#563722",
+        "#ffb86b",
+    ),
+    ThemeInfo(
+        "jurassic",
+        "Jurassic Ferns",
+        "🦖",
+        "jurassic park rainforest terminal",
+        "#10261f",
+        "#17382c",
+        "#1d523d",
+        "#7cff6b",
+    ),
+    ThemeInfo(
+        "space",
+        "Space Alien",
+        "👽",
+        "space alien mothership with cute paw console",
+        "#081525",
+        "#121a39",
+        "#1f295a",
+        "#9d8cff",
+    ),
+    ThemeInfo(
+        "mars",
+        "Mars Invader",
+        "🛸",
+        "mars invader arcade red planet",
+        "#251111",
+        "#3a1818",
+        "#5c241e",
+        "#ff6d4d",
+    ),
+    ThemeInfo(
+        "ocean",
+        "Deep Sea Synth",
+        "🐚",
+        "deep sea synthwave coral reef",
+        "#071e24",
+        "#0d2e36",
+        "#134751",
+        "#55e6c1",
+    ),
+)
+
+
+def find_theme(value: str) -> ThemeInfo | None:
+    needle = value.strip().casefold()
+    if not needle:
+        return None
+    for theme in THEME_GALLERY:
+        if needle in {theme.id.casefold(), theme.name.casefold()}:
+            return theme
+    return None
+
+
+def _resolve_theme(prompt: str) -> ThemeInfo:
+    """Map any prompt to a theme: an exact match, else a stable hash pick."""
+    theme = find_theme(prompt)
+    if theme is not None:
+        return theme
+    index = sum(ord(ch) for ch in prompt) % len(THEME_GALLERY)
+    return THEME_GALLERY[index]
+
+
+def palette_for_prompt(prompt: str) -> tuple[str, str, str]:
+    return _resolve_theme(prompt).palette
+
+
+def accent_for_prompt(prompt: str) -> str:
+    """The theme's bright accent — used to colour the welcome logo."""
+    return _resolve_theme(prompt).accent
+
+
+def mix_hex(left: str, right: str, amount: float) -> str:
+    """Blend two ``#rrggbb`` colours; ``amount`` is the weight of ``right``."""
+
+    def channels(value: str) -> tuple[int, int, int]:
+        cleaned = value.removeprefix("#")
+        return (
+            int(cleaned[0:2], 16),
+            int(cleaned[2:4], 16),
+            int(cleaned[4:6], 16),
+        )
+
+    left_rgb = channels(left)
+    right_rgb = channels(right)
+    mixed = tuple(
+        round(a + (b - a) * amount) for a, b in zip(left_rgb, right_rgb)
+    )
+    return "#{:02x}{:02x}{:02x}".format(*mixed)

--- a/src/qwenpaw/cli/tui/themes.py
+++ b/src/qwenpaw/cli/tui/themes.py
@@ -172,4 +172,4 @@ def mix_hex(left: str, right: str, amount: float) -> str:
     mixed = tuple(
         round(a + (b - a) * amount) for a, b in zip(left_rgb, right_rgb)
     )
-    return "#{:02x}{:02x}{:02x}".format(*mixed)
+    return f"#{mixed[0]:02x}{mixed[1]:02x}{mixed[2]:02x}"

--- a/src/qwenpaw/cli/tui/transport/__init__.py
+++ b/src/qwenpaw/cli/tui/transport/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""TUI transports: ACP subprocess."""
+
+from __future__ import annotations
+
+from .base import TuiTransport
+
+__all__ = ["TuiTransport"]

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -256,7 +256,12 @@ class AcpTransport:
         # of opening a fresh one.
         self._resume_session_id = resume_session_id
         # Default: re-invoke this very interpreter as `python -m qwenpaw acp`.
-        self._command = command or [sys.executable, "-m", "qwenpaw", "acp"]
+        # Copy the caller's list so appending ``--agent`` never mutates it.
+        self._command = (
+            list(command)
+            if command
+            else [sys.executable, "-m", "qwenpaw", "acp"]
+        )
         if agent:
             self._command += ["--agent", agent]
 

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -1,0 +1,581 @@
+# -*- coding: utf-8 -*-
+"""Default TUI transport: drive ``qwenpaw acp`` over ACP/stdio.
+
+The transport spawns ``qwenpaw acp`` as a subprocess and connects an ACP
+client to it (the same ``spawn_agent_process`` plumbing the in-process ACP
+service uses, see ``qwenpaw/agents/acp/service.py``). All agent capabilities —
+tools, memory, slash commands, permissions, model switching — come for free
+because the ACP server already exposes them.
+
+The client object is duck-typed (mirroring ``ACPHostedClient``): the connection
+only ever calls ``session_update``, ``request_permission`` and the ``ext_*``
+hooks for the QwenPaw agent, so we implement exactly those.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import uuid
+from contextlib import AsyncExitStack
+from typing import Any, AsyncIterator
+
+from acp import (
+    PROTOCOL_VERSION,
+    spawn_agent_process,
+    text_block,
+)
+from acp.schema import (
+    AllowedOutcome,
+    ClientCapabilities,
+    DeniedOutcome,
+    Implementation,
+    RequestPermissionResponse,
+)
+
+from ..__version__ import __version__
+from ..events import (
+    BackendWarmed,
+    Connected,
+    PermissionOption,
+    PermissionRequest,
+    PushMessage,
+    SessionSummary,
+    TransportError,
+    TurnEnded,
+    TuiEvent,
+)
+from ..normalize import normalize_update
+
+logger = logging.getLogger(__name__)
+
+# Sentinel pushed onto the queue to end ``events()`` iteration.
+_CLOSED = object()
+
+# The agent (`run_agent`) may emit JSON-RPC lines up to ~50 MB (e.g. a browser
+# screenshot in a tool result). The default asyncio StreamReader line limit is
+# 64 KB, which would drop the connection on a big tool payload — match the
+# agent's buffer so large messages stream through (same as service.py).
+_STDIO_BUFFER_LIMIT = 50 * 1024 * 1024
+
+_WARMUP_PROMPT = (
+    "Warm up the QwenPaw backend for an interactive terminal session. "
+    "Reply with exactly: ready. Do not call tools."
+)
+
+# ``_meta`` flag marking the warmup session ephemeral so the QwenPaw ACP server
+# never registers a console chat or persists state for it. Passed as an extra
+# kwarg on ``new_session``/``prompt`` (the ACP client folds extra kwargs into
+# the request's ``_meta``). Mirrors the server's ``ACP_EPHEMERAL_META_KEY``.
+_EPHEMERAL_META_KEY = "qwenpaw.ephemeral"
+
+
+def _open_agent_stderr_log() -> tuple[int | None, str | None]:
+    """Open a file to receive the agent subprocess's stderr.
+
+    ``spawn_agent_process`` defaults the child's stderr to an *unread* PIPE.
+    Chatty tools (Chromium via ``browser_use``) flood it, fill the 64 KB pipe
+    buffer, block the agent, and the JSON-RPC stream dies ("Connection
+    closed"). Draining stderr to a file avoids the deadlock and keeps the logs
+    for debugging. Falls back to ``DEVNULL`` if the file can't be opened.
+    """
+    try:
+        from ..paths import log_path
+
+        path = str(log_path("acp.log"))
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        return fd, path
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("falling back to DEVNULL for agent stderr: %s", exc)
+        try:
+            return os.open(os.devnull, os.O_WRONLY), None
+        except Exception:  # noqa: BLE001
+            return None, None
+
+
+def _warmup_disabled() -> bool:
+    return os.getenv("PAW_DISABLE_BACKEND_WARMUP", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _kill_process_tree(pid: int) -> None:
+    """Best-effort recursive kill (mirrors acp/service.py fix #4615)."""
+    try:
+        import psutil  # local import; psutil is already a QwenPaw dep
+    except Exception:  # pragma: no cover - psutil always present in app
+        return
+    try:
+        parent = psutil.Process(pid)
+    except Exception:
+        return
+    for child in parent.children(recursive=True):
+        try:
+            child.kill()
+        except Exception:
+            pass
+    try:
+        parent.kill()
+    except Exception:
+        pass
+
+
+class _TuiClient:
+    """ACP client callbacks → push normalized events onto a queue."""
+
+    def __init__(self, queue: "asyncio.Queue[Any]") -> None:
+        self._queue = queue
+        self._pending: dict[str, asyncio.Future[str | None]] = {}
+        self._session_id: str | None = None
+        self._ignored_sessions: set[str] = set()
+
+    def set_session_id(self, session_id: str) -> None:
+        self._session_id = session_id
+
+    def ignore_session(self, session_id: str) -> None:
+        self._ignored_sessions.add(session_id)
+
+    # -- connection lifecycle ------------------------------------------------
+    def on_connect(self, conn: Any) -> None:  # noqa: D401 - ACP hook
+        self._conn = conn
+
+    # -- streaming updates ---------------------------------------------------
+    async def session_update(
+        self, session_id: str, update: Any, **_: Any
+    ) -> None:
+        if session_id in self._ignored_sessions:
+            return
+        if self._session_id is not None and session_id != self._session_id:
+            return
+        for event in normalize_update(update):
+            await self._queue.put(event)
+
+    # -- permission round-trip ----------------------------------------------
+    async def request_permission(
+        self,
+        options: list[Any],
+        session_id: str,
+        tool_call: Any,
+        **_: Any,
+    ) -> RequestPermissionResponse:
+        if session_id in self._ignored_sessions:
+            return RequestPermissionResponse(
+                outcome=DeniedOutcome(outcome="cancelled")
+            )
+        if self._session_id is not None and session_id != self._session_id:
+            return RequestPermissionResponse(
+                outcome=DeniedOutcome(outcome="cancelled")
+            )
+        request_id = uuid.uuid4().hex
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[str | None] = loop.create_future()
+        self._pending[request_id] = future
+
+        title = (
+            getattr(tool_call, "title", None)
+            or getattr(tool_call, "tool_call_id", None)
+            or "Permission required"
+        )
+        await self._queue.put(
+            PermissionRequest(
+                request_id=request_id,
+                title=str(title),
+                tool_kind=getattr(tool_call, "kind", None),
+                options=[
+                    PermissionOption(
+                        option_id=getattr(o, "option_id", ""),
+                        name=getattr(o, "name", "")
+                        or getattr(o, "option_id", ""),
+                        kind=getattr(o, "kind", "allow_once"),
+                    )
+                    for o in options
+                ],
+            )
+        )
+
+        try:
+            option_id = await future
+        finally:
+            self._pending.pop(request_id, None)
+
+        if option_id is None:
+            return RequestPermissionResponse(
+                outcome=DeniedOutcome(outcome="cancelled")
+            )
+        return RequestPermissionResponse(
+            outcome=AllowedOutcome(outcome="selected", option_id=option_id)
+        )
+
+    def resolve(self, request_id: str, option_id: str | None) -> None:
+        future = self._pending.get(request_id)
+        if future is not None and not future.done():
+            future.set_result(option_id)
+
+    def cancel_pending(self) -> None:
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_result(None)
+        self._pending.clear()
+
+    # -- extensions: server-initiated push (design §4.3) --------------------
+    async def ext_notification(
+        self, method: str, params: dict[str, Any]
+    ) -> None:
+        if method in ("qwenpaw/push_message", "session/push_message"):
+            text = str(params.get("text") or params.get("message") or "")
+            if text:
+                await self._queue.put(PushMessage(text))
+        # Unknown notifications are ignored (degrade gracefully).
+
+    async def ext_method(
+        self, method: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        del params
+        logger.debug("Ignoring unsupported ACP ext method: %s", method)
+        return {}
+
+
+class AcpTransport:
+    """Spawns ``qwenpaw acp`` and drives one session over ACP/stdio."""
+
+    def __init__(
+        self,
+        *,
+        agent: str | None = None,
+        cwd: str | None = None,
+        command: list[str] | None = None,
+        resume_session_id: str | None = None,
+    ) -> None:
+        self._agent = agent
+        self._cwd = cwd or os.getcwd()
+        # When set, ``start()`` resumes this session (load + replay) instead
+        # of opening a fresh one.
+        self._resume_session_id = resume_session_id
+        # Default: re-invoke this very interpreter as `python -m qwenpaw acp`.
+        self._command = command or [sys.executable, "-m", "qwenpaw", "acp"]
+        if agent:
+            self._command += ["--agent", agent]
+
+        self._queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._client = _TuiClient(self._queue)
+        self._stack: AsyncExitStack | None = None
+        self._conn: Any = None
+        self._process: Any = None
+        self._session_id: str | None = None
+        self._prompt_task: asyncio.Task[Any] | None = None
+        self._warmup_task: asyncio.Task[Any] | None = None
+        self._stderr_fd: int | None = None
+        self._stderr_path: str | None = None
+        self._closed = False
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    async def start(self) -> Connected:
+        self._stack = AsyncExitStack()
+        cmd, *args = self._command
+        self._stderr_fd, self._stderr_path = _open_agent_stderr_log()
+        transport_kwargs: dict[str, Any] = {"limit": _STDIO_BUFFER_LIMIT}
+        if self._stderr_fd is not None:
+            transport_kwargs["stderr"] = self._stderr_fd
+        self._conn, self._process = await self._stack.enter_async_context(
+            spawn_agent_process(
+                self._client,
+                cmd,
+                *args,
+                cwd=self._cwd,
+                env={**os.environ},
+                transport_kwargs=transport_kwargs,
+            )
+        )
+        initialized = await self._conn.initialize(
+            protocol_version=PROTOCOL_VERSION,
+            client_capabilities=ClientCapabilities(),
+            client_info=Implementation(name="paw", version=__version__),
+        )
+        if initialized.protocol_version != PROTOCOL_VERSION:
+            logger.warning(
+                "ACP protocol mismatch: agent=%s client=%s",
+                initialized.protocol_version,
+                PROTOCOL_VERSION,
+            )
+        if self._resume_session_id is not None:
+            # Point the client at the resumed session before loading so its
+            # replayed history updates (tagged with this id) aren't filtered.
+            self._session_id = self._resume_session_id
+            self._client.set_session_id(self._session_id)
+            session = await self._conn.load_session(
+                cwd=self._cwd, session_id=self._session_id
+            )
+            # LoadSessionResponse carries no model list; it populates from the
+            # first turn's usage report instead.
+            model = None
+        else:
+            session = await self._conn.new_session(cwd=self._cwd)
+            self._session_id = session.session_id
+            self._client.set_session_id(self._session_id)
+            model = _current_model(session)
+        if not _warmup_disabled():
+            self._warmup_task = asyncio.create_task(self._warm_backend())
+        return Connected(
+            session_id=self._session_id,
+            # Prefer the agent the server actually resolved (via _meta) over
+            # the one we requested, so the UI shows the real agent.
+            agent=_session_agent(session) or self._agent,
+            model=model,
+            qwenpaw_version=_agent_version(initialized),
+            warming=self._warmup_task is not None,
+        )
+
+    async def _warm_backend(self) -> None:
+        warm_session_id: str | None = None
+        try:
+            if self._conn is None:
+                return
+            warm_session = await self._conn.new_session(
+                cwd=self._cwd, **{_EPHEMERAL_META_KEY: True}
+            )
+            warm_session_id = warm_session.session_id
+            if warm_session_id == self._session_id:
+                logger.debug(
+                    "skipping ACP warmup because agent reused session id %s",
+                    warm_session_id,
+                )
+                await self._queue.put(
+                    BackendWarmed(
+                        success=False,
+                        message="warmup skipped: duplicate session id",
+                    )
+                )
+                return
+            self._client.ignore_session(warm_session_id)
+            await self._conn.prompt(
+                prompt=[text_block(_WARMUP_PROMPT)],
+                session_id=warm_session_id,
+                **{_EPHEMERAL_META_KEY: True},
+            )
+            await self._queue.put(BackendWarmed())
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - warmup is best-effort
+            logger.debug("ACP warmup failed: %s", exc, exc_info=True)
+            await self._queue.put(
+                BackendWarmed(success=False, message=str(exc))
+            )
+        finally:
+            if (
+                warm_session_id is not None
+                and self._conn is not None
+                and not self._closed
+            ):
+                try:
+                    await self._conn.close_session(session_id=warm_session_id)
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "failed to close warmup session", exc_info=True
+                    )
+
+    async def send(self, text: str) -> None:
+        if self._conn is None or self._session_id is None:
+            raise RuntimeError("transport not started")
+        if self._prompt_task is not None and not self._prompt_task.done():
+            raise RuntimeError("a turn is already in progress")
+        self._prompt_task = asyncio.create_task(
+            self._run_prompt_after_warmup(text)
+        )
+
+    async def _run_prompt_after_warmup(self, text: str) -> None:
+        if self._warmup_task is not None and not self._warmup_task.done():
+            try:
+                await self._warmup_task
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                logger.debug("warmup task failed before prompt", exc_info=True)
+        await self._run_prompt(text)
+
+    async def _run_prompt(self, text: str) -> None:
+        stop_reason: str | None = None
+        try:
+            response = await self._conn.prompt(
+                prompt=[text_block(text)],
+                session_id=self._session_id,
+            )
+            stop_reason = getattr(response, "stop_reason", None)
+            # The ACP connection resolves the prompt *response* inline but
+            # dispatches session_update *notifications* via an async queue, so
+            # prompt() can return before the final tool/text update has been
+            # delivered. Let those in-flight updates land so TurnEnded is last.
+            await self._settle()
+        except asyncio.CancelledError:
+            stop_reason = "cancelled"
+            raise
+        except Exception as exc:  # noqa: BLE001 - surface to UI, don't crash
+            await self._queue.put(TransportError(str(exc)))
+        finally:
+            await self._queue.put(TurnEnded(stop_reason=stop_reason))
+
+    async def _settle(self, *, max_idle: int = 3) -> None:
+        """Yield until the event queue stops growing (in-flight notifications
+        have all been enqueued). Bounded and cheap: each ``sleep(0)`` lets one
+        queued ACP notification task run."""
+        idle = 0
+        while idle < max_idle:
+            before = self._queue.qsize()
+            await asyncio.sleep(0)
+            if self._queue.qsize() == before:
+                idle += 1
+            else:
+                idle = 0
+
+    async def interrupt(self) -> None:
+        if self._conn is None or self._session_id is None:
+            return
+        # Free any blocked permission first so the prompt task can unwind.
+        self._client.cancel_pending()
+        try:
+            await self._conn.cancel(session_id=self._session_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("cancel failed: %s", exc)
+
+    async def list_sessions(self) -> list[SessionSummary]:
+        if self._conn is None:
+            raise RuntimeError("transport not started")
+        # No cwd filter: QwenPaw runs every session in its single workspace
+        # dir regardless of where paw was launched, so all past sessions are
+        # equally resumable. Listing them folder-scoped would just hide work.
+        response = await self._conn.list_sessions()
+        summaries: list[SessionSummary] = []
+        for info in getattr(response, "sessions", None) or []:
+            session_id = getattr(info, "session_id", None)
+            if not session_id:
+                continue
+            summaries.append(
+                SessionSummary(
+                    session_id=str(session_id),
+                    title=str(getattr(info, "title", "") or ""),
+                    cwd=str(getattr(info, "cwd", "") or ""),
+                    updated_at=str(getattr(info, "updated_at", "") or ""),
+                )
+            )
+        return summaries
+
+    async def load_session(self, session_id: str) -> None:
+        if self._conn is None:
+            raise RuntimeError("transport not started")
+        if self._prompt_task is not None and not self._prompt_task.done():
+            raise RuntimeError("a turn is already in progress")
+        # Let any in-flight warmup finish first; it drives its own (ignored)
+        # session, but loading mid-warmup risks interleaved backend work.
+        if self._warmup_task is not None and not self._warmup_task.done():
+            try:
+                await self._warmup_task
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - warmup is best-effort
+                logger.debug("warmup task failed before load", exc_info=True)
+        # Point the client at the resumed session *before* loading so the
+        # replayed history updates (tagged with this id) aren't filtered out.
+        self._session_id = session_id
+        self._client.set_session_id(session_id)
+        await self._conn.load_session(cwd=self._cwd, session_id=session_id)
+
+    async def resolve_permission(
+        self, request_id: str, option_id: str | None
+    ) -> None:
+        self._client.resolve(request_id, option_id)
+
+    async def events(self) -> AsyncIterator[TuiEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is _CLOSED:
+                return
+            yield item
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._client.cancel_pending()
+        if self._warmup_task is not None and not self._warmup_task.done():
+            self._warmup_task.cancel()
+            try:
+                await self._warmup_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        if self._prompt_task is not None and not self._prompt_task.done():
+            self._prompt_task.cancel()
+            try:
+                await self._prompt_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        if self._conn is not None and self._session_id is not None:
+            try:
+                await asyncio.wait_for(
+                    self._conn.close_session(session_id=self._session_id),
+                    timeout=5.0,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        if self._process is not None:
+            _kill_process_tree(self._process.pid)
+        if self._stack is not None:
+            try:
+                await self._stack.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+        if self._stderr_fd is not None:
+            try:
+                os.close(self._stderr_fd)
+            except OSError:
+                pass
+            self._stderr_fd = None
+        await self._queue.put(_CLOSED)
+
+
+# ``_meta`` key QwenPaw sets on the session response with the resolved agent
+# id; mirrors the ACP server's ``ACP_AGENT_META_KEY``.
+_AGENT_META_KEY = "qwenpaw.agent"
+
+
+def _session_agent(new_session: Any) -> str | None:
+    """The resolved agent id the server reported via ``_meta``, if any."""
+    meta = getattr(new_session, "field_meta", None)
+    if isinstance(meta, dict):
+        agent = meta.get(_AGENT_META_KEY)
+        if agent:
+            return str(agent)
+    return None
+
+
+def _current_model(new_session: Any) -> str | None:
+    """Best-effort extraction of the current model name from new_session."""
+    models = getattr(new_session, "models", None)
+    if not models:
+        return None
+    current_id = getattr(models, "current_model_id", None) or getattr(
+        models, "current", None
+    )
+    available = getattr(models, "available_models", None) or getattr(
+        models, "models", None
+    )
+    if available:
+        for model in available:
+            mid = getattr(model, "model_id", None) or getattr(
+                model, "id", None
+            )
+            if mid == current_id:
+                return getattr(model, "name", None) or str(mid)
+    return str(current_id) if current_id else None
+
+
+def _agent_version(initialized: Any) -> str | None:
+    """Best-effort extraction of the ACP server's implementation version."""
+    info = getattr(initialized, "agent_info", None)
+    version = getattr(info, "version", None)
+    return str(version) if version else None

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -20,7 +20,7 @@ import os
 import sys
 import uuid
 from contextlib import AsyncExitStack
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, cast
 
 from acp import (
     PROTOCOL_VERSION,
@@ -145,7 +145,10 @@ class _TuiClient:
 
     # -- streaming updates ---------------------------------------------------
     async def session_update(
-        self, session_id: str, update: Any, **_: Any
+        self,
+        session_id: str,
+        update: Any,
+        **_: Any,
     ) -> None:
         if session_id in self._ignored_sessions:
             return
@@ -164,11 +167,11 @@ class _TuiClient:
     ) -> RequestPermissionResponse:
         if session_id in self._ignored_sessions:
             return RequestPermissionResponse(
-                outcome=DeniedOutcome(outcome="cancelled")
+                outcome=DeniedOutcome(outcome="cancelled"),
             )
         if self._session_id is not None and session_id != self._session_id:
             return RequestPermissionResponse(
-                outcome=DeniedOutcome(outcome="cancelled")
+                outcome=DeniedOutcome(outcome="cancelled"),
             )
         request_id = uuid.uuid4().hex
         loop = asyncio.get_running_loop()
@@ -194,7 +197,7 @@ class _TuiClient:
                     )
                     for o in options
                 ],
-            )
+            ),
         )
 
         try:
@@ -204,10 +207,10 @@ class _TuiClient:
 
         if option_id is None:
             return RequestPermissionResponse(
-                outcome=DeniedOutcome(outcome="cancelled")
+                outcome=DeniedOutcome(outcome="cancelled"),
             )
         return RequestPermissionResponse(
-            outcome=AllowedOutcome(outcome="selected", option_id=option_id)
+            outcome=AllowedOutcome(outcome="selected", option_id=option_id),
         )
 
     def resolve(self, request_id: str, option_id: str | None) -> None:
@@ -223,7 +226,9 @@ class _TuiClient:
 
     # -- extensions: server-initiated push (design §4.3) --------------------
     async def ext_notification(
-        self, method: str, params: dict[str, Any]
+        self,
+        method: str,
+        params: dict[str, Any],
     ) -> None:
         if method in ("qwenpaw/push_message", "session/push_message"):
             text = str(params.get("text") or params.get("message") or "")
@@ -232,7 +237,9 @@ class _TuiClient:
         # Unknown notifications are ignored (degrade gracefully).
 
     async def ext_method(
-        self, method: str, params: dict[str, Any]
+        self,
+        method: str,
+        params: dict[str, Any],
     ) -> dict[str, Any]:
         del params
         logger.debug("Ignoring unsupported ACP ext method: %s", method)
@@ -296,7 +303,7 @@ class AcpTransport:
                 cwd=self._cwd,
                 env={**os.environ},
                 transport_kwargs=transport_kwargs,
-            )
+            ),
         )
         initialized = await self._conn.initialize(
             protocol_version=PROTOCOL_VERSION,
@@ -312,23 +319,24 @@ class AcpTransport:
         if self._resume_session_id is not None:
             # Point the client at the resumed session before loading so its
             # replayed history updates (tagged with this id) aren't filtered.
-            self._session_id = self._resume_session_id
-            self._client.set_session_id(self._session_id)
+            session_id = self._resume_session_id
             session = await self._conn.load_session(
-                cwd=self._cwd, session_id=self._session_id
+                cwd=self._cwd,
+                session_id=session_id,
             )
             # LoadSessionResponse carries no model list; it populates from the
             # first turn's usage report instead.
             model = None
         else:
             session = await self._conn.new_session(cwd=self._cwd)
-            self._session_id = session.session_id
-            self._client.set_session_id(self._session_id)
+            session_id = cast(str, session.session_id)
             model = _current_model(session)
+        self._session_id = session_id
+        self._client.set_session_id(session_id)
         if not _warmup_disabled():
             self._warmup_task = asyncio.create_task(self._warm_backend())
         return Connected(
-            session_id=self._session_id,
+            session_id=session_id,
             # Prefer the agent the server actually resolved (via _meta) over
             # the one we requested, so the UI shows the real agent.
             agent=_session_agent(session) or self._agent,
@@ -343,9 +351,10 @@ class AcpTransport:
             if self._conn is None:
                 return
             warm_session = await self._conn.new_session(
-                cwd=self._cwd, **{_EPHEMERAL_META_KEY: True}
+                cwd=self._cwd,
+                **{_EPHEMERAL_META_KEY: True},
             )
-            warm_session_id = warm_session.session_id
+            warm_session_id = cast(str, warm_session.session_id)
             if warm_session_id == self._session_id:
                 logger.debug(
                     "skipping ACP warmup because agent reused session id %s",
@@ -355,7 +364,7 @@ class AcpTransport:
                     BackendWarmed(
                         success=False,
                         message="warmup skipped: duplicate session id",
-                    )
+                    ),
                 )
                 return
             self._client.ignore_session(warm_session_id)
@@ -365,12 +374,12 @@ class AcpTransport:
                 **{_EPHEMERAL_META_KEY: True},
             )
             await self._queue.put(BackendWarmed())
-        except asyncio.CancelledError:
+        except asyncio.CancelledError:  # pylint: disable=try-except-raise
             raise
         except Exception as exc:  # noqa: BLE001 - warmup is best-effort
             logger.debug("ACP warmup failed: %s", exc, exc_info=True)
             await self._queue.put(
-                BackendWarmed(success=False, message=str(exc))
+                BackendWarmed(success=False, message=str(exc)),
             )
         finally:
             if (
@@ -382,7 +391,8 @@ class AcpTransport:
                     await self._conn.close_session(session_id=warm_session_id)
                 except Exception:  # noqa: BLE001
                     logger.debug(
-                        "failed to close warmup session", exc_info=True
+                        "failed to close warmup session",
+                        exc_info=True,
                     )
 
     async def send(self, text: str) -> None:
@@ -391,14 +401,14 @@ class AcpTransport:
         if self._prompt_task is not None and not self._prompt_task.done():
             raise RuntimeError("a turn is already in progress")
         self._prompt_task = asyncio.create_task(
-            self._run_prompt_after_warmup(text)
+            self._run_prompt_after_warmup(text),
         )
 
     async def _run_prompt_after_warmup(self, text: str) -> None:
         if self._warmup_task is not None and not self._warmup_task.done():
             try:
                 await self._warmup_task
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception:  # noqa: BLE001
                 logger.debug("warmup task failed before prompt", exc_info=True)
@@ -466,7 +476,7 @@ class AcpTransport:
                     title=str(getattr(info, "title", "") or ""),
                     cwd=str(getattr(info, "cwd", "") or ""),
                     updated_at=str(getattr(info, "updated_at", "") or ""),
-                )
+                ),
             )
         return summaries
 
@@ -480,7 +490,7 @@ class AcpTransport:
         if self._warmup_task is not None and not self._warmup_task.done():
             try:
                 await self._warmup_task
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 raise
             except Exception:  # noqa: BLE001 - warmup is best-effort
                 logger.debug("warmup task failed before load", exc_info=True)
@@ -491,7 +501,9 @@ class AcpTransport:
         await self._conn.load_session(cwd=self._cwd, session_id=session_id)
 
     async def resolve_permission(
-        self, request_id: str, option_id: str | None
+        self,
+        request_id: str,
+        option_id: str | None,
     ) -> None:
         self._client.resolve(request_id, option_id)
 
@@ -564,15 +576,21 @@ def _current_model(new_session: Any) -> str | None:
     if not models:
         return None
     current_id = getattr(models, "current_model_id", None) or getattr(
-        models, "current", None
+        models,
+        "current",
+        None,
     )
     available = getattr(models, "available_models", None) or getattr(
-        models, "models", None
+        models,
+        "models",
+        None,
     )
     if available:
         for model in available:
             mid = getattr(model, "model_id", None) or getattr(
-                model, "id", None
+                model,
+                "id",
+                None,
             )
             if mid == current_id:
                 return getattr(model, "name", None) or str(mid)

--- a/src/qwenpaw/cli/tui/transport/base.py
+++ b/src/qwenpaw/cli/tui/transport/base.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""The transport interface shared by all TUI back-ends."""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, Protocol, runtime_checkable
+
+from ..events import Connected, SessionSummary, TuiEvent
+
+
+@runtime_checkable
+class TuiTransport(Protocol):
+    """Drives one agent conversation and yields normalized ``TuiEvent``s.
+
+    Implementation: :class:`~qwenpaw.cli.tui.transport.acp.AcpTransport`
+    (spawns ``qwenpaw acp``). The UI layer only ever sees this interface.
+    """
+
+    async def start(self) -> Connected:
+        """Connect / spawn the agent and open a session."""
+        ...
+
+    async def send(self, text: str) -> None:
+        """Send a user turn (plain text). Returns once the turn is queued."""
+        ...
+
+    async def interrupt(self) -> None:
+        """Cancel the in-flight turn, if any."""
+        ...
+
+    async def list_sessions(self) -> list[SessionSummary]:
+        """Return resumable past sessions (most recent first)."""
+        ...
+
+    async def load_session(self, session_id: str) -> None:
+        """Switch to a past session and replay its saved transcript."""
+        ...
+
+    def events(self) -> AsyncIterator[TuiEvent]:
+        """Yield events until the transport is closed."""
+        ...
+
+    async def resolve_permission(
+        self, request_id: str, option_id: str | None
+    ) -> None:
+        """Answer a pending permission request (``None`` = deny/cancel)."""
+        ...
+
+    async def close(self) -> None:
+        """Tear down the session and any subprocess."""
+        ...

--- a/src/qwenpaw/cli/tui/transport/base.py
+++ b/src/qwenpaw/cli/tui/transport/base.py
@@ -18,34 +18,28 @@ class TuiTransport(Protocol):
 
     async def start(self) -> Connected:
         """Connect / spawn the agent and open a session."""
-        ...
 
     async def send(self, text: str) -> None:
         """Send a user turn (plain text). Returns once the turn is queued."""
-        ...
 
     async def interrupt(self) -> None:
         """Cancel the in-flight turn, if any."""
-        ...
 
     async def list_sessions(self) -> list[SessionSummary]:
         """Return resumable past sessions (most recent first)."""
-        ...
 
     async def load_session(self, session_id: str) -> None:
         """Switch to a past session and replay its saved transcript."""
-        ...
 
     def events(self) -> AsyncIterator[TuiEvent]:
         """Yield events until the transport is closed."""
-        ...
 
     async def resolve_permission(
-        self, request_id: str, option_id: str | None
+        self,
+        request_id: str,
+        option_id: str | None,
     ) -> None:
         """Answer a pending permission request (``None`` = deny/cancel)."""
-        ...
 
     async def close(self) -> None:
         """Tear down the session and any subprocess."""
-        ...

--- a/src/qwenpaw/cli/tui/widgets/__init__.py
+++ b/src/qwenpaw/cli/tui/widgets/__init__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Textual widgets for the QwenPaw TUI."""
+
+from __future__ import annotations
+
+from .command_menu import CommandMenu, CommandSuggester, PromptInput
+from .messages import (
+    ActivityLine,
+    AgentLabel,
+    AssistantMessage,
+    ErrorMessage,
+    FileLinkBox,
+    InfoMessage,
+    PushMessageBox,
+    QueuedMessage,
+    ThoughtMessage,
+    WelcomeMessage,
+    UserMessage,
+)
+from .permission_modal import PermissionModal
+from .session_picker import SessionPicker
+from .status_bar import StatusBar
+from .theme_picker import ThemePicker
+from .tool_panel import ToolPanel
+
+__all__ = [
+    "AgentLabel",
+    "ActivityLine",
+    "AssistantMessage",
+    "CommandMenu",
+    "CommandSuggester",
+    "PromptInput",
+    "ErrorMessage",
+    "FileLinkBox",
+    "InfoMessage",
+    "PushMessageBox",
+    "QueuedMessage",
+    "ThemePicker",
+    "ThoughtMessage",
+    "UserMessage",
+    "WelcomeMessage",
+    "PermissionModal",
+    "SessionPicker",
+    "StatusBar",
+    "ToolPanel",
+]

--- a/src/qwenpaw/cli/tui/widgets/_anim.py
+++ b/src/qwenpaw/cli/tui/widgets/_anim.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Tiny animation helpers shared by live widgets (thinking lane, running
+tool panels): a braille spinner and a pulsing blue→purple colour cycle.
+
+Frame-indexed so callers just keep a counter and tick it on a timer."""
+
+from __future__ import annotations
+
+# Braille spinner frames (smooth, monospace-friendly).
+_SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+# Blue→purple shimmer; bounces so the pulse feels continuous.
+_PULSE = (
+    "#6db8ff",
+    "#7fa6ff",
+    "#9c8cff",
+    "#b48cff",
+    "#9c8cff",
+    "#7fa6ff",
+)
+
+# Recommended timer interval (seconds) for ticking the frame counter.
+TICK = 0.1
+
+
+def spinner(frame: int) -> str:
+    """Spinner glyph for *frame*."""
+    return _SPINNER[frame % len(_SPINNER)]
+
+
+def pulse(frame: int) -> str:
+    """Pulsing colour (hex) for *frame*."""
+    return _PULSE[frame % len(_PULSE)]

--- a/src/qwenpaw/cli/tui/widgets/command_menu.py
+++ b/src/qwenpaw/cli/tui/widgets/command_menu.py
@@ -151,7 +151,10 @@ class PromptInput(TextArea):
         self.text = text
 
     def set_programmatic_value(
-        self, text: str, *, cursor_end: bool = False
+        self,
+        text: str,
+        *,
+        cursor_end: bool = False,
     ) -> None:
         self._ignore_change_events += 1
         self.text = text
@@ -164,6 +167,7 @@ class PromptInput(TextArea):
         self._ignore_change_events -= 1
         return True
 
+    # pylint: disable-next=too-many-return-statements
     async def _on_key(self, event: events.Key) -> None:
         if self._consume_suppressed_paste_tail(event):
             return
@@ -196,7 +200,7 @@ class PromptInput(TextArea):
         if event.key == "enter":
             event.prevent_default()
             event.stop()
-            await app._submit_prompt()
+            await app._submit_prompt()  # pylint: disable=protected-access
             return
         if event.key in {"shift+enter", "ctrl+j"}:
             event.prevent_default()
@@ -216,7 +220,8 @@ class PromptInput(TextArea):
         replacement = await handler(event.text)
         if replacement is None:
             if result := self._replace_via_keyboard(
-                event.text, *self.selection
+                event.text,
+                *self.selection,
             ):
                 self.move_cursor(result.end_location)
                 self.focus()

--- a/src/qwenpaw/cli/tui/widgets/command_menu.py
+++ b/src/qwenpaw/cli/tui/widgets/command_menu.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+"""Slash-command auto-suggestion: an inline ghost completion plus a
+filtered dropdown list.
+
+The agent advertises its commands over ACP (``available_commands_update``);
+:class:`CommandSuggester` drives the single inline ghost completion on the
+``TextArea`` and :class:`CommandMenu` renders the navigable dropdown. Both
+share the same command list, set via :meth:`set_commands`.
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual import events
+from textual.suggester import Suggester
+from textual.widgets import OptionList, TextArea
+from textual.widgets.option_list import Option
+
+from ..events import SlashCommand
+
+
+def _query(value: str) -> str | None:
+    """The command prefix being typed, or ``None`` if not applicable.
+
+    The menu suggests whole slash-command lines, not only command names, so
+    arguments can be completed too (``/theme cy`` → ``/theme cyberpunk``).
+    """
+    if not value.startswith("/"):
+        return None
+    return value[1:].lstrip()
+
+
+def _matches(commands: list[SlashCommand], query: str) -> list[SlashCommand]:
+    q = query.lower()
+    if " " not in q:
+        return [
+            c
+            for c in commands
+            if " " not in c.name and c.name.lower().startswith(q)
+        ]
+    return [c for c in commands if c.name.lower().startswith(q)]
+
+
+class CommandSuggester(Suggester):
+    """Inline ghost completion for the top matching command."""
+
+    def __init__(self) -> None:
+        super().__init__(use_cache=False, case_sensitive=False)
+        self._commands: list[SlashCommand] = []
+
+    def set_commands(self, commands: list[SlashCommand]) -> None:
+        self._commands = list(commands)
+
+    async def get_suggestion(self, value: str) -> str | None:
+        query = _query(value)
+        if not query:  # empty query → nothing to complete yet
+            return None
+        hits = _matches(self._commands, query)
+        return f"/{hits[0].name}" if hits else None
+
+
+class CommandMenu(OptionList):
+    """Dropdown of matching commands, navigated from the focused input.
+
+    Focus stays on the ``TextArea``; the owning app routes ↑/↓/⏎/⇥/esc here
+    via :meth:`cursor_up`, :meth:`cursor_down` and :attr:`selected`.
+    """
+
+    # The input keeps focus so typing continues uninterrupted.
+    can_focus = False
+
+    DEFAULT_CSS = """
+    CommandMenu {
+        layer: overlay;
+        dock: bottom;
+        height: auto;
+        max-height: 9;
+        margin: 0 2 4 2;
+        border: round #ff7ad9;
+        background: #101827 92%;
+        display: none;
+    }
+    CommandMenu > .option-list--option-highlighted {
+        background: #2b1741;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__(id="cmd-menu")
+        self._commands: list[SlashCommand] = []
+
+    def set_commands(self, commands: list[SlashCommand]) -> None:
+        self._commands = list(commands)
+
+    def update_for(self, value: str) -> None:
+        """Refilter and show/hide the dropdown for the current input."""
+        query = _query(value)
+        hits = _matches(self._commands, query) if query is not None else []
+        if query is not None and " " in query:
+            normalized = query.rstrip().lower()
+            if any(cmd.name.lower() == normalized for cmd in hits):
+                self.display = False
+                return
+        if not hits:
+            self.display = False
+            return
+        self.clear_options()
+        for cmd in hits:
+            label = Text()
+            label.append(f"/{cmd.name}", style="bold #b48cff")
+            if cmd.description:
+                label.append(f"  {cmd.description}", style="#8a8a8a")
+            self.add_option(Option(label, id=cmd.name))
+        self.highlighted = 0
+        self.display = True
+
+    @property
+    def selected(self) -> str | None:
+        """The highlighted command name, or ``None`` when empty."""
+        if not self.display or self.highlighted is None:
+            return None
+        return self.get_option_at_index(self.highlighted).id
+
+    def cursor_up(self) -> None:
+        self.action_cursor_up()
+
+    def cursor_down(self) -> None:
+        self.action_cursor_down()
+
+
+class PromptInput(TextArea):
+    """The chat input, wired to drive an open :class:`CommandMenu`.
+
+    ``_on_key`` runs before ``TextArea``'s own bindings, so intercepting the
+    navigation keys here (and stopping them) keeps ⏎/⇥/↑/↓/esc from reaching
+    submit, focus-change or interrupt while the dropdown is open.
+    """
+
+    def __init__(self, menu: CommandMenu, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._menu = menu
+        self._ignore_change_events = 0
+        self._suppress_paste_tail = ""
+
+    @property
+    def value(self) -> str:
+        return self.text
+
+    @value.setter
+    def value(self, text: str) -> None:
+        self.text = text
+
+    def set_programmatic_value(
+        self, text: str, *, cursor_end: bool = False
+    ) -> None:
+        self._ignore_change_events += 1
+        self.text = text
+        if cursor_end:
+            self.move_cursor(self.document.end)
+
+    def consume_programmatic_change(self) -> bool:
+        if self._ignore_change_events <= 0:
+            return False
+        self._ignore_change_events -= 1
+        return True
+
+    async def _on_key(self, event: events.Key) -> None:
+        if self._consume_suppressed_paste_tail(event):
+            return
+        if self._menu.display:
+            if event.key == "down":
+                self._menu.cursor_down()
+            elif event.key == "up":
+                self._menu.cursor_up()
+            elif event.key == "escape":
+                self._menu.display = False
+            elif event.key in ("enter", "tab"):
+                name = self._menu.selected
+                if name is None:
+                    return
+                self.set_programmatic_value(f"/{name} ", cursor_end=True)
+                self._menu.display = False
+            else:
+                await super()._on_key(event)
+                return
+            event.prevent_default()
+            event.stop()
+            return
+
+        app = self.app
+        if event.key == "up" and not self.value:
+            event.prevent_default()
+            event.stop()
+            await app.action_recall_queued()
+            return
+        if event.key == "enter":
+            event.prevent_default()
+            event.stop()
+            await app._submit_prompt()
+            return
+        if event.key in {"shift+enter", "ctrl+j"}:
+            event.prevent_default()
+            event.stop()
+            self.insert("\n")
+            return
+        await super()._on_key(event)
+
+    async def _on_paste(self, event: events.Paste) -> None:
+        app = self.app
+        handler = getattr(app, "_handle_prompt_paste", None)
+        if handler is None:
+            await super()._on_paste(event)
+            return
+        event.stop()
+        event.prevent_default()
+        replacement = await handler(event.text)
+        if replacement is None:
+            if result := self._replace_via_keyboard(
+                event.text, *self.selection
+            ):
+                self.move_cursor(result.end_location)
+                self.focus()
+            return
+        self._suppress_paste_tail = event.text
+        if result := self._replace_via_keyboard(replacement, *self.selection):
+            self.move_cursor(result.end_location)
+            self.focus()
+
+    def _consume_suppressed_paste_tail(self, event: events.Key) -> bool:
+        if not self._suppress_paste_tail:
+            return False
+        character = getattr(event, "character", None)
+        if character and self._suppress_paste_tail.startswith(character):
+            self._suppress_paste_tail = self._suppress_paste_tail[
+                len(character) :
+            ]
+            event.stop()
+            event.prevent_default()
+            return True
+        self._suppress_paste_tail = ""
+        return False

--- a/src/qwenpaw/cli/tui/widgets/messages.py
+++ b/src/qwenpaw/cli/tui/widgets/messages.py
@@ -1,0 +1,461 @@
+# -*- coding: utf-8 -*-
+"""Transcript message widgets (user / assistant / thinking / errors)."""
+
+from __future__ import annotations
+
+import time
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Collapsible, Markdown, Static
+
+from ._anim import TICK, pulse, spinner
+
+
+class _Bubble(Static):
+    """A rounded message card.
+
+    The fill is transparent so the bubble blends into the static background; a
+    rounded border outlines it. The background no longer animates, so
+    transparency is safe — there is nothing to re-blend against each frame, and
+    the rounded corners simply show the background.
+    """
+
+    def __init__(self, renderable, *, classes: str = "") -> None:
+        super().__init__(renderable, classes=f"msg {classes}".strip())
+
+
+class UserMessage(_Bubble):
+    """A user turn, shown with a prompt glyph."""
+
+    def __init__(self, text: str) -> None:
+        body = Text()
+        body.append("❯ ", style="bold #6db8ff")
+        body.append(text)
+        super().__init__(body, classes="user")
+
+
+class QueuedMessage(_Bubble):
+    """A user message waiting its turn while the agent is still working.
+
+    Sent while busy, it sits dimmed in the transcript until the current turn
+    ends (then it's delivered) or the user recalls it with ↑ to edit.
+    """
+
+    def __init__(self, text: str) -> None:
+        body = Text()
+        body.append("⏳ ", style="#8a8a8a")
+        body.append(text, style="#8a8a8a")
+        super().__init__(body, classes="queued")
+
+
+class AgentLabel(Static):
+    """The ``qwenpaw`` lane label, shown once at the start of a turn.
+
+    Kept separate from :class:`AssistantMessage` so a turn that interleaves
+    thinking, tools and several answer chunks shows a single label above the
+    whole group rather than one per bubble.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            Text("qwenpaw", style="bold #b48cff"),
+            classes="agentlabel",
+        )
+
+
+class WelcomeMessage(Static):
+    """Startup greeting rendered as embossed terminal pixels (static)."""
+
+    _LOGO_PIXELS = (
+        " ███████                              ████████    O O O",
+        "███   ███ ███   ███  ██████  ███████  ███   ███  ███████  ███   ███",
+        "███   ███ ███   ███ ███  ███ ███  ███ ███   ███ ███   ███ ███   ███",
+        "███   ███ ███ █ ███ ████████ ███  ███ █████████ ███   ███ ███ █ ███",
+        "███ █ ███ █████████ ███      ███  ███ ███       ███   ███ █████████",
+        " ███████   ███ ███   ██████  ███  ███ ███        █████ ██  ███ ███",
+        "     ████",
+    )
+
+    def __init__(
+        self,
+        palette: tuple[str, str, str] | None = None,
+        accent: str | None = None,
+    ) -> None:
+        # ``_frame`` is fixed at 0: the logo colour is static (no animation),
+        # so the gradient is a fixed vertical wash with the embossed shading.
+        self._frame = 0
+        self._accent = accent
+        self._gradient_stops = (
+            "#bfe1ff",
+            "#8fd7ff",
+            "#c8b6ff",
+            "#ffd08a",
+        )
+        if palette is not None:
+            self._set_palette_colors(palette)
+        super().__init__(self._render_body(), classes="msg welcome")
+
+    def set_palette(
+        self, palette: tuple[str, str, str], accent: str | None = None
+    ) -> None:
+        if accent is not None:
+            self._accent = accent
+        self._set_palette_colors(palette)
+        self.update(self._render_body())
+
+    def _set_palette_colors(self, palette: tuple[str, str, str]) -> None:
+        screen, prompt_bg, chrome = palette
+        if self._accent:
+            # Brand-coloured logo: a vertical gradient built around the theme
+            # accent (e.g. QwenPaw orange), kept saturated rather than washed
+            # out so the wordmark reads as the brand colour.
+            accent = self._accent
+            deep = _mix_hex(accent, screen, 0.45)
+            self._gradient_stops = (
+                _mix_hex(accent, "#ffffff", 0.42),
+                accent,
+                _mix_hex(accent, deep, 0.5),
+                _mix_hex(accent, "#ffd08a", 0.5),
+            )
+            return
+        cool = _mix_hex(chrome, "#ffffff", 0.62)
+        warm = _mix_hex(prompt_bg, "#ffd08a", 0.46)
+        bright = _mix_hex(prompt_bg, "#ffffff", 0.56)
+        deep = _mix_hex(screen, chrome, 0.52)
+        self._gradient_stops = (
+            bright,
+            cool,
+            _mix_hex(cool, warm, 0.42),
+            _mix_hex(deep, "#ffffff", 0.48),
+        )
+
+    def _render_body(self) -> Text:
+        body = Text()
+        for row in self._render_pixel_rows():
+            body.append(row)
+        return body
+
+    def _render_pixel_rows(self) -> list[Text]:
+        rows: list[Text] = []
+        for index, row in enumerate(self._LOGO_PIXELS):
+            line = Text()
+            base = self._gradient_color(index)
+            for ch in row:
+                if ch == " ":
+                    line.append(" ")
+                elif ch == "O":
+                    line.append("█", style=_bright_dot_hex(base))
+                else:
+                    line.append("█", style=base)
+            rows.append(line)
+            if index + 1 < len(self._LOGO_PIXELS):
+                line.append("\n")
+        return rows
+
+    def _gradient_color(self, row_index: int) -> str:
+        stops = self._gradient_stops
+        position = (row_index * 0.72 + self._frame * 0.26) % len(stops)
+        start = int(position)
+        amount = position - start
+        return _mix_hex(stops[start], stops[(start + 1) % len(stops)], amount)
+
+
+def _mix_hex(left: str, right: str, amount: float) -> str:
+    left_rgb = _hex_to_rgb(left)
+    right_rgb = _hex_to_rgb(right)
+    mixed = tuple(
+        round(a + (b - a) * amount)
+        for a, b in zip(left_rgb, right_rgb, strict=True)
+    )
+    return "#{:02x}{:02x}{:02x}".format(*mixed)
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    cleaned = value.removeprefix("#")
+    return (
+        int(cleaned[0:2], 16),
+        int(cleaned[2:4], 16),
+        int(cleaned[4:6], 16),
+    )
+
+
+def _bright_dot_hex(color: str) -> str:
+    bright = _mix_hex(color, "#ffffff", 0.82)
+    if _relative_luminance(bright) <= _relative_luminance(color):
+        return "#ffffff"
+    return bright
+
+
+def _contrast_ratio(left: str, right: str) -> float:
+    left_luminance = _relative_luminance(left)
+    right_luminance = _relative_luminance(right)
+    lighter = max(left_luminance, right_luminance)
+    darker = min(left_luminance, right_luminance)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _relative_luminance(color: str) -> float:
+    channels = []
+    for channel in _hex_to_rgb(color):
+        value = channel / 255
+        if value <= 0.03928:
+            channels.append(value / 12.92)
+        else:
+            channels.append(((value + 0.055) / 1.055) ** 2.4)
+    red, green, blue = channels
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+
+class AssistantMessage(Widget):
+    """Streaming assistant answer rendered as markdown.
+
+    ``append()`` accumulates deltas and re-renders. The lane label is mounted
+    separately (see :class:`AgentLabel`) so post-tool answer chunks flow
+    under the same label instead of looking like new messages.
+    """
+
+    DEFAULT_CSS = """
+    AssistantMessage { height: auto; }
+    AssistantMessage > Markdown { height: auto; margin: 0; }
+    """
+
+    def __init__(self) -> None:
+        super().__init__(classes="msg assistant")
+        self._text = ""
+        self._md = Markdown("")
+
+    def compose(self) -> ComposeResult:
+        yield self._md
+
+    async def append(self, delta: str) -> None:
+        self._text += delta
+        await self._md.update(self._text)
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+
+class ThoughtMessage(Collapsible):
+    """Dimmed agent thinking lane, collapsed by default.
+
+    The reasoning streams into the (hidden) body; the user can expand the
+    header to read it. Reused for plan summaries via the ``title`` argument.
+
+    When ``live=True`` the header animates (spinner + pulsing colour) and
+    shows the elapsed time while the agent thinks; calling :meth:`done`
+    freezes it to ``💭 thought for Ns``.
+    """
+
+    def __init__(
+        self,
+        title: str = "💭 thinking",
+        collapsed: bool = True,
+        *,
+        live: bool = False,
+    ) -> None:
+        self._text = ""
+        self._live = live
+        self._start: float | None = None
+        self._timer = None
+        self._frame = 0
+        self._finished = False
+        self._body = Static(Text("", style="italic #8a8a8a"))
+        super().__init__(
+            self._body,
+            title=title,
+            collapsed=collapsed,
+            classes="msg thought",
+        )
+
+    def on_mount(self) -> None:
+        if self._live:
+            self._start = time.monotonic()
+            self._timer = self.set_interval(TICK, self._tick)
+            self._tick()
+
+    def _elapsed(self) -> int:
+        if self._start is None:
+            return 0
+        return int(time.monotonic() - self._start)
+
+    def _tick(self) -> None:
+        if self._finished:
+            return
+        self._frame += 1
+        head = Text()
+        head.append("💭 ", style="")
+        head.append(f"thinking {self._elapsed()}s ", style="italic #8a8a8a")
+        head.append(spinner(self._frame), style=f"bold {pulse(self._frame)}")
+        self.title = head
+
+    def done(self) -> None:
+        """Freeze the header to the final elapsed time."""
+        if self._finished or not self._live:
+            return
+        self._finished = True
+        if self._timer is not None:
+            self._timer.stop()
+        self.title = f"💭 thought for {self._elapsed()}s"
+
+    def append(self, delta: str) -> None:
+        self._text += delta
+        self._body.update(Text(self._text, style="italic #8a8a8a"))
+
+
+class ActivityLine(_Bubble):
+    """Single friendly row for the current hidden thought/tool chain."""
+
+    _TERMINAL = {"completed", "failed"}
+
+    def __init__(self) -> None:
+        self._mode = "thinking"
+        self._label = "thinking"
+        self._status = "in_progress"
+        self._summary = ""
+        self._frame = 0
+        self._timer = None
+        self._start = time.monotonic()
+        super().__init__(self._render_line(), classes="activity")
+
+    def on_mount(self) -> None:
+        self._timer = self.set_interval(TICK, self._tick)
+
+    def on_unmount(self) -> None:
+        if self._timer is not None:
+            self._timer.stop()
+
+    def _tick(self) -> None:
+        if self._status in self._TERMINAL:
+            return
+        self._frame += 1
+        self.update(self._render_line())
+
+    def set_thinking(self) -> None:
+        self._mode = "thinking"
+        self._label = "thinking"
+        self._status = "in_progress"
+        self._summary = ""
+        self.update(self._render_line())
+
+    def set_tool(
+        self,
+        *,
+        title: str | None = None,
+        kind: str | None = None,
+        status: str | None = None,
+        params: str | None = None,
+    ) -> None:
+        self._mode = "tool"
+        if title or kind:
+            self._label = self._tool_label(title, kind)
+        self._status = status or self._status
+        if params is not None:
+            self._summary = self._tool_summary(params)
+        self.update(self._render_line())
+
+    def done(self) -> None:
+        if self._status not in self._TERMINAL:
+            self._status = "completed"
+        if self._mode == "thinking":
+            self._label = "thought complete"
+        if self._timer is not None:
+            self._timer.stop()
+            self._timer = None
+        self.update(self._render_line())
+
+    def _render_line(self) -> Text:
+        text = Text()
+        if self._status in self._TERMINAL:
+            glyph = "✓" if self._status == "completed" else "✗"
+            color = "#6dff9d" if self._status == "completed" else "#ff6d6d"
+        else:
+            glyph = spinner(self._frame)
+            color = pulse(self._frame)
+        text.append(f"{glyph} ", style=f"bold {color}")
+        if self._mode == "tool":
+            text.append("using ", style="#8a8a8a")
+            text.append(self._label, style="bold")
+        else:
+            elapsed = int(time.monotonic() - self._start)
+            text.append(f"{self._label} {elapsed}s", style="italic #8a8a8a")
+        if self._summary:
+            text.append("  ")
+            text.append(self._summary, style="#7fb7d9")
+        return text
+
+    def _tool_label(self, title: str | None, kind: str | None) -> str:
+        value = (title or "").strip()
+        if value and value.lower() != "tool":
+            return value
+        return kind or "tool"
+
+    def _tool_summary(self, params: str | None) -> str:
+        if not params:
+            return ""
+        first = params.strip().splitlines()[0].strip()
+        return first[:72] + " ..." if len(first) > 72 else first
+
+
+class FileLinkBox(_Bubble):
+    """A file the agent sent (e.g. via ``send_file_to_user``).
+
+    Rendered as a distinct, always-visible transcript line (the originating
+    tool panel auto-collapses) and clickable: a click opens the file with the
+    OS handler via ``App.open_url``.
+    """
+
+    DEFAULT_CSS = """
+    FileLinkBox:hover { background: #23233a; }
+    """
+
+    def __init__(self, name: str, uri: str) -> None:
+        self._uri = uri
+        body = Text()
+        body.append("📎 ", style="bold #6db8ff")
+        body.append(name or uri, style="underline #6db8ff")
+        body.append("  (click to open)", style="#5a5a5a")
+        super().__init__(body, classes="file")
+
+    def on_click(self) -> None:
+        try:
+            self.app.open_url(self._uri)
+        except Exception:  # noqa: BLE001 - opening is best-effort
+            pass
+
+
+class PushMessageBox(_Bubble):
+    """A server-initiated proactive message."""
+
+    def __init__(self, text: str) -> None:
+        body = Text()
+        body.append("✦ ", style="bold #ffcf6d")
+        body.append(text, style="#ffcf6d")
+        super().__init__(body, classes="push")
+
+
+class InfoMessage(_Bubble):
+    """A friendly local UI notice."""
+
+    def __init__(self, text: str, *, level: str = "info") -> None:
+        marker, color = {
+            "info": ("•", "#8fd3ff"),
+            "ok": ("✓", "#6dff9d"),
+            "warn": ("!", "#ffcf6d"),
+        }.get(level, ("•", "#8fd3ff"))
+        body = Text()
+        body.append(f"{marker} ", style=f"bold {color}")
+        body.append(text, style=color)
+        super().__init__(body, classes=f"info {level}")
+
+
+class ErrorMessage(_Bubble):
+    """A transport/agent error."""
+
+    def __init__(self, text: str) -> None:
+        body = Text()
+        body.append("⚠ ", style="bold #ff6d6d")
+        body.append(text, style="#ff9d9d")
+        super().__init__(body, classes="error")

--- a/src/qwenpaw/cli/tui/widgets/messages.py
+++ b/src/qwenpaw/cli/tui/widgets/messages.py
@@ -22,6 +22,7 @@ class _Bubble(Static):
     the rounded corners simply show the background.
     """
 
+    # pylint: disable-next=useless-parent-delegation
     def __init__(self, renderable, *, classes: str = "") -> None:
         super().__init__(renderable, classes=f"msg {classes}".strip())
 
@@ -98,7 +99,9 @@ class WelcomeMessage(Static):
         super().__init__(self._render_body(), classes="msg welcome")
 
     def set_palette(
-        self, palette: tuple[str, str, str], accent: str | None = None
+        self,
+        palette: tuple[str, str, str],
+        accent: str | None = None,
     ) -> None:
         if accent is not None:
             self._accent = accent
@@ -169,7 +172,7 @@ def _mix_hex(left: str, right: str, amount: float) -> str:
         round(a + (b - a) * amount)
         for a, b in zip(left_rgb, right_rgb, strict=True)
     )
-    return "#{:02x}{:02x}{:02x}".format(*mixed)
+    return f"#{mixed[0]:02x}{mixed[1]:02x}{mixed[2]:02x}"
 
 
 def _hex_to_rgb(value: str) -> tuple[int, int, int]:

--- a/src/qwenpaw/cli/tui/widgets/permission_modal.py
+++ b/src/qwenpaw/cli/tui/widgets/permission_modal.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Modal overlay for tool-permission requests."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+from ..events import PermissionRequest
+
+# allow_* kinds get a positive button, reject_* a negative one.
+_VARIANT = {
+    "allow_once": "success",
+    "allow_always": "success",
+    "reject_once": "error",
+    "reject_always": "error",
+}
+
+
+class PermissionModal(ModalScreen[str | None]):
+    """Asks the user to approve/deny a tool call.
+
+    Dismisses with the chosen ``option_id`` or ``None`` (deny/escape).
+    """
+
+    BINDINGS = [("escape", "deny", "Deny")]
+
+    DEFAULT_CSS = """
+    PermissionModal { align: center middle; }
+    PermissionModal > Vertical {
+        width: 64; height: auto; padding: 1 2;
+        border: round #b48cff; background: $surface;
+    }
+    PermissionModal .ptitle { text-style: bold; margin-bottom: 1; }
+    PermissionModal .pkind { color: #8a8a8a; margin-bottom: 1; }
+    PermissionModal Button { width: 100%; margin-bottom: 1; }
+    """
+
+    def __init__(self, request: PermissionRequest) -> None:
+        super().__init__()
+        self._request = request
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static(f"🔐 {self._request.title}", classes="ptitle")
+            if self._request.tool_kind:
+                yield Static(
+                    f"kind: {self._request.tool_kind}", classes="pkind"
+                )
+            for option in self._request.options:
+                yield Button(
+                    option.name,
+                    variant=_VARIANT.get(option.kind, "default"),
+                    id=f"opt-{option.option_id}",
+                )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        option_id = str(event.button.id or "").removeprefix("opt-")
+        self.dismiss(option_id or None)
+
+    def action_deny(self) -> None:
+        self.dismiss(None)

--- a/src/qwenpaw/cli/tui/widgets/permission_modal.py
+++ b/src/qwenpaw/cli/tui/widgets/permission_modal.py
@@ -47,7 +47,8 @@ class PermissionModal(ModalScreen[str | None]):
             yield Static(f"🔐 {self._request.title}", classes="ptitle")
             if self._request.tool_kind:
                 yield Static(
-                    f"kind: {self._request.tool_kind}", classes="pkind"
+                    f"kind: {self._request.tool_kind}",
+                    classes="pkind",
                 )
             for option in self._request.options:
                 yield Button(

--- a/src/qwenpaw/cli/tui/widgets/session_picker.py
+++ b/src/qwenpaw/cli/tui/widgets/session_picker.py
@@ -16,6 +16,7 @@ from textual.widgets import Input, ListItem, ListView, Static
 from ..events import SessionSummary
 
 
+# pylint: disable-next=too-many-return-statements
 def _relative_time(iso: str) -> str:
     """Render an ISO-8601 timestamp as a compact 'x ago' label."""
     if not iso:
@@ -27,9 +28,7 @@ def _relative_time(iso: str) -> str:
     if when.tzinfo is None:
         when = when.replace(tzinfo=timezone.utc)
     delta = datetime.now(timezone.utc) - when
-    secs = int(delta.total_seconds())
-    if secs < 0:
-        secs = 0
+    secs = max(int(delta.total_seconds()), 0)
     if secs < 60:
         return "just now"
     mins = secs // 60

--- a/src/qwenpaw/cli/tui/widgets/session_picker.py
+++ b/src/qwenpaw/cli/tui/widgets/session_picker.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""Picker for resuming a previous session."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from rich.text import Text
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, ListItem, ListView, Static
+
+from ..events import SessionSummary
+
+
+def _relative_time(iso: str) -> str:
+    """Render an ISO-8601 timestamp as a compact 'x ago' label."""
+    if not iso:
+        return ""
+    try:
+        when = datetime.fromisoformat(iso)
+    except ValueError:
+        return iso
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - when
+    secs = int(delta.total_seconds())
+    if secs < 0:
+        secs = 0
+    if secs < 60:
+        return "just now"
+    mins = secs // 60
+    if mins < 60:
+        return f"{mins}m ago"
+    hours = mins // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    if days < 30:
+        return f"{days}d ago"
+    return when.strftime("%Y-%m-%d")
+
+
+class SessionPicker(ModalScreen[str | None]):
+    """Pick a past session to resume. Dismisses with its ``session_id``."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    CSS = """
+    SessionPicker {
+        align: center middle;
+        background: transparent;
+    }
+    #session-modal {
+        width: 72%;
+        height: 26;
+        background: #101827;
+        border: thick #68d391;
+        padding: 1 2;
+    }
+    #session-title {
+        height: 1;
+        color: #d1ffe6;
+    }
+    #session-search {
+        margin-top: 1;
+    }
+    #session-list {
+        height: 1fr;
+        margin-top: 1;
+    }
+    #session-help {
+        height: 2;
+        color: #9fb0c2;
+    }
+    """
+
+    def __init__(self, sessions: list[SessionSummary]) -> None:
+        super().__init__()
+        self._sessions = sessions
+        self.item_sessions: dict[str, SessionSummary] = {}
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="session-modal"):
+            yield Static("Resume a previous session", id="session-title")
+            yield Input(placeholder="Search by title", id="session-search")
+            yield ListView(*self._session_items(), id="session-list")
+            yield Static(
+                "Enter resumes the highlighted session. Esc cancels.",
+                id="session-help",
+            )
+
+    async def on_mount(self) -> None:
+        self.query_one("#session-list", ListView).index = 0
+        self.query_one("#session-search", Input).focus()
+
+    def on_key(self, event: events.Key) -> None:
+        # Search keeps focus for typing, so the single-line Input ignores
+        # up/down (they bubble here) — route them to move the list selection.
+        if event.key not in ("up", "down"):
+            return
+        session_list = self.query_one("#session-list", ListView)
+        if event.key == "down":
+            session_list.action_cursor_down()
+        else:
+            session_list.action_cursor_up()
+        event.stop()
+        event.prevent_default()
+
+    async def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "session-search":
+            return
+        event.stop()
+        await self._refresh(event.value)
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id != "session-search":
+            return
+        event.stop()
+        item = self.query_one("#session-list", ListView).highlighted_child
+        if item is not None and item.id in self.item_sessions:
+            self.dismiss(self.item_sessions[item.id].session_id)
+
+    async def on_list_view_selected(self, event: ListView.Selected) -> None:
+        event.stop()
+        if event.item.id in self.item_sessions:
+            self.dismiss(self.item_sessions[event.item.id].session_id)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    async def _refresh(self, query: str) -> None:
+        session_list = self.query_one("#session-list", ListView)
+        await session_list.clear()
+        for item in self._session_items(query):
+            await session_list.append(item)
+        session_list.index = 0 if session_list.children else None
+
+    def _session_items(self, query: str = "") -> list[ListItem]:
+        self.item_sessions = {}
+        needle = query.casefold().strip()
+        matches = [
+            session
+            for session in self._sessions
+            if needle in session.title.casefold()
+        ]
+        if not matches:
+            message = (
+                "No sessions match" if needle else "No previous sessions yet"
+            )
+            return [ListItem(Static(message), disabled=True)]
+        items: list[ListItem] = []
+        for index, session in enumerate(matches):
+            item_id = f"session-{index}"
+            self.item_sessions[item_id] = session
+            label = Text()
+            label.append(session.title or "(untitled)", style="bold #d1ffe6")
+            when = _relative_time(session.updated_at)
+            if when:
+                label.append(f"   {when}", style="#9fb0c2")
+            items.append(ListItem(Static(label), id=item_id))
+        return items

--- a/src/qwenpaw/cli/tui/widgets/status_bar.py
+++ b/src/qwenpaw/cli/tui/widgets/status_bar.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Top status bar: agent, model, session, token usage, busy state."""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.widgets import Static
+
+from ._anim import TICK, pulse, spinner
+
+# Public field name -> internal attribute. Internal names are namespaced with
+# ``_sb_`` so they never clash with Textual ``Widget`` internals (``_size``,
+# ``size``, ``region`` ...).
+_FIELDS = (
+    "agent",
+    "model",
+    "session",
+    "used",
+    "size",
+    "tok_in",
+    "tok_out",
+    "tok_out_approx",
+    "state",
+    "qwenpaw_version",
+    "tui_version",
+)
+
+
+def _fmt_count(n: int) -> str:
+    """Compact, readable token count: ``842`` · ``6.4k`` · ``1.5M``.
+
+    Exact below 1,000; abbreviated above so the bar stays tidy when a long
+    session runs into the hundreds of thousands or millions of tokens.
+    """
+    if n < 1000:
+        return str(n)
+    if n < 1_000_000:
+        return f"{n / 1000:.1f}".rstrip("0").rstrip(".") + "k"
+    return f"{n / 1_000_000:.2f}".rstrip("0").rstrip(".") + "M"
+
+
+class StatusBar(Static):
+    """A one-line header rendered from a few fields via :meth:`set`."""
+
+    def __init__(self, *, tui_version: str = "—") -> None:
+        self._frame = 0
+        self._timer = None
+        self._sb_agent = "default"
+        self._sb_model = "—"
+        self._sb_session = "—"
+        self._sb_used = 0
+        self._sb_size = 0
+        self._sb_tok_in = 0
+        self._sb_tok_out = 0
+        self._sb_tok_out_approx = False
+        self._sb_state = "starting"
+        self._sb_qwenpaw_version = "—"
+        self._sb_tui_version = tui_version
+        # Pass an initial renderable so the first arrange has a valid visual.
+        super().__init__(self._compose_line(), classes="statusbar")
+
+    def on_mount(self) -> None:
+        self._timer = self.set_interval(TICK, self._tick)
+
+    def _tick(self) -> None:
+        if self._sb_state not in {
+            "connecting",
+            "starting",
+            "warming",
+            "waiting",
+            "thinking",
+            "interrupting",
+        }:
+            return
+        self._frame += 1
+        self.update(self._compose_line())
+
+    def set(self, **kwargs: object) -> None:
+        for key, value in kwargs.items():
+            if key in _FIELDS and value is not None:
+                setattr(self, f"_sb_{key}", value)
+        # Only repaint once mounted; before that the __init__ renderable
+        # stands in (and tests can read ``summary`` without an app).
+        if self.is_mounted:
+            self.update(self._compose_line())
+
+    @property
+    def summary(self) -> str:
+        """Plain-text view of the bar (handy for tests)."""
+        return self._compose_line().plain
+
+    def _compose_line(self) -> Text:
+        state_color = {
+            "connecting": "#ffcf6d",
+            "starting": "#ffcf6d",
+            "warming": "#ffcf6d",
+            "waiting": "#ffcf6d",
+            "ready": "#6dff9d",
+            "thinking": "#6db8ff",
+            "interrupting": "#ffcf6d",
+            "error": "#ff6d6d",
+        }.get(self._sb_state, "#8a8a8a")
+
+        line = Text()
+        # Version badge — top-left (replaces the old "paw" badge).
+        line.append(
+            f" QwenPaw {self._sb_qwenpaw_version}  "
+            f"TUI {self._sb_tui_version} ",
+            style="bold on #2a2a3a",
+        )
+        line.append("  agent:", style="#8a8a8a")
+        line.append(f"{self._sb_agent}", style="bold")
+        line.append("  ", style="")
+        line.append(f"{self._sb_model}", style="#b48cff")
+        line.append("  session:", style="#8a8a8a")
+        line.append(f"{str(self._sb_session)[:8]}", style="")
+        if self._sb_used:
+            tokens = _fmt_count(self._sb_used)
+            if self._sb_size:
+                tokens += f"/{_fmt_count(self._sb_size)}"
+            line.append(f"  tokens:{tokens}", style="#8a8a8a")
+        if self._sb_tok_in or self._sb_tok_out:
+            line.append("  tok", style="#8a8a8a")
+            # Show input only once it's known (it can't be estimated live),
+            # so it never flashes ``↑0`` while the first reply streams; the
+            # confirmed total then carries forward across later turns.
+            if self._sb_tok_in:
+                line.append(
+                    f" ↑{_fmt_count(self._sb_tok_in)}", style="#7fb7d9"
+                )
+            if self._sb_tok_out:
+                approx = "~" if self._sb_tok_out_approx else ""
+                line.append(
+                    f" ↓{approx}{_fmt_count(self._sb_tok_out)}",
+                    style="#6dff9d",
+                )
+        if self._sb_state in {
+            "connecting",
+            "starting",
+            "warming",
+            "waiting",
+            "thinking",
+            "interrupting",
+        }:
+            glyph = spinner(self._frame)
+            state_color = pulse(self._frame)
+        elif self._sb_state == "error":
+            glyph = "✗"
+        else:
+            glyph = "●"
+        # State indicator — pushed to the right edge.
+        right = Text()
+        right.append(f"{glyph} {self._sb_state}", style=f"bold {state_color}")
+        mounted = getattr(self, "_is_mounted", False)
+        width = self.size.width if mounted else 0
+        gap = max(3, width - line.cell_len - right.cell_len)
+        line.append(" " * gap)
+        line.append(right)
+        return line

--- a/src/qwenpaw/cli/tui/widgets/status_bar.py
+++ b/src/qwenpaw/cli/tui/widgets/status_bar.py
@@ -126,7 +126,8 @@ class StatusBar(Static):
             # confirmed total then carries forward across later turns.
             if self._sb_tok_in:
                 line.append(
-                    f" ↑{_fmt_count(self._sb_tok_in)}", style="#7fb7d9"
+                    f" ↑{_fmt_count(self._sb_tok_in)}",
+                    style="#7fb7d9",
                 )
             if self._sb_tok_out:
                 approx = "~" if self._sb_tok_out_approx else ""

--- a/src/qwenpaw/cli/tui/widgets/status_bar.py
+++ b/src/qwenpaw/cli/tui/widgets/status_bar.py
@@ -22,7 +22,6 @@ _FIELDS = (
     "tok_out_approx",
     "state",
     "qwenpaw_version",
-    "tui_version",
 )
 
 
@@ -42,7 +41,7 @@ def _fmt_count(n: int) -> str:
 class StatusBar(Static):
     """A one-line header rendered from a few fields via :meth:`set`."""
 
-    def __init__(self, *, tui_version: str = "—") -> None:
+    def __init__(self) -> None:
         self._frame = 0
         self._timer = None
         self._sb_agent = "default"
@@ -55,7 +54,6 @@ class StatusBar(Static):
         self._sb_tok_out_approx = False
         self._sb_state = "starting"
         self._sb_qwenpaw_version = "—"
-        self._sb_tui_version = tui_version
         # Pass an initial renderable so the first arrange has a valid visual.
         super().__init__(self._compose_line(), classes="statusbar")
 
@@ -104,8 +102,7 @@ class StatusBar(Static):
         line = Text()
         # Version badge — top-left (replaces the old "paw" badge).
         line.append(
-            f" QwenPaw {self._sb_qwenpaw_version}  "
-            f"TUI {self._sb_tui_version} ",
+            f" QwenPaw {self._sb_qwenpaw_version} ",
             style="bold on #2a2a3a",
         )
         line.append("  agent:", style="#8a8a8a")

--- a/src/qwenpaw/cli/tui/widgets/theme_picker.py
+++ b/src/qwenpaw/cli/tui/widgets/theme_picker.py
@@ -127,8 +127,9 @@ class ThemePicker(ModalScreen[ThemeInfo | str | None]):
         if not themes:
             return [
                 ListItem(
-                    Static("Use Enter for a custom prompt"), disabled=True
-                )
+                    Static("Use Enter for a custom prompt"),
+                    disabled=True,
+                ),
             ]
         items: list[ListItem] = []
         for index, theme in enumerate(themes):

--- a/src/qwenpaw/cli/tui/widgets/theme_picker.py
+++ b/src/qwenpaw/cli/tui/widgets/theme_picker.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Theme gallery picker."""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, ListItem, ListView, Static
+
+from ..themes import THEME_GALLERY, ThemeInfo
+
+
+class ThemePicker(ModalScreen[ThemeInfo | str | None]):
+    """Pick a named theme or type a custom prompt."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    CSS = """
+    ThemePicker {
+        align: center middle;
+        background: transparent;
+    }
+    #theme-modal {
+        width: 72%;
+        height: 26;
+        background: #101827;
+        border: thick #ff7ad9;
+        padding: 1 2;
+    }
+    #theme-title {
+        height: 1;
+        color: #ffd1f1;
+    }
+    #theme-search {
+        margin-top: 1;
+    }
+    #theme-list {
+        height: 1fr;
+        margin-top: 1;
+    }
+    #theme-help {
+        height: 2;
+        color: #9fb0c2;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.item_themes: dict[str, ThemeInfo] = {}
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="theme-modal"):
+            yield Static("Pick a QwenPaw vibe", id="theme-title")
+            yield Input(
+                placeholder="Search or type a custom theme prompt",
+                id="theme-search",
+            )
+            yield ListView(*self._theme_items(), id="theme-list")
+            yield Static(
+                "Enter selects. Type anything for a custom generated palette.",
+                id="theme-help",
+            )
+
+    async def on_mount(self) -> None:
+        self.query_one("#theme-list", ListView).index = 0
+        self.query_one("#theme-search", Input).focus()
+
+    def on_key(self, event: events.Key) -> None:
+        # Search keeps focus for typing, so the single-line Input ignores
+        # up/down (they bubble here) — route them to move the list selection.
+        if event.key not in ("up", "down"):
+            return
+        theme_list = self.query_one("#theme-list", ListView)
+        if event.key == "down":
+            theme_list.action_cursor_down()
+        else:
+            theme_list.action_cursor_up()
+        event.stop()
+        event.prevent_default()
+
+    async def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "theme-search":
+            return
+        event.stop()
+        await self._refresh(event.value)
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id != "theme-search":
+            return
+        event.stop()
+        item = self.query_one("#theme-list", ListView).highlighted_child
+        if item and item.id in self.item_themes:
+            self.dismiss(self.item_themes[item.id])
+            return
+        value = event.value.strip()
+        self.dismiss(value if value else None)
+
+    async def on_list_view_selected(self, event: ListView.Selected) -> None:
+        event.stop()
+        if event.item.id in self.item_themes:
+            self.dismiss(self.item_themes[event.item.id])
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    async def _refresh(self, query: str) -> None:
+        theme_list = self.query_one("#theme-list", ListView)
+        await theme_list.clear()
+        for item in self._theme_items(query):
+            await theme_list.append(item)
+        theme_list.index = 0 if theme_list.children else None
+
+    def _theme_items(self, query: str = "") -> list[ListItem]:
+        self.item_themes = {}
+        needle = query.casefold().strip()
+        themes = [
+            theme
+            for theme in THEME_GALLERY
+            if needle in theme.name.casefold()
+            or needle in theme.id.casefold()
+            or needle in theme.prompt.casefold()
+        ]
+        if not themes:
+            return [
+                ListItem(
+                    Static("Use Enter for a custom prompt"), disabled=True
+                )
+            ]
+        items: list[ListItem] = []
+        for index, theme in enumerate(themes):
+            item_id = f"theme-{index}"
+            self.item_themes[item_id] = theme
+            label = Text()
+            label.append(f"{theme.emoji}  ", style=theme.accent)
+            label.append(theme.name, style=f"bold {theme.accent}")
+            label.append(f"  /theme {theme.id}", style="#9fb0c2")
+            items.append(ListItem(Static(label), id=item_id))
+        return items

--- a/src/qwenpaw/cli/tui/widgets/tool_panel.py
+++ b/src/qwenpaw/cli/tui/widgets/tool_panel.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Collapsible tool-call panel (merges start + update by tool_call_id).
+
+The panel is expanded while the tool is pending/running so the user can watch
+it, then auto-collapses to a one-line summary once it completes or fails. The
+header (status, title, params summary) stays visible; the body (params +
+output) can be re-opened on demand.
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.content import Content
+from textual.widgets import Collapsible, Static
+
+from ._anim import TICK, pulse, spinner
+
+_STATUS_GLYPH = {
+    "pending": ("◌", "#8a8a8a"),
+    "in_progress": ("◍", "#6db8ff"),
+    "completed": ("●", "#6dff9d"),
+    "failed": ("✗", "#ff6d6d"),
+}
+
+_TERMINAL = ("completed", "failed")
+
+
+class ToolPanel(Collapsible):
+    """One tool call. Updated in place as ACP sends progress events."""
+
+    def __init__(
+        self,
+        tool_call_id: str,
+        title: str,
+        kind: str | None = None,
+        params: str | None = None,
+    ) -> None:
+        self._id = tool_call_id
+        self._title_text = title or "tool"
+        self._kind = kind
+        self._params = params
+        self._status = "pending"
+        self._output: str | None = None
+        self._frame = 0
+        self._timer = None
+        self._body = Static(self._render_body())
+        super().__init__(
+            self._body,
+            title=self._render_title(),
+            collapsed=False,
+            classes="tool",
+        )
+
+    def on_mount(self) -> None:
+        # Animate the status glyph while the tool is still running.
+        self._timer = self.set_interval(TICK, self._tick)
+
+    def _tick(self) -> None:
+        if self._status in _TERMINAL:
+            if self._timer is not None:
+                self._timer.stop()
+                self._timer = None
+            return
+        self._frame += 1
+        self.title = self._render_title()
+
+    def update_call(
+        self,
+        *,
+        title: str | None = None,
+        kind: str | None = None,
+        status: str | None = None,
+        output: str | None = None,
+        params: str | None = None,
+    ) -> None:
+        prev = self._status
+        if title:
+            self._title_text = title
+        if kind:
+            self._kind = kind
+        if status:
+            self._status = status
+        if output is not None:
+            self._output = output
+        if params is not None:
+            self._params = params
+        self.title = self._render_title()
+        self._body.update(self._render_body())
+        # Auto-collapse once on the transition to a terminal state; leave the
+        # user free to re-open it afterwards, and stop the spinner.
+        if self._status in _TERMINAL and prev not in _TERMINAL:
+            self.collapsed = True
+            if self._timer is not None:
+                self._timer.stop()
+                self._timer = None
+
+    @property
+    def is_done(self) -> bool:
+        """True once the tool has finished (completed or failed)."""
+        return self._status in _TERMINAL
+
+    def _label(self) -> str:
+        """Best available name for the tool.
+
+        The ACP ``title`` is the ideal label, but some agents leave it empty
+        (so it falls back to the generic ``"tool"``). In that case the tool
+        ``kind`` (read / execute / search / …) is far more informative.
+        """
+        title = (self._title_text or "").strip()
+        if title and title.lower() != "tool":
+            return title
+        return self._kind or "tool"
+
+    def _summary(self) -> str:
+        """A compact one-line gist of the params (e.g. the actual command)."""
+        if not self._params:
+            return ""
+        first = self._params.strip().splitlines()[0].strip()
+        return first[:72] + " …" if len(first) > 72 else first
+
+    def _render_title(self) -> Content:
+        # The glyph + colour already encode status, so we drop the redundant
+        # "completed" word and surface the param summary instead — that's what
+        # actually tells finished tools apart in the collapsed list.
+        if self._status in _TERMINAL:
+            glyph, color = _STATUS_GLYPH.get(self._status, ("◌", "#8a8a8a"))
+        else:
+            # Running: animated spinner + pulsing colour.
+            glyph, color = spinner(self._frame), pulse(self._frame)
+        parts: list[object] = [
+            (f"{glyph} ", f"bold {color}"),
+            "🔧 ",
+            (self._label(), "bold"),
+        ]
+        summary = self._summary()
+        if summary:
+            parts.append(("  " + summary, "#7fb7d9"))
+        return Content.assemble(*parts)
+
+    def _render_body(self) -> Text:
+        segments: list[Text] = []
+        if self._params:
+            params = self._params.strip()
+            if len(params) > 600:
+                params = params[:600] + " …"
+            segments.append(Text(params, style="#7fb7d9"))
+        if self._output:
+            snippet = self._output.strip()
+            if len(snippet) > 600:
+                snippet = snippet[:600] + " …"
+            segments.append(Text(snippet, style="#b0b0b0"))
+        if not segments:
+            return Text("(no output)", style="#5a5a5a")
+        out = Text()
+        for i, seg in enumerate(segments):
+            if i:
+                out.append("\n")
+            out.append_text(seg)
+        return out

--- a/tests/cli/tui/_fake_acp_agent.py
+++ b/tests/cli/tui/_fake_acp_agent.py
@@ -13,6 +13,10 @@ backend (agentscope, etc.).
 
 from __future__ import annotations
 
+# Test double: it intentionally overrides ACP Agent methods with simplified
+# signatures and ignores most params.
+# pylint: disable=arguments-renamed,unused-argument
+
 import asyncio
 
 from acp import (
@@ -73,7 +77,11 @@ class FakeAgent(Agent):
         )
 
     async def new_session(
-        self, cwd, additional_directories=None, mcp_servers=None, **kw
+        self,
+        cwd,
+        additional_directories=None,
+        mcp_servers=None,
+        **kw,
     ):  # noqa: ANN001
         self._session_count += 1
         return NewSessionResponse(session_id=f"sess-{self._session_count}")
@@ -84,7 +92,11 @@ class FakeAgent(Agent):
             ev.set()
 
     async def list_sessions(
-        self, cursor=None, cwd=None, additional_directories=None, **kw
+        self,
+        cursor=None,
+        cwd=None,
+        additional_directories=None,
+        **kw,
     ):  # noqa: ANN001
         return ListSessionsResponse(
             sessions=[
@@ -93,8 +105,8 @@ class FakeAgent(Agent):
                     cwd=cwd or "",
                     title=_PAST_SESSION_TITLE,
                     updated_at="2026-01-01T00:00:00+00:00",
-                )
-            ]
+                ),
+            ],
         )
 
     async def load_session(
@@ -111,12 +123,17 @@ class FakeAgent(Agent):
             else:
                 update = update_agent_message(text_block(text))
             await self._conn.session_update(
-                session_id=session_id, update=update
+                session_id=session_id,
+                update=update,
             )
         return LoadSessionResponse()
 
     async def prompt(
-        self, prompt, session_id, message_id=None, **kw
+        self,
+        prompt,
+        session_id,
+        message_id=None,
+        **kw,
     ):  # noqa: ANN001
         text = ""
         for block in prompt:
@@ -142,19 +159,26 @@ class FakeAgent(Agent):
             outcome = await self._conn.request_permission(
                 options=[
                     PermissionOption(
-                        option_id="allow", name="Allow", kind="allow_once"
+                        option_id="allow",
+                        name="Allow",
+                        kind="allow_once",
                     ),
                     PermissionOption(
-                        option_id="deny", name="Deny", kind="reject_once"
+                        option_id="deny",
+                        name="Deny",
+                        kind="reject_once",
                     ),
                 ],
                 session_id=session_id,
                 tool_call=ToolCallUpdate(
-                    tool_call_id="t1", title="dangerous_tool"
+                    tool_call_id="t1",
+                    title="dangerous_tool",
                 ),
             )
             chosen = getattr(
-                getattr(outcome, "outcome", None), "option_id", "cancelled"
+                getattr(outcome, "outcome", None),
+                "option_id",
+                "cancelled",
             )
             await self._conn.session_update(
                 session_id=session_id,
@@ -165,7 +189,10 @@ class FakeAgent(Agent):
         await self._conn.session_update(
             session_id=session_id,
             update=start_tool_call(
-                "t2", "read_file", kind="read", status="in_progress"
+                "t2",
+                "read_file",
+                kind="read",
+                status="in_progress",
             ),
         )
         await self._conn.session_update(

--- a/tests/cli/tui/_fake_acp_agent.py
+++ b/tests/cli/tui/_fake_acp_agent.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""A minimal ACP agent used to exercise the TUI's AcpTransport in tests.
+
+Run as ``python _fake_acp_agent.py`` (stdio). It speaks just enough ACP to:
+* answer ``initialize`` / ``new_session``
+* stream a thought, two text deltas and a completed tool call on ``prompt``
+* request permission when the prompt text contains ``need-permission``
+* honour ``cancel``
+
+This lets the transport be tested end-to-end without the heavy QwenPaw
+backend (agentscope, etc.).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from acp import (
+    Agent,
+    InitializeResponse,
+    LoadSessionResponse,
+    NewSessionResponse,
+    PROTOCOL_VERSION,
+    PromptResponse,
+    run_agent,
+    start_tool_call,
+    text_block,
+    tool_content,
+    update_agent_message,
+    update_agent_thought,
+    update_tool_call,
+    update_user_message,
+)
+from acp.schema import (
+    AgentCapabilities,
+    Implementation,
+    ListSessionsResponse,
+    PermissionOption,
+    SessionInfo,
+    ToolCallUpdate,
+)
+
+# A canned "past" session the resume tests can list and load.
+_PAST_SESSION_ID = "old-session-1"
+_PAST_SESSION_TITLE = "Earlier chat about Rust"
+_PAST_HISTORY = [
+    ("user", "How do I write a loop in Rust?"),
+    ("agent", "Use a `for` loop over a range."),
+    ("user", "Thanks!"),
+]
+
+
+class FakeAgent(Agent):
+    def __init__(self) -> None:
+        self._conn = None
+        self._cancel: dict[str, asyncio.Event] = {}
+        self._session_count = 0
+
+    def on_connect(self, conn) -> None:  # noqa: ANN001
+        self._conn = conn
+
+    async def initialize(
+        self,
+        protocol_version,
+        client_capabilities=None,
+        client_info=None,
+        **kw,
+    ):  # noqa: ANN001
+        return InitializeResponse(
+            protocol_version=PROTOCOL_VERSION,
+            agent_capabilities=AgentCapabilities(),
+            agent_info=Implementation(name="fake-agent", version="0.0.1"),
+        )
+
+    async def new_session(
+        self, cwd, additional_directories=None, mcp_servers=None, **kw
+    ):  # noqa: ANN001
+        self._session_count += 1
+        return NewSessionResponse(session_id=f"sess-{self._session_count}")
+
+    async def cancel(self, session_id, **kw):  # noqa: ANN001
+        ev = self._cancel.get(session_id)
+        if ev:
+            ev.set()
+
+    async def list_sessions(
+        self, cursor=None, cwd=None, additional_directories=None, **kw
+    ):  # noqa: ANN001
+        return ListSessionsResponse(
+            sessions=[
+                SessionInfo(
+                    session_id=_PAST_SESSION_ID,
+                    cwd=cwd or "",
+                    title=_PAST_SESSION_TITLE,
+                    updated_at="2026-01-01T00:00:00+00:00",
+                )
+            ]
+        )
+
+    async def load_session(
+        self,
+        cwd,
+        session_id,
+        additional_directories=None,
+        mcp_servers=None,
+        **kw,
+    ):  # noqa: ANN001
+        for role, text in _PAST_HISTORY:
+            if role == "user":
+                update = update_user_message(text_block(text))
+            else:
+                update = update_agent_message(text_block(text))
+            await self._conn.session_update(
+                session_id=session_id, update=update
+            )
+        return LoadSessionResponse()
+
+    async def prompt(
+        self, prompt, session_id, message_id=None, **kw
+    ):  # noqa: ANN001
+        text = ""
+        for block in prompt:
+            text += getattr(block, "text", "") or ""
+
+        cancel = asyncio.Event()
+        self._cancel[session_id] = cancel
+
+        await self._conn.session_update(
+            session_id=session_id,
+            update=update_agent_thought(text_block("thinking...")),
+        )
+        await self._conn.session_update(
+            session_id=session_id,
+            update=update_agent_message(text_block("Hello ")),
+        )
+        await self._conn.session_update(
+            session_id=session_id,
+            update=update_agent_message(text_block("world")),
+        )
+
+        if "need-permission" in text:
+            outcome = await self._conn.request_permission(
+                options=[
+                    PermissionOption(
+                        option_id="allow", name="Allow", kind="allow_once"
+                    ),
+                    PermissionOption(
+                        option_id="deny", name="Deny", kind="reject_once"
+                    ),
+                ],
+                session_id=session_id,
+                tool_call=ToolCallUpdate(
+                    tool_call_id="t1", title="dangerous_tool"
+                ),
+            )
+            chosen = getattr(
+                getattr(outcome, "outcome", None), "option_id", "cancelled"
+            )
+            await self._conn.session_update(
+                session_id=session_id,
+                update=update_agent_message(text_block(f" [perm:{chosen}]")),
+            )
+
+        # A tool call: start then complete.
+        await self._conn.session_update(
+            session_id=session_id,
+            update=start_tool_call(
+                "t2", "read_file", kind="read", status="in_progress"
+            ),
+        )
+        await self._conn.session_update(
+            session_id=session_id,
+            update=update_tool_call(
+                "t2",
+                status="completed",
+                content=[tool_content(text_block("file contents"))],
+            ),
+        )
+
+        if "loop" in text:
+            # Stay busy so the test can exercise cancel().
+            try:
+                await asyncio.wait_for(cancel.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                pass
+
+        self._cancel.pop(session_id, None)
+        return PromptResponse(stop_reason="end_turn")
+
+    async def close_session(self, session_id, **kw):  # noqa: ANN001
+        return None
+
+
+if __name__ == "__main__":
+    asyncio.run(run_agent(FakeAgent()))

--- a/tests/cli/tui/conftest.py
+++ b/tests/cli/tui/conftest.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Test fixtures: keep paw's state (logs) out of the real state dir."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+# Point paw's state dir at a temp location for the whole test session before
+# any paw module reads it.
+os.environ.setdefault(
+    "PAW_STATE_DIR", os.path.join(tempfile.gettempdir(), "paw-test-state")
+)

--- a/tests/cli/tui/conftest.py
+++ b/tests/cli/tui/conftest.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import os
 import tempfile
 
-# Point paw's state dir at a temp location for the whole test session before
-# any paw module reads it.
-os.environ.setdefault(
-    "PAW_STATE_DIR", os.path.join(tempfile.gettempdir(), "paw-test-state")
-)
+# Point the TUI's state dir at a unique temp location for the whole test
+# session before any TUI module reads it. A unique per-session dir (vs a fixed
+# path) avoids cross-run/cross-worker (xdist) pollution and leftover files.
+if "PAW_STATE_DIR" not in os.environ:
+    os.environ["PAW_STATE_DIR"] = tempfile.mkdtemp(prefix="paw-test-state-")

--- a/tests/cli/tui/test_acp_transport.py
+++ b/tests/cli/tui/test_acp_transport.py
@@ -141,7 +141,8 @@ async def test_list_sessions():
     try:
         await asyncio.wait_for(transport.start(), timeout=10.0)
         sessions = await asyncio.wait_for(
-            transport.list_sessions(), timeout=10.0
+            transport.list_sessions(),
+            timeout=10.0,
         )
     finally:
         await transport.close()
@@ -155,7 +156,8 @@ async def test_list_sessions():
 @pytest.mark.asyncio
 async def test_start_with_resume_loads_and_replays():
     transport = AcpTransport(
-        command=[sys.executable, FAKE], resume_session_id="old-session-1"
+        command=[sys.executable, FAKE],
+        resume_session_id="old-session-1",
     )
     try:
         connected = await asyncio.wait_for(transport.start(), timeout=10.0)
@@ -185,7 +187,8 @@ async def test_load_session_replays_history():
     try:
         await asyncio.wait_for(transport.start(), timeout=10.0)
         await asyncio.wait_for(
-            transport.load_session("old-session-1"), timeout=10.0
+            transport.load_session("old-session-1"),
+            timeout=10.0,
         )
         assert transport.session_id == "old-session-1"
         # The replayed history is delivered as session updates; drain until

--- a/tests/cli/tui/test_acp_transport.py
+++ b/tests/cli/tui/test_acp_transport.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""End-to-end test of AcpTransport against a fake ACP agent subprocess."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+from qwenpaw.cli.tui.events import (
+    BackendWarmed,
+    Connected,
+    PermissionRequest,
+    TextDelta,
+    ThoughtDelta,
+    ToolCall,
+    TransportError,
+    TurnEnded,
+    UserTurn,
+)
+from qwenpaw.cli.tui.transport.acp import AcpTransport
+
+FAKE = os.path.join(os.path.dirname(__file__), "_fake_acp_agent.py")
+
+
+def _transport() -> AcpTransport:
+    return AcpTransport(command=[sys.executable, FAKE])
+
+
+async def _collect_turn(transport: AcpTransport, *, timeout: float = 10.0):
+    """Drain events until TurnEnded; return the list."""
+    events = []
+
+    async def _run():
+        async for ev in transport.events():
+            events.append(ev)
+            if isinstance(ev, TurnEnded):
+                return
+
+    await asyncio.wait_for(_run(), timeout=timeout)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_start_and_basic_turn():
+    transport = _transport()
+    try:
+        connected = await asyncio.wait_for(transport.start(), timeout=10.0)
+        assert isinstance(connected, Connected)
+        assert connected.session_id == "sess-1"
+        assert connected.qwenpaw_version == "0.0.1"
+        assert connected.warming is True
+
+        await transport.send("hi there")
+        events = await _collect_turn(transport)
+    finally:
+        await transport.close()
+
+    assert any(isinstance(e, ThoughtDelta) for e in events)
+    assert any(isinstance(e, BackendWarmed) for e in events)
+    text = "".join(e.text for e in events if isinstance(e, TextDelta))
+    assert text == "Hello world"
+
+    # ACP sends a start (carries the title) then an update (carries status/
+    # output) sharing one tool_call_id; the UI merges them by id.
+    tools = [e for e in events if isinstance(e, ToolCall)]
+    assert any(t.title == "read_file" and t.kind == "read" for t in tools)
+    assert any(
+        t.tool_call_id == "t2"
+        and t.status == "completed"
+        and t.output == "file contents"
+        for t in tools
+    )
+    assert not any(isinstance(e, TransportError) for e in events)
+    assert isinstance(events[-1], TurnEnded)
+
+
+@pytest.mark.asyncio
+async def test_permission_allow():
+    transport = _transport()
+    try:
+        await asyncio.wait_for(transport.start(), timeout=10.0)
+        await transport.send("please need-permission now")
+
+        # Drive the turn, answering the permission prompt with "allow".
+        events = []
+
+        async def _run():
+            async for ev in transport.events():
+                events.append(ev)
+                if isinstance(ev, PermissionRequest):
+                    assert {o.option_id for o in ev.options} == {
+                        "allow",
+                        "deny",
+                    }
+                    await transport.resolve_permission(ev.request_id, "allow")
+                if isinstance(ev, TurnEnded):
+                    return
+
+        await asyncio.wait_for(_run(), timeout=10.0)
+    finally:
+        await transport.close()
+
+    text = "".join(e.text for e in events if isinstance(e, TextDelta))
+    assert "[perm:allow]" in text
+
+
+@pytest.mark.asyncio
+async def test_interrupt_cancels_turn():
+    transport = _transport()
+    try:
+        await asyncio.wait_for(transport.start(), timeout=10.0)
+        await transport.send("please loop forever")
+
+        events = []
+        seen_tool = asyncio.Event()
+
+        async def _run():
+            async for ev in transport.events():
+                events.append(ev)
+                if isinstance(ev, ToolCall) and ev.status == "completed":
+                    seen_tool.set()
+                if isinstance(ev, TurnEnded):
+                    return
+
+        runner = asyncio.create_task(_run())
+        await asyncio.wait_for(seen_tool.wait(), timeout=10.0)
+        await transport.interrupt()
+        await asyncio.wait_for(runner, timeout=10.0)
+    finally:
+        await transport.close()
+
+    assert isinstance(events[-1], TurnEnded)
+
+
+@pytest.mark.asyncio
+async def test_list_sessions():
+    transport = _transport()
+    try:
+        await asyncio.wait_for(transport.start(), timeout=10.0)
+        sessions = await asyncio.wait_for(
+            transport.list_sessions(), timeout=10.0
+        )
+    finally:
+        await transport.close()
+
+    assert len(sessions) == 1
+    assert sessions[0].session_id == "old-session-1"
+    assert sessions[0].title == "Earlier chat about Rust"
+    assert sessions[0].updated_at
+
+
+@pytest.mark.asyncio
+async def test_start_with_resume_loads_and_replays():
+    transport = AcpTransport(
+        command=[sys.executable, FAKE], resume_session_id="old-session-1"
+    )
+    try:
+        connected = await asyncio.wait_for(transport.start(), timeout=10.0)
+        # start() loaded the requested session instead of opening a new one.
+        assert connected.session_id == "old-session-1"
+        assert transport.session_id == "old-session-1"
+
+        events = []
+
+        async def _run():
+            async for ev in transport.events():
+                events.append(ev)
+                if len([e for e in events if isinstance(e, UserTurn)]) >= 2:
+                    return
+
+        await asyncio.wait_for(_run(), timeout=5.0)
+    finally:
+        await transport.close()
+
+    users = [e.text for e in events if isinstance(e, UserTurn)]
+    assert users == ["How do I write a loop in Rust?", "Thanks!"]
+
+
+@pytest.mark.asyncio
+async def test_load_session_replays_history():
+    transport = _transport()
+    try:
+        await asyncio.wait_for(transport.start(), timeout=10.0)
+        await asyncio.wait_for(
+            transport.load_session("old-session-1"), timeout=10.0
+        )
+        assert transport.session_id == "old-session-1"
+        # The replayed history is delivered as session updates; drain until
+        # both replayed user turns have arrived (a BackendWarmed event from
+        # the warmup may be interleaved ahead of them).
+        events = []
+
+        async def _run():
+            async for ev in transport.events():
+                events.append(ev)
+                if len([e for e in events if isinstance(e, UserTurn)]) >= 2:
+                    return
+
+        await asyncio.wait_for(_run(), timeout=5.0)
+    finally:
+        await transport.close()
+
+    user_turns = [e for e in events if isinstance(e, UserTurn)]
+    assert [u.text for u in user_turns] == [
+        "How do I write a loop in Rust?",
+        "Thanks!",
+    ]
+    replayed = "".join(e.text for e in events if isinstance(e, TextDelta))
+    assert "Use a `for` loop over a range." in replayed
+
+
+def test_session_agent_reads_meta():
+    from types import SimpleNamespace
+
+    from qwenpaw.cli.tui.transport.acp import _session_agent
+
+    # Agent id reported via the session response _meta.
+    sess = SimpleNamespace(field_meta={"qwenpaw.agent": "writer"})
+    assert _session_agent(sess) == "writer"
+
+    # Missing / unrelated meta → None (caller falls back to the requested id).
+    assert _session_agent(SimpleNamespace(field_meta={"other": 1})) is None
+    assert _session_agent(SimpleNamespace(field_meta=None)) is None

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+# Tests poke at the app's internals and use terse fixtures.
+# pylint: disable=protected-access,not-an-iterable,disallowed-name
+# pylint: disable=consider-using-with,unnecessary-lambda
+# pylint: disable=use-implicit-booleaness-not-comparison
+
 import asyncio
 
 import pytest
@@ -89,7 +94,7 @@ class FakeTransport:
                         PermissionOption("allow", "Allow", "allow_once"),
                         PermissionOption("deny", "Deny", "reject_once"),
                     ],
-                )
+                ),
             )
             return
         for chunk in ("Hello ", "there"):
@@ -101,7 +106,7 @@ class FakeTransport:
                 kind="read",
                 status="completed",
                 output="data",
-            )
+            ),
         )
         await self._queue.put(TurnEnded(stop_reason="end_turn"))
 
@@ -307,7 +312,7 @@ async def test_running_tool_expanded_then_collapsed_when_done():
                 kind="execute",
                 status="in_progress",
                 params="command: ls -la",
-            )
+            ),
         )
         await pilot.pause()
         panel = app.query(ToolPanel).first()
@@ -320,7 +325,7 @@ async def test_running_tool_expanded_then_collapsed_when_done():
                 kind="execute",
                 status="completed",
                 output="total 0",
-            )
+            ),
         )
         await pilot.pause()
         assert panel.collapsed is True  # done → collapsed, re-openable
@@ -336,10 +341,10 @@ async def test_tool_name_persists_after_completion_update():
         await pilot.pause()
         # start: real name; completion: no title, just status + output
         await app._dispatch(
-            ToolCall("t1", "execute_shell_command", status="in_progress")
+            ToolCall("t1", "execute_shell_command", status="in_progress"),
         )
         await app._dispatch(
-            ToolCall("t1", "", status="completed", output="done")
+            ToolCall("t1", "", status="completed", output="done"),
         )
         await pilot.pause()
         panel = app.query(ToolPanel).first()
@@ -361,7 +366,7 @@ async def test_finished_tool_header_is_informative():
                 status="completed",
                 params="command: ls -la /tmp\nshell: zsh",
                 output="x",
-            )
+            ),
         )
         await pilot.pause()
         panel = app.query(ToolPanel).first()
@@ -378,10 +383,10 @@ async def test_toggle_hides_finished_tools_only():
     async with app.run_test() as pilot:
         await pilot.pause()
         await app._dispatch(
-            ToolCall("done", "read_file", kind="read", status="completed")
+            ToolCall("done", "read_file", kind="read", status="completed"),
         )
         await app._dispatch(
-            ToolCall("live", "grep", kind="search", status="in_progress")
+            ToolCall("live", "grep", kind="search", status="in_progress"),
         )
         await pilot.pause()
         done = app._tools["done"]
@@ -447,7 +452,7 @@ async def test_friendly_mode_collapses_tool_chain_to_one_activity_line():
                 status="completed",
                 params="path: README.md",
                 output="...",
-            )
+            ),
         )
         await app._dispatch(
             ToolCall(
@@ -456,7 +461,7 @@ async def test_friendly_mode_collapses_tool_chain_to_one_activity_line():
                 kind="execute",
                 status="in_progress",
                 params="command: pytest -q",
-            )
+            ),
         )
         await pilot.pause()
 
@@ -533,8 +538,8 @@ async def test_slash_command_suggestions():
                     SlashCommand("model", "switch model"),
                     SlashCommand("agent", "change agent"),
                     SlashCommand("clear", "clear session"),
-                ]
-            )
+                ],
+            ),
         )
         menu = app.query_one(CommandMenu)
         prompt = app.query_one("#prompt")
@@ -697,7 +702,7 @@ async def test_resume_opens_picker_and_replays_selected_session():
             session_id="old-1",
             title="Earlier chat about Rust",
             updated_at="2026-01-01T00:00:00+00:00",
-        )
+        ),
     ]
     app = PawApp(transport)
     async with app.run_test() as pilot:
@@ -797,7 +802,8 @@ async def test_resume_autosuggest_lists_recent_ten():
     # 12 sessions; only the most recent 10 should become suggestions.
     transport.sessions = [
         SessionSummary(
-            session_id=f"{i:02d}cdef00" + "0" * 24, title=f"Chat {i}"
+            session_id=f"{i:02d}cdef00" + "0" * 24,
+            title=f"Chat {i}",
         )
         for i in range(12)
     ]
@@ -859,7 +865,8 @@ async def test_resume_flag_skips_welcome_and_replays_at_start():
 
 @pytest.mark.asyncio
 async def test_named_theme_command_applies_gallery_theme(
-    tmp_path, monkeypatch
+    tmp_path,
+    monkeypatch,
 ):
     monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
     transport = FakeTransport()
@@ -903,7 +910,7 @@ async def test_single_agent_label_per_turn_above_thinking():
         # above the first activity (the thinking lane).
         await app._dispatch(ThoughtDelta("hmm"))
         await app._dispatch(
-            ToolCall("t1", "grep", kind="search", status="in_progress")
+            ToolCall("t1", "grep", kind="search", status="in_progress"),
         )
         await app._dispatch(TextDelta("Done."))
         await pilot.pause()
@@ -941,7 +948,7 @@ async def test_text_after_tool_mounts_below_it():
         # that order (the post-tool text must not fold into the first bubble).
         await app._dispatch(TextDelta("Let me check."))
         await app._dispatch(
-            ToolCall("t1", "grep", kind="search", status="in_progress")
+            ToolCall("t1", "grep", kind="search", status="in_progress"),
         )
         await app._dispatch(TextDelta("Found it."))
         await pilot.pause()
@@ -993,7 +1000,7 @@ async def test_live_token_estimate_then_exact():
 
         # Exact usage for the call replaces the estimate (no tilde).
         await app._dispatch(
-            TokenUsage(input_tokens=1200, output_tokens=7, model="m")
+            TokenUsage(input_tokens=1200, output_tokens=7, model="m"),
         )
         await pilot.pause()
         assert "↓7" in bar.summary
@@ -1204,7 +1211,8 @@ async def test_file_path_paste_is_copied_to_attachment(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_embedded_escaped_file_path_paste_is_copied(
-    tmp_path, monkeypatch
+    tmp_path,
+    monkeypatch,
 ):
     monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
     source = tmp_path / "Screenshot 2026-06-06 at 9.31.17 PM.png"
@@ -1215,7 +1223,7 @@ async def test_embedded_escaped_file_path_paste_is_copied(
     async with app.run_test() as pilot:
         await pilot.pause()
         replacement = await app._handle_prompt_paste(
-            f"Can you describe this image? {escaped}"
+            f"Can you describe this image? {escaped}",
         )
         assert replacement is not None
         assert replacement.startswith("Can you describe this image? ")

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -1,0 +1,1240 @@
+# -*- coding: utf-8 -*-
+"""Pilot-driven smoke tests for the Textual app with a fake transport."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from textual.widgets import ListView
+
+from qwenpaw.cli.tui.app import PawApp
+from qwenpaw.cli.tui.__version__ import __version__
+from qwenpaw.cli.tui.events import (
+    AvailableCommands,
+    BackendWarmed,
+    Connected,
+    FileLink,
+    PermissionOption,
+    PermissionRequest,
+    SessionSummary,
+    SessionTitle,
+    SlashCommand,
+    TextDelta,
+    ThoughtDelta,
+    TokenUsage,
+    ToolCall,
+    TurnEnded,
+    UserTurn,
+)
+from qwenpaw.cli.tui.widgets import (
+    ActivityLine,
+    AgentLabel,
+    AssistantMessage,
+    CommandMenu,
+    ErrorMessage,
+    FileLinkBox,
+    InfoMessage,
+    PermissionModal,
+    QueuedMessage,
+    SessionPicker,
+    StatusBar,
+    ThoughtMessage,
+    ToolPanel,
+    UserMessage,
+    WelcomeMessage,
+    ThemePicker,
+)
+
+
+class FakeTransport:
+    """In-process transport that scripts a canned turn for the UI."""
+
+    def __init__(self, *, resume_session_id: str | None = None) -> None:
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.sent: list[str] = []
+        self.interrupted = False
+        self.resolved: list[tuple[str, str | None]] = []
+        self.closed = False
+        self._permission_mode = "none"
+        # Resume support: past sessions to offer, and a record of loads.
+        self.sessions: list[SessionSummary] = []
+        self.loaded: list[str] = []
+        self._resume_session_id = resume_session_id
+
+    async def start(self) -> Connected:
+        if self._resume_session_id is not None:
+            await self.load_session(self._resume_session_id)
+            return Connected(
+                session_id=self._resume_session_id,
+                agent="default",
+                qwenpaw_version="9.8.7",
+            )
+        return Connected(
+            session_id="sess-abc",
+            agent="default",
+            model="qwen-max",
+            qwenpaw_version="9.8.7",
+        )
+
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+        if "permission" in text:
+            await self._queue.put(
+                PermissionRequest(
+                    request_id="r1",
+                    title="dangerous_tool",
+                    options=[
+                        PermissionOption("allow", "Allow", "allow_once"),
+                        PermissionOption("deny", "Deny", "reject_once"),
+                    ],
+                )
+            )
+            return
+        for chunk in ("Hello ", "there"):
+            await self._queue.put(TextDelta(chunk))
+        await self._queue.put(
+            ToolCall(
+                "t1",
+                "read_file",
+                kind="read",
+                status="completed",
+                output="data",
+            )
+        )
+        await self._queue.put(TurnEnded(stop_reason="end_turn"))
+
+    async def interrupt(self) -> None:
+        self.interrupted = True
+        await self._queue.put(TurnEnded(stop_reason="cancelled"))
+
+    async def list_sessions(self) -> list[SessionSummary]:
+        return list(self.sessions)
+
+    async def load_session(self, session_id: str) -> None:
+        self.loaded.append(session_id)
+        # Replay a tiny saved transcript, like the real backend does.
+        await self._queue.put(UserTurn("How do I write a loop in Rust?"))
+        await self._queue.put(TextDelta("Use a `for` loop."))
+        await self._queue.put(UserTurn("Thanks!"))
+
+    def events(self):
+        async def _gen():
+            while True:
+                item = await self._queue.get()
+                if item is None:
+                    return
+                yield item
+
+        return _gen()
+
+    async def resolve_permission(self, request_id, option_id):
+        self.resolved.append((request_id, option_id))
+        await self._queue.put(TextDelta(f"[{option_id}]"))
+        await self._queue.put(TurnEnded())
+
+    async def close(self):
+        self.closed = True
+        await self._queue.put(None)
+
+
+class SlowStartTransport(FakeTransport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = asyncio.Event()
+
+    async def start(self) -> Connected:
+        await self.release.wait()
+        return await super().start()
+
+
+class WarmingTransport(FakeTransport):
+    async def start(self) -> Connected:
+        connected = await super().start()
+        return Connected(
+            session_id=connected.session_id,
+            agent=connected.agent,
+            model=connected.model,
+            qwenpaw_version=connected.qwenpaw_version,
+            warming=True,
+        )
+
+
+class QuietTransport(FakeTransport):
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+
+
+class WarmingQuietTransport(WarmingTransport):
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+
+
+@pytest.mark.asyncio
+async def test_basic_turn_renders():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # status bar picked up the Connected event
+        assert "qwen-max" in app.query_one("StatusBar").summary
+
+        prompt = app.query_one("#prompt")
+        prompt.value = "hi"
+        await pilot.press("enter")
+        # let the scripted events drain
+        for _ in range(10):
+            await pilot.pause()
+            if not app._busy:
+                break
+
+        assert transport.sent == ["hi"]
+        assert any(isinstance(w, UserMessage) for w in app.query(UserMessage))
+        assistant = app.query(AssistantMessage).first()
+        assert assistant.text == "Hello there"
+        tools = list(app.query(ToolPanel))
+        assert tools and tools[0]._status == "completed"
+
+
+class EmptyTurnTransport(FakeTransport):
+    """A turn that ends with no content — e.g. an unusable model."""
+
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+        await self._queue.put(TurnEnded(stop_reason="end_turn"))
+
+
+@pytest.mark.asyncio
+async def test_empty_turn_surfaces_error():
+    """A turn with no visible output reports an error, not a silent return."""
+    transport = EmptyTurnTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._model = "dashscope:qwen3-max"
+        app.query_one("#prompt").value = "hi"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if not app._busy:
+                break
+
+        assert not app._busy  # not stuck busy
+        errors = list(app.query(ErrorMessage))
+        assert errors, "expected an error message for an empty turn"
+        assert "No response" in errors[-1].content.plain
+        assert "dashscope:qwen3-max" in errors[-1].content.plain
+
+
+@pytest.mark.asyncio
+async def test_cancelled_empty_turn_is_not_an_error():
+    """Interrupting a turn before any output must not look like a failure."""
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(TurnEnded(stop_reason="cancelled"))
+        await pilot.pause()
+        assert not list(app.query(ErrorMessage))
+
+
+@pytest.mark.asyncio
+async def test_message_bubbles_are_transparent():
+    """Message bubbles blend into the background.
+
+    The background is a static colour and the bubble fills are transparent, so
+    text and bubble are consistent with the overall background; only a rounded
+    border outlines each one.
+    """
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "hi"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if not app._busy:
+                break
+
+        bubbles = [
+            app.query(UserMessage).first(),
+            app.query(AssistantMessage).first(),
+            app.query(AssistantMessage).first().query_one("Markdown"),
+            app.query(ToolPanel).first(),
+        ]
+        for bubble in bubbles:
+            assert (
+                bubble.styles.background.a == 0
+            ), f"{type(bubble).__name__} background is not transparent"
+
+
+@pytest.mark.asyncio
+async def test_assistant_bubble_has_no_trailing_blank_row():
+    """A single-line answer is border + one text row + border = 3 rows.
+
+    A trailing markdown paragraph margin would make it 4 (uneven bottom
+    padding); the last-child margin reset keeps top and bottom even.
+    """
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "hi"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if not app._busy:
+                break
+
+        assistant = app.query(AssistantMessage).first()
+        assert assistant.region.height == 3
+
+
+@pytest.mark.asyncio
+async def test_running_tool_expanded_then_collapsed_when_done():
+    """A tool stays open while running, then auto-collapses on completion."""
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        await app._dispatch(
+            ToolCall(
+                "t1",
+                "execute_shell_command",
+                kind="execute",
+                status="in_progress",
+                params="command: ls -la",
+            )
+        )
+        await pilot.pause()
+        panel = app.query(ToolPanel).first()
+        assert panel.collapsed is False  # running → expanded
+
+        await app._dispatch(
+            ToolCall(
+                "t1",
+                "execute_shell_command",
+                kind="execute",
+                status="completed",
+                output="total 0",
+            )
+        )
+        await pilot.pause()
+        assert panel.collapsed is True  # done → collapsed, re-openable
+
+
+@pytest.mark.asyncio
+async def test_tool_name_persists_after_completion_update():
+    """The agent only sends the name on the start event; the completion
+    update (title="") must not overwrite it back to a placeholder."""
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # start: real name; completion: no title, just status + output
+        await app._dispatch(
+            ToolCall("t1", "execute_shell_command", status="in_progress")
+        )
+        await app._dispatch(
+            ToolCall("t1", "", status="completed", output="done")
+        )
+        await pilot.pause()
+        panel = app.query(ToolPanel).first()
+        assert "execute_shell_command" in panel.title.plain
+
+
+@pytest.mark.asyncio
+async def test_finished_tool_header_is_informative():
+    """A completed tool with a generic title still shows kind + params."""
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(
+            ToolCall(
+                "t1",
+                "tool",
+                kind="execute",
+                status="completed",
+                params="command: ls -la /tmp\nshell: zsh",
+                output="x",
+            )
+        )
+        await pilot.pause()
+        panel = app.query(ToolPanel).first()
+        title = panel.title.plain
+        assert "execute" in title  # falls back to kind, not bare "tool"
+        assert "ls -la /tmp" in title  # primary param surfaced
+        assert "completed" not in title  # redundant status word dropped
+
+
+@pytest.mark.asyncio
+async def test_toggle_hides_finished_tools_only():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(
+            ToolCall("done", "read_file", kind="read", status="completed")
+        )
+        await app._dispatch(
+            ToolCall("live", "grep", kind="search", status="in_progress")
+        )
+        await pilot.pause()
+        done = app._tools["done"]
+        live = app._tools["live"]
+        assert done.has_class("hidden")
+        assert live.has_class("hidden")
+
+        await pilot.press("ctrl+i")
+        assert not done.has_class("hidden")
+        assert not live.has_class("hidden")
+
+        await pilot.press("ctrl+t")
+        assert done.has_class("hidden")  # finished → hidden
+        assert not live.has_class("hidden")  # running → still visible
+
+        await pilot.press("ctrl+t")
+        assert not done.has_class("hidden")  # toggled back for inspection
+
+
+@pytest.mark.asyncio
+async def test_thinking_collapsed_by_default():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(ThoughtDelta("pondering the question"))
+        await pilot.pause()
+        thought = app.query(ThoughtMessage).first()
+        assert thought.collapsed is True
+        assert thought.has_class("hidden")
+        activity = app.query(ActivityLine).first()
+        assert "thinking" in activity.content.plain
+
+
+@pytest.mark.asyncio
+async def test_new_thoughts_expand_when_inspection_mode_is_active():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+i")
+        await app._dispatch(ThoughtDelta("show the details"))
+        await pilot.pause()
+
+        thought = app.query(ThoughtMessage).first()
+        assert thought.collapsed is False
+        assert not thought.has_class("hidden")
+        assert app.query(ActivityLine).first().has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_friendly_mode_collapses_tool_chain_to_one_activity_line():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(ThoughtDelta("planning"))
+        await app._dispatch(
+            ToolCall(
+                "t1",
+                "read_file",
+                kind="read",
+                status="completed",
+                params="path: README.md",
+                output="...",
+            )
+        )
+        await app._dispatch(
+            ToolCall(
+                "t2",
+                "execute_shell_command",
+                kind="execute",
+                status="in_progress",
+                params="command: pytest -q",
+            )
+        )
+        await pilot.pause()
+
+        activities = list(app.query(ActivityLine))
+        assert len(activities) == 1
+        assert "execute_shell_command" in activities[0].content.plain
+        assert "pytest -q" in activities[0].content.plain
+        assert all(panel.has_class("hidden") for panel in app.query(ToolPanel))
+        assert app.query(ThoughtMessage).first().has_class("hidden")
+
+        await pilot.press("ctrl+i")
+        assert activities[0].has_class("hidden")
+        assert all(
+            not panel.has_class("hidden") for panel in app.query(ToolPanel)
+        )
+        assert not app.query(ThoughtMessage).first().has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_activity_line_stops_thinking_when_answer_streams():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(ThoughtDelta("pondering"))
+        await pilot.pause()
+        activity = app.query(ActivityLine).first()
+        assert "thinking" in activity.content.plain
+
+        # Once the visible answer begins, the activity row must stop animating
+        # "thinking" — the thought chain is complete.
+        await app._dispatch(TextDelta("Here is the answer."))
+        await pilot.pause()
+        assert "thinking" not in activity.content.plain
+        assert "thought complete" in activity.content.plain
+        # The reference is dropped so resumed reasoning starts a fresh line.
+        assert app._activity is None
+
+
+@pytest.mark.asyncio
+async def test_permission_modal_resolves():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = "do permission thing"
+        await pilot.press("enter")
+
+        # The modal should appear; pick the first (Allow) button.
+        for _ in range(10):
+            await pilot.pause()
+            if isinstance(app.screen, PermissionModal):
+                break
+        assert isinstance(app.screen, PermissionModal)
+        await pilot.press("enter")  # default-focused first button = Allow
+        for _ in range(10):
+            await pilot.pause()
+            if transport.resolved:
+                break
+
+        assert transport.resolved == [("r1", "allow")]
+
+
+@pytest.mark.asyncio
+async def test_slash_command_suggestions():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(
+            AvailableCommands(
+                commands=[
+                    SlashCommand("model", "switch model"),
+                    SlashCommand("agent", "change agent"),
+                    SlashCommand("clear", "clear session"),
+                ]
+            )
+        )
+        menu = app.query_one(CommandMenu)
+        prompt = app.query_one("#prompt")
+
+        # Plain text → no dropdown.
+        prompt.value = "hi"
+        await pilot.pause()
+        assert not menu.display
+
+        # "/" opens the dropdown with local commands plus agent commands.
+        prompt.value = "/"
+        await pilot.pause()
+        assert menu.display
+        assert menu.option_count >= 3
+        command_names = [command.name for command in app._suggester._commands]
+        assert {"model", "agent", "clear", "theme"}.issubset(command_names)
+
+        # Inline ghost completion offers the top match.
+        assert await app._suggester.get_suggestion("/mod") == "/model"
+
+        # Typing narrows the list.
+        prompt.value = "/a"
+        await pilot.pause()
+        assert menu.display
+        assert menu.selected == "agent"
+
+        # Tab accepts the highlighted command (note trailing space) and the
+        # menu steps aside instead of submitting.
+        await pilot.press("tab")
+        assert prompt.value == "/agent "
+        assert not menu.display
+        assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_slash_command_suggests_theme_arguments():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        menu = app.query_one(CommandMenu)
+        prompt = app.query_one("#prompt")
+
+        prompt.value = "/theme c"
+        await pilot.pause()
+        assert menu.display
+        assert menu.selected == "theme cyberpunk"
+
+        await pilot.press("tab")
+        assert prompt.value == "/theme cyberpunk "
+        assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_welcome_message_mounts_with_qwenpaw_greeting():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        welcome = app.query(WelcomeMessage).first()
+        plain = welcome.content.plain
+        assert "█" in plain
+        assert "▀" not in plain
+        assert plain.count("█") > 150
+        assert "QwenPaw 9.8.7" not in plain
+        assert f"TUI {__version__}" not in plain
+        assert "works for you" not in plain
+        assert "/theme" not in plain
+        assert len(plain.splitlines()) >= 6
+        status = app.query_one(StatusBar).summary
+        assert "QwenPaw 9.8.7" in status
+        assert f"TUI {__version__}" in status
+
+
+@pytest.mark.asyncio
+async def test_status_stays_starting_until_backend_connects():
+    transport = SlowStartTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert "starting" in app.query_one(StatusBar).summary
+        assert "ready" not in app.query_one(StatusBar).summary
+
+        transport.release.set()
+        for _ in range(10):
+            await pilot.pause()
+            if "ready" in app.query_one(StatusBar).summary:
+                break
+        assert "ready" in app.query_one(StatusBar).summary
+
+
+@pytest.mark.asyncio
+async def test_status_stays_warming_until_backend_warmup_finishes():
+    transport = WarmingTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        summary = app.query_one(StatusBar).summary
+        assert "warming" in summary
+        assert "ready" not in summary
+
+        await app._dispatch(BackendWarmed())
+        summary = app.query_one(StatusBar).summary
+        assert "ready" in summary
+        assert "warming" not in summary
+
+
+@pytest.mark.asyncio
+async def test_first_turn_shows_warming_until_backend_updates():
+    transport = WarmingQuietTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._submit("hello")
+        assert transport.sent == ["hello"]
+        summary = app.query_one(StatusBar).summary
+        assert "warming" in summary
+        assert "thinking" not in summary
+
+        await app._dispatch(TextDelta("hi"))
+        summary = app.query_one(StatusBar).summary
+        assert "thinking" in summary
+
+
+@pytest.mark.asyncio
+async def test_theme_command_opens_gallery_without_chat_turn():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = "/theme gallery"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.screen, ThemePicker)
+        assert transport.sent == []
+        app.screen.dismiss(None)
+
+
+@pytest.mark.asyncio
+async def test_resume_with_no_sessions_shows_info():
+    transport = FakeTransport()  # no past sessions
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "/resume "
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not isinstance(app.screen, SessionPicker)
+        infos = [i.content.plain for i in app.query(InfoMessage)]
+        assert any("No previous sessions yet" in text for text in infos)
+        assert transport.sent == []  # never forwarded to the agent
+
+
+@pytest.mark.asyncio
+async def test_resume_opens_picker_and_replays_selected_session():
+    transport = FakeTransport()
+    transport.sessions = [
+        SessionSummary(
+            session_id="old-1",
+            title="Earlier chat about Rust",
+            updated_at="2026-01-01T00:00:00+00:00",
+        )
+    ]
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "/resume list"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if isinstance(app.screen, SessionPicker):
+                break
+        assert isinstance(app.screen, SessionPicker)
+
+        # Pick the only session.
+        app.screen.dismiss("old-1")
+        for _ in range(10):
+            await pilot.pause()
+            if transport.loaded:
+                break
+
+        assert transport.loaded == ["old-1"]
+        # Welcome banner is cleared; the replayed transcript renders instead.
+        assert not list(app.query(WelcomeMessage))
+        user_msgs = [u.content.plain for u in app.query(UserMessage)]
+        assert "How do I write a loop in Rust?" in " ".join(user_msgs)
+        assert "Thanks!" in " ".join(user_msgs)
+        assistant = app.query(AssistantMessage).first()
+        assert "Use a `for` loop." in assistant.text
+        assert transport.sent == []
+        assert "old-1" in app.query_one(StatusBar).summary
+
+
+@pytest.mark.asyncio
+async def test_session_picker_arrow_keys_move_selection():
+    transport = FakeTransport()
+    transport.sessions = [
+        SessionSummary(session_id="s1", title="First chat"),
+        SessionSummary(session_id="s2", title="Second chat"),
+        SessionSummary(session_id="s3", title="Third chat"),
+    ]
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "/resume list"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if isinstance(app.screen, SessionPicker):
+                break
+        assert isinstance(app.screen, SessionPicker)
+        # Search input has focus, yet ↓/↑ move the list selection.
+        assert app.screen.query_one("#session-list", ListView).index == 0
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.screen.query_one("#session-list", ListView).index == 1
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.screen.query_one("#session-list", ListView).index == 2
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.screen.query_one("#session-list", ListView).index == 1
+
+        # Enter resumes whatever is highlighted (the 2nd session).
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if transport.loaded:
+                break
+        assert transport.loaded == ["s2"]
+
+
+@pytest.mark.asyncio
+async def test_theme_picker_arrow_keys_move_selection():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "/theme gallery"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if isinstance(app.screen, ThemePicker):
+                break
+        assert isinstance(app.screen, ThemePicker)
+        assert app.screen.query_one("#theme-list", ListView).index == 0
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.screen.query_one("#theme-list", ListView).index == 1
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.screen.query_one("#theme-list", ListView).index == 0
+        app.screen.dismiss(None)
+
+
+@pytest.mark.asyncio
+async def test_resume_autosuggest_lists_recent_ten():
+    transport = FakeTransport()
+    # 12 sessions; only the most recent 10 should become suggestions.
+    transport.sessions = [
+        SessionSummary(
+            session_id=f"{i:02d}cdef00" + "0" * 24, title=f"Chat {i}"
+        )
+        for i in range(12)
+    ]
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        for _ in range(10):
+            await pilot.pause()
+            if app._session_commands:
+                break
+        names = [c.name for c in app._menu._commands]
+        resume_entries = [n for n in names if n.startswith("resume ")]
+        assert len(resume_entries) == 10  # capped at the 10 most recent
+        # Short id + the session title as description, like /theme <id>.
+        assert "resume 00cdef00" in names
+        cmd = next(
+            c for c in app._menu._commands if c.name == "resume 00cdef00"
+        )
+        assert cmd.description == "Chat 0"
+
+
+@pytest.mark.asyncio
+async def test_resume_with_id_arg_resumes_directly_without_picker():
+    transport = FakeTransport()
+    full_id = "00cdef00" + "0" * 24
+    transport.sessions = [SessionSummary(session_id=full_id, title="Chat 0")]
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Trailing space closes the suggest menu so Enter submits the line.
+        app.query_one("#prompt").value = "/resume 00cdef00 "
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if transport.loaded:
+                break
+        # Resolved the short id to the full session and resumed it directly.
+        assert transport.loaded == [full_id]
+        assert not isinstance(app.screen, SessionPicker)
+        assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_resume_flag_skips_welcome_and_replays_at_start():
+    transport = FakeTransport(resume_session_id="old-1")
+    app = PawApp(transport, resume_session_id="old-1")
+    async with app.run_test() as pilot:
+        for _ in range(10):
+            await pilot.pause()
+            if transport.loaded:
+                break
+        # No welcome banner; the resumed transcript renders instead.
+        assert not list(app.query(WelcomeMessage))
+        assert transport.loaded == ["old-1"]
+        user_msgs = " ".join(u.content.plain for u in app.query(UserMessage))
+        assert "How do I write a loop in Rust?" in user_msgs
+        assert "Thanks!" in user_msgs
+        assert "old-1" in app.query_one(StatusBar).summary
+
+
+@pytest.mark.asyncio
+async def test_named_theme_command_applies_gallery_theme(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = "/theme cyberpunk"
+        await pilot.press("enter")
+        await pilot.pause()
+        saved = (tmp_path / "state" / "theme.json").read_text(encoding="utf-8")
+        assert "cyberpunk tiger-paw alley" in saved
+        assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_terminal_title_uses_session_then_title():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    titles: list[str] = []
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Capture what we write to the terminal.
+        app._set_terminal_title = lambda t: titles.append(t)  # type: ignore
+
+        app._on_connected(Connected(session_id="abcd1234ef", agent="a"))
+        assert titles[-1] == "QwenPaw abcd1234"
+
+        await app._dispatch(SessionTitle("Fix the parser"))
+        await pilot.pause()
+        assert titles[-1] == "QwenPaw Fix the parser"
+
+
+@pytest.mark.asyncio
+async def test_single_agent_label_per_turn_above_thinking():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # thinking → tool → answer: exactly one "qwenpaw" label, and it sits
+        # above the first activity (the thinking lane).
+        await app._dispatch(ThoughtDelta("hmm"))
+        await app._dispatch(
+            ToolCall("t1", "grep", kind="search", status="in_progress")
+        )
+        await app._dispatch(TextDelta("Done."))
+        await pilot.pause()
+
+        labels = list(app.query(AgentLabel))
+        assert len(labels) == 1
+        assert labels[0].content.plain == "qwenpaw"
+
+        transcript = app.query_one("#transcript")
+        types = [
+            type(w).__name__
+            for w in transcript.children
+            if isinstance(
+                w,
+                (
+                    AgentLabel,
+                    ActivityLine,
+                    ThoughtMessage,
+                    ToolPanel,
+                    AssistantMessage,
+                ),
+            )
+        ]
+        assert types[0] == "AgentLabel"
+        assert types[1] == "ActivityLine"
+
+
+@pytest.mark.asyncio
+async def test_text_after_tool_mounts_below_it():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # text → tool → more text: the transcript should read top-down in
+        # that order (the post-tool text must not fold into the first bubble).
+        await app._dispatch(TextDelta("Let me check."))
+        await app._dispatch(
+            ToolCall("t1", "grep", kind="search", status="in_progress")
+        )
+        await app._dispatch(TextDelta("Found it."))
+        await pilot.pause()
+
+        transcript = app.query_one("#transcript")
+        kinds = [
+            type(w).__name__
+            for w in transcript.children
+            if isinstance(w, (AssistantMessage, ToolPanel))
+        ]
+        assert kinds == ["AssistantMessage", "ToolPanel", "AssistantMessage"]
+
+        bubbles = list(app.query(AssistantMessage))
+        assert bubbles[0].text == "Let me check."
+        assert bubbles[1].text == "Found it."
+
+
+@pytest.mark.asyncio
+async def test_thinking_finalizes_to_thought_for():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(ThoughtDelta("pondering..."))
+        await pilot.pause()
+        thought = app.query(ThoughtMessage).first()
+        assert "thinking" in str(thought.title)
+        assert not thought._finished
+
+        # The visible answer beginning finalizes the thinking lane.
+        await app._dispatch(TextDelta("Here is the answer."))
+        await pilot.pause()
+        assert thought._finished
+        assert "thought for" in str(thought.title)
+
+
+@pytest.mark.asyncio
+async def test_live_token_estimate_then_exact():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one("StatusBar")
+
+        # Stream 40 chars of assistant text → ~10 token estimate, marked "~".
+        await app._dispatch(TextDelta("x" * 40))
+        await pilot.pause()
+        assert "↓~10" in bar.summary
+
+        # Exact usage for the call replaces the estimate (no tilde).
+        await app._dispatch(
+            TokenUsage(input_tokens=1200, output_tokens=7, model="m")
+        )
+        await pilot.pause()
+        assert "↓7" in bar.summary
+        assert "↓~" not in bar.summary
+        assert "↑1.2k" in bar.summary
+        assert app._tok_out == 7 and app._stream_chars == 0
+
+
+@pytest.mark.asyncio
+async def test_interrupt_action():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = (
+            "permission please"  # leaves it busy awaiting permission
+        )
+        await pilot.press("enter")
+        await pilot.pause()
+        # dismiss modal if present so escape hits the app
+        if isinstance(app.screen, PermissionModal):
+            app.screen.dismiss(None)
+            await pilot.pause()
+        app._busy = True
+        await app.action_interrupt()
+        assert transport.interrupted
+        # The status bar reflects the request immediately.
+        assert "interrupting" in app.query_one("StatusBar").summary
+
+
+@pytest.mark.asyncio
+async def test_escape_keypress_interrupts_when_busy():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._busy = True
+        app.query_one("#prompt").focus()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert transport.interrupted
+
+
+@pytest.mark.asyncio
+async def test_escape_clears_input_when_idle():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = "half-typed message"
+        prompt.focus()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert prompt.value == ""
+        assert not transport.interrupted  # idle esc never interrupts
+
+
+@pytest.mark.asyncio
+async def test_file_link_mounts_clickable_box_once():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        link = FileLink(uri="file:///tmp/report.pdf", name="report.pdf")
+        event = ToolCall(
+            "t1",
+            "send_file_to_user",
+            kind="other",
+            status="completed",
+            output="File sent successfully.",
+            links=(link,),
+        )
+        await app._dispatch(event)
+        await pilot.pause()
+
+        boxes = list(app.query(FileLinkBox))
+        assert len(boxes) == 1
+        assert boxes[0]._uri == "file:///tmp/report.pdf"
+
+        # A repeated update for the same tool call must not duplicate the link.
+        await app._dispatch(event)
+        await pilot.pause()
+        assert len(list(app.query(FileLinkBox))) == 1
+
+
+@pytest.mark.asyncio
+async def test_messages_queue_while_busy_and_drain_on_turn_end():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Pretend the agent is mid-turn.
+        app._busy = True
+        prompt = app.query_one("#prompt")
+
+        prompt.value = "first queued"
+        await pilot.press("enter")
+        prompt.value = "second queued"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # Both wait in the queue (dimmed), nothing sent yet.
+        assert [t for t, _ in app._queued] == ["first queued", "second queued"]
+        assert len(list(app.query(QueuedMessage))) == 2
+        assert transport.sent == []
+
+        # The turn ends → the first queued message is delivered.
+        await app._dispatch(TurnEnded())
+        for _ in range(10):
+            await pilot.pause()
+            if not app._busy:
+                break
+        # FakeTransport auto-ends each turn, so the second drains too.
+        for _ in range(10):
+            await pilot.pause()
+            if transport.sent == ["first queued", "second queued"]:
+                break
+        assert transport.sent == ["first queued", "second queued"]
+        assert app._queued == []
+        assert len(list(app.query(QueuedMessage))) == 0
+
+
+@pytest.mark.asyncio
+async def test_up_recalls_queued_message_to_edit():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._busy = True
+        prompt = app.query_one("#prompt")
+
+        prompt.value = "draft to fix"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert len(list(app.query(QueuedMessage))) == 1
+
+        # ↑ pulls the last queued message back into the input for editing.
+        await pilot.press("up")
+        await pilot.pause()
+        assert prompt.value == "draft to fix"
+        assert app._queued == []
+        assert len(list(app.query(QueuedMessage))) == 0
+        assert transport.sent == []
+
+
+@pytest.mark.asyncio
+async def test_multiline_prompt_sends_full_text():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = "first line\nsecond line"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if transport.sent:
+                break
+        assert transport.sent == ["first line\nsecond line"]
+
+
+@pytest.mark.asyncio
+async def test_model_command_is_forwarded_to_agent():
+    """paw no longer manages models — /model is QwenPaw's, so forwarded."""
+    transport = QuietTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#prompt").value = "/model dashscope:qwen-max"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert transport.sent == ["/model dashscope:qwen-max"]
+
+
+@pytest.mark.asyncio
+async def test_long_paste_is_stored_as_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        replacement = await app._handle_prompt_paste("x" * 2200)
+        assert replacement is not None
+        path = replacement.removeprefix("[pasted text: ").removesuffix("]")
+        assert "pasted-text" in path
+        assert open(path, encoding="utf-8").read() == "x" * 2200
+
+
+@pytest.mark.asyncio
+async def test_file_path_paste_is_copied_to_attachment(tmp_path, monkeypatch):
+    monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
+    source = tmp_path / "note.txt"
+    source.write_text("hello", encoding="utf-8")
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        replacement = await app._handle_prompt_paste(str(source))
+        assert replacement is not None
+        path = replacement.removeprefix("[attached file: ").removesuffix("]")
+        assert path.endswith(".txt")
+        assert open(path, encoding="utf-8").read() == "hello"
+
+
+@pytest.mark.asyncio
+async def test_embedded_escaped_file_path_paste_is_copied(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
+    source = tmp_path / "Screenshot 2026-06-06 at 9.31.17 PM.png"
+    source.write_bytes(b"png")
+    escaped = str(source).replace(" ", "\\ ")
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        replacement = await app._handle_prompt_paste(
+            f"Can you describe this image? {escaped}"
+        )
+        assert replacement is not None
+        assert replacement.startswith("Can you describe this image? ")
+        assert str(source) not in replacement
+        assert escaped not in replacement
+        path = replacement.rsplit("[attached file: ", 1)[1].removesuffix("]")
+        assert path.endswith(".png")
+        assert open(path, "rb").read() == b"png"
+
+
+@pytest.mark.asyncio
+async def test_theme_prompt_persists(tmp_path, monkeypatch):
+    monkeypatch.setenv("PAW_STATE_DIR", str(tmp_path / "state"))
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._apply_theme_prompt("rainbow workspace")
+        await pilot.pause()
+        assert "rainbow workspace" in (
+            tmp_path / "state" / "theme.json"
+        ).read_text(encoding="utf-8")

--- a/tests/cli/tui/test_app.py
+++ b/tests/cli/tui/test_app.py
@@ -15,7 +15,6 @@ import pytest
 from textual.widgets import ListView
 
 from qwenpaw.cli.tui.app import PawApp
-from qwenpaw.cli.tui.__version__ import __version__
 from qwenpaw.cli.tui.events import (
     AvailableCommands,
     BackendWarmed,
@@ -605,13 +604,13 @@ async def test_welcome_message_mounts_with_qwenpaw_greeting():
         assert "▀" not in plain
         assert plain.count("█") > 150
         assert "QwenPaw 9.8.7" not in plain
-        assert f"TUI {__version__}" not in plain
         assert "works for you" not in plain
         assert "/theme" not in plain
         assert len(plain.splitlines()) >= 6
         status = app.query_one(StatusBar).summary
         assert "QwenPaw 9.8.7" in status
-        assert f"TUI {__version__}" in status
+        # The TUI version is no longer shown — only QwenPaw's.
+        assert "TUI" not in status
 
 
 @pytest.mark.asyncio

--- a/tests/cli/tui/test_launch.py
+++ b/tests/cli/tui/test_launch.py
@@ -8,6 +8,9 @@ QwenPaw. The TUI now spawns ``qwenpaw acp`` using the *current* interpreter.
 
 from __future__ import annotations
 
+# Tests assert on transport internals and use a stub run_tui.
+# pylint: disable=protected-access,unused-argument
+
 import sys
 
 from click.testing import CliRunner

--- a/tests/cli/tui/test_launch.py
+++ b/tests/cli/tui/test_launch.py
@@ -17,18 +17,14 @@ from qwenpaw.cli.tui.launch import _build_transport, tui_cmd
 
 def test_default_transport_targets_current_interpreter():
     """Default spawns this very ``python -m qwenpaw acp`` (no PATH lookup)."""
-    transport, description = _build_transport(
-        agent=None, agent_cmd=None, resume=None
-    )
+    transport, description = _build_transport(agent=None, resume=None)
     assert transport._command == [sys.executable, "-m", "qwenpaw", "acp"]
     assert "qwenpaw acp" in description
 
 
 def test_default_transport_appends_agent_once():
     """``--agent`` is appended exactly once (by the transport)."""
-    transport, _ = _build_transport(
-        agent="writer", agent_cmd=None, resume=None
-    )
+    transport, _ = _build_transport(agent="writer", resume=None)
     assert transport._command == [
         sys.executable,
         "-m",
@@ -39,41 +35,23 @@ def test_default_transport_appends_agent_once():
     ]
 
 
-def test_explicit_agent_cmd_is_split():
-    transport, description = _build_transport(
-        agent=None, agent_cmd="qwenpaw acp", resume=None
-    )
-    assert transport._command == ["qwenpaw", "acp"]
-    assert "custom" in description
-
-
-def test_explicit_agent_cmd_with_agent_suffix():
-    transport, _ = _build_transport(
-        agent="writer", agent_cmd="qwenpaw acp", resume=None
-    )
-    assert transport._command == ["qwenpaw", "acp", "--agent", "writer"]
-
-
 def test_resume_is_threaded_through():
-    transport, _ = _build_transport(
-        agent=None, agent_cmd=None, resume="sess-123"
-    )
+    transport, _ = _build_transport(agent=None, resume="sess-123")
     assert transport._resume_session_id == "sess-123"
 
 
 def test_tui_help():
     result = CliRunner().invoke(tui_cmd, ["--help"])
     assert result.exit_code == 0
-    assert "--agent-cmd" in result.output
+    assert "--agent" in result.output
     assert "--resume" in result.output
 
 
 def test_tui_cmd_invokes_run_tui(monkeypatch):
     calls = {}
 
-    def fake_run_tui(*, agent, agent_cmd, resume):
+    def fake_run_tui(*, agent, resume):
         calls["agent"] = agent
-        calls["agent_cmd"] = agent_cmd
         calls["resume"] = resume
 
     monkeypatch.setattr("qwenpaw.cli.tui.launch.run_tui", fake_run_tui)
@@ -81,7 +59,6 @@ def test_tui_cmd_invokes_run_tui(monkeypatch):
     assert result.exit_code == 0
     assert calls == {
         "agent": "writer",
-        "agent_cmd": None,
         "resume": None,
     }
 

--- a/tests/cli/tui/test_launch.py
+++ b/tests/cli/tui/test_launch.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""Tests for launching the bundled TUI (`qwenpaw` / `qwenpaw tui`).
+
+Replaces paw's old ``test_cli.py`` + ``test_resolve.py``: the standalone
+``paw`` command and PATH-based resolution were dropped when the TUI moved into
+QwenPaw. The TUI now spawns ``qwenpaw acp`` using the *current* interpreter.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from click.testing import CliRunner
+
+from qwenpaw.cli.tui.launch import _build_transport, tui_cmd
+
+
+def test_default_transport_targets_current_interpreter():
+    """Default spawns this very ``python -m qwenpaw acp`` (no PATH lookup)."""
+    transport, description = _build_transport(
+        agent=None, agent_cmd=None, resume=None
+    )
+    assert transport._command == [sys.executable, "-m", "qwenpaw", "acp"]
+    assert "qwenpaw acp" in description
+
+
+def test_default_transport_appends_agent_once():
+    """``--agent`` is appended exactly once (by the transport)."""
+    transport, _ = _build_transport(
+        agent="writer", agent_cmd=None, resume=None
+    )
+    assert transport._command == [
+        sys.executable,
+        "-m",
+        "qwenpaw",
+        "acp",
+        "--agent",
+        "writer",
+    ]
+
+
+def test_explicit_agent_cmd_is_split():
+    transport, description = _build_transport(
+        agent=None, agent_cmd="qwenpaw acp", resume=None
+    )
+    assert transport._command == ["qwenpaw", "acp"]
+    assert "custom" in description
+
+
+def test_explicit_agent_cmd_with_agent_suffix():
+    transport, _ = _build_transport(
+        agent="writer", agent_cmd="qwenpaw acp", resume=None
+    )
+    assert transport._command == ["qwenpaw", "acp", "--agent", "writer"]
+
+
+def test_resume_is_threaded_through():
+    transport, _ = _build_transport(
+        agent=None, agent_cmd=None, resume="sess-123"
+    )
+    assert transport._resume_session_id == "sess-123"
+
+
+def test_tui_help():
+    result = CliRunner().invoke(tui_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "--agent-cmd" in result.output
+    assert "--resume" in result.output
+
+
+def test_tui_cmd_invokes_run_tui(monkeypatch):
+    calls = {}
+
+    def fake_run_tui(*, agent, agent_cmd, resume):
+        calls["agent"] = agent
+        calls["agent_cmd"] = agent_cmd
+        calls["resume"] = resume
+
+    monkeypatch.setattr("qwenpaw.cli.tui.launch.run_tui", fake_run_tui)
+    result = CliRunner().invoke(tui_cmd, ["--agent", "writer"])
+    assert result.exit_code == 0
+    assert calls == {
+        "agent": "writer",
+        "agent_cmd": None,
+        "resume": None,
+    }
+
+
+def test_bare_qwenpaw_launches_tui(monkeypatch):
+    """Bare ``qwenpaw`` (no subcommand) opens the TUI."""
+    from qwenpaw.cli.main import cli
+
+    launched = {"called": False}
+
+    def fake_run_tui(*args, **kwargs):
+        launched["called"] = True
+
+    monkeypatch.setattr("qwenpaw.cli.tui.launch.run_tui", fake_run_tui)
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code == 0
+    assert launched["called"] is True

--- a/tests/cli/tui/test_normalize.py
+++ b/tests/cli/tui/test_normalize.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+# ``assert normalize_update(...) == []`` reads clearer than ``not ...`` here.
+# pylint: disable=use-implicit-booleaness-not-comparison
+
 from acp import (
     start_tool_call,
     text_block,
@@ -62,7 +65,7 @@ def test_usage_meta_chunk_is_token_usage():
                 "outputTokens": 340,
                 "totalTokens": 1540,
                 "model": "qwen3.6-plus",
-            }
+            },
         },
     )
     assert normalize_update(chunk) == [
@@ -71,7 +74,7 @@ def test_usage_meta_chunk_is_token_usage():
             output_tokens=340,
             total_tokens=1540,
             model="qwen3.6-plus",
-        )
+        ),
     ]
 
 
@@ -82,7 +85,7 @@ def test_thought_chunk():
 
 def test_tool_call_start_and_update():
     start = normalize_update(
-        start_tool_call("t1", "grep", kind="search", status="in_progress")
+        start_tool_call("t1", "grep", kind="search", status="in_progress"),
     )
     assert start == [
         E.ToolCall(
@@ -90,7 +93,7 @@ def test_tool_call_start_and_update():
             title="grep",
             kind="search",
             status="in_progress",
-        )
+        ),
     ]
 
     done = normalize_update(
@@ -98,7 +101,7 @@ def test_tool_call_start_and_update():
             "t1",
             status="completed",
             content=[tool_content(text_block("3 hits"))],
-        )
+        ),
     )
     assert len(done) == 1
     ev = done[0]
@@ -121,10 +124,10 @@ def test_tool_call_extracts_resource_link():
                         uri="file:///tmp/report.pdf",
                         name="report.pdf",
                         mime_type="application/pdf",
-                    )
+                    ),
                 ),
             ],
-        )
+        ),
     )
     assert ev.output == "File sent successfully."
     assert ev.links == (
@@ -142,7 +145,7 @@ def test_tool_call_without_links_has_empty_tuple():
             "t10",
             status="completed",
             content=[tool_content(text_block("plain output"))],
-        )
+        ),
     )
     assert ev.links == ()
 
@@ -160,10 +163,10 @@ def test_tool_call_drops_non_local_link_schemes():
                         type="resource_link",
                         uri="https://evil.example/login",
                         name="totally-a-file",
-                    )
+                    ),
                 ),
             ],
-        )
+        ),
     )
     assert ev.links == ()
 
@@ -176,7 +179,7 @@ def test_tool_call_renders_raw_input_params():
             kind="execute",
             status="in_progress",
             raw_input={"command": "ls -la /tmp"},
-        )
+        ),
     )
     assert ev.params == "command: ls -la /tmp"
 
@@ -187,7 +190,7 @@ def test_tool_call_renders_raw_input_params():
             "t3",
             "grep",
             raw_input={"pattern": "TODO", "max": 5},
-        )
+        ),
     )
     assert multi.params == "pattern: TODO\nmax: 5"
 
@@ -210,7 +213,7 @@ def test_plan_update():
 
 def test_usage_update():
     out = normalize_update(
-        UsageUpdate(session_update="usage_update", used=1200, size=8000)
+        UsageUpdate(session_update="usage_update", used=1200, size=8000),
     )
     assert out == [E.Usage(used=1200, size=8000)]
 
@@ -229,8 +232,8 @@ def test_available_commands_update():
             commands=[
                 E.SlashCommand(name="model", description="switch model"),
                 E.SlashCommand(name="agent", description=""),
-            ]
-        )
+            ],
+        ),
     ]
 
 
@@ -238,7 +241,8 @@ def test_session_info_update_is_session_title():
     from acp.schema import SessionInfoUpdate
 
     upd = SessionInfoUpdate(
-        sessionUpdate="session_info_update", title="Fix the parser"
+        sessionUpdate="session_info_update",
+        title="Fix the parser",
     )
     assert normalize_update(upd) == [E.SessionTitle("Fix the parser")]
 

--- a/tests/cli/tui/test_normalize.py
+++ b/tests/cli/tui/test_normalize.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the ACP-update → TuiEvent normalizer."""
+
+from __future__ import annotations
+
+from acp import (
+    start_tool_call,
+    text_block,
+    tool_content,
+    update_agent_message,
+    update_agent_thought,
+    update_tool_call,
+)
+from acp.schema import (
+    AgentMessageChunk,
+    AgentPlanUpdate,
+    AvailableCommand,
+    AvailableCommandsUpdate,
+    PlanEntry,
+    ResourceContentBlock,
+    UsageUpdate,
+)
+
+from qwenpaw.cli.tui import events as E
+from qwenpaw.cli.tui.normalize import normalize_update
+
+
+def test_message_chunk_is_text_delta():
+    out = normalize_update(update_agent_message(text_block("hi")))
+    assert out == [E.TextDelta("hi")]
+
+
+def test_empty_message_chunk_is_dropped():
+    assert normalize_update(update_agent_message(text_block(""))) == []
+
+
+def test_message_chunk_with_error_meta_is_transport_error():
+    chunk = AgentMessageChunk(
+        sessionUpdate="agent_message_chunk",
+        content=text_block("Error: bad key"),
+        field_meta={"qwenpaw.error": True},
+    )
+    assert normalize_update(chunk) == [E.TransportError("Error: bad key")]
+
+
+def test_message_chunk_with_unrelated_meta_is_text():
+    chunk = AgentMessageChunk(
+        sessionUpdate="agent_message_chunk",
+        content=text_block("hello"),
+        field_meta={"other": 42},
+    )
+    assert normalize_update(chunk) == [E.TextDelta("hello")]
+
+
+def test_usage_meta_chunk_is_token_usage():
+    chunk = AgentMessageChunk(
+        sessionUpdate="agent_message_chunk",
+        content=text_block(""),
+        field_meta={
+            "usage": {
+                "inputTokens": 1200,
+                "outputTokens": 340,
+                "totalTokens": 1540,
+                "model": "qwen3.6-plus",
+            }
+        },
+    )
+    assert normalize_update(chunk) == [
+        E.TokenUsage(
+            input_tokens=1200,
+            output_tokens=340,
+            total_tokens=1540,
+            model="qwen3.6-plus",
+        )
+    ]
+
+
+def test_thought_chunk():
+    out = normalize_update(update_agent_thought(text_block("ponder")))
+    assert out == [E.ThoughtDelta("ponder")]
+
+
+def test_tool_call_start_and_update():
+    start = normalize_update(
+        start_tool_call("t1", "grep", kind="search", status="in_progress")
+    )
+    assert start == [
+        E.ToolCall(
+            tool_call_id="t1",
+            title="grep",
+            kind="search",
+            status="in_progress",
+        )
+    ]
+
+    done = normalize_update(
+        update_tool_call(
+            "t1",
+            status="completed",
+            content=[tool_content(text_block("3 hits"))],
+        )
+    )
+    assert len(done) == 1
+    ev = done[0]
+    assert ev.tool_call_id == "t1"
+    assert ev.status == "completed"
+    assert ev.output == "3 hits"
+
+
+def test_tool_call_extracts_resource_link():
+    # send_file_to_user → a text block + a resource_link content block.
+    [ev] = normalize_update(
+        update_tool_call(
+            "t9",
+            status="completed",
+            content=[
+                tool_content(text_block("File sent successfully.")),
+                tool_content(
+                    ResourceContentBlock(
+                        type="resource_link",
+                        uri="file:///tmp/report.pdf",
+                        name="report.pdf",
+                        mime_type="application/pdf",
+                    )
+                ),
+            ],
+        )
+    )
+    assert ev.output == "File sent successfully."
+    assert ev.links == (
+        E.FileLink(
+            uri="file:///tmp/report.pdf",
+            name="report.pdf",
+            mime_type="application/pdf",
+        ),
+    )
+
+
+def test_tool_call_without_links_has_empty_tuple():
+    [ev] = normalize_update(
+        update_tool_call(
+            "t10",
+            status="completed",
+            content=[tool_content(text_block("plain output"))],
+        )
+    )
+    assert ev.links == ()
+
+
+def test_tool_call_renders_raw_input_params():
+    [ev] = normalize_update(
+        start_tool_call(
+            "t2",
+            "execute_shell_command",
+            kind="execute",
+            status="in_progress",
+            raw_input={"command": "ls -la /tmp"},
+        )
+    )
+    assert ev.params == "command: ls -la /tmp"
+
+    # Multi-key input renders one ``key: value`` line each; non-string
+    # values are JSON-encoded.
+    [multi] = normalize_update(
+        start_tool_call(
+            "t3",
+            "grep",
+            raw_input={"pattern": "TODO", "max": 5},
+        )
+    )
+    assert multi.params == "pattern: TODO\nmax: 5"
+
+
+def test_plan_update():
+    upd = AgentPlanUpdate(
+        session_update="plan",
+        entries=[
+            PlanEntry(content="step 1", status="completed", priority="high"),
+            PlanEntry(content="step 2", status="pending", priority="low"),
+        ],
+    )
+    out = normalize_update(upd)
+    assert len(out) == 1
+    plan = out[0]
+    assert isinstance(plan, E.PlanUpdate)
+    assert [e.content for e in plan.entries] == ["step 1", "step 2"]
+    assert plan.entries[0].status == "completed"
+
+
+def test_usage_update():
+    out = normalize_update(
+        UsageUpdate(session_update="usage_update", used=1200, size=8000)
+    )
+    assert out == [E.Usage(used=1200, size=8000)]
+
+
+def test_available_commands_update():
+    upd = AvailableCommandsUpdate(
+        session_update="available_commands_update",
+        available_commands=[
+            AvailableCommand(name="model", description="switch model"),
+            AvailableCommand(name="agent", description=""),
+        ],
+    )
+    out = normalize_update(upd)
+    assert out == [
+        E.AvailableCommands(
+            commands=[
+                E.SlashCommand(name="model", description="switch model"),
+                E.SlashCommand(name="agent", description=""),
+            ]
+        )
+    ]
+
+
+def test_session_info_update_is_session_title():
+    from acp.schema import SessionInfoUpdate
+
+    upd = SessionInfoUpdate(
+        sessionUpdate="session_info_update", title="Fix the parser"
+    )
+    assert normalize_update(upd) == [E.SessionTitle("Fix the parser")]
+
+    # No title → nothing surfaced.
+    cleared = SessionInfoUpdate(sessionUpdate="session_info_update")
+    assert normalize_update(cleared) == []
+
+
+def test_unknown_update_is_empty():
+    class Weird:
+        session_update = "something_new"
+
+    assert normalize_update(Weird()) == []

--- a/tests/cli/tui/test_normalize.py
+++ b/tests/cli/tui/test_normalize.py
@@ -147,6 +147,27 @@ def test_tool_call_without_links_has_empty_tuple():
     assert ev.links == ()
 
 
+def test_tool_call_drops_non_local_link_schemes():
+    # A buggy/hostile agent emitting an http(s) resource_link must not become a
+    # one-click-openable FileLink; only file:// / local paths are surfaced.
+    [ev] = normalize_update(
+        update_tool_call(
+            "t11",
+            status="completed",
+            content=[
+                tool_content(
+                    ResourceContentBlock(
+                        type="resource_link",
+                        uri="https://evil.example/login",
+                        name="totally-a-file",
+                    )
+                ),
+            ],
+        )
+    )
+    assert ev.links == ()
+
+
 def test_tool_call_renders_raw_input_params():
     [ev] = normalize_update(
         start_tool_call(

--- a/tests/cli/tui/test_status_bar.py
+++ b/tests/cli/tui/test_status_bar.py
@@ -34,12 +34,13 @@ def test_initial_state_is_starting_not_ready():
     assert "ready" not in summary
 
 
-def test_versions_render_in_status_bar():
-    bar = StatusBar(tui_version="0.1.0")
+def test_version_renders_in_status_bar():
+    bar = StatusBar()
     bar.set(qwenpaw_version="1.1.10")
     summary = bar.summary
     assert "QwenPaw 1.1.10" in summary
-    assert "TUI 0.1.0" in summary
+    # Only QwenPaw's version is shown; the TUI version was removed.
+    assert "TUI" not in summary
 
 
 def test_estimate_is_marked_with_tilde():

--- a/tests/cli/tui/test_status_bar.py
+++ b/tests/cli/tui/test_status_bar.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Status bar: compact token formatting and the in-flight estimate marker."""
+
+from __future__ import annotations
+
+from qwenpaw.cli.tui.widgets.status_bar import StatusBar, _fmt_count
+
+
+def test_fmt_count_compacts_large_numbers():
+    assert _fmt_count(0) == "0"
+    assert _fmt_count(842) == "842"
+    assert _fmt_count(6370) == "6.4k"
+    assert _fmt_count(6000) == "6k"  # trailing .0 trimmed
+    assert _fmt_count(1_540_000) == "1.54M"
+    assert _fmt_count(2_000_000) == "2M"
+
+
+def test_token_counts_rendered_compactly():
+    bar = StatusBar()
+    bar.set(tok_in=1200, tok_out=6370)
+    summary = bar.summary
+    assert "↑1.2k" in summary
+    assert "↓6.4k" in summary
+    assert "~" not in summary  # exact, not an estimate
+
+
+def test_initial_state_is_starting_not_ready():
+    bar = StatusBar()
+    summary = bar.summary
+    assert "starting" in summary
+    assert "ready" not in summary
+
+
+def test_versions_render_in_status_bar():
+    bar = StatusBar(tui_version="0.1.0")
+    bar.set(qwenpaw_version="1.1.10")
+    summary = bar.summary
+    assert "QwenPaw 1.1.10" in summary
+    assert "TUI 0.1.0" in summary
+
+
+def test_estimate_is_marked_with_tilde():
+    bar = StatusBar()
+    bar.set(tok_in=1200, tok_out=512, tok_out_approx=True)
+    assert "↓~512" in bar.summary
+
+
+def test_input_not_shown_as_zero_during_first_stream():
+    # Before any usage arrives, input is unknown — show only the output
+    # estimate, never "↑0".
+    bar = StatusBar()
+    bar.set(tok_in=0, tok_out=10, tok_out_approx=True)
+    summary = bar.summary
+    assert "↓~10" in summary
+    assert "↑" not in summary
+
+
+def test_active_state_uses_spinner_glyph():
+    bar = StatusBar()
+    bar.set(state="thinking")
+    assert "thinking" in bar.summary
+    assert "● thinking" not in bar.summary

--- a/tests/cli/tui/test_status_bar.py
+++ b/tests/cli/tui/test_status_bar.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+# ``bar`` is a fine local name for a StatusBar widget under test.
+# pylint: disable=disallowed-name
+
 from qwenpaw.cli.tui.widgets.status_bar import StatusBar, _fmt_count
 
 

--- a/tests/cli/tui/test_welcome_message.py
+++ b/tests/cli/tui/test_welcome_message.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+# Tests exercise the widget's private rendering helpers directly.
+# pylint: disable=protected-access
+
 from qwenpaw.cli.tui.widgets.messages import (
     WelcomeMessage,
     _bright_dot_hex,
@@ -43,7 +46,7 @@ def test_welcome_logo_dots_are_brighter_than_current_letter_color():
         dot_color = _bright_dot_hex(letter_color)
 
         assert _relative_luminance(dot_color) > _relative_luminance(
-            letter_color
+            letter_color,
         )
 
 

--- a/tests/cli/tui/test_welcome_message.py
+++ b/tests/cli/tui/test_welcome_message.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Welcome logo rendering."""
+
+from __future__ import annotations
+
+from qwenpaw.cli.tui.widgets.messages import (
+    WelcomeMessage,
+    _bright_dot_hex,
+    _relative_luminance,
+)
+
+
+def test_welcome_logo_palette_changes_rendered_colors():
+    welcome = WelcomeMessage(("#071b2c", "#101f3c", "#163857"))
+    before = {str(span.style) for span in welcome._render_body().spans}
+
+    welcome._set_palette_colors(("#281b19", "#38261f", "#563722"))
+    rendered = welcome._render_body()
+    after = {str(span.style) for span in rendered.spans}
+
+    assert "█" in rendered.plain
+    assert before != after
+    assert "#ff9d4d" not in after
+
+
+def test_welcome_logo_gradient_animates_vertically():
+    welcome = WelcomeMessage(("#071b2c", "#101f3c", "#163857"))
+    first = [welcome._gradient_color(row) for row in range(4)]
+
+    welcome._frame += 1
+    second = [welcome._gradient_color(row) for row in range(4)]
+
+    assert len(set(first)) == 4
+    assert first != second
+
+
+def test_welcome_logo_dots_are_brighter_than_current_letter_color():
+    welcome = WelcomeMessage(("#071b2c", "#101f3c", "#163857"))
+
+    for frame in range(6):
+        welcome._frame = frame
+        letter_color = welcome._gradient_color(1)
+        dot_color = _bright_dot_hex(letter_color)
+
+        assert _relative_luminance(dot_color) > _relative_luminance(
+            letter_color
+        )
+
+
+def test_welcome_logo_rows_use_a_single_flat_color():
+    """No per-cell emboss: each row's letter blocks share one gradient color.
+
+    The old bevel shading tinted nearly every block lighter/darker, which read
+    as grainy "low-resolution" noise on a 6-row block font. The blocks in a row
+    should now all carry that row's flat gradient tone (only the eye dots,
+    which are deliberately brightened, may differ).
+    """
+    welcome = WelcomeMessage(("#071b2c", "#101f3c", "#163857"))
+    # Row 1 ("███   ███ ...") is all letter strokes, no dots.
+    row = welcome._render_pixel_rows()[1]
+    block_colors = {
+        str(span.style)
+        for span in row.spans
+        if row.plain[span.start : span.end] == "█"
+    }
+    assert block_colors == {welcome._gradient_color(1)}


### PR DESCRIPTION
## Description

Bundle the standalone `paw` terminal chat UI into QwenPaw so that running
`qwenpaw` with no subcommand opens an interactive TUI — **Phase 1** of the
design in `docs/design/qwenpaw-cli-tui.md`.

The UI is relocated behind its existing transport seam: widgets/app only ever
see a normalized `TuiEvent` union produced by a `TuiTransport`. ACP is just one
implementation. Phase 1 ships the proven **ACP-subprocess** transport as the
default (bare `qwenpaw` spawns `qwenpaw acp` via the current interpreter), so
every agent capability — tools, memory, permissions, slash commands, model
switching, session resume — comes for free and is testable without model keys.
A future in-process transport can replace the subprocess behind the same seam
(one-line default flip), so this PR makes no UI-level commitment to ACP.

What's here:
- Relocate the Textual app, widgets, `TuiEvent` union, `normalize.py`, and
  `TuiTransport`/`AcpTransport` into `src/qwenpaw/cli/tui/`.
- `launch.py`: build the transport (default `[sys.executable, -m, qwenpaw,
  acp]` — drives the same venv, no `PATH` lookup) and run the app; exposes
  `qwenpaw tui` (`--agent` / `--resume`).
- `cli/main.py`: register `tui` and set the root group
  `invoke_without_command=True` so bare `qwenpaw` opens the UI.
- Add `textual>=4.0` dependency.
- Port the TUI test suite to `tests/cli/tui/` (runs against a fake ACP agent —
  no heavy backend); add `test_launch.py`.
- Add design doc `docs/design/qwenpaw-cli-tui.md`.

**Related Issue:** N/A

**Security Considerations:** None. The TUI is a client that drives
`qwenpaw acp` over stdio; no change to channel auth or env/config handling.
The default transport spawns the current interpreter's `qwenpaw acp`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes — *pre-commit
  isn't installed in this env and the full hook set needs the backend; instead
  ran `black --line-length 79` and `flake8 --extend-ignore=E203` (matching the
  pinned hook config) on the changed files — clean (see evidence). Please
  re-run pre-commit in CI.*
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — added `docs/design/qwenpaw-cli-tui.md`
- [x] Ready for review

## Testing

Try it:

```bash
qwenpaw          # bare command opens the TUI
qwenpaw tui      # explicit, with --agent / --resume options
```

Automated suite (no heavy backend; drives a fake ACP agent — see the project's
lean-venv recipe):

```bash
PYTHONPATH=src python -m pytest tests/cli/tui/ \
  --noconftest -p no:cacheprovider -q -o asyncio_mode=auto
```

## Local Verification Evidence

```bash
# flake8 (matches the pinned hook: --extend-ignore=E203)
$ flake8 --extend-ignore=E203 src/qwenpaw/cli/tui src/qwenpaw/cli/main.py tests/cli/tui
# (no output — clean)

# black (line-length 79)
$ black --line-length 79 --check src/qwenpaw/cli/tui tests/cli/tui src/qwenpaw/cli/main.py
All done! ✨ 🍰 ✨
30 files would be left unchanged.

# TUI test suite
$ PYTHONPATH=src python -m pytest tests/cli/tui/ --noconftest -p no:cacheprovider -q -o asyncio_mode=auto
85 passed
```

Also verified against the real backend on this branch (agentscope 2.0): an
editable install into `~/.qwenpaw/venv` succeeded, and a live `qwenpaw acp`
process completed the ACP `initialize` + `new_session` handshake the TUI
performs on startup.

## Additional Notes

- **Scope:** Phase 1 = TUI client only. The server-side features the TUI can
  consume — session resume (`list_sessions`/`load_session`), command
  advertising, file links, agent/model meta, warmup-hygiene — are **not** in
  this PR. They live in PRs #4949 (merged to `main`) and #5027 (draft on
  `main`), but `main` is agentscope 1.x while `dev/agentscope2.0` is 2.0 and the
  relevant `runner.py` internals moved, so cherry-picking would conflict
  heavily. Those will be re-implemented natively against the 2.0 server as a
  follow-up. Until then the TUI **degrades gracefully**: `/resume` shows an
  empty list, the slash menu shows only local commands, and the status-bar
  agent/model are blank — nothing errors.
- `--agent-cmd` was intentionally omitted for simplicity; `AcpTransport` still
  accepts a custom `command`, so a remote/dev escape hatch can be re-exposed
  later without UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
