### PR TITLE
fix(local_models): parse llama.cpp server version without fixed-width slice

### DIFF
--- a/src/qwenpaw/local_models/llamacpp.py
+++ b/src/qwenpaw/local_models/llamacpp.py
@@ -339,9 +339,15 @@ class LlamaCppBackend:
             timeout=30,
         )
         lines = result.stderr_lines
+        prefix = "version:"
         for line in lines:
-            if line.startswith("version:"):
-                return line[9:13]
+            if line.startswith(prefix):
+                # Output looks like "version: 8514 (406f4e3f6)"; take the
+                # first whitespace-delimited token instead of a fixed-width
+                # slice, which breaks once the build number is not 4 digits.
+                tokens = line.removeprefix(prefix).split()
+                if tokens:
+                    return tokens[0]
         raise RuntimeError(
             "Unexpected version output from llama.cpp server: "
             f"{result.combined_output}",


### PR DESCRIPTION
## What

`LlamaCppBackend.get_version()` parsed the llama.cpp build number with a hardcoded `line[9:13]` slice, assuming the number is always exactly 4 digits.

## Why it's a bug

llama.cpp build numbers increase monotonically (currently ~8514). Once they reach 5 digits the fixed-width slice silently truncates:

| `llama-server --version` line | old `line[9:13]` | correct |
| --- | --- | --- |
| `version: 8514 (406f4e3f6)` | `8514` ✅ | `8514` |
| `version: 10005 (deadbeef)` | `1000` ❌ | `10005` |
| `version: 999 (abc1234)` | `999 ` (trailing space) ❌ | `999` |

The value is consumed as an `int` in `has_update()`:

```python
return int(latest_version[1:]) > int((await self.get_version()))
```

so once the build number crosses 10000, `get_version()` returns a wrong (truncated) number and update detection breaks — e.g. it keeps reporting that an update is available.

## Fix

Take the first whitespace-delimited token after the `version:` prefix instead of a fixed-width slice. As a small bonus, malformed output with no number now falls through to the existing `RuntimeError` instead of returning `""`.

## Tests

Added a parametrized regression test `test_get_version_parses_varied_build_number_widths` covering 3-, 4-, and 5-digit build numbers. The 5-digit case (`10005`) fails on the old code and passes on the new.

## Local checks

- `black==23.3.0 --line-length=79` — clean
- `flake8==6.1.0` (repo `.flake8`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
