### PR TITLE
fix(config): avoid IndexError on empty Exec= in Linux browser detection

### DIFF
--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -307,7 +307,13 @@ def _get_linux_default_browser() -> Tuple[Optional[str], Optional[str]]:
             with open(path, encoding="utf-8") as f:
                 for line in f:
                     if line.strip().startswith("Exec="):
-                        exe = line.split("=", 1)[1].strip().split()[0]
+                        # An empty/malformed "Exec=" yields no tokens; skip
+                        # rather than let [0] raise IndexError (callers rely
+                        # on a (None, None) result, never an exception).
+                        parts = line.split("=", 1)[1].strip().split()
+                        if not parts:
+                            break
+                        exe = parts[0]
                         if exe.startswith("/") and Path(exe).is_file():
                             return _linux_desktop_to_kind_and_path(exe)
                         for p in ["/usr/bin", "/usr/local/bin"]:


### PR DESCRIPTION
## What

`_get_linux_default_browser()` (used by `get_system_default_browser()`) parses the `.desktop` entry's `Exec=` line as:

```python
exe = line.split("=", 1)[1].strip().split()[0]
```

## Why it's a bug

If the matched line is an empty or whitespace-only `Exec=` (`Exec=`, `Exec=   `, `Exec=\t`), the trailing `.split()` returns `[]`, so `[0]` raises `IndexError`. It is **not** caught by the surrounding `except OSError`, so it escapes `get_system_default_browser()` — whose docstring promises a `(None, None)` result when detection fails:

> Returns (None, None) if detection fails or unsupported.

A malformed default-handler `.desktop` file therefore crashes browser detection instead of degrading gracefully.

## Fix

Guard the token list; an empty `Exec` is treated as "no executable found" (the existing `break` path → `(None, None)`).

## Tests

Added `tests/unit/config/test_config_utils.py` — a parametrized regression test for empty / whitespace-only `Exec=` values. It raises `IndexError` on the old code and passes on the new.

## Local checks

- `black==23.3.0 --line-length=79`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean
- `pytest tests/unit/config/test_config_utils.py` — **3 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
