### PR TITLE
fix(context): guard empty msg list in LightContextManager.pre_reply

### DIFF
--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -686,7 +686,9 @@ class LightContextManager(BaseContextManager):
         before the ReAct loop runs.
         """
         msg = kwargs.get("msg")
-        if msg is None:
+        if msg is None or (isinstance(msg, list) and not msg):
+            # Nothing to augment; an empty list would also make msg[-1]
+            # below raise IndexError.
             return None
 
         last_msg = msg[-1] if isinstance(msg, list) else msg


### PR DESCRIPTION
## What

`LightContextManager.pre_reply()` reads `msg = kwargs.get("msg")`, guards `msg is None`, then does:

```python
last_msg = msg[-1] if isinstance(msg, list) else msg
```

## Why it's a bug

For an empty list (`msg == []`), `isinstance(msg, list)` is `True` and `msg[-1]` raises `IndexError`. This runs **before** the `try/except` a few lines below, so the exception escapes the hook instead of being swallowed and logged. The existing `if msg is None` guard shows the "no message" case was meant to be handled — the empty-list form was simply missed.

## Fix

Treat an empty list the same as `None` (nothing to augment) and return early. Behavior is unchanged for `None` and non-empty inputs.

## Tests

Added `tests/unit/agents/context/test_light_context_manager.py` asserting `pre_reply` returns `None` for `msg=[]` (previously raised `IndexError`).

## Local checks

- `black==23.3.0 --line-length=79`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean (10/10)
- The unit test imports the full agentscope stack, so it runs in CI. The fix logic was verified directly: old → `IndexError` on `[]`, new → returns `None`; identical for `None` and non-empty inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
