### PR TITLE
fix(crons): tolerate invalid jobs in jobs.json instead of failing all

### DIFF
--- a/src/qwenpaw/app/crons/repo/json_repo.py
+++ b/src/qwenpaw/app/crons/repo/json_repo.py
@@ -8,10 +8,13 @@ import os
 import shutil
 import uuid
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote
 
+from pydantic import ValidationError
+
 from .base import BaseJobRepository
-from ..models import CronExecutionRecord, JobsFile
+from ..models import CronExecutionRecord, CronJobSpec, JobsFile
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +47,43 @@ class JsonJobRepository(BaseJobRepository):
             return JobsFile(version=1, jobs=[])
 
         data = json.loads(self._path.read_text(encoding="utf-8"))
-        return JobsFile.model_validate(data)
+        try:
+            return JobsFile.model_validate(data)
+        except ValidationError:
+            # A single malformed job must not break the whole workspace:
+            # keep the valid jobs, drop the invalid ones, and log each drop
+            # so it stays visible (issue #4835).
+            return self._load_tolerant(data)
+
+    def _load_tolerant(self, data: Any) -> JobsFile:
+        """Build a JobsFile, skipping jobs that fail validation."""
+        if not isinstance(data, dict):
+            logger.error(
+                "jobs file %s is not a JSON object; starting with no jobs",
+                self._path,
+            )
+            return JobsFile(version=1, jobs=[])
+
+        raw_jobs = data.get("jobs")
+        if not isinstance(raw_jobs, list):
+            raw_jobs = []
+
+        jobs: list[CronJobSpec] = []
+        for index, raw in enumerate(raw_jobs):
+            try:
+                jobs.append(CronJobSpec.model_validate(raw))
+            except ValidationError as exc:
+                logger.error(
+                    "Skipping invalid job at index %d in %s: %s",
+                    index,
+                    self._path,
+                    exc,
+                )
+
+        version = data.get("version", 1)
+        if not isinstance(version, int):
+            version = 1
+        return JobsFile(version=version, jobs=jobs)
 
     async def save(self, jobs_file: JobsFile) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/app/crons/test_json_repo.py
+++ b/tests/unit/app/crons/test_json_repo.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for JsonJobRepository tolerant loading (issue #4835)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.app.crons.repo.json_repo import JsonJobRepository
+
+_VALID_JOB = {
+    "name": "valid-job",
+    "task_type": "text",
+    "text": "hello",
+    "schedule": {"type": "cron", "cron": "0 9 * * *"},
+    "dispatch": {"target": {"user_id": "u1", "session_id": "s1"}},
+}
+_INVALID_JOB = {"name": "broken"}  # missing required schedule + dispatch
+
+
+def _write_jobs(path: Path, jobs: list) -> None:
+    path.write_text(
+        json.dumps({"version": 1, "jobs": jobs}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_keeps_valid_drops_invalid(tmp_path: Path) -> None:
+    jobs_path = tmp_path / "jobs.json"
+    _write_jobs(jobs_path, [_VALID_JOB, _INVALID_JOB])
+
+    result = await JsonJobRepository(jobs_path).load()
+
+    assert [job.name for job in result.jobs] == ["valid-job"]
+    assert result.version == 1
+
+
+@pytest.mark.asyncio
+async def test_load_all_valid_is_unchanged(tmp_path: Path) -> None:
+    jobs_path = tmp_path / "jobs.json"
+    _write_jobs(jobs_path, [_VALID_JOB])
+
+    result = await JsonJobRepository(jobs_path).load()
+
+    assert len(result.jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_load_only_invalid_returns_empty(tmp_path: Path) -> None:
+    jobs_path = tmp_path / "jobs.json"
+    _write_jobs(jobs_path, [_INVALID_JOB])
+
+    result = await JsonJobRepository(jobs_path).load()
+
+    assert result.jobs == []


### PR DESCRIPTION
Fixes #4835

## What

`JsonJobRepository.load()` parsed `jobs.json` with `JobsFile.model_validate(data)`, which validates the whole file atomically.

## Why it's a bug

A single malformed job — e.g. one missing `dispatch.target.session_id` — makes pydantic raise `ValidationError` for the entire `JobsFile`, so `load()` raises, `cron_manager` fails to start, and the whole workspace hangs (Console stuck loading):

```
ERROR | Failed to start service cron_manager: 1 validation error for JobsFile
jobs.14.dispatch.target.session_id - Field required
```

One typo in one job breaks the entire system.

## Fix

Keep the fast path; on `ValidationError`, fall back to per-job validation — load the valid jobs, skip the invalid ones, and log each drop. This matches the behavior requested in the issue (skip invalid, load valid, log errors). Well-formed files are unaffected.

## Tests

Added `tests/unit/app/crons/test_json_repo.py`:
- mixed valid + invalid → keeps only the valid job
- all valid → unchanged
- only invalid → empty (no crash)

## Local checks

- `black==23.3.0 --line-length=79`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean (10/10)
- `pytest tests/unit/app/crons/test_json_repo.py` — **3 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
