### PR TITLE
fix(backup): skip unreadable files instead of failing the whole backup

### DIFF
--- a/src/qwenpaw/backup/_ops/create_helpers.py
+++ b/src/qwenpaw/backup/_ops/create_helpers.py
@@ -46,12 +46,33 @@ def add_agent_workspaces(
         ws = Path(ref.workspace_dir).expanduser().resolve()
         if ws.is_dir():
             file_count = 0
+            skipped = 0
             for entry in sorted(ws.rglob("*")):
-                if entry.is_file():
-                    rel = entry.relative_to(ws).as_posix()
-                    arcname = f"{PREFIX_WORKSPACES}{aid}/{rel}"
+                if not entry.is_file():
+                    continue
+                rel = entry.relative_to(ws).as_posix()
+                arcname = f"{PREFIX_WORKSPACES}{aid}/{rel}"
+                try:
                     zf.write(entry, arcname)
-                    file_count += 1
+                except (PermissionError, OSError) as exc:
+                    # A file that can't be added (e.g. an open Chromium
+                    # cache file the backend has locked) must not abort
+                    # the whole backup; skip it and continue (#4916).
+                    skipped += 1
+                    logger.warning(
+                        "Skipping %s (could not be added to backup): %s",
+                        entry,
+                        exc,
+                    )
+                    continue
+                file_count += 1
+            if skipped:
+                logger.warning(
+                    "Agent '%s': skipped %d file(s) that could not be "
+                    "added to the backup",
+                    aid,
+                    skipped,
+                )
             logger.debug(
                 "Agent '%s': %d file(s) added from %s",
                 aid,


### PR DESCRIPTION
Fixes #4916

## What

`add_agent_workspaces()` (`src/qwenpaw/backup/_ops/create_helpers.py`) zips every file under each agent workspace with a bare `zf.write(entry, arcname)`.

## Why it's a bug

If any single file can't be read, `zf.write` raises and the **entire backup fails**. On Windows this reliably happens with the bundled browser: while an agent's Chromium is open, the backend holds locks on cache files, so:

```
PermissionError: [Errno 13] Permission denied:
  '...\workspaces\default\browser\user_data\Default\Cache\Cache_Data\data_0'
```

One locked cache file makes "Create Backup" fail completely — and everything after that file in the walk is lost too.

## Fix

Catch `PermissionError`/`OSError` per file, log a warning, skip the file, and continue — then log a per-agent summary of how many files were skipped. A backup should degrade gracefully on a few unreadable files rather than abort wholesale.

Scoped to `add_agent_workspaces` (the reported failure point). Happy to extend the same guard to the other `add_*` helpers if maintainers prefer.

## Tests

Added `tests/unit/backup/test_create_helpers.py`: a workspace with one writable and one "locked" file (a fake zip whose `write` raises `PermissionError`) — the backup keeps the readable file and skips the locked one instead of raising.

## Local checks

- `black==23.3.0 --line-length=79`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean (10/10)
- `pytest tests/unit/backup/test_create_helpers.py` — **1 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
