### PR TITLE
fix: change system theme toggle icon from computer to sun

### DIFF
--- a/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -40,9 +40,7 @@ describe("ThemeToggleButton", () => {
 
   it("shows sun-moon icon when system mode is active", () => {
     renderWithTheme("system");
-    expect(
-      document.querySelector(".lucide-sun-moon"),
-    ).toBeInTheDocument();
+    expect(document.querySelector(".lucide-sun-moon")).toBeInTheDocument();
   });
 
   it("renders without crashing", () => {

--- a/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -38,10 +38,10 @@ describe("ThemeToggleButton", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows sun icon when system mode is active", () => {
+  it("shows sun-moon icon when system mode is active", () => {
     renderWithTheme("system");
     expect(
-      document.querySelector('[data-icon="SparkSunLine"]'),
+      document.querySelector('[data-icon="SunMoonLine"]'),
     ).toBeInTheDocument();
   });
 

--- a/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -38,10 +38,10 @@ describe("ThemeToggleButton", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows computer icon when system mode is active", () => {
+  it("shows sun icon when system mode is active", () => {
     renderWithTheme("system");
     expect(
-      document.querySelector('[data-icon="SparkComputerLine"]'),
+      document.querySelector('[data-icon="SparkSunLine"]'),
     ).toBeInTheDocument();
   });
 

--- a/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
+++ b/console/src/components/ThemeToggleButton/ThemeToggleButton.test.tsx
@@ -41,7 +41,7 @@ describe("ThemeToggleButton", () => {
   it("shows sun-moon icon when system mode is active", () => {
     renderWithTheme("system");
     expect(
-      document.querySelector('[data-icon="SunMoonLine"]'),
+      document.querySelector(".lucide-sun-moon"),
     ).toBeInTheDocument();
   });
 

--- a/console/src/components/ThemeToggleButton/index.module.less
+++ b/console/src/components/ThemeToggleButton/index.module.less
@@ -14,6 +14,7 @@
   color: rgba(0, 0, 0, 0.65);
   padding: 0;
   flex-shrink: 0;
+  font-size: 24px;
 
   &:hover {
     background: rgba(97, 92, 237, 0.08);

--- a/console/src/components/ThemeToggleButton/index.tsx
+++ b/console/src/components/ThemeToggleButton/index.tsx
@@ -1,45 +1,15 @@
 import { Dropdown, Button, type MenuProps } from "antd";
 import { SparkMoonLine, SparkSunLine } from "@agentscope-ai/icons";
+import { SunMoon } from "lucide-react";
 import { useTheme, type ThemeMode } from "../../contexts/ThemeContext";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import styles from "./index.module.less";
 
-/** Sun & Moon combined icon representing "follow system" theme. */
-function SunMoonIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      width="1em"
-      height="1em"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      data-icon="SunMoonLine"
-    >
-      {/* Sun circle */}
-      <circle cx="12" cy="12" r="4" />
-      {/* Sun rays */}
-      <path d="M12 2v2" />
-      <path d="M12 20v2" />
-      <path d="m4.93 4.93 1.41 1.41" />
-      <path d="m17.66 17.66 1.41 1.41" />
-      <path d="M2 12h2" />
-      <path d="M20 12h2" />
-      <path d="m6.34 17.66-1.41 1.41" />
-      <path d="m19.07 4.93-1.41 1.41" />
-      {/* Moon crescent overlay */}
-      <path d="M17.7 13.7A7 7 0 0 1 10.3 6.3" />
-    </svg>
-  );
-}
-
 const ICONS: Record<ThemeMode, ReactNode> = {
   light: <SparkSunLine />,
   dark: <SparkMoonLine />,
-  system: <SunMoonIcon />,
+  system: <SunMoon size="1em" />,
 };
 
 export default function ThemeToggleButton() {

--- a/console/src/components/ThemeToggleButton/index.tsx
+++ b/console/src/components/ThemeToggleButton/index.tsx
@@ -1,9 +1,5 @@
 import { Dropdown, Button, type MenuProps } from "antd";
-import {
-  SparkMoonLine,
-  SparkSunLine,
-  SparkComputerLine,
-} from "@agentscope-ai/icons";
+import { SparkMoonLine, SparkSunLine } from "@agentscope-ai/icons";
 import { useTheme, type ThemeMode } from "../../contexts/ThemeContext";
 import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
@@ -12,7 +8,7 @@ import styles from "./index.module.less";
 const ICONS: Record<ThemeMode, ReactNode> = {
   light: <SparkSunLine />,
   dark: <SparkMoonLine />,
-  system: <SparkComputerLine />,
+  system: <SparkSunLine />,
 };
 
 export default function ThemeToggleButton() {

--- a/console/src/components/ThemeToggleButton/index.tsx
+++ b/console/src/components/ThemeToggleButton/index.tsx
@@ -5,10 +5,41 @@ import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import styles from "./index.module.less";
 
+/** Sun & Moon combined icon representing "follow system" theme. */
+function SunMoonIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      data-icon="SunMoonLine"
+    >
+      {/* Sun circle */}
+      <circle cx="12" cy="12" r="4" />
+      {/* Sun rays */}
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+      {/* Moon crescent overlay */}
+      <path d="M17.7 13.7A7 7 0 0 1 10.3 6.3" />
+    </svg>
+  );
+}
+
 const ICONS: Record<ThemeMode, ReactNode> = {
   light: <SparkSunLine />,
   dark: <SparkMoonLine />,
-  system: <SparkSunLine />,
+  system: <SunMoonIcon />,
 };
 
 export default function ThemeToggleButton() {

--- a/console/src/test/icons-mock.ts
+++ b/console/src/test/icons-mock.ts
@@ -32,4 +32,3 @@ export const SparkRusLine = makeIcon("SparkRusLine");
 // Theme toggle icons
 export const SparkMoonLine = makeIcon("SparkMoonLine");
 export const SparkSunLine = makeIcon("SparkSunLine");
-export const SparkComputerLine = makeIcon("SparkComputerLine");


### PR DESCRIPTION
Replace SparkComputerLine with SparkSunLine for the 'follow system' theme mode button, as the computer icon was unclear in meaning.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
