### PR TITLE
fix(matrix): use nio client.download for encrypted media

### DIFF
--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -1910,7 +1910,7 @@ class MatrixChannel(BaseChannel):
             return None
         if not self._client:
             logger.warning(
-                "MatrixChannel: _download_mxc called without client"
+                "MatrixChannel: _download_mxc called without client",
             )
             return None
         try:

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -1908,26 +1908,31 @@ class MatrixChannel(BaseChannel):
         """Download mxc:// to a local file; return path or None."""
         if not mxc_url.startswith("mxc://"):
             return None
-        try:
-            rest = mxc_url[6:]  # strip "mxc://"
-            server, media_id = rest.split("/", 1)
-            url = (
-                f"{self.homeserver}/_matrix/media/v3/download"
-                f"/{server}/{media_id}"
+        if not self._client:
+            logger.warning(
+                "MatrixChannel: _download_mxc called without client"
             )
-            headers = {"Authorization": f"Bearer {self.access_token}"}
-            if not self._http_client:
-                logger.warning("MatrixChannel: HTTP client not initialized")
+            return None
+        try:
+            resp = await self._client.download(mxc=mxc_url)
+            from nio.responses import DownloadError
+
+            if isinstance(resp, DownloadError):
+                logger.warning(
+                    "MatrixChannel: failed to download mxc %s: %s %s",
+                    mxc_url,
+                    type(resp).__name__,
+                    getattr(resp, "message", ""),
+                )
                 return None
-            resp = await self._http_client.get(url, headers=headers)
-            resp.raise_for_status()
+
             dest = self._media_dir() / filename
-            dest.write_bytes(resp.content)
+            dest.write_bytes(resp.body)
             logger.debug("MatrixChannel: downloaded %s → %s", mxc_url, dest)
             return str(dest)
         except Exception as exc:
-            logger.warning(
-                "MatrixChannel: failed to download %s: %s",
+            logger.exception(
+                "MatrixChannel: unexpected error downloading %s: %s",
                 mxc_url,
                 exc,
             )
@@ -1949,29 +1954,23 @@ class MatrixChannel(BaseChannel):
         if not mxc_url.startswith("mxc://") or not self._client:
             return None
         try:
-            rest = mxc_url[6:]
-            server, media_id = rest.split("/", 1)
-            url = (
-                f"{self.homeserver}/_matrix/media/v3/download"
-                f"/{server}/{media_id}"
-            )
-            headers = {"Authorization": f"Bearer {self.access_token}"}
-            if not self._http_client:
-                logger.warning("MatrixChannel: HTTP client not initialized")
+            resp = await self._client.download(mxc=mxc_url)
+            from nio.responses import DownloadError
+
+            if isinstance(resp, DownloadError):
+                logger.warning(
+                    "MatrixChannel: failed to download encrypted %s: %s %s",
+                    mxc_url,
+                    type(resp).__name__,
+                    getattr(resp, "message", ""),
+                )
                 return None
-            resp = await self._http_client.get(url, headers=headers)
-            resp.raise_for_status()
 
             from nio.crypto.attachments import decrypt_attachment
 
             jwk_key = key.get("k", "")
             sha256_hash = hashes.get("sha256", "")
-            plaintext = decrypt_attachment(
-                resp.content,
-                jwk_key,
-                sha256_hash,
-                iv,
-            )
+            plaintext = decrypt_attachment(resp.body, jwk_key, sha256_hash, iv)
 
             dest = self._media_dir() / filename
             dest.write_bytes(plaintext)
@@ -1982,7 +1981,7 @@ class MatrixChannel(BaseChannel):
             )
             return str(dest)
         except Exception as exc:
-            logger.warning(
+            logger.exception(
                 "MatrixChannel: failed to download encrypted %s: %s",
                 mxc_url,
                 exc,


### PR DESCRIPTION
## Description
Encrypted media messages sent in Matrix E2EE rooms were failing with "Encrypted media unavailable" in production logs, with empty exception strings making debugging impossible.
Root cause: `_download_mxc` and `_download_encrypted_mxc` used a manual httpx.AsyncClient to download media, bypassing matrix-nio's built-in authentication handling. When the download failed (e.g. auth issues with certain homeservers), the error was caught with logger.warning but the exception had an empty str() representation, producing logs like:
MatrixChannel: failed to download encrypted `mxc://server/media_id:`
This PR replaces the manual httpx approach with matrix-nio's `self._client.download()` which handles auth automatically via query parameters, and improves error logging with full stack traces.
Related Issue: N/A
Security Considerations: Auth token no longer manually constructed in HTTP headers; matrix-nio's internal auth mechanism is used instead.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
