### PR TITLE
fix(e2e): fix token usage test empty state detection in clean environment

### DIFF
--- a/e2e/tests/test_token_usage.py
+++ b/e2e/tests/test_token_usage.py
@@ -106,8 +106,12 @@ class TestTokenUsageDisplay:
         if not has_table and not has_empty:
             main = page.locator('main, [class*="content"], [class*="pageContent"]').first
             body = main if main.count() > 0 else page.locator("body")
-            page_text = body.inner_text()
-            if any(kw in page_text for kw in ("No token", "暂无", "no data", "No data", "暂无数据")):
+            page_text = body.inner_text().lower()
+            empty_state_keywords = (
+                "no token", "no tokens", "no data",
+                "no usage", "no usage data", "暂无", "暂无数据",
+            )
+            if any(kw in page_text for kw in empty_state_keywords):
                 logger.info("Page shows text-based empty state (no table or empty component rendered)")
                 log_test_result(test_name, "PASS", "Token usage page empty state validated")
                 return

--- a/e2e/tests/test_token_usage.py
+++ b/e2e/tests/test_token_usage.py
@@ -103,6 +103,15 @@ class TestTokenUsageDisplay:
         has_table = table_area.count() > 0 and table_area.is_visible(timeout=5000)
         has_empty = empty_state.count() > 0 and empty_state.is_visible(timeout=3000)
 
+        if not has_table and not has_empty:
+            main = page.locator('main, [class*="content"], [class*="pageContent"]').first
+            body = main if main.count() > 0 else page.locator("body")
+            page_text = body.inner_text()
+            if any(kw in page_text for kw in ("No token", "暂无", "no data", "No data", "暂无数据")):
+                logger.info("Page shows text-based empty state (no table or empty component rendered)")
+                log_test_result(test_name, "PASS", "Token usage page empty state validated")
+                return
+
         assert has_table or has_empty, \
             "Token Usage page should display data table or empty state"
 


### PR DESCRIPTION
## Summary

Fix `test_token_usage_overview` failure in nightly E2E ([run #27229106431](https://github.com/agentscope-ai/QwenPaw/actions/runs/27229106431)).

In a clean environment with no token data, the page renders plain-text empty state (e.g. "No token usage data") instead of an Ant Design `Empty` component or `<table>`. The test only checked for component-level empty states, so both `has_table` and `has_empty` were false, causing the assertion to fail.

## Changes

Add a scoped text-based fallback when neither table nor empty component is found:
- Case-insensitive matching (`.lower()`)
- Expanded keyword list (`no token`, `no tokens`, `no data`, `no usage`, `暂无`, etc.) to reduce flakiness from frontend copy changes

## Test Results

- Fork CI E2E full suite: 172 passed, 0 failed ([run #27251453004](https://github.com/yutai78786/QwenPaw/actions/runs/27251453004))

🤖 Generated with [Claude Code](https://claude.com/claude-code)