### PR TITLE
 feat(dingtalk): enable inline image preview and video playback card via webhook

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -1359,6 +1359,35 @@ class DingTalkChannel(BaseChannel):
             )
             return None
 
+    async def _generate_video_cover_media_id(self) -> Optional[str]:
+        """Generate and upload a placeholder cover image for video.
+
+        Creates a simple 640x360 dark solid color PNG using Pillow.
+        Returns the media_id of the uploaded cover image.
+        """
+        try:
+            from PIL import Image
+
+            import io
+
+            img = Image.new("RGB", (640, 360), color=(45, 45, 48))
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            png_data = buf.getvalue()
+
+            media_id = await self._upload_media(
+                png_data,
+                "image",
+                filename="video_cover.png",
+                content_type="image/png",
+            )
+            return media_id
+        except Exception:
+            logger.exception(
+                "dingtalk _generate_video_cover_media_id failed",
+            )
+            return None
+
     async def _fetch_bytes_from_url(self, url: str) -> Optional[bytes]:
         """Download binary content from URL. Returns None on failure.
 
@@ -1540,8 +1569,21 @@ class DingTalkChannel(BaseChannel):
                 return False
 
             if upload_type == "image":
-                # sendBySession supports image by picURL;
-                # but if we only have mediaId, send as file
+                # Use markdown with media_id for inline image preview
+                payload = {
+                    "msgtype": "markdown",
+                    "markdown": {
+                        "title": filename or "image",
+                        "text": f"![{filename or 'image'}]({media_id})",
+                    },
+                }
+                ok = await self._send_payload_via_session_webhook(
+                    session_webhook,
+                    payload,
+                )
+                if ok:
+                    return True
+                # Fallback to file card if markdown fails
                 payload = {
                     "msgtype": "file",
                     "file": {
@@ -1585,15 +1627,18 @@ class DingTalkChannel(BaseChannel):
                         "msgtype": "video",
                         "video": {
                             "videoMediaId": media_id,
+                            "videoType": ext or "mp4",
                             "duration": str(int(duration)),
                             "picMediaId": pic_media_id,
                         },
                     }
-                    return await self._send_payload_via_session_webhook(
+                    ok = await self._send_payload_via_session_webhook(
                         session_webhook,
                         payload,
                     )
-                # No picMediaId: send as file so user still gets the video
+                    if ok:
+                        return True
+                # No picMediaId or video send failed: send as file
                 payload = {
                     "msgtype": "file",
                     "file": {
@@ -1693,7 +1738,21 @@ class DingTalkChannel(BaseChannel):
 
         # ---------- send ----------
         if upload_type == "image":
-            # no public url -> safest is send as file (your current behavior)
+            # Use markdown with media_id for inline image preview
+            payload = {
+                "msgtype": "markdown",
+                "markdown": {
+                    "title": filename or "image",
+                    "text": f"![{filename or 'image'}]({media_id})",
+                },
+            }
+            ok = await self._send_payload_via_session_webhook(
+                session_webhook,
+                payload,
+            )
+            if ok:
+                return True
+            # Fallback to file card if markdown fails
             payload = {
                 "msgtype": "file",
                 "file": {
@@ -1728,6 +1787,11 @@ class DingTalkChannel(BaseChannel):
                 or getattr(part, "picMediaId", None)
                 or ""
             ).strip()
+            if not pic_media_id:
+                # Auto-generate placeholder cover image
+                pic_media_id = (
+                    await self._generate_video_cover_media_id()
+                ) or ""
             if pic_media_id:
                 duration = getattr(part, "duration", None)
                 if duration is None:
@@ -1736,15 +1800,18 @@ class DingTalkChannel(BaseChannel):
                     "msgtype": "video",
                     "video": {
                         "videoMediaId": media_id,
+                        "videoType": ext or "mp4",
                         "duration": str(int(duration)),
                         "picMediaId": pic_media_id,
                     },
                 }
-                return await self._send_payload_via_session_webhook(
+                ok = await self._send_payload_via_session_webhook(
                     session_webhook,
                     payload,
                 )
-            # No picMediaId: send as file so user still gets the video
+                if ok:
+                    return True
+            # Fallback to file card if video send fails or no cover
             payload = {
                 "msgtype": "file",
                 "file": {


### PR DESCRIPTION
## Description

Improve media display in DingTalk channel when sending via session webhook:

- Image: When no public URL is available, send images as markdown messages with media_id reference (![filename](@mediaId)) for inline preview, with fallback to file card if send fails.
- Video: Auto-generate a placeholder cover image (640×360 solid dark PNG via Pillow) when no picMediaId is provided, add required videoType field based on file extension, and send as msgtype: "video" for playable card display, with fallback to file card on failure.
- Open API path (scheduled tasks) remains unchanged.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
