### PR TITLE
perf(backend): Unblock Event Loop & Parallelize Startup

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -270,11 +270,21 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
     )
 
     # Migrations offloaded to thread pool — they do heavy file I/O.
+    # Workspace migration must finish first (others read its output).
+    # ensure_default/qa_agent both read-modify-write config.json so
+    # they stay sequential; skills migration only reads config + writes
+    # skill files so it can overlap safely.
     logger.debug("Checking for legacy config migration...")
     await asyncio.to_thread(migrate_legacy_workspace_to_default_agent)
-    await asyncio.to_thread(ensure_default_agent_exists)
-    await asyncio.to_thread(migrate_legacy_skills_to_skill_pool)
-    await asyncio.to_thread(ensure_qa_agent_exists)
+
+    async def _agent_ensures():
+        await asyncio.to_thread(ensure_default_agent_exists)
+        await asyncio.to_thread(ensure_qa_agent_exists)
+
+    await asyncio.gather(
+        _agent_ensures(),
+        asyncio.to_thread(migrate_legacy_skills_to_skill_pool),
+    )
 
     # Create core managers (instant — no I/O)
     logger.debug("Initializing MultiAgentManager...")
@@ -324,38 +334,38 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
     async def _background_startup():  # pylint: disable=too-many-statements
         try:
-            # Start all configured agents (truly parallel now)
-            await multi_agent_manager.start_all_configured_agents()
+            # ---- Parallel: agents + plugins + local model resume ----
+            # These are independent and together dominate startup time.
+
+            async def _load_plugins():
+                logger.debug("Initializing plugin system...")
+                from ..plugins.loader import PluginLoader
+                from ..config.utils import get_plugins_dir
+
+                plugin_dirs = [get_plugins_dir()]
+                loader = PluginLoader(plugin_dirs)
+                loader.registry.set_plugin_http_app(app)
+
+                cfg = load_config(get_config_path())
+                plugin_cfgs = cfg.plugins if hasattr(cfg, "plugins") else {}
+                logger.debug(
+                    f"Loading plugins with " f"{len(plugin_cfgs)} config(s)",
+                )
+                loaded = await loader.load_all_plugins(
+                    configs=plugin_cfgs,
+                )
+                logger.debug(f"Loaded {len(loaded)} plugin(s)")
+                return loader
+
+            plugin_loader, _ = await asyncio.gather(
+                _load_plugins(),
+                multi_agent_manager.start_all_configured_agents(),
+            )
 
             provider_manager.start_local_model_resume(local_model_manager)
 
-            # ---- Plugin System ----
-            logger.debug("Initializing plugin system...")
-
-            from ..plugins.loader import PluginLoader
+            # ---- Plugin providers (depends on plugins loaded) ----
             from ..plugins.runtime import RuntimeHelpers
-            from ..config.utils import get_plugins_dir
-
-            plugin_dirs = [
-                get_plugins_dir(),
-            ]
-
-            plugin_loader = PluginLoader(plugin_dirs)
-
-            plugin_loader.registry.set_plugin_http_app(app)
-
-            config = load_config(get_config_path())
-            plugin_configs = (
-                config.plugins if hasattr(config, "plugins") else {}
-            )
-            logger.debug(
-                f"Loading plugins with {len(plugin_configs)} config(s)",
-            )
-
-            loaded_plugins = await plugin_loader.load_all_plugins(
-                configs=plugin_configs,
-            )
-            logger.debug(f"Loaded {len(loaded_plugins)} plugin(s)")
 
             runtime_helpers = RuntimeHelpers(
                 provider_manager=provider_manager,
@@ -411,34 +421,57 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                         exc_info=True,
                     )
 
-            # ---- Startup Hooks ----
+            # ---- Startup Hooks (same priority run concurrently) ----
             logger.debug("Executing plugin startup hooks...")
             startup_hooks = plugin_loader.registry.get_startup_hooks()
-            for hook in startup_hooks:
-                try:
-                    logger.debug(
-                        f"Executing startup hook '{hook.hook_name}' "
-                        f"from plugin '{hook.plugin_id}' "
-                        f"(priority={hook.priority})",
-                    )
 
-                    result = hook.callback()
-                    if inspect.iscoroutine(
-                        result,
-                    ) or inspect.isawaitable(result):
-                        await result
+            from itertools import groupby
 
-                    logger.debug(
-                        f"Completed startup hook '{hook.hook_name}' "
-                        f"from plugin '{hook.plugin_id}'",
+            async def _run_hook(hook):
+                logger.debug(
+                    f"Executing startup hook '{hook.hook_name}' "
+                    f"from plugin '{hook.plugin_id}' "
+                    f"(priority={hook.priority})",
+                )
+                result = hook.callback()
+                if inspect.iscoroutine(
+                    result,
+                ) or inspect.isawaitable(result):
+                    await result
+                logger.debug(
+                    f"Completed startup hook '{hook.hook_name}' "
+                    f"from plugin '{hook.plugin_id}'",
+                )
+
+            for _priority, group in groupby(
+                startup_hooks,
+                key=lambda h: h.priority,
+            ):
+                hooks_in_group = list(group)
+                if len(hooks_in_group) == 1:
+                    try:
+                        await _run_hook(hooks_in_group[0])
+                    except Exception as e:
+                        logger.error(
+                            f"✗ Failed startup hook "
+                            f"'{hooks_in_group[0].hook_name}' "
+                            f"from '{hooks_in_group[0].plugin_id}'"
+                            f": {e}",
+                            exc_info=True,
+                        )
+                else:
+                    results = await asyncio.gather(
+                        *[_run_hook(h) for h in hooks_in_group],
+                        return_exceptions=True,
                     )
-                except Exception as e:
-                    logger.error(
-                        f"✗ Failed to execute startup hook "
-                        f"'{hook.hook_name}' "
-                        f"from plugin '{hook.plugin_id}': {e}",
-                        exc_info=True,
-                    )
+                    for hook, res in zip(hooks_in_group, results):
+                        if isinstance(res, Exception):
+                            logger.error(
+                                f"✗ Failed startup hook "
+                                f"'{hook.hook_name}' from "
+                                f"'{hook.plugin_id}': {res}",
+                                exc_info=True,
+                            )
 
             # ---- Approval Service ----
             try:

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -245,28 +245,36 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
     auto_register_from_env()
 
-    try:
-        from ..utils.telemetry import (
-            collect_and_upload_telemetry,
-            has_telemetry_been_collected,
-            is_telemetry_opted_out,
-        )
+    # Telemetry runs in a background thread to avoid blocking startup.
+    def _maybe_collect_telemetry():
+        try:
+            from ..utils.telemetry import (
+                collect_and_upload_telemetry,
+                has_telemetry_been_collected,
+                is_telemetry_opted_out,
+            )
 
-        if not is_telemetry_opted_out(
-            WORKING_DIR,
-        ) and not has_telemetry_been_collected(WORKING_DIR):
-            collect_and_upload_telemetry(WORKING_DIR)
-    except Exception:
-        logger.debug(
-            "Telemetry collection skipped due to error",
-            exc_info=True,
-        )
+            if not is_telemetry_opted_out(
+                WORKING_DIR,
+            ) and not has_telemetry_been_collected(WORKING_DIR):
+                collect_and_upload_telemetry(WORKING_DIR)
+        except Exception:
+            logger.debug(
+                "Telemetry collection skipped due to error",
+                exc_info=True,
+            )
 
+    asyncio.get_event_loop().run_in_executor(
+        None,
+        _maybe_collect_telemetry,
+    )
+
+    # Migrations offloaded to thread pool — they do heavy file I/O.
     logger.debug("Checking for legacy config migration...")
-    migrate_legacy_workspace_to_default_agent()
-    ensure_default_agent_exists()
-    migrate_legacy_skills_to_skill_pool()
-    ensure_qa_agent_exists()
+    await asyncio.to_thread(migrate_legacy_workspace_to_default_agent)
+    await asyncio.to_thread(ensure_default_agent_exists)
+    await asyncio.to_thread(migrate_legacy_skills_to_skill_pool)
+    await asyncio.to_thread(ensure_qa_agent_exists)
 
     # Create core managers (instant — no I/O)
     logger.debug("Initializing MultiAgentManager...")

--- a/src/qwenpaw/app/auth.py
+++ b/src/qwenpaw/app/auth.py
@@ -579,6 +579,26 @@ def _resolve_client_ip(request: Request) -> str:
     return request.client.host if request.client else ""
 
 
+# Cached config for hot-path auth checks (avoids disk read per request)
+_auth_config_cache: tuple = (0, None)  # (mtime_ns, config)
+
+
+def _get_config_cached():
+    """Return config with mtime-based cache (stat is ~1us vs read ~1ms)."""
+    global _auth_config_cache  # noqa: PLW0603
+    from ..config import load_config
+    from ..config.utils import get_config_path
+
+    config_path = get_config_path()
+    try:
+        mtime_ns = config_path.stat().st_mtime_ns
+    except OSError:
+        mtime_ns = 0
+    if mtime_ns != _auth_config_cache[0] or _auth_config_cache[1] is None:
+        _auth_config_cache = (mtime_ns, load_config())
+    return _auth_config_cache[1]
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """Middleware that checks Bearer token on protected routes."""
 
@@ -633,10 +653,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return True
 
         # Check if client host is in allow_no_auth_hosts whitelist
-        from ..config import load_config
-
         client_host = _resolve_client_ip(request)
-        config = load_config()
+        config = _get_config_cached()
         allowed_hosts = config.security.allow_no_auth_hosts
         return client_host in allowed_hosts
 

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -86,6 +86,9 @@ class ChannelManager:
         # Track enqueue tasks for graceful shutdown
         self._enqueue_tasks: set[asyncio.Task] = set()
 
+        # Track channel-start tasks for graceful shutdown
+        self._start_tasks: set[asyncio.Task] = set()
+
     @classmethod
     def from_env(
         cls,
@@ -484,15 +487,33 @@ class ChannelManager:
             f"Starting channels: {[g.channel for g in snapshot]}",
         )
 
-        # Start each channel
-        for g in snapshot:
+        # Fire-and-forget: channels connect in background so startup
+        # is not blocked by slow network handshakes (e.g. WebSocket).
+        async def _start_channel(g):
             try:
                 await g.start()
             except Exception:
-                logger.exception(f"failed to start channels={g.channel}")
+                logger.exception(
+                    f"failed to start channel={g.channel}",
+                )
+
+        for g in snapshot:
+            task = asyncio.create_task(_start_channel(g))
+            self._start_tasks.add(task)
+            task.add_done_callback(self._start_tasks.discard)
 
     async def stop_all(self) -> None:
         """Stop all channels and queue manager."""
+        # Cancel in-progress channel-start tasks
+        if self._start_tasks:
+            for task in self._start_tasks:
+                task.cancel()
+            await asyncio.wait(
+                self._start_tasks,
+                timeout=3.0,
+            )
+            self._start_tasks.clear()
+
         # Cancel all pending enqueue tasks
         if self._enqueue_tasks:
             logger.info(

--- a/src/qwenpaw/app/routers/fork.py
+++ b/src/qwenpaw/app/routers/fork.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import subprocess
 from pathlib import Path
 from typing import Optional
 from uuid import uuid4
@@ -176,7 +175,7 @@ def _write_fork_session(
     )
 
 
-def _create_worktree(
+async def _create_worktree(
     project_dir: Path,
     worktree_id: str,
 ) -> tuple[Path, str]:
@@ -188,25 +187,26 @@ def _create_worktree(
     worktree_path = project_dir / _WORKTREE_BASE / worktree_id
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
-    result = subprocess.run(
-        [
-            "git",
-            "worktree",
-            "add",
-            str(worktree_path),
-            "-b",
-            branch,
-        ],
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "worktree",
+        "add",
+        str(worktree_path),
+        "-b",
+        branch,
         cwd=str(project_dir),
-        capture_output=True,
-        text=True,
-        timeout=60,
-        check=False,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
     )
-    if result.returncode != 0:
+    _, stderr = await asyncio.wait_for(
+        proc.communicate(),
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        detail = stderr.decode("utf-8", errors="replace").strip()
         raise HTTPException(
             status_code=500,
-            detail=f"git worktree add failed: {result.stderr.strip()}",
+            detail=f"git worktree add failed: {detail}",
         )
 
     logger.info(
@@ -310,8 +310,7 @@ async def fork_agent(
     worktree_branch = ""
 
     if project_dir is not None:
-        wt_path, wt_branch = await asyncio.to_thread(
-            _create_worktree,
+        wt_path, wt_branch = await _create_worktree(
             project_dir,
             fork_id,
         )

--- a/src/qwenpaw/app/routers/fork.py
+++ b/src/qwenpaw/app/routers/fork.py
@@ -198,10 +198,18 @@ async def _create_worktree(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    _, stderr = await asyncio.wait_for(
-        proc.communicate(),
-        timeout=60,
-    )
+    try:
+        _, stderr = await asyncio.wait_for(
+            proc.communicate(),
+            timeout=60,
+        )
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise HTTPException(
+            status_code=500,
+            detail="git worktree add timed out (60s)",
+        ) from exc
     if proc.returncode != 0:
         detail = stderr.decode("utf-8", errors="replace").strip()
         raise HTTPException(

--- a/src/qwenpaw/app/runner/session.py
+++ b/src/qwenpaw/app/runner/session.py
@@ -6,6 +6,7 @@ Windows filenames cannot contain: \\ / : * ? " < > |
 This module wraps agentscope's SessionBase so that session_id and user_id
 are sanitized before being used as filenames.
 """
+import asyncio
 import os
 import re
 import json
@@ -244,6 +245,15 @@ class SafeJSONSession(SessionBase):
                 The directory to save the session state.
         """
         self.save_dir = save_dir
+        self._write_locks: dict[str, asyncio.Lock] = {}
+
+    def _get_write_lock(self, path: str) -> asyncio.Lock:
+        """Per-path lock to serialize read-modify-write cycles."""
+        lock = self._write_locks.get(path)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._write_locks[path] = lock
+        return lock
 
     def _get_save_path(
         self,
@@ -318,7 +328,12 @@ class SafeJSONSession(SessionBase):
             user_id=user_id,
             channel=channel,
         )
-        _atomic_write_json(session_save_path, state_dicts)
+        async with self._get_write_lock(session_save_path):
+            await asyncio.to_thread(
+                _atomic_write_json,
+                session_save_path,
+                state_dicts,
+            )
 
         logger.info(
             "Saved session state to %s successfully.",
@@ -387,24 +402,6 @@ class SafeJSONSession(SessionBase):
             channel=channel,
         )
 
-        if os.path.exists(session_save_path):
-            async with aiofiles.open(
-                session_save_path,
-                "r",
-                encoding="utf-8",
-                errors="surrogatepass",
-            ) as f:
-                content = await f.read()
-                states = _safe_json_loads(content, session_save_path)
-
-        else:
-            if not create_if_not_exist:
-                raise AgentStateError(
-                    session_id=session_id,
-                    message=f"Session file {session_save_path} does not exist",
-                )
-            states = {}
-
         path = key.split(".") if isinstance(key, str) else list(key)
         if not path:
             raise ConfigurationException(
@@ -412,15 +409,43 @@ class SafeJSONSession(SessionBase):
                 message="key path is empty",
             )
 
-        cur = states
-        for k in path[:-1]:
-            if k not in cur or not isinstance(cur[k], dict):
-                cur[k] = {}
-            cur = cur[k]
+        async with self._get_write_lock(session_save_path):
+            if os.path.exists(session_save_path):
+                async with aiofiles.open(
+                    session_save_path,
+                    "r",
+                    encoding="utf-8",
+                    errors="surrogatepass",
+                ) as f:
+                    content = await f.read()
+                    states = _safe_json_loads(
+                        content,
+                        session_save_path,
+                    )
+            else:
+                if not create_if_not_exist:
+                    raise AgentStateError(
+                        session_id=session_id,
+                        message=(
+                            f"Session file {session_save_path}"
+                            f" does not exist"
+                        ),
+                    )
+                states = {}
 
-        cur[path[-1]] = value
+            cur = states
+            for k in path[:-1]:
+                if k not in cur or not isinstance(cur[k], dict):
+                    cur[k] = {}
+                cur = cur[k]
 
-        _atomic_write_json(session_save_path, states)
+            cur[path[-1]] = value
+
+            await asyncio.to_thread(
+                _atomic_write_json,
+                session_save_path,
+                states,
+            )
 
         logger.info(
             "Updated session state key '%s' in %s successfully.",

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -259,7 +259,10 @@ class Workspace:
             ),
         )
 
-        # Priority 30: Channel manager
+        # Channel manager: only needs the runner reference (P10).
+        # Runs concurrent with other P20 services so its heavy SDK
+        # imports overlap with memory_manager init (~1s each).
+        # start_all() fires channel connections in background.
         sm.register(
             ServiceDescriptor(
                 name="channel_manager",
@@ -267,8 +270,8 @@ class Workspace:
                 post_init=create_channel_service,
                 start_method="start_all",
                 stop_method="stop_all",
-                priority=30,
-                concurrent_init=False,
+                priority=20,
+                concurrent_init=True,
             ),
         )
 


### PR DESCRIPTION
## Summary

This PR eliminates UI lag caused by synchronous I/O blocking the single-worker event loop, and reduces cold startup time from **5–8s to ~3.5s** by parallelizing independent initialization steps.

QwenPaw runs as a Tauri sidecar with a single uvicorn worker — any blocking I/O freezes all concurrent HTTP requests, SSE streams, and WebSocket frames. Users reported intermittent UI freezes during chat interactions and slow app launch times.

## Changes

### 1. `session.py` — Non-blocking session writes

**Problem**: `save_session_state` and `update_session_state` call `_atomic_write_json` (tempfile → fsync → os.replace) directly in async context. A 500KB session write blocks the event loop for 5–50ms on SSD, up to 200ms on HDD/encrypted FS. During this time, no other request can be served.

**Fix**: Wrap writes in `asyncio.to_thread()` with a per-path `asyncio.Lock`. The lock serializes writes to the same session file (preventing read-modify-write races), while `to_thread` keeps the event loop free.

**Impact**: Event loop probe test shows baseline collects **0 samples** (completely frozen) vs optimized collecting **399 samples** with P50 jitter of 14μs during the same 10×500KB write workload.

### 2. `auth.py` — mtime-based config cache

**Problem**: Every HTTP request invokes `load_config()` in the auth middleware — a full YAML file read + parse. At 100 req/s this is 100 unnecessary disk reads/sec for data that changes once per user action.

**Fix**: Cache the parsed config alongside its `st_mtime_ns`. Each request does a single `stat()` call (~1μs) and only reloads when the file is actually modified.

**Impact**: ~1000× reduction in per-request auth overhead.

### 3. `_app.py` — Parallel startup (Phase 1 & Phase 2)

**Problem**: Startup was largely sequential:
- 4 migration functions ran one after another
- Agent initialization completed before plugin loading began
- Startup hooks ran one-by-one regardless of priority

**Fix**:
- **Migrations**: `migrate_legacy_workspace` runs first (others depend on it), then `ensure_default_agent` + `ensure_qa_agent` (sequential — they share config.json) run in parallel with `migrate_legacy_skills` (read-only on config).
- **Phase 2**: `start_all_configured_agents()` and `load_all_plugins()` execute concurrently via `asyncio.gather` — the biggest single win since they're completely independent.
- **Startup hooks**: Grouped by priority; hooks at the same priority level run concurrently.
- **Telemetry**: Fire-and-forget in thread pool.
- **Migrations**: Offloaded to `asyncio.to_thread`.

**Impact**: Phase 2 wall time reduced from sequential sum (~4.7s) to max of the two slowest branches (~3.3s).

### 4. `channels/manager.py` — Fire-and-forget channel connections

**Problem**: `ChannelManager.start_all()` sequentially `await`s each channel's `start()` method. The Feishu/Lark WebSocket handshake alone takes 1–3s, blocking all subsequent service initialization.

**Fix**: Replace `await g.start()` with `asyncio.create_task(...)`. Channels connect in the background — the app doesn't need inbound message channels to be connected before serving HTTP requests.

**Impact**: Channel connection no longer blocks startup. Channels become available as their connections complete asynchronously.

### 5. `workspace/workspace.py` — Channel manager priority change

**Problem**: Channel manager was registered at priority 30 (sequential, after runner_start at P25). Its `post_init` (SDK imports + channel object construction) takes ~1.5s and ran sequentially after memory_manager (~1s at P20).

**Fix**: Move to priority 20 with `concurrent_init=True`. Channel creation only needs the runner object reference (available at P10), not the runner to be fully started. Now overlaps with memory_manager initialization.

**Impact**: Per-agent service startup reduced from ~2.8s (1.0s + 1.5s sequential) to ~1.5s (max of concurrent).

### 6. `routers/fork.py` — Async subprocess for git operations

**Problem**: `subprocess.run(["git", "worktree", "add", ...])` blocks the event loop for 0.5–2s while git creates a worktree.

**Fix**: Replace with `asyncio.create_subprocess_exec` + `asyncio.wait_for(timeout=60)`.

**Impact**: Fork operations no longer freeze the UI.

## Benchmark Results

| Metric | Before | After |
|--------|--------|-------|
| Startup time (cold) | 5–8s | ~3.5s |
| Event loop blocked during 10×500KB session writes | 100% (0 probe samples) | <1% (399 samples, P50=14μs) |
| Per-request auth config overhead | ~1ms (full YAML parse) | ~1μs (stat only) |
| Fork endpoint event loop block | 0.5–2s | 0 (async) |

## Test Results

- 206 app unit tests: PASSED
- 24 session-specific tests: PASSED
- Pre-commit (black, flake8, pylint, mypy): All PASSED
- 3 pre-existing failures in `test_agent_status.py` (unrelated, present on main)

## Files Changed

| File | Lines | Purpose |
|------|-------|---------|
| `src/qwenpaw/app/runner/session.py` | +77 -33 | asyncio.to_thread + per-path Lock |
| `src/qwenpaw/app/_app.py` | +177 -112 | Parallel migrations, agents∥plugins, concurrent hooks |
| `src/qwenpaw/app/auth.py` | +24 -2 | mtime config cache |
| `src/qwenpaw/app/channels/manager.py` | +12 -5 | Fire-and-forget channel start |
| `src/qwenpaw/app/routers/fork.py` | +35 -35 | async subprocess |
| `src/qwenpaw/app/workspace/workspace.py` | +9 -9 | Channel manager P20 concurrent |
| `design/BACKEND_CONCURRENCY_BENCHMARK.md` | +159 | Benchmark methodology & results |
