### PR TITLE
fix(build): use certifi CA bundle for Windows build verification

### DIFF
--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -112,6 +112,11 @@ if (Test-Path $CondaUnpack) {
     }
     
     # Verify the fix worked
+    # Use certifi CA bundle to avoid ssl.SSLError from
+    # corrupted certs in Windows certificate store on CI
+    $env:SSL_CERT_FILE = (
+      & $pythonExe -c "import certifi; print(certifi.where())"
+    )
     Write-Host "[build_win] Verifying fix..."
     & $pythonExe -c "from huggingface_hub import file_download; print('✓ huggingface_hub import OK')"
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
aiohttp creates a module-level SSL context on import, which fails when the CI runner's Windows certificate store contains corrupted entries (ssl.SSLError: ASN1 NOT_ENOUGH_DATA). Setting SSL_CERT_FILE to certifi's bundle bypasses the Windows store entirely.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
