### PR TITLE
fix(pack): compile-check discord after conda-unpack

### DIFF
--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -117,10 +117,15 @@ if (Test-Path $CondaUnpack) {
     if ($LASTEXITCODE -ne 0) {
       throw "CRITICAL: huggingface_hub still has import errors after reinstall. See issue.md"
     }
-    & $pythonExe -c "import discord; print('✓ discord.py import OK')"
-    if ($LASTEXITCODE -ne 0) {
-      throw "CRITICAL: discord.py still has import errors after reinstall."
+    $discordPackage = Join-Path $EnvRoot "Lib\site-packages\discord"
+    if (-not (Test-Path $discordPackage)) {
+      throw "CRITICAL: discord.py package not found after reinstall."
     }
+    & $pythonExe -m compileall -q $discordPackage
+    if ($LASTEXITCODE -ne 0) {
+      throw "CRITICAL: discord.py still has syntax errors after reinstall."
+    }
+    Write-Host "[build_win] discord.py compile OK"
     Write-Host "[build_win] ✓ conda-unpack corruption fixed successfully."
   } else {
     Write-Host "[build_win] WARN: wheels_cache not found at $WheelsCache" -ForegroundColor Yellow


### PR DESCRIPTION
﻿## Description

Replace the Windows packaging verification for the `discord.py` conda-unpack workaround with a compile-only check of the installed `discord` package.

The packaging script only needs to verify that `conda-unpack` did not corrupt Python source files containing Windows path escape sequences. Importing `discord` pulls in `aiohttp`, which initializes an SSL context at import time and can fail on hosted Windows runners when Python reads malformed certificates from the Windows certificate store. That failure is unrelated to whether the conda-unpack source rewrite was repaired.

**Related Issue:** Relates to the Windows desktop build failure seen in QwenPaw Desktop Build run `27266730441`.

**Security Considerations:** No runtime security-sensitive behavior changes. This only narrows a Windows packaging verification step so it checks package syntax instead of importing networking dependencies.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Manual verification:

- Parsed `scripts/pack/build_win.ps1` with the PowerShell parser successfully.
- Triggered QwenPaw Desktop Build on the fork branch: https://github.com/jinglinpeng/CoPaw/actions/runs/27277926721

The workflow_dispatch build is still in progress at PR creation time; this PR is draft while the packaging run completes.

## Local Verification Evidence

```bash
# PowerShell parser check
PowerShell parse OK

# Remote packaging validation
QwenPaw Desktop Build: https://github.com/jinglinpeng/CoPaw/actions/runs/27277926721
# Status at draft creation: in progress
```

## Additional Notes

This is the lower-risk packaging-only fix. It verifies the conda-unpack workaround without exercising `aiohttp` SSL initialization during build.
