### PR TITLE
fix(pack): use certifi for discord import check

### DIFF
--- a/scripts/pack/build_win.ps1
+++ b/scripts/pack/build_win.ps1
@@ -117,6 +117,14 @@ if (Test-Path $CondaUnpack) {
     if ($LASTEXITCODE -ne 0) {
       throw "CRITICAL: huggingface_hub still has import errors after reinstall. See issue.md"
     }
+    $certFile = (& $pythonExe -c "import certifi; print(certifi.where())").Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $certFile -or -not (Test-Path $certFile)) {
+      throw "CRITICAL: failed to resolve certifi certificate bundle for discord.py import verification."
+    }
+    $env:SSL_CERT_FILE = $certFile
+    $env:REQUESTS_CA_BUNDLE = $certFile
+    $env:CURL_CA_BUNDLE = $certFile
+    Write-Host "[build_win] Using certifi bundle for import verification: $certFile"
     & $pythonExe -c "import discord; print('✓ discord.py import OK')"
     if ($LASTEXITCODE -ne 0) {
       throw "CRITICAL: discord.py still has import errors after reinstall."


### PR DESCRIPTION
﻿## Description

Keep the Windows packaging `import discord` verification, but configure the packaged Python process to use its bundled `certifi` certificate bundle before importing `discord`.

The failing build path imports `discord`, which imports `aiohttp`; `aiohttp` creates a default SSL context during import. On hosted Windows runners, Python can fail while reading the Windows certificate store with `ssl.SSLError: [ASN1: NOT_ENOUGH_DATA]`. The installed application launcher already resolves and exports a certifi bundle for runtime. This change applies the same principle to the packaging-time import verification.

**Related Issue:** Relates to the Windows desktop build failure seen in QwenPaw Desktop Build run `27266730441`.

**Security Considerations:** This affects only the build-time verification environment. It does not disable certificate verification; it points SSL-related environment variables at the packaged certifi CA bundle before the import check.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Manual verification:

- Parsed `scripts/pack/build_win.ps1` with the PowerShell parser successfully.
- Triggered QwenPaw Desktop Build on the fork branch: https://github.com/jinglinpeng/CoPaw/actions/runs/27277958015

The workflow_dispatch build is still in progress at PR creation time; this PR is draft while the packaging run completes.

## Local Verification Evidence

```bash
# PowerShell parser check
PowerShell parse OK

# Remote packaging validation
QwenPaw Desktop Build: https://github.com/jinglinpeng/CoPaw/actions/runs/27277958015
# Status at draft creation: in progress
```

## Additional Notes

This is the runtime-like verification fix. It keeps the import check but avoids depending on the hosted runner's Windows certificate store during the packaging check.
