### PR TITLE
fix(pack): pin Windows OpenSSL for desktop build

### DIFF
--- a/scripts/pack/build_common.py
+++ b/scripts/pack/build_common.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ENV_PREFIX = "qwenpaw_pack_"
+# OpenSSL 3.5.7 regressed Windows cert-store DER cadata loading,
+# which breaks ssl.create_default_context() during aiohttp/discord imports.
+WINDOWS_OPENSSL_PIN = "openssl=3.5.6"
 
 # Packages affected by conda-unpack bug on Windows (conda-pack Issue #154)
 # conda-unpack modifies Python source files to replace path prefixes, but uses
@@ -72,6 +75,12 @@ def _pick_wheel(wheel_arg: str | None) -> Path:
     return wheels[0]
 
 
+def _windows_openssl_pin() -> list[str]:
+    if sys.platform != "win32":
+        return []
+    return [WINDOWS_OPENSSL_PIN]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Conda-pack QwenPaw (temp env).",
@@ -120,6 +129,12 @@ def main() -> int:
     )
 
     conda = _conda_exe()
+    openssl_pin = _windows_openssl_pin()
+    if openssl_pin:
+        print(
+            f"Pinning {WINDOWS_OPENSSL_PIN} on Windows to avoid "
+            "OpenSSL 3.5.7 cert-store regression.",
+        )
     try:
         _run(
             [
@@ -128,6 +143,7 @@ def main() -> int:
                 "-n",
                 env_name,
                 f"python={args.python}",
+                *openssl_pin,
                 "pip",
                 "-y",
             ],
@@ -201,6 +217,7 @@ def main() -> int:
                 "pip",
                 "setuptools",
                 "wheel",
+                *openssl_pin,
             ],
         )
         _run(
@@ -213,8 +230,29 @@ def main() -> int:
                 "install",
                 "-y",
                 "conda-pack",
+                *openssl_pin,
             ],
         )
+        if openssl_pin:
+            _run(
+                [
+                    conda,
+                    "run",
+                    "-n",
+                    env_name,
+                    "python",
+                    "-c",
+                    (
+                        "import ssl; "
+                        "version = ssl.OPENSSL_VERSION; "
+                        "print(f'OpenSSL OK: {version}'); "
+                        "raise SystemExit("
+                        "0 if version.startswith('OpenSSL 3.5.6 ') "
+                        "else f'Unexpected OpenSSL version: {version}'"
+                        ")"
+                    ),
+                ],
+            )
         if out_path.exists():
             out_path.unlink()
         pack_cmd = [


### PR DESCRIPTION
## Description

Pin the conda-pack Windows desktop environment to `openssl=3.5.6` when creating and maintaining the packed env.

Root cause: the floating conda environment started resolving `openssl-3.5.7` on Windows, which regressed Windows cert-store DER cadata loading. That breaks `ssl.create_default_context()` during import-time initialization in dependencies such as `aiohttp`/`discord.py`, causing the desktop packaging/runtime smoke path to fail with `ssl.SSLError: [ASN1: NOT_ENOUGH_DATA]`.

This keeps the pin Windows-only, reapplies it during later conda installs for `pip`/`setuptools`/`wheel` and `conda-pack`, and verifies the final packed env still reports OpenSSL 3.5.6 before packing.

**Related Issue:** Fixes #5086

**Security Considerations:** No auth, token, channel permission, or secret-handling changes. This only constrains the OpenSSL package version used by the Windows desktop packaging env to avoid a known regression.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `python -m py_compile scripts\pack\build_common.py`
- `python scripts\pack\build_common.py --help`
- `git diff --check`
- Fork packaging workflow started for this branch: https://github.com/jinglinpeng/CoPaw/actions/runs/27321175481

## Local Verification Evidence

```bash
python -m py_compile scripts\pack\build_common.py
# passed

python scripts\pack\build_common.py --help
# passed

git diff --check
# passed
```

## Additional Notes

This PR intentionally keeps the workaround scoped to Windows because the observed failure path is Python's Windows certificate store loading through OpenSSL 3.5.7. The legacy macOS job in the fork workflow is not affected by this pin because `_windows_openssl_pin()` returns no package constraint off Windows.