### PR TITLE
fix(security): fix Shield icon centering by targeting space-item child

### DIFF
--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -639,7 +639,9 @@
 
 /* ---- Host row (shield icon centering) ---- */
 
-.hostRow > .qwenpaw-space-item {
-  display: inline-flex;
-  align-items: center;
+.hostRow {
+  :global(.qwenpaw-space-item) {
+    display: inline-flex;
+    align-items: center;
+  }
 }

--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -639,7 +639,7 @@
 
 /* ---- Host row (shield icon centering) ---- */
 
-.hostRow {
+.hostRow > .qwenpaw-space-item {
   display: inline-flex;
   align-items: center;
 }


### PR DESCRIPTION
## Description

Fix the Shield icon not being vertically centered in the "Allow No Auth Hosts" page under Security settings.

The previous CSS style `.hostRow { display: inline-flex; align-items: center }` was applied to the parent Space component, but the icon alignment issue is actually caused by the Space's child elements (space-item). This fix targets the child element selector instead.

**Related Issue:** Fixes the styles from PR #4765

**Security Considerations:** None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Build the console assets and navigate to Security → Allow No Auth Hosts page to verify Shield icons are vertically centered with IP text.

## Additional Notes

**Before:**
```css
.hostRow {
  display: inline-flex;
  align-items: center;
}
```

**After:**
```css
.hostRow > .qwenpaw-space-item {
  display: inline-flex;
  align-items: center;
}
```
