### PR TITLE
fix(pack): pin openssl<3.5.7 to fix desktop startup failure (#5086)

### DIFF
--- a/scripts/pack/build_common.py
+++ b/scripts/pack/build_common.py
@@ -128,6 +128,12 @@ def main() -> int:
                 "-n",
                 env_name,
                 f"python={args.python}",
+                # OpenSSL 3.5.7 has a regression (upstream commit 738688d76206
+                # reworking asn1_d2i_read_bio) that breaks
+                # ssl.SSLContext.load_verify_locations(cadata=<DER>), which
+                # _load_windows_store_certs relies on. aiohttp then fails at
+                # import time and the desktop backend never starts. See #5086.
+                "openssl<3.5.7",
                 "pip",
                 "-y",
             ],


### PR DESCRIPTION
## Summary

- Pin `openssl<3.5.7` when creating the conda env that gets conda-packed into the desktop bundles (Windows + macOS share `scripts/pack/build_common.py`).

Fixes #5086.

## Root cause

OpenSSL 3.5.7 (published to conda channels on ~Jun 9) contains a regression introduced by upstream commit [`738688d76206`](https://github.com/openssl/openssl/commit/738688d76206) ("Add intelligence to asn1_d2i_read_bio for reading entire header without blocking for extra data", a backport for openssl/openssl#26272). It reworked `asn1_d2i_read_bio()` so that reading DER from a memory BIO now fails with `ASN1_R_NOT_ENOUGH_DATA`.

CPython's `ssl.SSLContext.load_verify_locations(cadata=<DER bytes>)` goes through exactly that code path (`BIO_new_mem_buf` + `d2i_X509_bio`). On Windows, `ssl._load_windows_store_certs` loads the system cert store via `cadata`, so `ssl.create_default_context()` raises. `aiohttp` calls it at import time (`connector.py`: `_SSL_CONTEXT_VERIFIED = _make_ssl_context(True)`), which crashes the backend before FastAPI starts, leaving the desktop stuck at "Waiting for HTTP ready...".

The packaging env was created with only `python=3.10` unpinned, so the v1.1.11 build (Jun 10) silently picked up the just-released openssl 3.5.7, while v1.1.10 (Jun 1) got an older, working version.

## Verification

Bisected on a Windows machine using the same env-creation path as `build_common.py`:

| Test | openssl 3.5.7 | openssl 3.5.6 |
|---|---|---|
| `ssl.create_default_context()` | FAIL `[ASN1: NOT_ENOUGH_DATA]` | OK |
| Load each of 56 Windows store DER certs individually via `cadata` | all 56 FAIL | all 56 OK |
| Load concatenated DER (what stdlib does) | FAIL | OK |

Also verified the new pin resolves correctly through the same `subprocess` invocation `build_common.py` uses: `conda create ... python=3.10 "openssl<3.5.7" pip` resolves to `openssl-3.5.6`.

## Follow-up

- Report the regression upstream to openssl and lift the pin once a fixed release (3.5.8+) is available.
