### PR TITLE
【Dont merge】style: polish toolcard styles and chat page layout

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
@@ -8,12 +8,15 @@
 import React, { useCallback, useState } from "react";
 import { Attachments } from "@agentscope-ai/chat";
 import { Audio, Video } from "@agentscope-ai/design";
-import { Image, ConfigProvider, Alert } from "antd";
+import { Image, ConfigProvider, Alert, message } from "antd";
 import type { Locale } from "antd/es/locale";
 import { DownloadOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { MediaInfo } from "./utils";
-import { openExternalLink } from "../../../../utils/openExternalLink";
+import {
+  downloadFileFromUrl,
+  DownloadCancelledError,
+} from "../../../../utils/downloadFileFromUrl";
 import styles from "./toolCards.module.less";
 
 export interface MediaPreviewProps {
@@ -93,7 +96,6 @@ const MediaPreview: React.FC<MediaPreviewProps> = ({ media }) => {
               {
                 uid: media.name,
                 name: media.name,
-                url: media.url,
                 status: "done",
               } as any
             }
@@ -101,7 +103,14 @@ const MediaPreview: React.FC<MediaPreviewProps> = ({ media }) => {
           {media.url && (
             <div
               className={styles.bubbleFileDownload}
-              onClick={() => openExternalLink(media.url)}
+              onClick={() => {
+                downloadFileFromUrl(media.url, media.name).catch((error) => {
+                  if (error instanceof DownloadCancelledError) return;
+                  message.error(
+                    error?.message || "Download failed",
+                  );
+                });
+              }}
             >
               <DownloadOutlined />
             </div>

--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
@@ -106,9 +106,7 @@ const MediaPreview: React.FC<MediaPreviewProps> = ({ media }) => {
               onClick={() => {
                 downloadFileFromUrl(media.url, media.name).catch((error) => {
                   if (error instanceof DownloadCancelledError) return;
-                  message.error(
-                    error?.message || "Download failed",
-                  );
+                  message.error(error?.message || "Download failed");
                 });
               }}
             >

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -58,7 +58,7 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
             {icon}
           </span>
         )}
-        <span className={styles.toolCallLabel}>
+        <span className={styles.toolCallLabel} title={title}>
           {title}
           {isLoading && t("tool.loading")}
         </span>

--- a/console/src/components/Chat/ToolCards/shared/toolCards.module.less
+++ b/console/src/components/Chat/ToolCards/shared/toolCards.module.less
@@ -22,7 +22,7 @@
 }
 
 .toolCallCompactSummary {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 6px;
   font-size: 13px;
@@ -30,6 +30,7 @@
   user-select: none;
   list-style: none;
   padding: 2px 0;
+  max-width: 100%;
 
   &::-webkit-details-marker {
     display: none;
@@ -73,6 +74,10 @@
 
 .toolCallLabel {
   color: var(--ant-color-text, rgba(0, 0, 0, 0.88));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 0 1 auto;
 
   &:hover {
     color: var(--ant-color-primary, #1677ff);

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -77,7 +77,10 @@ import {
   type CopyableResponse,
   type RuntimeLoadingBridgeApi,
 } from "./utils";
-import { openExternalLink } from "../../utils/openExternalLink";
+import {
+  downloadFileFromUrl,
+  DownloadCancelledError,
+} from "../../utils/downloadFileFromUrl";
 import { getLastEditorCopy } from "../Coding/lastEditorCopy";
 import { useUploadLimitStore } from "../../stores/uploadLimitStore";
 
@@ -994,9 +997,12 @@ export default function ChatPage() {
 
   const onFileCardClick = useCallback(
     (fileInfo: { name?: string; size?: number; url?: string }) => {
-      if (fileInfo.url) {
-        openExternalLink(fileInfo.url);
-      }
+      if (!fileInfo.url) return;
+      const filename = fileInfo.name || "download";
+      downloadFileFromUrl(fileInfo.url, filename).catch((error) => {
+        if (error instanceof DownloadCancelledError) return;
+        console.error("File download failed:", error);
+      });
     },
     [],
   );


### PR DESCRIPTION
1. Tool card titles are now truncated to a single line.

2. Download files using `downloadFileFromUrl` instead of `openExternalLink`.

Fixes #5102

<img width="945" height="381" alt="image" src="https://github.com/user-attachments/assets/0caafc00-04ab-476c-9288-57b9a2fd609f" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
