### PR TITLE
fix: show local providers (ollama/lmstudio) in PRO tab of ModelSelector

### DIFF
--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -165,7 +165,10 @@ export default function ModelSelector() {
       }
       // PRO: show paid models when API key is configured, or when
       // the provider doesn't require an API key (e.g. ollama, lmstudio)
-      if (proModels.length > 0 && (p.has_api_key || p.require_api_key === false)) {
+      if (
+        proModels.length > 0 &&
+        (p.has_api_key || p.require_api_key === false)
+      ) {
         proMap.set(p.id, { ...p, models: proModels });
       }
     }

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -163,8 +163,9 @@ export default function ModelSelector() {
       if (freeModels.length > 0 || (p.is_free_tier && p.models.length === 0)) {
         freeMap.set(p.id, { ...p, models: freeModels });
       }
-      // PRO: only show paid models when user has API key configured
-      if (proModels.length > 0 && p.has_api_key) {
+      // PRO: show paid models when API key is configured, or when
+      // the provider doesn't require an API key (e.g. ollama, lmstudio)
+      if (proModels.length > 0 && (p.has_api_key || p.require_api_key === false)) {
         proMap.set(p.id, { ...p, models: proModels });
       }
     }


### PR DESCRIPTION
Providers with require_api_key=false (e.g. ollama, lmstudio) had has_api_key=false, causing them to be excluded from the PRO tab even when configured with a base_url and available models.

Fixes #5108

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
