### PR TITLE
fix(security): block agent workspaces in auto-loaded code / secret dirs

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -32,6 +32,10 @@ from ...agents.utils import copy_workspace_md_files, normalize_agent_language
 from ...agents.skill_system import SkillPoolService, get_workspace_skills_dir
 from ..multi_agent_manager import MultiAgentManager
 from ...constant import WORKING_DIR
+from ...security.workspace_paths import (
+    ReservedWorkspaceError,
+    assert_workspace_dir_allowed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -303,6 +307,10 @@ async def create_agent(
     workspace_dir = Path(
         request.workspace_dir or f"{WORKING_DIR}/workspaces/{new_id}",
     ).expanduser()
+    try:
+        assert_workspace_dir_allowed(workspace_dir)
+    except ReservedWorkspaceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
     from ...config.config import (

--- a/src/qwenpaw/backup/_ops/restore_helpers.py
+++ b/src/qwenpaw/backup/_ops/restore_helpers.py
@@ -17,8 +17,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .._utils.constants import PREFIX_SECRETS, PREFIX_WORKSPACES
-from ..models import BackupMeta, RestoreBackupRequest
+from ..models import BackupMeta, BackupValidationError, RestoreBackupRequest
 from ...constant import BACKUP_DIR, SECRET_DIR, WORKING_DIR
+from ...security.workspace_paths import reserved_workspace_root_for
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,63 @@ def collect_workspace_agents_from_zip(zf: zipfile.ZipFile) -> set[str]:
     return agents
 
 
+def _resolve_path(p: Path) -> Path:
+    """Resolve *p* even when it does not exist yet.
+
+    Falls back to absolute path when resolve() fails.
+    """
+    try:
+        return p.resolve()
+    except OSError:
+        return p.absolute()
+
+
+def assert_safe_agent_id(aid: str) -> None:
+    """Reject agent ids that are not a single safe path segment.
+
+    Restore derives both filesystem destinations and zip entry prefixes from
+    the agent id.  Values such as ``..`` or ones containing path separators
+    let a crafted backup escape the workspace area during extraction (e.g. a
+    ``data/workspaces/../custom_channels/...`` entry lands in
+    ``custom_channels`` → remote code execution), bypassing the reserved
+    directory guard which only inspects the resolved destination directory.
+    Rejecting unsafe ids before any path is built closes that gap.
+    """
+    separators = {"/", "\\", os.sep}
+    if os.altsep:
+        separators.add(os.altsep)
+    has_separator = any(sep in aid for sep in separators)
+    if aid in ("", ".", "..") or has_separator:
+        raise BackupValidationError(
+            "restore_invalid_agent_id",
+            f"Agent id {aid!r} is not a valid single path segment and "
+            "cannot be restored.",
+            {"agent_id": aid},
+        )
+
+
+def assert_safe_workspace_dst(dst: Path, aid: str) -> None:
+    """Reject restore destinations that target reserved server directories.
+
+    ``default_workspace_dir`` and the agent id are attacker influenceable
+    through a crafted restore request.  Placing a workspace inside an
+    auto-loaded code directory (e.g. ``custom_channels``) lets the next agent
+    reload import attacker-controlled modules, yielding remote code execution;
+    placing it inside ``SECRET_DIR`` tampers with stored credentials.  Custom
+    workspace paths elsewhere remain allowed.
+    """
+    reserved = reserved_workspace_root_for(dst)
+    if reserved is not None:
+        raise BackupValidationError(
+            "restore_workspace_dir_reserved",
+            "Restore destination for agent "
+            f"'{aid}' ({dst}) targets a reserved directory ({reserved}). "
+            "Agent workspaces cannot be restored into custom_channels, "
+            "plugins, or the secrets directory.",
+            {"agent_id": aid, "destination": str(dst)},
+        )
+
+
 def resolve_workspace_dst(
     aid: str,
     ref,  # AgentProfileRef | None
@@ -87,10 +145,19 @@ def resolve_workspace_dst(
     All returned paths are fully resolved (absolute, symlinks expanded) so
     that ``str(dst)`` is always canonical regardless of which branch is taken.
     """
+    # The agent id feeds both the destination path and the zip entry prefix,
+    # so validate it before it is used to build either.
+    assert_safe_agent_id(aid)
+
     if ref is not None:
         dst = Path(ref.workspace_dir).expanduser()
         if dst.exists():
-            return dst.resolve(), False
+            resolved = dst.resolve()
+            # An existing profile may point at a reserved directory (e.g. an
+            # agent created with workspace_dir inside custom_channels); still
+            # block restoring code/secrets there.
+            assert_safe_workspace_dst(resolved, aid)
+            return resolved, False
         # Existing agent in config but local path is absent (cross-machine
         # restore or manually deleted directory) – fall through to defaults.
 
@@ -101,12 +168,14 @@ def resolve_workspace_dst(
 
     # Resolve even when the directory does not yet exist so that the returned
     # path string is always in fully-qualified, canonical form.
-    try:
-        return dst.resolve(), ref is None
-    except OSError:
-        # resolve() can fail on some platforms when parts of the path don't
-        # exist; fall back to absolute path without symlink expansion.
-        return dst.absolute(), ref is None
+    resolved = _resolve_path(dst)
+
+    # Block restores into auto-loaded code / secret directories (RCE / secret
+    # tampering) before any files are extracted, while still allowing custom
+    # workspace locations anywhere else.
+    assert_safe_workspace_dst(resolved, aid)
+
+    return resolved, ref is None
 
 
 def rewrite_agent_workspace_dir(dst: Path, aid: str) -> None:

--- a/src/qwenpaw/cli/agents_cmd.py
+++ b/src/qwenpaw/cli/agents_cmd.py
@@ -25,6 +25,10 @@ from ..config.config import (
 from ..constant import WORKING_DIR
 from ..config.config import ModelSlotConfig
 from ..providers.provider_manager import ProviderManager
+from ..security.workspace_paths import (
+    ReservedWorkspaceError,
+    assert_workspace_dir_allowed,
+)
 from .http import print_json, resolve_base_url
 
 SUPPORTED_AGENT_TEMPLATES = list_supported_agent_templates()
@@ -591,6 +595,10 @@ def create_cmd(
         new_id,
         workspace_dir,
     )
+    try:
+        assert_workspace_dir_allowed(resolved_workspace_dir)
+    except ReservedWorkspaceError as exc:
+        raise click.ClickException(str(exc)) from exc
     resolved_workspace_dir.mkdir(parents=True, exist_ok=True)
 
     effective_template = template or DEFAULT_AGENT_TEMPLATE

--- a/src/qwenpaw/security/workspace_paths.py
+++ b/src/qwenpaw/security/workspace_paths.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""Shared guard for agent workspace locations.
+
+Several entry points let a user choose where an agent workspace lives
+(HTTP ``create_agent``, the ``qwenpaw agents create`` CLI, and backup
+restore).  Custom locations are an intended feature, so the guard does not
+restrict *where* a workspace may go; it only blocks directories the server
+auto-loads code from or that hold credentials, because placing a workspace
+there turns "write files" into code execution or secret tampering:
+
+* ``custom_channels`` – modules here are imported on agent reload.
+* ``plugins`` – plugin packages here are discovered and executed.
+* ``SECRET_DIR`` – holds credentials and the master key.
+
+Constants are read lazily on each call so tests (and runtime overrides of
+``WORKING_DIR``) are honoured.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _resolve_path(p: Path) -> Path:
+    """Resolve *p* even when it does not exist yet.
+
+    Falls back to the absolute path when ``resolve()`` fails.
+    """
+    try:
+        return p.resolve()
+    except OSError:
+        return p.absolute()
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    """Return True when *child* is *parent* itself or nested under it."""
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def reserved_workspace_roots() -> tuple[Path, ...]:
+    """Return resolved directories a workspace must never be placed in."""
+    from .. import constant
+
+    return (
+        _resolve_path(Path(constant.CUSTOM_CHANNELS_DIR)),
+        _resolve_path(Path(constant.PLUGINS_DIR)),
+        _resolve_path(Path(constant.SECRET_DIR)),
+    )
+
+
+def reserved_workspace_root_for(path: Path | str) -> Path | None:
+    """Return the reserved root *path* conflicts with, or ``None`` if safe.
+
+    A path conflicts with a reserved directory when it lives **inside** it (or
+    is it), or is an **ancestor** of it.  The ancestor case matters because a
+    workspace placed at e.g. ``WORKING_DIR`` would, on restore, receive the
+    workspace's own relative files (such as a nested ``custom_channels``
+    package) directly into the real reserved directory.
+
+    The returned path is the matched reserved directory (resolved), suitable
+    for inclusion in an error message.
+    """
+    resolved = _resolve_path(Path(path).expanduser())
+    for reserved in reserved_workspace_roots():
+        if _is_within(resolved, reserved) or _is_within(reserved, resolved):
+            return reserved
+    return None
+
+
+class ReservedWorkspaceError(ValueError):
+    """Raised when a workspace path targets a reserved server directory."""
+
+    def __init__(self, path: Path, reserved: Path) -> None:
+        self.path = path
+        self.reserved = reserved
+        super().__init__(
+            f"workspace_dir '{path}' targets reserved directory "
+            f"'{reserved}'. The server auto-loads code from "
+            "custom_channels/plugins and stores credentials in the secrets "
+            "directory; placing a workspace there is unsafe.",
+        )
+
+
+def assert_workspace_dir_allowed(path: Path | str) -> Path:
+    """Return the resolved *path*, or raise :class:`ReservedWorkspaceError`.
+
+    Shared entry point for the HTTP and CLI agent-creation flows so the check
+    and its message live in one place.
+    """
+    resolved = _resolve_path(Path(path).expanduser())
+    reserved = reserved_workspace_root_for(resolved)
+    if reserved is not None:
+        raise ReservedWorkspaceError(resolved, reserved)
+    return resolved

--- a/tests/unit/app/routers/test_agents_router.py
+++ b/tests/unit/app/routers/test_agents_router.py
@@ -269,3 +269,42 @@ def test_delete_agent_happy_path_calls_stop_and_saves(
     manager_mock.stop_agent.assert_awaited_once_with("bot")
     save_mock.assert_called_once()
     assert "bot" not in fake_config.agents.profiles
+
+
+# ---------------------------------------------------------------------------
+# POST /agents — reserved workspace_dir guard
+# ---------------------------------------------------------------------------
+
+
+def test_create_agent_rejects_custom_channels_workspace(
+    client,
+    fake_config,
+    tmp_path,
+):
+    """workspace_dir inside custom_channels must be refused (RCE vector)."""
+    from qwenpaw import constant
+
+    custom_channels = tmp_path / "custom_channels"
+    with (
+        patch(
+            "qwenpaw.app.routers.agents.load_config",
+            return_value=fake_config,
+        ),
+        patch.object(constant, "CUSTOM_CHANNELS_DIR", custom_channels),
+        patch.object(constant, "PLUGINS_DIR", tmp_path / "plugins"),
+        patch.object(constant, "SECRET_DIR", tmp_path / "secret"),
+        patch("qwenpaw.app.routers.agents.save_config") as save_mock,
+    ):
+        response = client.post(
+            "/api/agents",
+            json={
+                "id": "evilbot",
+                "name": "Evil",
+                "workspace_dir": str(custom_channels / "evilbot"),
+            },
+        )
+
+    assert response.status_code == 400
+    assert "reserved directory" in response.json()["detail"]
+    save_mock.assert_not_called()
+    assert not custom_channels.exists()

--- a/tests/unit/backup/test_restore_workspace_dst.py
+++ b/tests/unit/backup/test_restore_workspace_dst.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+"""Guards for restore workspace destination resolution.
+
+Custom workspace locations (including paths outside ``WORKING_DIR``) are a
+supported feature, so the guard only blocks restoring into directories the
+server auto-loads code from (``custom_channels``, ``plugins``) or the secrets
+store. Those are the vectors that turn "restore files" into code execution or
+credential tampering.
+"""
+# pylint: disable=redefined-outer-name,protected-access,unused-argument
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw import constant
+from qwenpaw.backup._ops import restore_helpers
+from qwenpaw.backup.models import BackupValidationError
+
+
+@pytest.fixture()
+def working_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    """Point the restore helpers at an isolated WORKING_DIR layout.
+
+    ``restore_helpers.WORKING_DIR`` drives the default-branch destination,
+    while the reserved-dir guard lives in ``security.workspace_paths`` and
+    reads the reserved directories from ``qwenpaw.constant`` lazily.
+    """
+    working = (tmp_path / "working").resolve()
+    (working / "workspaces").mkdir(parents=True)
+    monkeypatch.setattr(restore_helpers, "WORKING_DIR", working)
+    monkeypatch.setattr(
+        constant,
+        "CUSTOM_CHANNELS_DIR",
+        working / "custom_channels",
+    )
+    monkeypatch.setattr(constant, "PLUGINS_DIR", working / "plugins")
+    monkeypatch.setattr(
+        constant,
+        "SECRET_DIR",
+        (tmp_path / "working.secret").resolve(),
+    )
+    return working
+
+
+def test_default_placement_is_allowed(working_dir: Path) -> None:
+    dst, is_new = restore_helpers.resolve_workspace_dst("agent1", None, None)
+    assert dst == working_dir / "workspaces" / "agent1"
+    assert is_new is True
+
+
+def test_explicit_workspace_dir_inside_working_dir_is_allowed(
+    working_dir: Path,
+) -> None:
+    base = str(working_dir / "workspaces")
+    dst, _ = restore_helpers.resolve_workspace_dst("agent1", None, base)
+    assert dst == working_dir / "workspaces" / "agent1"
+
+
+def test_custom_workspace_dir_outside_working_dir_is_allowed(
+    working_dir: Path,
+    tmp_path: Path,
+) -> None:
+    # Users may intentionally place agent workspaces outside WORKING_DIR;
+    # this must remain a supported restore destination.
+    base = str(tmp_path / "custom-agents")
+    dst, _ = restore_helpers.resolve_workspace_dst("agent1", None, base)
+    assert dst == (tmp_path / "custom-agents" / "agent1").resolve()
+
+
+def test_custom_channels_destination_is_rejected(working_dir: Path) -> None:
+    base = str(working_dir / "custom_channels")
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst("pocpkg", None, base)
+    assert exc_info.value.code == "restore_workspace_dir_reserved"
+
+
+def test_plugins_destination_is_rejected(working_dir: Path) -> None:
+    base = str(working_dir / "plugins")
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst("pocpkg", None, base)
+    assert exc_info.value.code == "restore_workspace_dir_reserved"
+
+
+def test_secrets_destination_is_rejected(
+    working_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secrets = working_dir / "secrets"
+    monkeypatch.setattr(constant, "SECRET_DIR", secrets)
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst("agent1", None, str(secrets))
+    assert exc_info.value.code == "restore_workspace_dir_reserved"
+
+
+def test_relative_traversal_into_custom_channels_is_rejected(
+    working_dir: Path,
+) -> None:
+    base = str(working_dir / "workspaces" / ".." / "custom_channels")
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst("pocpkg", None, base)
+    assert exc_info.value.code == "restore_workspace_dir_reserved"
+
+
+@pytest.mark.parametrize("aid", ["..", ".", "../evil", "a/b", "a\\b", ""])
+def test_traversal_agent_id_is_rejected(working_dir: Path, aid: str) -> None:
+    # A "../" agent id resolves dst back up to WORKING_DIR (which passes the
+    # reserved-dir check) and reintroduces custom_channels via the zip prefix
+    # during extraction. Reject unsafe ids before any path is built.
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst(aid, None, None)
+    assert exc_info.value.code == "restore_invalid_agent_id"
+
+
+def test_existing_ref_inside_custom_channels_is_rejected(
+    working_dir: Path,
+) -> None:
+    # An agent profile may already point at custom_channels (create_agent
+    # accepts an arbitrary workspace_dir); restoring into it must still be
+    # blocked even though this branch reuses the existing path.
+    ws = working_dir / "custom_channels" / "pocpkg"
+    ws.mkdir(parents=True)
+    ref = SimpleNamespace(workspace_dir=str(ws))
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst("pocpkg", ref, None)
+    assert exc_info.value.code == "restore_workspace_dir_reserved"
+
+
+def test_workspace_dir_that_is_ancestor_of_reserved_is_rejected(
+    working_dir: Path,
+    tmp_path: Path,
+) -> None:
+    # default_workspace_dir=WORKING_DIR.parent with aid=WORKING_DIR.name makes
+    # dst == WORKING_DIR, an ancestor of custom_channels/plugins. A workspace
+    # entry like custom_channels/pocpkg/__init__.py would then land in the
+    # real custom_channels during extraction (RCE), so this must be rejected.
+    base = str(working_dir.parent)
+    aid = working_dir.name
+    with pytest.raises(BackupValidationError) as exc_info:
+        restore_helpers.resolve_workspace_dst(aid, None, base)
+    assert exc_info.value.code == "restore_workspace_dir_reserved"
+
+
+def test_existing_ref_in_normal_workspace_is_allowed(
+    working_dir: Path,
+) -> None:
+    ws = working_dir / "workspaces" / "agent1"
+    ws.mkdir(parents=True)
+    ref = SimpleNamespace(workspace_dir=str(ws))
+    dst, is_new = restore_helpers.resolve_workspace_dst("agent1", ref, None)
+    assert dst == ws.resolve()
+    assert is_new is False

--- a/tests/unit/security/test_workspace_paths.py
+++ b/tests/unit/security/test_workspace_paths.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Tests for the shared reserved-workspace-directory guard."""
+# pylint: disable=redefined-outer-name,unused-argument
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qwenpaw import constant
+from qwenpaw.security import workspace_paths
+
+
+@pytest.fixture()
+def reserved_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    working = (tmp_path / "working").resolve()
+    (working / "workspaces").mkdir(parents=True)
+    monkeypatch.setattr(
+        constant,
+        "CUSTOM_CHANNELS_DIR",
+        working / "custom_channels",
+    )
+    monkeypatch.setattr(constant, "PLUGINS_DIR", working / "plugins")
+    monkeypatch.setattr(
+        constant,
+        "SECRET_DIR",
+        (tmp_path / "working.secret").resolve(),
+    )
+    return working
+
+
+def test_normal_workspace_is_not_reserved(reserved_layout: Path) -> None:
+    target = reserved_layout / "workspaces" / "agent1"
+    assert workspace_paths.reserved_workspace_root_for(target) is None
+
+
+def test_custom_path_outside_working_dir_is_not_reserved(
+    reserved_layout: Path,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "elsewhere" / "agent1"
+    assert workspace_paths.reserved_workspace_root_for(target) is None
+
+
+@pytest.mark.parametrize("sub", ["custom_channels", "plugins"])
+def test_auto_loaded_dirs_are_reserved(
+    reserved_layout: Path,
+    sub: str,
+) -> None:
+    target = reserved_layout / sub / "evil"
+    matched = workspace_paths.reserved_workspace_root_for(target)
+    assert matched == (reserved_layout / sub).resolve()
+
+
+def test_secret_dir_is_reserved(reserved_layout: Path) -> None:
+    matched = workspace_paths.reserved_workspace_root_for(constant.SECRET_DIR)
+    assert matched == Path(constant.SECRET_DIR).resolve()
+
+
+def test_relative_traversal_into_reserved_is_detected(
+    reserved_layout: Path,
+) -> None:
+    target = reserved_layout / "workspaces" / ".." / "plugins" / "x"
+    matched = workspace_paths.reserved_workspace_root_for(target)
+    assert matched == (reserved_layout / "plugins").resolve()
+
+
+def test_ancestor_of_reserved_is_detected(reserved_layout: Path) -> None:
+    # A destination equal to WORKING_DIR is an ancestor of custom_channels /
+    # plugins; restoring a workspace there would drop the workspace's own
+    # custom_channels/... files into the real reserved directory.
+    matched = workspace_paths.reserved_workspace_root_for(reserved_layout)
+    assert matched in (
+        (reserved_layout / "custom_channels").resolve(),
+        (reserved_layout / "plugins").resolve(),
+    )
+
+
+def test_parent_of_working_dir_is_detected(
+    reserved_layout: Path,
+    tmp_path: Path,
+) -> None:
+    # WORKING_DIR.parent is an ancestor of every reserved directory too.
+    matched = workspace_paths.reserved_workspace_root_for(tmp_path)
+    assert matched is not None
+
+
+def test_assert_allows_normal_workspace(reserved_layout: Path) -> None:
+    target = reserved_layout / "workspaces" / "agent1"
+    assert workspace_paths.assert_workspace_dir_allowed(target) == (
+        target.resolve()
+    )
+
+
+def test_assert_raises_for_reserved(reserved_layout: Path) -> None:
+    target = reserved_layout / "plugins" / "evil"
+    with pytest.raises(workspace_paths.ReservedWorkspaceError) as exc_info:
+        workspace_paths.assert_workspace_dir_allowed(target)
+    assert exc_info.value.reserved == (reserved_layout / "plugins").resolve()


### PR DESCRIPTION
## Description

Several entry points let a user choose where an agent workspace lives, but none validated the location. Placing a workspace inside a directory the server auto-loads code from — `custom_channels/` (modules imported on agent reload) or `plugins/` (plugin packages discovered and executed) — leads to remote code execution; placing it in `SECRET_DIR` tampers with stored credentials.

This PR introduces a shared reserved-directory guard (`qwenpaw.security.workspace_paths`) and applies it at every place that establishes a workspace location. The guard flags a path that **equals**, lives **inside**, or is an **ancestor of** a reserved directory — the ancestor case matters because a workspace placed at `WORKING_DIR` would, on restore, receive its own relative `custom_channels/...` files into the real reserved directory.

### Backup restore (`resolve_workspace_dst`)

1. **Reserved directory guard** — reject destinations resolving into `custom_channels/`, `plugins/`, or `SECRET_DIR`, before any files are extracted.
2. **Agent id validation** — reject agent ids that are not a single safe path segment (e.g. `..`, ids containing `/` or `\`). An `..` id otherwise resolves the destination back up to `WORKING_DIR` (passing the reserved-dir check) while a `data/workspaces/../custom_channels/...` zip entry reintroduces `custom_channels` during extraction, regaining RCE.
3. **Existing-profile branch** — apply the guard even when an agent profile already exists, since an agent could have been registered with a workspace inside `custom_channels`.

### Agent creation

4. **HTTP `POST /api/agents`** (`create_agent`) — reject a `workspace_dir` inside a reserved directory (HTTP 400) before `mkdir`.
5. **CLI `qwenpaw agents create`** — same guard; reserved destinations raise a `ClickException` before `mkdir`.

Without (4)/(5) an authenticated user could create an agent whose workspace is under `custom_channels`, then drop an importable module there via a workspace file write (the code-files API or the agent's own file tools) and trigger reload → RCE, bypassing the restore-only guard.

**Note:** Custom agent workspace paths are an intended feature — agents may legitimately live outside `WORKING_DIR`. The guard does not restrict *where* a workspace may be placed; it only blocks the auto-loaded code / secret directories that turn "write files" into code execution.

**Related Issue:** No linked issue (security audit finding)

**Security Considerations:** Blocks authenticated backup restore from being used to place importable Python packages into auto-loaded directories or to overwrite the secrets store, while preserving custom workspace path support.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `tests/unit/security/test_workspace_paths.py` — shared guard: normal/custom-outside paths allowed; `custom_channels`, `plugins`, `SECRET_DIR`, and relative traversal into reserved dirs detected.
- `tests/unit/backup/test_restore_workspace_dst.py` — restore: allowed (default, in-tree, custom outside `WORKING_DIR`, existing normal profile); rejected (reserved dirs, traversal/separator agent ids, existing profile inside `custom_channels`).
- `tests/unit/app/routers/test_agents_router.py` — `POST /api/agents` with `workspace_dir` inside `custom_channels` returns 400 and does not create the directory.

## Local Verification Evidence

```bash
pre-commit run --files <changed files>
# all hooks Passed

pytest tests/unit/backup tests/unit/security/test_workspace_paths.py tests/unit/app/routers/test_agents_router.py -q
# all passed
```

Note: two pre-existing `tests/unit/cli/test_cli_task.py` symlink tests fail locally on Windows with `WinError 1314` (no privilege to create symlinks); unrelated to this change.

## Additional Notes

Restore requests targeting reserved destinations now fail early with `BackupValidationError` (HTTP 400) during destination planning, before archive extraction.
