### PR TITLE
feat(ci): add release verification gate between build and publish

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,8 @@
 # Build QwenPaw multi-arch Docker image and push to DockerHub + Aliyun ACR on release.
 # Pre-release: update <version> and pre only.
 # Formal release: update <version>, pre and latest.
+#
+# Pipeline: verify (build amd64 + health-check) → build-and-push (multi-arch).
 name: Docker Build and Push on Release
 
 on:
@@ -23,7 +25,16 @@ env:
   IMAGE: agentscope/qwenpaw
 
 jobs:
+  # ── Stage 1: Verify Docker image boots correctly ───────────────────────────
+  verify-docker:
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_docker: true
+    secrets: inherit
+
+  # ── Stage 2: Build multi-arch and push ─────────────────────────────────────
   build-and-push:
+    needs: [verify-docker]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/fork-verify.yml
+++ b/.github/workflows/fork-verify.yml
@@ -1,0 +1,83 @@
+# One-click release verification for fork repositories.
+# Builds the wheel, then runs all verification jobs (pip, Docker, script install).
+#
+# Docker uses public base images (node:20-slim, ghcr.io/astral-sh/uv) instead of
+# the private ACR registry, so forks can validate the full pipeline without credentials.
+#
+# Usage: trigger manually via Actions → Fork Release Verification → Run workflow.
+
+name: Fork Release Verification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Build wheel (same steps as publish-pypi.yml build job) ─────────────────
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up Node (for console build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Build console frontend
+        run: |
+          cd console && npm ci && npm run build
+
+      - name: Copy console build into package
+        run: |
+          rm -rf src/qwenpaw/console/*
+          mkdir -p src/qwenpaw/console
+          cp -R console/dist/* src/qwenpaw/console/
+
+      - name: Bundle docs into package
+        run: |
+          rm -rf src/qwenpaw/docs
+          mkdir -p src/qwenpaw/docs
+          cp website/public/docs/*.md src/qwenpaw/docs/
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist/
+          retention-days: 7
+
+      - name: Upload version metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: src/qwenpaw/__version__.py
+          retention-days: 7
+
+  # ── Run all verification jobs ──────────────────────────────────────────────
+  verify:
+    needs: [build]
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_pip: true
+      verify_docker: true
+      verify_script_install: true
+      docker_node_image: "node:20-slim"
+      docker_uv_image: "ghcr.io/astral-sh/uv:latest"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,8 @@
 # Build includes console frontend (see scripts/wheel_build.sh).
 # Manual trigger: can optionally force push to PyPI or just upload artifacts.
 # Release trigger: publishes to PyPI.
+#
+# Pipeline: build → verify (install + boot + health-check) → publish.
 
 name: Publish Python Package to PyPI
 
@@ -20,7 +22,8 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  # ── Stage 1: Build wheel ───────────────────────────────────────────────────
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,16 +64,41 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Upload wheel to artifacts (manual trigger without force push)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi != 'true'
+      - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: qwenpaw-wheel
-          path: dist/*.whl
+          name: qwenpaw-dist
+          path: dist/
           retention-days: 30
 
+      - name: Upload version metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: src/qwenpaw/__version__.py
+          retention-days: 30
+
+  # ── Stage 2: Verify installation ───────────────────────────────────────────
+  verify:
+    needs: [build]
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_pip: true
+      verify_script_install: true
+
+  # ── Stage 3: Publish to PyPI ───────────────────────────────────────────────
+  publish:
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi == 'true')
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist
+
       - name: Publish package to PyPI
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_push_to_pypi == 'true')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,344 @@
+# Reusable verification gate: install the built artefacts, boot the server,
+# and hit /api/version before any publish step runs.
+# Called by publish-pypi.yml, docker-release.yml, and fork-verify.yml.
+
+name: Release Verification
+
+on:
+  workflow_call:
+    inputs:
+      verify_pip:
+        description: "Run pip-install-from-wheel verification"
+        type: boolean
+        default: false
+      verify_docker:
+        description: "Run Docker build + health-check verification"
+        type: boolean
+        default: false
+      verify_script_install:
+        description: "Run install-script (install.sh / install.ps1) verification"
+        type: boolean
+        default: false
+      docker_node_image:
+        description: "Override Dockerfile NODE_IMAGE build-arg (for fork without ACR access)"
+        type: string
+        default: ""
+      docker_uv_image:
+        description: "Override Dockerfile UV_IMAGE build-arg (for fork without ACR access)"
+        type: string
+        default: ""
+
+jobs:
+  # ── pip install wheel ──────────────────────────────────────────────────────
+  verify-pip:
+    if: inputs.verify_pip
+    name: Verify pip install - py${{ matrix.python-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.10"
+
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist
+
+      - name: Download version file
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: version-meta
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install wheel in clean venv
+        shell: bash
+        run: |
+          python -m venv .verify-venv
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            VENV_BIN="$(cd .verify-venv/Scripts && pwd)"
+          else
+            VENV_BIN="$(cd .verify-venv/bin && pwd)"
+          fi
+          source "$VENV_BIN/activate"
+          python -m pip install --upgrade pip
+          pip install dist/*.whl
+          echo "$VENV_BIN" >> "$GITHUB_PATH"
+
+      - name: Read expected version
+        id: expected
+        shell: bash
+        run: |
+          ver=$(python -c "
+          import re, pathlib
+          text = pathlib.Path('version-meta/__version__.py').read_text()
+          print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', text).group(1))
+          ")
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Verify CLI version
+        shell: bash
+        run: |
+          actual=$(qwenpaw --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.]*' | head -1)
+          expected="${{ steps.expected.outputs.version }}"
+          echo "Expected: $expected"
+          echo "Actual:   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Version mismatch: expected=$expected actual=$actual"
+            exit 1
+          fi
+
+      - name: Verify Python import
+        shell: bash
+        run: |
+          python -c "from qwenpaw.cli.main import cli; print('import OK')"
+
+      - name: Initialize and start server
+        shell: bash
+        run: |
+          qwenpaw init --defaults --accept-security
+          qwenpaw app --host 127.0.0.1 --port 8088 &
+          echo $! > "$RUNNER_TEMP/qwenpaw.pid" || true
+
+      - name: Wait for /api/version
+        shell: bash
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8088/api/version; then
+              echo ""
+              echo "Server is up after ~$((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Server did not respond within 120s"
+          exit 1
+
+      - name: Verify server version
+        shell: bash
+        run: |
+          response=$(curl -sf http://127.0.0.1:8088/api/version)
+          server_ver=$(echo "$response" | python -c "import sys,json; print(json.load(sys.stdin)['version'])")
+          expected="${{ steps.expected.outputs.version }}"
+          echo "Server version: $server_ver"
+          if [ "$server_ver" != "$expected" ]; then
+            echo "::error::Server version mismatch: expected=$expected server=$server_ver"
+            exit 1
+          fi
+
+      - name: Stop server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/qwenpaw.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/qwenpaw.pid")" 2>/dev/null || true
+          fi
+          if [ "$RUNNER_OS" = "Linux" ] || [ "$RUNNER_OS" = "macOS" ]; then
+            lsof -ti:8088 | xargs kill 2>/dev/null || true
+          fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            pid=$(netstat -ano 2>/dev/null | grep ':8088 ' | grep LISTEN | awk '{print $5}' | tr -d '\r' | head -1) || true
+            if [ -n "$pid" ]; then taskkill //F //PID "$pid" 2>/dev/null || true; fi
+          fi
+
+  # ── Docker build + health check ────────────────────────────────────────────
+  verify-docker:
+    if: inputs.verify_docker
+    name: Verify Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      ACR_REGISTRY: agentscope-registry.ap-southeast-1.cr.aliyuncs.com
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Aliyun ACR (when credentials available)
+        if: env.ACR_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACR_REGISTRY }}
+          username: ${{ secrets.ALIYUN_ACR_USERNAME }}
+          password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
+        env:
+          ACR_USERNAME: ${{ secrets.ALIYUN_ACR_USERNAME }}
+
+      - name: Build Docker image (amd64 only)
+        env:
+          DOCKER_NODE_IMAGE: ${{ inputs.docker_node_image }}
+          DOCKER_UV_IMAGE: ${{ inputs.docker_uv_image }}
+        run: |
+          BUILD_ARGS=""
+          if [ -n "$DOCKER_NODE_IMAGE" ]; then
+            BUILD_ARGS="$BUILD_ARGS --build-arg NODE_IMAGE=$DOCKER_NODE_IMAGE"
+          fi
+          if [ -n "$DOCKER_UV_IMAGE" ]; then
+            BUILD_ARGS="$BUILD_ARGS --build-arg UV_IMAGE=$DOCKER_UV_IMAGE"
+          fi
+          docker build \
+            -f deploy/Dockerfile \
+            -t qwenpaw-verify:test \
+            $BUILD_ARGS \
+            .
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name qwenpaw-test \
+            -p 8088:8088 \
+            qwenpaw-verify:test
+
+      - name: Wait for /api/version
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf http://127.0.0.1:8088/api/version; then
+              echo ""
+              echo "Container is up after ~$((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Container did not respond within 180s"
+          docker logs qwenpaw-test
+          exit 1
+
+      - name: Verify container version
+        run: |
+          expected=$(python3 -c "
+          import re, pathlib
+          text = pathlib.Path('src/qwenpaw/__version__.py').read_text()
+          print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', text).group(1))
+          ")
+          response=$(curl -sf http://127.0.0.1:8088/api/version)
+          echo "Response: $response"
+          actual=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
+          echo "Expected: $expected"
+          echo "Actual:   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Docker version mismatch: expected=$expected actual=$actual"
+            exit 1
+          fi
+
+      - name: Show container logs
+        if: always()
+        run: docker logs qwenpaw-test 2>&1 | tail -50
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f qwenpaw-test 2>/dev/null || true
+
+  # ── Script install (install.sh / install.ps1) ──────────────────────────────
+  verify-script-install:
+    if: inputs.verify_script_install
+    name: Verify script install - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js (for console build during from-source install)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Build console frontend
+        shell: bash
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+        run: |
+          cd console && npm ci && npm run build
+
+      - name: Copy console build into package
+        shell: bash
+        run: |
+          rm -rf src/qwenpaw/console/*
+          mkdir -p src/qwenpaw/console
+          cp -R console/dist/* src/qwenpaw/console/
+
+      - name: Run install script (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          bash scripts/install.sh --from-source "$(pwd)"
+
+      - name: Run install script (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          .\scripts\install.ps1 -FromSource -SourceDir "$PWD"
+
+      - name: Verify CLI, init, start server, and health check
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            source "$USERPROFILE/.qwenpaw/venv/Scripts/activate"
+          else
+            export PATH="$HOME/.qwenpaw/bin:$PATH"
+          fi
+
+          # Verify version matches source
+          expected=$(python -c "
+          import re, pathlib
+          text = pathlib.Path('src/qwenpaw/__version__.py').read_text()
+          print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', text).group(1))
+          ")
+          actual=$(qwenpaw --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.]*' | head -1)
+          echo "Expected: $expected"
+          echo "Actual:   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Version mismatch: expected=$expected actual=$actual"
+            exit 1
+          fi
+
+          qwenpaw init --defaults --accept-security
+          qwenpaw app --host 127.0.0.1 --port 8088 &
+          echo $! > "$RUNNER_TEMP/qwenpaw.pid" || true
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8088/api/version; then
+              echo ""
+              echo "Server is up after ~$((i*2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Server did not respond within 120s"
+          exit 1
+
+      - name: Stop server
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$RUNNER_TEMP/qwenpaw.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/qwenpaw.pid")" 2>/dev/null || true
+          fi
+          if [ "$RUNNER_OS" = "Linux" ] || [ "$RUNNER_OS" = "macOS" ]; then
+            lsof -ti:8088 | xargs kill 2>/dev/null || true
+          fi
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            pid=$(netstat -ano 2>/dev/null | grep ':8088 ' | grep LISTEN | awk '{print $5}' | tr -d '\r' | head -1) || true
+            if [ -n "$pid" ]; then taskkill //F //PID "$pid" 2>/dev/null || true; fi
+          fi

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,15 +1,22 @@
+# Base images — override with --build-arg for environments without ACR access.
+ARG NODE_IMAGE=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim
+ARG UV_IMAGE=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/uv:latest
+
 # -----------------------------------------------------------------------------
 # Stage 1: build console frontend (dist not committed in repo).
 # -----------------------------------------------------------------------------
-FROM agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim AS console-builder
+FROM ${NODE_IMAGE} AS console-builder
 WORKDIR /app
 COPY console /app/console
 RUN cd /app/console && npm ci --include=dev && npm run build
 
+# Alias for uv binary so COPY --from can reference a build-arg image.
+FROM ${UV_IMAGE} AS uv-src
+
 # -----------------------------------------------------------------------------
 # Stage 2: runtime image with Python, Chromium, and app.
 # -----------------------------------------------------------------------------
-FROM agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/node:slim
+FROM ${NODE_IMAGE}
 
 # ENV variables
 ENV NODE_ENV=production
@@ -89,7 +96,7 @@ COPY website/public/docs/ ./src/qwenpaw/docs/
 # Inject console dist from build stage (repo does not commit dist).
 COPY --from=console-builder /app/console/dist/ ./src/qwenpaw/console/
 # Speed up Python package installation with uv.
-COPY --from=agentscope-registry.ap-southeast-1.cr.aliyuncs.com/agentscope/uv:latest /uv /bin/uv
+COPY --from=uv-src /uv /bin/uv
 RUN uv pip install --no-cache-dir . && rm -rf ./build
 
 


### PR DESCRIPTION
## Description

Introduce a **Release Verification Gate** — a reusable workflow that ensures build artifacts pass end-to-end installation, boot, and health-check verification before publishing to PyPI / DockerHub.

### Motivation

The current release pipeline publishes immediately after building, with no automated verification. If artifacts have installation failures, boot issues, or version mismatches, they are only discovered after users install them.

### Changes

**New files:**
- `release-verify.yml` — Reusable verification workflow (`workflow_call`) with three verification jobs:
  - **verify-pip**: Multi-platform (Ubuntu/macOS/Windows) × multi-Python (3.10/3.13) — wheel install → CLI version → Python import → server boot → `/api/version` health check → three-way version comparison
  - **verify-docker**: Build amd64 image → start container → health check → version verification
  - **verify-script-install**: Multi-platform `install.sh` / `install.ps1` → CLI version check → server boot → health check

- `fork-verify.yml` — One-click verification for fork repositories (`workflow_dispatch`), uses public images instead of private ACR so contributors can validate the full pipeline without any secrets

**Modified files:**
- `publish-pypi.yml` — Split into build → verify → publish three-stage pipeline
- `docker-release.yml` — Add verify-docker stage before build-and-push
- `deploy/Dockerfile` — Parameterize base images (NODE_IMAGE, UV_IMAGE) via `ARG` to support forks using public images

**Related Issue:** N/A

**Security Considerations:** Docker build step passes workflow inputs via `env` variables instead of inline `${{ }}` expressions to prevent potential shell injection

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

Full verification via fork repository `Fork Release Verification` workflow:

```bash
gh workflow run fork-verify.yml --ref feat/release-verify -R yutai78786/QwenPaw
```

All 9 jobs passed (Ubuntu/macOS/Windows × pip/docker/script-install):
- Fork CI Run: https://github.com/yutai78786/QwenPaw/actions/runs/27332408434

## Local Verification Evidence

```
Fork CI Run: https://github.com/yutai78786/QwenPaw/actions/runs/27332408434
All 9 jobs passed ✓
```

## Additional Notes

- 13 iterative commits squashed into 1 for clean history
- Consider upgrading Node.js 20 actions to Node.js 24-compatible versions (GitHub will force switch on 2026-06-16)