### PR TITLE
fix(desktop): harden Tauri Windows CI against crates.io fetch failures

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -161,13 +161,23 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: console/src-tauri
 
       - name: Install NSIS
         uses: negrutiu/nsis-install@v2
@@ -227,9 +237,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: console/src-tauri
 
       - name: Clean dist directory
         run: rm -rf dist && mkdir -p dist

--- a/scripts/pack-tauri/build_win_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_win_pyinstaller.ps1
@@ -16,6 +16,33 @@ if (-not [System.IO.Path]::IsPathRooted($DIST)) {
 }
 $VERSION_FILE = "src\qwenpaw\__version__.py"
 
+function Invoke-NativeWithRetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Description,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Command,
+        [int]$MaxAttempts = 5,
+        [int]$DelaySeconds = 20
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        Write-Host "$Description (attempt $attempt/$MaxAttempts)..."
+        & $Command
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0) {
+            return
+        }
+
+        if ($attempt -eq $MaxAttempts) {
+            throw "$Description failed after $MaxAttempts attempts (exit code $exitCode)"
+        }
+
+        Write-Host "$Description failed with exit code $exitCode; retrying in $DelaySeconds seconds..." -ForegroundColor Yellow
+        Start-Sleep -Seconds $DelaySeconds
+    }
+}
+
 # Extract version
 if (Test-Path $VERSION_FILE) {
     $content = Get-Content $VERSION_FILE -Raw
@@ -135,6 +162,23 @@ if ($LASTEXITCODE -ne 0) {
     throw "PyInstaller build failed"
 }
 Write-Host "PyInstaller backend ready" -ForegroundColor Green
+Write-Host ""
+
+# Step 2b: Fetch Tauri Rust dependencies
+Write-Host "== Step 2b: Fetching Tauri Rust Dependencies ==" -ForegroundColor Yellow
+if (-not $env:CARGO_NET_RETRY) {
+    $env:CARGO_NET_RETRY = "10"
+}
+if (-not $env:CARGO_HTTP_MULTIPLEXING) {
+    $env:CARGO_HTTP_MULTIPLEXING = "false"
+}
+
+$TAURI_MANIFEST = Join-Path $REPO_ROOT "console\src-tauri\Cargo.toml"
+Invoke-NativeWithRetry -Description "cargo fetch for Tauri dependencies" -Command {
+    cargo fetch --locked --target x86_64-pc-windows-msvc --manifest-path $TAURI_MANIFEST
+}
+$env:CARGO_NET_OFFLINE = "true"
+Write-Host "Tauri Rust dependencies fetched; Cargo offline mode enabled" -ForegroundColor Green
 Write-Host ""
 
 # Step 3: Build Tauri app


### PR DESCRIPTION
## Summary
- Pre-fetch Tauri Rust dependencies with retry and offline build on Windows to avoid transient crates.io TLS failures during `tauri build`.
- Add uv, npm, and Rust caches to Tauri desktop CI jobs so Windows builds align with macOS and reuse dependency artifacts across runs.

## Test plan
- [ ] Verify `build-tauri-windows` succeeds on fork CI (workflow dispatch triggered on `fix/tauri-windows-cargo-fetch`).
- [ ] Confirm `build-tauri-macos` still passes with added npm/Rust caches.
- [ ] Check staged Windows installer artifact is produced and uploadable.
