### PR TITLE
group langfuse observations by agent loop

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -784,58 +784,69 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
     async def _acting(self, tool_call) -> dict | None:
         """Check plan tool gate before delegating to ToolGuardMixin."""
         from ..plan.hints import check_plan_tool_gate
+        from ..observability.langfuse import tool_span
 
         tool_name = str(tool_call.get("name", ""))
 
-        if tool_name in self._PLAN_TOOLS_WITH_JSON_ARGS:
-            self._fix_stringified_json_args(tool_call)
+        async with tool_span(
+            name=tool_name or "unknown",
+            input=tool_call.get("input"),
+            metadata={"tool_call_id": tool_call.get("id")},
+        ) as langfuse_span:
+            if tool_name in self._PLAN_TOOLS_WITH_JSON_ARGS:
+                self._fix_stringified_json_args(tool_call)
 
-        nb = getattr(self, "plan_notebook", None)
+            nb = getattr(self, "plan_notebook", None)
 
-        # Pre-lock BEFORE executing create_plan / revise_current_plan so that
-        # parallel tool calls (asyncio.gather) cannot slip an execution
-        # tool past the gate before the lock is set.
-        # pylint: disable=protected-access
-        if nb is not None and tool_name in {
-            "create_plan",
-            "revise_current_plan",
-        }:
-            nb._plan_awaiting_user_confirm = True
-
-        if nb is not None:
-            err = check_plan_tool_gate(nb, tool_name)
-            if err:
-                from agentscope.message import ToolResultBlock
-
-                tool_res_msg = Msg(
-                    "system",
-                    [
-                        ToolResultBlock(
-                            type="tool_result",
-                            id=tool_call["id"],
-                            name=tool_name,
-                            output=[{"type": "text", "text": err}],
-                        ),
-                    ],
-                    "system",
-                )
-                await self.print(tool_res_msg, True)
-                await self.memory.add(tool_res_msg)
-                return None
-
-        result = await super()._acting(tool_call)
-
-        if nb is not None and tool_name in {
-            "create_plan",
-            "revise_current_plan",
-        }:
-            # Force the next post-plan reasoning pass to be text-only.  This
-            # prevents models from emitting other tools in the same turn
-            # run before the user has confirmed the plan or modified it.
+            # Pre-lock BEFORE executing create_plan / revise_current_plan so
+            # that parallel tool calls (asyncio.gather) cannot slip an
+            # execution tool past the gate before the lock is set.
             # pylint: disable=protected-access
-            nb._plan_text_only_after_mutation = True
+            if nb is not None and tool_name in {
+                "create_plan",
+                "revise_current_plan",
+            }:
+                nb._plan_awaiting_user_confirm = True
 
-        return result
+            if nb is not None:
+                err = check_plan_tool_gate(nb, tool_name)
+                if err:
+                    from agentscope.message import ToolResultBlock
+
+                    tool_res_msg = Msg(
+                        "system",
+                        [
+                            ToolResultBlock(
+                                type="tool_result",
+                                id=tool_call["id"],
+                                name=tool_name,
+                                output=[{"type": "text", "text": err}],
+                            ),
+                        ],
+                        "system",
+                    )
+                    await self.print(tool_res_msg, True)
+                    await self.memory.add(tool_res_msg)
+                    if langfuse_span is not None:
+                        langfuse_span.update(output={"blocked": err})
+                    return None
+
+            result = await super()._acting(tool_call)
+
+            if langfuse_span is not None:
+                langfuse_span.update(output=result)
+
+            if nb is not None and tool_name in {
+                "create_plan",
+                "revise_current_plan",
+            }:
+                # Force the next post-plan reasoning pass to be text-only. This
+                # prevents models from emitting other tools in the same turn run
+                # before the user has confirmed the plan or modified it.
+                # pylint: disable=protected-access
+                nb._plan_text_only_after_mutation = True
+
+            return result
 
     _AUTO_CONTINUE_MAX_EXTRA = 2
     _AUTO_CONTINUE_TAIL_CHARS = 600

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -272,9 +272,11 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
                     "delegate_external_agent",
                 }
                 async_execution_tools = {
-                    name: builtin_tools.get(name).async_execution
-                    if name in builtin_tools
-                    else False
+                    name: (
+                        builtin_tools.get(name).async_execution
+                        if name in builtin_tools
+                        else False
+                    )
                     for name in async_capable_tool_names
                 }
         except Exception as e:
@@ -840,9 +842,10 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
                 "create_plan",
                 "revise_current_plan",
             }:
-                # Force the next post-plan reasoning pass to be text-only. This
-                # prevents models from emitting other tools in the same turn run
-                # before the user has confirmed the plan or modified it.
+                # Force the next post-plan reasoning pass to be text-only.
+                # This prevents models from emitting other tools in the same
+                # turn run before the user has confirmed the plan or modified
+                # it.
                 # pylint: disable=protected-access
                 nb._plan_text_only_after_mutation = True
 

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine
 
@@ -874,43 +875,67 @@ class AgentRunner(Runner):
             agent.rebuild_sys_prompt()
 
             # --- Execution: Mission Mode (phased) or standard -----
-            if mission_info is not None:
-                from ...agents.mission.mission_runner import (
-                    run_mission_phase1,
-                    run_mission_phase2,
-                )
+            from ...observability.langfuse import agent_trace_scope
 
-                phase = mission_info["mission_phase"]
-                loop_dir = Path(mission_info["loop_dir"])
-                max_iters = mission_info.get(
-                    "max_iterations",
-                    20,
-                )
+            root_session_id = base_request_context.get(
+                "root_session_id",
+                session_id,
+            )
+            trace_metadata = {
+                "session_id": session_id,
+                "root_session_id": root_session_id,
+                "user_id": user_id,
+                "channel": channel,
+                "agent_id": self.agent_id,
+                "root_agent_id": base_request_context.get("root_agent_id"),
+                "source": base_request_context.get("source"),
+            }
+            async with agent_trace_scope(
+                trace_id=uuid.uuid4().hex,
+                name="qwenpaw.agent.react_loop",
+                metadata=trace_metadata,
+                input={
+                    "query": query,
+                    "messages_count": len(msgs) if msgs else 0,
+                },
+            ):
+                if mission_info is not None:
+                    from ...agents.mission.mission_runner import (
+                        run_mission_phase1,
+                        run_mission_phase2,
+                    )
 
-                if phase == 1:
-                    async for msg, last in run_mission_phase1(
-                        agent=agent,
-                        msgs=msgs,
-                        loop_dir=loop_dir,
-                        max_iterations=max_iters,
-                        agent_id=self.agent_id,
-                    ):
-                        yield msg, last
+                    phase = mission_info["mission_phase"]
+                    loop_dir = Path(mission_info["loop_dir"])
+                    max_iters = mission_info.get(
+                        "max_iterations",
+                        20,
+                    )
+
+                    if phase == 1:
+                        async for msg, last in run_mission_phase1(
+                            agent=agent,
+                            msgs=msgs,
+                            loop_dir=loop_dir,
+                            max_iterations=max_iters,
+                            agent_id=self.agent_id,
+                        ):
+                            yield msg, last
+                    else:
+                        async for msg, last in run_mission_phase2(
+                            agent=agent,
+                            msgs=msgs,
+                            loop_dir=loop_dir,
+                            max_iterations=max_iters,
+                            agent_id=self.agent_id,
+                        ):
+                            yield msg, last
                 else:
-                    async for msg, last in run_mission_phase2(
-                        agent=agent,
-                        msgs=msgs,
-                        loop_dir=loop_dir,
-                        max_iterations=max_iters,
-                        agent_id=self.agent_id,
+                    async for msg, last in _stream_printing_messages_interruptible(
+                        agents=[agent],
+                        coroutine_task=agent(msgs),
                     ):
                         yield msg, last
-            else:
-                async for msg, last in _stream_printing_messages_interruptible(
-                    agents=[agent],
-                    coroutine_task=agent(msgs),
-                ):
-                    yield msg, last
 
         except asyncio.CancelledError as exc:
             logger.info(f"query_handler: {session_id} cancelled!")

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -931,7 +931,10 @@ class AgentRunner(Runner):
                         ):
                             yield msg, last
                 else:
-                    async for msg, last in _stream_printing_messages_interruptible(
+                    async for (
+                        msg,
+                        last,
+                    ) in _stream_printing_messages_interruptible(
                         agents=[agent],
                         coroutine_task=agent(msgs),
                     ):
@@ -955,11 +958,14 @@ class AgentRunner(Runner):
             )
             if cancelled_count > 0:
                 logger.info(
-                    "Auto-denied %d pending approval(s) for root session %s",
+                    "Auto-denied %d pending approval(s) for root "
+                    "session %s",
                     cancelled_count,
-                    root_session_id[:8]
-                    if len(root_session_id) >= 8
-                    else root_session_id,
+                    (
+                        root_session_id[:8]
+                        if len(root_session_id) >= 8
+                        else root_session_id
+                    ),
                 )
 
             if agent is not None:

--- a/src/qwenpaw/observability/__init__.py
+++ b/src/qwenpaw/observability/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Observability helpers."""

--- a/src/qwenpaw/observability/langfuse.py
+++ b/src/qwenpaw/observability/langfuse.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Langfuse trace context for QwenPaw agent turns.
+
+This module is intentionally optional: QwenPaw does not depend on langfuse at
+install time, so every helper becomes a no-op when Langfuse is unavailable.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LangfuseTraceContext:
+    trace_id: str
+    parent_observation_id: str | None
+    name: str
+    metadata: dict[str, Any]
+
+
+_current_trace: ContextVar[LangfuseTraceContext | None] = ContextVar(
+    "qwenpaw_langfuse_trace",
+    default=None,
+)
+
+
+def _langfuse_available() -> bool:
+    return importlib.util.find_spec("langfuse") is not None
+
+
+def is_langfuse_enabled() -> bool:
+    """Return True when the Langfuse OpenAI instrumentation can be used."""
+
+    if not os.environ.get("LANGFUSE_SECRET_KEY") or not _langfuse_available():
+        return False
+    try:
+        import langfuse.openai  # noqa: F401  # type: ignore[import]
+    except Exception:
+        logger.debug("Failed to register Langfuse OpenAI tracing", exc_info=True)
+        return False
+    return True
+
+
+def _langfuse_client() -> Any | None:
+    if not _langfuse_available():
+        return None
+    try:
+        from langfuse import get_client  # type: ignore[import]
+
+        return get_client()
+    except Exception:
+        logger.debug("Failed to initialize Langfuse client", exc_info=True)
+        return None
+
+
+def set_current_trace(
+    *,
+    trace_id: str,
+    parent_observation_id: str | None,
+    name: str,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    _current_trace.set(
+        LangfuseTraceContext(
+            trace_id=trace_id,
+            parent_observation_id=parent_observation_id,
+            name=name,
+            metadata=dict(metadata or {}),
+        ),
+    )
+
+
+def clear_current_trace() -> None:
+    _current_trace.set(None)
+
+
+def get_current_trace() -> LangfuseTraceContext | None:
+    return _current_trace.get()
+
+
+def current_generation_kwargs(model_name: str | None = None) -> dict[str, Any]:
+    """Build Langfuse-only kwargs for the OpenAI SDK wrapper."""
+
+    ctx = get_current_trace()
+    if ctx is None:
+        return {}
+
+    metadata = {
+        **ctx.metadata,
+        "langfuse_observation_kind": "llm",
+    }
+    name = f"llm.{model_name}" if model_name else "llm"
+    kwargs: dict[str, Any] = {
+        "trace_id": ctx.trace_id,
+        "name": name,
+        "metadata": metadata,
+    }
+    if ctx.parent_observation_id:
+        kwargs["parent_observation_id"] = ctx.parent_observation_id
+    return kwargs
+
+
+@asynccontextmanager
+async def agent_trace_scope(
+    *,
+    trace_id: str,
+    name: str,
+    metadata: dict[str, Any],
+    input: Any | None = None,  # pylint: disable=redefined-builtin
+    client_factory: Callable[[], Any | None] | None = None,
+) -> AsyncIterator[Any | None]:
+    """Create the root Langfuse span for one agent ReAct loop."""
+
+    previous = get_current_trace()
+    if client_factory is None and not is_langfuse_enabled():
+        yield None
+        return
+
+    client = (client_factory or _langfuse_client)()
+    root = None
+    parent_observation_id: str | None = None
+
+    try:
+        if client is not None:
+            root = client.start_observation(
+                as_type="span",
+                name=name,
+                input=input,
+                metadata=metadata,
+                trace_context={"trace_id": trace_id},
+            )
+            parent_observation_id = str(getattr(root, "id", "") or "") or None
+
+        set_current_trace(
+            trace_id=trace_id,
+            parent_observation_id=parent_observation_id,
+            name=name,
+            metadata=metadata,
+        )
+        yield root
+        if root is not None:
+            root.update(output={"status": "success"})
+    except Exception as exc:
+        if root is not None:
+            root.update(
+                level="ERROR",
+                status_message=str(exc),
+                output={"status": "error"},
+            )
+        raise
+    finally:
+        if root is not None:
+            root.end()
+        if previous is None:
+            clear_current_trace()
+        else:
+            set_current_trace(
+                trace_id=previous.trace_id,
+                parent_observation_id=previous.parent_observation_id,
+                name=previous.name,
+                metadata=previous.metadata,
+            )
+
+
+@asynccontextmanager
+async def tool_span(
+    *,
+    name: str,
+    input: Any | None = None,  # pylint: disable=redefined-builtin
+    metadata: dict[str, Any] | None = None,
+    client_factory: Callable[[], Any | None] | None = None,
+) -> AsyncIterator[Any | None]:
+    """Create a Langfuse tool observation under the current agent trace."""
+
+    ctx = get_current_trace()
+    if client_factory is None and not is_langfuse_enabled():
+        yield None
+        return
+
+    client = (client_factory or _langfuse_client)() if ctx is not None else None
+    observation = None
+
+    try:
+        if client is not None and ctx is not None:
+            trace_context: dict[str, str] = {"trace_id": ctx.trace_id}
+            if ctx.parent_observation_id:
+                trace_context["parent_span_id"] = ctx.parent_observation_id
+            observation = client.start_observation(
+                as_type="tool",
+                name=f"tool.{name}",
+                input=input,
+                metadata={
+                    **ctx.metadata,
+                    **(metadata or {}),
+                    "langfuse_observation_kind": "tool",
+                    "tool_name": name,
+                },
+                trace_context=trace_context,
+            )
+        yield observation
+    except Exception as exc:
+        if observation is not None:
+            observation.update(
+                level="ERROR",
+                status_message=str(exc),
+                output={"status": "error"},
+            )
+        raise
+    finally:
+        if observation is not None:
+            observation.end()

--- a/src/qwenpaw/observability/langfuse.py
+++ b/src/qwenpaw/observability/langfuse.py
@@ -6,6 +6,7 @@ install time, so every helper becomes a no-op when Langfuse is unavailable.
 """
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import logging
 import os
@@ -41,9 +42,12 @@ def is_langfuse_enabled() -> bool:
     if not os.environ.get("LANGFUSE_SECRET_KEY") or not _langfuse_available():
         return False
     try:
-        import langfuse.openai  # noqa: F401  # type: ignore[import]
+        importlib.import_module("langfuse.openai")
     except Exception:
-        logger.debug("Failed to register Langfuse OpenAI tracing", exc_info=True)
+        logger.debug(
+            "Failed to register Langfuse OpenAI tracing",
+            exc_info=True,
+        )
         return False
     return True
 
@@ -184,7 +188,9 @@ async def tool_span(
         yield None
         return
 
-    client = (client_factory or _langfuse_client)() if ctx is not None else None
+    client = (
+        (client_factory or _langfuse_client)() if ctx is not None else None
+    )
     observation = None
 
     try:

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -399,6 +399,14 @@ class OpenAIChatModelCompat(OpenAIChatModel):
             if extra_body:
                 self.generate_kwargs["extra_body"] = extra_body
 
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        from qwenpaw.observability.langfuse import current_generation_kwargs
+
+        langfuse_kwargs = current_generation_kwargs(self.model_name)
+        if langfuse_kwargs:
+            kwargs = {**langfuse_kwargs, **kwargs}
+        return await super().__call__(*args, **kwargs)
+
     def _format_tools_json_schemas(
         self,
         schemas: list[dict[str, Any]],

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -400,7 +400,7 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                 self.generate_kwargs["extra_body"] = extra_body
 
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        from qwenpaw.observability.langfuse import current_generation_kwargs
+        from ..observability.langfuse import current_generation_kwargs
 
         langfuse_kwargs = current_generation_kwargs(self.model_name)
         if langfuse_kwargs:

--- a/tests/unit/observability/test_langfuse_context.py
+++ b/tests/unit/observability/test_langfuse_context.py
@@ -1,0 +1,112 @@
+import pytest
+
+from qwenpaw.observability import langfuse as lf
+
+
+class FakeObservation:
+    def __init__(self, observation_id: str):
+        self.id = observation_id
+        self.updates = []
+        self.ended = False
+
+    def update(self, **kwargs):
+        self.updates.append(kwargs)
+        return self
+
+    def end(self):
+        self.ended = True
+        return self
+
+
+class FakeClient:
+    def __init__(self):
+        self.started = []
+        self.next_id = 0
+
+    def start_observation(self, **kwargs):
+        self.started.append(kwargs)
+        self.next_id += 1
+        return FakeObservation(f"obs-{self.next_id}")
+
+
+@pytest.fixture(autouse=True)
+def reset_context(monkeypatch):
+    lf.clear_current_trace()
+    monkeypatch.setattr(lf, "_langfuse_client", lambda: None)
+    yield
+    lf.clear_current_trace()
+
+
+def test_model_kwargs_include_current_agent_trace_context():
+    lf.set_current_trace(
+        trace_id="trace-1",
+        parent_observation_id="root-1",
+        name="agent.react_loop",
+        metadata={
+            "session_id": "session-a",
+            "agent_id": "default",
+        },
+    )
+
+    kwargs = lf.current_generation_kwargs("qwen-max")
+
+    assert kwargs == {
+        "trace_id": "trace-1",
+        "parent_observation_id": "root-1",
+        "name": "llm.qwen-max",
+        "metadata": {
+            "session_id": "session-a",
+            "agent_id": "default",
+            "langfuse_observation_kind": "llm",
+        },
+    }
+
+
+async def test_agent_trace_scope_creates_root_span_and_restores_context():
+    client = FakeClient()
+
+    async with lf.agent_trace_scope(
+        trace_id="trace-1",
+        name="agent.react_loop",
+        metadata={"session_id": "session-a"},
+        client_factory=lambda: client,
+    ):
+        kwargs = lf.current_generation_kwargs("qwen-max")
+
+    assert len(client.started) == 1
+    assert client.started[0]["as_type"] == "span"
+    assert client.started[0]["name"] == "agent.react_loop"
+    assert client.started[0]["trace_context"] == {"trace_id": "trace-1"}
+    assert kwargs["parent_observation_id"] == "obs-1"
+    assert lf.current_generation_kwargs("qwen-max") == {}
+
+
+async def test_tool_span_records_input_output_and_error_status():
+    client = FakeClient()
+    lf.set_current_trace(
+        trace_id="trace-1",
+        parent_observation_id="root-1",
+        name="agent.react_loop",
+        metadata={"session_id": "session-a"},
+    )
+
+    with pytest.raises(RuntimeError):
+        async with lf.tool_span(
+            name="execute_shell_command",
+            input={"command": "false"},
+            client_factory=lambda: client,
+        ) as span:
+            assert span is not None
+            raise RuntimeError("boom")
+
+    assert len(client.started) == 1
+    assert client.started[0]["as_type"] == "tool"
+    assert client.started[0]["name"] == "tool.execute_shell_command"
+    assert client.started[0]["trace_context"] == {
+        "trace_id": "trace-1",
+        "parent_span_id": "root-1",
+    }
+    observation = span
+    assert observation.updates[-1]["level"] == "ERROR"
+    assert observation.updates[-1]["status_message"] == "boom"
+    assert observation.ended is True

--- a/tests/unit/observability/test_langfuse_context.py
+++ b/tests/unit/observability/test_langfuse_context.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from qwenpaw.observability import langfuse as lf
@@ -78,7 +79,7 @@ async def test_agent_trace_scope_creates_root_span_and_restores_context():
     assert client.started[0]["name"] == "agent.react_loop"
     assert client.started[0]["trace_context"] == {"trace_id": "trace-1"}
     assert kwargs["parent_observation_id"] == "obs-1"
-    assert lf.current_generation_kwargs("qwen-max") == {}
+    assert not lf.current_generation_kwargs("qwen-max")
 
 
 async def test_tool_span_records_input_output_and_error_status():


### PR DESCRIPTION


## Description

This PR improves Langfuse observability by grouping one full agent ReAct loop into a single trace.

Previously, each OpenAI-compatible LLM call could be reported as a separate Langfuse trace, which made one conversation turn appear as many disconnected traces. This PR adds an agent-level Langfuse trace scope around each runner execution, then attaches LLM generations and tool calls as child observations under that trace.

**Related Issue:** Fixes #5127

**Security Considerations:** Langfuse integration remains optional and environment-gated. No secrets are logged or persisted by this change. Trace metadata includes runtime identifiers such as session ID, user ID, channel, and agent ID, matching observability use cases.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Tested the Langfuse trace-context helpers and related provider/agent/runner behavior with focused unit tests.

The covered behavior includes:

- agent trace context propagation into model generation kwargs
- root span creation and context restoration
- tool observation creation under the current trace
- error handling for tool observations
- existing OpenAI provider compatibility tests
- existing runner/session behavior tests

## Local Verification Evidence

```bash
uv run --no-project --with-editable . --with pytest --with pytest-asyncio --with langfuse python -m pytest tests/unit/observability/test_langfuse_context.py tests/unit/providers/test_openai_provider.py tests/unit/providers/test_openai_stream_toolcall_compat.py tests/unit/agents/test_tool_guard_mixin.py tests/unit/app/runner/test_command_dispatch.py tests/unit/app/runner/test_session.py -q
# 118 passed, 1 warning in 1.20s
```

```bash
uv run --no-project --with-editable . --with langfuse python -m py_compile src/qwenpaw/observability/langfuse.py src/qwenpaw/providers/openai_chat_model_compat.py src/qwenpaw/agents/react_agent.py src/qwenpaw/app/runner/runner.py
# passed
```

```bash
pre-commit run --all-files
# not run
```

## Additional Notes

This change does not alter behavior when Langfuse is unavailable or not configured. In that case, the observability helpers become no-ops and normal agent execution continues unchanged.
