### PR TITLE
fix(skill): Improve skill-slash-inject and display

### DIFF
--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -265,16 +265,40 @@ class AgentRunner(Runner):
                 ],
             )
 
-        # /<name> <input> → rewrite user message with skill body.
+        # /<name> <input> → append the skill body to the user message as
+        # a trailing <skill> block. The typed command stays verbatim at
+        # the head; everything injected lives inside the block.
+        original_text = AgentRunner._extract_text_content(msgs[-1])
         merged = (
-            f"Use the [{display_name}] skill in "
-            f"`{skill_dir}` to fulfill "
-            f"user's task: {user_input}\n\n"
-            f"{post.content}"
+            f"{original_text}\n\n"
+            f'<skill name="{display_name}" dir="{skill_dir}">\n'
+            f"This block was injected because the user invoked the "
+            f"[{display_name}] skill above. It is the full content of "
+            f"the skill's SKILL.md — do not re-read that file. Follow "
+            f"these instructions to fulfill the user's task: "
+            f"{user_input}\n"
+            f"Relative paths inside the skill (e.g. `scripts/`) resolve "
+            f"against the skill directory.\n\n"
+            f"{post.content.strip()}\n"
+            f"</skill>"
         )
         AgentRunner._rewrite_last_message_text(msgs, merged)
         logger.info("Skill invocation: %s", name)
         return None
+
+    @staticmethod
+    def _extract_text_content(msg) -> str:
+        """Return the concatenated text of a Msg's content."""
+        content = getattr(msg, "content", None)
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "\n".join(
+                block.get("text") or ""
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        return ""
 
     @staticmethod
     def _rewrite_last_message_text(

--- a/src/qwenpaw/app/runner/utils.py
+++ b/src/qwenpaw/app/runner/utils.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import platform
+import re
 from datetime import datetime, timezone
 from typing import List, Optional, Union
 from urllib.parse import unquote, urlparse
@@ -328,6 +329,27 @@ def _build_media_message_from_block(
     return media_message
 
 
+# Matches the trailing <skill> block appended to a user message by
+# slash-command skill expansion (runner._maybe_inject_skill).
+_INJECTED_SKILL_BLOCK_RE = re.compile(
+    r"\s*<skill\b[^>]*>.*</skill>\s*$",
+    re.DOTALL,
+)
+
+
+def strip_injected_skill_block(text: str, role: str) -> str:
+    """Hide the system-injected <skill> block from display.
+
+    Slash-command skill expansion keeps the user's typed text at the
+    head of the message and appends the skill body in a trailing
+    <skill> block. The block is model-facing context; transcripts
+    should show only what the user typed.
+    """
+    if role != "user" or "<skill" not in text:
+        return text
+    return _INJECTED_SKILL_BLOCK_RE.sub("", text)
+
+
 # pylint: disable=too-many-branches,too-many-statements, too-many-nested-blocks
 def agentscope_msg_to_message(
     messages: Union[Msg, List[Msg]],
@@ -385,7 +407,7 @@ def agentscope_msg_to_message(
             text_content = TextContent(
                 delta=False,
                 index=None,
-                text=msg.content,
+                text=strip_injected_skill_block(msg.content, role),
             )
             message.add_content(new_content=text_content)
             results.append(message)
@@ -414,7 +436,10 @@ def agentscope_msg_to_message(
                 text_content = TextContent(
                     delta=False,
                     index=None,
-                    text=block.get("text", ""),
+                    text=strip_injected_skill_block(
+                        block.get("text", ""),
+                        role,
+                    ),
                 )
                 current_message.add_content(new_content=text_content)
 


### PR DESCRIPTION
## Description

Use skill block as skill injection. <skill & </skill>

Remove full skill.md in display.

**Related Issue:** Fixes #5031.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic
