### PR TITLE
fix(console): fixed session redirection when switching code mode

### DIFF
--- a/console/src/components/CodingModeToggle/index.tsx
+++ b/console/src/components/CodingModeToggle/index.tsx
@@ -6,8 +6,12 @@ import { useCodingMode, useProjectDir } from "../../stores/codingModeStore";
 import { useAgentStore } from "../../stores/agentStore";
 import { getApiUrl } from "../../api/config";
 import { buildAuthHeaders } from "../../api/authHeaders";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import ProjectSelectModal from "../ProjectSelectModal";
+import {
+  buildSessionPath,
+  getSessionIdFromPath,
+} from "../../utils/sessionRoute";
 import styles from "./index.module.less";
 
 const CONFIRMED_KEY = "qwenpaw-coding-mode-confirmed";
@@ -17,6 +21,7 @@ export default function CodingModeToggle() {
   const { codingMode, initialized, setCodingMode } = useCodingMode();
   const { selectedAgent } = useAgentStore();
   const navigate = useNavigate();
+  const location = useLocation();
   const { projectDir } = useProjectDir();
   const [loading, setLoading] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -36,13 +41,14 @@ export default function CodingModeToggle() {
         body: JSON.stringify({ enabled: true }),
       });
       setCodingMode(true);
-      navigate("/coding");
+      const currentSessionId = getSessionIdFromPath(location.pathname);
+      navigate(buildSessionPath("coding", currentSessionId));
     } catch {
       // Silently ignore
     } finally {
       setLoading(false);
     }
-  }, [loading, selectedAgent, setCodingMode, navigate]);
+  }, [loading, selectedAgent, setCodingMode, navigate, location.pathname]);
 
   const deactivate = useCallback(async () => {
     if (loading) return;
@@ -58,13 +64,14 @@ export default function CodingModeToggle() {
         body: JSON.stringify({ enabled: false }),
       });
       setCodingMode(false);
-      navigate("/chat");
+      const currentSessionId = getSessionIdFromPath(location.pathname);
+      navigate(buildSessionPath("chat", currentSessionId));
     } catch {
       // Silently ignore
     } finally {
       setLoading(false);
     }
-  }, [loading, selectedAgent, setCodingMode, navigate]);
+  }, [loading, selectedAgent, setCodingMode, navigate, location.pathname]);
 
   const toggle = useCallback(async () => {
     if (codingMode) {

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Layout, Menu, Button, Modal, Input, Form, Tooltip, Badge } from "antd";
 import { useState, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "../hooks/useAppMessage";
 import AgentSelector from "../components/AgentSelector";
@@ -16,6 +16,7 @@ import { clearAuthToken } from "../api/config";
 import { authApi } from "../api/modules/auth";
 import api from "../api";
 import { useCodingMode } from "../stores/codingModeStore";
+import { buildSessionPath, getSessionIdFromPath } from "../utils/sessionRoute";
 import styles from "./index.module.less";
 import { useTheme } from "../contexts/ThemeContext";
 import { useMenuItems, useRoutes } from "../plugins/registry/hooks";
@@ -57,13 +58,18 @@ interface SidebarProps {
 
 export default function Sidebar({ selectedKey }: SidebarProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation();
   const { message } = useAppMessage();
   const { isDark } = useTheme();
   // When coding mode is on, the sidebar "Chat" entry should land on /coding
   // (FileTree + Editor + Chat panel) rather than the bare Chat page.
   const { codingMode } = useCodingMode();
-  const chatPath = codingMode ? "/coding" : "/chat";
+  const currentSessionId = getSessionIdFromPath(location.pathname);
+  const chatPath = buildSessionPath(
+    codingMode ? "coding" : "chat",
+    currentSessionId,
+  );
   const [authEnabled, setAuthEnabled] = useState(false);
   const [accountModalOpen, setAccountModalOpen] = useState(false);
   const [accountLoading, setAccountLoading] = useState(false);

--- a/console/src/layouts/registry/builtinRoutes.tsx
+++ b/console/src/layouts/registry/builtinRoutes.tsx
@@ -82,7 +82,7 @@ function ACPRedirect() {
 export const BUILTIN_ROUTES: Route[] = [
   { id: "core.root", path: "/", component: DefaultRedirect },
   { id: "core.chat", path: "/chat/*", component: Chat },
-  { id: "core.coding", path: "/coding", component: CodingPage },
+  { id: "core.coding", path: "/coding/*", component: CodingPage },
   { id: "core.channels", path: "/channels", component: ChannelsPage },
   { id: "core.sessions", path: "/sessions", component: SessionsPage },
   { id: "core.inbox", path: "/inbox", component: InboxPage },

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from "react-i18next";
 import type { ChatStatus } from "../../../../api/types/chat";
 import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
+import { buildSessionPath } from "../../../../utils/sessionRoute";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import ChatSessionItem from "../ChatSessionItem";
 import { getChannelLabel } from "../../../Control/Channels/components";
@@ -296,15 +297,14 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       sessionApi
         .preloadSession(sessionId)
         .then(({ realId }) => {
-          // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
-          // The redirect effect in ChatPage would immediately navigate back
-          // to /coding before session data loads, causing the switch to fail.
-          // Instead, just set the session directly — the UI stays on /coding.
-          if (!codingMode) {
-            const targetUrl = `/chat/${realId || sessionId}`;
-            sessionApi.lastNavigatedChatId = realId || sessionId;
-            navigate(targetUrl, { replace: true });
-          }
+          // Issue #5142: Navigate to the correct URL for the current mode.
+          const effectiveId = realId || sessionId;
+          const targetUrl = buildSessionPath(
+            codingMode ? "coding" : "chat",
+            effectiveId,
+          );
+          sessionApi.lastNavigatedChatId = effectiveId;
+          navigate(targetUrl, { replace: true });
           // Now set currentSessionId — the library's getSession will hit cache.
           setCurrentSessionId(sessionId);
         })

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -2,9 +2,13 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
 import sessionApi from "../../sessionApi";
+import { getSessionIdFromPath } from "../../../../utils/sessionRoute";
 
 /**
  * URL chatId → context currentSessionId (one direction of bidirectional sync).
+ *
+ * Extracts sessionId from both `/chat/<id>` and `/coding/<id>` URLs so that
+ * Coding mode sessions survive page refreshes (issue #5142).
  *
  * Only reacts to URL or session list changes. currentSessionId is read via ref
  * to avoid triggering the effect when the context changes from the other direction
@@ -16,10 +20,13 @@ import sessionApi from "../../sessionApi";
  */
 const ChatSessionInitializer: React.FC = () => {
   const location = useLocation();
-  const chatId = useMemo(() => {
-    const match = location.pathname.match(/^\/chat\/(.+)$/);
-    return match?.[1];
-  }, [location.pathname]);
+
+  // Issue #5142: Match both /chat/<id> and /coding/<id> so that Coding mode
+  // sessions are restored from the URL on page refresh, just like Chat mode.
+  const chatId = useMemo(
+    () => getSessionIdFromPath(location.pathname),
+    [location.pathname],
+  );
 
   const { sessions, currentSessionId, setCurrentSessionId } =
     useChatAnywhereSessionsState();

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -77,6 +77,12 @@ import {
   type CopyableResponse,
   type RuntimeLoadingBridgeApi,
 } from "./utils";
+import {
+  getSessionIdFromPath,
+  buildBasePath,
+  buildSessionPath,
+  type SessionRouteMode,
+} from "../../utils/sessionRoute";
 import { openExternalLink } from "../../utils/openExternalLink";
 import { getLastEditorCopy } from "../Coding/lastEditorCopy";
 import { useUploadLimitStore } from "../../stores/uploadLimitStore";
@@ -698,18 +704,25 @@ export default function ChatPage() {
   const location = useLocation();
   const { isDark } = useTheme();
   const { codingMode, initialized } = useCodingMode();
+  const codingModeRef = useRef(codingMode);
+  codingModeRef.current = codingMode;
 
-  // Redirect to /coding when coding mode is active
+  // Redirect to /coding when coding mode is active, preserving sessionId.
   useEffect(() => {
-    if (initialized && codingMode) {
-      navigate("/coding", { replace: true });
+    if (initialized && codingMode && !location.pathname.startsWith("/coding")) {
+      // Issue #5142: Carry over the current chatId so the session survives
+      // the redirect from /chat/<id> to /coding/<id>.
+      const currentChatId = getSessionIdFromPath(location.pathname);
+      navigate(buildSessionPath("coding", currentChatId), {
+        replace: true,
+      });
     }
-  }, [initialized, codingMode, navigate]);
+  }, [initialized, codingMode, navigate, location.pathname]);
 
-  const chatId = useMemo(() => {
-    const match = location.pathname.match(/^\/chat\/(.+)$/);
-    return match?.[1];
-  }, [location.pathname]);
+  const chatId = useMemo(
+    () => getSessionIdFromPath(location.pathname),
+    [location.pathname],
+  );
   const [showModelPrompt, setShowModelPrompt] = useState(false);
   const [rateLimitAlternatives, setRateLimitAlternatives] = useState<
     Array<{
@@ -772,8 +785,12 @@ export default function ChatPage() {
   }, [selectedAgent]);
 
   const isChatActiveRef = useRef(false);
+  // Issue #5142: In Coding mode the Chat component is embedded under /coding/*,
+  // so session callbacks must also fire on /coding paths.
   isChatActiveRef.current =
-    location.pathname === "/" || location.pathname.startsWith("/chat");
+    location.pathname === "/" ||
+    location.pathname.startsWith("/chat") ||
+    location.pathname.startsWith("/coding");
 
   const isChatActive = useCallback(() => isChatActiveRef.current, []);
 
@@ -1040,12 +1057,20 @@ export default function ChatPage() {
   // Register session API event callbacks for URL synchronization
 
   useEffect(() => {
+    const getCurrentRouteMode = (): SessionRouteMode =>
+      codingModeRef.current ? "coding" : "chat";
+
+    const buildCurrentSessionPath = (sessionId: string) =>
+      buildSessionPath(getCurrentRouteMode(), sessionId);
+
+    const buildCurrentBasePath = () => buildBasePath(getCurrentRouteMode());
+
     sessionApi.onSessionIdResolved = (realId) => {
       if (!isChatActiveRef.current) return;
       // Update URL when realId is resolved, regardless of current chatId
       // (chatId may be undefined if URL was cleared in onSessionCreated)
       lastSessionIdRef.current = realId;
-      navigateRef.current(`/chat/${realId}`, { replace: true });
+      navigateRef.current(buildCurrentSessionPath(realId), { replace: true });
     };
 
     sessionApi.onSessionRemoved = (removedId) => {
@@ -1057,7 +1082,7 @@ export default function ChatPage() {
       );
       if (chatIdRef.current === removedId || currentRealId === removedId) {
         lastSessionIdRef.current = null;
-        navigateRef.current("/chat", { replace: true });
+        navigateRef.current(buildCurrentBasePath(), { replace: true });
       }
     };
 
@@ -1102,7 +1127,9 @@ export default function ChatPage() {
       if (targetId !== lastSessionIdRef.current) {
         lastSessionIdRef.current = targetId;
         sessionApi.lastNavigatedChatId = targetId;
-        navigateRef.current(`/chat/${targetId}`, { replace: true });
+        navigateRef.current(buildCurrentSessionPath(targetId), {
+          replace: true,
+        });
       }
     };
 
@@ -1110,7 +1137,7 @@ export default function ChatPage() {
       if (!isChatActiveRef.current) return;
       // Clear URL when creating new session, wait for realId resolution to update
       lastSessionIdRef.current = null;
-      navigateRef.current("/chat", { replace: true });
+      navigateRef.current(buildCurrentBasePath(), { replace: true });
     };
 
     return () => {
@@ -1139,7 +1166,9 @@ export default function ChatPage() {
       // Restore last chat ID for the agent we're switching to
       const restored = getLastChatId(selectedAgent);
       if (restored) {
-        navigateRef.current(`/chat/${restored}`, { replace: true });
+        navigateRef.current(buildSessionPath("chat", restored), {
+          replace: true,
+        });
         sessionApi.preferredChatId = restored;
       } else {
         navigateRef.current("/chat", { replace: true });

--- a/console/src/pages/Coding/index.tsx
+++ b/console/src/pages/Coding/index.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { Badge, Tooltip } from "antd";
 import {
@@ -26,6 +26,10 @@ import FileTree from "./FileTree";
 import TabbedEditor from "./TabbedEditor";
 import GitPanel from "./GitPanel";
 import Chat from "../Chat";
+import {
+  buildSessionPath,
+  getSessionIdFromPath,
+} from "../../utils/sessionRoute";
 import { useCodingMode } from "../../stores/codingModeStore";
 import {
   useCurrentTabs,
@@ -40,6 +44,7 @@ type LeftPane = "files" | "git";
 
 export default function CodingPage() {
   const { codingMode, initialized } = useCodingMode();
+  const location = useLocation();
 
   // ---- Panel visibility --------------------------------------------------
   const [leftOpen, setLeftOpen] = useState(true);
@@ -134,7 +139,8 @@ export default function CodingPage() {
   );
 
   if (initialized && !codingMode) {
-    return <Navigate to="/chat" replace />;
+    const currentSessionId = getSessionIdFromPath(location.pathname);
+    return <Navigate to={buildSessionPath("chat", currentSessionId)} replace />;
   }
 
   const dirtyCount = tabs.filter((t) => t.dirty).length;

--- a/console/src/utils/sessionRoute.ts
+++ b/console/src/utils/sessionRoute.ts
@@ -1,0 +1,18 @@
+export type SessionRouteMode = "chat" | "coding";
+
+export function getSessionIdFromPath(pathname: string): string | undefined {
+  const match = pathname.match(/^\/(?:chat|coding)\/(.+)$/);
+  return match?.[1];
+}
+
+export function buildBasePath(mode: SessionRouteMode): string {
+  return `/${mode}`;
+}
+
+export function buildSessionPath(
+  mode: SessionRouteMode,
+  sessionId?: string | null,
+): string {
+  const basePath = buildBasePath(mode);
+  return sessionId ? `${basePath}/${sessionId}` : basePath;
+}


### PR DESCRIPTION
## Solution

The Coding route has been modified to support `/coding/*`.

A new common utility, `console/src/utils/sessionRoute.ts`, has been added for unified handling of: `getSessionIdFromPath`, `buildBasePath`, and `buildSessionPath`. This common helper will be used uniformly in `ChatSessionInitializer`, `Chat/index.tsx`, `ChatSessionDrawer`, `CodingModeToggle`, `Sidebar`, and `Coding/index.tsx`.

The current session will be retained when switching between Chat/Coding modes, switching session drawers, accessing the sidebar entry, and exiting Coding.

Fixes #5142

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
