### PR TITLE
feat(yuanbao): add bot message filtering and environment variable support

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -159,6 +159,7 @@ export interface YuanbaoConfig extends BaseChannelConfig {
   app_secret: string;
   api_domain: string;
   media_dir?: string;
+  accept_bot_messages?: boolean;
 }
 
 export interface OneBotConfig extends BaseChannelConfig {

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1219,6 +1219,14 @@ export function ChannelDrawer({
             <Form.Item name="media_dir" label={t("channels.wechatMediaDir")}>
               <Input placeholder={defaultMediaDir} />
             </Form.Item>
+            <Form.Item
+              name="accept_bot_messages"
+              label={t("channels.acceptBotMessages")}
+              valuePropName="checked"
+              tooltip={t("channels.acceptBotMessagesTooltip")}
+            >
+              <Switch />
+            </Form.Item>
           </>
         );
 

--- a/src/qwenpaw/app/channels/yuanbao/channel.py
+++ b/src/qwenpaw/app/channels/yuanbao/channel.py
@@ -150,6 +150,7 @@ class YuanbaoChannel(BaseChannel):
         require_mention: bool = True,
         access_control_dm: bool = False,
         access_control_group: bool = False,
+        accept_bot_messages: bool = False,
     ):
         super().__init__(
             process,
@@ -166,6 +167,7 @@ class YuanbaoChannel(BaseChannel):
             access_control_group=access_control_group,
         )
 
+        self.accept_bot_messages = accept_bot_messages
         self.enabled = enabled
         self.app_id = app_id
         self.app_secret = app_secret
@@ -225,6 +227,40 @@ class YuanbaoChannel(BaseChannel):
     # ------------------------------------------------------------------
 
     @classmethod
+    def from_env(
+        cls,
+        process: ProcessHandler,
+        on_reply_sent: OnReplySent = None,
+    ) -> "YuanbaoChannel":
+        import os
+
+        allow_from_env = os.getenv("YUANBAO_ALLOW_FROM", "")
+        allow_from = (
+            [s.strip() for s in allow_from_env.split(",") if s.strip()]
+            if allow_from_env
+            else []
+        )
+        return cls(
+            process=process,
+            enabled=os.getenv("YUANBAO_CHANNEL_ENABLED", "1") == "1",
+            app_id=os.getenv("YUANBAO_APP_ID", ""),
+            app_secret=os.getenv("YUANBAO_APP_SECRET", ""),
+            api_domain=os.getenv("YUANBAO_API_DOMAIN", DEFAULT_API_DOMAIN),
+            bot_prefix=os.getenv("YUANBAO_BOT_PREFIX", ""),
+            on_reply_sent=on_reply_sent,
+            dm_policy=os.getenv("YUANBAO_DM_POLICY", "open"),
+            group_policy=os.getenv("YUANBAO_GROUP_POLICY", "open"),
+            allow_from=allow_from,
+            deny_message=os.getenv("YUANBAO_DENY_MESSAGE", ""),
+            require_mention=os.getenv("YUANBAO_REQUIRE_MENTION", "1") == "1",
+            accept_bot_messages=os.getenv(
+                "YUANBAO_ACCEPT_BOT_MESSAGES",
+                "0",
+            )
+            == "1",
+        )
+
+    @classmethod
     def from_config(
         cls,
         process: ProcessHandler,
@@ -263,6 +299,9 @@ class YuanbaoChannel(BaseChannel):
                 access_control_group=bool(
                     config.get("access_control_group", False),
                 ),
+                accept_bot_messages=bool(
+                    config.get("accept_bot_messages", False),
+                ),
             )
 
         return cls(
@@ -288,6 +327,9 @@ class YuanbaoChannel(BaseChannel):
             ),
             access_control_group=bool(
                 getattr(config, "access_control_group", False),
+            ),
+            accept_bot_messages=bool(
+                getattr(config, "accept_bot_messages", False),
             ),
         )
 
@@ -852,8 +894,10 @@ class YuanbaoChannel(BaseChannel):
         chat_type = "group" if is_group else "c2c"
         group_code = inbound.get("group_code", "") if is_group else ""
 
-        # Ignore messages from self
-        if raw_sender_id == self._bot_id:
+        # Filter bot messages unless accept_bot_messages is enabled.
+        # Yuanbao does not push the bot's own messages back, so there is
+        # no need to filter by self._bot_id here.
+        if not self.accept_bot_messages and self._is_bot_message(inbound):
             return
 
         # Parse content from msg_body
@@ -976,6 +1020,32 @@ class YuanbaoChannel(BaseChannel):
                 return custom.get("user_id", "") == self._bot_id
         except (ValueError, TypeError):
             pass
+        return False
+
+    def _is_bot_message(self, inbound: dict) -> bool:
+        """Return True if the inbound message was sent by a bot.
+
+        Two signals are used in combination:
+        1. ``from_account`` starts with ``bot_`` — the platform uses this
+           prefix for all custom bot accounts.
+        2. Any ``TIMTextElem`` carries a ``data`` field whose JSON payload
+           has ``elem_type == 1013`` — the platform attaches this structured
+           copy exclusively to bot-originated text messages.
+        """
+        if inbound.get("from_account", "").startswith("bot_"):
+            return True
+        for elem in inbound.get("msg_body", []):
+            if elem.get("msg_type") != "TIMTextElem":
+                continue
+            data_str = elem.get("msg_content", {}).get("data", "")
+            if not data_str:
+                continue
+            try:
+                parsed = json.loads(data_str)
+                if parsed.get("elem_type") == 1013:
+                    return True
+            except (ValueError, TypeError):
+                pass
         return False
 
     # pylint: disable=unused-argument,too-many-branches

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -426,6 +426,7 @@ class YuanbaoConfig(BaseChannelConfig):
     app_secret: str = ""
     api_domain: str = "bot.yuanbao.tencent.com"
     media_dir: Optional[str] = None
+    accept_bot_messages: bool = False
 
 
 class WeChatConfig(BaseChannelConfig):

--- a/tests/unit/channels/test_yuanbao.py
+++ b/tests/unit/channels/test_yuanbao.py
@@ -1112,13 +1112,13 @@ class TestHandleChatMessage:
         await connected_channel._handle_chat_message(inbound)
         assert connected_channel._enqueue.call_count == 1
 
-    async def test_ignores_self_message(self, connected_channel):
-        """Messages from bot itself should be ignored."""
+    async def test_bot_account_filtered_by_default(self, connected_channel):
+        """Bot accounts (bot_ prefix) should be ignored by default."""
         connected_channel._enqueue = MagicMock()
-        connected_channel._bot_id = "test_bot_id"
+        connected_channel.accept_bot_messages = False
         inbound = {
             "callback_command": "C2C.CallbackAfterSendMsg",
-            "from_account": "test_bot_id",
+            "from_account": "bot_test_bot_id",
             "sender_nickname": "Bot",
             "msg_id": "msg_self",
             "msg_body": [
@@ -1226,6 +1226,94 @@ class TestHandleChatMessage:
 
         session_file = tmp_path / "yuanbao_sessions.json"
         assert session_file.exists()
+
+    async def test_bot_message_filtered_by_default(self, connected_channel):
+        """Bot messages should be dropped when accept_bot_messages is False."""
+        import json
+
+        connected_channel._enqueue = MagicMock()
+        connected_channel.accept_bot_messages = False
+        inbound = {
+            "callback_command": "Group.CallbackAfterSendMsg",
+            "from_account": "szUvRH8s4ekettawNjDREmAG4W7h",
+            "sender_nickname": "元宝",
+            "group_code": "293831858",
+            "msg_id": "msg_bot_1",
+            "msg_body": [
+                {
+                    "msg_type": "TIMTextElem",
+                    "msg_content": {
+                        "text": "在呢～",
+                        "data": json.dumps(
+                            {
+                                "elem_type": 1013,
+                                "text": "在呢～",
+                                "user_id": "",
+                                "content": "",
+                            },
+                        ),
+                    },
+                },
+            ],
+        }
+        await connected_channel._handle_chat_message(inbound)
+        connected_channel._enqueue.assert_not_called()
+
+    async def test_bot_message_accepted_when_enabled(self, connected_channel):
+        """Bot messages pass through when accept_bot_messages is True."""
+        import json
+
+        connected_channel._enqueue = MagicMock()
+        connected_channel.accept_bot_messages = True
+        connected_channel.require_mention = False
+        inbound = {
+            "callback_command": "Group.CallbackAfterSendMsg",
+            "from_account": "szUvRH8s4ekettawNjDREmAG4W7h",
+            "sender_nickname": "元宝",
+            "group_code": "293831858",
+            "msg_id": "msg_bot_2",
+            "msg_body": [
+                {
+                    "msg_type": "TIMTextElem",
+                    "msg_content": {
+                        "text": "在呢～",
+                        "data": json.dumps(
+                            {
+                                "elem_type": 1013,
+                                "text": "在呢～",
+                                "user_id": "",
+                                "content": "",
+                            },
+                        ),
+                    },
+                },
+            ],
+        }
+        await connected_channel._handle_chat_message(inbound)
+        connected_channel._enqueue.assert_called_once()
+
+    async def test_custom_bot_filtered_by_from_account_prefix(
+        self,
+        connected_channel,
+    ):
+        """Custom bots with bot_ prefixed from_account should be filtered."""
+        connected_channel._enqueue = MagicMock()
+        connected_channel.accept_bot_messages = False
+        inbound = {
+            "callback_command": "Group.CallbackAfterSendMsg",
+            "from_account": "bot_3c71636ecdf9455783ab22d3bfa21fd2",
+            "sender_nickname": "灰的Bot3",
+            "group_code": "293831858",
+            "msg_id": "msg_custom_bot_1",
+            "msg_body": [
+                {
+                    "msg_type": "TIMTextElem",
+                    "msg_content": {"text": "收到！"},
+                },
+            ],
+        }
+        await connected_channel._handle_chat_message(inbound)
+        connected_channel._enqueue.assert_not_called()
 
 
 # =============================================================================


### PR DESCRIPTION
## Description

Add bot message filtering and environment variable support to the Yuanbao channel.

- Add `accept_bot_messages` config field (default `false`), consistent with Discord channel
- Introduce `_is_bot_message()` with two detection signals:
  1. `from_account` starts with `bot_` — platform prefix for all custom bot accounts
  2. `TIMTextElem.data` contains `elem_type == 1013` — platform marker present only in bot-originated messages
- Add `from_env()` class method with full `YUANBAO_*` environment variable support for container/CI deployments
- Add `accept_bot_messages` toggle to the frontend channel config drawer and TypeScript types

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
