### PR TITLE
fix(GitPanel): fix tabs styles not applied due to incorrect class prefix

### DIFF
--- a/console/src/pages/Coding/GitPanel.module.less
+++ b/console/src/pages/Coding/GitPanel.module.less
@@ -25,7 +25,7 @@
   flex: 1;
   min-width: 0;
 
-  :global(.ant-select-selector) {
+  :global(.qwenpaw-select-selector) {
     font-size: 12px !important;
   }
 }
@@ -44,18 +44,18 @@
   display: flex;
   flex-direction: column;
 
-  :global(.ant-tabs-nav) {
+  :global(.qwenpaw-tabs-nav) {
     margin-bottom: 0;
     padding: 0 8px;
   }
 
-  :global(.ant-tabs-content-holder) {
+  :global(.qwenpaw-tabs-content-holder) {
     flex: 1;
     overflow-y: auto;
     min-height: 0;
   }
 
-  :global(.ant-tabs-tabpane) {
+  :global(.qwenpaw-tabs-tabpane) {
     height: 100%;
   }
 }


### PR DESCRIPTION
## Description

GitPanel 的 Tabs 相关样式未生效。

根因分析：
`GitPanel.module.less` 中使用了 `ant-` 前缀的 CSS 选择器，但 `App.tsx` 的 ConfigProvider 配置了 `prefixCls="qwenpaw"`，导致选择器无法匹配 DOM 元素。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Additional Notes

将 `.less` 文件中的类名前缀从 `ant-` 改为 `qwenpaw-`：

| Before | After |
|--------|-------|
| `.ant-select-selector` | `.qwenpaw-select-selector` |
| `.ant-tabs-nav` | `.qwenpaw-tabs-nav` |
| `.ant-tabs-content-holder` | `.qwenpaw-tabs-content-holder` |
| `.ant-tabs-tabpane` | `.qwenpaw-tabs-tabpane` |

## Files Changed
- `console/src/pages/Coding/GitPanel.module.less` - 4 changes

<img width="915" height="251" alt="Snipaste_2026-06-12_14-48-29" src="https://github.com/user-attachments/assets/44ac28b2-1e9b-49bb-a127-5410d68e0680" />
