### PR TITLE
fix(release): switch version to 1.1.12b1

### DIFF
--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.1.12.beta1"
+__version__ = "1.1.12b1"


### PR DESCRIPTION
## Summary
- Rebase the bump work on latest `upstream/main` and keep the change isolated.
- Update `src/qwenpaw/__version__.py` from `1.1.12.beta1` to `1.1.12b1`.
- Keep this PR focused on the version format correction only.

## Test plan
- [x] Confirm `src/qwenpaw/__version__.py` contains `__version__ = \"1.1.12b1\"`.
- [x] Pre-commit hooks pass during commit.
- [ ] CI passes on this PR.

Made with [Cursor](https://cursor.com)