### PR TITLE
feat(yuanbao): support quoted messages and unify media download pipeline

### DIFF
--- a/src/qwenpaw/app/channels/yuanbao/channel.py
+++ b/src/qwenpaw/app/channels/yuanbao/channel.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import aiohttp
 
 from agentscope_runtime.engine.schemas.agent_schemas import (
+    AudioContent,
     ContentType,
     FileContent,
     ImageContent,
@@ -79,6 +80,30 @@ if TYPE_CHECKING:
     from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
 
 logger = logging.getLogger(__name__)
+
+
+# File extensions treated as audio.  Files with these suffixes are wrapped
+# as ``AudioContent`` so they flow through the unified ASR pipeline; all
+# other suffixes fall back to ``FileContent``.
+_AUDIO_EXTS = frozenset(
+    {
+        ".mp3",
+        ".wav",
+        ".m4a",
+        ".ogg",
+        ".opus",
+        ".silk",
+        ".amr",
+        ".aac",
+        ".flac",
+    },
+)
+
+# Yuanbao ``cloud_custom_data.quote.type`` -> human-readable kind label.
+# 1 = text (desc carries text content)
+# 2 = image (desc empty)
+# 3 = file or audio (desc carries filename; routed by suffix below)
+_QUOTE_TYPE_LABEL = {1: "message", 2: "image", 3: "file"}
 
 
 def _short_id(raw_id: str) -> str:
@@ -719,7 +744,12 @@ class YuanbaoChannel(BaseChannel):
 
     @staticmethod
     def _normalize_inbound(data: dict) -> dict:
-        """Normalize inbound JSON — ensure msg_content is always a dict."""
+        """Normalize inbound JSON.
+
+        Ensures ``msg_content`` is always a dict and parses the
+        ``cloud_custom_data`` JSON string into a dict (used for quoted
+        message extraction downstream).
+        """
         msg_body = []
         for elem in data.get("msg_body", []):
             content = elem.get("msg_content", {})
@@ -737,8 +767,18 @@ class YuanbaoChannel(BaseChannel):
                 },
             )
 
+        ccd = data.get("cloud_custom_data", "")
+        if isinstance(ccd, str):
+            try:
+                ccd = json.loads(ccd) if ccd else {}
+            except (ValueError, TypeError):
+                ccd = {}
+        if not isinstance(ccd, dict):
+            ccd = {}
+
         normalized = dict(data)
         normalized["msg_body"] = msg_body
+        normalized["cloud_custom_data"] = ccd
         return normalized
 
     async def _handle_auth_failure(self) -> None:
@@ -784,6 +824,7 @@ class YuanbaoChannel(BaseChannel):
     # Inbound message handling
     # ------------------------------------------------------------------
 
+    # pylint: disable=too-many-branches
     async def _handle_chat_message(
         self,
         inbound: Dict[str, Any],
@@ -822,6 +863,37 @@ class YuanbaoChannel(BaseChannel):
         )
         if not content_parts:
             return
+
+        # Inject quoted-message prefix from cloud_custom_data.quote, if any.
+        # Yuanbao only provides desc/sender_* in quote payloads (no url/key,
+        # no API to fetch original), so we surface a textual placeholder
+        # so the model knows the kind/filename it is replying to.
+        #
+        # Aligns with wecom / dingtalk: prepend the placeholder to the first
+        # TextContent so quote + user input stay as one logical text block.
+        # Falls back to a standalone TextContent only when the message has
+        # no text part at all (e.g. quoting then sending only an image).
+        quote = (inbound.get("cloud_custom_data") or {}).get("quote")
+        if isinstance(quote, dict):
+            prefix = self._build_quoted_prefix(quote)
+            if prefix:
+                for i, part in enumerate(content_parts):
+                    if isinstance(part, TextContent):
+                        content_parts[i] = TextContent(
+                            type=ContentType.TEXT,
+                            text=f"{prefix}\n{part.text}",
+                        )
+                        break
+                else:
+                    content_parts.insert(
+                        0,
+                        TextContent(type=ContentType.TEXT, text=prefix),
+                    )
+                logger.info(
+                    "yuanbao quoted: type=%s desc_len=%s",
+                    quote.get("type"),
+                    len(quote.get("desc") or ""),
+                )
 
         # Build meta early so _check_group_mention can inspect it
         meta: Dict[str, Any] = {
@@ -906,12 +978,25 @@ class YuanbaoChannel(BaseChannel):
             pass
         return False
 
-    async def _parse_msg_body(  # pylint: disable=too-many-branches,too-many-statements,unused-argument  # noqa: E501
+    # pylint: disable=unused-argument,too-many-branches
+    async def _parse_msg_body(
         self,
         msg_body: List[dict],
         is_group: bool = False,
     ) -> tuple:
-        """Parse msg_body elements into content parts."""
+        """Parse msg_body elements into content parts.
+
+        Yuanbao only emits four element kinds in practice:
+          * ``TIMCustomElem`` (elem_type=1002) -- @mention tag
+          * ``TIMTextElem`` -- plain text
+          * ``TIMImageElem`` -- image with multi-resolution url array
+          * ``TIMFileElem`` -- generic file (incl. audio uploaded as file)
+
+        Audio is routed to :class:`AudioContent` based on the file-name
+        suffix so it joins the unified ASR pipeline.  Video / voice elem
+        types historically supported by TIM are not pushed by Yuanbao;
+        an ``unhandled msg_type`` warning is emitted as a safety net.
+        """
         parts: List[Any] = []
         bot_mentioned = False
 
@@ -929,127 +1014,130 @@ class YuanbaoChannel(BaseChannel):
 
             if msg_type == "TIMTextElem":
                 text = content.get("text", "").strip()
+                if text and self._bot_id:
+                    text = text.replace(f"@{self._bot_id}", "").strip()
                 if text:
-                    if self._bot_id:
-                        text = text.replace(
-                            f"@{self._bot_id}",
-                            "",
-                        ).strip()
-                    if text:
-                        parts.append(
-                            TextContent(
-                                type=ContentType.TEXT,
-                                text=text,
-                            ),
-                        )
+                    parts.append(
+                        TextContent(type=ContentType.TEXT, text=text),
+                    )
 
             elif msg_type == "TIMImageElem":
                 image_url = ""
-                for img_info in content.get(
-                    "image_info_array",
-                    [],
-                ):
+                for img_info in content.get("image_info_array", []):
                     if img_info.get("url"):
                         image_url = img_info["url"]
                         break
                 if not image_url:
                     image_url = content.get("url", "")
                 if image_url:
-                    resolved_url = await self._resolve_media_url(image_url)
-                    local_path = await download_media(
-                        resolved_url,
-                        self._media_dir,
+                    part = await self._download_and_wrap(
+                        image_url,
                         filename="image.jpg",
+                        kind="image",
                     )
-                    if local_path:
-                        file_uri = Path(local_path).resolve().as_uri()
-                        parts.append(
-                            ImageContent(
-                                type=ContentType.IMAGE,
-                                image_url=file_uri,
-                            ),
-                        )
-                    else:
-                        parts.append(
-                            ImageContent(
-                                type=ContentType.IMAGE,
-                                image_url=image_url,
-                            ),
-                        )
+                    if part is not None:
+                        parts.append(part)
 
             elif msg_type == "TIMFileElem":
                 file_url = content.get("url", "")
-                filename = content.get("file_name", "file")
+                filename = content.get("file_name", "file") or "file"
                 if file_url:
-                    resolved_url = await self._resolve_media_url(file_url)
-                    local_path = await download_media(
-                        resolved_url,
-                        self._media_dir,
+                    kind = self._classify_file(filename)
+                    part = await self._download_and_wrap(
+                        file_url,
                         filename=filename,
+                        kind=kind,
                     )
-                    if local_path:
-                        file_uri = Path(local_path).resolve().as_uri()
-                        parts.append(
-                            FileContent(
-                                type=ContentType.FILE,
-                                file_url=file_uri,
-                                filename=filename,
-                            ),
-                        )
-                    else:
-                        parts.append(
-                            FileContent(
-                                type=ContentType.FILE,
-                                file_url=file_url,
-                                filename=filename,
-                            ),
-                        )
+                    if part is not None:
+                        parts.append(part)
 
-            elif msg_type == "TIMVideoFileElem":
-                video_url = content.get("videoUrl", "") or content.get(
-                    "url",
-                    "",
+            else:
+                logger.warning(
+                    "yuanbao: unhandled msg_type=%s",
+                    msg_type,
                 )
-                video_name = (
-                    content.get("videoName", "video.mp4") or "video.mp4"
-                )
-                if video_url:
-                    resolved_url = await self._resolve_media_url(video_url)
-                    local_path = await download_media(
-                        resolved_url,
-                        self._media_dir,
-                        filename=video_name,
-                    )
-                    if local_path:
-                        file_uri = Path(local_path).resolve().as_uri()
-                        parts.append(
-                            FileContent(
-                                type=ContentType.FILE,
-                                file_url=file_uri,
-                                filename=video_name,
-                            ),
-                        )
-
-            elif msg_type == "TIMSoundElem":
-                sound_url = content.get("url", "")
-                if sound_url:
-                    resolved_url = await self._resolve_media_url(sound_url)
-                    local_path = await download_media(
-                        resolved_url,
-                        self._media_dir,
-                        filename="voice.wav",
-                    )
-                    if local_path:
-                        file_uri = Path(local_path).resolve().as_uri()
-                        parts.append(
-                            FileContent(
-                                type=ContentType.FILE,
-                                file_url=file_uri,
-                                filename="voice.wav",
-                            ),
-                        )
 
         return parts, bot_mentioned
+
+    @staticmethod
+    def _classify_file(filename: str) -> str:
+        """Classify a TIMFileElem payload as ``audio`` or ``file``.
+
+        Returns ``audio`` when the filename suffix is in :data:`_AUDIO_EXTS`,
+        otherwise ``file``.
+        """
+        if Path(filename).suffix.lower() in _AUDIO_EXTS:
+            return "audio"
+        return "file"
+
+    async def _download_and_wrap(
+        self,
+        url: str,
+        *,
+        filename: str,
+        kind: str,
+    ) -> Any | None:
+        """Resolve + download a media URL and wrap into a Content part.
+
+        On failure, returns a :class:`TextContent` placeholder such as
+        ``[image: download failed]`` so the model is still informed and
+        no expired CDN URL leaks downstream.
+        """
+        resolved_url = await self._resolve_media_url(url)
+        local_path = await download_media(
+            resolved_url,
+            self._media_dir,
+            filename=filename,
+        )
+        if not local_path:
+            return TextContent(
+                type=ContentType.TEXT,
+                text=f"[{kind}: download failed]",
+            )
+        file_uri = Path(local_path).resolve().as_uri()
+        if kind == "image":
+            return ImageContent(
+                type=ContentType.IMAGE,
+                image_url=file_uri,
+            )
+        if kind == "audio":
+            return AudioContent(
+                type=ContentType.AUDIO,
+                data=file_uri,
+            )
+        return FileContent(
+            type=ContentType.FILE,
+            file_url=file_uri,
+            filename=filename,
+        )
+
+    @staticmethod
+    def _build_quoted_prefix(quote: dict) -> Optional[str]:
+        """Render an inline placeholder for ``cloud_custom_data.quote``.
+
+        Yuanbao only includes ``id`` / ``desc`` / ``sender_*`` in quote
+        payloads (no url/key, no API to fetch the original message), so
+        this returns a plain bracketed text the model can read.
+
+        The placeholder tells the model:
+          * the **kind** of the quoted item (message / image / file / audio)
+          * the **filename** when the upstream provides one (type=3)
+        so the model can match it against earlier turns in history.
+        """
+        if not isinstance(quote, dict):
+            return None
+        qtype_raw = quote.get("type")
+        qtype = qtype_raw if isinstance(qtype_raw, int) else 0
+        desc = (quote.get("desc") or "").strip()
+        label = _QUOTE_TYPE_LABEL.get(qtype, "message")
+        # type=3 carries a filename in desc; use the same suffix set as
+        # _classify_file so wording stays consistent with non-quoted
+        # messages the model has already seen.
+        if qtype == 3 and desc and Path(desc).suffix.lower() in _AUDIO_EXTS:
+            label = "audio"
+        if desc:
+            return f"[quoted {label}: {desc}]"
+        return f"[quoted {label}]"
 
     def _prune_seen_ids(self) -> None:
         sorted_ids = sorted(

--- a/src/qwenpaw/app/channels/yuanbao/utils.py
+++ b/src/qwenpaw/app/channels/yuanbao/utils.py
@@ -71,7 +71,11 @@ async def download_media(
                 )
 
                 extension = _resolve_extension(content_type, filename)
-                safe_name = _build_safe_filename(filename, extension)
+                safe_name = _build_safe_filename(
+                    filename,
+                    extension,
+                    media_dir,
+                )
                 local_path = media_dir / safe_name
 
                 local_path.write_bytes(data)
@@ -111,24 +115,45 @@ def guess_mime_type(file_path: str) -> str:
 
 
 def _resolve_extension(content_type: str, filename: str) -> str:
-    """Determine file extension from content type or filename."""
-    if content_type:
-        ext = mimetypes.guess_extension(content_type)
-        if ext:
-            return ext
+    """Determine file extension.
+
+    Priority: original filename suffix > content-type guess > .bin.
+    The original suffix is preferred because Yuanbao CDN often returns a
+    generic ``application/octet-stream`` content-type that would otherwise
+    silently rewrite ``.txt`` to ``.bin`` or ``.mp3`` to ``.mpga``.
+    """
     if filename:
         suffix = Path(filename).suffix
         if suffix:
             return suffix
+    if content_type:
+        ext = mimetypes.guess_extension(content_type)
+        if ext:
+            return ext
     return ".bin"
 
 
-def _build_safe_filename(filename: str, extension: str) -> str:
-    """Build a safe, unique filename for local storage."""
-    uid = uuid.uuid4().hex[:12]
+def _build_safe_filename(
+    filename: str,
+    extension: str,
+    media_dir: Path,
+) -> str:
+    """Build a safe filename for local storage, preserving original name.
+
+    Keeps alphanumeric (incl. CJK), dash, underscore, dot, and parens.
+    Whitespace and shell-meta chars are dropped to avoid quoting hassles.
+    A short uid suffix is appended only when the target path already
+    exists, so unique uploads keep their human-readable filename.
+    """
     if filename:
         stem = Path(filename).stem
-        safe_stem = "".join(c for c in stem if c.isalnum() or c in "-_")
-        if safe_stem:
-            return f"{safe_stem}_{uid}{extension}"
-    return f"yuanbao_{uid}{extension}"
+        safe_stem = (
+            "".join(c for c in stem if c.isalnum() or c in "-_.()") or "file"
+        )
+    else:
+        safe_stem = f"yuanbao_{uuid.uuid4().hex[:12]}"
+    candidate = f"{safe_stem}{extension}"
+    if not (media_dir / candidate).exists():
+        return candidate
+    # Conflict: append short uid before extension.
+    return f"{safe_stem}_{uuid.uuid4().hex[:8]}{extension}"

--- a/tests/unit/channels/test_yuanbao.py
+++ b/tests/unit/channels/test_yuanbao.py
@@ -786,6 +786,44 @@ class TestNormalizeInbound:
         result = YuanbaoChannel._normalize_inbound(data)
         assert result["msg_body"][0]["msg_content"] == {"text": "plain text"}
 
+    def test_parses_cloud_custom_data_quote(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        raw = {
+            "msg_body": [],
+            "cloud_custom_data": (
+                '{"quote":{"id":"abc","seq":1,"type":1,"desc":"hi"}}'
+            ),
+        }
+        out = YuanbaoChannel._normalize_inbound(raw)
+        ccd = out["cloud_custom_data"]
+        assert isinstance(ccd, dict)
+        quote = ccd.get("quote")
+        assert isinstance(quote, dict)
+        assert quote.get("desc") == "hi"
+
+    def test_cloud_custom_data_empty_string_becomes_empty_dict(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        out = YuanbaoChannel._normalize_inbound(
+            {"msg_body": [], "cloud_custom_data": ""},
+        )
+        assert not out["cloud_custom_data"]
+
+    def test_cloud_custom_data_invalid_json_becomes_empty_dict(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        out = YuanbaoChannel._normalize_inbound(
+            {"msg_body": [], "cloud_custom_data": "{not json"},
+        )
+        assert not out["cloud_custom_data"]
+
+    def test_cloud_custom_data_missing_field_becomes_empty_dict(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        out = YuanbaoChannel._normalize_inbound({"msg_body": []})
+        assert out["cloud_custom_data"] == {}
+
 
 @pytest.mark.asyncio
 class TestParseMsgBody:
@@ -855,8 +893,9 @@ class TestParseMsgBody:
         assert mentioned is False
         assert len(parts) == 1
 
-    async def test_parse_image_elem(self, connected_channel):
+    async def test_parse_image_elem(self, connected_channel, tmp_path):
         """TIMImageElem should download and return ImageContent."""
+        connected_channel._media_dir = tmp_path
         msg_body = [
             {
                 "msg_type": "TIMImageElem",
@@ -868,10 +907,16 @@ class TestParseMsgBody:
                 },
             },
         ]
+
+        async def fake_download(url, media_dir, filename=""):
+            target = media_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"\x00")
+            return str(target)
+
         with patch(
             "qwenpaw.app.channels.yuanbao.channel.download_media",
-            new_callable=AsyncMock,
-            return_value=None,
+            side_effect=fake_download,
         ), patch.object(
             connected_channel,
             "_resolve_media_url",
@@ -881,12 +926,170 @@ class TestParseMsgBody:
             parts, _ = await connected_channel._parse_msg_body(msg_body)
 
         assert len(parts) == 1
-        assert parts[0].image_url == "https://example.com/img.jpg"
+        assert parts[0].image_url.startswith("file://")
+        assert parts[0].image_url.endswith("image.jpg")
 
     async def test_parse_empty_body(self, connected_channel):
         parts, mentioned = await connected_channel._parse_msg_body([])
         assert parts == []
         assert mentioned is False
+
+    async def test_parse_file_elem_audio_routed_to_audio_content(
+        self,
+        connected_channel,
+        tmp_path,
+    ):
+        """TIMFileElem with audio suffix should yield AudioContent."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            AudioContent,
+        )
+
+        connected_channel._media_dir = tmp_path
+
+        async def fake_download(url, media_dir, filename=""):
+            target = media_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"\x00")
+            return str(target)
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.download_media",
+            side_effect=fake_download,
+        ):
+            connected_channel._resolve_media_url = AsyncMock(
+                side_effect=lambda u: u,
+            )
+            parts, _ = await connected_channel._parse_msg_body(
+                [
+                    {
+                        "msg_type": "TIMFileElem",
+                        "msg_content": {
+                            "url": "https://cdn.example.com/x",
+                            "file_name": "test_副本.mp3",
+                        },
+                    },
+                ],
+            )
+
+        assert len(parts) == 1
+        assert isinstance(parts[0], AudioContent)
+
+    async def test_parse_file_elem_doc_routed_to_file_content(
+        self,
+        connected_channel,
+        tmp_path,
+    ):
+        """TIMFileElem with non-audio suffix should yield FileContent."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            FileContent,
+        )
+
+        connected_channel._media_dir = tmp_path
+
+        async def fake_download(url, media_dir, filename=""):
+            target = media_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"text")
+            return str(target)
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.download_media",
+            side_effect=fake_download,
+        ):
+            connected_channel._resolve_media_url = AsyncMock(
+                side_effect=lambda u: u,
+            )
+            parts, _ = await connected_channel._parse_msg_body(
+                [
+                    {
+                        "msg_type": "TIMFileElem",
+                        "msg_content": {
+                            "url": "https://cdn.example.com/x",
+                            "file_name": "陈灵威.txt",
+                        },
+                    },
+                ],
+            )
+
+        assert len(parts) == 1
+        assert isinstance(parts[0], FileContent)
+        assert parts[0].filename == "陈灵威.txt"
+
+    async def test_parse_file_elem_without_filename_uses_fallback(
+        self,
+        connected_channel,
+        tmp_path,
+    ):
+        """Missing ``file_name`` should fall back to literal ``file``."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            FileContent,
+        )
+
+        connected_channel._media_dir = tmp_path
+
+        async def fake_download(url, media_dir, filename=""):
+            target = media_dir / (filename or "file")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"x")
+            return str(target)
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.download_media",
+            side_effect=fake_download,
+        ):
+            connected_channel._resolve_media_url = AsyncMock(
+                side_effect=lambda u: u,
+            )
+            parts, _ = await connected_channel._parse_msg_body(
+                [
+                    {
+                        "msg_type": "TIMFileElem",
+                        "msg_content": {
+                            "url": "https://cdn.example.com/x",
+                        },
+                    },
+                ],
+            )
+
+        assert len(parts) == 1
+        assert isinstance(parts[0], FileContent)
+        assert parts[0].filename == "file"
+
+    async def test_parse_image_elem_download_failure_emits_placeholder(
+        self,
+        connected_channel,
+        tmp_path,
+    ):
+        """Failed download should surface a TextContent placeholder."""
+        from agentscope_runtime.engine.schemas.agent_schemas import (
+            TextContent,
+        )
+
+        connected_channel._media_dir = tmp_path
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.download_media",
+            new=AsyncMock(return_value=None),
+        ):
+            connected_channel._resolve_media_url = AsyncMock(
+                side_effect=lambda u: u,
+            )
+            parts, _ = await connected_channel._parse_msg_body(
+                [
+                    {
+                        "msg_type": "TIMImageElem",
+                        "msg_content": {
+                            "image_info_array": [
+                                {"url": "https://cdn/example.jpg"},
+                            ],
+                        },
+                    },
+                ],
+            )
+
+        assert len(parts) == 1
+        assert isinstance(parts[0], TextContent)
+        assert parts[0].text == "[image: download failed]"
 
 
 @pytest.mark.asyncio
@@ -1048,3 +1251,307 @@ class TestCleanup:
         connected_channel._media_session = None
         await connected_channel._cleanup_session()
         assert connected_channel._media_session is None
+
+
+# =============================================================================
+# P1: Filename / Extension Preservation (utils.py)
+# =============================================================================
+
+
+class TestResolveExtension:
+    """``_resolve_extension`` should prefer the original filename suffix."""
+
+    def test_filename_suffix_takes_priority_over_octet_stream(self):
+        from qwenpaw.app.channels.yuanbao.utils import _resolve_extension
+
+        # CDN often returns application/octet-stream; the real .txt must
+        # not be silently rewritten to .bin.
+        assert (
+            _resolve_extension(
+                "application/octet-stream",
+                "陈灵威.txt",
+            )
+            == ".txt"
+        )
+
+    def test_filename_suffix_takes_priority_over_audio_mpeg(self):
+        from qwenpaw.app.channels.yuanbao.utils import _resolve_extension
+
+        # audio/mpeg may guess to .mpga depending on mime db; .mp3 must win.
+        assert _resolve_extension("audio/mpeg", "test_副本.mp3") == ".mp3"
+
+    def test_falls_back_to_content_type_when_no_filename_suffix(self):
+        from qwenpaw.app.channels.yuanbao.utils import _resolve_extension
+
+        ext = _resolve_extension("image/jpeg", "noext")
+        assert ext in (".jpg", ".jpeg", ".jpe")
+
+    def test_falls_back_to_bin_when_nothing_known(self):
+        from qwenpaw.app.channels.yuanbao.utils import _resolve_extension
+
+        assert _resolve_extension("", "") == ".bin"
+
+
+class TestBuildSafeFilename:
+    """``_build_safe_filename`` should preserve the original name."""
+
+    def test_preserves_cjk_when_no_conflict(self, tmp_path):
+        from qwenpaw.app.channels.yuanbao.utils import _build_safe_filename
+
+        assert _build_safe_filename("陈灵威.txt", ".txt", tmp_path) == "陈灵威.txt"
+
+    def test_strips_whitespace_keeps_parens(self, tmp_path):
+        from qwenpaw.app.channels.yuanbao.utils import _build_safe_filename
+
+        assert (
+            _build_safe_filename("test 副本(1).mp3", ".mp3", tmp_path)
+            == "test副本(1).mp3"
+        )
+
+    def test_appends_uid_only_on_conflict(self, tmp_path):
+        from qwenpaw.app.channels.yuanbao.utils import _build_safe_filename
+
+        existing = tmp_path / "陈灵威.txt"
+        existing.write_text("seed")
+        result = _build_safe_filename("陈灵威.txt", ".txt", tmp_path)
+        assert result.startswith("陈灵威_")
+        assert result.endswith(".txt")
+        assert result != "陈灵威.txt"
+
+    def test_blank_filename_uses_yuanbao_prefix(self, tmp_path):
+        from qwenpaw.app.channels.yuanbao.utils import _build_safe_filename
+
+        result = _build_safe_filename("", ".bin", tmp_path)
+        assert result.startswith("yuanbao_")
+        assert result.endswith(".bin")
+
+    def test_all_whitespace_falls_back_to_file(self, tmp_path):
+        from qwenpaw.app.channels.yuanbao.utils import _build_safe_filename
+
+        # "  " (only whitespace) -> stripped to empty -> "file"
+        assert _build_safe_filename("   .txt", ".txt", tmp_path) == "file.txt"
+
+
+# =============================================================================
+# P1: Quote Prefix Helpers (channel.py)
+# =============================================================================
+
+
+class TestClassifyFile:
+    """``_classify_file`` routes audio extensions to AudioContent."""
+
+    def test_audio_extensions(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        for name in (
+            "test_副本.mp3",
+            "voice.WAV",
+            "a.m4a",
+            "x.opus",
+            "y.silk",
+        ):
+            assert YuanbaoChannel._classify_file(name) == "audio"
+
+    def test_non_audio_extensions(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        for name in ("陈灵威.txt", "doc.pdf", "img.png", "noext"):
+            assert YuanbaoChannel._classify_file(name) == "file"
+
+
+class TestBuildQuotedPrefix:
+    """``_build_quoted_prefix`` covers the 5 yuanbao quote scenarios."""
+
+    def test_text_quote(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert (
+            YuanbaoChannel._build_quoted_prefix(
+                {"type": 1, "desc": "你好呀"},
+            )
+            == "[quoted message: 你好呀]"
+        )
+
+    def test_image_quote_empty_desc(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert (
+            YuanbaoChannel._build_quoted_prefix({"type": 2, "desc": ""})
+            == "[quoted image]"
+        )
+
+    def test_file_quote_with_filename(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert (
+            YuanbaoChannel._build_quoted_prefix(
+                {"type": 3, "desc": "陈灵威.txt"},
+            )
+            == "[quoted file: 陈灵威.txt]"
+        )
+
+    def test_audio_quote_routed_by_suffix(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert (
+            YuanbaoChannel._build_quoted_prefix(
+                {"type": 3, "desc": "test_副本.mp3"},
+            )
+            == "[quoted audio: test_副本.mp3]"
+        )
+
+    def test_file_type_with_empty_desc(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert (
+            YuanbaoChannel._build_quoted_prefix({"type": 3, "desc": ""})
+            == "[quoted file]"
+        )
+
+    def test_unknown_type_falls_back_to_message(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert (
+            YuanbaoChannel._build_quoted_prefix({"type": 99, "desc": ""})
+            == "[quoted message]"
+        )
+
+    def test_non_dict_returns_none(self):
+        from qwenpaw.app.channels.yuanbao.channel import YuanbaoChannel
+
+        assert YuanbaoChannel._build_quoted_prefix(None) is None
+        assert YuanbaoChannel._build_quoted_prefix("oops") is None
+
+
+@pytest.mark.asyncio
+class TestHandleChatMessageQuoteInjection:
+    """End-to-end check that quoted prefix lands at content_parts[0]."""
+
+    async def test_quote_prefix_prepended_for_text_quote(
+        self,
+        connected_channel,
+    ):
+        captured: list = []
+        connected_channel._enqueue = captured.append
+        connected_channel._bot_id = "bot_xxx"
+
+        inbound = {
+            "callback_command": "C2C.CallbackAfterSendMsg",
+            "msg_id": "msg_with_quote",
+            "from_account": "user_account",
+            "sender_nickname": "灰",
+            "msg_body": [
+                {
+                    "msg_type": "TIMTextElem",
+                    "msg_content": {"text": "11"},
+                },
+            ],
+            "cloud_custom_data": {"quote": {"type": 1, "desc": "你好呀"}},
+        }
+        await connected_channel._handle_chat_message(inbound)
+
+        assert len(captured) == 1
+        parts = captured[0]["content_parts"]
+        # quote prefix is merged into the same TextContent as user input,
+        # mirroring wecom / dingtalk behavior.
+        assert len(parts) == 1
+        assert parts[0].text == "[quoted message: 你好呀]\n11"
+
+    async def test_quote_prefix_prepended_for_audio_quote(
+        self,
+        connected_channel,
+    ):
+        captured: list = []
+        connected_channel._enqueue = captured.append
+
+        inbound = {
+            "callback_command": "C2C.CallbackAfterSendMsg",
+            "msg_id": "msg_audio_quote",
+            "from_account": "user_account",
+            "sender_nickname": "灰",
+            "msg_body": [
+                {
+                    "msg_type": "TIMTextElem",
+                    "msg_content": {"text": "11"},
+                },
+            ],
+            "cloud_custom_data": {
+                "quote": {"type": 3, "desc": "test_副本.mp3"},
+            },
+        }
+        await connected_channel._handle_chat_message(inbound)
+
+        parts = captured[0]["content_parts"]
+        assert len(parts) == 1
+        assert parts[0].text == "[quoted audio: test_副本.mp3]\n11"
+
+    async def test_quote_prefix_falls_back_when_no_text_part(
+        self,
+        connected_channel,
+        tmp_path,
+    ):
+        """Image-only msg + quote: prefix becomes standalone TextContent."""
+        captured: list = []
+        connected_channel._enqueue = captured.append
+        connected_channel._media_dir = tmp_path
+
+        async def fake_download(url, media_dir, filename=""):
+            target = media_dir / (filename or "image.jpg")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"x")
+            return str(target)
+
+        with patch(
+            "qwenpaw.app.channels.yuanbao.channel.download_media",
+            side_effect=fake_download,
+        ):
+            inbound = {
+                "callback_command": "C2C.CallbackAfterSendMsg",
+                "msg_id": "msg_img_quote",
+                "from_account": "user_account",
+                "sender_nickname": "灰",
+                "msg_body": [
+                    {
+                        "msg_type": "TIMImageElem",
+                        "msg_content": {
+                            "image_info_array": [
+                                {"url": "https://cdn.example.com/x.jpg"},
+                            ],
+                        },
+                    },
+                ],
+                "cloud_custom_data": {
+                    "quote": {"type": 1, "desc": "hi"},
+                },
+            }
+            await connected_channel._handle_chat_message(inbound)
+
+        parts = captured[0]["content_parts"]
+        # No TextContent in original parts -> prefix becomes standalone
+        # at index 0; image part follows.
+        assert len(parts) == 2
+        assert parts[0].text == "[quoted message: hi]"
+        assert parts[1].image_url.startswith("file://")
+
+    async def test_no_quote_no_prefix(self, connected_channel):
+        captured: list = []
+        connected_channel._enqueue = captured.append
+
+        inbound = {
+            "callback_command": "C2C.CallbackAfterSendMsg",
+            "msg_id": "msg_plain",
+            "from_account": "user_account",
+            "sender_nickname": "灰",
+            "msg_body": [
+                {
+                    "msg_type": "TIMTextElem",
+                    "msg_content": {"text": "hello"},
+                },
+            ],
+            "cloud_custom_data": {},
+        }
+        await connected_channel._handle_chat_message(inbound)
+
+        parts = captured[0]["content_parts"]
+        assert len(parts) == 1
+        assert parts[0].text == "hello"


### PR DESCRIPTION
## Description

This PR brings the Yuanbao channel to feature parity with WeCom / DingTalk on
**quoted-message handling**, and along the way refactors the media download
path to fix two latent bugs and remove dead code.

### What's new

1. **Quoted message support** (`cloud_custom_data.quote`).
   Yuanbao's quote payload only carries `id` / `desc` / `sender_*` — there is
   no url/key and no API to refetch the original message. We therefore
   surface a textual placeholder describing the **kind** of the quoted item
   and (when available) its **filename**, so the model can match it against
   earlier turns in chat history:
   - `[quoted message: 你好啊]`     (type=1, text)
   - `[quoted image]`                (type=2, no desc)
   - `[quoted file: report.pdf]`     (type=3, file)
   - `[quoted audio: voice.mp3]`     (type=3, audio suffix)

   **Cross-channel consistency:** the placeholder is **prepended to the
   first `TextContent`** (joined with `\n`) so the quote and user input
   stay as one logical text block — same shape WeCom / DingTalk produce.
   When the message has no text part (e.g. quote + image-only reply) the
   placeholder falls back to a standalone `TextContent`.

2. **Unified `_download_and_wrap` helper.**
   `TIMImageElem` / `TIMFileElem` paths used to duplicate ~30 LOC of
   resolve → download → wrap each. Now collapsed into one helper that
   returns the right `Content` subclass based on `kind`.

3. **Audio routing.**
   `TIMFileElem` payloads with audio suffixes
   (`.mp3 .wav .m4a .ogg .opus .silk .amr .aac .flac`) are now wrapped
   as `AudioContent` so they flow through the unified ASR pipeline
   instead of becoming inert `FileContent`.

### Bug fixes

- **No more leaking expired CDN URLs to the model.**
  When `download_media` failed, the previous code fell back to the
  original pre-signed URL, which expires within minutes and yields
  broken-image errors downstream. We now emit a `TextContent` placeholder
  (`[image: download failed]` / `[file: download failed]`) so the model
  is informed and no stale URL leaks.

- **File extension preserved.**
  `_resolve_extension` previously consulted `Content-Type` first, which
  caused `application/octet-stream` from Yuanbao's CDN to silently rewrite
  `.txt` → `.bin` and `.mp3` → `.mpga`. Priority is now
  *original suffix → content-type guess → `.bin`*.

- **Filename is human-readable.**
  `_build_safe_filename` no longer mangles every upload to
  `<sanitized>_<uid>.<ext>`. Originals are kept verbatim (CJK preserved);
  a short uid is appended only when a name collision is detected on disk.

### Dead code removed

`TIMVideoFileElem` and `TIMSoundElem` branches — Yuanbao's official client
never emits them. Replaced by a single `unhandled msg_type=...` warning
as a safety net.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactoring

## Component(s) Affected

- [x] Channels (Yuanbao)
- [x] Tests

## Checklist

- [x] `pre-commit run --all-files` passes (mypy / black / flake8 / pylint)
- [x] `pytest tests/unit/channels/test_yuanbao.py` passes (93 tests)
- [x] No new contract test for Yuanbao — pre-existing gap, tracked
      separately

## Test Coverage (93 unit tests, 17 test classes)

New coverage added in this PR:
- `_classify_file` audio-suffix routing
- `_build_quoted_prefix` (text / image / file / audio / missing-desc)
- `_handle_chat_message` quote injection:
  - merged into first TextContent (text / audio quote)
  - standalone fallback when no TextContent in parts (image-only reply)
- `_build_safe_filename` collision-on-disk + whitespace-only fallback
- `_resolve_extension` original-suffix-wins-over-content-type
- `_normalize_inbound` `cloud_custom_data` JSON / malformed / missing
- `_download_and_wrap` failure returns TextContent placeholder
- `TIMFileElem` without `file_name` falls back to literal `file`

## Risk Assessment

- **Backward compat:** the only behavioral change visible to existing
  flows is that download failures now produce a placeholder TextContent
  instead of leaking an expired URL. Both cases were "broken" downstream
  anyway; the new behavior is strictly better.
- **No protocol/auth changes.** WSS handshake, sign-token logic, and
  the heartbeat path are untouched.
- **Cross-channel consistency:** quote injection shape now matches
  WeCom / DingTalk so upstream agents see a uniform input structure.