### PR TITLE
perf(agents): cache PROFILE.md reads on the agent-list endpoint

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -114,24 +114,38 @@ def _normalized_agent_order(config) -> list[str]:
     """Return a deduplicated agent order covering every configured agent."""
     profile_ids = list(config.agents.profiles.keys())
     ordered_ids: list[str] = []
+    seen: set[str] = set()
 
     for agent_id in config.agents.agent_order:
-        if agent_id in config.agents.profiles and agent_id not in ordered_ids:
+        if agent_id in config.agents.profiles and agent_id not in seen:
             ordered_ids.append(agent_id)
+            seen.add(agent_id)
 
     for agent_id in profile_ids:
-        if agent_id not in ordered_ids:
+        if agent_id not in seen:
             ordered_ids.append(agent_id)
+            seen.add(agent_id)
 
     return ordered_ids
 
 
+# mtime-cache parsed PROFILE.md snippets so the agent-list endpoint does
+# not re-read/re-parse every agent's PROFILE.md on each request (#4559).
+_profile_desc_cache: dict[str, tuple[float, str]] = {}
+
+
 def _read_profile_description(workspace_dir: str) -> str:
-    """Read description from PROFILE.md if exists."""
+    """Read description from PROFILE.md if exists (mtime-cached)."""
     try:
         profile_path = Path(workspace_dir) / "PROFILE.md"
         if not profile_path.exists():
             return ""
+
+        cache_key = str(profile_path)
+        mtime = profile_path.stat().st_mtime
+        cached = _profile_desc_cache.get(cache_key)
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
 
         content = read_text_file_with_encoding_fallback(profile_path).strip()
         lines = []
@@ -149,7 +163,9 @@ def _read_profile_description(workspace_dir: str) -> str:
                 if line.strip() and not line.strip().startswith("#"):
                     lines.append(line.strip())
 
-        return " ".join(lines)[:200] if lines else ""
+        description = " ".join(lines)[:200] if lines else ""
+        _profile_desc_cache[cache_key] = (mtime, description)
+        return description
     except Exception:  # noqa: E722
         return ""
 


### PR DESCRIPTION
## What

`list_agents()` (`GET /agents`) calls `_read_profile_description()` for **every** agent, which reads and parses that agent's `PROFILE.md` from disk on **every** request. `_normalized_agent_order()` on the same path also dedups via `O(n²)` list membership.

## Why

With many agents this is repeated disk I/O + parsing on a hot path, re-done on every list request — reported as a slowdown with 40+ agents in #4559. `load_agent_config()` on the same loop is already mtime-cached; the `PROFILE.md` read is not.

## Change

- Cache the parsed `PROFILE.md` snippet keyed on the file's `mtime`, mirroring the existing `_agent_config_cache` pattern — unchanged files are read/parsed once, not per request. Edits are still picked up (mtime change → cache miss).
- Dedup `_normalized_agent_order` with a set: `O(n²)` → `O(n)` membership.

Behaviour-preserving: identical description and ordering returned.

## Verification

- `black==23.3.0`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean (10/10)
- Verified the new ordering returns byte-identical output to the old across cases, and the cache parses once on repeated reads while refreshing on `mtime` change.

Related: #4559. Happy to add a benchmark or narrow scope if you'd prefer.
