### PR TITLE
fix(console): wrap approval command text with word-break to prevent horizontal overflow (#4985)

### DIFF
--- a/console/src/components/ApprovalCard/ApprovalCard.module.less
+++ b/console/src/components/ApprovalCard/ApprovalCard.module.less
@@ -279,7 +279,8 @@
   font-size: 11px;
   line-height: 1.6;
   overflow-x: auto;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-all;
   max-height: 200px;
   overflow-y: auto;
 


### PR DESCRIPTION
## Description

Approval command parameters displayed in `<pre>` blocks do not wrap, causing long lines (especially file deletion commands with full paths) to overflow horizontally. Users must manually drag the scrollbar to read the full command.

Changed `white-space: pre` → `white-space: pre-wrap` + `word-break: break-all` on `.paramsCode` so text wraps naturally.

**Related Issue:** Fixes #4985

**Security Considerations:** None — CSS-only change to the console frontend.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open the approval dialog for any tool call with long parameters (e.g. `write_file`, `execute_shell_command`)
2. Observe that the parameter text now wraps instead of requiring horizontal scroll

## Local Verification Evidence

```
CSS change only — one file modified:
  console/src/components/ApprovalCard/ApprovalCard.module.less
  Changed: white-space: pre → white-space: pre-wrap + word-break: break-all
```

## Additional Notes

No pre-commit/pytest needed — this is a CSS-only console change.
