### PR TITLE
feat(console): add session filter by title (#4999)

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1191,6 +1191,7 @@
     "saveSuccess": "Session saved successfully",
     "saveFailed": "Failed to save session",
     "batchDeleteButton": "Batch Delete",
+    "filterTitle": "Filter by Title",
     "filterUserId": "Filter by User ID",
     "filterChannel": "Filter by Channel",
     "allChannels": "All Channels",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -895,6 +895,7 @@
     "saveSuccess": "セッションを保存しました",
     "saveFailed": "セッションの保存に失敗しました",
     "batchDeleteButton": "一括削除",
+    "filterTitle": "タイトルで絞り込み",
     "filterUserId": "ユーザーIDで絞り込み",
     "filterChannel": "チャンネルで絞り込み",
     "allChannels": "すべてのチャンネル",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1102,6 +1102,7 @@
     "saveSuccess": "Session saved successfully",
     "saveFailed": "Falhou to Salvar session",
     "batchDeleteButton": "Batch Excluir",
+    "filterTitle": "Filtrar por Título",
     "filterUserId": "Filtrar by Usuario ID",
     "filterChannel": "Filtrar by Channel",
     "allChannels": "Todos Canais",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -895,6 +895,7 @@
     "saveSuccess": "Сессия успешно сохранена",
     "saveFailed": "Не удалось сохранить сессию",
     "batchDeleteButton": "Массовое удаление",
+    "filterTitle": "Фильтр по названию",
     "filterUserId": "Фильтр по ID пользователя",
     "filterChannel": "Фильтр по каналу",
     "allChannels": "Все каналы",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1040,6 +1040,7 @@
     "saveSuccess": "会话保存成功",
     "saveFailed": "会话保存失败",
     "batchDeleteButton": "批量删除",
+    "filterTitle": "按标题筛选",
     "filterUserId": "按用户ID筛选",
     "filterChannel": "按频道筛选",
     "allChannels": "全部频道",

--- a/console/src/pages/Control/Sessions/components/FilterBar.tsx
+++ b/console/src/pages/Control/Sessions/components/FilterBar.tsx
@@ -5,22 +5,34 @@ import styles from "../index.module.less";
 interface FilterBarProps {
   filterUserId: string;
   filterChannel: string;
+  filterTitle: string;
   uniqueChannels: string[];
   onUserIdChange: (value: string) => void;
   onChannelChange: (value: string) => void;
+  onTitleChange: (value: string) => void;
 }
 
 export function FilterBar({
   filterUserId,
   filterChannel,
+  filterTitle,
   uniqueChannels,
   onUserIdChange,
   onChannelChange,
+  onTitleChange,
 }: FilterBarProps) {
   const { t } = useTranslation();
 
   return (
     <div className={styles.filterBar}>
+      <Input
+        placeholder={t("sessions.filterTitle")}
+        value={filterTitle}
+        onChange={(e) => onTitleChange(e.target.value)}
+        allowClear
+        className="sessions-filter-input"
+        style={{ width: 200, marginRight: 8 }}
+      />
       <Input
         placeholder={t("sessions.filterUserId")}
         value={filterUserId}

--- a/console/src/pages/Control/Sessions/index.tsx
+++ b/console/src/pages/Control/Sessions/index.tsx
@@ -35,6 +35,7 @@ function SessionsPage() {
   // Filter states
   const [filterUserId, setFilterUserId] = useState<string>("");
   const [filterChannel, setFilterChannel] = useState<string>("");
+  const [filterTitle, setFilterTitle] = useState<string>("");
   const [availableChannels, setAvailableChannels] = useState<string[]>([]);
 
   const { message } = useAppMessage();
@@ -68,8 +69,15 @@ function SessionsPage() {
       );
     }
 
+    if (filterTitle) {
+      filtered = filtered.filter((session: Session) => {
+        const name = session.name || "";
+        return name.toLowerCase().includes(filterTitle.toLowerCase());
+      });
+    }
+
     setFilteredSessions(filtered);
-  }, [sessions, filterUserId, filterChannel]);
+  }, [sessions, filterUserId, filterChannel, filterTitle]);
 
   const handleEdit = (session: Session) => {
     setEditingSession(session);
@@ -164,9 +172,11 @@ function SessionsPage() {
             <FilterBar
               filterUserId={filterUserId}
               filterChannel={filterChannel}
+              filterTitle={filterTitle}
               uniqueChannels={availableChannels}
               onUserIdChange={setFilterUserId}
               onChannelChange={setFilterChannel}
+              onTitleChange={setFilterTitle}
             />
             {selectedRowKeys.length > 0 && (
               <Button type="primary" danger onClick={handleBatchDelete}>


### PR DESCRIPTION
## Description

Adds a "Filter by Title" text input to the Sessions page filter bar, allowing users to filter sessions by their display name/title. This is particularly useful when users have many sessions and need to find a specific one quickly.

The title filter joins the existing User ID and Channel filters, and all three filters work together (AND logic).

**Related Issue:** Fixes #4999

**Security Considerations:** None — this is a console-only UI feature.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend
- [x] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Navigate to Control → Sessions
2. Type in the "Filter by Title" input
3. Verify that only sessions whose name/title matches the search term are shown
4. Verify it works together with User ID and Channel filters
