### PR TITLE
fix(skills): expand multi-agent collaboration skill trigger keywords

### DIFF
--- a/src/qwenpaw/agents/skills/multi_agent_collaboration-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/multi_agent_collaboration-en/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi_agent_collaboration
-description: Use this skill when another agent's expertise or context is needed, or when the user explicitly asks to involve another agent. First list agents, then use qwenpaw agents chat for two-way communication with replies.
+description: Use this skill when another agent's expertise or context is needed, or when the user explicitly asks to involve another agent, or mentions team collaboration / collaborate / multi-agent / 多智能体 / 团队协作 to complete a task together. First list agents, then use qwenpaw agents chat for two-way communication with replies.
 metadata:
   builtin_skill_version: "1.4"
   qwenpaw:

--- a/src/qwenpaw/agents/skills/multi_agent_collaboration-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/multi_agent_collaboration-zh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi_agent_collaboration
-description: 当需要其他 agent 的专长、上下文或协作支持，或用户明确要求调用其他 agent 时，使用本 skill。先查询可用 agents，再用 qwenpaw agents chat 进行双向沟通。
+description: 当需要其他 agent 的专长、上下文或协作支持，或用户明确要求调用其他 agent，或用户提到"团队协作""多智能体""合作""多 agent"时，使用本 skill。先查询可用 agents，再用 qwenpaw agents chat 进行双向沟通。
 metadata:
   builtin_skill_version: "1.4"
   qwenpaw:


### PR DESCRIPTION
## Description

When users explicitly ask to work in "team collaboration" mode (团队协作), the agent sometimes ignores the instruction on the first attempt and only responds after interruption + retry. The root cause is that the `multi_agent_collaboration` SKILL.md descriptions lack the trigger keywords users typically say.

This PR adds explicit trigger keywords to both the English and Chinese skill descriptions so the model reliably recognizes "team collaboration" requests.

**Related Issue:** Fixes #3113

**Security Considerations:** None — only SKILL.md description text changed, no code.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Configure an agent with multi-agent collaboration enabled
2. Send a prompt: "请以团队协作的形式完成以下任务：调查..."
3. Observe that the agent now triggers the `qwenpaw agents list` / `qwenpaw agents chat` flow on the first attempt, not after interruption

## Local Verification Evidence

```bash
# pre-commit unavailable in this environment (Python 3.14 not supported by qwenpaw)
# Changes are limited to SKILL.md description frontmatter — no code affected
```

## Additional Notes

EN description now includes: "team collaboration", "collaborate", "multi-agent", "多智能体", "团队协作"
ZH description now includes: "团队协作", "多智能体", "合作", "多 agent"
