### PR TITLE
fix(crons): increase cron/heartbeat timeout and add autonomous context prompt

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -469,6 +469,28 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
             language=self._language,
             memory_manager=self.memory_manager,
         )
+
+        # Inject autonomous context header for cron/heartbeat sources
+        source = (
+            str(self._request_context.get("source", "")).strip().lower()
+            if self._request_context
+            else ""
+        )
+        if source in ("cron", "heartbeat"):
+            context_header = (
+                "# Autonomous Execution Context\n\n"
+                "You are running in an automated context (source: "
+                + source
+                + "). "
+                "Execute the instructions fully and autonomously. "
+                "You have access to all tools — including "
+                "``write_file``, ``spawn_subagent``, "
+                "``execute_shell_command``, and others — and you are "
+                "expected to use them as needed to complete the task. "
+                "Do not skip or defer multi-step operations."
+            )
+            sys_prompt = context_header + "\n\n" + sys_prompt
+
         logger.debug("System prompt:\n%s...", sys_prompt[:100])
 
         from .prompt_builder import PromptBuilder

--- a/src/qwenpaw/app/crons/heartbeat.py
+++ b/src/qwenpaw/app/crons/heartbeat.py
@@ -248,7 +248,7 @@ async def run_heartbeat_once(
                     )
 
             try:
-                await asyncio.wait_for(_run_and_dispatch(), timeout=120)
+                await asyncio.wait_for(_run_and_dispatch(), timeout=300)
             except asyncio.TimeoutError:
                 logger.warning("heartbeat run timed out")
             return
@@ -281,7 +281,7 @@ async def run_heartbeat_once(
                 pass
 
         try:
-            await asyncio.wait_for(_run_only(), timeout=120)
+            await asyncio.wait_for(_run_only(), timeout=300)
             delta = await append_trace_from_session_delta(
                 run_id=run_id,
                 runner=runner,
@@ -374,6 +374,6 @@ async def run_heartbeat_once(
             pass
 
     try:
-        await asyncio.wait_for(_run_without_dispatch(), timeout=120)
+        await asyncio.wait_for(_run_without_dispatch(), timeout=300)
     except asyncio.TimeoutError:
         logger.warning("heartbeat run timed out")

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -153,7 +153,7 @@ class DispatchSpec(BaseModel):
 
 class JobRuntimeSpec(BaseModel):
     max_concurrency: int = Field(default=1, ge=1)
-    timeout_seconds: int = Field(default=120, ge=1)
+    timeout_seconds: int = Field(default=300, ge=1)
     misfire_grace_seconds: int = Field(default=60, ge=0)
     share_session: bool = Field(
         default=True,


### PR DESCRIPTION
## Description

Two issues reported about cron/heartbeat agents:

1. **Timeout too short**: Cron jobs and heartbeat tasks default to 120s timeout, but complex multi-step operations (write_file, spawn_subagent, etc.) can easily exceed this, causing silent failures.

2. **No autonomous context**: The cron/heartbeat agent runs with the same system prompt as a regular chat session — it doesn't know it's in an automated context where it should fully execute multi-step tasks using all available tools.

Fixes:
- Increase `JobRuntimeSpec.timeout_seconds` default from 120 → 300
- Increase all three `asyncio.wait_for` timeout values in `heartbeat.py` from 120 → 300
- Inject an autonomous execution context header into the system prompt when `source=cron` or `source=heartbeat`, explicitly telling the agent to use `write_file`, `spawn_subagent`, and all other tools

**Related Issue:** Fixes #5174

**Security Considerations:** None — timeouts increased to reduce false failures; prompt injection only affects cron/heartbeat sessions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Create a cron job with task_type=agent that performs a multi-step operation (e.g. execute_shell_command then write_file)
2. Verify it completes before the 300s timeout
3. Verify the system prompt contains the autonomous execution context header in the agent logs when source=cron or source=heartbeat

## Local Verification Evidence

```bash
# pre-commit unavailable in this environment (Python 3.14 not supported by qwenpaw)
# Changes:
#   models.py — default value change (120 → 300)
#   heartbeat.py — three timeout parameter changes (120 → 300)
#   react_agent.py — ~15 lines added in _build_sys_prompt
```

## Additional Notes

The autonomous context header is only injected when `request_context.source` is exactly `"cron"` or `"heartbeat"`. Regular chat sessions are not affected.
