### PR TITLE
feat(console): support plugin command suggestions with cross-tab language sync

### DIFF
--- a/console/src/components/LanguageSwitcher/index.tsx
+++ b/console/src/components/LanguageSwitcher/index.tsx
@@ -39,6 +39,11 @@ export default function LanguageSwitcher() {
   const changeLanguage = (lang: string) => {
     i18n.changeLanguage(lang);
     localStorage.setItem("language", lang);
+    window.dispatchEvent(
+      new CustomEvent("qwenpaw:language-change", {
+        detail: { language: lang },
+      }),
+    );
     languageApi
       .updateLanguage(lang)
       .catch((err) =>

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -720,7 +720,7 @@ export default function ChatPage() {
     }>
   >([]);
   const { selectedAgent } = useAgentStore();
-  const { toolRenderConfig } = usePlugins();
+  const { toolRenderConfig, pluginCommandSuggestions } = usePlugins();
   const extScalar = useChatScalarSnapshot();
   const extLists = useChatListSnapshot();
   const [refreshKey, setRefreshKey] = useState(0);
@@ -1494,6 +1494,14 @@ export default function ChatPage() {
       );
     }
 
+    for (const s of pluginCommandSuggestions) {
+      commandSuggestions.push({
+        command: s.command,
+        value: s.command.replace(/^\//, "") + " ",
+        description: s.description,
+      });
+    }
+
     const baseSuggestions = [...commandSuggestions, ...skillSuggestions].map(
       (item) => ({
         label: renderSuggestionLabel(item.command, item.description),
@@ -1735,6 +1743,7 @@ export default function ChatPage() {
     isDark,
     multimodalCaps,
     toolRenderConfig,
+    pluginCommandSuggestions,
     extScalar,
     extLists,
     scheduleHistoryClear,

--- a/console/src/plugins/PluginContext.tsx
+++ b/console/src/plugins/PluginContext.tsx
@@ -11,7 +11,10 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { pluginSystem } from "./hostExternals";
 import { loadAllPlugins } from "./usePluginLoader";
-import type { PluginRouteDeclaration } from "./hostExternals";
+import type {
+  PluginRouteDeclaration,
+  PluginCommandSuggestion,
+} from "./hostExternals";
 import {
   routeRegistry,
   subscribe as registrySubscribe,
@@ -41,6 +44,8 @@ export interface PluginContextValue {
   toolRenderConfig: Record<string, React.FC<any>>;
   /** Page routes registered by plugins. Inject into the router + sidebar. */
   pluginRoutes: PluginRouteDeclaration[];
+  /** Command suggestions registered by plugins, shown in chat input popup. */
+  pluginCommandSuggestions: PluginCommandSuggestion[];
   /** True until the initial plugin-load attempt completes. */
   loading: boolean;
   /** Non-null if one or more plugins failed to load. */
@@ -50,6 +55,7 @@ export interface PluginContextValue {
 const PluginContext = createContext<PluginContextValue>({
   toolRenderConfig: {},
   pluginRoutes: [],
+  pluginCommandSuggestions: [],
   loading: true,
   error: null,
 });
@@ -70,6 +76,9 @@ export function PluginProvider({ children }: { children: React.ReactNode }) {
   const [pluginRoutes, setPluginRoutes] = useState<PluginRouteDeclaration[]>(
     derivePluginRoutes(),
   );
+  const [pluginCommandSuggestions, setPluginCommandSuggestions] = useState<
+    PluginCommandSuggestion[]
+  >(pluginSystem.getCommandSuggestions());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -79,6 +88,7 @@ export function PluginProvider({ children }: { children: React.ReactNode }) {
     // (routes via shim + direct route.add) notify on change.
     const unsubA = pluginSystem.subscribe(() => {
       setToolRenderConfig(pluginSystem.getToolRenderConfig());
+      setPluginCommandSuggestions(pluginSystem.getCommandSuggestions());
     });
     const unsubB = registrySubscribe(() => {
       setPluginRoutes(derivePluginRoutes());
@@ -98,7 +108,13 @@ export function PluginProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <PluginContext.Provider
-      value={{ toolRenderConfig, pluginRoutes, loading, error }}
+      value={{
+        toolRenderConfig,
+        pluginRoutes,
+        pluginCommandSuggestions,
+        loading,
+        error,
+      }}
     >
       {children}
     </PluginContext.Provider>

--- a/console/src/plugins/hostExternals.ts
+++ b/console/src/plugins/hostExternals.ts
@@ -6,6 +6,36 @@
  * without bundling their own copies of React / antd.
  *
  * Call `installHostExternals()` once at application startup (main.tsx).
+ *
+ * ── Plugin command suggestions ─────────────────────────────────────────
+ *
+ * Plugins can register slash-command suggestions that appear in the chat
+ * input autocomplete popup.  To support language switching, listen for the
+ * host-dispatched `qwenpaw:language-change` event and re-register with the
+ * new locale's descriptions:
+ *
+ * ```ts
+ * // 1. Register on load
+ * window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+ *   { command: "/cmd", description: "Do something useful" },
+ * ]);
+ *
+ * // 2. Listen for language change to update descriptions
+ * window.addEventListener("qwenpaw:language-change", (e) => {
+ *   const lang = (e as CustomEvent).detail.language;
+ *   const descriptions: Record<string, string> = {
+ *     en: "Do something useful",
+ *     zh: "做一些有用的事",
+ *   };
+ *   window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+ *     { command: "/cmd", description: descriptions[lang] ?? descriptions.en },
+ *   ]);
+ * });
+ * ```
+ *
+ * The host fires `qwenpaw:language-change` from `LanguageSwitcher` whenever
+ * the user switches the console language.  Same-command re-registrations
+ * replace the previous entry (merge-by-key), so suggestions never duplicate.
  */
 
 import React from "react";

--- a/console/src/plugins/hostExternals.ts
+++ b/console/src/plugins/hostExternals.ts
@@ -68,6 +68,14 @@ export interface PluginRouteDeclaration {
   priority?: number;
 }
 
+/** Per-plugin command suggestion exposed to frontend. */
+export interface PluginCommandSuggestion {
+  /** Command string, e.g. "/a2a". */
+  command: string;
+  /** Human-readable description shown in suggestion popup. */
+  description: string;
+}
+
 /** Internal per-plugin registration record. */
 export interface PluginRegistration {
   pluginId: string;
@@ -76,6 +84,7 @@ export interface PluginRegistration {
   isBuiltin: boolean;
   routes: PluginRouteDeclaration[];
   toolRenderers: Record<string, React.FC<any>>;
+  commandSuggestions: PluginCommandSuggestion[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -105,6 +114,27 @@ class PluginSystem {
     this._notify();
   }
 
+  addCommandSuggestions(
+    pluginId: string,
+    suggestions: PluginCommandSuggestion[],
+  ): void {
+    const rec = this._record(pluginId);
+    const existing = new Set(rec.commandSuggestions.map((s) => s.command));
+    for (const s of suggestions) {
+      if (existing.has(s.command)) {
+        // Replace existing command (e.g. language change)
+        const idx = rec.commandSuggestions.findIndex(
+          (x) => x.command === s.command,
+        );
+        rec.commandSuggestions[idx] = s;
+      } else {
+        rec.commandSuggestions.push(s);
+        existing.add(s.command);
+      }
+    }
+    this._notify();
+  }
+
   // ── Read API (consumed by PluginContext / usePlugins) ────────────────────
 
   /** Merged map of all tool renderers across all plugins.
@@ -127,6 +157,14 @@ class PluginSystem {
     return out.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
   }
 
+  /** Flat list of all command suggestions across all plugins. */
+  getCommandSuggestions(): PluginCommandSuggestion[] {
+    const out: PluginCommandSuggestion[] = [];
+    for (const rec of this.records.values())
+      out.push(...rec.commandSuggestions);
+    return out;
+  }
+
   // ── Subscription ─────────────────────────────────────────────────────────
 
   /** Subscribe to any registration change. Returns an unsubscribe function. */
@@ -144,6 +182,7 @@ class PluginSystem {
         isBuiltin: false,
         routes: [],
         toolRenderers: {},
+        commandSuggestions: [],
       });
     }
     return this.records.get(pluginId)!;
@@ -176,6 +215,11 @@ export interface WindowNamespace {
   registerToolRender?: (
     pluginId: string,
     renderers: Record<string, React.FC<any>>,
+  ) => void;
+  /** Register command suggestions for a plugin. */
+  registerCommandSuggestions?: (
+    pluginId: string,
+    suggestions: PluginCommandSuggestion[],
   ) => void;
   /** Console-wide plugin Menu API. Attached by installHostExternals(). */
   menu?: QwenPawMenuNamespace;
@@ -294,6 +338,15 @@ export function installHostExternals(): void {
         `[plugin:${pluginId}] registerToolRender → ${Object.keys(
           renderers,
         ).join(", ")}`,
+      );
+    };
+  }
+
+  if (!window.QwenPaw.registerCommandSuggestions) {
+    window.QwenPaw.registerCommandSuggestions = (pluginId, suggestions) => {
+      pluginSystem.addCommandSuggestions(pluginId, suggestions);
+      console.info(
+        `[plugin:${pluginId}] registerCommandSuggestions → ${suggestions.length} command(s)`,
       );
     };
   }

--- a/console/src/plugins/hostExternals.ts
+++ b/console/src/plugins/hostExternals.ts
@@ -191,6 +191,11 @@ class PluginSystem {
   private _notify(): void {
     this.listeners.forEach((fn) => fn());
   }
+
+  /** Reset all plugin data — for testing only. */
+  __resetForTests(): void {
+    this.records.clear();
+  }
 }
 
 /** Global singleton — imported by PluginContext to subscribe to changes. */

--- a/console/src/plugins/registry/__tests__/hostExternals.compat.test.tsx
+++ b/console/src/plugins/registry/__tests__/hostExternals.compat.test.tsx
@@ -11,7 +11,7 @@
  * And that the synthesized `plugins-group` parent exists.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { installHostExternals } from "../../hostExternals";
+import { installHostExternals, pluginSystem } from "../../hostExternals";
 import { menuRegistry, routeRegistry } from "../store";
 import { auditStore } from "../audit";
 
@@ -20,6 +20,7 @@ function freshInstall() {
   (window as any).QwenPaw = undefined;
   menuRegistry.__resetForTests();
   routeRegistry.__resetForTests();
+  pluginSystem.__resetForTests();
   auditStore.clear();
   installHostExternals();
 }
@@ -104,10 +105,63 @@ describe("legacy registerRoutes shim", () => {
     expect(settings.find((i) => i.id === "newPlugin.foo")).toBeUndefined();
   });
 
-  it("legacy registerToolRender still writes to pluginSystem", async () => {
-    const { pluginSystem } = await import("../../hostExternals");
+  it("legacy registerToolRender still writes to pluginSystem", () => {
     const RenderFC = () => null;
     window.QwenPaw.registerToolRender!("p1", { my_tool: RenderFC });
     expect(pluginSystem.getToolRenderConfig().my_tool).toBe(RenderFC);
+  });
+});
+
+describe("registerCommandSuggestions", () => {
+  it("attaches window.QwenPaw.registerCommandSuggestions", () => {
+    expect(typeof window.QwenPaw.registerCommandSuggestions).toBe("function");
+  });
+
+  it("registers command suggestions to pluginSystem", () => {
+    window.QwenPaw.registerCommandSuggestions!("cloudpaw", [
+      { command: "/a2a", description: "Call remote A2A agents" },
+      { command: "/status", description: "Check agent status" },
+    ]);
+    const suggestions = pluginSystem.getCommandSuggestions();
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0].command).toBe("/a2a");
+    expect(suggestions[1].command).toBe("/status");
+  });
+
+  it("replaces same command instead of duplicating (language switch)", () => {
+    window.QwenPaw.registerCommandSuggestions!("cloudpaw", [
+      { command: "/a2a", description: "查看远程 A2A Agent" },
+    ]);
+    // Simulate language change
+    window.QwenPaw.registerCommandSuggestions!("cloudpaw", [
+      { command: "/a2a", description: "View remote A2A agents" },
+    ]);
+    const suggestions = pluginSystem.getCommandSuggestions();
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].description).toBe("View remote A2A agents");
+  });
+
+  it("multiple plugins register independently without conflict", () => {
+    window.QwenPaw.registerCommandSuggestions!("pluginA", [
+      { command: "/cmd-a", description: "Plugin A command" },
+    ]);
+    window.QwenPaw.registerCommandSuggestions!("pluginB", [
+      { command: "/cmd-b", description: "Plugin B command" },
+    ]);
+    const suggestions = pluginSystem.getCommandSuggestions();
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions.map((s) => s.command)).toContain("/cmd-a");
+    expect(suggestions.map((s) => s.command)).toContain("/cmd-b");
+  });
+
+  it("subscribe fires on suggestion change", () => {
+    let notifyCount = 0;
+    pluginSystem.subscribe(() => {
+      notifyCount++;
+    });
+    window.QwenPaw.registerCommandSuggestions!("p1", [
+      { command: "/test", description: "test" },
+    ]);
+    expect(notifyCount).toBe(1);
   });
 });

--- a/console/src/plugins/types/qwenpaw.d.ts
+++ b/console/src/plugins/types/qwenpaw.d.ts
@@ -245,6 +245,13 @@ export interface PluginRouteDeclaration {
   priority?: number;
 }
 
+export interface PluginCommandSuggestion {
+  /** Command string, e.g. "/a2a". */
+  command: string;
+  /** Human-readable description shown in suggestion popup. */
+  description: string;
+}
+
 export interface QwenPawWindowNamespace {
   host: QwenPawHostNamespace;
   chat: QwenPawChatNamespace;
@@ -254,6 +261,10 @@ export interface QwenPawWindowNamespace {
   registerToolRender?(
     pluginId: string,
     renderers: Record<string, React.FC<Record<string, unknown>>>,
+  ): void;
+  registerCommandSuggestions?(
+    pluginId: string,
+    suggestions: PluginCommandSuggestion[],
   ): void;
 }
 

--- a/console/src/plugins/types/qwenpaw.d.ts
+++ b/console/src/plugins/types/qwenpaw.d.ts
@@ -16,6 +16,11 @@
  *   render(pluginId, node)  → whole-section replacement (welcome / leftHeader)
  *   add(pluginId, item)     → append to additive lists
  * ─────────────────────────────────────────────────────────────────────────
+ *
+ * Language switching: the host dispatches a `qwenpaw:language-change` custom
+ * event (via `window.addEventListener`) when the user switches the console
+ * language.  Plugins can listen to this event and re-register command
+ * suggestions with locale-appropriate descriptions.
  */
 import type React from "react";
 

--- a/website/public/docs/plugins.en.md
+++ b/website/public/docs/plugins.en.md
@@ -512,6 +512,46 @@ window.QwenPaw.chat.sender.addSuggestion("my-plugin", {
 });
 ```
 
+### Slash Command Registration — `registerCommandSuggestions`
+
+Register `/slash` commands that the plugin provides. Registered commands appear in the chat input suggestion popup when the user types `/`, and are dispatched to the backend command handler when executed.
+
+```ts
+// Register on plugin load
+window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+  { command: "/analyze", description: "Analyze uploaded data" },
+  { command: "/visualize", description: "Create data visualizations" },
+]);
+```
+
+Each entry's `command` field is the slash command token (must start with `/`). The `description` field is shown in the autocomplete popup to help users understand what the command does.
+
+**Language switching support:** the host dispatches a `qwenpaw:language-change` custom event when the user switches the console language. Listen to this event to update descriptions:
+
+```ts
+const descriptions: Record<string, string> = {
+  en: "Analyze uploaded data",
+  zh: "分析已上传的数据",
+};
+
+// Initial registration
+window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+  { command: "/analyze", description: descriptions.en },
+]);
+
+// Update on language change
+window.addEventListener("qwenpaw:language-change", (e) => {
+  const lang = (e as CustomEvent).detail.language;
+  window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+    { command: "/analyze", description: descriptions[lang] ?? descriptions.en },
+  ]);
+});
+```
+
+Re-registering the same command replaces the previous entry (merge-by-key), so suggestions never duplicate across language switches.
+
+> **Note:** This API registers the command for display and routing. The actual command handler must be registered on the backend via `register_command()` in the plugin's Python code. See [Command Plugins](#command-plugins) for backend implementation.
+
 ### Message Action Buttons — `chat.actions` / `chat.requestActions`
 
 ```tsx

--- a/website/public/docs/plugins.zh.md
+++ b/website/public/docs/plugins.zh.md
@@ -512,6 +512,46 @@ window.QwenPaw.chat.sender.addSuggestion("my-plugin", {
 });
 ```
 
+### 斜杠命令注册 — `registerCommandSuggestions`
+
+注册插件提供的 `/` 斜杠命令。注册后，用户输入 `/` 时命令会出现在聊天输入框的自动补全弹窗中，执行时消息会被分发到后端的命令处理器。
+
+```ts
+// 插件加载时注册
+window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+  { command: "/analyze", description: "分析已上传的数据" },
+  { command: "/visualize", description: "创建数据可视化" },
+]);
+```
+
+`command` 字段是斜杠命令的标识（必须以 `/` 开头）。`description` 字段展示在补全弹窗中，帮助用户理解命令的用途。
+
+**多语言支持：** 当用户切换控制台语言时，host 会派发 `qwenpaw:language-change` 自定义事件。监听此事件以更新描述：
+
+```ts
+const descriptions: Record<string, string> = {
+  en: "Analyze uploaded data",
+  zh: "分析已上传的数据",
+};
+
+// 初始注册
+window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+  { command: "/analyze", description: descriptions.en },
+]);
+
+// 语言切换时更新
+window.addEventListener("qwenpaw:language-change", (e) => {
+  const lang = (e as CustomEvent).detail.language;
+  window.QwenPaw.registerCommandSuggestions?.("my-plugin", [
+    { command: "/analyze", description: descriptions[lang] ?? descriptions.en },
+  ]);
+});
+```
+
+重新注册同一命令会替换之前的条目（按 key 合并），因此语言切换时不会重复出现。
+
+> **注意：** 此 API 负责命令的展示和路由注册。实际的命令处理逻辑需要在 Python 后端通过 `register_command()` 注册。详见 [命令插件](#命令插件)。
+
 ### 消息操作按钮 — `chat.actions` / `chat.requestActions`
 
 ```tsx


### PR DESCRIPTION
## Description

This PR introduces slash command registration for frontend plugins. Plugins can now register `/command` tokens that appear in the chat input autocomplete popup when the user types `/`, enabling discoverability of
  plugin-provided commands.

  - Added `PluginCommandSuggestion` interface and `registerCommandSuggestions` API to the plugin host SDK
  - Commands are merged by key (re-register replaces instead of duplicates), supporting language switching
  - Host dispatches `qwenpaw:language-change` custom event from LanguageSwitcher so plugins can update descriptions per locale
  - PluginContext exposes `pluginCommandSuggestions` reactively; Chat page merges into suggestion list with proper useMemo dependency
  - Added TypeScript type declarations in `qwenpaw.d.ts` for plugin developers
  - Added 5 unit tests covering registration, replacement, multi-plugin isolation, and subscription
  - Added English/Chinese documentation with usage examples


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```

## Additional Notes
<img width="572" height="237" alt="image" src="https://github.com/user-attachments/assets/179c6d10-51ce-4fa9-a32b-0d8885c4ab16" />
