### PR TITLE
fix(desktop): guard against Windows console crash and self-kill commands

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -363,6 +363,70 @@ def _execute_subprocess_sync(
                     pass
 
 
+_DANGER_NAMES = {"python", "pythonw", "cmd", "powershell", "pwsh", "conhost"}
+
+# Prefix that ensures kill/taskkill is at command start or after a separator
+# (&&, ;, |).  Prevents false positives like echo "do not kill python".
+_KILL_PREFIX = r"(?:^|[;&|]\s*)\s*"
+
+# Matches PID-based kills: taskkill /PID 123, kill -9 123, kill 123.
+# Uses greedy .* to capture the last number (PID), not intermediate flags like -9.
+# \b ensures "kill" is matched as a whole word (e.g. "skill" won't trigger).
+_KILL_PID_RE = re.compile(
+    rf"{_KILL_PREFIX}(?:taskkill|kill|stop-process)\b.*(?:/PID|-p|-pid|\b)\s*(\d+)",
+    re.IGNORECASE,
+)
+
+# Matches dangerous process names as /IM targets or bare kill targets.
+# \b word boundaries prevent false positives (e.g. "command" → "cmd",
+# "skill" → "kill", "pythonic" → "python").
+_DANGER_NAME_RE = re.compile(
+    rf"{_KILL_PREFIX}(?:taskkill|kill|stop-process)\b.*?\b({'|'.join(_DANGER_NAMES)})(?:\.exe)?\b",
+    re.IGNORECASE,
+)
+
+# Shell variables that reference the current/parent PID.
+_SHELL_PID_VARS = {"$$", "$ppid", "$pid"}
+
+
+def _is_dangerous_self_kill(cmd: str) -> bool:
+    """Return True if *cmd* would kill the current process or its parent.
+
+    Uses token-based regex matching to avoid false positives from
+    substring matching (e.g. ``echo "do not kill python"`` is safe).
+
+    Blocks three patterns:
+    1. ``taskkill /IM <dangerous_name>`` — kills by image name.
+    2. ``kill <pid>`` / ``taskkill /PID <pid>`` targeting our PID or parent.
+    3. Shell variable self-kill: ``kill -9 $$``, ``kill $PPID``.
+    """
+    lower = cmd.lower()
+
+    # Rule 1: Block killing by dangerous process names
+    if _DANGER_NAME_RE.search(lower):
+        return True
+
+    # Rule 2: Block shell variable self-kill ($$ = current PID, $PPID = parent)
+    if "kill" in lower or "stop-process" in lower:
+        if any(var in lower for var in _SHELL_PID_VARS):
+            return True
+
+    # Rule 3: Block targeted PID kill matching current or parent PID
+    m = _KILL_PID_RE.search(lower)
+    if m:
+        try:
+            target_pid = int(m.group(1))
+            protected_pids = {os.getpid()}
+            if hasattr(os, "getppid"):
+                protected_pids.add(os.getppid())
+            if target_pid in protected_pids:
+                return True
+        except ValueError:
+            pass
+
+    return False
+
+
 # pylint: disable=too-many-branches, too-many-statements
 async def execute_shell_command(
     command: str,
@@ -397,6 +461,22 @@ async def execute_shell_command(
     """
 
     cmd = _collapse_embedded_newlines((command or "").strip())
+
+    # Guard against self-kill: block taskkill / kill commands that target
+    # the current process tree.  LLMs may generate these accidentally
+    # (e.g. "taskkill /F /IM python.exe") which would terminate QwenPaw.
+    if _is_dangerous_self_kill(cmd):
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        "Blocked: this command would self-kill the current "
+                        "process and is not allowed."
+                    ),
+                ),
+            ],
+        )
 
     if isinstance(timeout, str):
         try:

--- a/src/qwenpaw/utils/startup_display.py
+++ b/src/qwenpaw/utils/startup_display.py
@@ -8,6 +8,19 @@ from rich.panel import Panel
 from rich.tree import Tree
 
 
+def _safe_print(console: Console, *args, **kwargs) -> None:
+    """Call ``console.print`` with an OSError fallback for legacy Windows.
+
+    On legacy Windows consoles Rich can raise
+    ``OSError: [Errno 22] Invalid argument``.  When that happens we fall
+    back to the built-in ``print`` so the application does not crash.
+    """
+    try:
+        console.print(*args, **kwargs)
+    except OSError:
+        print(*args, **kwargs)
+
+
 def print_ready_banner(
     api_info: Optional[Tuple[str, int]] = None,
     elapsed_seconds: Optional[float] = None,
@@ -28,7 +41,7 @@ def print_ready_banner(
     console = Console()
 
     # Extra spacing before banner
-    console.print()
+    _safe_print(console)
 
     if api_info:
         host, port = api_info
@@ -76,5 +89,5 @@ def print_ready_banner(
             expand=False,
         )
 
-    console.print(panel)
-    console.print()
+    _safe_print(console, panel)
+    _safe_print(console)

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -23,6 +23,7 @@ from qwenpaw.agents.tools.shell import (
     _collapse_newlines_outside_quotes,
     _extract_powershell_command,
     _is_cmd,
+    _is_dangerous_self_kill,
     _is_powershell,
     _read_temp_file,
     _sanitize_win_cmd,
@@ -274,6 +275,87 @@ class TestSmartDecode:
         data = b"\xff\xfe"  # BOM for UTF-16-LE, invalid UTF-8
         result = smart_decode(data)
         assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# _is_dangerous_self_kill
+# ---------------------------------------------------------------------------
+
+
+class TestIsDangerousSelfKill:
+    """Tests for _is_dangerous_self_kill."""
+
+    def test_taskkill_by_image_name_python(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM python.exe")
+
+    def test_taskkill_by_image_name_pythonw(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM pythonw.exe")
+
+    def test_taskkill_by_image_name_cmd(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM cmd.exe")
+
+    def test_taskkill_by_image_name_powershell(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM powershell.exe")
+
+    def test_taskkill_by_image_name_pwsh(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM pwsh.exe")
+
+    def test_taskkill_by_image_name_conhost(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM conhost.exe")
+
+    def test_taskkill_by_image_name_without_exe(self):
+        assert _is_dangerous_self_kill("taskkill /F /IM python")
+
+    def test_taskkill_by_pid_self(self):
+        import os
+
+        assert _is_dangerous_self_kill(f"taskkill /F /PID {os.getpid()}")
+
+    def test_taskkill_by_pid_parent(self):
+        import os
+
+        if hasattr(os, "getppid"):
+            assert _is_dangerous_self_kill(f"taskkill /F /PID {os.getppid()}")
+
+    def test_taskkill_by_pid_other_is_safe(self):
+        assert not _is_dangerous_self_kill("taskkill /F /PID 99999")
+
+    def test_kill_unix_pid_self(self):
+        import os
+
+        assert _is_dangerous_self_kill(f"kill -9 {os.getpid()}")
+
+    def test_kill_unix_pid_other_is_safe(self):
+        assert not _is_dangerous_self_kill("kill -9 99999")
+
+    def test_kill_shell_var_dollar_dollar(self):
+        assert _is_dangerous_self_kill("kill -9 $$")
+
+    def test_kill_shell_var_ppid(self):
+        assert _is_dangerous_self_kill("kill $PPID")
+
+    def test_kill_shell_var_pid(self):
+        assert _is_dangerous_self_kill("kill $PID")
+
+    def test_false_positive_command_contains_cmd(self):
+        """'command' contains 'cmd' but should not be blocked."""
+        assert not _is_dangerous_self_kill("echo 'run a command'")
+
+    def test_false_positive_echo_kill_python(self):
+        """echo with 'kill python' in text should not be blocked."""
+        assert not _is_dangerous_self_kill(
+            'echo "do not kill python"',
+        )
+
+    def test_false_positive_cat_file(self):
+        """Reading a file named kill_list_python.txt should not be blocked."""
+        assert not _is_dangerous_self_kill("cat kill_list_python.txt")
+
+    def test_safe_command(self):
+        assert not _is_dangerous_self_kill("echo hello")
+
+    def test_stop_process_by_name(self):
+        assert _is_dangerous_self_kill("Stop-Process -Name python")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes two issues that cause QwenPaw to crash or terminate unexpectedly on Windows:

### 1. Rich console crash on legacy Windows terminals
The `print_ready_banner` function in `startup_display.py` uses Rich's `console.print()` which can throw `OSError: [Errno 22] Invalid argument` on legacy Windows consoles, causing the entire application to crash during startup. Introduced a `_safe_print` helper that wraps all `console.print()` calls (including the leading/trailing blank lines) with an `OSError` fallback to built-in `print()`.

### 2. LLM-generated self-kill commands
The `execute_shell_command` tool in `shell.py` did not guard against commands like `taskkill /F /IM python.exe` or `kill -9 $$` that could terminate the QwenPaw process itself. Added a `_is_dangerous_self_kill` check using token-based regex matching (with `\b` word boundaries to avoid false positives) that intercepts and blocks such commands before execution.

## Changes

- **`src/qwenpaw/utils/startup_display.py`**: Add `_safe_print` helper wrapping all `console.print()` calls with `OSError` fallback; unify trailing blank line behavior across Rich/fallback paths
- **`src/qwenpaw/agents/tools/shell.py`**: Add `_is_dangerous_self_kill` guard with three detection rules:
  - `_DANGER_NAME_RE`: blocks `taskkill /IM <name>`, `kill <name>`, `Stop-Process -Name <name>` using `\b` word boundaries to prevent false positives (e.g. `echo "do not kill python"` is safe)
  - `_SHELL_PID_VARS`: blocks shell variable self-kill (`$$`, `$PPID`, `$PID`)
  - `_KILL_PID_RE`: blocks PID-based kills targeting current or parent process (`os.getpid()` / `os.getppid()`)
- **`tests/unit/agents/tools/test_shell.py`**: Add 17 unit tests for `_is_dangerous_self_kill` covering true positives, false positives, and edge cases

## Testing

- All existing lint checks pass (black, flake8, pylint, mypy)
- 17 new unit tests for self-kill detection logic
- Verified `print_ready_banner` falls back gracefully when Rich fails