### PR TITLE
fix(mcp): avoid IndexError on empty authorization_servers in OAuth discovery

### DIFF
--- a/src/qwenpaw/app/routers/mcp_oauth.py
+++ b/src/qwenpaw/app/routers/mcp_oauth.py
@@ -141,7 +141,7 @@ async def _resolve_auth_server_url(
     rm_url = await _probe_resource_metadata_url(client, mcp_url)
     if rm_url:
         prm = await _fetch_json(client, rm_url)
-        if prm and "authorization_servers" in prm:
+        if prm and prm.get("authorization_servers"):
             return prm["authorization_servers"][0]
 
     # Fall back to well-known PRM paths
@@ -158,7 +158,7 @@ async def _resolve_auth_server_url(
         if not url:
             continue
         prm = await _fetch_json(client, url)
-        if prm and "authorization_servers" in prm:
+        if prm and prm.get("authorization_servers"):
             return prm["authorization_servers"][0]
     return None
 


### PR DESCRIPTION
## What

`_resolve_auth_server_url()` in `src/qwenpaw/app/routers/mcp_oauth.py` resolves the OAuth authorization-server URL from a Protected Resource Metadata (PRM) response. At two call sites it guards only that the key is present, then indexes `[0]`:

```python
if prm and "authorization_servers" in prm:
    return prm["authorization_servers"][0]
```

## Why it's a bug

`authorization_servers` can be an **empty list** in a valid PRM JSON response. The `in` check passes, but `[0]` then raises `IndexError`, surfacing as a **500** from `POST /api/mcp/oauth/start/{client_key}` (reached when adding an OAuth-protected MCP server in the Console) instead of cleanly falling back to the well-known PRM paths.

## Fix

Use `prm.get("authorization_servers")` (truthy ⇒ present **and** non-empty) at both sites — completing the existing guard. Behaviour is unchanged for a populated list; an empty/absent list now falls through as intended.

## Verification

- `black==23.3.0`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean (10/10)
- Verified directly: old code raises `IndexError` on `{"authorization_servers": []}`; new code falls through; both identical for a populated or absent list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
