### PR TITLE
fix(tools): set explicit user_id in inter-agent chat payload

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -218,6 +218,12 @@ def build_agent_chat_request(
     final_text = ensure_agent_identity_prefix(text, caller_agent_id)
     request_payload = {
         "session_id": final_session_id,
+        # Pass an explicit, non-empty user_id (the calling agent) so the
+        # runtime does not fall back to ``user_id = user_id or session_id``.
+        # Without it the session file is named
+        # ``{session_id}_{session_id}.json`` -- doubling its length and
+        # overflowing the Windows MAX_PATH limit (issue #5025).
+        "user_id": caller_agent_id,
         "input": [
             {
                 "role": "user",

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -91,6 +91,27 @@ def test_build_agent_chat_request_adds_identity_prefix():
     )
 
 
+def test_build_agent_chat_request_sets_caller_as_user_id():
+    """Payload carries an explicit non-empty ``user_id`` (the caller agent).
+
+    Without it the runtime applies ``user_id = user_id or session_id`` and the
+    session file becomes ``{session_id}_{session_id}.json`` -- doubling its
+    length and overflowing the Windows MAX_PATH (260) limit. Regression test
+    for issue #5025.
+    """
+    (
+        _session_id,
+        payload,
+        _prefix_added,
+    ) = agent_management.build_agent_chat_request(
+        "bot_b",
+        "Need a summary",
+        from_agent="bot_a",
+    )
+
+    assert payload.get("user_id") == "bot_a"
+
+
 def test_build_agent_chat_request_discovers_calling_agent(monkeypatch):
     monkeypatch.setattr(
         agent_management,
@@ -113,6 +134,9 @@ def test_build_agent_chat_request_discovers_calling_agent(monkeypatch):
         "[Agent auto_bot requesting] ",
     )
     assert prefix_added is True
+    # Real bug path (#5025): when from_agent is None the caller is resolved
+    # from context, and that resolved id must still become the user_id.
+    assert payload["user_id"] == "auto_bot"
 
 
 def test_build_agent_chat_request_reuses_session_id_when_provided():


### PR DESCRIPTION
## Summary

Inter-agent calls (`submit_to_agent` / `chat_with_agent`) built the chat payload with only `session_id`. The runtime then applies `user_id = user_id or session_id` (`agentscope_runtime/engine/runner.py`), so the session file is named `{session_id}_{session_id}.json` — the globally-unique `session_id` (`{from}:to:{to}:{ts}:{uuid}`) written **twice**. On Windows the doubled name overflows the `MAX_PATH` (260) limit and the session file can't be created, raising `FileNotFoundError`.

This passes the already-resolved `caller_agent_id` (computed two lines above for the identity prefix / `root_agent_id`) as an explicit, non-empty `user_id`, which stops the fallback and keeps a single copy of the session id in the filename.

Fixes #5025

## Why this over "use a shorter agent_id"

The inter-agent `session_id` is already globally unique, so reusing the whole string as the `user_id` prefix adds no namespacing value — the doubled name is redundant on **every** platform (Linux/macOS simply don't crash on it). Passing the caller as `user_id` is also the more correct semantics: the "user" of an inter-agent session is the calling agent.

## Verification

Filename produced by the real `SafeJSONSession` for a representative long agent pair:

| | filename length | illegal `:` |
|---|---|---|
| before (`user_id == session_id`) | 170 | none (`sanitize_filename` maps `:`→`--`) |
| after (`user_id == caller_agent_id`) | 109 | none |

Unit tests cover both the explicit `from_agent` path and the `from_agent=None` / context-resolved path (the real reproduction path).

```
pre-commit run --files src/qwenpaw/agents/tools/agent_management.py tests/unit/agents/tools/test_agent_management.py
pytest tests/unit/agents/tools/ tests/unit/app/runner/
```
Both green (268 passed; flake8/black/mypy/pylint pass).

## Scope / known limitations (intentionally out of scope)

- This removes the **doubling** root cause. A pathological, very long `agent_id` could in principle still approach `MAX_PATH`; that long-path-robustness hardening is a separate concern and left out of this change.
- **Backward-compat:** brand-new inter-agent sessions are unaffected (each call mints a fresh uuid). The only edge is continuing an *explicitly reused* `session_id` created before this change — the new filename won't find the old file (`allow_not_exist=True` avoids a crash but starts fresh). Inter-agent sessions are effectively one-shot, so impact is low.
- `spawn_subagent` (non-fork) follows the same payload pattern but its `session_id` is short (`sub-{uuid8}`), so it isn't affected by `MAX_PATH`; left unchanged for a focused diff.
