### PR TITLE
test(integration): add Sprint 2.4 cron execution and tool API tests

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import shutil
 import time
+from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any
 
@@ -227,3 +228,306 @@ def make_event(
         "read": read,
         "created_at": (created_at if created_at is not None else time.time()),
     }
+
+
+# ------------------------------------------------------------------ #
+# Mock LLM server
+# ------------------------------------------------------------------ #
+
+MOCK_LLM_RESPONSE = "Mock heartbeat response from integration test."
+MOCK_LLM_PROVIDER_ID = "integ-mock-llm"
+_HTTP_TIMEOUT = 15.0
+
+
+class MockLLMHandler(BaseHTTPRequestHandler):
+    """OpenAI-compatible streaming server with tool_call support.
+
+    Behaviour matrix (checked in order):
+      1. ``server.force_error`` is True  → 422
+      2. Request has ``tools`` AND no ``role=tool`` message
+         → stream a tool_call for ``get_current_time``
+      3. Request has a ``role=tool`` message (round 2)
+         → stream text summarising the tool result
+      4. Otherwise → stream ``MOCK_LLM_RESPONSE``
+    """
+
+    def do_POST(self):  # noqa: N802
+        if "/chat/completions" in self.path:
+            self._stream_completion()
+        else:
+            self.send_error(404)
+
+    def do_GET(self):  # noqa: N802
+        if "/models" in self.path:
+            self._list_models()
+        else:
+            self.send_error(404)
+
+    # -- internals ---------------------------------------------------
+
+    def _read_body(self) -> dict:
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            return json.loads(raw)
+        except (ValueError, UnicodeDecodeError):
+            return {}
+
+    def _stream_completion(self):
+        body = self._read_body()
+
+        delay = getattr(self.server, "response_delay", 0)
+        if delay:
+            time.sleep(delay)
+
+        if getattr(self.server, "force_error", False):
+            self._respond_error()
+            return
+
+        messages = body.get("messages", [])
+        tools = body.get("tools", [])
+        has_tool_result = any(m.get("role") == "tool" for m in messages)
+        force_tc = getattr(self.server, "force_tool_call", False)
+
+        if force_tc and tools and not has_tool_result:
+            self._stream_tool_call()
+        elif has_tool_result:
+            tool_content = ""
+            for m in messages:
+                if m.get("role") == "tool":
+                    tool_content = str(m.get("content", ""))
+            text = (
+                f"The current time is {tool_content}."
+                if tool_content
+                else MOCK_LLM_RESPONSE
+            )
+            self._stream_text(text)
+        else:
+            self._stream_text(MOCK_LLM_RESPONSE)
+
+    def _respond_error(self):
+        self.send_response(422)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        err = {
+            "error": {
+                "message": "forced",
+                "type": "invalid_request_error",
+            },
+        }
+        self.wfile.write(json.dumps(err).encode())
+
+    def _stream_text(self, text: str):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+
+        chunk = json.dumps(
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": "mock-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": text,
+                        },
+                        "finish_reason": None,
+                    },
+                ],
+                "usage": None,
+            },
+        )
+        self.wfile.write(f"data: {chunk}\n\n".encode())
+        self.wfile.flush()
+
+        final = json.dumps(
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": "mock-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    },
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            },
+        )
+        self.wfile.write(f"data: {final}\n\n".encode())
+        self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def _stream_tool_call(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+
+        chunk1 = json.dumps(
+            {
+                "id": "chatcmpl-mock-tc",
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": "mock-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_mock_tc",
+                                    "type": "function",
+                                    "function": {
+                                        "name": ("get_current_time"),
+                                        "arguments": "",
+                                    },
+                                },
+                            ],
+                        },
+                        "finish_reason": None,
+                    },
+                ],
+            },
+        )
+        self.wfile.write(f"data: {chunk1}\n\n".encode())
+        self.wfile.flush()
+
+        chunk2 = json.dumps(
+            {
+                "id": "chatcmpl-mock-tc",
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": "mock-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {
+                                        "arguments": "{}",
+                                    },
+                                },
+                            ],
+                        },
+                        "finish_reason": None,
+                    },
+                ],
+            },
+        )
+        self.wfile.write(f"data: {chunk2}\n\n".encode())
+        self.wfile.flush()
+
+        chunk3 = json.dumps(
+            {
+                "id": "chatcmpl-mock-tc",
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": "mock-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "tool_calls",
+                    },
+                ],
+                "usage": {
+                    "prompt_tokens": 15,
+                    "completion_tokens": 10,
+                    "total_tokens": 25,
+                },
+            },
+        )
+        self.wfile.write(f"data: {chunk3}\n\n".encode())
+        self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def _list_models(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "data": [
+                        {"id": "mock-model", "object": "model"},
+                    ],
+                },
+            ).encode(),
+        )
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+# ------------------------------------------------------------------ #
+# Mock LLM provider helpers
+# ------------------------------------------------------------------ #
+
+
+def register_mock_provider(app_server, mock_url: str) -> str:
+    """Register + activate mock LLM provider. Returns provider id."""
+    app_server.api_request(
+        "POST",
+        "/api/models/custom-providers",
+        json={
+            "id": MOCK_LLM_PROVIDER_ID,
+            "name": "Integration Mock",
+            "default_base_url": mock_url,
+            "chat_model": "OpenAIChatModel",
+            "models": [
+                {"id": "mock-model", "name": "Mock Model"},
+            ],
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    app_server.api_request(
+        "PUT",
+        f"/api/models/{MOCK_LLM_PROVIDER_ID}/config",
+        json={
+            "api_key": "test-key-mock",
+            "base_url": mock_url,
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    app_server.api_request(
+        "PUT",
+        "/api/models/active",
+        json={
+            "provider_id": MOCK_LLM_PROVIDER_ID,
+            "model": "mock-model",
+            "scope": "global",
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+    return MOCK_LLM_PROVIDER_ID
+
+
+def unregister_mock_provider(app_server, provider_id: str):
+    """Best-effort cleanup of mock provider."""
+    try:
+        app_server.api_request(
+            "DELETE",
+            f"/api/models/custom-providers/{provider_id}",
+            timeout=_HTTP_TIMEOUT,
+        )
+    except Exception:
+        pass

--- a/tests/integration/test_cron_execution.py
+++ b/tests/integration/test_cron_execution.py
@@ -1,0 +1,708 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for cron job *execution* (text and agent types).
+
+Sprint 2.1/2.2 covered cron CRUD lifecycle (create, pause, resume,
+delete, history seeding).  This module covers the **execution** path:
+POST /run triggers real ``CronExecutor.execute()`` and we verify
+history records, inbox events, and channel delivery.
+
+Agent-type tests use the shared Mock LLM (``helpers.MockLLMHandler``)
+with tool_call support to validate the full pipeline:
+  Mock LLM → tool_call(get_current_time) → Agent executes → Round 2
+  → text response → history success.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from http.server import HTTPServer
+
+import pytest
+
+from helpers import (
+    MOCK_LLM_PROVIDER_ID,
+    MockLLMHandler,
+    clean_inbox,
+    register_mock_provider,
+    unregister_mock_provider,
+)
+
+_CRON_HTTP_TIMEOUT = 15.0
+_NEVER_FIRE_SCHEDULE = "0 0 1 1 *"
+
+
+# ------------------------------------------------------------------ #
+# fixtures
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture(scope="module")
+def mock_llm():
+    """Module-scoped mock OpenAI server with tool_call support."""
+    srv = HTTPServer(("127.0.0.1", 0), MockLLMHandler)
+    srv.force_error = False
+    srv.force_tool_call = False
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield srv, f"http://127.0.0.1:{port}/v1"
+    srv.shutdown()
+
+
+# ------------------------------------------------------------------ #
+# helpers
+# ------------------------------------------------------------------ #
+
+
+def _text_spec(name, *, text="Hello from cron", channel="console"):
+    return {
+        "name": name,
+        "enabled": True,
+        "schedule": {
+            "type": "cron",
+            "cron": _NEVER_FIRE_SCHEDULE,
+            "timezone": "UTC",
+        },
+        "task_type": "text",
+        "text": text,
+        "dispatch": {
+            "type": "channel",
+            "channel": channel,
+            "target": {
+                "user_id": f"cron-exec-{name}",
+                "session_id": f"console:cron-exec-{name}-sess",
+            },
+            "mode": "stream",
+        },
+    }
+
+
+def _agent_input(text):
+    """Build AgentRequest-compatible input list."""
+    return [
+        {
+            "role": "user",
+            "type": "message",
+            "content": [{"type": "text", "text": text}],
+        },
+    ]
+
+
+def _agent_spec(
+    name,
+    *,
+    input_text="What time is it?",
+    save_inbox=False,
+):
+    spec = {
+        "name": name,
+        "enabled": True,
+        "schedule": {
+            "type": "cron",
+            "cron": _NEVER_FIRE_SCHEDULE,
+            "timezone": "UTC",
+        },
+        "task_type": "agent",
+        "request": {"input": _agent_input(input_text)},
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {
+                "user_id": f"cron-exec-{name}",
+                "session_id": f"console:cron-exec-{name}-sess",
+            },
+            "mode": "stream",
+        },
+    }
+    if save_inbox:
+        spec["save_result_to_inbox"] = True
+    return spec
+
+
+def _create_job(app_server, spec):
+    resp = app_server.api_request(
+        "POST",
+        "/api/cron/jobs",
+        json=spec,
+        timeout=_CRON_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    job_id = resp.json().get("id")
+    assert isinstance(job_id, str) and job_id
+    return job_id
+
+
+def _delete_job(app_server, job_id):
+    try:
+        app_server.api_request(
+            "DELETE",
+            f"/api/cron/jobs/{job_id}",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+    except Exception:
+        pass
+
+
+def _poll_history(app_server, job_id, deadline, *, min_count=1):
+    """Poll GET history until min_count records appear."""
+    while time.time() < deadline:
+        resp = app_server.api_request(
+            "GET",
+            f"/api/cron/jobs/{job_id}/history",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            records = resp.json()
+            if isinstance(records, list) and len(records) >= min_count:
+                return records
+        time.sleep(1.0)
+    return []
+
+
+def _poll_inbox_cron(app_server, deadline, *, event_type=None):
+    """Poll inbox for cron-sourced events."""
+    while time.time() < deadline:
+        resp = app_server.api_request(
+            "GET",
+            "/api/console/inbox/events",
+            params={"source_type": "cron"},
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            body = resp.json()
+            events = body.get(
+                "events",
+                body if isinstance(body, list) else [],
+            )
+            if event_type:
+                events = [
+                    e for e in events if e.get("event_type") == event_type
+                ]
+            if events:
+                return events
+        time.sleep(1.0)
+    return []
+
+
+# ------------------------------------------------------------------ #
+# A1: text-type manual run → history record
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_cron_text_manual_run_creates_history(app_server) -> None:
+    """Test purpose:
+    - Verify POST /run on a text-type cron job creates a history
+      record with trigger=manual and status=success.
+
+    Test flow:
+    1. POST create text-type cron job (never-fire schedule).
+    2. POST run (manual trigger).
+    3. Poll GET history until a record appears.
+    4. Assert record fields: trigger=manual, status=success.
+    5. Cleanup: DELETE job.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/run
+    - GET /api/cron/jobs/{job_id}/history
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    spec = _text_spec("integ_text_hist")
+    job_id = _create_job(app_server, spec)
+    try:
+        run_resp = app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200
+        assert run_resp.json().get("started") is True
+
+        records = _poll_history(
+            app_server,
+            job_id,
+            time.time() + 15.0,
+        )
+        assert (
+            len(records) >= 1
+        ), f"No history record after 15s: {app_server.logs_tail()}"
+
+        rec = records[0]
+        assert rec["trigger"] == "manual"
+        assert rec["status"] == "success"
+        assert "run_at" in rec
+    finally:
+        _delete_job(app_server, job_id)
+
+
+# ------------------------------------------------------------------ #
+# A2: agent-type manual run with Mock LLM (text only, no tool_call)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_cron_agent_manual_run_with_mock_llm(
+    app_server,
+    mock_llm,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test purpose:
+    - Verify POST /run on an agent-type cron job with Mock LLM
+      produces a successful history record.
+
+    Test flow:
+    1. Register mock LLM provider.
+    2. POST create agent-type cron job.
+    3. POST run (manual trigger).
+    4. Poll history until success record appears.
+    5. Cleanup.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/run
+    - GET /api/cron/jobs/{job_id}/history
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    srv, mock_url = mock_llm
+    srv.force_error = False
+    unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+    provider_id = register_mock_provider(app_server, mock_url)
+    spec = _agent_spec("integ_agent_hist", input_text="Hello")
+    job_id = _create_job(app_server, spec)
+    try:
+        run_resp = app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200
+        assert run_resp.json().get("started") is True
+
+        records = _poll_history(
+            app_server,
+            job_id,
+            time.time() + 30.0,
+        )
+        assert (
+            len(records) >= 1
+        ), f"No history record after 30s: {app_server.logs_tail()}"
+
+        rec = records[0]
+        assert rec["trigger"] == "manual"
+        assert rec["status"] == "success"
+    finally:
+        _delete_job(app_server, job_id)
+        unregister_mock_provider(app_server, provider_id)
+
+
+# ------------------------------------------------------------------ #
+# A3: agent-type with tool_call (get_current_time) — full pipeline
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_cron_agent_tool_call_execution(
+    app_server,
+    mock_llm,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test purpose:
+    - Verify Mock LLM tool_call round-trip: the agent receives a
+      tool_call for get_current_time, executes it, sends the result
+      back, and the second LLM round produces a text summary.
+
+    Test flow:
+    1. Register mock LLM provider.
+    2. POST create agent-type cron job with save_result_to_inbox=true.
+    3. POST run.
+    4. Poll history → status=success.
+    5. Poll inbox → cron_result event body contains time info.
+    6. Cleanup.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/run
+    - GET /api/cron/jobs/{job_id}/history
+    - GET /api/console/inbox/events
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    srv, mock_url = mock_llm
+    srv.force_error = False
+    srv.force_tool_call = True
+    clean_inbox(app_server.working_dir)
+    unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+    provider_id = register_mock_provider(app_server, mock_url)
+    spec = _agent_spec(
+        "integ_tool_call",
+        input_text="What time is it?",
+        save_inbox=True,
+    )
+    job_id = _create_job(app_server, spec)
+    try:
+        run_resp = app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200
+
+        records = _poll_history(
+            app_server,
+            job_id,
+            time.time() + 30.0,
+        )
+        assert (
+            len(records) >= 1
+        ), f"No history after 30s: {app_server.logs_tail()}"
+        assert records[0]["status"] == "success"
+
+        events = _poll_inbox_cron(
+            app_server,
+            time.time() + 10.0,
+            event_type="cron_result",
+        )
+        assert (
+            len(events) >= 1
+        ), f"No cron_result event: {app_server.logs_tail()}"
+        event = events[0]
+        assert event["source_type"] == "cron"
+        assert event.get("body"), "event body should not be empty"
+    finally:
+        srv.force_tool_call = False
+        _delete_job(app_server, job_id)
+        clean_inbox(app_server.working_dir)
+        unregister_mock_provider(app_server, provider_id)
+
+
+# ------------------------------------------------------------------ #
+# A4: agent run → inbox event
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_cron_agent_run_creates_inbox_event(
+    app_server,
+    mock_llm,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test purpose:
+    - Verify an agent-type cron run with save_result_to_inbox
+      creates a cron_result inbox event with correct metadata.
+
+    Test flow:
+    1. Register mock LLM provider.
+    2. POST create agent-type job with save_result_to_inbox=true.
+    3. POST run.
+    4. Poll inbox for cron_result event.
+    5. Assert event fields: source_type, event_type, agent_id.
+    6. Cleanup.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/run
+    - GET /api/console/inbox/events
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    srv, mock_url = mock_llm
+    srv.force_error = False
+    clean_inbox(app_server.working_dir)
+    unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+    provider_id = register_mock_provider(app_server, mock_url)
+    spec = _agent_spec(
+        "integ_inbox_event",
+        input_text="Say hello",
+        save_inbox=True,
+    )
+    job_id = _create_job(app_server, spec)
+    try:
+        app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+
+        events = _poll_inbox_cron(
+            app_server,
+            time.time() + 30.0,
+            event_type="cron_result",
+        )
+        assert (
+            len(events) >= 1
+        ), f"No cron_result inbox event: {app_server.logs_tail()}"
+
+        event = events[0]
+        assert event["source_type"] == "cron"
+        assert event["event_type"] == "cron_result"
+        assert event["agent_id"] == "default"
+        assert event["status"] == "success"
+        assert event["severity"] == "info"
+    finally:
+        _delete_job(app_server, job_id)
+        clean_inbox(app_server.working_dir)
+        unregister_mock_provider(app_server, provider_id)
+
+
+# ------------------------------------------------------------------ #
+# A5: text delivery to custom channel
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_cron_text_delivery_to_custom_channel(
+    app_server,
+    channel_callback_server,
+) -> None:
+    """Test purpose:
+    - Verify a text-type cron job dispatched to the test_echo custom
+      channel delivers the text to the callback server.
+
+    Test flow:
+    1. Enable test_echo channel.
+    2. POST create text-type job dispatched to test_echo.
+    3. POST run.
+    4. Poll callback server recorded payloads.
+    5. Assert the text arrives at the callback.
+    6. Cleanup.
+
+    API endpoints:
+    - PUT /api/config/channels/test_echo
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/run
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    server = channel_callback_server
+    server.recorded.clear()
+
+    app_server.api_request(
+        "PUT",
+        "/api/config/channels/test_echo",
+        json={"enabled": True},
+        timeout=_CRON_HTTP_TIMEOUT,
+    )
+    time.sleep(1.0)
+
+    cron_text = "cron-delivery-test-payload"
+    spec = _text_spec(
+        "integ_text_channel",
+        text=cron_text,
+        channel="test_echo",
+    )
+    job_id = _create_job(app_server, spec)
+    try:
+        run_resp = app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200
+
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not server.recorded:
+            time.sleep(0.5)
+
+        assert (
+            len(server.recorded) >= 1
+        ), "callback server did not receive cron text"
+        assert server.recorded[0].get("text") == cron_text
+    finally:
+        _delete_job(app_server, job_id)
+
+
+# ------------------------------------------------------------------ #
+# A6: agent run error → error history record
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_cron_delivery_error_creates_error_record(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify that a cron job whose channel delivery fails creates
+      a history record with status=error and a descriptive error.
+      Dispatches to a non-existent channel to trigger KeyError
+      in channel_manager.send_text().
+
+    Test flow:
+    1. POST create text-type job dispatched to non-existent channel.
+    2. POST run.
+    3. Poll history → status=error record with delivery error.
+    4. Cleanup.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/run
+    - GET /api/cron/jobs/{job_id}/history
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    spec = _text_spec(
+        "integ_delivery_error",
+        channel="nonexistent_integ_xyz",
+    )
+    job_id = _create_job(app_server, spec)
+    try:
+        app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+
+        records = _poll_history(
+            app_server,
+            job_id,
+            time.time() + 15.0,
+        )
+        assert (
+            len(records) >= 1
+        ), f"No history record after 15s: {app_server.logs_tail()}"
+        assert records[0]["status"] == "error"
+        assert records[0].get("error")
+    finally:
+        _delete_job(app_server, job_id)
+
+
+# ------------------------------------------------------------------ #
+# A7: scheduler fires on schedule (P2 — nightly only, ~70s wait)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_cron_scheduler_fires_on_schedule(app_server) -> None:
+    """Test purpose:
+    - Verify a cron job with ``* * * * *`` schedule fires
+      automatically via the APScheduler within ~70 seconds.
+
+    Test flow:
+    1. POST create text-type job with ``* * * * *``.
+    2. Wait up to 80s.
+    3. Poll history → at least 1 record with trigger=scheduled.
+    4. Cleanup.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - GET /api/cron/jobs/{job_id}/history
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    spec = _text_spec("integ_sched_fire")
+    spec["schedule"]["cron"] = "* * * * *"
+    job_id = _create_job(app_server, spec)
+    try:
+        records = _poll_history(
+            app_server,
+            job_id,
+            time.time() + 80.0,
+        )
+        assert len(records) >= 1, (
+            f"No scheduled record after 80s: " f"{app_server.logs_tail()}"
+        )
+        scheduled = [r for r in records if r.get("trigger") == "scheduled"]
+        assert len(scheduled) >= 1, f"No trigger=scheduled record: {records}"
+    finally:
+        _delete_job(app_server, job_id)
+
+
+# ------------------------------------------------------------------ #
+# A8: paused job not fired by scheduler (P2 — nightly only, ~70s)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_cron_paused_job_not_fired_by_scheduler(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify a paused cron job with ``* * * * *`` does NOT fire
+      automatically even after waiting past its schedule.
+
+    Test flow:
+    1. POST create text-type job with ``* * * * *``.
+    2. POST pause the job.
+    3. Wait 70s.
+    4. GET history → should be empty (no scheduled runs).
+    5. Cleanup.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    - POST /api/cron/jobs/{job_id}/pause
+    - GET /api/cron/jobs/{job_id}/history
+    - DELETE /api/cron/jobs/{job_id}
+    """
+    spec = _text_spec("integ_paused_no_fire")
+    spec["schedule"]["cron"] = "* * * * *"
+    job_id = _create_job(app_server, spec)
+    try:
+        pause_resp = app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/pause",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert pause_resp.status_code == 200
+
+        time.sleep(70.0)
+
+        hist_resp = app_server.api_request(
+            "GET",
+            f"/api/cron/jobs/{job_id}/history",
+            timeout=_CRON_HTTP_TIMEOUT,
+        )
+        assert hist_resp.status_code == 200
+        records = hist_resp.json()
+        assert isinstance(records, list)
+        assert len(records) == 0, f"paused job should not fire, got: {records}"
+    finally:
+        _delete_job(app_server, job_id)
+
+
+# ------------------------------------------------------------------ #
+# A9: validation — text job without text field → 422
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_cron_create_text_without_text_rejected(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify POST create with task_type=text but no text field
+      returns 422 (Pydantic validation).
+
+    Test flow:
+    1. POST /api/cron/jobs with task_type=text, text omitted.
+    2. Assert 422.
+
+    API endpoints:
+    - POST /api/cron/jobs
+    """
+    spec = {
+        "name": "integ_bad_text_job",
+        "enabled": True,
+        "schedule": {
+            "type": "cron",
+            "cron": "0 0 * * *",
+        },
+        "task_type": "text",
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {
+                "user_id": "cron-bad",
+                "session_id": "console:cron-bad-sess",
+            },
+        },
+    }
+    resp = app_server.api_request(
+        "POST",
+        "/api/cron/jobs",
+        json=spec,
+        timeout=_CRON_HTTP_TIMEOUT,
+    )
+    assert (
+        resp.status_code == 422
+    ), f"expected 422, got {resp.status_code}: {resp.text}"

--- a/tests/integration/test_memory_context.py
+++ b/tests/integration/test_memory_context.py
@@ -13,136 +13,34 @@ Existing CRUD roundtrip coverage (not duplicated here):
 """
 from __future__ import annotations
 
-import json as _json
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import HTTPServer
 from pathlib import Path
 
 import pytest
 
 from helpers import (
+    MOCK_LLM_PROVIDER_ID,
+    MockLLMHandler,
     clean_inbox,
     create_agent,
     delete_agent_quietly,
+    register_mock_provider,
     scoped,
     toggle_agent,
+    unregister_mock_provider,
 )
 
 _HTTP_TIMEOUT = 15.0
-_MOCK_LLM_RESPONSE = "Mock heartbeat response from integration test."
-
-
-# ================================================================== #
-#  Mock LLM infrastructure
-# ================================================================== #
-
-
-class _MockLLMHandler(BaseHTTPRequestHandler):
-    """Minimal OpenAI-compatible streaming server."""
-
-    def do_POST(self):  # noqa: N802
-        if "/chat/completions" in self.path:
-            self._stream_completion()
-        else:
-            self.send_error(404)
-
-    def do_GET(self):  # noqa: N802
-        if "/models" in self.path:
-            self._list_models()
-        else:
-            self.send_error(404)
-
-    def _stream_completion(self):
-        length = int(self.headers.get("Content-Length", 0))
-        if length:
-            self.rfile.read(length)
-
-        if getattr(self.server, "force_error", False):
-            self.send_response(422)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            err = {
-                "error": {
-                    "message": "forced",
-                    "type": "invalid_request_error",
-                },
-            }
-            self.wfile.write(_json.dumps(err).encode())
-            return
-
-        self.send_response(200)
-        self.send_header("Content-Type", "text/event-stream")
-        self.send_header("Cache-Control", "no-cache")
-        self.end_headers()
-
-        chunk_content = _json.dumps(
-            {
-                "id": "chatcmpl-mock",
-                "object": "chat.completion.chunk",
-                "created": 1700000000,
-                "model": "mock-model",
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {
-                            "role": "assistant",
-                            "content": _MOCK_LLM_RESPONSE,
-                        },
-                        "finish_reason": None,
-                    },
-                ],
-                "usage": None,
-            },
-        )
-        self.wfile.write(f"data: {chunk_content}\n\n".encode())
-        self.wfile.flush()
-
-        chunk_final = _json.dumps(
-            {
-                "id": "chatcmpl-mock",
-                "object": "chat.completion.chunk",
-                "created": 1700000000,
-                "model": "mock-model",
-                "choices": [
-                    {
-                        "index": 0,
-                        "delta": {},
-                        "finish_reason": "stop",
-                    },
-                ],
-                "usage": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 5,
-                    "total_tokens": 15,
-                },
-            },
-        )
-        self.wfile.write(f"data: {chunk_final}\n\n".encode())
-        self.wfile.flush()
-
-        self.wfile.write(b"data: [DONE]\n\n")
-        self.wfile.flush()
-
-    def _list_models(self):
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        self.wfile.write(
-            _json.dumps(
-                {"data": [{"id": "mock-model", "object": "model"}]},
-            ).encode(),
-        )
-
-    def log_message(self, fmt, *args):
-        pass
 
 
 @pytest.fixture(scope="module")
 def mock_llm():
     """Start a module-scoped mock OpenAI server, yield (server, url)."""
-    srv = HTTPServer(("127.0.0.1", 0), _MockLLMHandler)
+    srv = HTTPServer(("127.0.0.1", 0), MockLLMHandler)
     srv.force_error = False
+    srv.force_tool_call = False
     port = srv.server_address[1]
     t = threading.Thread(target=srv.serve_forever, daemon=True)
     t.start()
@@ -583,54 +481,11 @@ def test_running_config_extra_fields_ignored(
 
 
 def _register_mock_provider(app_server, mock_llm_url):
-    """Register + activate mock LLM provider. Returns provider id."""
-    provider_id = "integ-mock-llm"
-    app_server.api_request(
-        "POST",
-        "/api/models/custom-providers",
-        json={
-            "id": provider_id,
-            "name": "Integration Mock",
-            "default_base_url": mock_llm_url,
-            "chat_model": "OpenAIChatModel",
-            "models": [
-                {"id": "mock-model", "name": "Mock Model"},
-            ],
-        },
-        timeout=_HTTP_TIMEOUT,
-    )
-    app_server.api_request(
-        "PUT",
-        f"/api/models/{provider_id}/config",
-        json={
-            "api_key": "test-key-mock",
-            "base_url": mock_llm_url,
-        },
-        timeout=_HTTP_TIMEOUT,
-    )
-    app_server.api_request(
-        "PUT",
-        "/api/models/active",
-        json={
-            "provider_id": provider_id,
-            "model": "mock-model",
-            "scope": "global",
-        },
-        timeout=_HTTP_TIMEOUT,
-    )
-    return provider_id
+    return register_mock_provider(app_server, mock_llm_url)
 
 
 def _unregister_mock_provider(app_server, provider_id):
-    """Best-effort cleanup of mock provider."""
-    try:
-        app_server.api_request(
-            "DELETE",
-            f"/api/models/custom-providers/{provider_id}",
-            timeout=_HTTP_TIMEOUT,
-        )
-    except Exception:
-        pass
+    unregister_mock_provider(app_server, provider_id)
 
 
 def _poll_inbox_heartbeat(
@@ -961,3 +816,142 @@ def test_heartbeat_inbox_delete_cleans_trace(
         assert trace_resp.status_code == 404
     finally:
         _teardown_heartbeat(app_server, ctx)
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_heartbeat_resilient_to_llm_error(
+    app_server,
+    mock_llm,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test purpose:
+    - Verify that a heartbeat run against a failing LLM (422) does
+      not crash and still creates a heartbeat_result inbox event.
+      Runner.stream_query() swallows LLM errors internally, so the
+      heartbeat completes normally even when the LLM returns errors.
+
+    Test flow:
+    1. Set mock LLM to force 422 errors.
+    2. Setup heartbeat with mock provider.
+    3. POST heartbeat/run.
+    4. Poll inbox for heartbeat_result event.
+    5. Assert the event was created (heartbeat did not crash).
+    6. Restore mock LLM to normal.
+
+    API endpoints:
+    - POST /api/agents/{agentId}/config/heartbeat/run
+    - GET /api/console/inbox/events
+    """
+    srv, mock_url = mock_llm
+    srv.force_error = False
+    ctx = _setup_heartbeat(app_server, mock_url)
+    srv.force_error = True
+    try:
+        run_resp = app_server.api_request(
+            "POST",
+            scoped("default", "/config/heartbeat/run"),
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200
+
+        events = _poll_inbox_heartbeat(
+            app_server,
+            time.time() + 30.0,
+            event_type="heartbeat_result",
+        )
+        assert len(events) >= 1, (
+            "Heartbeat should complete even with LLM errors: "
+            f"{app_server.logs_tail()}"
+        )
+
+        event = events[0]
+        assert event["source_type"] == "heartbeat"
+        assert event["event_type"] == "heartbeat_result"
+    finally:
+        srv.force_error = False
+        _teardown_heartbeat(app_server, ctx)
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_heartbeat_auto_schedule_fires(
+    app_server,
+    mock_llm,  # pylint: disable=redefined-outer-name
+) -> None:
+    """Test purpose:
+    - Verify that a heartbeat configured with every=60s fires
+      automatically via the scheduler without a manual POST run.
+
+    Test flow:
+    1. Setup heartbeat with every=60s.
+    2. Wait ~70s for the scheduler to fire.
+    3. Poll inbox for heartbeat_result event.
+    4. Assert event was created by the scheduler.
+
+    API endpoints:
+    - PUT /api/agents/{agentId}/config/heartbeat
+    - GET /api/console/inbox/events
+    """
+    srv, mock_url = mock_llm
+    srv.force_error = False
+    working_dir = app_server.working_dir
+    clean_inbox(working_dir)
+    unregister_mock_provider(
+        app_server,
+        MOCK_LLM_PROVIDER_ID,
+    )
+
+    provider_id = register_mock_provider(app_server, mock_url)
+
+    hb_before = app_server.api_request(
+        "GET",
+        scoped("default", "/config/heartbeat"),
+        timeout=_HTTP_TIMEOUT,
+    ).json()
+
+    ws_dir = Path(working_dir) / "workspaces" / "default"
+    hb_file = ws_dir / "HEARTBEAT.md"
+    ws_dir.mkdir(parents=True, exist_ok=True)
+    hb_original = hb_file.read_text("utf-8") if hb_file.exists() else None
+    hb_file.write_text(
+        "Auto-schedule heartbeat test query",
+        encoding="utf-8",
+    )
+
+    app_server.api_request(
+        "PUT",
+        scoped("default", "/config/heartbeat"),
+        json={
+            "enabled": True,
+            "target": "inbox",
+            "every": "60s",
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+
+    try:
+        events = _poll_inbox_heartbeat(
+            app_server,
+            time.time() + 80.0,
+            event_type="heartbeat_result",
+        )
+        assert len(events) >= 1, (
+            "No auto-scheduled heartbeat event after 80s: "
+            f"{app_server.logs_tail()}"
+        )
+        event = events[0]
+        assert event["source_type"] == "heartbeat"
+        assert event["event_type"] == "heartbeat_result"
+    finally:
+        clean_inbox(working_dir)
+        if hb_original is not None:
+            hb_file.write_text(hb_original, encoding="utf-8")
+        elif hb_file.exists():
+            hb_file.unlink()
+        app_server.api_request(
+            "PUT",
+            scoped("default", "/config/heartbeat"),
+            json=hb_before,
+            timeout=_HTTP_TIMEOUT,
+        )
+        unregister_mock_provider(app_server, provider_id)

--- a/tests/integration/test_tool_config.py
+++ b/tests/integration/test_tool_config.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for tool configuration HTTP API.
+
+Covers GET /tools (list), PATCH /tools/{name}/toggle, and
+GET /tools/{name}/config endpoints.  Verifies that builtin tools
+(e.g. get_current_time) appear in the list and can be toggled.
+"""
+from __future__ import annotations
+
+import pytest
+
+from helpers import scoped
+
+_TOOL_HTTP_TIMEOUT = 15.0
+
+
+# ------------------------------------------------------------------ #
+# C1: tool list includes get_current_time
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_tool_list_includes_get_current_time(app_server) -> None:
+    """Test purpose:
+    - Verify GET /tools returns a list that includes the
+      get_current_time builtin tool with enabled=true.
+
+    Test flow:
+    1. GET /api/agents/default/tools.
+    2. Assert response is a list.
+    3. Find get_current_time in the list.
+    4. Assert it is enabled.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools
+    """
+    resp = app_server.api_request(
+        "GET",
+        scoped("default", "/tools"),
+        timeout=_TOOL_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    tools = resp.json()
+    assert isinstance(tools, list)
+    assert len(tools) > 0, "tool list should not be empty"
+
+    names = {t.get("name") for t in tools}
+    assert (
+        "get_current_time" in names
+    ), f"get_current_time not in tool list: {names}"
+
+    tool = next(t for t in tools if t["name"] == "get_current_time")
+    assert tool.get("enabled") is True
+
+
+# ------------------------------------------------------------------ #
+# C2: tool toggle disable / enable
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_tool_toggle_disable_enable(app_server) -> None:
+    """Test purpose:
+    - Verify PATCH /tools/{name}/toggle toggles the tool's
+      enabled state and the change is reflected in GET /tools.
+
+    Test flow:
+    1. PATCH toggle get_current_time → should return toggled state.
+    2. GET /tools → verify new enabled state.
+    3. PATCH toggle again to restore original state.
+    4. GET /tools → verify restored.
+
+    API endpoints:
+    - PATCH /api/agents/{agentId}/tools/{tool_name}/toggle
+    - GET /api/agents/{agentId}/tools
+    """
+    get_before = app_server.api_request(
+        "GET",
+        scoped("default", "/tools"),
+        timeout=_TOOL_HTTP_TIMEOUT,
+    )
+    assert get_before.status_code == 200
+    tools = get_before.json()
+    tool = next(t for t in tools if t["name"] == "get_current_time")
+    original_enabled = tool["enabled"]
+
+    try:
+        toggle_resp = app_server.api_request(
+            "PATCH",
+            scoped("default", "/tools/get_current_time/toggle"),
+            timeout=_TOOL_HTTP_TIMEOUT,
+        )
+        assert toggle_resp.status_code == 200
+        toggled = toggle_resp.json()
+        assert toggled.get("enabled") is (not original_enabled)
+
+        get_after = app_server.api_request(
+            "GET",
+            scoped("default", "/tools"),
+            timeout=_TOOL_HTTP_TIMEOUT,
+        )
+        assert get_after.status_code == 200
+        after_tool = next(
+            t for t in get_after.json() if t["name"] == "get_current_time"
+        )
+        assert after_tool["enabled"] is (not original_enabled)
+    finally:
+        app_server.api_request(
+            "PATCH",
+            scoped("default", "/tools/get_current_time/toggle"),
+            timeout=_TOOL_HTTP_TIMEOUT,
+        )
+
+
+# ------------------------------------------------------------------ #
+# C3: agent-scoped tool list matches global
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_tool_list_agent_scoped_matches_global(
+    app_server,
+) -> None:
+    """Test purpose:
+    - Verify agent-scoped GET /tools and header GET /tools return
+      the same set of tool names for the default agent.
+
+    Test flow:
+    1. GET /api/agents/default/tools (scoped).
+    2. GET /api/tools with X-Agent-Id: default (header).
+    3. Assert both return the same tool name set.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools
+    - GET /api/tools
+    """
+    scoped_resp = app_server.api_request(
+        "GET",
+        scoped("default", "/tools"),
+        timeout=_TOOL_HTTP_TIMEOUT,
+    )
+    assert scoped_resp.status_code == 200
+
+    header_resp = app_server.api_request(
+        "GET",
+        "/api/tools",
+        headers={"X-Agent-Id": "default"},
+        timeout=_TOOL_HTTP_TIMEOUT,
+    )
+    assert header_resp.status_code == 200
+
+    scoped_names = {t["name"] for t in scoped_resp.json()}
+    header_names = {t["name"] for t in header_resp.json()}
+    assert scoped_names == header_names
+
+
+# ------------------------------------------------------------------ #
+# C4: tool config get returns dict
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p2
+def test_tool_config_get_returns_dict(app_server) -> None:
+    """Test purpose:
+    - Verify GET /tools/{name}/config returns a valid dict.
+
+    Test flow:
+    1. GET /api/agents/default/tools/get_current_time/config.
+    2. Assert 200 + response is dict.
+
+    API endpoints:
+    - GET /api/agents/{agentId}/tools/{tool_name}/config
+    """
+    resp = app_server.api_request(
+        "GET",
+        scoped("default", "/tools/get_current_time/config"),
+        timeout=_TOOL_HTTP_TIMEOUT,
+    )
+    assert resp.status_code == 200, app_server.logs_tail()
+    config = resp.json()
+    assert isinstance(config, dict)


### PR DESCRIPTION
## Description

Add Sprint 2.4 integration tests covering cron job execution paths (text and agent types) and tool configuration API. Refactor shared Mock LLM infrastructure into `helpers.py` to eliminate duplication across test modules.

## Type of Change

- [x] New feature
- [x] Refactoring

## Component(s) Affected

- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Ready for review

## Testing

- `pytest tests/integration/test_cron_execution.py` — cron execution (text/agent/failure/history)
- `pytest tests/integration/test_tool_config.py` — tool list, toggle, config API
- `pytest tests/integration/test_memory_context.py` — heartbeat tests (using shared Mock LLM)

## Local Verification Evidence

```bash
pre-commit run --all-files
# All passed (16/16 hooks)

pytest tests/unit/ -x -q
# 3072 passed, 1 skipped in 53.57s

pytest tests/integration/test_cron_execution.py tests/integration/test_tool_config.py tests/integration/test_memory_context.py -q
# 31 passed in 236.00s
```

## Additional Notes

- `helpers.py`: Added `MockLLMHandler` (OpenAI-compatible mock with tool_call support), `register/unregister_mock_provider` shared utilities
- `test_memory_context.py`: Migrated inline Mock LLM to shared helpers, removing duplication
- Total: 15 new test cases added