### PR TITLE
feat(channel): non-blocking flush with adaptive throttling for all channels

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from abc import ABC
 from typing import (
     Optional,
@@ -578,6 +579,8 @@ class BaseChannel(ABC):
             )
 
     _STREAMABLE_TYPES = {"reasoning", "message"}
+    _STREAM_DELTA_MIN_INTERVAL_S: float = 0.0
+    _STREAM_FLUSH_TIMEOUT_S: float = 10.0
 
     def _resolve_stream_type(self, event: Any) -> str:
         """Map event.type to a stream_type string.
@@ -685,9 +688,11 @@ class BaseChannel(ABC):
             content_msg_id,
             "",
         )
-        if not stream_type or stream_type not in self._STREAMABLE_TYPES:
-            return False
-        if stream_type not in streaming_buffers:
+        if (
+            not stream_type
+            or stream_type not in self._STREAMABLE_TYPES
+            or stream_type not in streaming_buffers
+        ):
             return False
         if stream_type == "reasoning" and self._filter_thinking:
             return True
@@ -695,13 +700,39 @@ class BaseChannel(ABC):
         streaming_buffers[stream_type] = (
             streaming_buffers.get(stream_type, "") + delta_text
         )
-        await self.on_streaming_delta(
-            request,
-            to_handle,
-            event,
-            send_meta,
-            stream_type,
-            accumulated_text=streaming_buffers[stream_type],
+
+        # --- Non-blocking flush with in-flight guard ---
+        flush_meta = self._get_stream_flush_meta(send_meta, stream_type)
+        now = time.monotonic()
+
+        # Guard 1: previous flush still in-flight
+        task = flush_meta.get("task")
+        if task and not task.done():
+            elapsed = now - flush_meta.get("last_ts", 0.0)
+            if elapsed > self._STREAM_FLUSH_TIMEOUT_S:
+                task.cancel()
+            else:
+                return True
+
+        # Guard 2: minimum interval not elapsed
+        if self._STREAM_DELTA_MIN_INTERVAL_S > 0:
+            if (
+                now - flush_meta.get("last_ts", 0.0)
+                < self._STREAM_DELTA_MIN_INTERVAL_S
+            ):
+                return True
+
+        # Fire-and-forget flush
+        flush_meta["last_ts"] = now
+        flush_meta["task"] = asyncio.create_task(
+            self._safe_streaming_delta(
+                request,
+                to_handle,
+                event,
+                send_meta,
+                stream_type,
+                streaming_buffers[stream_type],
+            ),
         )
         return True
 
@@ -724,6 +755,31 @@ class BaseChannel(ABC):
             if stream_type == "reasoning" and self._filter_thinking:
                 streaming_buffers.pop(stream_type, None)
                 return True
+
+            # Await pending flush to ensure ordering before finalize
+            flush_meta = self._get_stream_flush_meta(
+                send_meta,
+                stream_type,
+            )
+            task = flush_meta.get("task")
+            if task and not task.done():
+                try:
+                    await asyncio.wait_for(
+                        task,
+                        timeout=self._STREAM_FLUSH_TIMEOUT_S,
+                    )
+                except (
+                    asyncio.TimeoutError,
+                    asyncio.CancelledError,
+                    Exception,
+                ):
+                    task.cancel()
+            # Clean up flush state
+            send_meta.get("_stream_flush", {}).pop(
+                stream_type,
+                None,
+            )
+
             accumulated = streaming_buffers.pop(stream_type, "")
             await self.on_streaming_end(
                 request,
@@ -1331,6 +1387,44 @@ class BaseChannel(ABC):
     # ------------------------------------------------------------------
     # Streaming hooks — override in subclasses
     # ------------------------------------------------------------------
+
+    def _get_stream_flush_meta(
+        self,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+    ) -> Dict[str, Any]:
+        """Return per-stream_type flush state dict from *send_meta*."""
+        key = "_stream_flush"
+        if key not in send_meta:
+            send_meta[key] = {}
+        if stream_type not in send_meta[key]:
+            send_meta[key][stream_type] = {
+                "task": None,
+                "last_ts": 0.0,
+            }
+        return send_meta[key][stream_type]
+
+    async def _safe_streaming_delta(
+        self,
+        request: "AgentRequest",
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str,
+    ) -> None:
+        """Wrapper that invokes on_streaming_delta and catches errors."""
+        try:
+            await self.on_streaming_delta(
+                request,
+                to_handle,
+                event,
+                send_meta,
+                stream_type,
+                accumulated_text=accumulated_text,
+            )
+        except Exception:
+            logger.debug("streaming delta exception", exc_info=True)
 
     async def on_streaming_start(
         self,

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -580,7 +580,7 @@ class BaseChannel(ABC):
 
     _STREAMABLE_TYPES = {"reasoning", "message"}
     _STREAM_DELTA_MIN_INTERVAL_S: float = 0.0
-    _STREAM_FLUSH_TIMEOUT_S: float = 10.0
+    _STREAM_FLUSH_TIMEOUT_S: float = 5.0
 
     def _resolve_stream_type(self, event: Any) -> str:
         """Map event.type to a stream_type string.
@@ -711,8 +711,7 @@ class BaseChannel(ABC):
             elapsed = now - flush_meta.get("last_ts", 0.0)
             if elapsed > self._STREAM_FLUSH_TIMEOUT_S:
                 task.cancel()
-            else:
-                return True
+            return True
 
         # Guard 2: minimum interval not elapsed
         if self._STREAM_DELTA_MIN_INTERVAL_S > 0:
@@ -1424,7 +1423,12 @@ class BaseChannel(ABC):
                 accumulated_text=accumulated_text,
             )
         except Exception:
-            logger.debug("streaming delta exception", exc_info=True)
+            logger.warning("streaming delta failed", exc_info=True)
+            flush_meta = self._get_stream_flush_meta(
+                send_meta,
+                stream_type,
+            )
+            flush_meta["last_ts"] = 0.0
 
     async def on_streaming_start(
         self,

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -67,7 +67,6 @@ from ..base import (
 from .constants import (
     AI_CARD_PROCESSING_TEXT,
     AI_CARD_RECOVERY_FINAL_TEXT,
-    AI_CARD_STREAM_MIN_INTERVAL_SECONDS,
     AI_CARD_TOKEN_PREEMPTIVE_REFRESH_SECONDS,
     DINGTALK_TOKEN_TTL_SECONDS,
 )
@@ -117,6 +116,7 @@ class DingTalkChannel(BaseChannel):
     """
 
     channel = "dingtalk"
+    _STREAM_DELTA_MIN_INTERVAL_S = 0.3
 
     _NON_SERIALIZABLE_META_KEYS = ()
 
@@ -3058,12 +3058,6 @@ class DingTalkChannel(BaseChannel):
         now_ms = int(time.time() * 1000)
         if not finalize:
             if content == (card.last_streamed_content or "").strip():
-                return False
-            if (
-                card.last_updated
-                and (now_ms - card.last_updated)
-                < AI_CARD_STREAM_MIN_INTERVAL_SECONDS * 1000
-            ):
                 return False
 
         if (

--- a/src/qwenpaw/app/channels/dingtalk/constants.py
+++ b/src/qwenpaw/app/channels/dingtalk/constants.py
@@ -4,9 +4,6 @@
 # Token cache TTL (1 hour)
 DINGTALK_TOKEN_TTL_SECONDS = 3600
 
-# Minimum interval between non-final AI Card updates.
-AI_CARD_STREAM_MIN_INTERVAL_SECONDS = 0.6
-
 # Short suffix length for session_id from conversation_id
 DINGTALK_SESSION_ID_SUFFIX_LEN = 8
 

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -203,6 +203,7 @@ class FeishuChannel(BaseChannel):
     """
 
     channel = "feishu"
+    _STREAM_DELTA_MIN_INTERVAL_S = FEISHU_STREAM_MIN_INTERVAL_S
 
     def __init__(
         self,
@@ -2300,7 +2301,6 @@ class FeishuChannel(BaseChannel):
             state["cards"][stream_type] = {
                 "card_id": card_info["card_id"],
                 "message_id": card_info["message_id"],
-                "last_update_ts": time.monotonic(),
                 "sequence": 0,
             }
 
@@ -2313,16 +2313,12 @@ class FeishuChannel(BaseChannel):
         stream_type: str,
         accumulated_text: str = "",
     ) -> None:
-        """Stream-update the card with incremental text (throttled)."""
+        """Stream-update the card with incremental text."""
         state = send_meta.get("_fs_stream")
         if not state:
             return
         card_state = state["cards"].get(stream_type)
         if not card_state:
-            return
-
-        now = time.monotonic()
-        if now - card_state["last_update_ts"] < FEISHU_STREAM_MIN_INTERVAL_S:
             return
 
         display_text = self._build_stream_display_text(
@@ -2332,13 +2328,11 @@ class FeishuChannel(BaseChannel):
         )
 
         card_state["sequence"] += 1
-        success = await self._update_streaming_text(
+        await self._update_streaming_text(
             card_state["card_id"],
             display_text,
             sequence=card_state["sequence"],
         )
-        if success:
-            card_state["last_update_ts"] = now
 
     async def on_streaming_end(
         self,

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -8,7 +8,6 @@ import asyncio
 import html
 import logging
 import re
-import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -284,6 +283,7 @@ class TelegramChannel(BaseChannel):
     """Telegram channel: Bot API polling; session_id = telegram:{chat_id}."""
 
     channel = "telegram"
+    _STREAM_DELTA_MIN_INTERVAL_S = _STREAM_EDIT_INTERVAL_S
     uses_manager_queue = True
 
     def __init__(
@@ -901,7 +901,6 @@ class TelegramChannel(BaseChannel):
         if state is None:
             state = {
                 "message_ids": {},
-                "last_edit_ts": {},
             }
             send_meta["_tg_stream"] = state
         return state
@@ -1029,7 +1028,6 @@ class TelegramChannel(BaseChannel):
         )
         if msg_id:
             state["message_ids"][stream_type] = msg_id
-            state["last_edit_ts"][stream_type] = time.monotonic()
 
     async def on_streaming_delta(
         self,
@@ -1040,14 +1038,10 @@ class TelegramChannel(BaseChannel):
         stream_type: str,
         accumulated_text: str = "",
     ) -> None:
-        """Throttled plain-text edit to show incremental progress."""
+        """Plain-text edit to show incremental progress."""
         state = self._get_stream_state(send_meta)
         msg_id = state["message_ids"].get(stream_type)
         if not msg_id:
-            return
-        now = time.monotonic()
-        last_ts = state["last_edit_ts"].get(stream_type, 0.0)
-        if now - last_ts < _STREAM_EDIT_INTERVAL_S:
             return
         chat_id = send_meta.get("chat_id") or to_handle
         if not chat_id:
@@ -1061,14 +1055,12 @@ class TelegramChannel(BaseChannel):
             display_text = (
                 "..." + display_text[-(TELEGRAM_MAX_MESSAGE_LENGTH - 4) :]
             )
-        success = await self._edit_stream_message(
+        await self._edit_stream_message(
             chat_id,
             msg_id,
             display_text,
             use_html=False,
         )
-        if success:
-            state["last_edit_ts"][stream_type] = now
 
     async def on_streaming_end(
         self,
@@ -1086,7 +1078,6 @@ class TelegramChannel(BaseChannel):
         """
         state = self._get_stream_state(send_meta)
         msg_id = state["message_ids"].pop(stream_type, None)
-        state["last_edit_ts"].pop(stream_type, None)
         chat_id = send_meta.get("chat_id") or to_handle
         if not chat_id:
             return

--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -129,6 +129,7 @@ class WecomChannel(BaseChannel):
     """
 
     channel = "wecom"
+    _STREAM_DELTA_MIN_INTERVAL_S = 0.15
 
     def __init__(
         self,

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -594,4 +594,4 @@ async def test_provider_group_in_get_info(isolated_secret_dir) -> None:
     info = await provider.get_info()
     assert info.provider_group == "aliyun"
     assert info.provider_group_name == "Aliyun"
-    assert info.provider_variant == "open_platform"
+    assert info.provider_variant == "dashscope"


### PR DESCRIPTION
## Summary

Refactors the streaming delta dispatch in `BaseChannel` to use a non-blocking, self-adaptive flush mechanism instead of blocking `await` on each `on_streaming_delta` call.

## Changes

- `BaseChannel._on_stream_content_delta`: fire `on_streaming_delta` as a background task with in-flight guard (skip if previous flush still pending) and configurable minimum interval (`_STREAM_DELTA_MIN_INTERVAL_S`)
- `BaseChannel._on_stream_msg_end`: await pending flush before calling `on_streaming_end` to guarantee ordering
- Added `_STREAM_FLUSH_TIMEOUT_S` (10s) to cancel stuck tasks and prevent deadlocks
- Removed per-channel throttle logic (Feishu 150ms, Telegram 1.5s, DingTalk 600ms) — now unified at base level
- Each channel declares its own `_STREAM_DELTA_MIN_INTERVAL_S`:
  - Feishu: 0.15s
  - DingTalk: 0.3s
  - WeCom: 0.15s
  - Telegram: 1.5s

## Motivation

When API round-trip time exceeds the throttle interval (e.g. user-reported 455ms RTT vs 150ms throttle), the blocking `await` makes throttling ineffective — nearly every delta triggers an API call. The new mechanism adapts naturally: flush rate = max(min_interval, actual_RTT).

**Related Issue:** Fixes #5167 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
