### PR TITLE
feat(plugins): add AgentScope middleware registration, structured ver…

### DIFF
--- a/plugins/bundle/cloudpaw/plugin.json
+++ b/plugins/bundle/cloudpaw/plugin.json
@@ -14,7 +14,10 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "1.1.7",
+  "qwenpaw_version": {
+    "min": "1.1.7",
+    "max": "2.1.0"
+  },
   "meta": {
     "category": "cloud-deployment",
     "features": [

--- a/plugins/bundle/qwenpaw-pet/plugin.json
+++ b/plugins/bundle/qwenpaw-pet/plugin.json
@@ -20,7 +20,10 @@
     "pillow>=10.0",
     "pyside6-essentials>=6.6"
   ],
-  "min_version": "1.1.5",
+  "qwenpaw_version": {
+    "min": "1.1.5",
+    "max": "2.1.0"
+  },
   "meta": {
     "desktop_url": "http://127.0.0.1:8765"
   }

--- a/plugins/middleware-demo/README.md
+++ b/plugins/middleware-demo/README.md
@@ -8,8 +8,8 @@ into the agent's reasoning loop.
 
 | Plugin | Hook | Behavior |
 |--------|------|----------|
-| `tracing-middleware` | `on_acting` | Logs every tool call (name, duration) to a file. Conditionally activated only when `debug` mode is enabled. |
-| `thinking-log-middleware` | `on_reasoning` | Prints the model's reasoning steps to stdout with a `[THINKING]` prefix. Always active. |
+| `tracing-middleware` | `on_acting` | Logs every tool call (name, duration) to a file. Conditionally activated only when `QWENPAW_TRACE` env var is set. |
+| `thinking-log-middleware` | `on_reasoning` | Prints model reasoning stream events to stdout (`[THINKING]` for chain-of-thought, `[TEXT]` for text responses). Always active. |
 
 ## Installation
 

--- a/plugins/middleware-demo/README.md
+++ b/plugins/middleware-demo/README.md
@@ -1,0 +1,57 @@
+# Middleware Demo Plugins
+
+Two example plugins demonstrating `PluginApi.register_middleware()` — the
+plugin-based mechanism for injecting AgentScope `MiddlewareBase` instances
+into the agent's reasoning loop.
+
+## Included Demos
+
+| Plugin | Hook | Behavior |
+|--------|------|----------|
+| `tracing-middleware` | `on_acting` | Logs every tool call (name, duration) to a file. Conditionally activated only when `debug` mode is enabled. |
+| `thinking-log-middleware` | `on_reasoning` | Prints the model's reasoning steps to stdout with a `[THINKING]` prefix. Always active. |
+
+## Installation
+
+These plugins are **not** auto-loaded. Install them explicitly:
+
+```bash
+# While QwenPaw is running (hot-load, no restart needed):
+qwenpaw plugin install plugins/middleware-demo/tracing-middleware
+qwenpaw plugin install plugins/middleware-demo/thinking-log-middleware
+
+# Or when QwenPaw is stopped (loaded on next start):
+qwenpaw plugin install plugins/middleware-demo/tracing-middleware
+qwenpaw plugin install plugins/middleware-demo/thinking-log-middleware
+```
+
+## Uninstall
+
+```bash
+qwenpaw plugin uninstall middleware-demo-tracing
+qwenpaw plugin uninstall middleware-demo-thinking-log
+```
+
+## How It Works
+
+Each plugin registers a **middleware factory** via `api.register_middleware(factory, priority=N)`.
+
+The factory is called once per request during agent assembly:
+
+```python
+def my_factory(ctx, agent_config):
+    # ctx: HookContext (session_id, agent_id, workspace_dir, ...)
+    # agent_config: AgentProfileConfig
+    #
+    # Return a MiddlewareBase instance to activate, or None to skip.
+    return MyMiddleware()
+```
+
+The returned middleware wraps the agent's inner reasoning loop using the
+standard AgentScope 2.0 onion model (`on_reply`, `on_reasoning`, `on_acting`).
+
+## Priority
+
+Lower priority values run as the outermost layer (execute first on the way
+in, last on the way out). The built-in middlewares use implicit ordering;
+plugin middlewares append after them sorted by priority.

--- a/plugins/middleware-demo/thinking-log-middleware/plugin.json
+++ b/plugins/middleware-demo/thinking-log-middleware/plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "middleware-demo-thinking-log",
+  "name": "Thinking Log Middleware Demo",
+  "version": "1.0.0",
+  "description": "Demo: prints model reasoning steps to stdout",
+  "author": "QwenPaw Team",
+  "type": "general",
+  "entry": {
+    "backend": "thinking_log_plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  },
+  "meta": {}
+}

--- a/plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py
+++ b/plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Thinking Log Middleware Demo Plugin.
+
+Demonstrates `on_reasoning` middleware that captures and prints the
+model's chain-of-thought reasoning steps to stdout.
+
+This middleware is always active (the factory unconditionally returns
+an instance), showing the simplest possible registration pattern.
+"""
+
+import logging
+import sys
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+from agentscope.message import TextBlock
+
+from qwenpaw.plugins.api import PluginApi
+
+logger = logging.getLogger(__name__)
+
+
+class ThinkingLogMiddleware(MiddlewareBase):
+    """Prints each reasoning step to stdout with a [THINKING] prefix."""
+
+    async def on_reasoning(  # pylint: disable=unused-argument
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        events = []
+        async for item in next_handler():
+            events.append(item)
+            yield item
+
+        for event in events:
+            if isinstance(event, TextBlock):
+                text = getattr(event, "text", str(event))
+                if text.strip():
+                    print(
+                        f"[THINKING] {text[:200]}",
+                        file=sys.stdout,
+                        flush=True,
+                    )
+
+
+def _thinking_log_factory(
+    ctx: Any,
+    agent_config: Any,
+) -> ThinkingLogMiddleware:
+    """Always create the middleware (unconditional activation)."""
+    del ctx, agent_config  # unused — always active
+    return ThinkingLogMiddleware()
+
+
+class ThinkingLogPlugin:
+    """Plugin entry point."""
+
+    def register(self, api: PluginApi) -> None:
+        api.register_middleware(_thinking_log_factory, priority=80)
+
+
+plugin = ThinkingLogPlugin()

--- a/plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py
+++ b/plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py
@@ -13,7 +13,7 @@ import sys
 from typing import Any, AsyncGenerator, Callable
 
 from agentscope.middleware import MiddlewareBase
-from agentscope.message import TextBlock
+from agentscope.event import ThinkingBlockDeltaEvent, TextBlockDeltaEvent
 
 from qwenpaw.plugins.api import PluginApi
 
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class ThinkingLogMiddleware(MiddlewareBase):
-    """Prints each reasoning step to stdout with a [THINKING] prefix."""
+    """Prints reasoning stream events to stdout."""
 
     async def on_reasoning(  # pylint: disable=unused-argument
         self,
@@ -29,20 +29,22 @@ class ThinkingLogMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., AsyncGenerator[Any, None]],
     ) -> AsyncGenerator[Any, None]:
-        events = []
         async for item in next_handler():
-            events.append(item)
+            if isinstance(item, ThinkingBlockDeltaEvent):
+                print(
+                    f"[THINKING] {item.delta}",
+                    end="",
+                    file=sys.stdout,
+                    flush=True,
+                )
+            elif isinstance(item, TextBlockDeltaEvent):
+                print(
+                    f"[TEXT] {item.delta}",
+                    end="",
+                    file=sys.stdout,
+                    flush=True,
+                )
             yield item
-
-        for event in events:
-            if isinstance(event, TextBlock):
-                text = getattr(event, "text", str(event))
-                if text.strip():
-                    print(
-                        f"[THINKING] {text[:200]}",
-                        file=sys.stdout,
-                        flush=True,
-                    )
 
 
 def _thinking_log_factory(

--- a/plugins/middleware-demo/tracing-middleware/plugin.json
+++ b/plugins/middleware-demo/tracing-middleware/plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "middleware-demo-tracing",
+  "name": "Tracing Middleware Demo",
+  "version": "1.0.0",
+  "description": "Demo: logs tool calls with execution timing to a trace file",
+  "author": "QwenPaw Team",
+  "type": "general",
+  "entry": {
+    "backend": "tracing_plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  },
+  "meta": {}
+}

--- a/plugins/middleware-demo/tracing-middleware/tracing_plugin.py
+++ b/plugins/middleware-demo/tracing-middleware/tracing_plugin.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Tracing Middleware Demo Plugin.
+
+Demonstrates `on_acting` middleware that logs every tool call with
+timing information to a trace file in the workspace.
+
+The middleware factory conditionally activates: it returns None (skip)
+when the agent's debug mode is not enabled.
+"""
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+
+from qwenpaw.plugins.api import PluginApi
+
+logger = logging.getLogger(__name__)
+
+
+class TracingMiddleware(MiddlewareBase):
+    """Logs tool call name, arguments, and execution duration."""
+
+    def __init__(self, trace_file: Path) -> None:
+        self._trace_file = trace_file
+        self._trace_file.parent.mkdir(parents=True, exist_ok=True)
+
+    async def on_acting(  # pylint: disable=unused-argument
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        tool_call = input_kwargs["tool_call"]
+        tool_name = getattr(tool_call, "name", str(tool_call))
+        tool_args = getattr(tool_call, "arguments", "")
+
+        start = time.perf_counter()
+        try:
+            async for item in next_handler():
+                yield item
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            line = (
+                f"[{time.strftime('%H:%M:%S')}] "
+                f"{tool_name}({tool_args}) — {elapsed_ms:.1f}ms\n"
+            )
+            try:
+                with open(self._trace_file, "a", encoding="utf-8") as f:
+                    f.write(line)
+            except OSError:
+                logger.debug("Failed to write trace log")
+
+
+def _tracing_factory(ctx: Any, agent_config: Any) -> TracingMiddleware | None:
+    """Create TracingMiddleware only when debug mode is enabled."""
+    running = getattr(agent_config, "running", None)
+    if running is None or not getattr(running, "debug", False):
+        return None
+
+    workspace_dir = getattr(ctx, "workspace_dir", None)
+    if workspace_dir is None:
+        return None
+
+    trace_file = Path(workspace_dir) / ".qwenpaw" / "trace.log"
+    return TracingMiddleware(trace_file=trace_file)
+
+
+class TracingPlugin:
+    """Plugin entry point."""
+
+    def register(self, api: PluginApi) -> None:
+        api.register_middleware(_tracing_factory, priority=50)
+
+
+plugin = TracingPlugin()

--- a/plugins/middleware-demo/tracing-middleware/tracing_plugin.py
+++ b/plugins/middleware-demo/tracing-middleware/tracing_plugin.py
@@ -5,10 +5,11 @@ Demonstrates `on_acting` middleware that logs every tool call with
 timing information to a trace file in the workspace.
 
 The middleware factory conditionally activates: it returns None (skip)
-when the agent's debug mode is not enabled.
+unless the ``QWENPAW_TRACE`` environment variable is set.
 """
 
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class TracingMiddleware(MiddlewareBase):
-    """Logs tool call name, arguments, and execution duration."""
+    """Logs tool call name, input, and execution duration."""
 
     def __init__(self, trace_file: Path) -> None:
         self._trace_file = trace_file
@@ -35,7 +36,7 @@ class TracingMiddleware(MiddlewareBase):
     ) -> AsyncGenerator[Any, None]:
         tool_call = input_kwargs["tool_call"]
         tool_name = getattr(tool_call, "name", str(tool_call))
-        tool_args = getattr(tool_call, "arguments", "")
+        tool_input = getattr(tool_call, "input", "")
 
         start = time.perf_counter()
         try:
@@ -45,7 +46,7 @@ class TracingMiddleware(MiddlewareBase):
             elapsed_ms = (time.perf_counter() - start) * 1000
             line = (
                 f"[{time.strftime('%H:%M:%S')}] "
-                f"{tool_name}({tool_args}) — {elapsed_ms:.1f}ms\n"
+                f"{tool_name}({tool_input[:100]}) — {elapsed_ms:.1f}ms\n"
             )
             try:
                 with open(self._trace_file, "a", encoding="utf-8") as f:
@@ -55,9 +56,9 @@ class TracingMiddleware(MiddlewareBase):
 
 
 def _tracing_factory(ctx: Any, agent_config: Any) -> TracingMiddleware | None:
-    """Create TracingMiddleware only when debug mode is enabled."""
-    running = getattr(agent_config, "running", None)
-    if running is None or not getattr(running, "debug", False):
+    """Create TracingMiddleware when QWENPAW_TRACE env var is set."""
+    del agent_config
+    if not os.environ.get("QWENPAW_TRACE"):
         return None
 
     workspace_dir = getattr(ctx, "workspace_dir", None)

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -13,7 +13,10 @@
     "backend": "gpt_image2.py"
   },
   "dependencies": ["httpx>=0.24.0"],
-  "min_version": "1.1.7",
+  "qwenpaw_version": {
+    "min": "1.1.7",
+    "max": "2.1.0"
+  },
   "meta": {
     "tools": [
       {

--- a/plugins/tool/qwen-image/plugin.json
+++ b/plugins/tool/qwen-image/plugin.json
@@ -12,7 +12,10 @@
     "backend": "qwen_image.py"
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
-  "min_version": "1.1.6",
+  "qwenpaw_version": {
+    "min": "1.1.6",
+    "max": "2.1.0"
+  },
   "meta": {
     "tools": [
       {

--- a/plugins/tool/wan27/plugin.json
+++ b/plugins/tool/wan27/plugin.json
@@ -12,7 +12,10 @@
     "backend": "wan27.py"
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
-  "min_version": "1.1.6",
+  "qwenpaw_version": {
+    "min": "1.1.6",
+    "max": "2.1.0"
+  },
   "meta": {
     "tools": [
       {

--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -40,8 +40,13 @@ def check_plugin_version_compat(
     """
     from .__version__ import __version__ as current_version_str
 
-    # Strip pre-release suffixes for comparison (e.g. "1.1.10b1" -> "1.1.10")
     current = Version(current_version_str)
+
+    # Pre-release versions (e.g. 2.0.0b2) should be treated as their base
+    # release for compatibility purposes — developers on a pre-release build
+    # must be able to load plugins targeting the upcoming release.
+    if current.pre is not None:
+        current = Version(f"{current.major}.{current.minor}.{current.micro}")
 
     qv = manifest.qwenpaw_version
     if qv is not None:

--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -56,6 +56,6 @@ def check_plugin_version_compat(
         )
 
     if current < min_v or current >= max_v:
-        msg = f"requires QwenPaw >={min_v}, <{max_v}, " f"current is {current}"
+        msg = f"requires QwenPaw >={min_v}, <{max_v}, current is {current}"
         return False, msg
     return True, ""

--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Plugin–QwenPaw version compatibility check.
+
+Semantics: left-closed, right-open interval  ``>=min, <max``.
+When ``max`` is not specified, it is derived from ``min`` as
+``{major}.{minor+1}.0`` (all patch versions of the same minor).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Tuple
+
+from packaging.version import Version
+
+if TYPE_CHECKING:
+    from .plugins.architecture import PluginManifest
+
+logger = logging.getLogger(__name__)
+
+
+def _derive_exclusive_max(min_str: str) -> Version:
+    """Derive exclusive upper bound from a min version string.
+
+    '1.1.6' -> Version('1.2.0')
+    """
+    parts = min_str.split(".")
+    major = int(parts[0])
+    minor = int(parts[1]) if len(parts) > 1 else 0
+    return Version(f"{major}.{minor + 1}.0")
+
+
+def check_plugin_version_compat(
+    manifest: "PluginManifest",
+) -> Tuple[bool, str]:
+    """Check whether a plugin is compatible with the running QwenPaw.
+
+    Returns:
+        (compatible, warning_message) — message is empty on success.
+    """
+    from .__version__ import __version__ as current_version_str
+
+    # Strip pre-release suffixes for comparison (e.g. "1.1.10b1" -> "1.1.10")
+    current = Version(current_version_str)
+
+    qv = manifest.qwenpaw_version
+    if qv is not None:
+        min_v = Version(qv.min)
+        max_v = Version(qv.max) if qv.max else _derive_exclusive_max(qv.min)
+    else:
+        min_v = Version(manifest.min_version)
+        max_v = (
+            Version(manifest.max_version)
+            if manifest.max_version
+            else _derive_exclusive_max(manifest.min_version)
+        )
+
+    if current < min_v or current >= max_v:
+        msg = f"requires QwenPaw >={min_v}, <{max_v}, " f"current is {current}"
+        return False, msg
+    return True, ""

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -322,6 +322,41 @@ class PluginApi:
                 f"'{handler.command_name}' (priority={priority_level})",
             )
 
+    def register_middleware(
+        self,
+        middleware_factory: Callable,
+        *,
+        priority: int = 100,
+    ) -> None:
+        """Register an AgentScope MiddlewareBase factory.
+
+        The factory is called once per request during agent assembly:
+            ``factory(ctx, agent_config) -> MiddlewareBase | None``
+
+        Returning None means the middleware is skipped for this request.
+        Priority controls ordering (lower = outermost in onion model).
+
+        Args:
+            middleware_factory: Callable that receives ``(ctx, agent_config)``
+                and returns a ``MiddlewareBase`` instance or None.
+            priority: Ordering priority (lower = outermost). Default: 100.
+
+        Example:
+            >>> def my_factory(ctx, agent_config):
+            ...     return MyMiddleware()
+            >>> api.register_middleware(my_factory, priority=50)
+        """
+        if self._registry:
+            self._registry.register_middleware(
+                plugin_id=self.plugin_id,
+                factory=middleware_factory,
+                priority=priority,
+            )
+            logger.info(
+                f"Plugin '{self.plugin_id}' registered middleware "
+                f"factory (priority={priority})",
+            )
+
     @property
     def runtime(self):
         """Access runtime helper functions.

--- a/src/qwenpaw/plugins/architecture.py
+++ b/src/qwenpaw/plugins/architecture.py
@@ -92,6 +92,20 @@ def _infer_type_from_meta(
     return PluginType.GENERAL
 
 
+class QwenPawVersionConstraint(BaseModel):
+    """QwenPaw version compatibility range (left-closed, right-open).
+
+    Semantics: ``>=min, <max``.  When ``max`` is omitted the allowed
+    range is all patch versions of the same minor (derived as
+    ``{major}.{minor+1}.0`` from ``min``).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    min: str
+    max: Optional[str] = None
+
+
 class PluginManifest(BaseModel):
     """Plugin manifest definition.
 
@@ -118,6 +132,8 @@ class PluginManifest(BaseModel):
     entry: PluginEntryPoints = Field(default_factory=PluginEntryPoints)
     dependencies: List[str] = Field(default_factory=list)
     min_version: str = "0.1.0"
+    max_version: Optional[str] = None
+    qwenpaw_version: Optional[QwenPawVersionConstraint] = None
     meta: Dict[str, Any] = Field(default_factory=dict)
     plugin_type: PluginType = PluginType.GENERAL
 

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import threading
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _dist_version
@@ -189,6 +189,23 @@ class PluginLoader:
         return PluginManifest.from_dict(data)
 
     @staticmethod
+    def _check_version_compatibility(
+        manifest: "PluginManifest",
+    ) -> tuple:
+        """Check plugin compatibility with current QwenPaw version.
+
+        Uses left-closed, right-open semantics: ``>=min, <max``.
+        When ``qwenpaw_version`` is absent, falls back to legacy
+        ``min_version`` / ``max_version`` top-level fields.
+
+        Returns:
+            (compatible, message) tuple.
+        """
+        from .._version_compat import check_plugin_version_compat
+
+        return check_plugin_version_compat(manifest)
+
+    @staticmethod
     def _is_requirement_satisfied(req: Requirement) -> bool:
         """Return True if *req* is already available.
 
@@ -316,6 +333,120 @@ class PluginLoader:
                 return
             self._install_requirements(requirements_file, plugin_id)
 
+    def _validate_entry_points(
+        self,
+        plugin_id: str,
+        backend_entry_file: Path | None,
+        frontend_entry_file: Path | None,
+    ) -> tuple[bool, bool]:
+        """Validate plugin entry points exist.
+
+        Returns:
+            Tuple of (backend_exists, frontend_exists).
+
+        Raises:
+            FileNotFoundError: If no entry points declared or files missing.
+        """
+        if backend_entry_file is None and frontend_entry_file is None:
+            raise FileNotFoundError(
+                f"Plugin '{plugin_id}' has no entry points declared "
+                f"(entry.backend or entry.frontend)",
+            )
+
+        backend_exists = (
+            backend_entry_file is not None and backend_entry_file.exists()
+        )
+        frontend_exists = (
+            frontend_entry_file is not None and frontend_entry_file.exists()
+        )
+
+        if not backend_exists and not frontend_exists:
+            missing = []
+            if backend_entry_file:
+                missing.append(str(backend_entry_file))
+            if frontend_entry_file:
+                missing.append(str(frontend_entry_file))
+            raise FileNotFoundError(
+                f"Plugin '{plugin_id}' entry point files not found: "
+                + ", ".join(missing),
+            )
+
+        return backend_exists, frontend_exists
+
+    async def _load_backend_module(
+        self,
+        plugin_id: str,
+        backend_entry_file: Path,
+        source_path: Path,
+        config: Optional[Dict],
+        manifest: "PluginManifest",
+    ) -> Any:
+        """Dynamically load and register backend plugin module.
+
+        Returns:
+            Plugin definition object.
+
+        Raises:
+            ImportError: If module spec cannot be created.
+            AttributeError: If plugin doesn't export required objects.
+        """
+        module_name = f"plugin_{plugin_id.replace('-', '_')}"
+        plugin_dir_str = str(source_path)
+
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            backend_entry_file,
+            submodule_search_locations=[plugin_dir_str],
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"Failed to load module spec for {backend_entry_file}",
+            )
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        module.__package__ = module_name
+        module.__path__ = [plugin_dir_str]
+        spec.loader.exec_module(module)
+
+        if not hasattr(module, "plugin"):
+            raise AttributeError(
+                "Plugin module must export 'plugin' object",
+            )
+
+        plugin_def = module.plugin
+
+        manifest_dict = {
+            "id": manifest.id,
+            "name": manifest.name,
+            "version": manifest.version,
+            "description": manifest.description,
+            "author": manifest.author,
+            "dependencies": manifest.dependencies,
+            "min_version": manifest.min_version,
+            "max_version": manifest.max_version,
+            "qwenpaw_version": (
+                manifest.qwenpaw_version.model_dump()
+                if manifest.qwenpaw_version
+                else None
+            ),
+            "meta": manifest.meta,
+        }
+        api = PluginApi(plugin_id, config or {}, manifest_dict)
+        api.set_registry(self.registry)
+        self.registry.register_plugin_manifest(plugin_id, manifest_dict)
+
+        if hasattr(plugin_def, "register"):
+            result = plugin_def.register(api)
+            if inspect.iscoroutine(result) or inspect.isawaitable(result):
+                await result
+        else:
+            raise AttributeError(
+                "Plugin must implement 'register(api)' method",
+            )
+
+        return plugin_def
+
     async def load_plugin(
         self,
         manifest: PluginManifest,
@@ -343,10 +474,26 @@ class PluginLoader:
             logger.warning(f"Plugin '{plugin_id}' already loaded")
             return self._loaded_plugins[plugin_id]
 
+        compatible, compat_msg = self._check_version_compatibility(manifest)
+        if not compatible:
+            logger.warning(
+                "Plugin '%s' is incompatible: %s",
+                plugin_id,
+                compat_msg,
+            )
+            record = PluginRecord(
+                manifest=manifest,
+                source_path=source_path,
+                enabled=False,
+                diagnostics=[compat_msg],
+            )
+            self._loaded_plugins[plugin_id] = record
+            return record
+
         # Ensure plugin dependencies are installed before loading
         await self._ensure_dependencies_installed(source_path, plugin_id)
 
-        # Load backend module (if declared and exists)
+
         backend_entry = manifest.entry.backend
         frontend_entry = manifest.entry.frontend
         backend_entry_file = (
@@ -355,102 +502,30 @@ class PluginLoader:
         frontend_entry_file = (
             source_path / frontend_entry if frontend_entry else None
         )
+
+        backend_exists, _ = self._validate_entry_points(
+            plugin_id,
+            backend_entry_file,
+            frontend_entry_file,
+        )
+
         plugin_def = None
-
-        if backend_entry_file is None and frontend_entry_file is None:
-            raise FileNotFoundError(
-                f"Plugin '{plugin_id}' has no entry points declared "
-                f"(entry.backend or entry.frontend)",
-            )
-
-        backend_exists = (
-            backend_entry_file is not None and backend_entry_file.exists()
-        )
-        frontend_exists = (
-            frontend_entry_file is not None and frontend_entry_file.exists()
-        )
-
-        if not backend_exists and not frontend_exists:
-            raise FileNotFoundError(
-                f"Plugin '{plugin_id}' entry point files not found: "
-                + (f"{backend_entry_file}" if backend_entry_file else "")
-                + (f", {frontend_entry_file}" if frontend_entry_file else ""),
-            )
-
         if not backend_exists:
-            # Frontend-only plugin — skip backend loading
             logger.info(
-                f"Plugin '{plugin_id}' has no backend entry point "
-                f"— loading as frontend-only plugin",
+                "Plugin '%s' has no backend entry point "
+                "— loading as frontend-only plugin",
+                plugin_id,
             )
         else:
+            assert backend_entry_file is not None
             try:
-                # Dynamic import of plugin module
-                # Use unique module name to avoid conflicts
-                module_name = f"plugin_{plugin_id.replace('-', '_')}"
-                plugin_dir_str = str(source_path)
-
-                # submodule_search_locations enables relative imports
-                # within plugin without polluting global sys.path
-                spec = importlib.util.spec_from_file_location(
-                    module_name,
-                    backend_entry_file,
-                    submodule_search_locations=[plugin_dir_str],
-                )
-                if spec is None or spec.loader is None:
-                    raise ImportError(
-                        f"Failed to load module spec for {backend_entry_file}",
-                    )
-
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-
-                # Set __package__ and __path__ to enable relative imports
-                module.__package__ = module_name
-                module.__path__ = [plugin_dir_str]
-
-                spec.loader.exec_module(module)
-
-                # Get plugin definition
-                if not hasattr(module, "plugin"):
-                    raise AttributeError(
-                        "Plugin module must export 'plugin' object",
-                    )
-
-                plugin_def = module.plugin
-
-                # Create plugin API instance with manifest
-                manifest_dict = {
-                    "id": manifest.id,
-                    "name": manifest.name,
-                    "version": manifest.version,
-                    "description": manifest.description,
-                    "author": manifest.author,
-                    "dependencies": manifest.dependencies,
-                    "min_version": manifest.min_version,
-                    "meta": manifest.meta,
-                }
-                api = PluginApi(plugin_id, config or {}, manifest_dict)
-                api.set_registry(self.registry)
-
-                # Register plugin manifest to registry
-                self.registry.register_plugin_manifest(
+                plugin_def = await self._load_backend_module(
                     plugin_id,
-                    manifest_dict,
+                    backend_entry_file,
+                    source_path,
+                    config,
+                    manifest,
                 )
-
-                # Call plugin's register method (support both sync and async)
-                if hasattr(plugin_def, "register"):
-                    result = plugin_def.register(api)
-                    if inspect.iscoroutine(result) or inspect.isawaitable(
-                        result,
-                    ):
-                        await result
-                else:
-                    raise AttributeError(
-                        "Plugin must implement 'register(api)' method",
-                    )
-
             except Exception as e:
                 logger.error(
                     f"Failed to load plugin '{plugin_id}': {e}",
@@ -458,17 +533,14 @@ class PluginLoader:
                 )
                 raise
 
-        # Create plugin record
         record = PluginRecord(
             manifest=manifest,
             source_path=source_path,
             enabled=True,
             instance=plugin_def,
         )
-
         self._loaded_plugins[plugin_id] = record
         logger.info(f"✓ Loaded plugin '{plugin_id}' successfully")
-
         return record
 
     async def load_all_plugins(

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -493,7 +493,6 @@ class PluginLoader:
         # Ensure plugin dependencies are installed before loading
         await self._ensure_dependencies_installed(source_path, plugin_id)
 
-
         backend_entry = manifest.entry.backend
         frontend_entry = manifest.entry.frontend
         backend_entry_file = (

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -84,6 +84,15 @@ class ControlCommandRegistration:
 
 
 @dataclass
+class MiddlewareRegistration:
+    """Middleware factory registration record."""
+
+    plugin_id: str
+    factory: Callable
+    priority: int = 100
+
+
+@dataclass
 class HttpRouterRegistration:
     """HTTP routes contributed by a backend plugin under ``/api``."""
 
@@ -134,6 +143,7 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         self._control_commands: List[ControlCommandRegistration] = []
         self._runtime_helpers = None
         self._plugin_manifests: Dict[str, Dict[str, Any]] = {}
+        self._middleware_registrations: List[MiddlewareRegistration] = []
         self._plugin_http_app: Optional[Any] = None
         self._http_router_registrations: List[HttpRouterRegistration] = []
         self._http_prefix_to_plugin: Dict[str, str] = {}
@@ -141,6 +151,44 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         self._prompt_section_names: set = set()
 
         self._initialized = True
+
+    def register_middleware(
+        self,
+        plugin_id: str,
+        factory: Callable,
+        priority: int = 100,
+    ) -> None:
+        """Register a middleware factory.
+
+        The factory is invoked per request during agent assembly:
+        ``factory(ctx, agent_config) -> MiddlewareBase | None``.
+
+        Args:
+            plugin_id: Plugin identifier
+            factory: Callable returning a MiddlewareBase or None
+            priority: Ordering priority (lower = outermost in onion model)
+        """
+        self._middleware_registrations.append(
+            MiddlewareRegistration(
+                plugin_id=plugin_id,
+                factory=factory,
+                priority=priority,
+            ),
+        )
+        self._middleware_registrations.sort(key=lambda r: r.priority)
+        logger.info(
+            "Registered middleware factory from plugin '%s' (priority=%d)",
+            plugin_id,
+            priority,
+        )
+
+    def get_middleware_factories(self) -> List[MiddlewareRegistration]:
+        """Get all middleware factory registrations sorted by priority.
+
+        Returns:
+            List of MiddlewareRegistration
+        """
+        return self._middleware_registrations.copy()
 
     def set_plugin_http_app(self, app: Any) -> None:
         """Attach the FastAPI application used to mount plugin HTTP routes.
@@ -691,6 +739,11 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         ]
         self._control_commands = [
             c for c in self._control_commands if c.plugin_id != plugin_id
+        ]
+        self._middleware_registrations = [
+            r
+            for r in self._middleware_registrations
+            if r.plugin_id != plugin_id
         ]
         removed_sections = [
             s for s in self._prompt_sections if s.plugin_id == plugin_id

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -683,6 +683,7 @@ class AgentBuilder:
         Order (onion model, outermost first):
         1. ToolCoordinatorMiddleware — tool call lifecycle management
         2. ToolResultPruningMiddleware — tiered tool result pruning
+        3. Plugin-registered middlewares (sorted by priority)
         """
         mws: list[Any] = []
 
@@ -769,6 +770,22 @@ class AgentBuilder:
                 "LangfuseToolSpanMiddleware not created",
                 exc_info=True,
             )
+
+        # Plugin-registered middlewares
+        from ..plugins.registry import PluginRegistry
+
+        registry = PluginRegistry()
+        for reg in registry.get_middleware_factories():
+            try:
+                mw = reg.factory(ctx, agent_config)
+                if mw is not None:
+                    mws.append(mw)
+            except Exception:
+                _logger.warning(
+                    "plugin %s middleware factory failed",
+                    reg.plugin_id,
+                    exc_info=True,
+                )
 
         return mws
 

--- a/tests/integration/test_plugin_types.py
+++ b/tests/integration/test_plugin_types.py
@@ -83,6 +83,7 @@ def _provider_plugin_zip(plugin_id: str) -> bytes:
         "plugin_type": "provider",
         "entry": {"backend": "plugin.py"},
         "meta": {"provider_id": f"{plugin_id}-prov"},
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(plugin_id, manifest, {"plugin.py": backend})
 
@@ -134,6 +135,7 @@ def _hook_plugin_zip(plugin_id: str) -> bytes:
         "plugin_type": "hook",
         "entry": {"backend": "plugin.py"},
         "meta": {"hook_type": "startup"},
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(plugin_id, manifest, {"plugin.py": backend})
 
@@ -172,6 +174,7 @@ def _command_plugin_zip(plugin_id: str) -> bytes:
         "plugin_type": "command",
         "entry": {"backend": "plugin.py"},
         "meta": {"command_name": f"/{plugin_id}-cmd"},
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(plugin_id, manifest, {"plugin.py": backend})
 
@@ -207,6 +210,7 @@ def _http_router_plugin_zip(plugin_id: str) -> bytes:
         "name": plugin_id,
         "plugin_type": "general",
         "entry": {"backend": "plugin.py"},
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(plugin_id, manifest, {"plugin.py": backend})
 
@@ -235,6 +239,7 @@ def _frontend_plugin_zip(plugin_id: str) -> bytes:
             "backend": "plugin.py",
             "frontend": "dist/index.js",
         },
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(
         plugin_id,
@@ -963,6 +968,7 @@ def _composite_plugin_zip(plugin_id: str) -> bytes:
             "backend": "plugin.py",
             "frontend": "dist/index.js",
         },
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(
         plugin_id,
@@ -979,6 +985,7 @@ def _no_entry_plugin_zip(plugin_id: str) -> bytes:
         "name": plugin_id,
         "plugin_type": "general",
         "entry": {},  # empty — no backend nor frontend
+        "qwenpaw_version": {"min": "2.0.0", "max": "2.1.0"},
     }
     return _build_zip(plugin_id, manifest, {})
 

--- a/website/public/docs/plugins.en.md
+++ b/website/public/docs/plugins.en.md
@@ -7,6 +7,7 @@ QwenPaw provides a plugin system that allows users to extend QwenPaw's functiona
 The plugin system supports the following extension capabilities:
 
 - **Provider Plugins**: Add new LLM providers and models
+- **Middleware Plugins**: Register AgentScope `MiddlewareBase` factories to wrap `on_acting` / `on_reasoning` hooks in the agent reasoning loop
 - **Hook Plugins**: Execute custom code during application startup/shutdown (app lifespan level, runs once)
 - **Command Plugins**: Register custom `/command` magic commands
 - **HTTP API Plugins**: Expose custom REST endpoints under `/api` via a FastAPI `APIRouter`
@@ -95,27 +96,32 @@ my-plugin/
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "0.1.0",
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  },
   "meta": {}
 }
 ```
 
 #### Manifest Field Reference
 
-| Field            | Type               | Required | Description                                                                                                                                                                |
-| ---------------- | ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`             | `string`           | yes      | Unique plugin identifier. Used as the install directory name; must not contain path separators.                                                                            |
-| `version`        | `string`           | yes      | Semantic version of the plugin (e.g. `1.0.0`).                                                                                                                             |
-| `name`           | `string` \| object | no       | Display name. Defaults to `id`. May also be `{"zh-CN": "...", "en-US": "..."}`; the first non-empty localised value is used (English preferred).                           |
-| `type`           | `string`           | no       | One of `tool`, `provider`, `hook`, `command`, `frontend`, `general`. When omitted, the type is inferred from `meta` / `entry` (legacy plugins). Prefer setting explicitly. |
-| `description`    | `string` \| object | no       | Short description shown in the plugin list. Localised form is accepted (see `name`).                                                                                       |
-| `author`         | `string`           | no       | Author or organisation name.                                                                                                                                               |
-| `entry.backend`  | `string`           | no\*     | Path (relative to plugin dir) of the Python entry file that exports `plugin`.                                                                                              |
-| `entry.frontend` | `string`           | no\*     | Path of the built frontend bundle (e.g. `dist/index.js`).                                                                                                                  |
-| `dependencies`   | `string[]`         | no       | Python package requirements installed via pip/uv at install time.                                                                                                          |
-| `min_version`    | `string`           | no       | Minimum QwenPaw version required. Defaults to `0.1.0`.                                                                                                                     |
-| `meta`           | `object`           | no       | Free-form plugin metadata. Used by the UI and by `type` inference (e.g. `meta.tools[]`, `meta.hook_type`, `meta.provider_id`).                                             |
-| `entry_point`    | `string`           | no       | **Legacy.** Equivalent to `entry.backend`. Still accepted for backwards compatibility with older plugins; new plugins should use `entry.backend`.                          |
+| Field             | Type               | Required | Description                                                                                                                                                                                          |
+| ----------------- | ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | `string`           | yes      | Unique plugin identifier. Used as the install directory name; must not contain path separators.                                                                                                      |
+| `version`         | `string`           | yes      | Semantic version of the plugin (e.g. `1.0.0`).                                                                                                                                                       |
+| `name`            | `string` \| object | no       | Display name. Defaults to `id`. May also be `{"zh-CN": "...", "en-US": "..."}`; the first non-empty localised value is used (English preferred).                                                     |
+| `type`            | `string`           | no       | One of `tool`, `provider`, `hook`, `command`, `frontend`, `general`. When omitted, the type is inferred from `meta` / `entry` (legacy plugins). Prefer setting explicitly.                           |
+| `description`     | `string` \| object | no       | Short description shown in the plugin list. Localised form is accepted (see `name`).                                                                                                                 |
+| `author`          | `string`           | no       | Author or organisation name.                                                                                                                                                                         |
+| `entry.backend`   | `string`           | no\*     | Path (relative to plugin dir) of the Python entry file that exports `plugin`.                                                                                                                        |
+| `entry.frontend`  | `string`           | no\*     | Path of the built frontend bundle (e.g. `dist/index.js`).                                                                                                                                            |
+| `dependencies`    | `string[]`         | no       | Python package requirements installed via pip/uv at install time.                                                                                                                                    |
+| `qwenpaw_version` | `object`           | no       | QwenPaw version constraint (recommended). Contains `min` (inclusive) and `max` (exclusive, optional) sub-fields. Semantics: `>=min, <max`. When `max` is omitted, defaults to `{major}.{minor+1}.0`. |
+| `min_version`     | `string`           | no       | **Legacy.** Minimum QwenPaw version required. Ignored when `qwenpaw_version` is present. Retained only for backward compatibility with third-party plugins.                                          |
+| `max_version`     | `string`           | no       | **Legacy.** First incompatible QwenPaw version (exclusive). Used with `min_version`; when omitted, derived from `min_version`.                                                                       |
+| `meta`            | `object`           | no       | Free-form plugin metadata. Used by the UI and by `type` inference (e.g. `meta.tools[]`, `meta.hook_type`, `meta.provider_id`).                                                                       |
+| `entry_point`     | `string`           | no       | **Legacy.** Equivalent to `entry.backend`. Still accepted for backwards compatibility with older plugins; new plugins should use `entry.backend`.                                                    |
 
 \* At least one of `entry.backend` / `entry.frontend` (or legacy `entry_point`) must be provided.
 
@@ -669,7 +675,10 @@ cd my-llm-provider
     "backend": "plugin.py"
   },
   "dependencies": ["httpx>=0.24.0"],
-  "min_version": "0.1.0",
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  },
   "meta": {
     "api_key_url": "https://example.com/get-api-key",
     "api_key_hint": "Get your API key from example.com"
@@ -804,7 +813,10 @@ cd monitoring-hook
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "0.1.0"
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
 }
 ```
 
@@ -894,7 +906,10 @@ cd status-command
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "0.1.0"
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
 }
 ```
 
@@ -1099,7 +1114,10 @@ mkdir pet-api-plugin && cd pet-api-plugin
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "1.1.5"
+  "qwenpaw_version": {
+    "min": "1.1.5",
+    "max": "2.1.0"
+  }
 }
 ```
 
@@ -1230,6 +1248,178 @@ curl -X POST http://127.0.0.1:8088/api/pets \
   `plugin:<plugin_id>` automatically for OpenAPI grouping.
 - Routes are unmounted automatically when the plugin is uninstalled
   or disabled.
+
+### Example 8: Tracing Middleware (Tool Call Tracing)
+
+This example demonstrates how to register an `on_acting` middleware that logs every tool call with timing information in debug mode.
+
+**plugin.json:**
+
+```json
+{
+  "id": "middleware-demo-tracing",
+  "name": "Tracing Middleware Demo",
+  "version": "1.0.0",
+  "description": "Demo: logs tool calls with execution timing to a trace file",
+  "author": "QwenPaw Team",
+  "type": "general",
+  "entry": {
+    "backend": "tracing_plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
+}
+```
+
+**tracing_plugin.py:**
+
+```python
+import time
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+from qwenpaw.plugins.api import PluginApi
+
+
+class TracingMiddleware(MiddlewareBase):
+    """Logs tool call name, arguments, and execution duration."""
+
+    def __init__(self, trace_file: Path) -> None:
+        self._trace_file = trace_file
+        self._trace_file.parent.mkdir(parents=True, exist_ok=True)
+
+    async def on_acting(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        tool_call = input_kwargs["tool_call"]
+        tool_name = getattr(tool_call, "name", str(tool_call))
+        tool_args = getattr(tool_call, "arguments", "")
+
+        start = time.perf_counter()
+        try:
+            async for item in next_handler():
+                yield item
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            line = f"[{time.strftime('%H:%M:%S')}] {tool_name}({tool_args}) — {elapsed_ms:.1f}ms\n"
+            with open(self._trace_file, "a", encoding="utf-8") as f:
+                f.write(line)
+
+
+def _tracing_factory(ctx: Any, agent_config: Any) -> TracingMiddleware | None:
+    """Create TracingMiddleware only when debug mode is enabled."""
+    running = getattr(agent_config, "running", None)
+    if running is None or not getattr(running, "debug", False):
+        return None
+    workspace_dir = getattr(ctx, "workspace_dir", None)
+    if workspace_dir is None:
+        return None
+    trace_file = Path(workspace_dir) / ".qwenpaw" / "trace.log"
+    return TracingMiddleware(trace_file=trace_file)
+
+
+class TracingPlugin:
+    def register(self, api: PluginApi) -> None:
+        api.register_middleware(_tracing_factory, priority=50)
+
+
+plugin = TracingPlugin()
+```
+
+**Key points:**
+
+- **Conditional activation**: The factory checks `agent_config.running.debug` and only activates in debug mode
+- **`priority=50`**: Higher priority (lower number = outermost in onion), ensuring tracing wraps other middlewares
+- **`on_acting` hook**: Measures execution time before/after tool calls
+- Full source: `plugins/middleware-demo/tracing-middleware/tracing_plugin.py`
+
+---
+
+### Example 9: Thinking Log Middleware (Reasoning Process Logger)
+
+This example demonstrates how to register an `on_reasoning` middleware that captures and prints the model's chain-of-thought.
+
+**plugin.json:**
+
+```json
+{
+  "id": "middleware-demo-thinking-log",
+  "name": "Thinking Log Middleware Demo",
+  "version": "1.0.0",
+  "description": "Demo: prints model reasoning steps to stdout",
+  "author": "QwenPaw Team",
+  "type": "general",
+  "entry": {
+    "backend": "thinking_log_plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
+}
+```
+
+**thinking_log_plugin.py:**
+
+```python
+import sys
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+from agentscope.message import TextBlock
+from qwenpaw.plugins.api import PluginApi
+
+
+class ThinkingLogMiddleware(MiddlewareBase):
+    """Prints each reasoning step to stdout with a [THINKING] prefix."""
+
+    async def on_reasoning(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        events = []
+        async for item in next_handler():
+            events.append(item)
+            yield item
+
+        for event in events:
+            if isinstance(event, TextBlock):
+                text = getattr(event, "text", str(event))
+                if text.strip():
+                    print(f"[THINKING] {text[:200]}", file=sys.stdout, flush=True)
+
+
+def _thinking_log_factory(ctx: Any, agent_config: Any) -> ThinkingLogMiddleware:
+    """Always create the middleware (unconditional activation)."""
+    return ThinkingLogMiddleware()
+
+
+class ThinkingLogPlugin:
+    def register(self, api: PluginApi) -> None:
+        api.register_middleware(_thinking_log_factory, priority=80)
+
+
+plugin = ThinkingLogPlugin()
+```
+
+**Key points:**
+
+- **Unconditional activation**: The factory always returns an instance, applied to every request
+- **`on_reasoning` hook**: Captures output during the model's reasoning phase
+- **Yield-then-process**: Reasoning events are forwarded downstream first, then printed — does not block streaming
+- Full source: `plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py`
+
+---
 
 ## Dependency Management
 
@@ -1367,7 +1557,7 @@ api.register_startup_hook("late", callback, priority=200)
 1. **Only install trusted plugins**: Plugin code executes in the QwenPaw process
 2. **Check dependencies**: Ensure plugin dependencies come from trusted sources
 3. **Review code**: Review plugin source code before installation
-4. **Offline operations**: Plugin install/uninstall requires QwenPaw to be offline
+4. **Hot-loading awareness**: The current version supports hot-installing/uninstalling plugins via API while the app is running. Be mindful of state consistency during hot-loading
 
 ## PluginApi Reference
 
@@ -1485,7 +1675,39 @@ config = api.get_tool_config(tool_name: str, agent_id: str)  # Returns dict
 api.set_tool_config(tool_name: str, agent_id: str, config: dict)
 ```
 
+### register_middleware
+
+Register an AgentScope `MiddlewareBase` factory.
+
+```python
+api.register_middleware(
+    middleware_factory: Callable,   # Factory function
+    *,
+    priority: int = 100,           # Priority (lower = outermost)
+)
+```
+
+Factory signature: `(ctx: HookContext, agent_config: AgentProfileConfig) -> MiddlewareBase | None`
+
+- `ctx` contains request-level context such as `session_id`, `agent_id`, `workspace_dir`
+- Returning `None` means this middleware is skipped for the current request
+- Lower `priority` values place the middleware further out in the onion model (executed first)
+
+The factory is called during `AgentBuilder.build()` for each request. The returned middleware instance is inserted into the agent's middleware chain.
+
+See [Example 8](#example-8-tracing-middleware) and [Example 9](#example-9-thinking-log-middleware) for full walkthroughs.
+
 ## Advanced Features
+
+### Modifying Agent Behavior
+
+To intercept or enhance agent request processing, use one of these approaches:
+
+- **Enhance the agent reasoning loop**: use `register_middleware` to inject AgentScope middlewares (`on_acting` / `on_reasoning` hooks)
+- **Intercept specific commands**: use `register_control_command` to register a custom command handler
+- **Inject logic into the request lifecycle**: use `HookRegistry` (8-phase hooks)
+
+The current request flow is `Runtime.run()` → `AgentBuilder.build()` → `AgentExecutor.run()`.
 
 ### Custom Commands
 
@@ -1547,12 +1769,15 @@ qwenpaw plugin install https://example.com/my-plugin-1.0.0.zip
 A: Plugins access core functionality through `PluginApi`, including:
 
 - Provider registration
+- Middleware registration (`register_middleware`)
 - Hook registration
+- Custom command registration (`register_control_command`)
+- HTTP router registration (`register_http_router`)
 - Runtime helpers (provider_manager, etc.)
 
 ### Q: Can plugins modify QwenPaw's core behavior?
 
-A: Yes, through `register_control_command`, `register_tool`, runtime hooks, and other PluginApi methods. Use with caution to avoid breaking core functionality.
+A: Yes, through `register_middleware` (inject AgentScope middlewares), `register_control_command`, `register_tool`, runtime hooks, and other PluginApi methods. Use with caution to avoid breaking core functionality.
 
 ### Q: Will plugins conflict with each other?
 

--- a/website/public/docs/plugins.en.md
+++ b/website/public/docs/plugins.en.md
@@ -1251,7 +1251,7 @@ curl -X POST http://127.0.0.1:8088/api/pets \
 
 ### Example 8: Tracing Middleware (Tool Call Tracing)
 
-This example demonstrates how to register an `on_acting` middleware that logs every tool call with timing information in debug mode.
+This example demonstrates how to register an `on_acting` middleware that logs every tool call with timing information when the `QWENPAW_TRACE` environment variable is set.
 
 **plugin.json:**
 
@@ -1277,6 +1277,7 @@ This example demonstrates how to register an `on_acting` middleware that logs ev
 **tracing_plugin.py:**
 
 ```python
+import os
 import time
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable
@@ -1286,7 +1287,7 @@ from qwenpaw.plugins.api import PluginApi
 
 
 class TracingMiddleware(MiddlewareBase):
-    """Logs tool call name, arguments, and execution duration."""
+    """Logs tool call name, input, and execution duration."""
 
     def __init__(self, trace_file: Path) -> None:
         self._trace_file = trace_file
@@ -1300,7 +1301,7 @@ class TracingMiddleware(MiddlewareBase):
     ) -> AsyncGenerator[Any, None]:
         tool_call = input_kwargs["tool_call"]
         tool_name = getattr(tool_call, "name", str(tool_call))
-        tool_args = getattr(tool_call, "arguments", "")
+        tool_input = getattr(tool_call, "input", "")
 
         start = time.perf_counter()
         try:
@@ -1308,15 +1309,14 @@ class TracingMiddleware(MiddlewareBase):
                 yield item
         finally:
             elapsed_ms = (time.perf_counter() - start) * 1000
-            line = f"[{time.strftime('%H:%M:%S')}] {tool_name}({tool_args}) — {elapsed_ms:.1f}ms\n"
+            line = f"[{time.strftime('%H:%M:%S')}] {tool_name}({tool_input[:100]}) — {elapsed_ms:.1f}ms\n"
             with open(self._trace_file, "a", encoding="utf-8") as f:
                 f.write(line)
 
 
 def _tracing_factory(ctx: Any, agent_config: Any) -> TracingMiddleware | None:
-    """Create TracingMiddleware only when debug mode is enabled."""
-    running = getattr(agent_config, "running", None)
-    if running is None or not getattr(running, "debug", False):
+    """Create TracingMiddleware when QWENPAW_TRACE env var is set."""
+    if not os.environ.get("QWENPAW_TRACE"):
         return None
     workspace_dir = getattr(ctx, "workspace_dir", None)
     if workspace_dir is None:
@@ -1335,7 +1335,7 @@ plugin = TracingPlugin()
 
 **Key points:**
 
-- **Conditional activation**: The factory checks `agent_config.running.debug` and only activates in debug mode
+- **Conditional activation**: The factory checks the `QWENPAW_TRACE` environment variable and only activates when set
 - **`priority=50`**: Higher priority (lower number = outermost in onion), ensuring tracing wraps other middlewares
 - **`on_acting` hook**: Measures execution time before/after tool calls
 - Full source: `plugins/middleware-demo/tracing-middleware/tracing_plugin.py`
@@ -1374,12 +1374,12 @@ import sys
 from typing import Any, AsyncGenerator, Callable
 
 from agentscope.middleware import MiddlewareBase
-from agentscope.message import TextBlock
+from agentscope.event import ThinkingBlockDeltaEvent, TextBlockDeltaEvent
 from qwenpaw.plugins.api import PluginApi
 
 
 class ThinkingLogMiddleware(MiddlewareBase):
-    """Prints each reasoning step to stdout with a [THINKING] prefix."""
+    """Prints reasoning stream events to stdout."""
 
     async def on_reasoning(
         self,
@@ -1387,16 +1387,12 @@ class ThinkingLogMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., AsyncGenerator[Any, None]],
     ) -> AsyncGenerator[Any, None]:
-        events = []
         async for item in next_handler():
-            events.append(item)
+            if isinstance(item, ThinkingBlockDeltaEvent):
+                print(f"[THINKING] {item.delta}", end="", file=sys.stdout, flush=True)
+            elif isinstance(item, TextBlockDeltaEvent):
+                print(f"[TEXT] {item.delta}", end="", file=sys.stdout, flush=True)
             yield item
-
-        for event in events:
-            if isinstance(event, TextBlock):
-                text = getattr(event, "text", str(event))
-                if text.strip():
-                    print(f"[THINKING] {text[:200]}", file=sys.stdout, flush=True)
 
 
 def _thinking_log_factory(ctx: Any, agent_config: Any) -> ThinkingLogMiddleware:
@@ -1415,8 +1411,8 @@ plugin = ThinkingLogPlugin()
 **Key points:**
 
 - **Unconditional activation**: The factory always returns an instance, applied to every request
-- **`on_reasoning` hook**: Captures output during the model's reasoning phase
-- **Yield-then-process**: Reasoning events are forwarded downstream first, then printed — does not block streaming
+- **`on_reasoning` hook**: Captures streaming events during the model's reasoning phase (`ThinkingBlockDeltaEvent` for chain-of-thought, `TextBlockDeltaEvent` for text responses)
+- **Real-time printing**: Each delta event is printed immediately while being yielded downstream — does not block streaming
 - Full source: `plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py`
 
 ---
@@ -1695,7 +1691,7 @@ Factory signature: `(ctx: HookContext, agent_config: AgentProfileConfig) -> Midd
 
 The factory is called during `AgentBuilder.build()` for each request. The returned middleware instance is inserted into the agent's middleware chain.
 
-See [Example 8](#example-8-tracing-middleware) and [Example 9](#example-9-thinking-log-middleware) for full walkthroughs.
+See [Example 8](#example-8-tracing-middleware) and [Example 9](#example-9-thinking-log-middleware) above for full walkthroughs.
 
 ## Advanced Features
 

--- a/website/public/docs/plugins.zh.md
+++ b/website/public/docs/plugins.zh.md
@@ -1240,7 +1240,7 @@ curl -X POST http://127.0.0.1:8088/api/pets \
 
 ### 示例 8：Tracing Middleware（工具调用追踪）
 
-本示例展示如何注册一个 `on_acting` middleware，在 debug 模式下记录每次 tool call 的名称、参数和执行耗时。
+本示例展示如何注册一个 `on_acting` middleware，当设置环境变量 `QWENPAW_TRACE` 时记录每次 tool call 的名称、参数和执行耗时。
 
 **plugin.json：**
 
@@ -1266,6 +1266,7 @@ curl -X POST http://127.0.0.1:8088/api/pets \
 **tracing_plugin.py：**
 
 ```python
+import os
 import time
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable
@@ -1275,7 +1276,7 @@ from qwenpaw.plugins.api import PluginApi
 
 
 class TracingMiddleware(MiddlewareBase):
-    """Logs tool call name, arguments, and execution duration."""
+    """Logs tool call name, input, and execution duration."""
 
     def __init__(self, trace_file: Path) -> None:
         self._trace_file = trace_file
@@ -1289,7 +1290,7 @@ class TracingMiddleware(MiddlewareBase):
     ) -> AsyncGenerator[Any, None]:
         tool_call = input_kwargs["tool_call"]
         tool_name = getattr(tool_call, "name", str(tool_call))
-        tool_args = getattr(tool_call, "arguments", "")
+        tool_input = getattr(tool_call, "input", "")
 
         start = time.perf_counter()
         try:
@@ -1297,15 +1298,14 @@ class TracingMiddleware(MiddlewareBase):
                 yield item
         finally:
             elapsed_ms = (time.perf_counter() - start) * 1000
-            line = f"[{time.strftime('%H:%M:%S')}] {tool_name}({tool_args}) — {elapsed_ms:.1f}ms\n"
+            line = f"[{time.strftime('%H:%M:%S')}] {tool_name}({tool_input[:100]}) — {elapsed_ms:.1f}ms\n"
             with open(self._trace_file, "a", encoding="utf-8") as f:
                 f.write(line)
 
 
 def _tracing_factory(ctx: Any, agent_config: Any) -> TracingMiddleware | None:
-    """Create TracingMiddleware only when debug mode is enabled."""
-    running = getattr(agent_config, "running", None)
-    if running is None or not getattr(running, "debug", False):
+    """Create TracingMiddleware when QWENPAW_TRACE env var is set."""
+    if not os.environ.get("QWENPAW_TRACE"):
         return None
     workspace_dir = getattr(ctx, "workspace_dir", None)
     if workspace_dir is None:
@@ -1324,7 +1324,7 @@ plugin = TracingPlugin()
 
 **要点：**
 
-- **条件激活**：工厂函数检测 `agent_config.running.debug`，仅 debug 模式启用
+- **条件激活**：工厂函数检测环境变量 `QWENPAW_TRACE`，仅设置时启用
 - **`priority=50`**：比默认优先级更高（数值更小 = 更靠外层），确保 tracing 包裹其他 middleware
 - **`on_acting` 钩子**：在 tool call 执行前/后测量耗时
 - 完整源码参见 `plugins/middleware-demo/tracing-middleware/tracing_plugin.py`
@@ -1363,12 +1363,12 @@ import sys
 from typing import Any, AsyncGenerator, Callable
 
 from agentscope.middleware import MiddlewareBase
-from agentscope.message import TextBlock
+from agentscope.event import ThinkingBlockDeltaEvent, TextBlockDeltaEvent
 from qwenpaw.plugins.api import PluginApi
 
 
 class ThinkingLogMiddleware(MiddlewareBase):
-    """Prints each reasoning step to stdout with a [THINKING] prefix."""
+    """Prints reasoning stream events to stdout."""
 
     async def on_reasoning(
         self,
@@ -1376,16 +1376,12 @@ class ThinkingLogMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., AsyncGenerator[Any, None]],
     ) -> AsyncGenerator[Any, None]:
-        events = []
         async for item in next_handler():
-            events.append(item)
+            if isinstance(item, ThinkingBlockDeltaEvent):
+                print(f"[THINKING] {item.delta}", end="", file=sys.stdout, flush=True)
+            elif isinstance(item, TextBlockDeltaEvent):
+                print(f"[TEXT] {item.delta}", end="", file=sys.stdout, flush=True)
             yield item
-
-        for event in events:
-            if isinstance(event, TextBlock):
-                text = getattr(event, "text", str(event))
-                if text.strip():
-                    print(f"[THINKING] {text[:200]}", file=sys.stdout, flush=True)
 
 
 def _thinking_log_factory(ctx: Any, agent_config: Any) -> ThinkingLogMiddleware:
@@ -1404,8 +1400,8 @@ plugin = ThinkingLogPlugin()
 **要点：**
 
 - **无条件激活**：工厂始终返回实例，适用于所有请求
-- **`on_reasoning` 钩子**：在模型推理阶段捕获输出流
-- **先 yield 后处理**：将推理事件透传给下游后再打印，不阻塞流式响应
+- **`on_reasoning` 钩子**：在模型推理阶段捕获流式事件（`ThinkingBlockDeltaEvent` 为思维链，`TextBlockDeltaEvent` 为文本响应）
+- **实时打印**：每收到一个 delta 事件即打印，同时 yield 给下游，不阻塞流式响应
 - 完整源码参见 `plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py`
 
 ---
@@ -1683,7 +1679,7 @@ api.register_middleware(
 
 工厂在每次请求的 `AgentBuilder.build()` 阶段被调用，返回的 middleware 实例将被插入到 agent 的中间件链中。
 
-完整步骤见下文「示例 8」和「示例 9」。
+完整步骤见上文「示例 8」和「示例 9」。
 
 ## 高级功能
 

--- a/website/public/docs/plugins.zh.md
+++ b/website/public/docs/plugins.zh.md
@@ -7,6 +7,7 @@ QwenPaw 提供了插件系统，允许用户扩展 QwenPaw 的功能。
 插件系统支持以下扩展能力：
 
 - **Provider 插件**：添加新的 LLM Provider 和模型
+- **Middleware 插件**：注册 AgentScope `MiddlewareBase` 工厂，在 agent 推理循环中包裹 `on_acting` / `on_reasoning` 等钩子
 - **Hook 插件**：在应用启动/关闭时执行自定义代码（app 生命周期级别，仅执行一次）
 - **Command 插件**：注册自定义的 `/command` 魔法命令
 - **HTTP API 插件**：通过 FastAPI `APIRouter` 在 `/api` 下暴露自定义 REST 接口
@@ -95,27 +96,32 @@ my-plugin/
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "0.1.0",
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  },
   "meta": {}
 }
 ```
 
 #### 清单字段说明
 
-| 字段             | 类型            | 必填 | 说明                                                                                                                                             |
-| ---------------- | --------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `id`             | `string`        | 是   | 插件唯一标识，同时作为安装目录名，不能包含路径分隔符。                                                                                           |
-| `version`        | `string`        | 是   | 插件语义化版本号（例如 `1.0.0`）。                                                                                                               |
-| `name`           | `string` 或对象 | 否   | 显示名称，缺省取 `id`。也可写成 `{"zh-CN": "...", "en-US": "..."}`，运行时按"英文优先"的顺序取第一个非空值。                                     |
-| `type`           | `string`        | 否   | 取值之一：`tool`、`provider`、`hook`、`command`、`frontend`、`general`。省略时会按 `meta` / `entry` 推断（仅为兼容旧插件），新插件建议显式声明。 |
-| `description`    | `string` 或对象 | 否   | 插件列表里的简短描述，支持本地化对象形式（同 `name`）。                                                                                          |
-| `author`         | `string`        | 否   | 作者或组织名称。                                                                                                                                 |
-| `entry.backend`  | `string`        | 否\* | 相对插件目录的 Python 入口文件路径，需在其中导出 `plugin`。                                                                                      |
-| `entry.frontend` | `string`        | 否\* | 已构建的前端 bundle 路径（如 `dist/index.js`）。                                                                                                 |
-| `dependencies`   | `string[]`      | 否   | Python 依赖列表，安装时通过 pip / uv 自动安装。                                                                                                  |
-| `min_version`    | `string`        | 否   | 需要的最低 QwenPaw 版本，缺省 `0.1.0`。                                                                                                          |
-| `meta`           | `object`        | 否   | 自由元数据。前端 UI 与 `type` 推断都会读取（如 `meta.tools[]`、`meta.hook_type`、`meta.provider_id`）。                                          |
-| `entry_point`    | `string`        | 否   | **遗留字段。** 等价于 `entry.backend`，仅为兼容老插件保留，新插件请使用 `entry.backend`。                                                        |
+| 字段              | 类型            | 必填 | 说明                                                                                                                                              |
+| ----------------- | --------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | `string`        | 是   | 插件唯一标识，同时作为安装目录名，不能包含路径分隔符。                                                                                            |
+| `version`         | `string`        | 是   | 插件语义化版本号（例如 `1.0.0`）。                                                                                                                |
+| `name`            | `string` 或对象 | 否   | 显示名称，缺省取 `id`。也可写成 `{"zh-CN": "...", "en-US": "..."}`，运行时按"英文优先"的顺序取第一个非空值。                                      |
+| `type`            | `string`        | 否   | 取值之一：`tool`、`provider`、`hook`、`command`、`frontend`、`general`。省略时会按 `meta` / `entry` 推断（仅为兼容旧插件），新插件建议显式声明。  |
+| `description`     | `string` 或对象 | 否   | 插件列表里的简短描述，支持本地化对象形式（同 `name`）。                                                                                           |
+| `author`          | `string`        | 否   | 作者或组织名称。                                                                                                                                  |
+| `entry.backend`   | `string`        | 否\* | 相对插件目录的 Python 入口文件路径，需在其中导出 `plugin`。                                                                                       |
+| `entry.frontend`  | `string`        | 否\* | 已构建的前端 bundle 路径（如 `dist/index.js`）。                                                                                                  |
+| `dependencies`    | `string[]`      | 否   | Python 依赖列表，安装时通过 pip / uv 自动安装。                                                                                                   |
+| `qwenpaw_version` | `object`        | 否   | QwenPaw 版本约束（推荐）。包含 `min`（包含）和 `max`（不包含，可选）两个子字段，语义为 `>=min, <max`。省略 `max` 时默认取 `{major}.{minor+1}.0`。 |
+| `min_version`     | `string`        | 否   | **遗留字段。** 需要的最低 QwenPaw 版本。当 `qwenpaw_version` 存在时被忽略，仅为兼容第三方旧插件保留。                                             |
+| `max_version`     | `string`        | 否   | **遗留字段。** 不兼容的第一个 QwenPaw 版本（不包含）。配合 `min_version` 使用；省略时从 `min_version` 推导。                                      |
+| `meta`            | `object`        | 否   | 自由元数据。前端 UI 与 `type` 推断都会读取（如 `meta.tools[]`、`meta.hook_type`、`meta.provider_id`）。                                           |
+| `entry_point`     | `string`        | 否   | **遗留字段。** 等价于 `entry.backend`，仅为兼容老插件保留，新插件请使用 `entry.backend`。                                                         |
 
 \* `entry.backend`、`entry.frontend`（或遗留 `entry_point`）至少需要提供其中之一。
 
@@ -669,7 +675,10 @@ cd my-llm-provider
     "backend": "plugin.py"
   },
   "dependencies": ["httpx>=0.24.0"],
-  "min_version": "0.1.0",
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  },
   "meta": {
     "api_key_url": "https://example.com/get-api-key",
     "api_key_hint": "Get your API key from example.com"
@@ -807,7 +816,10 @@ cd monitoring-hook
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "0.1.0"
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
 }
 ```
 
@@ -897,7 +909,10 @@ cd status-command
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "0.1.0"
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
 }
 ```
 
@@ -1093,7 +1108,10 @@ mkdir pet-api-plugin && cd pet-api-plugin
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "1.1.5"
+  "qwenpaw_version": {
+    "min": "1.1.5",
+    "max": "2.1.0"
+  }
 }
 ```
 
@@ -1219,6 +1237,178 @@ curl -X POST http://127.0.0.1:8088/api/pets \
 - 每个前缀只能被一个插件占用；重复注册相同前缀会抛出 `ValueError`。
 - `tags` 可选；省略时路由在 OpenAPI 中会默认打上 `plugin:<插件 id>` 标签。
 - 插件卸载或禁用时会自动卸载对应路由。
+
+### 示例 8：Tracing Middleware（工具调用追踪）
+
+本示例展示如何注册一个 `on_acting` middleware，在 debug 模式下记录每次 tool call 的名称、参数和执行耗时。
+
+**plugin.json：**
+
+```json
+{
+  "id": "middleware-demo-tracing",
+  "name": "Tracing Middleware Demo",
+  "version": "1.0.0",
+  "description": "Demo: logs tool calls with execution timing to a trace file",
+  "author": "QwenPaw Team",
+  "type": "general",
+  "entry": {
+    "backend": "tracing_plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
+}
+```
+
+**tracing_plugin.py：**
+
+```python
+import time
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+from qwenpaw.plugins.api import PluginApi
+
+
+class TracingMiddleware(MiddlewareBase):
+    """Logs tool call name, arguments, and execution duration."""
+
+    def __init__(self, trace_file: Path) -> None:
+        self._trace_file = trace_file
+        self._trace_file.parent.mkdir(parents=True, exist_ok=True)
+
+    async def on_acting(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        tool_call = input_kwargs["tool_call"]
+        tool_name = getattr(tool_call, "name", str(tool_call))
+        tool_args = getattr(tool_call, "arguments", "")
+
+        start = time.perf_counter()
+        try:
+            async for item in next_handler():
+                yield item
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            line = f"[{time.strftime('%H:%M:%S')}] {tool_name}({tool_args}) — {elapsed_ms:.1f}ms\n"
+            with open(self._trace_file, "a", encoding="utf-8") as f:
+                f.write(line)
+
+
+def _tracing_factory(ctx: Any, agent_config: Any) -> TracingMiddleware | None:
+    """Create TracingMiddleware only when debug mode is enabled."""
+    running = getattr(agent_config, "running", None)
+    if running is None or not getattr(running, "debug", False):
+        return None
+    workspace_dir = getattr(ctx, "workspace_dir", None)
+    if workspace_dir is None:
+        return None
+    trace_file = Path(workspace_dir) / ".qwenpaw" / "trace.log"
+    return TracingMiddleware(trace_file=trace_file)
+
+
+class TracingPlugin:
+    def register(self, api: PluginApi) -> None:
+        api.register_middleware(_tracing_factory, priority=50)
+
+
+plugin = TracingPlugin()
+```
+
+**要点：**
+
+- **条件激活**：工厂函数检测 `agent_config.running.debug`，仅 debug 模式启用
+- **`priority=50`**：比默认优先级更高（数值更小 = 更靠外层），确保 tracing 包裹其他 middleware
+- **`on_acting` 钩子**：在 tool call 执行前/后测量耗时
+- 完整源码参见 `plugins/middleware-demo/tracing-middleware/tracing_plugin.py`
+
+---
+
+### 示例 9：Thinking Log Middleware（推理过程日志）
+
+本示例展示如何注册一个 `on_reasoning` middleware，捕获并打印模型的思维链。
+
+**plugin.json：**
+
+```json
+{
+  "id": "middleware-demo-thinking-log",
+  "name": "Thinking Log Middleware Demo",
+  "version": "1.0.0",
+  "description": "Demo: prints model reasoning steps to stdout",
+  "author": "QwenPaw Team",
+  "type": "general",
+  "entry": {
+    "backend": "thinking_log_plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "1.0.0",
+    "max": "2.1.0"
+  }
+}
+```
+
+**thinking_log_plugin.py：**
+
+```python
+import sys
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+from agentscope.message import TextBlock
+from qwenpaw.plugins.api import PluginApi
+
+
+class ThinkingLogMiddleware(MiddlewareBase):
+    """Prints each reasoning step to stdout with a [THINKING] prefix."""
+
+    async def on_reasoning(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        events = []
+        async for item in next_handler():
+            events.append(item)
+            yield item
+
+        for event in events:
+            if isinstance(event, TextBlock):
+                text = getattr(event, "text", str(event))
+                if text.strip():
+                    print(f"[THINKING] {text[:200]}", file=sys.stdout, flush=True)
+
+
+def _thinking_log_factory(ctx: Any, agent_config: Any) -> ThinkingLogMiddleware:
+    """Always create the middleware (unconditional activation)."""
+    return ThinkingLogMiddleware()
+
+
+class ThinkingLogPlugin:
+    def register(self, api: PluginApi) -> None:
+        api.register_middleware(_thinking_log_factory, priority=80)
+
+
+plugin = ThinkingLogPlugin()
+```
+
+**要点：**
+
+- **无条件激活**：工厂始终返回实例，适用于所有请求
+- **`on_reasoning` 钩子**：在模型推理阶段捕获输出流
+- **先 yield 后处理**：将推理事件透传给下游后再打印，不阻塞流式响应
+- 完整源码参见 `plugins/middleware-demo/thinking-log-middleware/thinking_log_plugin.py`
+
+---
 
 ## 依赖管理
 
@@ -1356,7 +1546,7 @@ api.register_startup_hook("late", callback, priority=200)
 1. **只安装可信插件**：插件代码会在 QwenPaw 进程中执行
 2. **检查依赖**：确保插件依赖来自可信源
 3. **审查代码**：安装前审查插件源代码
-4. **离线操作**：插件安装/卸载需要 QwenPaw 离线
+4. **热加载注意**：当前版本支持运行中通过 API 热安装/热卸载插件，无需重启。请注意热加载时的状态一致性
 
 ## PluginApi 参考
 
@@ -1473,32 +1663,39 @@ config = api.get_tool_config(tool_name: str, agent_id: str)  # 返回 dict
 api.set_tool_config(tool_name: str, agent_id: str, config: dict)
 ```
 
-## 高级功能
+### register_middleware
 
-### 自定义命令
-
-在 2.0 中，推荐通过 `api.register_control_command()` 添加自定义 `/slash` 命令，取代旧版的 monkey patching 方式：
+注册 AgentScope `MiddlewareBase` 工厂。
 
 ```python
-from qwenpaw.runtime.commands.control.base import BaseControlCommandHandler
-
-class MyCommandHandler(BaseControlCommandHandler):
-    command_name = "mycommand"
-    help_text = "Description of my command"
-
-    async def handle(self, ctx, args: str):
-        from agentscope.message import Msg
-        return Msg(
-            name="system",
-            role="assistant",
-            content="Command result here.",
-        )
-
-api.register_control_command(
-    handler=MyCommandHandler(),
-    priority_level=10,
+api.register_middleware(
+    middleware_factory: Callable,   # 工厂函数
+    *,
+    priority: int = 100,           # 优先级（越低越靠外层）
 )
 ```
+
+工厂函数签名：`(ctx: HookContext, agent_config: AgentProfileConfig) -> MiddlewareBase | None`
+
+- `ctx` 包含 `session_id`、`agent_id`、`workspace_dir` 等请求级上下文
+- 返回 `None` 表示本次请求跳过该 middleware
+- `priority` 越小越先进入洋葱模型（即越靠外层）
+
+工厂在每次请求的 `AgentBuilder.build()` 阶段被调用，返回的 middleware 实例将被插入到 agent 的中间件链中。
+
+完整步骤见下文「示例 8」和「示例 9」。
+
+## 高级功能
+
+### 修改 Agent 行为
+
+如需拦截或增强 agent 的请求处理，推荐以下方式：
+
+- **增强 agent 推理循环**：使用 `register_middleware` 注册 AgentScope middleware（`on_acting` / `on_reasoning` 钩子）
+- **拦截特定命令**：使用 `register_control_command` 注册自定义命令处理器
+- **在请求生命周期中注入逻辑**：使用 `HookRegistry`（8 阶段 hook）
+
+当前请求流程为 `Runtime.run()` → `AgentBuilder.build()` → `AgentExecutor.run()`。
 
 ### 访问运行时信息
 
@@ -1535,13 +1732,15 @@ qwenpaw plugin install https://example.com/my-plugin-1.0.0.zip
 A: 插件通过 `PluginApi` 访问核心功能，包括：
 
 - Provider 注册
+- Middleware 注册（`register_middleware`）
 - Hook 注册
+- 自定义命令注册（`register_control_command`）
 - HTTP 路由注册（`register_http_router`）
 - Runtime helpers（provider_manager 等）
 
 ### Q: 插件可以修改 QwenPaw 的核心行为吗？
 
-A: 可以，通过 `register_control_command`、`register_tool`、runtime hooks 和其他 PluginApi 方法。请谨慎使用，确保不会破坏核心功能。
+A: 可以，通过 `register_middleware`（注入 AgentScope middleware）、`register_control_command`、`register_tool`、runtime hooks 和其他 PluginApi 方法。请谨慎使用，确保不会破坏核心功能。
 
 ### Q: 插件之间会冲突吗？
 


### PR DESCRIPTION
## Description

Add plugin-based middleware registration mechanism, enabling plugins to inject `MiddlewareBase` factories into the agent reasoning loop via `PluginApi.register_middleware()`. Also introduces structured version constraints (`qwenpaw_version` field with left-closed, right-open interval semantics) replacing the legacy `min_version` field, and includes two demo plugins showcasing the new capability.

**Key changes:**
- `PluginApi.register_middleware(factory, priority=N)` — new API for plugins to register middleware factories
- `PluginRegistry` stores and sorts middleware registrations; `AgentBuilder._build_middlewares()` consumes them
- `QwenPawVersionConstraint` model + `_version_compat.py` — version compatibility check with `[min, max)` semantics
- `PluginLoader` refactored: version check gate + extracted helper methods (`_validate_entry_points`, `_load_backend_module`)
- All bundled `plugin.json` files migrated from `min_version` to `qwenpaw_version`
- Two demo middleware plugins: `tracing-middleware` (`on_acting`, activated via `QWENPAW_TRACE` env var) and `thinking-log-middleware` (`on_reasoning`, always active)
- Documentation updated to reflect middleware plugin type, new versioning, `register_middleware` API reference, and runtime refactoring corrections

**Related Issue:** N/A

**Security Considerations:** Plugin middleware factories execute in the QwenPaw process with full access. Documentation updated to note hot-loading awareness.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. **Middleware registration** — install demo plugins and verify both hooks fire:
   ```bash
   qwenpaw plugin install plugins/middleware-demo/thinking-log-middleware
   qwenpaw plugin install plugins/middleware-demo/tracing-middleware
   QWENPAW_TRACE=1 qwenpaw app
   # Send a message → observe [TEXT] stream in stdout + trace.log in workspace
   ```

2. **Version constraint enforcement** — modify a plugin's `qwenpaw_version.max` to a version lower than current, attempt to load it, and verify it is marked as incompatible (`enabled=False`, diagnostics populated).

3. **Backward compatibility** — a plugin with only `min_version` (no `qwenpaw_version`) should still load correctly via the legacy fallback path.

## Local Verification Evidence

```bash
pre-commit run --all-files
# all checks passed (check-ast, black, flake8, pylint, mypy, etc.)

# thinking-log-middleware output (stdout):
[TEXT] I [TEXT] noticed [TEXT] that [TEXT] today's [TEXT] date is June 17, 2026...

# tracing-middleware output (trace.log):
[10:35:55] browser_use({"action": "open", "url": "..."}) — 5764.8ms
[10:35:56] browser_use({"action": "snapshot"}) — 45.3ms
```

## Additional Notes

- Legacy `min_version` field remains supported in the loader for third-party plugins but is no longer used in bundled plugin manifests.
- The `AgentRunner` monkey-patch pattern documented previously has been removed from docs as that class no longer exists after the runtime refactoring.
- `tracing-middleware` is gated by `QWENPAW_TRACE` env var (not a config field) for simplicity; `thinking-log-middleware` is always active.