### PR TITLE
fix(config): ensure deep copy of cached agent configurations

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2022,7 +2022,7 @@ def load_agent_config(  # pylint: disable=too-many-branches,too-many-statements
         if agent_id in _agent_config_cache:
             cached_config, cached_mtime = _agent_config_cache[agent_id]
             if cached_mtime == current_mtime:
-                return cached_config
+                return cached_config.model_copy(deep=True)
 
         # Need to reload config from disk
         with open(agent_config_path, "r", encoding="utf-8") as f:
@@ -2099,7 +2099,7 @@ def load_agent_config(  # pylint: disable=too-many-branches,too-many-statements
         # Cache the config with its mtime
         _agent_config_cache[agent_id] = (agent_config, current_mtime)
 
-        return agent_config
+        return agent_config.model_copy(deep=True)
 
 
 def save_agent_config(


### PR DESCRIPTION
- Modified cached config return to use model_copy(deep=True) instead of direct reference
- Updated both cache hit and reload paths to prevent shared mutable state
- Ensured configuration objects are properly isolated between different agent instances

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
