### PR TITLE
fix(compaction): add timeout protection to agent.reply() in _compact_context

### DIFF
--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-nested-blocks,too-many-branches
 # pylint: disable=too-many-return-statements,too-many-statements
 """Context manager for agents with compaction support."""
+import asyncio
 import logging
 import os
 import sys
@@ -523,12 +524,15 @@ class LightContextManager(BaseContextManager):
             f"user_message={user_message[:500]}...",
         )
 
-        compact_msg: Msg = await agent.reply(
-            Msg(
-                name="compactor",
-                role="user",
-                content=user_message,
+        compact_msg: Msg = await asyncio.wait_for(
+            agent.reply(
+                Msg(
+                    name="compactor",
+                    role="user",
+                    content=user_message,
+                ),
             ),
+            timeout=120,
         )
 
         history_compact: str = compact_msg.get_text_content() or ""

--- a/src/qwenpaw/agents/context/light_context_manager.py
+++ b/src/qwenpaw/agents/context/light_context_manager.py
@@ -412,6 +412,7 @@ class LightContextManager(BaseContextManager):
         max_input_length: int = 100000,
         compact_ratio: float = 0.5,
         add_thinking_block: bool = True,
+        compact_timeout: int = 120,
         **_kwargs,
     ) -> dict:
         """Compact messages into a condensed summary.
@@ -532,7 +533,7 @@ class LightContextManager(BaseContextManager):
                     content=user_message,
                 ),
             ),
-            timeout=120,
+            timeout=compact_timeout,
         )
 
         history_compact: str = compact_msg.get_text_content() or ""
@@ -584,6 +585,7 @@ class LightContextManager(BaseContextManager):
         max_input_length: int = 100000,
         compact_ratio: float = 0.5,
         add_thinking_block: bool = True,
+        compact_timeout: int = 120,
         **_kwargs,
     ) -> dict:
         """Safe wrapper for _compact_context with fallback on failure.
@@ -606,8 +608,23 @@ class LightContextManager(BaseContextManager):
                 max_input_length=max_input_length,
                 compact_ratio=compact_ratio,
                 add_thinking_block=add_thinking_block,
+                compact_timeout=compact_timeout,
                 **_kwargs,
             )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Context compaction timed out after %ss",
+                compact_timeout,
+            )
+            return {
+                "success": False,
+                "reason": f"timeout after {compact_timeout}s",
+                "user_message": "",
+                "history_compact": "",
+                "is_valid": False,
+                "before_tokens": 0,
+                "after_tokens": 0,
+            }
         except Exception as e:
             logger.exception("Context compaction failed: %s", e)
             return {
@@ -655,6 +672,7 @@ class LightContextManager(BaseContextManager):
             max_input_length=max_input_length,
             compact_ratio=ccc.compact_threshold_ratio,
             add_thinking_block=ccc.compact_with_thinking_block,
+            compact_timeout=ccc.compact_timeout,
         )
         return {
             "success": result.get("success", False),

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -154,7 +154,7 @@ class DispatchSpec(BaseModel):
 class JobRuntimeSpec(BaseModel):
     max_concurrency: int = Field(default=1, ge=1)
     timeout_seconds: int = Field(default=120, ge=1)
-    misfire_grace_seconds: int = Field(default=60, ge=0)
+    misfire_grace_seconds: int = Field(default=3600, ge=0)
     share_session: bool = Field(
         default=True,
         description=(

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -154,7 +154,7 @@ class DispatchSpec(BaseModel):
 class JobRuntimeSpec(BaseModel):
     max_concurrency: int = Field(default=1, ge=1)
     timeout_seconds: int = Field(default=120, ge=1)
-    misfire_grace_seconds: int = Field(default=3600, ge=0)
+    misfire_grace_seconds: int = Field(default=60, ge=0)
     share_session: bool = Field(
         default=True,
         description=(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -720,6 +720,16 @@ class ContextCompactConfig(BaseModel):
         description="Whether to include thinking blocks when compacting",
     )
 
+    compact_timeout: int = Field(
+        default=120,
+        ge=30,
+        le=600,
+        description=(
+            "Timeout in seconds for the compaction LLM call. "
+            "If the model takes longer, compaction is aborted gracefully."
+        ),
+    )
+
 
 class ToolResultPruningConfig(BaseModel):
     """Tool result pruning configuration."""


### PR DESCRIPTION
## Description

Add timeout protection to the `agent.reply()` call inside `_compact_context()` in `light_context_manager.py`. When the LLM API call hangs due to network issues, rate limiter contention, or slow model responses, the entire QwenPaw process freezes because `agent.reply()` has no timeout protection.

### Root Cause

In `_compact_context()`, a `ReActAgent` is created on-the-fly to generate a summary. The `await agent.reply(...)` call had no timeout — if the model API blocks indefinitely under the global `LLMRateLimiter(max_concurrent=1)`, the compaction hangs forever, cascading to freeze all agents sharing the same provider.

### Fix

Wrap `agent.reply()` with `asyncio.wait_for(timeout=120)`. On timeout:
- `asyncio.TimeoutError` is raised
- Caught by `_compact_context_safe()` existing `except Exception` handler
- Returns safe fallback with `success=False`
- Agent continues without compaction rather than freezing

**Related Issue:** Relates to #5218

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agent, runtime)
- [ ] Console / Frontend (web, terminal, desktop)
- [ ] Channels (Feishu, DingTalk, Slack, Matrix, etc.)
- [ ] Integration / MCP / Plugins
- [ ] Documentation
- [ ] Tests / CI / Build
- [ ] Other (please specify)

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and fixed all issues
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (or explained why tests are not feasible)
- [x] My code follows the style guidelines of this project
