### PR TITLE
fix(console): keep empty dream_cron empty to disable dream job

### DIFF
--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
@@ -57,6 +57,7 @@ export function ReMeLightMemoryCard() {
         label={t("agentConfig.dreamCron")}
         name={["reme_light_memory_config", "dream_cron"]}
         tooltip={t("agentConfig.dreamCronTooltip")}
+        normalize={(value) => value ?? ""}
       >
         <Input placeholder={t("agentConfig.dreamCronPlaceholder")} />
       </Form.Item>


### PR DESCRIPTION
## Description

Fix the `dream_cron` field in the Console ReMeLight memory config: ensure an empty value reliably reaches the backend when the user clears the field to disable the dream memory optimization job.

Previously, clearing the field could yield `undefined`. After passing through `deepMergeConfig`, the backend's Pydantic model falls back to the default cron (`0 23 * * *`), **silently re-enabling** the dream job. This PR normalizes the cleared value to `""` via `normalize={(value) => value ?? ""}`, so the backend's `if dream_cron:` check correctly treats it as disabled.

**Related Issue:** N/A

**Security Considerations:** None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Go to Agent Config → ReMeLight Memory card
2. Clear the "Dream Cron" input and save
3. Confirm the backend receives `dream_cron: ""` and the dream memory optimization job is disabled (not scheduled; no "Dream-based memory optimization job scheduled" log line)
4. Re-enter a valid cron expression and save, confirm the job is scheduled again

## Additional Notes

The backend logic (`if dream_cron:` at `src/qwenpaw/app/crons/manager.py:124`) already supports disabling via an empty value; this PR only fixes the frontend dropping the empty value on clear.

Want me to create the PR with gh? Branch sen/dream, commit f34a0711. Note I left the pre-commit/pytest checklist items unchecked since they haven't been fully run locally—check them off if you have.
