### PR TITLE
feat: add agent avatar upload and display

### DIFF
--- a/console/src/api/modules/agents.ts
+++ b/console/src/api/modules/agents.ts
@@ -1,4 +1,5 @@
 import { request } from "../request";
+import { getApiUrl } from "../config";
 import type {
   AgentListResponse,
   AgentProfileConfig,
@@ -52,4 +53,20 @@ export const agentsApi = {
         body: JSON.stringify({ enabled }),
       },
     ),
+
+  // Upload agent avatar
+  uploadAvatar: (agentId: string, file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    return request<{ success: boolean; avatar_url: string }>(
+      `/agents/${agentId}/avatar`,
+      {
+        method: "POST",
+        body: formData,
+      },
+    );
+  },
+
+  // Get agent avatar URL (full URL with API prefix)
+  getAvatarUrl: (agentId: string) => getApiUrl(`/agents/${agentId}/avatar`),
 };

--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -43,6 +43,7 @@ function buildHeaders(method?: string, extra?: HeadersInit): Headers {
   // Only add Content-Type for methods that typically have a body
   if (method && ["POST", "PUT", "PATCH"].includes(method.toUpperCase())) {
     // Don't override if caller explicitly set Content-Type
+    // Also skip for FormData — the browser sets the correct multipart boundary
     if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "application/json");
     }
@@ -63,7 +64,13 @@ export async function request<T = unknown>(
 ): Promise<T> {
   const url = getApiUrl(path);
   const method = options.method || "GET";
+  const isFormData = options.body instanceof FormData;
   const headers = buildHeaders(method, options.headers);
+
+  // Let the browser set the correct multipart boundary for FormData
+  if (isFormData) {
+    headers.delete("Content-Type");
+  }
 
   const response = await fetch(url, {
     ...options,

--- a/console/src/api/types/agents.ts
+++ b/console/src/api/types/agents.ts
@@ -6,6 +6,7 @@ export interface AgentSummary {
   id: string;
   name: string;
   description: string;
+  avatar_url: string;
   workspace_dir: string;
   enabled: boolean;
   active_model?: ModelSlotConfig | null;
@@ -24,6 +25,7 @@ export interface AgentProfileConfig {
   id: string;
   name: string;
   description?: string;
+  avatar_url?: string;
   workspace_dir?: string;
   approval_level?: string;
   active_model?: ModelSlotConfig | null;

--- a/console/src/components/AgentAvatar/index.tsx
+++ b/console/src/components/AgentAvatar/index.tsx
@@ -1,0 +1,45 @@
+import { RobotOutlined } from "@ant-design/icons";
+import { getApiUrl } from "../../api/config";
+
+interface AgentAvatarProps {
+  avatarUrl?: string;
+  size?: number;
+  opacity?: number;
+}
+
+/**
+ * Renders an agent avatar image or a fallback robot icon.
+ * Automatically wraps avatar_url with the API prefix.
+ */
+export function AgentAvatar({
+  avatarUrl,
+  size = 24,
+  opacity = 1,
+}: AgentAvatarProps) {
+  if (avatarUrl) {
+    return (
+      <img
+        src={getApiUrl(avatarUrl)}
+        alt=""
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          objectFit: "cover",
+          opacity,
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  return (
+    <RobotOutlined
+      style={{
+        fontSize: size * 0.67,
+        opacity: opacity * 0.85,
+        flexShrink: 0,
+      }}
+    />
+  );
+}

--- a/console/src/components/AgentAvatar/index.tsx
+++ b/console/src/components/AgentAvatar/index.tsx
@@ -10,6 +10,7 @@ interface AgentAvatarProps {
 /**
  * Renders an agent avatar image or a fallback robot icon.
  * Automatically wraps avatar_url with the API prefix.
+ * Adds cache-busting timestamp to prevent stale images.
  */
 export function AgentAvatar({
   avatarUrl,
@@ -17,9 +18,10 @@ export function AgentAvatar({
   opacity = 1,
 }: AgentAvatarProps) {
   if (avatarUrl) {
+    const cacheBustUrl = `${getApiUrl(avatarUrl)}?t=${Date.now()}`;
     return (
       <img
-        src={getApiUrl(avatarUrl)}
+        src={cacheBustUrl}
         alt=""
         style={{
           width: size,

--- a/console/src/components/AgentSelector/index.module.less
+++ b/console/src/components/AgentSelector/index.module.less
@@ -262,6 +262,21 @@
     color: #f07e26;
     box-shadow: 0 2px 6px rgba(240, 126, 38, 0.15);
   }
+
+  // When avatar image is present, remove background/border
+  &:has(img) {
+    background: none;
+    border: none;
+    border-radius: 50%;
+    padding: 0;
+    box-shadow: none !important;
+
+    .agentOption:hover & {
+      background: none;
+      border: none;
+      box-shadow: none !important;
+    }
+  }
 }
 
 .agentOptionContent {
@@ -454,6 +469,20 @@
       border-color: rgba(245, 160, 90, 0.4);
       color: #f5b87a;
       box-shadow: 0 2px 8px rgba(240, 126, 38, 0.3);
+    }
+
+    // When avatar image is present, remove background/border
+    &:has(img) {
+      background: none;
+      border: none;
+      border-radius: 50%;
+      box-shadow: none !important;
+
+      .agentOption:hover & {
+        background: none;
+        border: none;
+        box-shadow: none !important;
+      }
     }
   }
 

--- a/console/src/components/AgentSelector/index.tsx
+++ b/console/src/components/AgentSelector/index.tsx
@@ -1,9 +1,10 @@
 import { Select, Tag, Tooltip } from "antd";
 import { useEffect, useState } from "react";
-import { Bot, CheckCircle, EyeOff, ChevronRight } from "lucide-react";
+import { CheckCircle, EyeOff, ChevronRight } from "lucide-react";
 import { SparkDownLine, SparkUpLine } from "@agentscope-ai/icons";
 import { useAgentStore } from "../../stores/agentStore";
 import { agentsApi } from "../../api/modules/agents";
+import { AgentAvatar } from "../AgentAvatar";
 import { useTranslation } from "react-i18next";
 import { getAgentDisplayName } from "../../utils/agentDisplayName";
 import { useNavigate } from "react-router-dom";
@@ -96,7 +97,7 @@ export default function AgentSelector({
         overlayInnerStyle={{ background: "rgba(0,0,0,0.75)", color: "#fff" }}
       >
         <div className={styles.agentSelectorCollapsed}>
-          <Bot size={18} strokeWidth={2} />
+          <AgentAvatar avatarUrl={currentAgentInfo?.avatar_url} size={24} />
         </div>
       </Tooltip>
     );
@@ -149,7 +150,7 @@ export default function AgentSelector({
             disabled={!agent.enabled}
             label={
               <div className={styles.selectedAgentLabel}>
-                <Bot size={14} strokeWidth={2} />
+                <AgentAvatar avatarUrl={agent.avatar_url} size={18} />
                 <span>{getAgentDisplayName(agent, t)}</span>
                 {!agent.enabled && <EyeOff size={12} strokeWidth={2} />}
               </div>
@@ -161,7 +162,7 @@ export default function AgentSelector({
             >
               <div className={styles.agentOptionHeader}>
                 <div className={styles.agentOptionIcon}>
-                  <Bot size={16} strokeWidth={2} />
+                  <AgentAvatar avatarUrl={agent.avatar_url} size={30} />
                 </div>
                 <div className={styles.agentOptionContent}>
                   <div className={styles.agentOptionName}>

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -464,7 +464,10 @@
     "modelHelp": "Assign a specific LLM model to this agent. Leave empty to use the global default.",
     "modelPlaceholder": "Use global default",
     "noConfiguredModels": "No configured models",
-    "modelColumn": "Model"
+    "modelColumn": "Model",
+    "avatar": "Avatar",
+    "uploadAvatar": "Upload Avatar",
+    "previewAvatar": "Preview"
   },
   "skills": {
     "title": "Skills",
@@ -1438,7 +1441,7 @@
     "goConfigureBtn": "Configure a Provider",
     "availableGroup": "Available Providers",
     "clickToConfigure": "Click to configure",
-    "configureAction": "Configure \u2192",
+    "configureAction": "Configure →",
     "endpointCount": "{{count}} endpoints",
     "connect": "OAuth",
     "saveApiKey": "Save",

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -467,7 +467,8 @@
     "modelColumn": "Model",
     "avatar": "Avatar",
     "uploadAvatar": "Upload Avatar",
-    "previewAvatar": "Preview"
+    "previewAvatar": "Preview",
+    "uploadAvatarFailed": "Failed to upload avatar"
   },
   "skills": {
     "title": "Skills",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -302,7 +302,8 @@
     "modelColumn": "Model",
     "avatar": "Avatar",
     "uploadAvatar": "Unggah Avatar",
-    "previewAvatar": "Pratinjau"
+    "previewAvatar": "Pratinjau",
+    "uploadAvatarFailed": "Gagal mengunggah avatar"
   },
   "skills": {
     "title": "Skill",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -299,7 +299,10 @@
     "modelHelp": "Tetapkan model LLM khusus untuk agen ini. Kosongkan untuk memakai default global.",
     "modelPlaceholder": "Gunakan default global",
     "noConfiguredModels": "Tidak ada model yang dikonfigurasi",
-    "modelColumn": "Model"
+    "modelColumn": "Model",
+    "avatar": "Avatar",
+    "uploadAvatar": "Unggah Avatar",
+    "previewAvatar": "Pratinjau"
   },
   "skills": {
     "title": "Skill",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -161,7 +161,8 @@
     "addSkillsToAgent": "スキルを追加",
     "avatar": "アバター",
     "uploadAvatar": "アバターをアップロード",
-    "previewAvatar": "プレビュー"
+    "previewAvatar": "プレビュー",
+    "uploadAvatarFailed": "アバターのアップロードに失敗しました"
   },
   "workspace": {
     "title": "ファイル",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -158,7 +158,10 @@
     "selectBuiltin": "組み込み",
     "selectNone": "クリア",
     "noPoolSkills": "プールに利用可能なスキルがありません",
-    "addSkillsToAgent": "スキルを追加"
+    "addSkillsToAgent": "スキルを追加",
+    "avatar": "アバター",
+    "uploadAvatar": "アバターをアップロード",
+    "previewAvatar": "プレビュー"
   },
   "workspace": {
     "title": "ファイル",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -382,7 +382,10 @@
     "modelHelp": "Assign a specific LLM model to this agent. Leave empty to use the global default.",
     "modelPlaceholder": "Use global Padrao",
     "noConfiguredModels": "Nao configured Modelos",
-    "modelColumn": "Modelo"
+    "modelColumn": "Modelo",
+    "avatar": "Avatar",
+    "uploadAvatar": "Enviar Avatar",
+    "previewAvatar": "Visualizar"
   },
   "skills": {
     "title": "Skills",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -385,7 +385,8 @@
     "modelColumn": "Modelo",
     "avatar": "Avatar",
     "uploadAvatar": "Enviar Avatar",
-    "previewAvatar": "Visualizar"
+    "previewAvatar": "Visualizar",
+    "uploadAvatarFailed": "Falha ao enviar avatar"
   },
   "skills": {
     "title": "Skills",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -158,7 +158,10 @@
     "selectBuiltin": "Встроенные",
     "selectNone": "Очистить",
     "noPoolSkills": "В пуле нет доступных навыков",
-    "addSkillsToAgent": "Добавить навыки"
+    "addSkillsToAgent": "Добавить навыки",
+    "avatar": "Аватар",
+    "uploadAvatar": "Загрузить аватар",
+    "previewAvatar": "Просмотр"
   },
   "workspace": {
     "title": "Файлы",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -161,7 +161,8 @@
     "addSkillsToAgent": "Добавить навыки",
     "avatar": "Аватар",
     "uploadAvatar": "Загрузить аватар",
-    "previewAvatar": "Просмотр"
+    "previewAvatar": "Просмотр",
+    "uploadAvatarFailed": "Не удалось загрузить аватар"
   },
   "workspace": {
     "title": "Файлы",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -398,7 +398,10 @@
     "defaultDisplayName": "Agent mặc định",
     "currentWorkspace": "Agent hiện tại",
     "switchSuccess": "Đã chuyển agent thành công",
-    "switchFailed": "Chuyển agent thất bại"
+    "switchFailed": "Chuyển agent thất bại",
+    "avatar": "Ảnh đại diện",
+    "uploadAvatar": "Tải ảnh đại diện",
+    "previewAvatar": "Xem trước"
   },
   "environments": {
     "parent": "Cài đặt",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -401,7 +401,8 @@
     "switchFailed": "Chuyển agent thất bại",
     "avatar": "Ảnh đại diện",
     "uploadAvatar": "Tải ảnh đại diện",
-    "previewAvatar": "Xem trước"
+    "previewAvatar": "Xem trước",
+    "uploadAvatarFailed": "Tải ảnh đại diện thất bại"
   },
   "environments": {
     "parent": "Cài đặt",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -267,7 +267,10 @@
     "modelHelp": "为此智能体指定特定的 LLM 模型。留空则使用全局默认模型。",
     "modelPlaceholder": "使用全局默认",
     "noConfiguredModels": "暂无已配置的模型",
-    "modelColumn": "模型"
+    "modelColumn": "模型",
+    "avatar": "头像",
+    "uploadAvatar": "上传头像",
+    "previewAvatar": "预览"
   },
   "acp": {
     "title": "ACP",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -270,7 +270,8 @@
     "modelColumn": "模型",
     "avatar": "头像",
     "uploadAvatar": "上传头像",
-    "previewAvatar": "预览"
+    "previewAvatar": "预览",
+    "uploadAvatarFailed": "头像上传失败"
   },
   "acp": {
     "title": "ACP",

--- a/console/src/pages/Settings/Agents/components/AgentModal.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentModal.tsx
@@ -9,8 +9,14 @@ import {
   Typography,
   Empty,
   Spin,
+  Upload,
+  Image,
 } from "antd";
-import { CheckOutlined } from "@ant-design/icons";
+import {
+  CheckOutlined,
+  UploadOutlined,
+  RobotOutlined,
+} from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 import type { AgentSummary } from "@/api/types/agents";
 import type { ProviderInfo } from "@/api/types/provider";
@@ -18,6 +24,9 @@ import { getAgentDisplayName } from "@/utils/agentDisplayName";
 import type { PoolSkillSpec } from "@/api/types/skill";
 import { skillApi } from "@/api/modules/skill";
 import { providerApi } from "@/api/modules/provider";
+import { agentsApi } from "@/api/modules/agents";
+import { getApiUrl } from "@/api/config";
+import { useTheme } from "@/contexts/ThemeContext";
 import { providerIcon } from "../../Models/components/providerIcon";
 import styles from "../index.module.less";
 
@@ -51,11 +60,15 @@ export function AgentModal({
   onCancel,
 }: AgentModalProps) {
   const { t } = useTranslation();
+  const { isDark } = useTheme();
   const [poolSkills, setPoolSkills] = useState<PoolSkillSpec[]>([]);
   const [installedSkills, setInstalledSkills] = useState<string[]>([]);
   const [loadingSkills, setLoadingSkills] = useState(false);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [loadingProviders, setLoadingProviders] = useState(false);
+  const [avatarUrl, setAvatarUrl] = useState<string>("");
+  const [uploadingAvatar, setUploadingAvatar] = useState(false);
+  const [localAvatarUrl, setLocalAvatarUrl] = useState<string | null>(null);
 
   const selectedProviderId = Form.useWatch("active_model_provider", form);
   const selectedModelId = Form.useWatch("active_model_model", form);
@@ -84,8 +97,25 @@ export function AgentModal({
     return provider?.models ?? [];
   }, [selectedProviderId, eligibleProviders]);
 
+  // Revoke local object URL on unmount or when replaced
+  useEffect(() => {
+    return () => {
+      if (localAvatarUrl) {
+        URL.revokeObjectURL(localAvatarUrl);
+      }
+    };
+  }, [localAvatarUrl]);
+
   useEffect(() => {
     if (!open) return;
+
+    // Load existing avatar if editing
+    if (editingAgent?.avatar_url) {
+      setAvatarUrl(getApiUrl(editingAgent.avatar_url));
+    } else {
+      setAvatarUrl("");
+    }
+    setLocalAvatarUrl(null);
 
     setLoadingProviders(true);
     providerApi
@@ -121,6 +151,28 @@ export function AgentModal({
       })
       .finally(() => setLoadingSkills(false));
   }, [editingAgent, onInstalledSkillsLoaded, onSelectedSkillsChange, open]);
+
+  const handleUploadAvatar = async (file: File) => {
+    if (!editingAgent) {
+      // For new agents, use local preview with object URL
+      const localUrl = URL.createObjectURL(file);
+      setLocalAvatarUrl(localUrl);
+      setAvatarUrl(localUrl);
+      return false;
+    }
+
+    setUploadingAvatar(true);
+    try {
+      const result = await agentsApi.uploadAvatar(editingAgent.id, file);
+      setAvatarUrl(getApiUrl(result.avatar_url));
+      return false; // Prevent default upload behavior
+    } catch (error) {
+      console.error("Failed to upload avatar:", error);
+      return false;
+    } finally {
+      setUploadingAvatar(false);
+    }
+  };
 
   const handleProviderChange = (providerId: string) => {
     form.setFieldsValue({
@@ -194,6 +246,50 @@ export function AgentModal({
             <Input disabled />
           </Form.Item>
         )}
+        <Form.Item label={t("agent.avatar")}>
+          <Space>
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                width={64}
+                height={64}
+                style={{ objectFit: "cover", borderRadius: "50%" }}
+                wrapperStyle={{
+                  borderRadius: "50%",
+                  overflow: "hidden",
+                  flexShrink: 0,
+                }}
+                preview={{ mask: t("agent.previewAvatar") }}
+              />
+            ) : (
+              <div
+                style={{
+                  width: 64,
+                  height: 64,
+                  borderRadius: "50%",
+                  background: isDark
+                    ? "rgba(255,255,255,0.08)"
+                    : "rgba(0,0,0,0.04)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <RobotOutlined style={{ fontSize: 28, opacity: 0.45 }} />
+              </div>
+            )}
+            <Upload
+              accept="image/png,image/jpeg,image/gif,image/webp"
+              showUploadList={false}
+              beforeUpload={handleUploadAvatar}
+              disabled={uploadingAvatar}
+            >
+              <Button icon={<UploadOutlined />} loading={uploadingAvatar}>
+                {t("agent.uploadAvatar")}
+              </Button>
+            </Upload>
+          </Space>
+        </Form.Item>
         {!editingAgent && (
           <Form.Item
             name="id"

--- a/console/src/pages/Settings/Agents/components/AgentModal.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentModal.tsx
@@ -27,6 +27,7 @@ import { providerApi } from "@/api/modules/provider";
 import { agentsApi } from "@/api/modules/agents";
 import { getApiUrl } from "@/api/config";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useAppMessage } from "@/hooks/useAppMessage";
 import { providerIcon } from "../../Models/components/providerIcon";
 import styles from "../index.module.less";
 
@@ -45,7 +46,7 @@ interface AgentModalProps {
   selectedSkills: string[];
   onSelectedSkillsChange: (skills: string[]) => void;
   onInstalledSkillsLoaded: (skills: string[]) => void;
-  onSave: () => Promise<void>;
+  onSave: () => Promise<string | undefined>;
   onCancel: () => void;
 }
 
@@ -61,6 +62,7 @@ export function AgentModal({
 }: AgentModalProps) {
   const { t } = useTranslation();
   const { isDark } = useTheme();
+  const { message } = useAppMessage();
   const [poolSkills, setPoolSkills] = useState<PoolSkillSpec[]>([]);
   const [installedSkills, setInstalledSkills] = useState<string[]>([]);
   const [loadingSkills, setLoadingSkills] = useState(false);
@@ -69,6 +71,7 @@ export function AgentModal({
   const [avatarUrl, setAvatarUrl] = useState<string>("");
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const [localAvatarUrl, setLocalAvatarUrl] = useState<string | null>(null);
+  const [pendingAvatarFile, setPendingAvatarFile] = useState<File | null>(null);
 
   const selectedProviderId = Form.useWatch("active_model_provider", form);
   const selectedModelId = Form.useWatch("active_model_model", form);
@@ -116,6 +119,7 @@ export function AgentModal({
       setAvatarUrl("");
     }
     setLocalAvatarUrl(null);
+    setPendingAvatarFile(null);
 
     setLoadingProviders(true);
     providerApi
@@ -154,7 +158,8 @@ export function AgentModal({
 
   const handleUploadAvatar = async (file: File) => {
     if (!editingAgent) {
-      // For new agents, use local preview with object URL
+      // For new agents, store file for upload after creation
+      setPendingAvatarFile(file);
       const localUrl = URL.createObjectURL(file);
       setLocalAvatarUrl(localUrl);
       setAvatarUrl(localUrl);
@@ -165,12 +170,27 @@ export function AgentModal({
     try {
       const result = await agentsApi.uploadAvatar(editingAgent.id, file);
       setAvatarUrl(getApiUrl(result.avatar_url));
-      return false; // Prevent default upload behavior
+      return false;
     } catch (error) {
       console.error("Failed to upload avatar:", error);
+      message.error(t("agent.uploadAvatarFailed"));
       return false;
     } finally {
       setUploadingAvatar(false);
+    }
+  };
+
+  const handleSave = async () => {
+    const newAgentId = await onSave();
+
+    // Upload pending avatar after new agent is created
+    if (!editingAgent && pendingAvatarFile && newAgentId) {
+      try {
+        await agentsApi.uploadAvatar(newAgentId, pendingAvatarFile);
+      } catch (error) {
+        console.error("Failed to upload avatar for new agent:", error);
+        message.error(t("agent.uploadAvatarFailed"));
+      }
     }
   };
 
@@ -227,7 +247,7 @@ export function AgentModal({
           : t("agent.createTitle")
       }
       open={open}
-      onOk={onSave}
+      onOk={handleSave}
       onCancel={onCancel}
       width={640}
       okText={t("common.save")}

--- a/console/src/pages/Settings/Agents/components/AgentTable.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentTable.tsx
@@ -13,13 +13,14 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { EditOutlined, DeleteOutlined, RobotOutlined } from "@ant-design/icons";
+import { EditOutlined, DeleteOutlined } from "@ant-design/icons";
 import { EyeOff, Eye } from "lucide-react";
 import type { AgentSummary } from "../../../../api/types/agents";
 import { useTheme } from "../../../../contexts/ThemeContext";
 import { getAgentDisplayName } from "../../../../utils/agentDisplayName";
 import { SortableAgentRow, DragHandle } from "./SortableAgentRow";
 import { providerIcon } from "../../Models/components/providerIcon";
+import { AgentAvatar } from "../../../../components/AgentAvatar";
 import styles from "../index.module.less";
 
 interface AgentTableProps {
@@ -89,11 +90,10 @@ export function AgentTable({
       width: 300,
       render: (_text: string, record: AgentSummary) => (
         <Space>
-          <RobotOutlined
-            style={{
-              fontSize: 16,
-              opacity: record.enabled ? 1 : 0.5,
-            }}
+          <AgentAvatar
+            avatarUrl={record.avatar_url}
+            size={24}
+            opacity={record.enabled ? 1 : 0.5}
           />
           <span style={{ opacity: record.enabled ? 1 : 0.5 }}>
             {getAgentDisplayName(record, t)}

--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -89,7 +89,7 @@ export default function AgentsPage() {
     installedSkillsRef.current = skills;
   }, []);
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (): Promise<string | undefined> => {
     try {
       const values = await form.validateFields();
       const workspaceRaw = values.workspace_dir;
@@ -107,6 +107,8 @@ export default function AgentsPage() {
 
       const { active_model_provider, active_model_model, ...rest } = values;
       const payload = { ...rest, workspace_dir, active_model };
+
+      let agentId: string | undefined;
 
       if (editingAgent) {
         const previousInstalledSkills = installedSkillsRef.current;
@@ -129,6 +131,7 @@ export default function AgentsPage() {
         ];
         invalidateSkillCache({ agentId: editingAgent.id });
         message.success(t("agent.updateSuccess"));
+        agentId = editingAgent.id;
       } else {
         const result = await agentsApi.createAgent({
           ...payload,
@@ -136,16 +139,19 @@ export default function AgentsPage() {
           skill_names: selectedSkills,
         });
         message.success(`${t("agent.createSuccess")} (ID: ${result.id})`);
+        agentId = result.id;
       }
 
       setModalVisible(false);
       await loadAgents();
+      return agentId;
     } catch (error: any) {
       console.error("Failed to save agent:", error);
       if (editingAgent) {
         invalidateSkillCache({ agentId: editingAgent.id });
       }
       message.error(error.message || t("agent.saveFailed"));
+      return undefined;
     }
   };
 

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -7,8 +7,9 @@ Provides RESTful API for managing multiple agent instances.
 import json
 import logging
 from pathlib import Path
-from fastapi import APIRouter, Body, HTTPException, Request
+from fastapi import APIRouter, Body, HTTPException, Request, UploadFile, File
 from fastapi import Path as PathParam
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, field_validator
 
 from agentscope_runtime.engine.schemas.exception import (
@@ -37,6 +38,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
+AVATAR_ALLOWED_CONTENT_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+}
+AVATAR_CONTENT_TYPE_TO_EXTENSION = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+AVATAR_EXTENSION_TO_MEDIA_TYPE = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+AVATAR_SEARCH_EXTENSIONS = [".png", ".jpg", ".gif", ".webp"]
+AVATAR_MAX_SIZE = 2 * 1024 * 1024  # 2MB
+
 
 class AgentSummary(BaseModel):
     """Agent summary information."""
@@ -44,6 +66,7 @@ class AgentSummary(BaseModel):
     id: str
     name: str
     description: str
+    avatar_url: str = ""
     workspace_dir: str
     enabled: bool
     active_model: ModelSlotConfig | None = None
@@ -186,6 +209,7 @@ async def list_agents() -> AgentListResponse:
                     id=agent_id,
                     name=agent_config.name,
                     description=description,
+                    avatar_url=agent_config.avatar_url or "",
                     workspace_dir=agent_ref.workspace_dir,
                     enabled=getattr(agent_ref, "enabled", True),
                     active_model=active_model,
@@ -197,6 +221,7 @@ async def list_agents() -> AgentListResponse:
                     id=agent_id,
                     name=agent_id.title(),
                     description="",
+                    avatar_url="",
                     workspace_dir=agent_ref.workspace_dir,
                     enabled=getattr(agent_ref, "enabled", True),
                 ),
@@ -563,6 +588,94 @@ def _install_initial_skills(
                 workspace_dir,
                 e,
             )
+
+
+@router.post(
+    "/{agentId}/avatar",
+    summary="Upload agent avatar",
+    description=(
+        "Upload an avatar image for the agent " "(max 2MB, PNG/JPG/GIF/WEBP)"
+    ),
+)
+async def upload_agent_avatar(
+    agentId: str = PathParam(...),
+    file: UploadFile = File(...),
+) -> dict:
+    """Upload an avatar image for an agent."""
+    config = load_config()
+
+    if agentId not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agentId}' not found",
+        )
+
+    if file.content_type not in AVATAR_ALLOWED_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {file.content_type}. "
+            f"Allowed: PNG, JPG, GIF, WEBP",
+        )
+
+    content = await file.read()
+    if len(content) > AVATAR_MAX_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File too large ({len(content)} bytes). Max: 2MB",
+        )
+
+    agent_ref = config.agents.profiles[agentId]
+    avatars_dir = Path(agent_ref.workspace_dir) / "avatars"
+    avatars_dir.mkdir(parents=True, exist_ok=True)
+
+    extension = AVATAR_CONTENT_TYPE_TO_EXTENSION.get(file.content_type, ".png")
+    avatar_path = avatars_dir / f"avatar{extension}"
+
+    with open(avatar_path, "wb") as avatar_file:
+        avatar_file.write(content)
+
+    agent_config = load_agent_config(agentId)
+    agent_config.avatar_url = f"/agents/{agentId}/avatar"
+    save_agent_config(agentId, agent_config)
+
+    logger.info(f"Uploaded avatar for agent: {agentId}")
+
+    return {"success": True, "avatar_url": agent_config.avatar_url}
+
+
+@router.get(
+    "/{agentId}/avatar",
+    summary="Get agent avatar",
+    description="Get the avatar image for an agent",
+)
+async def get_agent_avatar(
+    agentId: str = PathParam(...),
+) -> FileResponse:
+    """Get the avatar image for an agent."""
+    config = load_config()
+
+    if agentId not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agentId}' not found",
+        )
+
+    agent_ref = config.agents.profiles[agentId]
+    avatars_dir = Path(agent_ref.workspace_dir) / "avatars"
+
+    for extension in AVATAR_SEARCH_EXTENSIONS:
+        avatar_path = avatars_dir / f"avatar{extension}"
+        if avatar_path.exists():
+            return FileResponse(
+                path=str(avatar_path),
+                media_type=AVATAR_EXTENSION_TO_MEDIA_TYPE.get(
+                    extension,
+                    "image/png",
+                ),
+                headers={"Cache-Control": "public, max-age=3600"},
+            )
+
+    raise HTTPException(status_code=404, detail="Avatar not found")
 
 
 def _initialize_agent_workspace(

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -58,6 +58,24 @@ AVATAR_EXTENSION_TO_MEDIA_TYPE = {
 }
 AVATAR_SEARCH_EXTENSIONS = [".png", ".jpg", ".gif", ".webp"]
 AVATAR_MAX_SIZE = 2 * 1024 * 1024  # 2MB
+AVATAR_READ_CHUNK_SIZE = 8192
+
+
+def _validate_avatar_magic_bytes(content: bytes) -> bool:
+    """Validate image file content by checking magic bytes."""
+    if content[:8] == b"\x89PNG\r\n\x1a\n":
+        return True
+    if content[:3] == b"\xff\xd8\xff":
+        return True
+    if content[:6] in (b"GIF87a", b"GIF89a"):
+        return True
+    if (
+        content[:4] == b"RIFF"
+        and len(content) >= 12
+        and content[8:12] == b"WEBP"
+    ):
+        return True
+    return False
 
 
 class AgentSummary(BaseModel):
@@ -617,18 +635,45 @@ async def upload_agent_avatar(
             f"Allowed: PNG, JPG, GIF, WEBP",
         )
 
-    content = await file.read()
-    if len(content) > AVATAR_MAX_SIZE:
+    # Read in chunks to prevent memory exhaustion from oversized uploads
+    chunks: list[bytes] = []
+    total_size = 0
+    while chunk := await file.read(AVATAR_READ_CHUNK_SIZE):
+        total_size += len(chunk)
+        if total_size > AVATAR_MAX_SIZE:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"File too large (>{AVATAR_MAX_SIZE} bytes). "
+                    f"Max: 2MB"
+                ),
+            )
+        chunks.append(chunk)
+    content = b"".join(chunks)
+
+    # Verify actual file content via magic bytes, not just Content-Type
+    if not _validate_avatar_magic_bytes(content):
         raise HTTPException(
             status_code=400,
-            detail=f"File too large ({len(content)} bytes). Max: 2MB",
+            detail=(
+                "Invalid file content: not a valid "
+                "PNG, JPG, GIF, or WEBP image"
+            ),
         )
 
     agent_ref = config.agents.profiles[agentId]
     avatars_dir = Path(agent_ref.workspace_dir) / "avatars"
     avatars_dir.mkdir(parents=True, exist_ok=True)
 
-    extension = AVATAR_CONTENT_TYPE_TO_EXTENSION.get(file.content_type, ".png")
+    # Remove old avatar files to prevent stale file served by GET
+    for ext in AVATAR_SEARCH_EXTENSIONS:
+        old_path = avatars_dir / f"avatar{ext}"
+        if old_path.exists():
+            old_path.unlink()
+
+    extension = AVATAR_CONTENT_TYPE_TO_EXTENSION.get(
+        file.content_type, ".png"
+    )
     avatar_path = avatars_dir / f"avatar{extension}"
 
     with open(avatar_path, "wb") as avatar_file:
@@ -672,7 +717,10 @@ async def get_agent_avatar(
                     extension,
                     "image/png",
                 ),
-                headers={"Cache-Control": "public, max-age=3600"},
+                headers={
+                    "Cache-Control": "public, max-age=3600",
+                    "X-Content-Type-Options": "nosniff",
+                },
             )
 
     raise HTTPException(status_code=404, detail="Avatar not found")

--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -644,8 +644,7 @@ async def upload_agent_avatar(
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"File too large (>{AVATAR_MAX_SIZE} bytes). "
-                    f"Max: 2MB"
+                    f"File too large (>{AVATAR_MAX_SIZE} bytes). " f"Max: 2MB"
                 ),
             )
         chunks.append(chunk)
@@ -672,7 +671,8 @@ async def upload_agent_avatar(
             old_path.unlink()
 
     extension = AVATAR_CONTENT_TYPE_TO_EXTENSION.get(
-        file.content_type, ".png"
+        file.content_type,
+        ".png",
     )
     avatar_path = avatars_dir / f"avatar{extension}"
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1113,6 +1113,10 @@ class AgentProfileConfig(BaseModel):
     id: str = Field(..., description="Unique agent ID")
     name: str = Field(..., description="Human-readable agent name")
     description: str = Field(default="", description="Agent description")
+    avatar_url: str = Field(
+        default="",
+        description="URL to agent's avatar image",
+    )
     workspace_dir: str = Field(
         default="",
         description="Path to agent's workspace (optional, for reference)",


### PR DESCRIPTION
- Add avatar_url field to AgentProfileConfig and AgentSummary
- Add POST/GET /agents/{agentId}/avatar API endpoints
- Support avatar upload in AgentModal (edit + create mode)
- Display avatars in AgentTable, AgentSelector (including collapsed mode)
- Extract AgentAvatar shared component to eliminate duplication
- Support FormData upload in request.ts
- Add avatar/uploadAvatar/previewAvatar i18n keys for all locales
- Fix avatar URL prefix issue (use getApiUrl wrapper)
- Fix avatar preview mask size with wrapperStyle
- Fix memory leak with URL.revokeObjectURL for local previews
- Remove background/border when avatar image present in selector

Fixes #4974

<img width="1510" height="445" alt="image" src="https://github.com/user-attachments/assets/886baab9-0f83-42d5-8fb8-9face70bf024" />
<img width="650" height="969" alt="image" src="https://github.com/user-attachments/assets/63116c47-a82a-4f3a-a88f-e0f0d656055b" />
<img width="655" height="978" alt="image" src="https://github.com/user-attachments/assets/71a10e0c-ed63-43f6-8408-c69f6c7b4daf" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
