### PR TITLE
fix(desktop): graceful shutdown endpoint + Tauri lifecycle fix

### DIFF
--- a/console/src-tauri/src/backend.rs
+++ b/console/src-tauri/src/backend.rs
@@ -87,11 +87,47 @@ impl BackendState {
     fn stop(&self) {
         self.next_generation();
         let child = self.with_inner(|inner| inner.child.take());
+        let port = self.port();
+
+        // 1 — Fire-and-forget graceful shutdown request to the FastAPI backend.
+        //     Ponytail: raw TCP instead of reqwest to avoid the `blocking`
+        //     feature flag.  Response doesn't matter — we're shutting down.
+        if let Some(port) = port {
+            log::info!("[backend] requesting graceful shutdown on port {port}");
+            let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+            std::thread::spawn(move || {
+                use std::io::Write;
+                use std::net::TcpStream;
+                use std::time::Duration;
+                if let Ok(mut stream) =
+                    TcpStream::connect_timeout(&addr, Duration::from_secs(3))
+                {
+                    let _ = stream.write_all(
+                        b"POST /api/shutdown HTTP/1.1\r\n\
+                          Host: 127.0.0.1\r\n\
+                          Content-Length: 0\r\n\r\n",
+                    );
+                    log::info!("[backend] graceful shutdown request sent");
+                }
+            });
+        }
+
+        // 2 — Give the backend time to shut down gracefully
+        //     before falling back to forced kill.
         if let Some(child) = child {
             let pid = child.pid();
-            log::info!("[backend] stopping process pid={pid}");
-            if let Err(err) = child.kill() {
-                log::warn!("[backend] failed to stop process: {err}");
+            log::info!("[backend] waiting for graceful exit pid={pid}");
+            std::thread::sleep(std::time::Duration::from_secs(5));
+
+            log::info!("[backend] forcing stop pid={pid}");
+            match child.kill() {
+                Ok(()) => log::info!("[backend] process pid={pid} killed"),
+                Err(err) => {
+                    // child.kill() returns Err when the process
+                    // already exited — which means graceful shutdown
+                    // succeeded.
+                    log::info!("[backend] process pid={pid} already exited: {err}");
+                }
             }
         }
     }

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -790,6 +790,81 @@ def get_doctor_runtime():
         "python_executable": sys.executable,
         "python_environment": summarize_python_environment(),
     }
+
+
+@app.post("/api/shutdown")
+async def shutdown_endpoint(request: Request):
+    """Gracefully shut down the FastAPI backend.
+
+    Ponytail: duplicates the lifespan finally block inline rather than
+    extracting a shared helper — YAGNI (only two callers: lifespan and
+    this endpoint).  Ceiling: if a third caller appears, factor out
+    ``_run_shutdown()``.
+    """
+    logger.info("Shutdown requested via /api/shutdown")
+
+    app_ = request.app
+
+    # Plugin shutdown hooks
+    plugin_registry = getattr(app_.state, "plugin_registry", None)
+    if plugin_registry is not None:
+        logger.info("Executing plugin shutdown hooks...")
+        for hook in plugin_registry.get_shutdown_hooks():
+            try:
+                result = hook.callback()
+                if inspect.iscoroutine(result) or inspect.isawaitable(result):
+                    await result
+            except Exception as e:
+                logger.error(f"Plugin shutdown hook failed: {e}")
+
+    # Local model server
+    local_model_mgr = getattr(app_.state, "local_model_manager", None)
+    if local_model_mgr is not None:
+        try:
+            await local_model_mgr.shutdown_server()
+        except Exception as exc:
+            logger.error(f"Local model shutdown error: {exc}")
+            with suppress(OSError, RuntimeError, ValueError):
+                local_model_mgr.shutdown_server_sync()
+
+    # Multi-agent manager (stops all agents + ReMeLight)
+    multi_agent_mgr = getattr(app_.state, "multi_agent_manager", None)
+    if multi_agent_mgr is not None:
+        try:
+            await multi_agent_mgr.stop_all()
+        except Exception as e:
+            logger.error(f"Error stopping MultiAgentManager: {e}")
+
+    # Token usage manager
+    from ..token_usage import get_token_usage_manager
+
+    try:
+        await get_token_usage_manager().stop()
+    except Exception as e:
+        logger.error(f"Error stopping TokenUsageManager: {e}")
+
+    # Browser instances
+    from ..agents.tools.browser_control import stop_all_browsers
+
+    try:
+        await stop_all_browsers()
+    except Exception as e:
+        logger.error(f"Error stopping browsers: {e}")
+
+    # Skills hub HTTP client
+    from ..agents.skill_system.hub import aclose_hub_client
+
+    try:
+        await aclose_hub_client()
+    except Exception as e:
+        logger.error(f"Error closing skills hub: {e}")
+
+    logger.info("Graceful shutdown complete — exiting process")
+
+    # Schedule exit after response is sent
+    import threading
+
+    threading.Thread(target=os._exit, args=(0,), daemon=True).start()
 
 
 app.include_router(api_router, prefix="/api")


### PR DESCRIPTION
Resolved conflict with agentscope 2.0 (origin/main). The previous memory-index fix (gh-5259) no longer applies because the memory manager was fully rewritten in agentscope 2.0 (now uses ReMe4). This PR now only contains the graceful shutdown changes:  1. **backend.rs**: Raw TCP shutdown request + 5s wait before forced kill 2. **_app.py**: /api/shutdown endpoint with full cleanup sequence  Closes gh-5265, gh-5259 (memory fix superseded by 2.0 architecture).