### PR TITLE
fix(install): default to stable PyPI releases only

### DIFF
--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -30,6 +30,7 @@ set "ARG_FROM_SOURCE=0"
 set "ARG_SOURCE_DIR="
 set "ARG_EXTRAS="
 set "ARG_UV_PATH="
+set "ARG_PRERELEASE=0"
 set "CONSOLE_COPIED=0"
 set "CONSOLE_AVAILABLE=0"
 
@@ -40,6 +41,7 @@ if /i "%~1"=="-Version"    goto :arg_version
 if /i "%~1"=="-FromSource" goto :arg_fromsource
 if /i "%~1"=="-SourceDir"  goto :arg_sourcedir
 if /i "%~1"=="-Extras"     goto :arg_extras
+if /i "%~1"=="-Prerelease" goto :arg_prerelease
 if /i "%~1"=="-UvPath"     goto :arg_uvpath
 if /i "%~1"=="-Help"       goto :show_help
 shift
@@ -65,6 +67,11 @@ set "ARG_EXTRAS=%~2"
 shift & shift
 goto :parse_args
 
+:arg_prerelease
+set "ARG_PRERELEASE=1"
+shift
+goto :parse_args
+
 :arg_uvpath
 set "ARG_UV_PATH=%~2"
 shift & shift
@@ -85,6 +92,7 @@ echo   -FromSource           Install from source (requires git, or use -SourceDi
 echo   -SourceDir ^<DIR^>      Local source directory (used with -FromSource)
 echo   -Extras ^<EXTRAS^>      Comma-separated optional extras to install
 echo                          (e.g. dev, whisper)
+echo   -Prerelease           Install the latest PyPI release, including pre-releases
 echo   -UvPath ^<PATH^>        Path to a pre-installed uv.exe (skips all auto-install)
 echo   -Help                 Show this help
 echo.
@@ -383,7 +391,7 @@ if not errorlevel 1 (
 rem === End Security Validation ===
 
 rem The input has now been verified as safe and can proceed with installation.
-uv pip install "%ARG_SOURCE_DIR%%EXTRAS_SUFFIX%" --python "%VENV_PYTHON%" --prerelease=allow
+uv pip install "%ARG_SOURCE_DIR%%EXTRAS_SUFFIX%" --python "%VENV_PYTHON%"
 set "_INST_ERR=%errorlevel%"
 call :cleanup_console "%ARG_SOURCE_DIR%"
 if %_INST_ERR% neq 0 (
@@ -410,7 +418,7 @@ if errorlevel 1 (
 )
 call :prepare_console "%CLONE_DIR%"
 echo [qwenpaw] Installing package from source...
-uv pip install "%CLONE_DIR%%EXTRAS_SUFFIX%" --python "%VENV_PYTHON%" --prerelease=allow
+uv pip install "%CLONE_DIR%%EXTRAS_SUFFIX%" --python "%VENV_PYTHON%"
 set "_INST_ERR=%errorlevel%"
 if exist "%CLONE_DIR%" rd /s /q "%CLONE_DIR%"
 if %_INST_ERR% neq 0 (
@@ -443,7 +451,10 @@ rem for safety, if ARG_EXTRAS is defined globally, it is best to reuse the valid
 rem Assume EXTRAS_SUFFIX is generated here based on the previously validated ARG_EXTRAS, or is empty.
 rem If ARG_EXTRAS is passed globally, it is recommended to validate it uniformly at the beginning of the script.
 
-uv pip install "%_PACKAGE%%EXTRAS_SUFFIX%" --python "%VENV_PYTHON%" --prerelease=allow --quiet --refresh-package qwenpaw
+set "PRERELEASE_ARG="
+if "%ARG_PRERELEASE%"=="1" set "PRERELEASE_ARG=--prerelease=allow"
+
+uv pip install "%_PACKAGE%%EXTRAS_SUFFIX%" --python "%VENV_PYTHON%" --quiet --refresh-package qwenpaw %PRERELEASE_ARG%
 if errorlevel 1 (
     echo [qwenpaw] ERROR: Installation failed
     exit /b 1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -21,6 +21,7 @@ param(
     [string]$SourceDir = "",
     [string]$Extras    = "",
     [string]$UvPath    = "",
+    [switch]$Prerelease,
     [switch]$Help
 )
 
@@ -52,6 +53,7 @@ Options:
   -SourceDir <DIR>      Local source directory (used with -FromSource)
   -Extras <EXTRAS>      Comma-separated optional extras to install
                         (e.g. dev, whisper)
+  -Prerelease           Install the latest PyPI release, including pre-releases
   -UvPath <PATH>        Path to a pre-installed uv.exe (skips all auto-install)
   -Help                 Show this help
 
@@ -288,7 +290,7 @@ if ($FromSource) {
         Write-Info "Installing QwenPaw from local source: $SourceDir"
         Prepare-Console $SourceDir
         Write-Info "Installing package from source..."
-        uv pip install "${SourceDir}${ExtrasSuffix}" --python $VenvPython --prerelease=allow
+        uv pip install "${SourceDir}${ExtrasSuffix}" --python $VenvPython
         if ($LASTEXITCODE -ne 0) { Stop-WithError "Installation from source failed" }
         Cleanup-Console $SourceDir
     } else {
@@ -302,7 +304,7 @@ if ($FromSource) {
             if ($LASTEXITCODE -ne 0) { Stop-WithError "Failed to clone repository" }
             Prepare-Console $cloneDir
             Write-Info "Installing package from source..."
-            uv pip install "${cloneDir}${ExtrasSuffix}" --python $VenvPython --prerelease=allow
+            uv pip install "${cloneDir}${ExtrasSuffix}" --python $VenvPython
             if ($LASTEXITCODE -ne 0) { Stop-WithError "Installation from source failed" }
         } finally {
             if (Test-Path $cloneDir) {
@@ -314,8 +316,11 @@ if ($FromSource) {
     $package = "qwenpaw"
     if ($Version) { $package = "qwenpaw==$Version" }
 
+    $prereleaseArgs = @()
+    if ($Prerelease) { $prereleaseArgs = @("--prerelease=allow") }
+
     Write-Info "Installing ${package}${ExtrasSuffix} from PyPI..."
-    uv pip install "${package}${ExtrasSuffix}" --python $VenvPython --prerelease=allow --quiet --refresh-package qwenpaw
+    uv pip install "${package}${ExtrasSuffix}" --python $VenvPython --quiet --refresh-package qwenpaw @prereleaseArgs
     if ($LASTEXITCODE -ne 0) { Stop-WithError "Installation failed" }
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,6 +53,7 @@ VERSION=""
 FROM_SOURCE=false
 SOURCE_DIR=""
 EXTRAS=""
+PRERELEASE=false
 
 # ── Parse args ────────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -69,6 +70,8 @@ while [[ $# -gt 0 ]]; do
             shift ;;
         --extras)
             EXTRAS="$2"; shift 2 ;;
+        --prerelease)
+            PRERELEASE=true; shift ;;
         -h|--help)
             cat <<EOF
 QwenPaw Installer
@@ -81,6 +84,7 @@ Options:
                         directory; otherwise clone from GitHub.
   --extras <EXTRAS>     Comma-separated optional extras to install
                         (e.g. dev, whisper)
+  --prerelease          Install the latest PyPI release, including pre-releases
   -h, --help            Show this help
 
 Environment:
@@ -244,7 +248,7 @@ if [ "$FROM_SOURCE" = true ]; then
         prepare_console "$SOURCE_DIR"
         prepare_docs "$SOURCE_DIR"
         info "Installing package from source..."
-        uv pip install "${SOURCE_DIR}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --prerelease=allow --index-url "$PYPI_MIRROR"
+        uv pip install "${SOURCE_DIR}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --index-url "$PYPI_MIRROR"
         cleanup_console "$SOURCE_DIR"
         cleanup_docs "$SOURCE_DIR"
     else
@@ -255,7 +259,7 @@ if [ "$FROM_SOURCE" = true ]; then
         prepare_console "$CLONE_DIR"
         prepare_docs "$CLONE_DIR"
         info "Installing package from source..."
-        uv pip install "${CLONE_DIR}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --prerelease=allow --index-url "$PYPI_MIRROR"
+        uv pip install "${CLONE_DIR}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --index-url "$PYPI_MIRROR"
         # CLONE_DIR is cleaned up by trap; no need for cleanup_console/cleanup_docs
     fi
 else
@@ -264,8 +268,13 @@ else
         PACKAGE="qwenpaw==$VERSION"
     fi
 
+    PRERELEASE_ARGS=()
+    if [ "$PRERELEASE" = true ]; then
+        PRERELEASE_ARGS=(--prerelease=allow)
+    fi
+
     info "Installing ${PACKAGE}${EXTRAS_SUFFIX} from PyPI..."
-    uv pip install "${PACKAGE}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --prerelease=allow --quiet --index-url "$PYPI_MIRROR" --refresh-package qwenpaw
+    uv pip install "${PACKAGE}${EXTRAS_SUFFIX}" --python "$QWENPAW_VENV/bin/python" --quiet --index-url "$PYPI_MIRROR" --refresh-package qwenpaw "${PRERELEASE_ARGS[@]}"
 fi
 
 # Verify the CLI entry point exists

--- a/src/qwenpaw/cli/update_cmd.py
+++ b/src/qwenpaw/cli/update_cmd.py
@@ -90,8 +90,8 @@ def _is_newer_version(latest: str, current: str) -> bool | None:
     return parsed_latest > parsed_current
 
 
-def _fetch_latest_version() -> str:
-    """Fetch the latest published QwenPaw version from PyPI."""
+def _fetch_pypi_release_data() -> dict[str, Any]:
+    """Fetch qwenpaw release metadata from PyPI."""
     try:
         resp = httpx.get(
             _PYPI_JSON_URL,
@@ -109,12 +109,55 @@ def _fetch_latest_version() -> str:
             "Received an invalid response from PyPI when checking for the "
             f"latest QwenPaw version: {exc}",
         ) from exc
-    version = str(data.get("info", {}).get("version", "")).strip()
-    if not version:
+    if not isinstance(data, dict):
         raise click.ClickException(
-            "Unable to determine the latest QwenPaw version.",
+            "Received an invalid response from PyPI when checking for the "
+            "latest QwenPaw version.",
         )
-    return version
+    return data
+
+
+def _select_latest_version(
+    data: dict[str, Any],
+    *,
+    include_prerelease: bool,
+) -> str:
+    """Return the newest published version from PyPI metadata."""
+    if include_prerelease:
+        version = str(data.get("info", {}).get("version", "")).strip()
+        if not version:
+            raise click.ClickException(
+                "Unable to determine the latest QwenPaw version.",
+            )
+        return version
+
+    releases = data.get("releases") or {}
+    candidates: list[Version] = []
+    for version_str, files in releases.items():
+        if not files:
+            continue
+        try:
+            parsed = Version(version_str)
+        except InvalidVersion:
+            continue
+        if parsed.is_prerelease:
+            continue
+        candidates.append(parsed)
+
+    if not candidates:
+        raise click.ClickException(
+            "Unable to determine the latest stable QwenPaw version.",
+        )
+    return str(max(candidates))
+
+
+def _fetch_latest_version(*, include_prerelease: bool = False) -> str:
+    """Fetch the latest published QwenPaw version from PyPI."""
+    data = _fetch_pypi_release_data()
+    return _select_latest_version(
+        data,
+        include_prerelease=include_prerelease,
+    )
 
 
 def _detect_source_type(
@@ -348,24 +391,25 @@ def _run_shutdown_for_update(
 def _build_upgrade_command(
     info: InstallInfo,
     latest_version: str,
+    *,
+    include_prerelease: bool = False,
 ) -> tuple[list[str], str]:
     """Build the installer command used by the detached update worker."""
     package_spec = f"qwenpaw=={latest_version}"
     installer = info.installer.lower()
     if installer.startswith("uv") and shutil.which("uv"):
-        return (
-            [
-                "uv",
-                "pip",
-                "install",
-                "--python",
-                info.python_executable,
-                "--upgrade",
-                package_spec,
-                "--prerelease=allow",
-            ],
-            "uv pip",
-        )
+        command = [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            info.python_executable,
+            "--upgrade",
+            package_spec,
+        ]
+        if include_prerelease:
+            command.append("--prerelease=allow")
+        return command, "uv pip"
     return (
         [
             info.python_executable,
@@ -635,11 +679,16 @@ def _confirm_source_override(info: InstallInfo, yes: bool) -> bool:
     is_flag=True,
     help="Do not prompt before starting the update",
 )
+@click.option(
+    "--prerelease",
+    is_flag=True,
+    help="Upgrade to the latest pre-release if it is newer than stable.",
+)
 @click.pass_context
-def update_cmd(ctx: click.Context, yes: bool) -> None:
+def update_cmd(ctx: click.Context, yes: bool, prerelease: bool) -> None:
     """Upgrade QwenPaw in the current Python environment."""
     info = _detect_installation()
-    latest_version = _fetch_latest_version()
+    latest_version = _fetch_latest_version(include_prerelease=prerelease)
 
     _echo_install_summary(info, latest_version)
 
@@ -702,7 +751,11 @@ def update_cmd(ctx: click.Context, yes: bool) -> None:
         click.echo("Cancelled.")
         return
 
-    command, installer_label = _build_upgrade_command(info, latest_version)
+    command, installer_label = _build_upgrade_command(
+        info,
+        latest_version,
+        include_prerelease=prerelease,
+    )
     plan = {
         "current_version": __version__,
         "latest_version": latest_version,

--- a/tests/unit/cli/test_cli_update.py
+++ b/tests/unit/cli/test_cli_update.py
@@ -14,6 +14,7 @@ from qwenpaw.cli.main import cli
 from qwenpaw.cli.update_cmd import (
     InstallInfo,
     RunningServiceInfo,
+    _build_upgrade_command,
     _detect_running_service,
     _detect_installation,
     _is_newer_version,
@@ -21,6 +22,7 @@ from qwenpaw.cli.update_cmd import (
     _detect_source_type,
     _run_update_worker_detached,
     _run_update_worker_foreground,
+    _select_latest_version,
     run_update_worker,
 )
 
@@ -60,6 +62,44 @@ def test_is_newer_version(
     expected: bool | None,
 ) -> None:
     assert _is_newer_version(latest, current) is expected
+
+
+def test_select_latest_version_prefers_stable_by_default() -> None:
+    data = {
+        "info": {"version": "2.0.0b1"},
+        "releases": {
+            "1.9.0": [{"url": "https://example.com/qwenpaw-1.9.0.tar.gz"}],
+            "2.0.0b1": [{"url": "https://example.com/qwenpaw-2.0.0b1.tar.gz"}],
+        },
+    }
+
+    assert _select_latest_version(data, include_prerelease=False) == "1.9.0"
+    assert _select_latest_version(data, include_prerelease=True) == "2.0.0b1"
+
+
+def test_build_upgrade_command_adds_prerelease_flag_for_uv_only_when_requested(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "qwenpaw.cli.update_cmd.shutil.which",
+        lambda name: "/usr/local/bin/uv" if name == "uv" else None,
+    )
+    info = _install_info(installer="uv")
+
+    stable_command, label = _build_upgrade_command(
+        info,
+        "1.9.0",
+        include_prerelease=False,
+    )
+    prerelease_command, _ = _build_upgrade_command(
+        info,
+        "2.0.0b1",
+        include_prerelease=True,
+    )
+
+    assert label == "uv pip"
+    assert "--prerelease=allow" not in stable_command
+    assert prerelease_command[-1] == "--prerelease=allow"
 
 
 @pytest.mark.parametrize(
@@ -177,7 +217,7 @@ def test_update_reports_up_to_date(monkeypatch) -> None:
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return __version__
 
     monkeypatch.setattr(
@@ -291,7 +331,7 @@ def test_update_blocks_running_service(monkeypatch) -> None:
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return "9.9.9"
 
     monkeypatch.setattr(
@@ -337,7 +377,7 @@ def test_update_can_cancel_forced_shutdown(monkeypatch) -> None:
     monkeypatch.setattr(
         update_cmd_module,
         "_fetch_latest_version",
-        lambda: "9.9.9",
+        lambda **_: "9.9.9",
     )
     monkeypatch.setattr(
         update_cmd_module,
@@ -392,7 +432,7 @@ def test_update_can_force_shutdown_running_service(
     monkeypatch.setattr(
         update_cmd_module,
         "_fetch_latest_version",
-        lambda: "9.9.9",
+        lambda **_: "9.9.9",
     )
     monkeypatch.setattr(
         update_cmd_module,
@@ -454,7 +494,7 @@ def test_update_can_cancel_non_pypi_override(monkeypatch) -> None:
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return "9.9.9"
 
     monkeypatch.setattr(
@@ -488,7 +528,7 @@ def test_update_can_override_non_pypi_install_with_yes(
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return "9.9.9"
 
     def _detect_running_service(
@@ -544,7 +584,7 @@ def test_update_spawns_worker(monkeypatch, tmp_path: Path) -> None:
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return "9.9.9"
 
     def _detect_running_service(
@@ -610,7 +650,7 @@ def test_update_prompts_when_version_is_not_comparable(
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return "main"
 
     monkeypatch.setattr(
@@ -643,7 +683,7 @@ def test_update_can_continue_when_version_is_not_comparable(
     def _detect_installation() -> InstallInfo:
         return install_info
 
-    def _fetch_latest_version() -> str:
+    def _fetch_latest_version(**_: object) -> str:
         return "main"
 
     def _detect_running_service(
@@ -704,7 +744,7 @@ def test_update_returns_worker_exit_code(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         update_cmd_module,
         "_fetch_latest_version",
-        lambda: "9.9.9",
+        lambda **_: "9.9.9",
     )
     monkeypatch.setattr(
         update_cmd_module,
@@ -742,7 +782,7 @@ def test_update_detaches_worker_on_windows(
     monkeypatch.setattr(
         update_cmd_module,
         "_fetch_latest_version",
-        lambda: "9.9.9",
+        lambda **_: "9.9.9",
     )
     monkeypatch.setattr(
         update_cmd_module,


### PR DESCRIPTION
Stop passing --prerelease=allow in official installers and qwenpaw update by default, and add an explicit --prerelease opt-in for beta installs.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
