### PR TITLE
refactor(xiaoyi): refactor connection to dual WebSocket & fix unusable channel

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -141,7 +141,6 @@ export interface XiaoYiConfig extends BaseChannelConfig {
   ak: string;
   sk: string;
   agent_id: string;
-  ws_url: string;
   task_timeout_ms?: number;
 }
 

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1070,9 +1070,6 @@ export function ChannelDrawer({
             >
               <Input placeholder="Agent ID from XiaoYi platform" />
             </Form.Item>
-            <Form.Item name="ws_url" label="WebSocket URL">
-              <Input placeholder="wss://hag.cloud.huawei.com/openclaw/v1/ws/link" />
-            </Form.Item>
           </>
         );
 

--- a/src/qwenpaw/app/channels/xiaoyi/__init__.py
+++ b/src/qwenpaw/app/channels/xiaoyi/__init__.py
@@ -7,10 +7,8 @@ This module implements A2A (Agent-to-Agent) protocol support.
 
 from .channel import XiaoYiChannel
 from .auth import generate_auth_headers
-from .constants import DEFAULT_WS_URL
 
 __all__ = [
     "XiaoYiChannel",
     "generate_auth_headers",
-    "DEFAULT_WS_URL",
 ]

--- a/src/qwenpaw/app/channels/xiaoyi/channel.py
+++ b/src/qwenpaw/app/channels/xiaoyi/channel.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """XiaoYi Channel implementation.
 
-XiaoYi uses A2A (Agent-to-Agent) protocol over WebSocket.
+XiaoYi uses A2A (Agent-to-Agent) protocol over dual WebSocket connections
+(primary domain + backup IP) for redundancy.
 """
 
 from __future__ import annotations
@@ -9,9 +10,21 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import platform
+import re
+import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    TYPE_CHECKING,
+)
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -34,6 +47,8 @@ from .auth import generate_auth_headers
 from .constants import (
     CONNECTION_TIMEOUT,
     DEFAULT_TASK_TIMEOUT_MS,
+    DEFAULT_WS_URL,
+    DEFAULT_WS_URL_BACKUP,
     HEARTBEAT_INTERVAL,
     MAX_RECONNECT_ATTEMPTS,
     RECONNECT_DELAYS,
@@ -46,8 +61,281 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
 
+# Type alias for message/disconnect callbacks
+_OnMessage = Callable[[Dict[str, Any], str], Coroutine[Any, Any, None]]
+_OnDisconnect = Callable[[str], Any]
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_IP_RE = re.compile(r"^(\d{1,3}\.){3}\d{1,3}$")
+
+
+def _is_ip_address(host: str) -> bool:
+    """Return True if *host* looks like an IPv4 address."""
+    return bool(_IP_RE.match(host)) and all(
+        0 <= int(p) <= 255 for p in host.split(".")
+    )
+
+
+def _get_ssl_for_url(url: str) -> Any:
+    """Return *ssl* kwarg for aiohttp ws_connect.
+
+    For IP-based URLs, return ``False`` to skip certificate verification
+    (the server cert CN won't match the IP).  For domain URLs, return
+    ``None`` (use default verification).
+    """
+    host = urlparse(url).hostname or ""
+    return False if _is_ip_address(host) else None
+
+
+# ---------------------------------------------------------------------------
+# XiaoYiConnection – single WebSocket link
+# ---------------------------------------------------------------------------
+
+
+class XiaoYiConnection:
+    """Manages a single WebSocket connection to one XiaoYi endpoint.
+
+    The *Channel* owns two of these (primary + backup) and coordinates
+    between them.
+    """
+
+    def __init__(
+        self,
+        server_name: str,
+        ws_url: str,
+        ak: str,
+        sk: str,
+        agent_id: str,
+        on_message: _OnMessage,
+        on_disconnect: _OnDisconnect,
+    ):
+        self.server_name = server_name
+        self.ws_url = ws_url
+        self.ak = ak
+        self.sk = sk
+        self.agent_id = agent_id
+        self.on_message = on_message
+        self.on_disconnect = on_disconnect
+
+        self._ssl = _get_ssl_for_url(ws_url)
+        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._heartbeat_task: Optional[asyncio.Task] = None
+        self._receive_task: Optional[asyncio.Task] = None
+        self.connected = False
+
+    # -- public API --------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Establish the WebSocket connection. Return True on success."""
+        headers = generate_auth_headers(self.ak, self.sk, self.agent_id)
+        await self._cleanup()
+
+        self._session = aiohttp.ClientSession()
+        ws_timeout = aiohttp.ClientWSTimeout(ws_close=CONNECTION_TIMEOUT)
+        try:
+            kwargs: Dict[str, Any] = {
+                "headers": headers,
+                "timeout": ws_timeout,
+            }
+            if self._ssl is not None:
+                kwargs["ssl"] = self._ssl
+            self._ws = await self._session.ws_connect(
+                self.ws_url,
+                **kwargs,
+            )
+            self.connected = True
+            logger.info(
+                "XiaoYi [%s]: WebSocket connected to %s",
+                self.server_name,
+                self.ws_url,
+            )
+            await self._send_init_message()
+            self._heartbeat_task = asyncio.create_task(
+                self._heartbeat_loop(),
+            )
+            self._receive_task = asyncio.create_task(
+                self._receive_loop(),
+            )
+            return True
+        except Exception as e:
+            logger.error(
+                "XiaoYi [%s]: Connection error: %s",
+                self.server_name,
+                e,
+            )
+            self.connected = False
+            await self._cleanup()
+            return False
+
+    async def disconnect(self) -> None:
+        """Gracefully tear down the connection."""
+        self.connected = False
+        if self._heartbeat_task:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            self._heartbeat_task = None
+        if self._receive_task:
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except asyncio.CancelledError:
+                pass
+            self._receive_task = None
+        await self._cleanup()
+        logger.info("XiaoYi [%s]: Disconnected", self.server_name)
+
+    async def send_json(self, data: Dict[str, Any]) -> bool:
+        """Send a JSON payload. Return True on success."""
+        if not self._ws or self._ws.closed or not self.connected:
+            return False
+        try:
+            await self._ws.send_json(data)
+            return True
+        except Exception as e:
+            logger.error(
+                "XiaoYi [%s]: Send error: %s",
+                self.server_name,
+                e,
+            )
+            return False
+
+    def transfer_callbacks(
+        self,
+        on_message: _OnMessage,
+        on_disconnect: _OnDisconnect,
+    ) -> None:
+        """Re-bind callbacks to a new Channel instance (hot-swap)."""
+        self.on_message = on_message
+        self.on_disconnect = on_disconnect
+
+    # -- internal ----------------------------------------------------------
+
+    async def _send_init_message(self) -> None:
+        if not self._ws:
+            return
+        try:
+            await self._ws.send_json(
+                {
+                    "msgType": "clawd_bot_init",
+                    "agentId": self.agent_id,
+                    "msgDetail": json.dumps(
+                        {
+                            "agentId": self.agent_id,
+                            "hostname": platform.node(),
+                        },
+                    ),
+                },
+            )
+        except Exception as e:
+            logger.error(
+                "XiaoYi [%s]: Failed to send init message: %s",
+                self.server_name,
+                e,
+            )
+
+    async def _heartbeat_loop(self) -> None:
+        """Send heartbeat messages periodically."""
+        while self.connected and self._ws and not self._ws.closed:
+            try:
+                await asyncio.sleep(HEARTBEAT_INTERVAL)
+                if not self.connected or not self._ws:
+                    break
+                await self._ws.send_json(
+                    {
+                        "msgType": "heartbeat",
+                        "agentId": self.agent_id,
+                        "msgDetail": json.dumps(
+                            {"timestamp": int(time.time() * 1000)},
+                        ),
+                    },
+                )
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(
+                    "XiaoYi [%s]: Heartbeat error: %s",
+                    self.server_name,
+                    e,
+                )
+                break
+
+    async def _receive_loop(self) -> None:
+        """Receive and dispatch messages from WebSocket."""
+        if not self._ws:
+            return
+        try:
+            async for msg in self._ws:
+                if msg.type == aiohttp.WSMsgType.TEXT:
+                    await self._handle_text(msg.data)
+                elif msg.type == aiohttp.WSMsgType.ERROR:
+                    logger.error(
+                        "XiaoYi [%s]: WebSocket error: %s",
+                        self.server_name,
+                        self._ws.exception(),
+                    )
+                    break
+                elif msg.type in (
+                    aiohttp.WSMsgType.CLOSED,
+                    aiohttp.WSMsgType.CLOSE,
+                ):
+                    logger.info(
+                        "XiaoYi [%s]: WebSocket closed",
+                        self.server_name,
+                    )
+                    break
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(
+                "XiaoYi [%s]: Receive loop error: %s",
+                self.server_name,
+                e,
+            )
+        finally:
+            self.connected = False
+            self.on_disconnect(self.server_name)
+
+    async def _handle_text(self, data: str) -> None:
+        try:
+            message = json.loads(data)
+        except json.JSONDecodeError as e:
+            logger.error(
+                "XiaoYi [%s]: Failed to parse message: %s",
+                self.server_name,
+                e,
+            )
+            return
+        await self.on_message(message, self.server_name)
+
+    async def _cleanup(self) -> None:
+        ws = self._ws
+        if ws:
+            self._ws = None
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        session = self._session
+        if session:
+            self._session = None
+            try:
+                await session.close()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
 # Class-level registry to track active connections per agent_id
+# ---------------------------------------------------------------------------
+
 _active_connections: Dict[str, "XiaoYiChannel"] = {}
 _active_connections_lock = asyncio.Lock()
 
@@ -69,7 +357,6 @@ class XiaoYiChannel(BaseChannel):
         ak: str,
         sk: str,
         agent_id: str,
-        ws_url: str,
         task_timeout_ms: int = DEFAULT_TASK_TIMEOUT_MS,
         on_reply_sent: OnReplySent = None,
         show_tool_details: bool = True,
@@ -95,7 +382,6 @@ class XiaoYiChannel(BaseChannel):
         self.ak = ak
         self.sk = sk
         self.agent_id = agent_id
-        self.ws_url = ws_url
         self.task_timeout_ms = task_timeout_ms
         self.bot_prefix = bot_prefix
 
@@ -113,21 +399,17 @@ class XiaoYiChannel(BaseChannel):
             self._media_dir = DEFAULT_MEDIA_DIR / "xiaoyi"
         self._media_dir.mkdir(parents=True, exist_ok=True)
 
-        # WebSocket state
-        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
-        self._session: Optional[aiohttp.ClientSession] = None
+        # Dual WebSocket connections
+        self._conn_primary: Optional[XiaoYiConnection] = None
+        self._conn_backup: Optional[XiaoYiConnection] = None
         self._connected = False
         self._reconnect_attempts = 0
         self._stopping = False  # Flag to prevent reconnect during stop
 
+        # Session routing: session_id -> server_name
+        self._session_server_map: Dict[str, str] = {}
         # Session -> task_id mapping
         self._session_task_map: Dict[str, str] = {}
-
-        # Heartbeat task
-        self._heartbeat_task: Optional[asyncio.Task] = None
-
-        # Receive loop task
-        self._receive_task: Optional[asyncio.Task] = None
 
     @classmethod
     def from_env(
@@ -144,10 +426,6 @@ class XiaoYiChannel(BaseChannel):
             ak=os.getenv("XIAOYI_AK", ""),
             sk=os.getenv("XIAOYI_SK", ""),
             agent_id=os.getenv("XIAOYI_AGENT_ID", ""),
-            ws_url=os.getenv(
-                "XIAOYI_WS_URL",
-                "wss://hag.cloud.huawei.com/openclaw/v1/ws/link",
-            ),
             on_reply_sent=on_reply_sent,
             media_dir=os.getenv("XIAOYI_MEDIA_DIR", ""),
         )
@@ -170,10 +448,6 @@ class XiaoYiChannel(BaseChannel):
                 ak=config.get("ak", ""),
                 sk=config.get("sk", ""),
                 agent_id=config.get("agent_id", ""),
-                ws_url=config.get(
-                    "ws_url",
-                    "wss://hag.cloud.huawei.com/openclaw/v1/ws/link",
-                ),
                 task_timeout_ms=config.get(
                     "task_timeout_ms",
                     DEFAULT_TASK_TIMEOUT_MS,
@@ -199,7 +473,6 @@ class XiaoYiChannel(BaseChannel):
             ak=config.ak,
             sk=config.sk,
             agent_id=config.agent_id,
-            ws_url=config.ws_url,
             task_timeout_ms=config.task_timeout_ms,
             on_reply_sent=on_reply_sent,
             show_tool_details=show_tool_details,
@@ -233,26 +506,25 @@ class XiaoYiChannel(BaseChannel):
                 "status": "disabled",
                 "detail": "XiaoYi channel is disabled.",
             }
-        if not self._connected:
+        c1 = self._conn_primary and self._conn_primary.connected
+        c2 = self._conn_backup and self._conn_backup.connected
+        if c1 or c2:
             return {
                 "channel": self.channel,
-                "status": "unhealthy",
-                "detail": "XiaoYi WebSocket is not connected.",
-            }
-        if self._ws is None or self._ws.closed:
-            return {
-                "channel": self.channel,
-                "status": "unhealthy",
-                "detail": "XiaoYi WebSocket connection is closed.",
+                "status": "healthy",
+                "detail": (
+                    f"primary={'ok' if c1 else 'down'}, "
+                    f"backup={'ok' if c2 else 'down'}"
+                ),
             }
         return {
             "channel": self.channel,
-            "status": "healthy",
-            "detail": "XiaoYi WebSocket is connected.",
+            "status": "unhealthy",
+            "detail": "No WebSocket connections active.",
         }
 
     async def start(self) -> None:
-        """Start WebSocket connection."""
+        """Start dual WebSocket connections."""
         if not self.enabled:
             logger.debug("XiaoYi: start() skipped (enabled=false)")
             return
@@ -265,8 +537,8 @@ class XiaoYiChannel(BaseChannel):
 
         # Check if there's already an active connection for this agent_id
         # and reuse it if only filter settings changed
+        # pylint: disable=global-variable-not-assigned
         global _active_connections
-        should_connect = True
         async with _active_connections_lock:
             existing = _active_connections.get(self.agent_id)
             if (
@@ -275,12 +547,10 @@ class XiaoYiChannel(BaseChannel):
                 and existing._connected  # pylint: disable=protected-access
             ):
                 # pylint: disable=protected-access
-                # Found active connection - update settings
                 logger.info(
                     "XiaoYi: Updating settings for existing "
                     f"connection agent_id={self.agent_id}",
                 )
-                # Update render style settings on the existing channel
                 existing._render_style.filter_tool_messages = (
                     self._render_style.filter_tool_messages
                 )
@@ -290,58 +560,114 @@ class XiaoYiChannel(BaseChannel):
                 existing._render_style.show_tool_details = (
                     self._render_style.show_tool_details
                 )
-                # Re-register this instance
-                # (so the new instance becomes the active one)
                 _active_connections[self.agent_id] = self
-                # Copy the WebSocket state to this instance
-                self._ws = existing._ws
-                self._session = existing._session
+                # Transfer connections to this instance
+                self._conn_primary = existing._conn_primary
+                self._conn_backup = existing._conn_backup
                 self._connected = existing._connected
-                self._heartbeat_task = existing._heartbeat_task
-                self._receive_task = existing._receive_task
                 self._session_task_map = existing._session_task_map
-                # Mark old instance as not owning the connection anymore
-                existing._ws = None
-                existing._session = None
+                self._session_server_map = existing._session_server_map
+                # Re-bind callbacks to new instance
+                if self._conn_primary:
+                    self._conn_primary.transfer_callbacks(
+                        self._handle_incoming_message,
+                        self._handle_disconnect,
+                    )
+                if self._conn_backup:
+                    self._conn_backup.transfer_callbacks(
+                        self._handle_incoming_message,
+                        self._handle_disconnect,
+                    )
+                # Mark old instance as inactive
+                existing._conn_primary = None
+                existing._conn_backup = None
                 existing._connected = False
-                existing._heartbeat_task = None
-                existing._receive_task = None
-                should_connect = False
+                logger.info(
+                    "XiaoYi: Reused existing connections",
+                )
+                return
 
-        if not should_connect:
-            logger.info(
-                "XiaoYi: Reused existing connection with updated settings",
-            )
-            return
-
-        # No existing connection or can't reuse - start new connection
+        # No existing connection or can't reuse - start new connections
         await self._wait_and_register_connection()
 
-        logger.info(f"XiaoYi: Connecting to {self.ws_url}...")
+        logger.info(
+            "XiaoYi: Connecting to %s + %s...",
+            DEFAULT_WS_URL,
+            DEFAULT_WS_URL_BACKUP,
+        )
 
-        try:
-            await self._connect()
-        except Exception as e:
-            logger.error(f"XiaoYi connection failed: {e}")
-            # Unregister on failure
+        await self._start_connections()
+
+    async def _start_connections(self) -> None:
+        """Connect to WebSocket endpoints.
+
+        Connects to *both* primary (domain) and backup (IP) endpoints
+        in parallel.  The XiaoYi server may route messages through
+        either endpoint, so both must be active.
+        """
+        # Disconnect any existing connections first
+        for conn in (self._conn_primary, self._conn_backup):
+            if conn:
+                await conn.disconnect()
+        self._conn_backup = None
+
+        self._conn_primary = XiaoYiConnection(
+            server_name="primary",
+            ws_url=DEFAULT_WS_URL,
+            ak=self.ak,
+            sk=self.sk,
+            agent_id=self.agent_id,
+            on_message=self._handle_incoming_message,
+            on_disconnect=self._handle_disconnect,
+        )
+
+        tasks = [self._conn_primary.connect()]
+
+        if DEFAULT_WS_URL_BACKUP:
+            self._conn_backup = XiaoYiConnection(
+                server_name="backup",
+                ws_url=DEFAULT_WS_URL_BACKUP,
+                ak=self.ak,
+                sk=self.sk,
+                agent_id=self.agent_id,
+                on_message=self._handle_incoming_message,
+                on_disconnect=self._handle_disconnect,
+            )
+            tasks.append(self._conn_backup.connect())
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        any_connected = any(
+            r is True for r in results if not isinstance(r, Exception)
+        )
+        if any_connected:
+            self._connected = True
+            self._reconnect_attempts = 0
+            c1 = self._conn_primary and self._conn_primary.connected
+            c2 = self._conn_backup and self._conn_backup.connected
+            logger.info(
+                "XiaoYi: Connected (primary=%s, backup=%s)",
+                "ok" if c1 else "fail",
+                "ok" if c2 else "fail",
+            )
+        else:
+            self._connected = False
+            logger.error("XiaoYi: All connections failed")
             await self._unregister_connection()
             self._schedule_reconnect()
 
     async def _wait_and_register_connection(self) -> None:
         """Stop any existing connection with same agent_id, then register."""
+        # pylint: disable=global-variable-not-assigned
         global _active_connections
 
-        # First, get existing connection and remove it from registry
         existing = None
         async with _active_connections_lock:
             existing = _active_connections.get(self.agent_id)
             if existing is not None and existing is not self:
-                # Remove from registry immediately
                 _active_connections.pop(self.agent_id, None)
-            # Register this instance
             _active_connections[self.agent_id] = self
 
-        # Now stop the old connection outside the lock
         if existing is not None and existing is not self:
             # pylint: disable=protected-access
             logger.info(
@@ -349,30 +675,21 @@ class XiaoYiChannel(BaseChannel):
                 f"agent_id={self.agent_id}",
             )
             try:
-                # Set stopping flag FIRST to prevent any reconnect
                 existing._stopping = True
                 existing._connected = False
-                # Cancel tasks and wait for them to finish
-                if existing._heartbeat_task:
-                    existing._heartbeat_task.cancel()
-                    try:
-                        await existing._heartbeat_task
-                    except asyncio.CancelledError:
-                        pass
-                if existing._receive_task:
-                    existing._receive_task.cancel()
-                    try:
-                        await existing._receive_task
-                    except asyncio.CancelledError:
-                        pass
-                # Close WebSocket
-                if existing._ws:
-                    await existing._ws.close()
-                if existing._session:
-                    await existing._session.close()
-                logger.debug("XiaoYi: Old connection stopped")
+                for conn in (
+                    existing._conn_primary,
+                    existing._conn_backup,
+                ):
+                    if conn:
+                        await conn.disconnect()
+                existing._conn_primary = None
+                existing._conn_backup = None
+                logger.debug("XiaoYi: Old connections stopped")
             except Exception as e:
-                logger.debug(f"XiaoYi: Error stopping old connection: {e}")
+                logger.debug(
+                    f"XiaoYi: Error stopping old connection: {e}",
+                )
 
         logger.debug(
             f"XiaoYi: Registered connection for agent_id={self.agent_id}",
@@ -380,6 +697,7 @@ class XiaoYiChannel(BaseChannel):
 
     async def _unregister_connection(self) -> None:
         """Unregister this connection from active connections."""
+        # pylint: disable=global-variable-not-assigned
         global _active_connections
         async with _active_connections_lock:
             if _active_connections.get(self.agent_id) is self:
@@ -389,112 +707,24 @@ class XiaoYiChannel(BaseChannel):
                     f"agent_id={self.agent_id}",
                 )
 
-    async def _connect(self) -> None:
-        """Establish WebSocket connection."""
-        headers = generate_auth_headers(self.ak, self.sk, self.agent_id)
+    # -----------------------------------------------------------------
+    # Message routing (dual connection)
+    # -----------------------------------------------------------------
 
-        # Clean up any existing session first
-        await self._cleanup_session()
-
-        self._session = aiohttp.ClientSession()
-        ws_timeout = aiohttp.ClientWSTimeout(ws_close=CONNECTION_TIMEOUT)
-
-        try:
-            self._ws = await self._session.ws_connect(
-                self.ws_url,
-                headers=headers,
-                timeout=ws_timeout,
-            )
-
-            self._connected = True
-            self._reconnect_attempts = 0
-            logger.info("XiaoYi: WebSocket connected")
-
-            # Send init message
-            await self._send_init_message()
-
-            # Start heartbeat
-            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-
-            # Start receive loop
-            self._receive_task = asyncio.create_task(self._receive_loop())
-
-        except Exception as e:
-            logger.error(f"XiaoYi: WebSocket connection error: {e}")
-            self._connected = False
-            raise
-
-    async def _send_init_message(self) -> None:
-        """Send init message to server."""
-        if not self._ws:
-            return
-
-        init_msg = {
-            "msgType": "clawd_bot_init",
-            "agentId": self.agent_id,
-        }
-
-        try:
-            await self._ws.send_json(init_msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send init message: {e}")
-
-    async def _heartbeat_loop(self) -> None:
-        """Send heartbeat messages periodically."""
-        while self._connected and self._ws:
-            try:
-                await asyncio.sleep(HEARTBEAT_INTERVAL)
-
-                if not self._connected or not self._ws:
-                    break
-
-                heartbeat_msg = {
-                    "msgType": "heartbeat",
-                    "agentId": self.agent_id,
-                }
-
-                await self._ws.send_json(heartbeat_msg)
-
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.error(f"XiaoYi: Heartbeat error: {e}")
-                break
-
-    async def _receive_loop(self) -> None:
-        """Receive and process messages from WebSocket."""
-        if not self._ws:
+    async def _handle_incoming_message(
+        self,
+        message: Dict[str, Any],
+        server_name: str,
+    ) -> None:
+        """Dispatch an incoming message from either connection."""
+        if self._stopping:
             return
 
         try:
-            async for msg in self._ws:
-                if msg.type == aiohttp.WSMsgType.TEXT:
-                    await self._handle_message(msg.data)
-                elif msg.type == aiohttp.WSMsgType.ERROR:
-                    logger.error(
-                        f"XiaoYi: WebSocket error: {self._ws.exception()}",
-                    )
-                    break
-                elif msg.type == aiohttp.WSMsgType.CLOSED:
-                    logger.info("XiaoYi: WebSocket closed")
-                    break
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            logger.error(f"XiaoYi: Receive loop error: {e}")
-        finally:
-            self._connected = False
-            # Only reconnect if not stopping
-            if not self._stopping:
-                self._schedule_reconnect()
-
-    async def _handle_message(self, data: str) -> None:
-        """Handle incoming WebSocket message."""
-        try:
-            message = json.loads(data)
             logger.debug(
-                "XiaoYi: Received message: "
-                f"{json.dumps(message, indent=2)}",
+                "XiaoYi [%s]: Received message: %s",
+                server_name,
+                json.dumps(message, indent=2),
             )
 
             # Validate agent_id
@@ -504,6 +734,13 @@ class XiaoYiChannel(BaseChannel):
                     f"{message['agentId']}, expected {self.agent_id}",
                 )
                 return
+
+            # Track which server this session came from
+            session_id = message.get("params", {}).get(
+                "sessionId",
+            ) or message.get("sessionId")
+            if session_id:
+                self._session_server_map[session_id] = server_name
 
             # Handle clear context
             if (
@@ -525,10 +762,56 @@ class XiaoYiChannel(BaseChannel):
             if message.get("method") == "message/stream":
                 await self._handle_a2a_request(message)
 
-        except json.JSONDecodeError as e:
-            logger.error(f"XiaoYi: Failed to parse message: {e}")
         except Exception as e:
-            logger.error(f"XiaoYi: Error handling message: {e}", exc_info=True)
+            logger.error(
+                "XiaoYi: Error handling message: %s",
+                e,
+                exc_info=True,
+            )
+
+    def _handle_disconnect(self, server_name: str) -> None:
+        """Called when one connection drops.
+
+        Only trigger reconnect when *both* connections are down.
+        """
+        if self._stopping:
+            return
+
+        logger.warning("XiaoYi [%s]: Disconnected", server_name)
+
+        # Clean session-server mappings for the dropped server
+        for sid, srv in list(self._session_server_map.items()):
+            if srv == server_name:
+                self._session_server_map.pop(sid, None)
+
+        c1 = self._conn_primary and self._conn_primary.connected
+        c2 = self._conn_backup and self._conn_backup.connected
+        if not c1 and not c2:
+            self._connected = False
+            self._schedule_reconnect()
+
+    async def _send_to_session_server(
+        self,
+        session_id: str,
+        msg: Dict[str, Any],
+    ) -> None:
+        """Route outgoing message to the server that owns the session."""
+        target = self._session_server_map.get(session_id, "primary")
+
+        # Try target server first, fallback to the other
+        if target == "backup":
+            if self._conn_backup and await self._conn_backup.send_json(msg):
+                return
+            # Fallback to primary
+            if self._conn_primary and await self._conn_primary.send_json(msg):
+                return
+        else:
+            if self._conn_primary and await self._conn_primary.send_json(msg):
+                return
+            # Fallback to backup
+            if self._conn_backup and await self._conn_backup.send_json(msg):
+                return
+        logger.warning("XiaoYi: No connection available to send message")
 
     async def _handle_a2a_request(self, message: Dict[str, Any]) -> None:
         """Handle A2A request message."""
@@ -669,7 +952,7 @@ class XiaoYiChannel(BaseChannel):
         success: bool = True,
     ) -> None:
         """Send clear context response."""
-        if not self._ws or not self._connected:
+        if not self._connected:
             return
 
         json_rpc_response = {
@@ -688,10 +971,7 @@ class XiaoYiChannel(BaseChannel):
             "msgDetail": json.dumps(json_rpc_response),
         }
 
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send clear context response: {e}")
+        await self._send_to_session_server(session_id, msg)
 
     async def _send_tasks_cancel_response(
         self,
@@ -700,7 +980,7 @@ class XiaoYiChannel(BaseChannel):
         success: bool = True,
     ) -> None:
         """Send tasks cancel response."""
-        if not self._ws or not self._connected:
+        if not self._connected:
             return
 
         json_rpc_response = {
@@ -720,10 +1000,7 @@ class XiaoYiChannel(BaseChannel):
             "msgDetail": json.dumps(json_rpc_response),
         }
 
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send cancel response: {e}")
+        await self._send_to_session_server(session_id, msg)
 
     def _schedule_reconnect(self) -> None:
         """Schedule reconnection attempt."""
@@ -747,74 +1024,33 @@ class XiaoYiChannel(BaseChannel):
             await asyncio.sleep(delay)
             if self._stopping or self._connected:
                 return
-
-            # Clean up old session before reconnecting
-            await self._cleanup_session()
-
             try:
-                await self._connect()
-                logger.info("XiaoYi: Reconnected successfully")
+                await self._start_connections()
+                if self._connected:
+                    logger.info("XiaoYi: Reconnected successfully")
             except Exception as e:
                 logger.error(f"XiaoYi: Reconnect failed: {e}")
                 self._schedule_reconnect()
 
         asyncio.create_task(reconnect())
 
-    async def _cleanup_session(self) -> None:
-        """Clean up WebSocket and session."""
-        if self._ws:
-            try:
-                await self._ws.close()
-            except Exception:
-                pass
-            self._ws = None
-
-        if self._session:
-            try:
-                await self._session.close()
-            except Exception:
-                pass
-            self._session = None
-
     async def stop(self) -> None:
-        """Stop WebSocket connection."""
+        """Stop WebSocket connections."""
         logger.info("XiaoYi: Stopping channel...")
 
         self._stopping = True  # Prevent reconnect during stop
         self._connected = False
 
-        # Cancel tasks
-        if self._heartbeat_task:
-            self._heartbeat_task.cancel()
-            try:
-                await self._heartbeat_task
-            except asyncio.CancelledError:
-                pass
-            self._heartbeat_task = None
-
-        if self._receive_task:
-            self._receive_task.cancel()
-            try:
-                await self._receive_task
-            except asyncio.CancelledError:
-                pass
-            self._receive_task = None
-
-        # Close WebSocket
-        if self._ws:
-            await self._ws.close()
-            self._ws = None
-
-        # Close session
-        if self._session:
-            await self._session.close()
-            self._session = None
+        # Disconnect both connections
+        for conn in (self._conn_primary, self._conn_backup):
+            if conn:
+                await conn.disconnect()
+        self._conn_primary = None
+        self._conn_backup = None
 
         # Unregister from active connections
         await self._unregister_connection()
 
-        # Keep _stopping = True to prevent any reconnection attempts
-        # This channel instance will not be reused after stop
         logger.info("XiaoYi: Channel stopped")
 
     async def send(
@@ -829,7 +1065,7 @@ class XiaoYiChannel(BaseChannel):
         at TEXT_CHUNK_LIMIT characters to avoid WebSocket disconnection
         on large messages.
         """
-        if not self.enabled or not self._ws or not self._connected:
+        if not self.enabled or not self._connected:
             logger.warning("XiaoYi: Cannot send - not connected")
             return
 
@@ -898,7 +1134,7 @@ class XiaoYiChannel(BaseChannel):
         task_id: str,
         message_id: str,
         parts: List[Dict[str, Any]],
-        last_chunk: bool = False,
+        *,
         final: bool = False,
     ) -> Dict[str, Any]:
         """Build artifact-update message for XiaoYi A2A protocol."""
@@ -910,7 +1146,7 @@ class XiaoYiChannel(BaseChannel):
                 "taskId": task_id,
                 "kind": "artifact-update",
                 "append": True,
-                "lastChunk": last_chunk,
+                "lastChunk": True,
                 "final": final,
                 "artifact": {
                     "artifactId": artifact_id,
@@ -934,7 +1170,7 @@ class XiaoYiChannel(BaseChannel):
         text: str,
     ) -> None:
         """Send a single text chunk via WebSocket."""
-        if not self._ws or not self._connected:
+        if not self._connected:
             return
         msg = self._build_artifact_msg(
             session_id,
@@ -942,10 +1178,7 @@ class XiaoYiChannel(BaseChannel):
             message_id,
             [{"kind": "text", "text": text}],
         )
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send chunk: {e}")
+        await self._send_to_session_server(session_id, msg)
 
     async def _send_reasoning_chunk(
         self,
@@ -955,7 +1188,7 @@ class XiaoYiChannel(BaseChannel):
         reasoning_text: str,
     ) -> None:
         """Send a reasoning/thinking chunk via WebSocket."""
-        if not self._ws or not self._connected:
+        if not self._connected:
             return
         msg = self._build_artifact_msg(
             session_id,
@@ -963,10 +1196,7 @@ class XiaoYiChannel(BaseChannel):
             message_id,
             [{"kind": "reasoningText", "reasoningText": reasoning_text}],
         )
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send reasoning chunk: {e}")
+        await self._send_to_session_server(session_id, msg)
 
     async def send_final_message(
         self,
@@ -974,21 +1204,64 @@ class XiaoYiChannel(BaseChannel):
         task_id: str,
         message_id: str,
     ) -> None:
-        """Send final empty message to end the stream."""
-        if not self.enabled or not self._ws or not self._connected:
+        """Send status-update + final artifact to end the stream.
+
+        The XiaoYi A2A protocol requires two messages to properly close
+        a response stream:
+        1. ``status-update`` with ``state: "completed"``
+        2. ``artifact-update`` with ``final: true`` (empty text)
+
+        Without step 1 the XiaoYi UI stays in "running" state.
+        """
+        if not self.enabled or not self._connected:
             return
-        msg = self._build_artifact_msg(
+
+        # Step 1: status-update  (state=completed)
+        status_msg = {
+            "msgType": "agent_response",
+            "agentId": self.agent_id,
+            "sessionId": session_id,
+            "taskId": task_id,
+            "msgDetail": json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {
+                        "taskId": task_id,
+                        "kind": "status-update",
+                        "final": False,
+                        "status": {
+                            "message": {
+                                "role": "agent",
+                                "parts": [
+                                    {"kind": "text", "text": ""},
+                                ],
+                            },
+                            "state": "completed",
+                        },
+                    },
+                },
+            ),
+        }
+        await self._send_to_session_server(session_id, status_msg)
+        logger.info(
+            "XiaoYi: Sent status-update(completed) for session=%s",
+            session_id,
+        )
+
+        # Step 2: artifact-update  (final=true, stream end)
+        final_msg = self._build_artifact_msg(
             session_id,
             task_id,
             message_id,
             [{"kind": "text", "text": ""}],
-            last_chunk=True,
             final=True,
         )
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send final message: {e}")
+        await self._send_to_session_server(session_id, final_msg)
+        logger.info(
+            "XiaoYi: Sent artifact-update(final) for session=%s",
+            session_id,
+        )
 
     async def send_media(
         self,
@@ -997,7 +1270,7 @@ class XiaoYiChannel(BaseChannel):
         meta: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Send media message via WebSocket."""
-        if not self.enabled or not self._ws or not self._connected:
+        if not self.enabled or not self._connected:
             return
 
         meta = meta or {}
@@ -1044,13 +1317,9 @@ class XiaoYiChannel(BaseChannel):
             task_id,
             str(uuid.uuid4()),
             [artifact_part],
-            last_chunk=True,
             final=True,
         )
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send media: {e}")
+        await self._send_to_session_server(session_id, msg)
 
     def _extract_xiaoyi_parts(
         self,
@@ -1247,7 +1516,7 @@ class XiaoYiChannel(BaseChannel):
         - kind: "text" or "reasoningText"
         - text/reasoningText: the content string
         """
-        if not self.enabled or not self._ws or not self._connected:
+        if not self.enabled or not self._connected:
             logger.warning("XiaoYi: Cannot send - not connected")
             return
 
@@ -1336,10 +1605,7 @@ class XiaoYiChannel(BaseChannel):
             message_id,
             artifact_parts,
         )
-        try:
-            await self._ws.send_json(msg)
-        except Exception as e:
-            logger.error(f"XiaoYi: Failed to send parts: {e}")
+        await self._send_to_session_server(session_id, msg)
 
     async def on_event_message_completed(
         self,
@@ -1410,56 +1676,30 @@ class XiaoYiChannel(BaseChannel):
             return session_id.split(":", 1)[-1]
         return user_id
 
-    async def _run_process_loop(
+    async def _on_process_completed(
         self,
         request: "AgentRequest",
         to_handle: str,
         send_meta: Dict[str, Any],
     ) -> None:
-        """Run process and send events. Override to send final message."""
-        from agentscope_runtime.engine.schemas.agent_schemas import RunStatus
-
-        last_response = None
+        """Send status-update + final artifact after processing."""
         session_id = send_meta.get("session_id") or to_handle
+        task_id = send_meta.get("task_id") or self._session_task_map.get(
+            session_id,
+        )
+        message_id = send_meta.get("message_id") or str(uuid.uuid4())
 
-        try:
-            async for event in self._process(request):
-                obj = getattr(event, "object", None)
-                status = getattr(event, "status", None)
-                if obj == "message" and status == RunStatus.Completed:
-                    await self.on_event_message_completed(
-                        request,
-                        to_handle,
-                        event,
-                        send_meta,
-                    )
-                elif obj == "response":
-                    last_response = event
-                    await self.on_event_response(request, event)
+        logger.info(
+            "XiaoYi: final msg session=%s task=%s",
+            session_id,
+            task_id,
+        )
 
-            # Send final message to end the stream
-            task_id = send_meta.get("task_id") or self._session_task_map.get(
+        if task_id and session_id:
+            await self.send_final_message(session_id, task_id, message_id)
+        else:
+            logger.warning(
+                "XiaoYi: Cannot send final - session=%s task=%s",
                 session_id,
-            )
-            message_id = str(uuid.uuid4())
-
-            if task_id and session_id:
-                await self.send_final_message(session_id, task_id, message_id)
-
-            err_msg = self._get_response_error_message(last_response)
-            if err_msg:
-                await self._on_consume_error(
-                    request,
-                    to_handle,
-                    f"Error: {err_msg}",
-                )
-            if self._on_reply_sent:
-                args = self.get_on_reply_sent_args(request, to_handle)
-                self._on_reply_sent(self.channel, *args)
-        except Exception:
-            logger.exception("XiaoYi channel consume_one failed")
-            await self._on_consume_error(
-                request,
-                to_handle,
-                "An error occurred while processing your request.",
+                task_id,
             )

--- a/src/qwenpaw/app/channels/xiaoyi/constants.py
+++ b/src/qwenpaw/app/channels/xiaoyi/constants.py
@@ -4,6 +4,9 @@
 # Default WebSocket URL
 DEFAULT_WS_URL = "wss://hag.cloud.huawei.com/openclaw/v1/ws/link"
 
+# Default backup WebSocket URL (IP direct)
+DEFAULT_WS_URL_BACKUP = "wss://116.63.174.231/openclaw/v1/ws/link"
+
 # Heartbeat interval (seconds)
 HEARTBEAT_INTERVAL = 30
 

--- a/src/qwenpaw/cli/doctor_connectivity.py
+++ b/src/qwenpaw/cli/doctor_connectivity.py
@@ -189,21 +189,36 @@ def _probe_voice(
 
 def _probe_xiaoyi(
     agent_id: str,
-    cfg: XiaoYiConfig,
+    _cfg: XiaoYiConfig,
     timeout: float,
 ) -> list[str]:
-    raw = (cfg.ws_url or "").strip()
-    if not raw:
-        return []
-    parsed = urlparse(raw)
-    host = parsed.hostname
-    if not host:
-        return [f"{agent_id}: xiaoyi: could not parse host from ws_url"]
-    port = parsed.port or (443 if parsed.scheme in ("wss", "https") else 80)
-    err = _tcp_check(host, port, timeout)
-    if err:
-        return [f"{agent_id}: xiaoyi: TCP {host}:{port} — {err}"]
-    return []
+    from qwenpaw.app.channels.xiaoyi.constants import (
+        DEFAULT_WS_URL,
+        DEFAULT_WS_URL_BACKUP,
+    )
+
+    notes: list[str] = []
+    for label, raw in (
+        ("primary", DEFAULT_WS_URL),
+        ("backup", DEFAULT_WS_URL_BACKUP),
+    ):
+        if not raw:
+            continue
+        parsed = urlparse(raw)
+        host = parsed.hostname
+        if not host:
+            continue
+        port = parsed.port or (
+            443 if parsed.scheme in ("wss", "https") else 80
+        )
+        err = _tcp_check(host, port, timeout)
+        if err:
+            notes.append(
+                f"{agent_id}: xiaoyi: "
+                f"TCP {host}:{port} ({label}) "
+                f"\u2014 {err}",
+            )
+    return notes
 
 
 def _probe_wechat(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -411,7 +411,6 @@ class XiaoYiConfig(BaseChannelConfig):
     ak: str = ""  # Access Key
     sk: str = ""  # Secret Key
     agent_id: str = ""  # Agent ID from XiaoYi platform
-    ws_url: str = "wss://hag.cloud.huawei.com/openclaw/v1/ws/link"
     task_timeout_ms: int = 3600000  # 1 hour task timeout
 
 

--- a/tests/unit/channels/test_xiaoyi.py
+++ b/tests/unit/channels/test_xiaoyi.py
@@ -12,12 +12,10 @@ Run:
 # pylint: disable=redefined-outer-name,protected-access,unused-argument
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-import aiohttp
 
 
 # =============================================================================
@@ -40,24 +38,6 @@ def mock_process():
 
 
 @pytest.fixture
-def mock_ws():
-    """Create mock WebSocket connection."""
-    ws = MagicMock()
-    ws.send_json = AsyncMock()
-    ws.close = AsyncMock()
-    return ws
-
-
-@pytest.fixture
-def mock_session(mock_ws):
-    """Create mock aiohttp ClientSession with WebSocket."""
-    session = MagicMock()
-    session.ws_connect = AsyncMock(return_value=mock_ws)
-    session.close = AsyncMock()
-    return session
-
-
-@pytest.fixture
 def xiaoyi_channel(mock_process, tmp_path):
     """Create XiaoYiChannel instance for testing."""
     from qwenpaw.app.channels.xiaoyi.channel import XiaoYiChannel
@@ -68,23 +48,11 @@ def xiaoyi_channel(mock_process, tmp_path):
         ak="test_ak_123456",
         sk="test_sk_abcdef",
         agent_id="test_agent_123",
-        ws_url="wss://test.example.com/ws",
         task_timeout_ms=3600000,
         bot_prefix="[小艺] ",
         media_dir=str(tmp_path / "media"),
     )
     return channel
-
-
-@pytest.fixture
-def mock_auth_headers():
-    """Mock authentication headers."""
-    return {
-        "x-access-key": "test_ak_123456",
-        "x-sign": "mock_signature",
-        "x-ts": "1234567890",
-        "x-agent-id": "test_agent_123",
-    }
 
 
 # =============================================================================
@@ -108,7 +76,6 @@ class TestXiaoYiChannelInit:
             ak="test_ak",
             sk="test_sk",
             agent_id="test_agent",
-            ws_url="wss://test.example.com/ws",
             task_timeout_ms=5000,
             bot_prefix="[Test] ",
             media_dir=str(tmp_path / "media"),
@@ -118,7 +85,6 @@ class TestXiaoYiChannelInit:
         assert channel.ak == "test_ak"
         assert channel.sk == "test_sk"
         assert channel.agent_id == "test_agent"
-        assert channel.ws_url == "wss://test.example.com/ws"
         assert channel.task_timeout_ms == 5000
         assert channel.bot_prefix == "[Test] "
         assert channel._media_dir == tmp_path / "media"
@@ -137,15 +103,16 @@ class TestXiaoYiChannelInit:
             ak="test_ak",
             sk="test_sk",
             agent_id="test_agent",
-            ws_url="wss://test.example.com/ws",
         )
 
         assert hasattr(channel, "_session_task_map")
         assert isinstance(channel._session_task_map, dict)
-        assert channel._ws is None
-        assert channel._session is None
+        assert channel._conn_primary is None
+        assert channel._conn_backup is None
         assert channel._connected is False
         assert channel._reconnect_attempts == 0
+        assert hasattr(channel, "_session_server_map")
+        assert isinstance(channel._session_server_map, dict)
 
     def test_init_with_workspace_dir(self, mock_process, tmp_path):
         """Constructor uses workspace-specific media dir when provided."""
@@ -158,7 +125,6 @@ class TestXiaoYiChannelInit:
             ak="test_ak",
             sk="test_sk",
             agent_id="test_agent",
-            ws_url="wss://test.example.com/ws",
             workspace_dir=workspace,
         )
 
@@ -189,7 +155,6 @@ class TestXiaoYiChannelFactoryMethods:
         monkeypatch.setenv("XIAOYI_AK", "env_ak_value")
         monkeypatch.setenv("XIAOYI_SK", "env_sk_value")
         monkeypatch.setenv("XIAOYI_AGENT_ID", "env_agent_123")
-        monkeypatch.setenv("XIAOYI_WS_URL", "wss://env.example.com/ws")
         monkeypatch.setenv("XIAOYI_MEDIA_DIR", str(tmp_path / "media"))
 
         channel = XiaoYiChannel.from_env(process=mock_process)
@@ -198,7 +163,6 @@ class TestXiaoYiChannelFactoryMethods:
         assert channel.ak == "env_ak_value"
         assert channel.sk == "env_sk_value"
         assert channel.agent_id == "env_agent_123"
-        assert channel.ws_url == "wss://env.example.com/ws"
 
     def test_from_env_uses_defaults(self, monkeypatch, mock_process):
         """from_env uses default values when env vars are missing."""
@@ -208,7 +172,6 @@ class TestXiaoYiChannelFactoryMethods:
         monkeypatch.delenv("XIAOYI_AK", raising=False)
         monkeypatch.delenv("XIAOYI_SK", raising=False)
         monkeypatch.delenv("XIAOYI_AGENT_ID", raising=False)
-        monkeypatch.delenv("XIAOYI_WS_URL", raising=False)
 
         channel = XiaoYiChannel.from_env(process=mock_process)
 
@@ -216,9 +179,6 @@ class TestXiaoYiChannelFactoryMethods:
         assert channel.ak == ""
         assert channel.sk == ""
         assert channel.agent_id == ""
-        assert (
-            channel.ws_url == "wss://hag.cloud.huawei.com/openclaw/v1/ws/link"
-        )
 
     def test_from_config_with_object(self, mock_process, tmp_path):
         """from_config should use config object values."""
@@ -229,7 +189,6 @@ class TestXiaoYiChannelFactoryMethods:
         config.ak = "config_ak"
         config.sk = "config_sk"
         config.agent_id = "config_agent"
-        config.ws_url = "wss://config.example.com/ws"
         config.task_timeout_ms = 60000
         config.bot_prefix = "[Config] "
         config.media_dir = str(tmp_path / "media")
@@ -255,7 +214,6 @@ class TestXiaoYiChannelFactoryMethods:
             "ak": "dict_ak",
             "sk": "dict_sk",
             "agent_id": "dict_agent",
-            "ws_url": "wss://dict.example.com/ws",
             "task_timeout_ms": 30000,
             "bot_prefix": "[Dict] ",
         }
@@ -269,7 +227,6 @@ class TestXiaoYiChannelFactoryMethods:
         assert channel.ak == "dict_ak"
         assert channel.sk == "dict_sk"
         assert channel.agent_id == "dict_agent"
-        assert channel.ws_url == "wss://dict.example.com/ws"
 
 
 # =============================================================================
@@ -293,7 +250,6 @@ class TestXiaoYiChannelValidation:
             ak="",
             sk="test_sk",
             agent_id="test_agent",
-            ws_url="wss://test.example.com/ws",
         )
 
         with pytest.raises(ValueError, match="AK"):
@@ -309,7 +265,6 @@ class TestXiaoYiChannelValidation:
             ak="test_ak",
             sk="",
             agent_id="test_agent",
-            ws_url="wss://test.example.com/ws",
         )
 
         with pytest.raises(ValueError, match="SK"):
@@ -325,7 +280,6 @@ class TestXiaoYiChannelValidation:
             ak="test_ak",
             sk="test_sk",
             agent_id="",
-            ws_url="wss://test.example.com/ws",
         )
 
         with pytest.raises(ValueError, match="Agent ID"):
@@ -361,9 +315,11 @@ class TestXiaoYiChannelLifecycle:
                 "_wait_and_register_connection",
                 new_callable=AsyncMock,
             ):
-                with patch("aiohttp.ClientSession") as MockSession:
-                    mock_session = MockSession.return_value
-                    mock_session.ws_connect = AsyncMock()
+                with patch.object(
+                    xiaoyi_channel,
+                    "_start_connections",
+                    new_callable=AsyncMock,
+                ):
                     await xiaoyi_channel.start()
                     mock_validate.assert_called_once()
 
@@ -376,53 +332,52 @@ class TestXiaoYiChannelLifecycle:
 
         assert xiaoyi_channel._connected is False
 
-    async def test_stop_cleans_up_resources(self, xiaoyi_channel, mock_ws):
+    async def test_stop_cleans_up_resources(self, xiaoyi_channel):
         """stop() should clean up all resources."""
-        xiaoyi_channel._ws = mock_ws
-        xiaoyi_channel._session = MagicMock()
-        xiaoyi_channel._session.close = AsyncMock()
+        from qwenpaw.app.channels.xiaoyi.channel import XiaoYiConnection
+
+        mock_conn = MagicMock(spec=XiaoYiConnection)
+        mock_conn.disconnect = AsyncMock()
+        mock_conn.connected = True
+        xiaoyi_channel._conn_primary = mock_conn
+        xiaoyi_channel._conn_backup = None
         xiaoyi_channel._connected = True
-        xiaoyi_channel._heartbeat_task = None
-        xiaoyi_channel._receive_task = None
 
         await xiaoyi_channel.stop()
 
         assert xiaoyi_channel._connected is False
         assert xiaoyi_channel._stopping is True
-        mock_ws.close.assert_called_once()
+        mock_conn.disconnect.assert_called_once()
+        assert xiaoyi_channel._conn_primary is None
 
-    async def test_stop_handles_missing_ws(self, xiaoyi_channel):
-        """stop() should handle missing WebSocket gracefully."""
-        xiaoyi_channel._ws = None
-        xiaoyi_channel._session = None
+    async def test_stop_handles_no_connections(self, xiaoyi_channel):
+        """stop() should handle missing connections gracefully."""
+        xiaoyi_channel._conn_primary = None
+        xiaoyi_channel._conn_backup = None
         xiaoyi_channel._connected = True
 
         await xiaoyi_channel.stop()
 
         assert xiaoyi_channel._connected is False
 
-    async def test_stop_cancels_tasks(self, xiaoyi_channel, mock_ws):
-        """stop() should cancel running tasks."""
-        xiaoyi_channel._ws = mock_ws
-        xiaoyi_channel._session = MagicMock()
-        xiaoyi_channel._session.close = AsyncMock()
+    async def test_stop_disconnects_both_connections(self, xiaoyi_channel):
+        """stop() should disconnect both connections."""
+        from qwenpaw.app.channels.xiaoyi.channel import XiaoYiConnection
+
+        conn1 = MagicMock(spec=XiaoYiConnection)
+        conn1.disconnect = AsyncMock()
+        conn2 = MagicMock(spec=XiaoYiConnection)
+        conn2.disconnect = AsyncMock()
+        xiaoyi_channel._conn_primary = conn1
+        xiaoyi_channel._conn_backup = conn2
         xiaoyi_channel._connected = True
-        xiaoyi_channel._stopping = False
-
-        # Create a real cancelled task for proper await
-        async def dummy_task():
-            while True:
-                await asyncio.sleep(0.1)
-
-        task1 = asyncio.create_task(dummy_task())
-        task2 = asyncio.create_task(dummy_task())
-        xiaoyi_channel._heartbeat_task = task1
-        xiaoyi_channel._receive_task = task2
 
         await xiaoyi_channel.stop()
 
-        assert task1.cancelled() or task1.done()
-        assert task2.cancelled() or task2.done()
+        conn1.disconnect.assert_called_once()
+        conn2.disconnect.assert_called_once()
+        assert xiaoyi_channel._conn_primary is None
+        assert xiaoyi_channel._conn_backup is None
 
 
 # =============================================================================
@@ -433,87 +388,75 @@ class TestXiaoYiChannelLifecycle:
 @pytest.mark.asyncio
 class TestXiaoYiChannelWebSocketConnection:
     """
-    P0: WebSocket connection tests.
+    P0: WebSocket connection tests (single connection + fallback).
     """
 
-    async def test_connect_establishes_websocket(
+    async def test_start_connections_primary_success(
         self,
         xiaoyi_channel,
-        mock_session,
-        mock_ws,
-        mock_auth_headers,
     ):
-        """_connect should establish WebSocket connection with auth headers."""
+        """_start_connections should connect both endpoints in parallel."""
         with patch(
-            "qwenpaw.app.channels.xiaoyi.channel.generate_auth_headers",
-            return_value=mock_auth_headers,
-        ):
-            with patch("aiohttp.ClientSession", return_value=mock_session):
-                await xiaoyi_channel._connect()
+            "qwenpaw.app.channels.xiaoyi.channel.XiaoYiConnection",
+        ) as MockConn:
+            mock_instance = MagicMock()
+            mock_instance.connect = AsyncMock(return_value=True)
+            mock_instance.disconnect = AsyncMock()
+            mock_instance.connected = True
+            MockConn.return_value = mock_instance
 
-        mock_session.ws_connect.assert_called_once()
+            await xiaoyi_channel._start_connections()
+
+        # Both primary and backup created
+        assert MockConn.call_count == 2
         assert xiaoyi_channel._connected is True
-        assert xiaoyi_channel._ws == mock_ws
 
-    async def test_connect_sends_init_message(
+    async def test_start_connections_fallback_to_backup(
         self,
         xiaoyi_channel,
-        mock_session,
-        mock_ws,
-        mock_auth_headers,
     ):
-        """_connect should send init message after connection."""
+        """_start_connections should succeed if at least one connects."""
+        call_count = 0
+
+        async def side_effect_connect():
+            nonlocal call_count
+            call_count += 1
+            return call_count != 1  # First fails, second succeeds
+
         with patch(
-            "qwenpaw.app.channels.xiaoyi.channel.generate_auth_headers",
-            return_value=mock_auth_headers,
-        ):
-            with patch("aiohttp.ClientSession", return_value=mock_session):
-                await xiaoyi_channel._connect()
+            "qwenpaw.app.channels.xiaoyi.channel.XiaoYiConnection",
+        ) as MockConn:
+            mock_instance = MagicMock()
+            mock_instance.connect = AsyncMock(side_effect=side_effect_connect)
+            mock_instance.disconnect = AsyncMock()
+            MockConn.return_value = mock_instance
 
-        mock_ws.send_json.assert_called_once()
-        call_args = mock_ws.send_json.call_args
-        sent_msg = call_args[0][0]
-        assert sent_msg["msgType"] == "clawd_bot_init"
-        assert sent_msg["agentId"] == xiaoyi_channel.agent_id
+            await xiaoyi_channel._start_connections()
 
-    async def test_connect_starts_heartbeat_and_receive(
+        assert MockConn.call_count == 2
+        assert xiaoyi_channel._connected is True
+
+    async def test_start_connections_no_backup(
         self,
         xiaoyi_channel,
-        mock_session,
-        mock_ws,
-        mock_auth_headers,
     ):
-        """_connect should start heartbeat and receive loops."""
+        """_start_connections with empty backup constant skips backup."""
         with patch(
-            "qwenpaw.app.channels.xiaoyi.channel.generate_auth_headers",
-            return_value=mock_auth_headers,
-        ):
-            with patch("aiohttp.ClientSession", return_value=mock_session):
-                await xiaoyi_channel._connect()
+            "qwenpaw.app.channels.xiaoyi.channel.DEFAULT_WS_URL_BACKUP",
+            "",
+        ), patch(
+            "qwenpaw.app.channels.xiaoyi.channel.XiaoYiConnection",
+        ) as MockConn:
+            mock_instance = MagicMock()
+            mock_instance.connect = AsyncMock(return_value=True)
+            mock_instance.disconnect = AsyncMock()
+            MockConn.return_value = mock_instance
 
-        assert xiaoyi_channel._heartbeat_task is not None
-        assert xiaoyi_channel._receive_task is not None
+            await xiaoyi_channel._start_connections()
 
-    async def test_connect_handles_connection_error(
-        self,
-        xiaoyi_channel,
-        mock_session,
-        mock_auth_headers,
-    ):
-        """_connect should handle connection errors."""
-        mock_session.ws_connect = AsyncMock(
-            side_effect=aiohttp.ClientError("Connection failed"),
-        )
-
-        with patch(
-            "qwenpaw.app.channels.xiaoyi.channel.generate_auth_headers",
-            return_value=mock_auth_headers,
-        ):
-            with patch("aiohttp.ClientSession", return_value=mock_session):
-                with pytest.raises(aiohttp.ClientError):
-                    await xiaoyi_channel._connect()
-
-        assert xiaoyi_channel._connected is False
+            assert MockConn.call_count == 1
+            assert xiaoyi_channel._conn_backup is None
+            assert xiaoyi_channel._connected is True
 
 
 # =============================================================================
@@ -528,7 +471,7 @@ class TestXiaoYiChannelMessageHandling:
     """
 
     async def test_handle_message_parses_json(self, xiaoyi_channel):
-        """_handle_message should parse JSON messages."""
+        """_handle_incoming_message should dispatch messages."""
         message = {
             "msgType": "message",
             "agentId": "test_agent_123",
@@ -547,11 +490,14 @@ class TestXiaoYiChannelMessageHandling:
             "_handle_a2a_request",
             new_callable=AsyncMock,
         ) as mock_handle:
-            await xiaoyi_channel._handle_message(json.dumps(message))
+            await xiaoyi_channel._handle_incoming_message(
+                message,
+                "primary",
+            )
             mock_handle.assert_called_once()
 
     async def test_handle_message_validates_agent_id(self, xiaoyi_channel):
-        """_handle_message should validate agent_id."""
+        """_handle_incoming_message should validate agent_id."""
         message = {
             "msgType": "message",
             "agentId": "wrong_agent",
@@ -563,11 +509,41 @@ class TestXiaoYiChannelMessageHandling:
             "_handle_a2a_request",
             new_callable=AsyncMock,
         ) as mock_handle:
-            await xiaoyi_channel._handle_message(json.dumps(message))
+            await xiaoyi_channel._handle_incoming_message(
+                message,
+                "primary",
+            )
             mock_handle.assert_not_called()
 
+    async def test_handle_message_tracks_session_server(
+        self,
+        xiaoyi_channel,
+    ):
+        """_handle_incoming_message should track session->server."""
+        message = {
+            "agentId": "test_agent_123",
+            "method": "message/stream",
+            "params": {
+                "sessionId": "session_456",
+                "id": "task_456",
+                "message": {
+                    "parts": [{"kind": "text", "text": "Hi"}],
+                },
+            },
+        }
+
+        mock_enqueue = MagicMock()
+        xiaoyi_channel._enqueue = mock_enqueue
+
+        await xiaoyi_channel._handle_incoming_message(
+            message,
+            "backup",
+        )
+
+        assert xiaoyi_channel._session_server_map["session_456"] == "backup"
+
     async def test_handle_message_handles_clear_context(self, xiaoyi_channel):
-        """_handle_message should handle clearContext messages."""
+        """_handle_incoming_message should handle clearContext."""
         message = {
             "agentId": "test_agent_123",
             "method": "clearContext",
@@ -580,11 +556,14 @@ class TestXiaoYiChannelMessageHandling:
             "_handle_clear_context",
             new_callable=AsyncMock,
         ) as mock_handle:
-            await xiaoyi_channel._handle_message(json.dumps(message))
+            await xiaoyi_channel._handle_incoming_message(
+                message,
+                "primary",
+            )
             mock_handle.assert_called_once()
 
     async def test_handle_message_handles_tasks_cancel(self, xiaoyi_channel):
-        """_handle_message should handle tasks/cancel messages."""
+        """_handle_incoming_message should handle tasks/cancel."""
         message = {
             "agentId": "test_agent_123",
             "method": "tasks/cancel",
@@ -598,13 +577,11 @@ class TestXiaoYiChannelMessageHandling:
             "_handle_tasks_cancel",
             new_callable=AsyncMock,
         ) as mock_handle:
-            await xiaoyi_channel._handle_message(json.dumps(message))
+            await xiaoyi_channel._handle_incoming_message(
+                message,
+                "primary",
+            )
             mock_handle.assert_called_once()
-
-    async def test_handle_message_handles_invalid_json(self, xiaoyi_channel):
-        """_handle_message should handle invalid JSON gracefully."""
-        # Should not raise
-        await xiaoyi_channel._handle_message("invalid json{{{")
 
 
 # =============================================================================
@@ -727,12 +704,15 @@ class TestXiaoYiChannelSend:
     async def test_send_skips_when_disabled(self, xiaoyi_channel):
         """send() should skip when channel is disabled."""
         xiaoyi_channel.enabled = False
-        xiaoyi_channel._ws = MagicMock()
         xiaoyi_channel._connected = True
 
-        await xiaoyi_channel.send("user123", "Hello")
-
-        xiaoyi_channel._ws.send_json.assert_not_called()
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel.send("user123", "Hello")
+            mock_send.assert_not_called()
 
     async def test_send_skips_when_not_connected(self, xiaoyi_channel):
         """send() should skip when not connected."""
@@ -741,23 +721,25 @@ class TestXiaoYiChannelSend:
 
         await xiaoyi_channel.send("user123", "Hello")
 
-    async def test_send_skips_empty_text(self, xiaoyi_channel, mock_ws):
+    async def test_send_skips_empty_text(self, xiaoyi_channel):
         """send() should skip empty text."""
-        xiaoyi_channel._ws = mock_ws
         xiaoyi_channel._connected = True
         xiaoyi_channel._session_task_map["session_123"] = "task_123"
 
-        await xiaoyi_channel.send(
-            "session_123",
-            "   ",
-            meta={"session_id": "session_123"},
-        )
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel.send(
+                "session_123",
+                "   ",
+                meta={"session_id": "session_123"},
+            )
+            mock_send.assert_not_called()
 
-        mock_ws.send_json.assert_not_called()
-
-    async def test_send_chunks_large_messages(self, xiaoyi_channel, mock_ws):
+    async def test_send_chunks_large_messages(self, xiaoyi_channel):
         """send() should chunk large messages."""
-        xiaoyi_channel._ws = mock_ws
         xiaoyi_channel._connected = True
         xiaoyi_channel._session_task_map["session_123"] = "task_123"
 
@@ -786,22 +768,36 @@ class TestXiaoYiChannelSend:
     async def test_send_final_message_sends_correct_format(
         self,
         xiaoyi_channel,
-        mock_ws,
     ):
-        """send_final_message should send correct format."""
-        xiaoyi_channel._ws = mock_ws
+        """send_final_message should send status-update + artifact."""
         xiaoyi_channel._connected = True
 
-        await xiaoyi_channel.send_final_message(
-            "session_123",
-            "task_123",
-            "msg_123",
-        )
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel.send_final_message(
+                "session_123",
+                "task_123",
+                "msg_123",
+            )
 
-        mock_ws.send_json.assert_called_once()
-        call_args = mock_ws.send_json.call_args[0][0]
-        assert call_args["msgType"] == "agent_response"
-        assert call_args["agentId"] == xiaoyi_channel.agent_id
+            # Two calls: status-update + artifact-update
+            assert mock_send.call_count == 2
+
+            # First call: status-update with state=completed
+            status_msg = mock_send.call_args_list[0][0][1]
+            assert status_msg["msgType"] == "agent_response"
+            status_detail = json.loads(status_msg["msgDetail"])
+            assert status_detail["result"]["kind"] == "status-update"
+            assert status_detail["result"]["status"]["state"] == "completed"
+
+            # Second call: artifact-update with final=true
+            final_msg = mock_send.call_args_list[1][0][1]
+            final_detail = json.loads(final_msg["msgDetail"])
+            assert final_detail["result"]["kind"] == "artifact-update"
+            assert final_detail["result"]["final"] is True
 
 
 # =============================================================================
@@ -866,9 +862,8 @@ class TestXiaoYiChannelMedia:
 
         await xiaoyi_channel.send_media("user123", mock_part)
 
-    async def test_send_media_handles_image(self, xiaoyi_channel, mock_ws):
+    async def test_send_media_handles_image(self, xiaoyi_channel):
         """send_media should handle image parts."""
-        xiaoyi_channel._ws = mock_ws
         xiaoyi_channel._connected = True
         xiaoyi_channel._session_task_map["session_123"] = "task_123"
 
@@ -882,37 +877,46 @@ class TestXiaoYiChannelMedia:
             image_url="http://example.com/image.png",
         )
 
-        await xiaoyi_channel.send_media(
-            "session_123",
-            image_part,
-            meta={"session_id": "session_123"},
-        )
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel.send_media(
+                "session_123",
+                image_part,
+                meta={"session_id": "session_123"},
+            )
 
-        mock_ws.send_json.assert_called_once()
-        call_args = mock_ws.send_json.call_args[0][0]
-        msg_detail = json.loads(call_args["msgDetail"])
-        assert msg_detail["result"]["artifact"]["parts"][0]["kind"] == "file"
+            mock_send.assert_called_once()
+            msg = mock_send.call_args[0][1]
+            msg_detail = json.loads(msg["msgDetail"])
+            assert (
+                msg_detail["result"]["artifact"]["parts"][0]["kind"] == "file"
+            )
 
     async def test_send_media_handles_unknown_type(
         self,
         xiaoyi_channel,
-        mock_ws,
     ):
         """send_media should skip unknown part types."""
-        xiaoyi_channel._ws = mock_ws
         xiaoyi_channel._connected = True
         xiaoyi_channel._session_task_map["session_123"] = "task_123"
 
         mock_part = MagicMock()
         mock_part.type = "unknown_type"
 
-        await xiaoyi_channel.send_media(
-            "session_123",
-            mock_part,
-            meta={"session_id": "session_123"},
-        )
-
-        mock_ws.send_json.assert_not_called()
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel.send_media(
+                "session_123",
+                mock_part,
+                meta={"session_id": "session_123"},
+            )
+            mock_send.assert_not_called()
 
 
 # =============================================================================
@@ -926,36 +930,44 @@ class TestXiaoYiChannelResponseHandling:
     P1: Response handling tests.
     """
 
-    async def test_send_clear_context_response(self, xiaoyi_channel, mock_ws):
+    async def test_send_clear_context_response(self, xiaoyi_channel):
         """_send_clear_context_response should send correct format."""
-        xiaoyi_channel._ws = mock_ws
         xiaoyi_channel._connected = True
 
-        await xiaoyi_channel._send_clear_context_response(
-            "req_123",
-            "session_123",
-        )
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel._send_clear_context_response(
+                "req_123",
+                "session_123",
+            )
 
-        mock_ws.send_json.assert_called_once()
-        call_args = mock_ws.send_json.call_args[0][0]
-        assert call_args["msgType"] == "agent_response"
-        msg_detail = json.loads(call_args["msgDetail"])
-        assert msg_detail["result"]["status"]["state"] == "cleared"
+            mock_send.assert_called_once()
+            msg = mock_send.call_args[0][1]
+            assert msg["msgType"] == "agent_response"
+            msg_detail = json.loads(msg["msgDetail"])
+            assert msg_detail["result"]["status"]["state"] == "cleared"
 
-    async def test_send_tasks_cancel_response(self, xiaoyi_channel, mock_ws):
+    async def test_send_tasks_cancel_response(self, xiaoyi_channel):
         """_send_tasks_cancel_response should send correct format."""
-        xiaoyi_channel._ws = mock_ws
         xiaoyi_channel._connected = True
 
-        await xiaoyi_channel._send_tasks_cancel_response(
-            "req_123",
-            "session_123",
-        )
+        with patch.object(
+            xiaoyi_channel,
+            "_send_to_session_server",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            await xiaoyi_channel._send_tasks_cancel_response(
+                "req_123",
+                "session_123",
+            )
 
-        mock_ws.send_json.assert_called_once()
-        call_args = mock_ws.send_json.call_args[0][0]
-        msg_detail = json.loads(call_args["msgDetail"])
-        assert msg_detail["result"]["status"]["state"] == "canceled"
+            mock_send.assert_called_once()
+            msg = mock_send.call_args[0][1]
+            msg_detail = json.loads(msg["msgDetail"])
+            assert msg_detail["result"]["status"]["state"] == "canceled"
 
 
 # =============================================================================
@@ -1056,6 +1068,7 @@ class TestXiaoYiChannelArtifactBuilding:
         assert msg_detail["id"] == "msg_123"
         assert msg_detail["result"]["kind"] == "artifact-update"
         assert msg_detail["result"]["append"] is True
+        assert msg_detail["result"]["lastChunk"] is True
 
     def test_build_artifact_msg_with_final(self, xiaoyi_channel):
         """_build_artifact_msg should set final flag when specified."""
@@ -1066,7 +1079,6 @@ class TestXiaoYiChannelArtifactBuilding:
             "task_123",
             "msg_123",
             parts,
-            last_chunk=True,
             final=True,
         )
 


### PR DESCRIPTION
## Summary

Refactor the XiaoYi channel from a single WebSocket connection to a 
dual-connection architecture (primary domain + backup IP), and align 
the A2A protocol with the official `@ynhcj/xiaoyi-channel` plugin.

## Changes

### Connection Refactor
- Extract `XiaoYiConnection` class to encapsulate a single WebSocket 
  link (connect, heartbeat, receive, send)
- Connect to both primary (`hag.cloud.huawei.com`) and backup 
  (`116.63.174.231`) endpoints in parallel
- Session-aware message routing: replies go to the server that 
  delivered the request, with automatic fallback
- Reconnect only triggers when both connections are down

### A2A Protocol Alignment
- Override `_on_process_completed` (instead of the legacy 
  `_run_process_loop`) to send `status-update(completed)` + 
  `artifact-update(final=true)` — fixes the "running" state stuck 
  issue on XiaoYi App
- Init message includes `msgDetail` with `agentId` and `hostname`
- Heartbeat includes `msgDetail` with millisecond `timestamp`
- All artifact-update messages set `lastChunk: true` to match 
  official plugin behavior

### Configuration Simplification
- Remove user-configurable `ws_url` / `ws_url_backup` from backend 
  config (`XiaoYiConfig`), frontend form (`ChannelDrawer`), and 
  TypeScript types — the endpoints are fixed SaaS URLs hardcoded 
  as constants
- Users only need to configure `ak`, `sk`, and `agent_id`
- Doctor connectivity now probes both fixed endpoints

### Cleanup
- Remove unused `_run_process_loop` override (legacy non-queue path)
- Remove `_default_backup_url()` helper
- Remove `DEFAULT_WS_URL` / `DEFAULT_WS_URL_BACKUP` from 
  `__init__.py` exports (internal constants)

**Related Issue:** Fixes #1911  #3840 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
