### PR TITLE
fix(proactive): prevent cache pollution of load_agent_config()

### DIFF
--- a/src/qwenpaw/agents/memory/proactive/proactive_responder.py
+++ b/src/qwenpaw/agents/memory/proactive/proactive_responder.py
@@ -101,8 +101,13 @@ async def _initialize_single_proactive_agent(
     agent_id: str = "proactive",
 ) -> ReActAgent:
     """Initialize a single proactive agent instance."""
+    # Use a local constant for the proactive-specific iteration limit.
+    # Do NOT mutate the cached config object returned by load_agent_config(),
+    # as that would pollute the global cache and cause user settings to be
+    # silently overwritten when save_agent_config() is later triggered.
+    _PROACTIVE_MAX_ITERS = 50
+
     agent_config = load_agent_config(agent_id)
-    agent_config.running.max_iters = 50
 
     # Create model and formatter for the agent
     from ...model_factory import create_model_and_formatter
@@ -128,7 +133,7 @@ async def _initialize_single_proactive_agent(
         toolkit=toolkit,
         formatter=formatter,
         memory=None,
-        max_iters=agent_config.running.max_iters,
+        max_iters=_PROACTIVE_MAX_ITERS,
     )
 
     return agent

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -10,6 +10,7 @@ Each Workspace represents a standalone agent workspace with its own:
 
 All existing single-agent components are reused without modification.
 """
+
 import logging
 from pathlib import Path
 from typing import Optional
@@ -129,7 +130,8 @@ class Workspace:
     @property
     def config(self):
         """Get agent configuration."""
-        self._config = load_agent_config(self.agent_id)
+        if self._config is None:
+            self._config = load_agent_config(self.agent_id)
         return self._config
 
     def set_manager(self, manager) -> None:


### PR DESCRIPTION


Changes:
- proactive_responder.py: use local constant _PROACTIVE_MAX_ITERS instead of mutating agent_config.running.max_iters
- workspace.py: cache config on first load (if self._config is None) instead of re-calling load_agent_config() on every access

## Description

### Change 1: proactive_responder.py (Eliminate Cache Mutation)

```python
# Before (mutates cached object)
agent_config = load_agent_config(agent_id)
agent_config.running.max_iters = 50  # ← Directly modifies the cached object!
...
max_iters=agent_config.running.max_iters

# After (local constant)
_PROACTIVE_MAX_ITERS = 50
agent_config = load_agent_config(agent_id)
...
max_iters=_PROACTIVE_MAX_ITERS  # ← No longer touches the cached object
```

### Change 2: workspace.py (Cache Config Property)

```python
# Before (reloads agent config on every access)
@property
def config(self):
    self._config = load_agent_config(self.agent_id)
    return self._config

# After (caches after first load)
@property
def config(self):
    if self._config is None:
        self._config = load_agent_config(self.agent_id)
    return self._config
```

**Related Issue: Issue  #5206 PR #5229


## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [X] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [X] I ran `pre-commit run --all-files` locally and it passes
- [X] If pre-commit auto-fixed files, I committed those changes and reran checks
- [X] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [X] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

set /proactive on, then get the agent config, now the max_iters is not replaced as 50.

## Additional Notes

[Optional: any other context]
