### PR TITLE
feat(migrate): add OpenClaw config migration CLI tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ adbpg = [
 whisper = [
     "openai-whisper>=20231117",
 ]
+migrate = [
+    "pyjson5>=1.6.0",
+]
 full = [
     "qwenpaw[local,whisper]",
 ]

--- a/src/qwenpaw/cli/main.py
+++ b/src/qwenpaw/cli/main.py
@@ -116,6 +116,11 @@ class LazyGroup(click.Group):
         "cron": ("qwenpaw.cli.cron_cmd", "cron_group", ".cron_cmd"),
         "env": ("qwenpaw.cli.env_cmd", "env_group", ".env_cmd"),
         "init": ("qwenpaw.cli.init_cmd", "init_cmd", ".init_cmd"),
+        "migrate": (
+            "qwenpaw.cli.migrate_cmd",
+            "migrate_group",
+            ".migrate_cmd",
+        ),
         "models": (
             "qwenpaw.cli.providers_cmd",
             "models_group",

--- a/src/qwenpaw/cli/migrate_cmd.py
+++ b/src/qwenpaw/cli/migrate_cmd.py
@@ -86,7 +86,12 @@ def openclaw_cmd(
     from qwenpaw.migrate.openclaw.orchestrator import run_migration
 
     include_set = set(include.split(",")) if include else None
-    exclude_set = set(exclude.split(",")) if exclude else {"history"}
+    if exclude:
+        exclude_set = set(exclude.split(","))
+    elif include_set and "history" in include_set:
+        exclude_set = set()
+    else:
+        exclude_set = {"history"}
     source_path = Path(source) if source else None
 
     run_migration(

--- a/src/qwenpaw/cli/migrate_cmd.py
+++ b/src/qwenpaw/cli/migrate_cmd.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""CLI commands for migrating configurations from other platforms."""
+from __future__ import annotations
+
+import click
+
+
+@click.group("migrate")
+def migrate_group():
+    """Migrate configurations from other platforms to QwenPaw."""
+
+
+@migrate_group.command("openclaw")
+@click.option(
+    "--source",
+    type=click.Path(exists=False),
+    default=None,
+    help="OpenClaw installation directory (default: auto-detect)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Preview changes without writing any files",
+)
+@click.option(
+    "--agent-id",
+    default="default",
+    help="Target QwenPaw agent ID",
+)
+@click.option(
+    "--include",
+    default=None,
+    help="Comma-separated categories to include (e.g. persona,memory,mcp)",
+)
+@click.option(
+    "--exclude",
+    default=None,
+    help="Comma-separated categories to exclude (default: history)",
+)
+@click.option(
+    "--migrate-secrets",
+    is_flag=True,
+    default=False,
+    help="Include API keys in migration",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing files",
+)
+@click.option(
+    "--no-backup",
+    is_flag=True,
+    default=False,
+    help="Skip pre-migration backup",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt",
+)
+@click.option(
+    "--openclaw-agent",
+    default="main",
+    help="OpenClaw agent ID to migrate",
+)
+def openclaw_cmd(
+    source,
+    dry_run,
+    agent_id,
+    include,
+    exclude,
+    migrate_secrets,
+    overwrite,
+    no_backup,
+    yes,
+    openclaw_agent,
+):
+    """Migrate OpenClaw configuration to QwenPaw."""
+    from pathlib import Path
+
+    from qwenpaw.migrate.openclaw.orchestrator import run_migration
+
+    include_set = set(include.split(",")) if include else None
+    exclude_set = set(exclude.split(",")) if exclude else {"history"}
+    source_path = Path(source) if source else None
+
+    run_migration(
+        source_path=source_path,
+        target_agent_id=agent_id,
+        openclaw_agent_id=openclaw_agent,
+        dry_run=dry_run,
+        include=include_set,
+        exclude=exclude_set,
+        migrate_secrets=migrate_secrets,
+        overwrite=overwrite,
+        no_backup=no_backup,
+        yes=yes,
+    )

--- a/src/qwenpaw/migrate/__init__.py
+++ b/src/qwenpaw/migrate/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from .models import (
+    ItemStatus,
+    MigrationItem,
+    MigrationPlan,
+    MigrationReport,
+    SourceInfo,
+)

--- a/src/qwenpaw/migrate/models.py
+++ b/src/qwenpaw/migrate/models.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+
+class ItemStatus(str, Enum):
+    OK = "ok"
+    SKIP = "skip"
+    CONFLICT = "conflict"
+    WARN = "warn"
+    ERROR = "error"
+    ARCHIVED = "archived"
+
+
+@dataclass
+class SourceInfo:
+    root: Path
+    flavor: str
+    config: dict
+    env: dict[str, str]
+    workspace: Path
+    agent_id: str
+    sessions_dir: Path | None = field(default=None)
+    cron_path: Path | None = field(default=None)
+
+
+@dataclass
+class MigrationItem:
+    category: str
+    source_path: str
+    target_path: str
+    status: ItemStatus
+    detail: str
+    write_fn: Callable | None = field(default=None)
+
+
+@dataclass
+class MigrationPlan:
+    source: SourceInfo
+    target_agent_id: str
+    target_workspace: Path
+    items: list[MigrationItem] = field(default_factory=list)
+
+
+@dataclass
+class MigrationReport:
+    plan: MigrationPlan
+    applied: int
+    skipped: int
+    conflicts: int
+    warnings: int
+    errors: int
+    backup_path: Path | None = field(default=None)

--- a/src/qwenpaw/migrate/models.py
+++ b/src/qwenpaw/migrate/models.py
@@ -27,6 +27,31 @@ class SourceInfo:
     sessions_dir: Path | None = field(default=None)
     cron_path: Path | None = field(default=None)
 
+    def source_candidate(self, *relative_paths: str) -> Path | None:
+        """Find first existing path among workspace-relative candidates.
+
+        Tries each path against the resolved workspace, then falls back to
+        ``workspace-main/`` and ``workspace.default/`` variants (OpenClaw
+        renamed ``workspace/`` in recent versions).
+        """
+        for rel in relative_paths:
+            candidate = self.root / rel
+            if candidate.exists():
+                return candidate
+            if rel.startswith("workspace/"):
+                suffix = rel[len("workspace/") :]
+                for variant in ("workspace-main", "workspace.default"):
+                    alt = self.root / variant / suffix
+                    if alt.exists():
+                        return alt
+        for rel in relative_paths:
+            if rel.startswith("workspace/"):
+                suffix = rel[len("workspace/") :]
+                alt = self.workspace / suffix
+                if alt.exists():
+                    return alt
+        return None
+
 
 @dataclass
 class MigrationItem:

--- a/src/qwenpaw/migrate/openclaw/__init__.py
+++ b/src/qwenpaw/migrate/openclaw/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""OpenClaw migration utilities."""

--- a/src/qwenpaw/migrate/openclaw/_json5.py
+++ b/src/qwenpaw/migrate/openclaw/_json5.py
@@ -17,21 +17,21 @@ def parse_json5(text: str) -> dict:
 
 
 def _process_normal(ch, text, i, n, result):
-    """Process character in normal state."""
+    """Process character in normal state. Returns (next_state, next_i)."""
     if ch == '"':
         result.append(ch)
-        return "in_string", i
+        return "in_string", i + 1
     nxt = text[i : i + 2] if i + 1 < n else ""
     if nxt == "//":
-        return "in_line_comment", i + 1
+        return "in_line_comment", i + 2
     if nxt == "/*":
-        return "in_block_comment", i + 1
+        return "in_block_comment", i + 2
     result.append(ch)
-    return "normal", i
+    return "normal", i + 1
 
 
 def _process_string(ch, text, i, n, result):
-    """Process character in string state."""
+    """Process character in string state. Returns (next_state, next_i)."""
     result.append(ch)
     if ch == "\\" and i + 1 < n:
         result.append(text[i + 1])

--- a/src/qwenpaw/migrate/openclaw/_json5.py
+++ b/src/qwenpaw/migrate/openclaw/_json5.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Lightweight JSON5 parser with graceful fallback."""
+from __future__ import annotations
+
+import json
+import re
+
+
+def parse_json5(text: str) -> dict:
+    """Parse JSON5, fallback to built-in stripper if pyjson5 unavailable."""
+    try:
+        import pyjson5
+
+        return pyjson5.loads(text)
+    except ImportError:
+        return json.loads(_strip_json5_features(text))
+
+
+def _process_normal(ch, text, i, n, result):
+    """Process character in normal state."""
+    if ch == '"':
+        result.append(ch)
+        return "in_string", i
+    nxt = text[i : i + 2] if i + 1 < n else ""
+    if nxt == "//":
+        return "in_line_comment", i + 1
+    if nxt == "/*":
+        return "in_block_comment", i + 1
+    result.append(ch)
+    return "normal", i
+
+
+def _process_string(ch, text, i, n, result):
+    """Process character in string state."""
+    result.append(ch)
+    if ch == "\\" and i + 1 < n:
+        result.append(text[i + 1])
+        return "in_string", i + 2
+    if ch == '"':
+        return "normal", i + 1
+    return "in_string", i + 1
+
+
+_STATE_HANDLERS = {
+    "normal": _process_normal,
+    "in_string": _process_string,
+}
+
+
+def _strip_json5_features(text: str) -> str:
+    """Remove JSON5 comments and trailing commas via state machine."""
+    result: list[str] = []
+    i = 0
+    n = len(text)
+    state = "normal"
+
+    while i < n:
+        ch = text[i]
+        handler = _STATE_HANDLERS.get(state)
+        if handler is not None:
+            state, i = handler(ch, text, i, n, result)
+        elif state == "in_line_comment":
+            if ch == "\n":
+                result.append("\n")
+                state = "normal"
+            i += 1
+        elif state == "in_block_comment":
+            if i + 1 < n and text[i : i + 2] == "*/":
+                state = "normal"
+                i += 2
+            else:
+                i += 1
+
+    stripped = "".join(result)
+    return re.sub(r",\s*([}\]])", r"\1", stripped)

--- a/src/qwenpaw/migrate/openclaw/channels.py
+++ b/src/qwenpaw/migrate/openclaw/channels.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import logging
+import re
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+logger = logging.getLogger(__name__)
+
+_ARCHIVED_PLATFORMS = {
+    "whatsapp",
+    "slack",
+    "signal",
+    "line",
+    "nostr",
+    "synology",
+}
+
+_NON_CHANNEL_KEYS = {"defaults", "modelByChannel"}
+
+
+def _resolve_token(value: Any, env: dict[str, str]) -> str | None:
+    if isinstance(value, str):
+        match = re.fullmatch(r"\$\{(\w+)}", value)
+        if match:
+            return env.get(match.group(1))
+        return value
+    if isinstance(value, dict):
+        if value.get("source") == "env":
+            return env.get(value.get("id", ""))
+        return None
+    return None
+
+
+def _map_allow_from(openclaw_allow: list[str] | None) -> list[str]:
+    if not openclaw_allow:
+        return []
+    return [str(e) for e in openclaw_allow if e != "*"]
+
+
+def _apply_access_control(result: dict, oc_cfg: dict) -> None:
+    dm_cfg = oc_cfg.get("dm", {}) if isinstance(oc_cfg.get("dm"), dict) else {}
+    dm_policy = oc_cfg.get("dmPolicy") or dm_cfg.get("policy", "open")
+    if dm_policy in ("allowlist", "pairing"):
+        result["access_control_dm"] = True
+    else:
+        result["access_control_dm"] = False
+
+    group_policy = oc_cfg.get("groupPolicy")
+    if group_policy == "allowlist":
+        result["access_control_group"] = True
+    elif group_policy == "open":
+        result["access_control_group"] = False
+
+    if oc_cfg.get("requireMention"):
+        result["require_mention"] = True
+
+
+def _extract_telegram(oc_cfg: dict, env: dict[str, str]) -> dict:
+    token = _resolve_token(oc_cfg.get("botToken"), env)
+    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    result: dict[str, Any] = {"enabled": True}
+    if token:
+        result["bot_token"] = token
+    if allow_from:
+        result["allow_from"] = allow_from
+    _apply_access_control(result, oc_cfg)
+    return result
+
+
+def _extract_discord(oc_cfg: dict, env: dict[str, str]) -> dict:
+    token = _resolve_token(oc_cfg.get("token"), env)
+    dm_cfg = oc_cfg.get("dm", {}) if isinstance(oc_cfg.get("dm"), dict) else {}
+    allow_from = _map_allow_from(
+        dm_cfg.get("allowFrom") or oc_cfg.get("allowFrom"),
+    )
+    result: dict[str, Any] = {"enabled": True}
+    if token:
+        result["bot_token"] = token
+    if allow_from:
+        result["allow_from"] = allow_from
+    _apply_access_control(result, oc_cfg)
+    return result
+
+
+def _extract_matrix(oc_cfg: dict, env: dict[str, str]) -> dict:
+    token = _resolve_token(oc_cfg.get("accessToken"), env)
+    homeserver = oc_cfg.get("homeserver")
+    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    result: dict[str, Any] = {"enabled": True}
+    if token:
+        result["access_token"] = token
+    if homeserver:
+        result["homeserver"] = homeserver
+    if allow_from:
+        result["allow_from"] = allow_from
+    _apply_access_control(result, oc_cfg)
+    return result
+
+
+def _extract_mattermost(oc_cfg: dict, env: dict[str, str]) -> dict:
+    token = _resolve_token(oc_cfg.get("botToken"), env)
+    url = oc_cfg.get("baseUrl") or oc_cfg.get("url")
+    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    result: dict[str, Any] = {"enabled": True}
+    if token:
+        result["bot_token"] = token
+    if url:
+        result["url"] = url
+    if allow_from:
+        result["allow_from"] = allow_from
+    _apply_access_control(result, oc_cfg)
+    return result
+
+
+def _extract_imessage(oc_cfg: dict, env: dict[str, str]) -> dict:
+    del env  # unused but kept for uniform extractor signature
+    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    result: dict[str, Any] = {"enabled": True}
+    if allow_from:
+        result["allow_from"] = allow_from
+    _apply_access_control(result, oc_cfg)
+    return result
+
+
+_CHANNEL_EXTRACTORS = {
+    "telegram": _extract_telegram,
+    "discord": _extract_discord,
+    "matrix": _extract_matrix,
+    "mattermost": _extract_mattermost,
+    "imessage": _extract_imessage,
+}
+
+
+def _write_channel(
+    target_workspace: Path,
+    channel_name: str,
+    channel_config: dict,
+):
+    agent_json = target_workspace / "agent.json"
+    data = {}
+    if agent_json.exists():
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+    channels = data.setdefault("channels", {})
+    channels[channel_name] = channel_config
+    agent_json.parent.mkdir(parents=True, exist_ok=True)
+    agent_json.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def plan_channel_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    items: list[MigrationItem] = []
+    oc_channels: dict = source.config.get("channels", {})
+
+    for name, oc_cfg in oc_channels.items():
+        if name in _NON_CHANNEL_KEYS:
+            continue
+        if not isinstance(oc_cfg, dict):
+            oc_cfg = {}
+
+        if name in _ARCHIVED_PLATFORMS:
+            items.append(
+                MigrationItem(
+                    category="channel",
+                    source_path=f"channels.{name}",
+                    target_path=f"agent.json#channels/{name}",
+                    status=ItemStatus.ARCHIVED,
+                    detail=f"Platform '{name}' is not supported in QwenPaw",
+                ),
+            )
+            continue
+
+        extractor = _CHANNEL_EXTRACTORS.get(name)
+        if extractor is None:
+            items.append(
+                MigrationItem(
+                    category="channel",
+                    source_path=f"channels.{name}",
+                    target_path=f"agent.json#channels/{name}",
+                    status=ItemStatus.WARN,
+                    detail=f"Unknown channel '{name}', skipped",
+                ),
+            )
+            continue
+
+        channel_config = extractor(oc_cfg, source.env)
+
+        target_agent_json = target_workspace / "agent.json"
+        if not overwrite and target_agent_json.exists():
+            existing = json.loads(
+                target_agent_json.read_text(encoding="utf-8"),
+            )
+            if name in existing.get("channels", {}):
+                items.append(
+                    MigrationItem(
+                        category="channel",
+                        source_path=f"channels.{name}",
+                        target_path=f"agent.json#channels/{name}",
+                        status=ItemStatus.CONFLICT,
+                        detail=f"Channel '{name}' already exists in target",
+                    ),
+                )
+                continue
+
+        cfg_snapshot = channel_config.copy()
+        items.append(
+            MigrationItem(
+                category="channel",
+                source_path=f"channels.{name}",
+                target_path=f"agent.json#channels/{name}",
+                status=ItemStatus.OK,
+                detail=f"Migrate channel '{name}'",
+                write_fn=partial(
+                    _write_channel,
+                    target_workspace,
+                    name,
+                    cfg_snapshot,
+                ),
+            ),
+        )
+
+    return items

--- a/src/qwenpaw/migrate/openclaw/channels.py
+++ b/src/qwenpaw/migrate/openclaw/channels.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 _ARCHIVED_PLATFORMS = {
     "whatsapp",
-    "slack",
     "signal",
     "line",
     "nostr",
@@ -37,10 +36,31 @@ def _resolve_token(value: Any, env: dict[str, str]) -> str | None:
     return None
 
 
+def _get_channel_field(ch_cfg: dict, field_name: str) -> Any:
+    """Get a field from channel config, checking flat and accounts.default."""
+    val = ch_cfg.get(field_name)
+    if val is not None:
+        return val
+    accounts = ch_cfg.get("accounts")
+    if isinstance(accounts, dict):
+        default = accounts.get("default")
+        if isinstance(default, dict):
+            return default.get(field_name)
+    return None
+
+
 def _map_allow_from(openclaw_allow: list[str] | None) -> list[str]:
     if not openclaw_allow:
         return []
-    return [str(e) for e in openclaw_allow if e != "*"]
+    result: list[str] = []
+    for e in openclaw_allow:
+        s = str(e).strip()
+        if s == "*":
+            continue
+        s = re.sub(r"^(telegram|tg):", "", s, flags=re.IGNORECASE)
+        if s:
+            result.append(s)
+    return result
 
 
 def _apply_access_control(result: dict, oc_cfg: dict) -> None:
@@ -62,8 +82,8 @@ def _apply_access_control(result: dict, oc_cfg: dict) -> None:
 
 
 def _extract_telegram(oc_cfg: dict, env: dict[str, str]) -> dict:
-    token = _resolve_token(oc_cfg.get("botToken"), env)
-    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    token = _resolve_token(_get_channel_field(oc_cfg, "botToken"), env)
+    allow_from = _map_allow_from(_get_channel_field(oc_cfg, "allowFrom"))
     result: dict[str, Any] = {"enabled": True}
     if token:
         result["bot_token"] = token
@@ -74,10 +94,10 @@ def _extract_telegram(oc_cfg: dict, env: dict[str, str]) -> dict:
 
 
 def _extract_discord(oc_cfg: dict, env: dict[str, str]) -> dict:
-    token = _resolve_token(oc_cfg.get("token"), env)
+    token = _resolve_token(_get_channel_field(oc_cfg, "token"), env)
     dm_cfg = oc_cfg.get("dm", {}) if isinstance(oc_cfg.get("dm"), dict) else {}
     allow_from = _map_allow_from(
-        dm_cfg.get("allowFrom") or oc_cfg.get("allowFrom"),
+        dm_cfg.get("allowFrom") or _get_channel_field(oc_cfg, "allowFrom"),
     )
     result: dict[str, Any] = {"enabled": True}
     if token:
@@ -88,10 +108,25 @@ def _extract_discord(oc_cfg: dict, env: dict[str, str]) -> dict:
     return result
 
 
+def _extract_slack(oc_cfg: dict, env: dict[str, str]) -> dict:
+    bot_token = _resolve_token(_get_channel_field(oc_cfg, "botToken"), env)
+    app_token = _resolve_token(_get_channel_field(oc_cfg, "appToken"), env)
+    allow_from = _map_allow_from(_get_channel_field(oc_cfg, "allowFrom"))
+    result: dict[str, Any] = {"enabled": True}
+    if bot_token:
+        result["bot_token"] = bot_token
+    if app_token:
+        result["app_token"] = app_token
+    if allow_from:
+        result["allow_from"] = allow_from
+    _apply_access_control(result, oc_cfg)
+    return result
+
+
 def _extract_matrix(oc_cfg: dict, env: dict[str, str]) -> dict:
-    token = _resolve_token(oc_cfg.get("accessToken"), env)
-    homeserver = oc_cfg.get("homeserver")
-    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    token = _resolve_token(_get_channel_field(oc_cfg, "accessToken"), env)
+    homeserver = _get_channel_field(oc_cfg, "homeserver")
+    allow_from = _map_allow_from(_get_channel_field(oc_cfg, "allowFrom"))
     result: dict[str, Any] = {"enabled": True}
     if token:
         result["access_token"] = token
@@ -104,9 +139,12 @@ def _extract_matrix(oc_cfg: dict, env: dict[str, str]) -> dict:
 
 
 def _extract_mattermost(oc_cfg: dict, env: dict[str, str]) -> dict:
-    token = _resolve_token(oc_cfg.get("botToken"), env)
-    url = oc_cfg.get("baseUrl") or oc_cfg.get("url")
-    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    token = _resolve_token(_get_channel_field(oc_cfg, "botToken"), env)
+    url = _get_channel_field(oc_cfg, "baseUrl") or _get_channel_field(
+        oc_cfg,
+        "url",
+    )
+    allow_from = _map_allow_from(_get_channel_field(oc_cfg, "allowFrom"))
     result: dict[str, Any] = {"enabled": True}
     if token:
         result["bot_token"] = token
@@ -119,8 +157,8 @@ def _extract_mattermost(oc_cfg: dict, env: dict[str, str]) -> dict:
 
 
 def _extract_imessage(oc_cfg: dict, env: dict[str, str]) -> dict:
-    del env  # unused but kept for uniform extractor signature
-    allow_from = _map_allow_from(oc_cfg.get("allowFrom"))
+    del env
+    allow_from = _map_allow_from(_get_channel_field(oc_cfg, "allowFrom"))
     result: dict[str, Any] = {"enabled": True}
     if allow_from:
         result["allow_from"] = allow_from
@@ -131,6 +169,7 @@ def _extract_imessage(oc_cfg: dict, env: dict[str, str]) -> dict:
 _CHANNEL_EXTRACTORS = {
     "telegram": _extract_telegram,
     "discord": _extract_discord,
+    "slack": _extract_slack,
     "matrix": _extract_matrix,
     "mattermost": _extract_mattermost,
     "imessage": _extract_imessage,

--- a/src/qwenpaw/migrate/openclaw/cron.py
+++ b/src/qwenpaw/migrate/openclaw/cron.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import logging
+from functools import partial
+from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _make_job_id(oc_job: dict) -> str:
+    oc_id = oc_job.get("id", oc_job.get("name", ""))
+    if oc_id:
+        return f"oc-{oc_id}"
+    content_hash = uuid5(NAMESPACE_URL, json.dumps(oc_job, sort_keys=True))
+    return f"oc-{content_hash}"
+
+
+def _extract_schedule(oc_job: dict) -> dict:
+    """Extract schedule from OpenClaw's formats into a QwenPaw schedule dict.
+
+    OpenClaw supports three schedule kinds:
+      - {kind: "cron", expr: "0 9 * * *", tz: "UTC"}
+      - {kind: "every", everyMs: 60000}
+      - {kind: "at", at: "2024-01-01T00:00:00Z"}
+    Legacy flat format: {"schedule": "0 9 * * *", "timezone": "UTC"}
+    """
+    raw = oc_job.get("schedule", "0 0 * * *")
+    if isinstance(raw, dict):
+        kind = raw.get("kind", "cron")
+        if kind == "every":
+            interval_ms = raw.get("everyMs", 60000)
+            return {
+                "type": "interval",
+                "interval_seconds": max(1, interval_ms // 1000),
+            }
+        if kind == "at":
+            return {"type": "once", "at": raw.get("at", "")}
+        return {
+            "type": "cron",
+            "cron": raw.get("expr", "0 0 * * *"),
+            "timezone": raw.get("tz", "UTC"),
+        }
+    return {
+        "type": "cron",
+        "cron": raw,
+        "timezone": oc_job.get("timezone", "UTC"),
+    }
+
+
+def _extract_prompt(oc_job: dict) -> tuple[str, str]:
+    """Extract prompt and payload kind from OpenClaw's formats.
+
+    OpenClaw payload kinds:
+      - {kind: "agentTurn", message: "..."}
+      - {kind: "systemEvent", text: "..."}
+      - {kind: "command", argv: [...]}
+    Legacy flat format: {"prompt": "..."}
+
+    Returns (prompt_text, payload_kind).
+    """
+    payload = oc_job.get("payload", {})
+    if isinstance(payload, dict):
+        kind = payload.get("kind", "")
+        if kind == "agentTurn":
+            return payload.get("message", ""), "agentTurn"
+        if kind == "systemEvent":
+            return payload.get("text", ""), "systemEvent"
+        if kind == "command":
+            argv = payload.get("argv", [])
+            return " ".join(argv) if argv else "", "command"
+        if payload.get("message"):
+            return payload["message"], "agentTurn"
+    return oc_job.get("prompt", ""), "agentTurn"
+
+
+def _extract_delivery(oc_job: dict) -> tuple[str, str]:
+    """Extract channel and target from OpenClaw's two formats.
+
+    Format 1 (legacy): {"channel": "telegram", "to": "123"}
+    Format 2 (current): {"delivery": {"channel": "telegram", "to": "123"}}
+    """
+    delivery = oc_job.get("delivery", {})
+    if isinstance(delivery, dict) and (
+        delivery.get("channel") or delivery.get("to")
+    ):
+        return delivery.get("channel", ""), delivery.get("to", "")
+    return oc_job.get("channel", ""), oc_job.get("to", "")
+
+
+def _convert_cron_job(oc_job: dict) -> dict:
+    schedule = _extract_schedule(oc_job)
+    prompt, payload_kind = _extract_prompt(oc_job)
+    channel, to = _extract_delivery(oc_job)
+    session_target = oc_job.get("sessionTarget", oc_job.get("session", "main"))
+
+    result: dict = {
+        "id": _make_job_id(oc_job),
+        "name": oc_job.get("name", oc_job.get("id", "Imported job")),
+        "enabled": oc_job.get("enabled", True),
+        "schedule": schedule,
+        "task_type": "command" if payload_kind == "command" else "agent",
+        "request": {
+            "input": prompt,
+        },
+        "dispatch": {
+            "channel": channel,
+            "target": {
+                "user_id": to,
+                "session_id": f"{channel}:{to}" if channel and to else "",
+            },
+        },
+        "runtime": {
+            "share_session": session_target != "isolated",
+        },
+    }
+    if oc_job.get("agentId"):
+        result["agent_id"] = oc_job["agentId"]
+    if oc_job.get("deleteAfterRun"):
+        result["one_shot"] = True
+    return result
+
+
+def _write_cron_jobs(target_workspace: Path, new_jobs: list[dict]):
+    jobs_json = target_workspace / "jobs.json"
+    existing: list[dict] = []
+    if jobs_json.exists():
+        data = json.loads(jobs_json.read_text(encoding="utf-8"))
+        existing = data.get("jobs", []) if isinstance(data, dict) else data
+    existing_ids = {j.get("id") for j in existing}
+    for job in new_jobs:
+        if job["id"] not in existing_ids:
+            existing.append(job)
+    jobs_json.parent.mkdir(parents=True, exist_ok=True)
+    jobs_json.write_text(
+        json.dumps({"jobs": existing}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def plan_cron_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    if source.cron_path is None or not source.cron_path.exists():
+        return []
+
+    try:
+        raw = json.loads(source.cron_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Failed to parse cron file %s: %s",
+            source.cron_path,
+            exc,
+        )
+        return [
+            MigrationItem(
+                category="cron",
+                source_path=str(source.cron_path),
+                target_path="jobs.json",
+                status=ItemStatus.ERROR,
+                detail=f"Cannot parse cron: {exc}",
+            ),
+        ]
+
+    oc_jobs: list[dict] = raw if isinstance(raw, list) else raw.get("jobs", [])
+
+    existing_ids: set[str] = set()
+    target_jobs_json = target_workspace / "jobs.json"
+    if target_jobs_json.exists():
+        try:
+            tdata = json.loads(target_jobs_json.read_text(encoding="utf-8"))
+            t_jobs = (
+                tdata.get("jobs", []) if isinstance(tdata, dict) else tdata
+            )
+            existing_ids = {j.get("id") for j in t_jobs}
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    items: list[MigrationItem] = []
+    converted_batch: list[dict] = []
+
+    for oc_job in oc_jobs:
+        converted = _convert_cron_job(oc_job)
+        job_id = converted["id"]
+        oc_label = oc_job.get(
+            "id",
+            oc_job.get("name", "?"),
+        )
+
+        if not overwrite and job_id in existing_ids:
+            items.append(
+                MigrationItem(
+                    category="cron",
+                    source_path=f"cron#{oc_label}",
+                    target_path=f"jobs.json#{job_id}",
+                    status=ItemStatus.CONFLICT,
+                    detail=(f"Job '{job_id}' already exists"),
+                ),
+            )
+            continue
+
+        converted_batch.append(converted)
+        items.append(
+            MigrationItem(
+                category="cron",
+                source_path=f"cron#{oc_label}",
+                target_path=f"jobs.json#{job_id}",
+                status=ItemStatus.OK,
+                detail=(f"Migrate cron '{converted['name']}'"),
+            ),
+        )
+
+    if converted_batch:
+        batch_snapshot = list(converted_batch)
+        items_ok = [i for i in items if i.status == ItemStatus.OK]
+        if items_ok:
+            last_ok = items_ok[-1]
+            last_ok.write_fn = partial(
+                _write_cron_jobs,
+                target_workspace,
+                batch_snapshot,
+            )
+
+    return items

--- a/src/qwenpaw/migrate/openclaw/detector.py
+++ b/src/qwenpaw/migrate/openclaw/detector.py
@@ -34,11 +34,18 @@ def detect(source: Path | None = None, agent_id: str = "main") -> SourceInfo:
 
     cron_path = _resolve_cron_path(root, config)
 
+    env_from_config = _parse_config_env(config)
+    merged_env = {**env_from_config, **env}
+
+    auth_keys = _parse_auth_profiles(root, agent_id)
+    for k, v in auth_keys.items():
+        merged_env.setdefault(k, v)
+
     return SourceInfo(
         root=root,
         flavor=flavor,
         config=config,
-        env=env,
+        env=merged_env,
         workspace=workspace,
         agent_id=agent_id,
         sessions_dir=sessions_dir,
@@ -51,6 +58,9 @@ def _find_root(source: Path | None) -> Path:
         resolved = Path(source).expanduser().resolve()
         if resolved.is_dir():
             return resolved
+        raise FileNotFoundError(
+            f"OpenClaw directory not found: {resolved}",
+        )
     for candidate in _CANDIDATE_ROOTS:
         path = Path(candidate).expanduser().resolve()
         if path.is_dir():
@@ -111,6 +121,64 @@ def _resolve_cron_path(root: Path, config: dict) -> Path | None:
     return None
 
 
+def _parse_config_env(config: dict) -> dict[str, str]:
+    """Extract env vars from openclaw.json ``env`` / ``env.vars``."""
+    json_env = config.get("env")
+    if not isinstance(json_env, dict):
+        return {}
+    result: dict[str, str] = {}
+    sources = [json_env]
+    env_vars = json_env.get("vars")
+    if isinstance(env_vars, dict):
+        sources.append(env_vars)
+    for src in sources:
+        for key, val in src.items():
+            if key == "vars":
+                continue
+            if isinstance(val, str) and val.strip():
+                result.setdefault(key, val.strip())
+    return result
+
+
+def _parse_auth_profiles(root: Path, agent_id: str) -> dict[str, str]:
+    """Extract API keys from ``agents/<id>/agent/auth-profiles.json``."""
+    auth_path = root / "agents" / agent_id / "agent" / "auth-profiles.json"
+    if not auth_path.is_file():
+        return {}
+    result: dict[str, str] = {}
+    _name_to_env = {
+        "openrouter": "OPENROUTER_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+    }
+    try:
+        import json
+
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return result
+        profiles = (
+            data.get("profiles", data)
+            if isinstance(data.get("profiles"), dict)
+            else data
+        )
+        for name, entry in profiles.items():
+            if not isinstance(entry, dict):
+                continue
+            api_key = entry.get("key", "") or entry.get("apiKey", "")
+            if not isinstance(api_key, str) or not api_key.strip():
+                continue
+            for pattern, env_var in _name_to_env.items():
+                if pattern in name.lower():
+                    result.setdefault(env_var, api_key.strip())
+                    break
+    except (json.JSONDecodeError, OSError):
+        pass
+    return result
+
+
 def _resolve_workspace(root: Path, config: dict, agent_id: str) -> Path:
     try:
         ws = config["agents"]["defaults"]["workspace"]
@@ -122,9 +190,12 @@ def _resolve_workspace(root: Path, config: dict, agent_id: str) -> Path:
 
     candidates = [
         root / "agents" / agent_id / "workspace",
+        root / f"workspace-{agent_id}",
+        root / "workspace-main",
         root / "workspace",
+        root / "workspace.default",
     ]
     for candidate in candidates:
         if candidate.is_dir():
             return candidate
-    return candidates[-1]
+    return root / "workspace"

--- a/src/qwenpaw/migrate/openclaw/detector.py
+++ b/src/qwenpaw/migrate/openclaw/detector.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""Auto-detect OpenClaw installation and parse configuration."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..models import SourceInfo
+from ._json5 import parse_json5
+
+logger = logging.getLogger(__name__)
+
+_CANDIDATE_ROOTS = ["~/.openclaw", "~/.clawdbot", "~/.moltbot"]
+_CONFIG_NAMES = ["openclaw.json", "clawdbot.json", "moltbot.json"]
+_FLAVOR_MAP = {
+    "openclaw.json": "openclaw",
+    "clawdbot.json": "clawdbot",
+    "moltbot.json": "clawdbot",
+}
+
+
+def detect(source: Path | None = None, agent_id: str = "main") -> SourceInfo:
+    root = _find_root(source)
+    config_path, flavor = _find_config(root)
+    logger.info("Found %s config at %s", flavor, config_path)
+
+    config = parse_json5(config_path.read_text(encoding="utf-8"))
+    env = _parse_dotenv(root / ".env")
+    workspace = _resolve_workspace(root, config, agent_id)
+
+    sessions_dir = root / "agents" / agent_id / "sessions"
+    if not sessions_dir.is_dir():
+        sessions_dir = None
+
+    cron_path = _resolve_cron_path(root, config)
+
+    return SourceInfo(
+        root=root,
+        flavor=flavor,
+        config=config,
+        env=env,
+        workspace=workspace,
+        agent_id=agent_id,
+        sessions_dir=sessions_dir,
+        cron_path=cron_path,
+    )
+
+
+def _find_root(source: Path | None) -> Path:
+    if source is not None:
+        resolved = Path(source).expanduser().resolve()
+        if resolved.is_dir():
+            return resolved
+    for candidate in _CANDIDATE_ROOTS:
+        path = Path(candidate).expanduser().resolve()
+        if path.is_dir():
+            logger.debug("Auto-detected root: %s", path)
+            return path
+    raise FileNotFoundError(
+        f"No OpenClaw installation found. Tried: {_CANDIDATE_ROOTS}",
+    )
+
+
+def _find_config(root: Path) -> tuple[Path, str]:
+    for name in _CONFIG_NAMES:
+        path = root / name
+        if path.is_file():
+            return path, _FLAVOR_MAP[name]
+    raise FileNotFoundError(
+        f"No config file found in {root}. Tried: {_CONFIG_NAMES}",
+    )
+
+
+def _parse_dotenv(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    env = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        if not _:
+            continue
+        value = value.strip()
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in ('"', "'")
+        ):
+            value = value[1:-1]
+        env[key.strip()] = value
+    return env
+
+
+def _resolve_cron_path(root: Path, config: dict) -> Path | None:
+    custom_store = (config.get("cron") or {}).get("store")
+    if custom_store:
+        p = Path(custom_store).expanduser().resolve()
+        if p.is_file():
+            return p
+
+    candidates = [
+        root / "cron" / "store.json",
+        root / "cron" / "cron.json",
+        root / "state" / "cron" / "store.json",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _resolve_workspace(root: Path, config: dict, agent_id: str) -> Path:
+    try:
+        ws = config["agents"]["defaults"]["workspace"]
+        path = Path(ws).expanduser().resolve()
+        if path.is_dir():
+            return path
+    except (KeyError, TypeError):
+        pass
+
+    candidates = [
+        root / "agents" / agent_id / "workspace",
+        root / "workspace",
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return candidates[-1]

--- a/src/qwenpaw/migrate/openclaw/history.py
+++ b/src/qwenpaw/migrate/openclaw/history.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""Conversation history migration (opt-in).
+
+OpenClaw JSONL sessions → QwenPaw dialog/ logs.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+
+def plan_history_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    if source.sessions_dir is None or not source.sessions_dir.is_dir():
+        return []
+
+    session_count = 0
+    sessions_meta = source.sessions_dir / "sessions.json"
+    if sessions_meta.is_file():
+        try:
+            meta = json.loads(sessions_meta.read_text(encoding="utf-8"))
+            session_count = (
+                len(meta)
+                if isinstance(meta, list)
+                else len(meta.get("sessions", []))
+            )
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    jsonl_files = sorted(source.sessions_dir.glob("*.jsonl"))
+    if not jsonl_files:
+        return []
+
+    detail = f"{len(jsonl_files)} session file(s)"
+    if session_count:
+        detail += f" ({session_count} in sessions.json)"
+
+    dialog_dir = target_workspace / "dialog"
+    status = ItemStatus.OK
+    if dialog_dir.is_dir() and any(dialog_dir.iterdir()) and not overwrite:
+        status = ItemStatus.CONFLICT
+        detail += " — dialog/ already has files (use --overwrite)"
+
+    return [
+        MigrationItem(
+            category="history",
+            source_path=str(source.sessions_dir),
+            target_path=str(dialog_dir),
+            status=status,
+            detail=detail,
+            write_fn=partial(
+                _convert_all_sessions,
+                source.sessions_dir,
+                target_workspace,
+            ),
+        ),
+    ]
+
+
+def _convert_all_sessions(sessions_dir: Path, target_workspace: Path) -> None:
+    dialog_dir = target_workspace / "dialog"
+    dialog_dir.mkdir(parents=True, exist_ok=True)
+    for jsonl_file in sorted(sessions_dir.glob("*.jsonl")):
+        _convert_session_to_dialog(jsonl_file, dialog_dir)
+
+
+def _convert_session_to_dialog(session_path: Path, dialog_dir: Path) -> None:
+    for line in session_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts_str = entry.get("timestamp", "")
+        msg = entry.get("message", {})
+        try:
+            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            date_str = ts.strftime("%Y-%m-%d")
+        except (ValueError, AttributeError):
+            date_str = "unknown"
+        out = {
+            "role": msg.get("role", "unknown"),
+            "content": msg.get("content", "")
+            if isinstance(msg.get("content"), str)
+            else str(msg.get("content", "")),
+            "timestamp": ts_str,
+        }
+        dialog_file = dialog_dir / f"{date_str}.jsonl"
+        with open(dialog_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(out, ensure_ascii=False) + "\n")

--- a/src/qwenpaw/migrate/openclaw/mcp.py
+++ b/src/qwenpaw/migrate/openclaw/mcp.py
@@ -56,6 +56,20 @@ def _build_client_config(srv: dict) -> dict:
     if cwd:
         client_config["cwd"] = cwd
 
+    if srv.get("timeout"):
+        client_config["timeout"] = srv["timeout"]
+    if srv.get("connectTimeout"):
+        client_config["connect_timeout"] = srv["connectTimeout"]
+
+    tools_cfg = srv.get("toolFilter") or srv.get("tools") or {}
+    if tools_cfg.get("include") or tools_cfg.get("exclude"):
+        tool_filter: dict = {}
+        if tools_cfg.get("include"):
+            tool_filter["include"] = tools_cfg["include"]
+        if tools_cfg.get("exclude"):
+            tool_filter["exclude"] = tools_cfg["exclude"]
+        client_config["tools"] = tool_filter
+
     return client_config
 
 

--- a/src/qwenpaw/migrate/openclaw/mcp.py
+++ b/src/qwenpaw/migrate/openclaw/mcp.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import logging
+from functools import partial
+from pathlib import Path
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _write_mcp_client(target_workspace: Path, key: str, client_config: dict):
+    agent_json = target_workspace / "agent.json"
+    data = {}
+    if agent_json.exists():
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+    mcp = data.setdefault("mcp", {})
+    clients = mcp.setdefault("clients", {})
+    clients[key] = client_config
+    agent_json.parent.mkdir(parents=True, exist_ok=True)
+    agent_json.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+_FIELD_MAP = (
+    ("command", "command"),
+    ("args", "args"),
+    ("env", "env"),
+    ("url", "url"),
+    ("headers", "headers"),
+)
+
+
+def _build_client_config(srv: dict) -> dict:
+    """Build QwenPaw MCP client config from OpenClaw server config."""
+    if srv.get("command"):
+        transport = "stdio"
+    elif srv.get("url"):
+        transport = "streamable_http"
+    else:
+        transport = "stdio"
+
+    enabled = srv.get("enabled", True)
+    client_config: dict = {"transport": transport, "enabled": enabled}
+
+    for src_key, dst_key in _FIELD_MAP:
+        val = srv.get(src_key)
+        if val:
+            client_config[dst_key] = val
+
+    cwd = srv.get("cwd") or srv.get("workingDirectory")
+    if cwd:
+        client_config["cwd"] = cwd
+
+    return client_config
+
+
+def plan_mcp_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    items: list[MigrationItem] = []
+
+    mcp_servers = source.config.get("mcp", {}).get("servers", {})
+    if not mcp_servers:
+        return items
+
+    existing_clients: dict = {}
+    agent_json = target_workspace / "agent.json"
+    if agent_json.exists():
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+        existing_clients = data.get("mcp", {}).get("clients", {})
+
+    for key, srv in mcp_servers.items():
+        if not isinstance(srv, dict):
+            continue
+        if key in existing_clients and not overwrite:
+            items.append(
+                MigrationItem(
+                    category="mcp",
+                    source_path=f"config.mcp.servers.{key}",
+                    target_path=f"agent.json#mcp.clients.{key}",
+                    status=ItemStatus.CONFLICT,
+                    detail=(f"MCP client '{key}' already exists"),
+                    write_fn=None,
+                ),
+            )
+            continue
+
+        client_config = _build_client_config(srv)
+        transport = client_config["transport"]
+
+        items.append(
+            MigrationItem(
+                category="mcp",
+                source_path=f"config.mcp.servers.{key}",
+                target_path=f"agent.json#mcp.clients.{key}",
+                status=ItemStatus.OK,
+                detail=f"MCP server '{key}' ({transport})",
+                write_fn=partial(
+                    _write_mcp_client,
+                    target_workspace,
+                    key,
+                    client_config,
+                ),
+            ),
+        )
+
+    return items

--- a/src/qwenpaw/migrate/openclaw/memory.py
+++ b/src/qwenpaw/migrate/openclaw/memory.py
@@ -2,12 +2,62 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
+from functools import partial
 from pathlib import Path
 
 from ..models import ItemStatus, MigrationItem, SourceInfo
 
 logger = logging.getLogger(__name__)
+
+ENTRY_DELIMITER = "\n§\n"
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())
+
+
+def _parse_entries(text: str) -> list[str]:
+    """Parse memory entries using § delimiter, fall back to line-based."""
+    if ENTRY_DELIMITER in text:
+        return [e.strip() for e in text.split(ENTRY_DELIMITER) if e.strip()]
+    entries: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            entries.append(line)
+    return entries
+
+
+def _merge_entries(
+    existing: list[str],
+    incoming: list[str],
+) -> tuple[list[str], int, int]:
+    """Merge incoming entries into existing, dedup by normalized text.
+
+    Returns (merged_list, added_count, dup_count).
+    """
+    seen = {_normalize(e) for e in existing}
+    merged = list(existing)
+    added, dups = 0, 0
+    for entry in incoming:
+        norm = _normalize(entry)
+        if not norm or norm in seen:
+            dups += 1
+            continue
+        seen.add(norm)
+        merged.append(entry)
+        added += 1
+    return merged, added, dups
+
+
+def _write_merged_memory(dst: Path, merged: list[str]):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    dst.write_text(
+        ENTRY_DELIMITER.join(merged) + ("\n" if merged else ""),
+        encoding="utf-8",
+    )
 
 
 def _make_copy_fn(src: Path, dst: Path):
@@ -18,7 +68,7 @@ def _make_copy_fn(src: Path, dst: Path):
     return _do
 
 
-def plan_memory_migration(
+def plan_memory_migration(  # pylint: disable=too-many-branches
     source: SourceInfo,
     target_workspace: Path,
     archive_dir: Path,
@@ -30,16 +80,53 @@ def plan_memory_migration(
     memory_src = ws / "MEMORY.md"
     memory_dst = target_workspace / "MEMORY.md"
     if memory_src.exists():
-        if memory_dst.exists() and not overwrite:
+        incoming = _parse_entries(
+            memory_src.read_text(encoding="utf-8"),
+        )
+        if not incoming:
             items.append(
                 MigrationItem(
                     category="memory",
                     source_path=str(memory_src),
                     target_path=str(memory_dst),
-                    status=ItemStatus.CONFLICT,
-                    detail="MEMORY.md already exists at target",
+                    status=ItemStatus.SKIP,
+                    detail="MEMORY.md has no importable entries",
                 ),
             )
+        elif memory_dst.exists() and not overwrite:
+            existing = _parse_entries(
+                memory_dst.read_text(encoding="utf-8"),
+            )
+            merged, added, dups = _merge_entries(existing, incoming)
+            if added == 0:
+                items.append(
+                    MigrationItem(
+                        category="memory",
+                        source_path=str(memory_src),
+                        target_path=str(memory_dst),
+                        status=ItemStatus.SKIP,
+                        detail=(f"All {dups} entries already exist at target"),
+                    ),
+                )
+            else:
+                snapshot = list(merged)
+                items.append(
+                    MigrationItem(
+                        category="memory",
+                        source_path=str(memory_src),
+                        target_path=str(memory_dst),
+                        status=ItemStatus.WARN,
+                        detail=(
+                            f"Merge {added} new entries into MEMORY.md"
+                            f" ({dups} duplicates skipped)"
+                        ),
+                        write_fn=partial(
+                            _write_merged_memory,
+                            memory_dst,
+                            snapshot,
+                        ),
+                    ),
+                )
         else:
             items.append(
                 MigrationItem(
@@ -54,27 +141,40 @@ def plan_memory_migration(
 
     memory_dir = ws / "memory"
     if memory_dir.is_dir():
+        all_daily_entries: list[str] = []
         for md_file in sorted(memory_dir.glob("*.md")):
-            dst = target_workspace / "memory" / md_file.name
-            if dst.exists() and not overwrite:
-                items.append(
-                    MigrationItem(
-                        category="memory",
-                        source_path=str(md_file),
-                        target_path=str(dst),
-                        status=ItemStatus.CONFLICT,
-                        detail=f"{md_file.name} already exists at target",
-                    ),
+            entries = _parse_entries(
+                md_file.read_text(encoding="utf-8"),
+            )
+            all_daily_entries.extend(entries)
+
+        if all_daily_entries:
+            if memory_dst.exists():
+                existing = _parse_entries(
+                    memory_dst.read_text(encoding="utf-8"),
                 )
             else:
+                existing = []
+            merged, added, dups = _merge_entries(existing, all_daily_entries)
+            if added > 0:
+                snapshot = list(merged)
                 items.append(
                     MigrationItem(
                         category="memory",
-                        source_path=str(md_file),
-                        target_path=str(dst),
-                        status=ItemStatus.OK,
-                        detail=f"copy memory/{md_file.name}",
-                        write_fn=_make_copy_fn(md_file, dst),
+                        source_path=str(memory_dir),
+                        target_path=str(memory_dst),
+                        status=ItemStatus.OK
+                        if not memory_dst.exists()
+                        else ItemStatus.WARN,
+                        detail=(
+                            f"Merge {added} daily memory entries"
+                            f" ({dups} duplicates skipped)"
+                        ),
+                        write_fn=partial(
+                            _write_merged_memory,
+                            memory_dst,
+                            snapshot,
+                        ),
                     ),
                 )
 
@@ -87,7 +187,7 @@ def plan_memory_migration(
                 source_path=str(dreams_src),
                 target_path=str(dreams_dst),
                 status=ItemStatus.ARCHIVED,
-                detail=("DREAMS.md archived " "(QwenPaw ReMe manages dreams)"),
+                detail="DREAMS.md archived (QwenPaw ReMe manages dreams)",
                 write_fn=_make_copy_fn(dreams_src, dreams_dst),
             ),
         )

--- a/src/qwenpaw/migrate/openclaw/memory.py
+++ b/src/qwenpaw/migrate/openclaw/memory.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _make_copy_fn(src: Path, dst: Path):
+    def _do():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+    return _do
+
+
+def plan_memory_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    archive_dir: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    items: list[MigrationItem] = []
+    ws = source.workspace
+
+    memory_src = ws / "MEMORY.md"
+    memory_dst = target_workspace / "MEMORY.md"
+    if memory_src.exists():
+        if memory_dst.exists() and not overwrite:
+            items.append(
+                MigrationItem(
+                    category="memory",
+                    source_path=str(memory_src),
+                    target_path=str(memory_dst),
+                    status=ItemStatus.CONFLICT,
+                    detail="MEMORY.md already exists at target",
+                ),
+            )
+        else:
+            items.append(
+                MigrationItem(
+                    category="memory",
+                    source_path=str(memory_src),
+                    target_path=str(memory_dst),
+                    status=ItemStatus.OK,
+                    detail="copy MEMORY.md",
+                    write_fn=_make_copy_fn(memory_src, memory_dst),
+                ),
+            )
+
+    memory_dir = ws / "memory"
+    if memory_dir.is_dir():
+        for md_file in sorted(memory_dir.glob("*.md")):
+            dst = target_workspace / "memory" / md_file.name
+            if dst.exists() and not overwrite:
+                items.append(
+                    MigrationItem(
+                        category="memory",
+                        source_path=str(md_file),
+                        target_path=str(dst),
+                        status=ItemStatus.CONFLICT,
+                        detail=f"{md_file.name} already exists at target",
+                    ),
+                )
+            else:
+                items.append(
+                    MigrationItem(
+                        category="memory",
+                        source_path=str(md_file),
+                        target_path=str(dst),
+                        status=ItemStatus.OK,
+                        detail=f"copy memory/{md_file.name}",
+                        write_fn=_make_copy_fn(md_file, dst),
+                    ),
+                )
+
+    dreams_src = ws / "DREAMS.md"
+    if dreams_src.exists():
+        dreams_dst = archive_dir / "DREAMS.md"
+        items.append(
+            MigrationItem(
+                category="memory",
+                source_path=str(dreams_src),
+                target_path=str(dreams_dst),
+                status=ItemStatus.ARCHIVED,
+                detail=("DREAMS.md archived " "(QwenPaw ReMe manages dreams)"),
+                write_fn=_make_copy_fn(dreams_src, dreams_dst),
+            ),
+        )
+
+    return items

--- a/src/qwenpaw/migrate/openclaw/orchestrator.py
+++ b/src/qwenpaw/migrate/openclaw/orchestrator.py
@@ -129,9 +129,10 @@ def run_migration(
     if not no_backup:
         backup_path = _create_pre_migration_backup(target_workspace, ts)
 
+    _writable = {ItemStatus.OK, ItemStatus.WARN, ItemStatus.ARCHIVED}
     applied, errors = 0, 0
     for item in plan.items:
-        if item.status == ItemStatus.OK and item.write_fn:
+        if item.status in _writable and item.write_fn:
             try:
                 item.write_fn()
                 applied += 1

--- a/src/qwenpaw/migrate/openclaw/orchestrator.py
+++ b/src/qwenpaw/migrate/openclaw/orchestrator.py
@@ -20,7 +20,7 @@ from .mcp import plan_mcp_migration
 from .channels import plan_channel_migration
 from .cron import plan_cron_migration
 from .history import plan_history_migration
-from .skills import plan_skill_report
+from .skills import plan_skill_migration
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ ALL_CATEGORIES = {
     "channels",
     "cron",
     "history",
+    "skills",
 }
 
 
@@ -106,13 +107,16 @@ def run_migration(
             target_workspace,
             overwrite,
         ),
+        "skills": lambda: plan_skill_migration(
+            source,
+            target_workspace,
+            overwrite,
+        ),
     }
 
     for name, converter_fn in converters.items():
         if name in active:
             plan.items.extend(converter_fn())
-
-    plan.items.extend(plan_skill_report(source))
 
     _print_preview(plan)
 

--- a/src/qwenpaw/migrate/openclaw/orchestrator.py
+++ b/src/qwenpaw/migrate/openclaw/orchestrator.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""Orchestrate the full OpenClaw → QwenPaw migration pipeline."""
+from __future__ import annotations
+
+import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+import click
+
+from ...config.utils import load_config
+from ...constant import WORKING_DIR
+from ..models import ItemStatus, MigrationPlan, MigrationReport
+from .detector import detect
+from .persona import plan_persona_migration
+from .memory import plan_memory_migration
+from .providers import plan_provider_migration
+from .mcp import plan_mcp_migration
+from .channels import plan_channel_migration
+from .cron import plan_cron_migration
+from .history import plan_history_migration
+from .skills import plan_skill_report
+
+logger = logging.getLogger(__name__)
+
+ALL_CATEGORIES = {
+    "persona",
+    "memory",
+    "providers",
+    "mcp",
+    "channels",
+    "cron",
+    "history",
+}
+
+
+def run_migration(
+    *,
+    source_path: Path | None,
+    target_agent_id: str,
+    openclaw_agent_id: str,
+    dry_run: bool,
+    include: set[str] | None,
+    exclude: set[str] | None,
+    migrate_secrets: bool,
+    overwrite: bool,
+    no_backup: bool,
+    yes: bool,
+) -> MigrationReport:
+    source = detect(source_path, openclaw_agent_id)
+
+    config = load_config()
+    if target_agent_id not in config.agents.profiles:
+        raise click.ClickException(
+            f"Agent '{target_agent_id}' not found. "
+            f"Available: {', '.join(config.agents.profiles.keys())}",
+        )
+    agent_ref = config.agents.profiles[target_agent_id]
+    target_workspace = Path(agent_ref.workspace_dir).expanduser()
+
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    archive_dir = WORKING_DIR / f"migration-archive/openclaw-{ts}"
+
+    plan = MigrationPlan(
+        source=source,
+        target_agent_id=target_agent_id,
+        target_workspace=target_workspace,
+        items=[],
+    )
+
+    active = (include if include else set(ALL_CATEGORIES)) - (exclude or set())
+
+    converters = {
+        "persona": lambda: plan_persona_migration(
+            source,
+            target_workspace,
+            archive_dir,
+            overwrite,
+        ),
+        "memory": lambda: plan_memory_migration(
+            source,
+            target_workspace,
+            archive_dir,
+            overwrite,
+        ),
+        "providers": lambda: plan_provider_migration(
+            source,
+            target_workspace,
+            migrate_secrets,
+            overwrite,
+        ),
+        "mcp": lambda: plan_mcp_migration(source, target_workspace, overwrite),
+        "channels": lambda: plan_channel_migration(
+            source,
+            target_workspace,
+            overwrite,
+        ),
+        "cron": lambda: plan_cron_migration(
+            source,
+            target_workspace,
+            overwrite,
+        ),
+        "history": lambda: plan_history_migration(
+            source,
+            target_workspace,
+            overwrite,
+        ),
+    }
+
+    for name, converter_fn in converters.items():
+        if name in active:
+            plan.items.extend(converter_fn())
+
+    plan.items.extend(plan_skill_report(source))
+
+    _print_preview(plan)
+
+    if dry_run:
+        report = _build_report(plan, applied=0, backup_path=None)
+        click.echo("\n[dry-run] No files were written.")
+        return report
+
+    if not yes:
+        if not click.confirm("\nProceed with migration?"):
+            raise click.Abort()
+
+    backup_path = None
+    if not no_backup:
+        backup_path = _create_pre_migration_backup(target_workspace, ts)
+
+    applied, errors = 0, 0
+    for item in plan.items:
+        if item.status == ItemStatus.OK and item.write_fn:
+            try:
+                item.write_fn()
+                applied += 1
+            except Exception as exc:
+                item.status = ItemStatus.ERROR
+                item.detail = str(exc)
+                errors += 1
+                logger.warning(
+                    "Migration failed for %s: %s",
+                    item.source_path,
+                    exc,
+                )
+
+    report = _build_report(plan, applied=applied, backup_path=backup_path)
+    _print_report(report)
+    return report
+
+
+def _build_report(
+    plan: MigrationPlan,
+    *,
+    applied: int,
+    backup_path: Path | None,
+) -> MigrationReport:
+    return MigrationReport(
+        plan=plan,
+        applied=applied,
+        skipped=sum(1 for i in plan.items if i.status == ItemStatus.SKIP),
+        conflicts=sum(
+            1 for i in plan.items if i.status == ItemStatus.CONFLICT
+        ),
+        warnings=sum(1 for i in plan.items if i.status == ItemStatus.WARN),
+        errors=sum(1 for i in plan.items if i.status == ItemStatus.ERROR),
+        backup_path=backup_path,
+    )
+
+
+def _create_pre_migration_backup(
+    target_workspace: Path,
+    ts: str,
+) -> Path | None:
+    if not target_workspace.exists():
+        return None
+    backup_dir = Path(f"{WORKING_DIR}.backups")
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = backup_dir / f"pre-migrate-{ts}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for fp in target_workspace.rglob("*"):
+            if fp.is_file():
+                zf.write(fp, fp.relative_to(target_workspace))
+    click.echo(f"Backup saved: {zip_path}")
+    return zip_path
+
+
+_STATUS_ICON = {
+    ItemStatus.OK: "✓",
+    ItemStatus.SKIP: "⊘",
+    ItemStatus.CONFLICT: "✗",
+    ItemStatus.WARN: "⚠",
+    ItemStatus.ERROR: "✗",
+    ItemStatus.ARCHIVED: "ⓘ",
+}
+
+
+def _print_preview(plan: MigrationPlan) -> None:
+    try:
+        _print_preview_rich(plan)
+    except ImportError:
+        _print_preview_plain(plan)
+
+
+def _print_preview_rich(plan: MigrationPlan) -> None:
+    from rich.console import Console
+    from rich.table import Table
+    from rich.panel import Panel
+
+    console = Console()
+    console.print(
+        Panel(
+            "[bold]QwenPaw Migration Preview[/bold]\n"
+            "[dim]OpenClaw → QwenPaw[/dim]",
+            expand=False,
+        ),
+    )
+    console.print(f"  Source:  {plan.source.root} ({plan.source.flavor})")
+    console.print(
+        f"  Agent:   {plan.source.agent_id} → {plan.target_agent_id}",
+    )
+    console.print(f"  Target:  {plan.target_workspace}\n")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Category", width=10)
+    table.add_column("Detail", min_width=30)
+    table.add_column("Status", width=10, justify="center")
+
+    status_style = {
+        ItemStatus.OK: "green",
+        ItemStatus.SKIP: "dim",
+        ItemStatus.CONFLICT: "red",
+        ItemStatus.WARN: "yellow",
+        ItemStatus.ERROR: "red bold",
+        ItemStatus.ARCHIVED: "cyan",
+    }
+    for item in plan.items:
+        icon = _STATUS_ICON.get(item.status, "?")
+        style = status_style.get(item.status, "")
+        table.add_row(
+            item.category,
+            item.detail,
+            f"[{style}]{icon} {item.status.value.upper()}[/{style}]",
+        )
+    console.print(table)
+
+
+def _print_preview_plain(plan: MigrationPlan) -> None:
+    click.echo("\n=== QwenPaw Migration Preview ===")
+    click.echo(f"Source:  {plan.source.root} ({plan.source.flavor})")
+    click.echo(f"Agent:   {plan.source.agent_id} → {plan.target_agent_id}")
+    click.echo(f"Target:  {plan.target_workspace}\n")
+    click.echo(f"{'Category':<12} {'Detail':<40} {'Status':<10}")
+    click.echo("-" * 62)
+    for item in plan.items:
+        icon = _STATUS_ICON.get(item.status, "?")
+        click.echo(
+            f"{item.category:<12} {item.detail:<40}"
+            f" {icon} {item.status.value.upper()}",
+        )
+
+
+def _print_report(report: MigrationReport) -> None:
+    try:
+        from rich.console import Console
+        from rich.panel import Panel
+
+        console = Console()
+        lines = [
+            f"[bold green]Applied:[/bold green]   {report.applied}",
+            f"[dim]Skipped:[/dim]   {report.skipped}",
+            f"[yellow]Warnings:[/yellow]  {report.warnings}",
+            f"[red]Conflicts:[/red] {report.conflicts}",
+            f"[red]Errors:[/red]    {report.errors}",
+        ]
+        if report.backup_path:
+            lines.append(f"[cyan]Backup:[/cyan]    {report.backup_path}")
+        console.print(
+            Panel("\n".join(lines), title="Migration Report", expand=False),
+        )
+    except ImportError:
+        click.echo("\n=== Migration Report ===")
+        click.echo(f"Applied:   {report.applied}")
+        click.echo(f"Skipped:   {report.skipped}")
+        click.echo(f"Warnings:  {report.warnings}")
+        click.echo(f"Conflicts: {report.conflicts}")
+        click.echo(f"Errors:    {report.errors}")
+        if report.backup_path:
+            click.echo(f"Backup:    {report.backup_path}")

--- a/src/qwenpaw/migrate/openclaw/persona.py
+++ b/src/qwenpaw/migrate/openclaw/persona.py
@@ -58,7 +58,10 @@ def plan_persona_migration(
     ws = source.workspace
 
     for name in ("SOUL.md", "AGENTS.md"):
-        src = ws / name
+        src = source.source_candidate(
+            f"workspace/{name}",
+            f"workspace.default/{name}",
+        ) or (ws / name)
         dst = target_workspace / name
         if not src.exists():
             items.append(
@@ -94,8 +97,14 @@ def plan_persona_migration(
         )
 
     # IDENTITY.md + USER.md → PROFILE.md
-    identity_src = ws / "IDENTITY.md"
-    user_src = ws / "USER.md"
+    identity_src = source.source_candidate(
+        "workspace/IDENTITY.md",
+        "workspace.default/IDENTITY.md",
+    ) or (ws / "IDENTITY.md")
+    user_src = source.source_candidate(
+        "workspace/USER.md",
+        "workspace.default/USER.md",
+    ) or (ws / "USER.md")
     profile_dst = target_workspace / "PROFILE.md"
     identity_md = (
         identity_src.read_text(encoding="utf-8")
@@ -142,7 +151,10 @@ def plan_persona_migration(
 
     # TOOLS.md, BOOTSTRAP.md → archive
     for name in ("TOOLS.md", "BOOTSTRAP.md", "HEARTBEAT.md"):
-        src = ws / name
+        src = source.source_candidate(
+            f"workspace/{name}",
+            f"workspace.default/{name}",
+        ) or (ws / name)
         if not src.exists():
             continue
         dst = archive_dir / name

--- a/src/qwenpaw/migrate/openclaw/persona.py
+++ b/src/qwenpaw/migrate/openclaw/persona.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+import shutil
+from datetime import date
+from pathlib import Path
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _make_copy_fn(src: Path, dst: Path):
+    def _do():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+    return _do
+
+
+def _build_imported_block(identity_md: str | None, user_md: str | None) -> str:
+    parts = [p for p in (identity_md, user_md) if p]
+    return "\n\n".join(parts)
+
+
+def _write_profile(
+    target: Path,
+    identity_md: str | None,
+    user_md: str | None,
+    overwrite: bool,
+) -> ItemStatus:
+    imported_block = _build_imported_block(identity_md, user_md)
+    if not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(imported_block, encoding="utf-8")
+        return ItemStatus.OK
+    if overwrite:
+        target.write_text(imported_block, encoding="utf-8")
+        return ItemStatus.OK
+    existing = target.read_text(encoding="utf-8")
+    separator = (
+        "\n\n---\n\n"
+        f"<!-- Imported from OpenClaw ({date.today().isoformat()}) -->"
+        "\n\n"
+    )
+    target.write_text(existing + separator + imported_block, encoding="utf-8")
+    return ItemStatus.WARN
+
+
+def plan_persona_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    archive_dir: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    items: list[MigrationItem] = []
+    ws = source.workspace
+
+    for name in ("SOUL.md", "AGENTS.md"):
+        src = ws / name
+        dst = target_workspace / name
+        if not src.exists():
+            items.append(
+                MigrationItem(
+                    category="persona",
+                    source_path=str(src),
+                    target_path=str(dst),
+                    status=ItemStatus.SKIP,
+                    detail=f"{name} not found in source",
+                ),
+            )
+            continue
+        if dst.exists() and not overwrite:
+            items.append(
+                MigrationItem(
+                    category="persona",
+                    source_path=str(src),
+                    target_path=str(dst),
+                    status=ItemStatus.CONFLICT,
+                    detail=f"{name} already exists at target",
+                ),
+            )
+            continue
+        items.append(
+            MigrationItem(
+                category="persona",
+                source_path=str(src),
+                target_path=str(dst),
+                status=ItemStatus.OK,
+                detail=f"copy {name}",
+                write_fn=_make_copy_fn(src, dst),
+            ),
+        )
+
+    # IDENTITY.md + USER.md → PROFILE.md
+    identity_src = ws / "IDENTITY.md"
+    user_src = ws / "USER.md"
+    profile_dst = target_workspace / "PROFILE.md"
+    identity_md = (
+        identity_src.read_text(encoding="utf-8")
+        if identity_src.exists()
+        else None
+    )
+    user_md = (
+        user_src.read_text(encoding="utf-8") if user_src.exists() else None
+    )
+
+    if identity_md or user_md:
+        if profile_dst.exists() and not overwrite:
+            status = ItemStatus.WARN
+            detail = "PROFILE.md exists; will append imported content"
+        else:
+            status = ItemStatus.OK
+            detail = "merge IDENTITY.md + USER.md → PROFILE.md"
+
+        items.append(
+            MigrationItem(
+                category="persona",
+                source_path=str(identity_src if identity_md else user_src),
+                target_path=str(profile_dst),
+                status=status,
+                detail=detail,
+                write_fn=lambda: _write_profile(
+                    profile_dst,
+                    identity_md,
+                    user_md,
+                    overwrite,
+                ),
+            ),
+        )
+    else:
+        items.append(
+            MigrationItem(
+                category="persona",
+                source_path=str(identity_src),
+                target_path=str(profile_dst),
+                status=ItemStatus.SKIP,
+                detail="neither IDENTITY.md nor USER.md found",
+            ),
+        )
+
+    # TOOLS.md, BOOTSTRAP.md → archive
+    for name in ("TOOLS.md", "BOOTSTRAP.md", "HEARTBEAT.md"):
+        src = ws / name
+        if not src.exists():
+            continue
+        dst = archive_dir / name
+        items.append(
+            MigrationItem(
+                category="persona",
+                source_path=str(src),
+                target_path=str(dst),
+                status=ItemStatus.ARCHIVED,
+                detail=f"{name} archived (no direct equivalent)",
+                write_fn=_make_copy_fn(src, dst),
+            ),
+        )
+
+    return items

--- a/src/qwenpaw/migrate/openclaw/providers.py
+++ b/src/qwenpaw/migrate/openclaw/providers.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import logging
+from functools import partial
+from pathlib import Path
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER_MAP = {
+    "anthropic": "anthropic",
+    "openai": "openai",
+    "google": "google",
+    "gemini": "google",
+    "openrouter": "openrouter",
+    "ollama": "ollama",
+    "lmstudio": "lmstudio",
+    "deepseek": "deepseek",
+    "groq": "groq",
+}
+
+_ALLOWED_KEY_TARGETS = {
+    "OPENAI_API_KEY": "openai",
+    "ANTHROPIC_API_KEY": "anthropic",
+    "OPENROUTER_API_KEY": "openrouter",
+    "DEEPSEEK_API_KEY": "deepseek",
+    "GEMINI_API_KEY": "google",
+    "GROQ_API_KEY": "groq",
+}
+
+
+def _resolve_secret_input(value, env: dict[str, str]) -> str | None:
+    """Resolve OpenClaw SecretInput to a plain string.
+
+    SecretInput can be a plain string or {source: "env", id: "VAR_NAME"}.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict) and value.get("source") == "env":
+        return env.get(value.get("id", ""))
+    return None
+
+
+def _parse_model_ref(model_str: str) -> tuple[str, str]:
+    parts = model_str.split("/", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return "", parts[0]
+
+
+def _write_default_model(target_workspace: Path, provider_id: str, model: str):
+    agent_json = target_workspace / "agent.json"
+    data = {}
+    if agent_json.exists():
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+    data.setdefault("active_model", {})
+    data["active_model"]["provider_id"] = provider_id
+    data["active_model"]["model"] = model
+    agent_json.parent.mkdir(parents=True, exist_ok=True)
+    agent_json.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _write_custom_provider(
+    target_workspace: Path,
+    provider_id: str,
+    base_url: str,
+    api_key: str | None,
+):
+    """Record custom provider config. API key is stored in plaintext here;
+    the orchestrator should ideally use ProviderManager for encryption."""
+    agent_json = target_workspace / "agent.json"
+    data = {}
+    if agent_json.exists():
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+    providers = data.setdefault("custom_providers", {})
+    providers[provider_id] = {"base_url": base_url}
+    if api_key:
+        providers[provider_id]["api_key"] = api_key
+    agent_json.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def plan_provider_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    migrate_secrets: bool,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    del overwrite  # reserved for future conflict handling
+    items: list[MigrationItem] = []
+
+    # --- Default model ---
+    defaults = source.config.get("agents", {}).get("defaults", {})
+    model_raw = defaults.get("model")
+    if not model_raw:
+        model_raw = source.config.get("agent", {}).get("model")
+    if model_raw:
+        model_str = (
+            model_raw
+            if isinstance(model_raw, str)
+            else model_raw.get("primary", "")
+        )
+        if model_str:
+            provider, model = _parse_model_ref(model_str)
+            mapped = _PROVIDER_MAP.get(provider)
+            if mapped:
+                items.append(
+                    MigrationItem(
+                        category="provider",
+                        source_path="config.agents.defaults.model",
+                        target_path="agent.json#active_model",
+                        status=ItemStatus.OK,
+                        detail=(f"{provider}/{model}" f" -> {mapped}/{model}"),
+                        write_fn=partial(
+                            _write_default_model,
+                            target_workspace,
+                            mapped,
+                            model,
+                        ),
+                    ),
+                )
+            else:
+                items.append(
+                    MigrationItem(
+                        category="provider",
+                        source_path="config.agents.defaults.model",
+                        target_path="agent.json#active_model",
+                        status=ItemStatus.WARN,
+                        detail=(
+                            f"Unknown provider '{provider}',"
+                            " skipping default model"
+                        ),
+                        write_fn=None,
+                    ),
+                )
+
+    # --- Custom providers ---
+    providers_cfg = source.config.get("models", {}).get("providers", {})
+    for pid, pcfg in providers_cfg.items():
+        if not isinstance(pcfg, dict):
+            continue
+        base_url = pcfg.get("baseUrl", pcfg.get("base_url", ""))
+        raw_key = pcfg.get("apiKey", pcfg.get("api_key"))
+        api_key = _resolve_secret_input(raw_key, source.env)
+        items.append(
+            MigrationItem(
+                category="provider",
+                source_path=f"config.models.providers.{pid}",
+                target_path=f"agent.json#custom_providers.{pid}",
+                status=ItemStatus.OK,
+                detail=(f"Custom provider '{pid}'" f" base_url={base_url}"),
+                write_fn=partial(
+                    _write_custom_provider,
+                    target_workspace,
+                    pid,
+                    base_url,
+                    api_key,
+                ),
+            ),
+        )
+
+    # --- API keys ---
+    if migrate_secrets:
+        for env_var, target_provider in _ALLOWED_KEY_TARGETS.items():
+            if env_var in source.env:
+                items.append(
+                    MigrationItem(
+                        category="secret",
+                        source_path=f"env.{env_var}",
+                        target_path=f"provider_secret:{target_provider}",
+                        status=ItemStatus.OK,
+                        detail=(f"API key {env_var}" f" -> {target_provider}"),
+                        write_fn=None,
+                    ),
+                )
+
+    return items

--- a/src/qwenpaw/migrate/openclaw/providers.py
+++ b/src/qwenpaw/migrate/openclaw/providers.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 from ..models import ItemStatus, MigrationItem, SourceInfo
 
@@ -12,8 +14,11 @@ logger = logging.getLogger(__name__)
 
 _PROVIDER_MAP = {
     "anthropic": "anthropic",
+    "anthropic-messages": "anthropic",
     "openai": "openai",
+    "openai-completions": "openai",
     "google": "google",
+    "google-generative-ai": "google",
     "gemini": "google",
     "openrouter": "openrouter",
     "ollama": "ollama",
@@ -29,18 +34,30 @@ _ALLOWED_KEY_TARGETS = {
     "DEEPSEEK_API_KEY": "deepseek",
     "GEMINI_API_KEY": "google",
     "GROQ_API_KEY": "groq",
+    "ZAI_API_KEY": "zai",
+    "MINIMAX_API_KEY": "minimax",
 }
 
 
-def _resolve_secret_input(value, env: dict[str, str]) -> str | None:
+def _resolve_secret_input(value: Any, env: dict[str, str]) -> str | None:
     """Resolve OpenClaw SecretInput to a plain string.
 
-    SecretInput can be a plain string or {source: "env", id: "VAR_NAME"}.
+    SecretInput can be:
+      - A plain string: "sk-..."
+      - An env template: "${VAR_NAME}"
+      - A SecretRef object: {"source": "env", "id": "VAR_NAME"}
     """
     if isinstance(value, str):
-        return value
-    if isinstance(value, dict) and value.get("source") == "env":
-        return env.get(value.get("id", ""))
+        m = re.fullmatch(r"\$\{(\w+)}", value.strip())
+        if m:
+            return env.get(m.group(1))
+        return value.strip() or None
+    if isinstance(value, dict):
+        source = value.get("source", "")
+        ref_id = value.get("id", "")
+        if source == "env" and ref_id:
+            return env.get(ref_id)
+        return None
     return None
 
 
@@ -49,6 +66,22 @@ def _parse_model_ref(model_str: str) -> tuple[str, str]:
     if len(parts) == 2:
         return parts[0], parts[1]
     return "", parts[0]
+
+
+def _map_provider(raw_provider: str, api_type: str = "") -> str | None:
+    """Resolve OpenClaw provider name or apiType to QwenPaw provider id."""
+    mapped = _PROVIDER_MAP.get(raw_provider)
+    if mapped:
+        return mapped
+    if api_type:
+        mapped = _PROVIDER_MAP.get(api_type)
+        if mapped:
+            return mapped
+    lower = raw_provider.lower()
+    for key, val in _PROVIDER_MAP.items():
+        if key in lower:
+            return val
+    return None
 
 
 def _write_default_model(target_workspace: Path, provider_id: str, model: str):
@@ -70,31 +103,49 @@ def _write_custom_provider(
     target_workspace: Path,
     provider_id: str,
     base_url: str,
-    api_key: str | None,
+    api_type: str,
 ):
-    """Record custom provider config. API key is stored in plaintext here;
-    the orchestrator should ideally use ProviderManager for encryption."""
     agent_json = target_workspace / "agent.json"
     data = {}
     if agent_json.exists():
         data = json.loads(agent_json.read_text(encoding="utf-8"))
     providers = data.setdefault("custom_providers", {})
-    providers[provider_id] = {"base_url": base_url}
-    if api_key:
-        providers[provider_id]["api_key"] = api_key
+    entry: dict[str, Any] = {"base_url": base_url}
+    if api_type:
+        entry["api_type"] = api_type
+    providers[provider_id] = entry
     agent_json.write_text(
         json.dumps(data, indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
 
 
+def _write_api_keys(target_workspace: Path, keys: dict[str, str]):
+    """Write migrated API keys into the agent's env file."""
+    env_path = target_workspace / ".env"
+    existing: dict[str, str] = {}
+    if env_path.is_file():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            k, _, v = line.partition("=")
+            if _:
+                existing[k.strip()] = v.strip()
+    existing.update(keys)
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{k}={v}" for k, v in sorted(existing.items())]
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# pylint: disable=too-many-branches,too-many-return-statements
 def plan_provider_migration(
     source: SourceInfo,
     target_workspace: Path,
     migrate_secrets: bool,
     overwrite: bool,
 ) -> list[MigrationItem]:
-    del overwrite  # reserved for future conflict handling
+    del overwrite
     items: list[MigrationItem] = []
 
     # --- Default model ---
@@ -110,7 +161,15 @@ def plan_provider_migration(
         )
         if model_str:
             provider, model = _parse_model_ref(model_str)
-            mapped = _PROVIDER_MAP.get(provider)
+            api_type = (
+                source.config.get("models", {})
+                .get("providers", {})
+                .get(provider, {})
+                .get("api", "")
+                if provider
+                else ""
+            )
+            mapped = _map_provider(provider, api_type)
             if mapped:
                 items.append(
                     MigrationItem(
@@ -118,7 +177,7 @@ def plan_provider_migration(
                         source_path="config.agents.defaults.model",
                         target_path="agent.json#active_model",
                         status=ItemStatus.OK,
-                        detail=(f"{provider}/{model}" f" -> {mapped}/{model}"),
+                        detail=f"{provider}/{model} -> {mapped}/{model}",
                         write_fn=partial(
                             _write_default_model,
                             target_workspace,
@@ -138,7 +197,6 @@ def plan_provider_migration(
                             f"Unknown provider '{provider}',"
                             " skipping default model"
                         ),
-                        write_fn=None,
                     ),
                 )
 
@@ -148,38 +206,114 @@ def plan_provider_migration(
         if not isinstance(pcfg, dict):
             continue
         base_url = pcfg.get("baseUrl", pcfg.get("base_url", ""))
-        raw_key = pcfg.get("apiKey", pcfg.get("api_key"))
-        api_key = _resolve_secret_input(raw_key, source.env)
+        api_type = pcfg.get("api", pcfg.get("apiType", ""))
         items.append(
             MigrationItem(
                 category="provider",
                 source_path=f"config.models.providers.{pid}",
                 target_path=f"agent.json#custom_providers.{pid}",
                 status=ItemStatus.OK,
-                detail=(f"Custom provider '{pid}'" f" base_url={base_url}"),
+                detail=f"Custom provider '{pid}' base_url={base_url}",
                 write_fn=partial(
                     _write_custom_provider,
                     target_workspace,
                     pid,
                     base_url,
-                    api_key,
+                    api_type,
                 ),
             ),
         )
 
     # --- API keys ---
     if migrate_secrets:
-        for env_var, target_provider in _ALLOWED_KEY_TARGETS.items():
-            if env_var in source.env:
-                items.append(
-                    MigrationItem(
-                        category="secret",
-                        source_path=f"env.{env_var}",
-                        target_path=f"provider_secret:{target_provider}",
-                        status=ItemStatus.OK,
-                        detail=(f"API key {env_var}" f" -> {target_provider}"),
-                        write_fn=None,
+        collected_keys: dict[str, str] = {}
+        for env_var, _ in _ALLOWED_KEY_TARGETS.items():
+            val = source.env.get(env_var)
+            if val:
+                collected_keys[env_var] = val
+
+        for pid, pcfg in providers_cfg.items():
+            if not isinstance(pcfg, dict):
+                continue
+            raw_key = pcfg.get("apiKey", pcfg.get("api_key"))
+            api_key = _resolve_secret_input(raw_key, source.env)
+            if not api_key:
+                if isinstance(raw_key, dict) and raw_key.get("source") in {
+                    "file",
+                    "exec",
+                }:
+                    items.append(
+                        MigrationItem(
+                            category="secret",
+                            source_path=f"models.providers.{pid}.apiKey",
+                            target_path="(manual)",
+                            status=ItemStatus.WARN,
+                            detail=(
+                                f"Provider '{pid}' uses a "
+                                f"{raw_key['source']}-backed SecretRef; "
+                                "add this key manually"
+                            ),
+                        ),
+                    )
+                continue
+            base_url = pcfg.get("baseUrl", "")
+            env_var = _infer_env_var(pid, base_url, pcfg.get("api", ""))
+            if env_var and env_var not in collected_keys:
+                collected_keys[env_var] = api_key
+
+        if collected_keys:
+            keys_snapshot = dict(collected_keys)
+            items.append(
+                MigrationItem(
+                    category="secret",
+                    source_path="env + config",
+                    target_path=f"{target_workspace}/.env",
+                    status=ItemStatus.OK,
+                    detail=(
+                        f"Migrate {len(keys_snapshot)} API key(s): "
+                        + ", ".join(sorted(keys_snapshot.keys()))
                     ),
-                )
+                    write_fn=partial(
+                        _write_api_keys,
+                        target_workspace,
+                        keys_snapshot,
+                    ),
+                ),
+            )
 
     return items
+
+
+def _infer_env_var(  # pylint: disable=too-many-return-statements
+    provider_name: str,
+    base_url: str,
+    api_type: str,
+) -> str | None:
+    """Infer the standard env var name for a provider API key."""
+    lower_url = (base_url or "").lower()
+    if "openrouter" in lower_url:
+        return "OPENROUTER_API_KEY"
+    if "openai.com" in lower_url:
+        return "OPENAI_API_KEY"
+    if "anthropic" in lower_url:
+        return "ANTHROPIC_API_KEY"
+    if "deepseek" in lower_url:
+        return "DEEPSEEK_API_KEY"
+
+    if api_type == "anthropic-messages":
+        return "ANTHROPIC_API_KEY"
+
+    name = provider_name.lower()
+    env_map = {
+        "openrouter": "OPENROUTER_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "anthropic": "ANTHROPIC_API_KEY",
+        "deepseek": "DEEPSEEK_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+        "google": "GEMINI_API_KEY",
+        "groq": "GROQ_API_KEY",
+    }
+    for key, var in env_map.items():
+        if key in name:
+            return var
+    return None

--- a/src/qwenpaw/migrate/openclaw/skills.py
+++ b/src/qwenpaw/migrate/openclaw/skills.py
@@ -1,38 +1,104 @@
 # -*- coding: utf-8 -*-
-"""Skill mapping report: scans OpenClaw skills (no writes)."""
+"""Skill migration: copy OpenClaw skills into QwenPaw workspace."""
 from __future__ import annotations
+
+import shutil
+from functools import partial
+from pathlib import Path
 
 from ..models import ItemStatus, MigrationItem, SourceInfo
 
+SKILL_IMPORT_DIRNAME = "openclaw-imports"
 
-def plan_skill_report(source: SourceInfo) -> list[MigrationItem]:
-    items: list[MigrationItem] = []
-    skill_dirs = []
+
+def _collect_skill_dirs(source: SourceInfo) -> list[tuple[Path, str]]:
+    """Find skill directories from all OpenClaw skill sources."""
+    candidates: list[tuple[Path, str]] = []
 
     ws_skills = source.workspace / "skills"
     if ws_skills.is_dir():
-        skill_dirs.extend(ws_skills.iterdir())
+        for d in sorted(ws_skills.iterdir()):
+            if d.is_dir() and (d / "SKILL.md").exists():
+                candidates.append((d, "workspace"))
 
     global_skills = source.root / "skills"
     if global_skills.is_dir():
-        skill_dirs.extend(global_skills.iterdir())
+        for d in sorted(global_skills.iterdir()):
+            if d.is_dir() and (d / "SKILL.md").exists():
+                candidates.append((d, "managed"))
 
+    personal = Path.home() / ".agents" / "skills"
+    if personal.is_dir():
+        for d in sorted(personal.iterdir()):
+            if d.is_dir() and (d / "SKILL.md").exists():
+                candidates.append((d, "personal"))
+
+    return candidates
+
+
+def _copy_skill(src: Path, dst: Path):
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def plan_skill_migration(
+    source: SourceInfo,
+    target_workspace: Path,
+    overwrite: bool,
+) -> list[MigrationItem]:
+    items: list[MigrationItem] = []
+    skill_dirs = _collect_skill_dirs(source)
+
+    if not skill_dirs:
+        items.append(
+            MigrationItem(
+                category="skills",
+                source_path="(none)",
+                target_path="(no skills found)",
+                status=ItemStatus.SKIP,
+                detail="No OpenClaw skills found",
+            ),
+        )
+        return items
+
+    import_dir = target_workspace / "skills" / SKILL_IMPORT_DIRNAME
     seen: set[str] = set()
-    for skill_dir in skill_dirs:
-        if not skill_dir.is_dir():
-            continue
+
+    for skill_dir, origin in skill_dirs:
         name = skill_dir.name
         if name in seen:
             continue
         seen.add(name)
+
+        dst = import_dir / name
+        if dst.exists() and not overwrite:
+            items.append(
+                MigrationItem(
+                    category="skills",
+                    source_path=str(skill_dir),
+                    target_path=str(dst),
+                    status=ItemStatus.CONFLICT,
+                    detail=f"Skill '{name}' already exists at target",
+                ),
+            )
+            continue
+
         items.append(
             MigrationItem(
                 category="skills",
                 source_path=str(skill_dir),
-                target_path="(no auto-migration)",
-                status=ItemStatus.ARCHIVED,
-                detail=f"OpenClaw skill '{name}' — manual install needed",
-                write_fn=None,
+                target_path=str(dst),
+                status=ItemStatus.OK,
+                detail=f"Copy {origin} skill '{name}'",
+                write_fn=partial(_copy_skill, skill_dir, dst),
             ),
         )
+
     return items
+
+
+def plan_skill_report(source: SourceInfo) -> list[MigrationItem]:
+    """Legacy report-only: kept for backward compatibility."""
+    return plan_skill_migration(source, Path("/dev/null"), overwrite=False)

--- a/src/qwenpaw/migrate/openclaw/skills.py
+++ b/src/qwenpaw/migrate/openclaw/skills.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Skill mapping report: scans OpenClaw skills (no writes)."""
+from __future__ import annotations
+
+from ..models import ItemStatus, MigrationItem, SourceInfo
+
+
+def plan_skill_report(source: SourceInfo) -> list[MigrationItem]:
+    items: list[MigrationItem] = []
+    skill_dirs = []
+
+    ws_skills = source.workspace / "skills"
+    if ws_skills.is_dir():
+        skill_dirs.extend(ws_skills.iterdir())
+
+    global_skills = source.root / "skills"
+    if global_skills.is_dir():
+        skill_dirs.extend(global_skills.iterdir())
+
+    seen: set[str] = set()
+    for skill_dir in skill_dirs:
+        if not skill_dir.is_dir():
+            continue
+        name = skill_dir.name
+        if name in seen:
+            continue
+        seen.add(name)
+        items.append(
+            MigrationItem(
+                category="skills",
+                source_path=str(skill_dir),
+                target_path="(no auto-migration)",
+                status=ItemStatus.ARCHIVED,
+                detail=f"OpenClaw skill '{name}' — manual install needed",
+                write_fn=None,
+            ),
+        )
+    return items

--- a/tests/unit/migrate/test_channels.py
+++ b/tests/unit/migrate/test_channels.py
@@ -47,7 +47,14 @@ class TestMapAllowFrom:
         assert _map_allow_from(["123", "456", "*"]) == ["123", "456"]
 
     def test_empty_input(self):
-        assert _map_allow_from(None) == []
+        assert not _map_allow_from(None)
+
+    def test_strips_telegram_prefix(self):
+        assert _map_allow_from(["tg:123", "telegram:456", "789"]) == [
+            "123",
+            "456",
+            "789",
+        ]
 
 
 class TestExtractTelegram:
@@ -83,7 +90,7 @@ class TestPlanChannelMigration:
         target_ws = tmp_path / "target"
         target_ws.mkdir()
 
-        config = {"channels": {"slack": {"token": "xoxb-123"}}}
+        config = {"channels": {"whatsapp": {"allowFrom": ["123"]}}}
         source = _make_source(source_ws, source_ws, config=config)
         items = plan_channel_migration(source, target_ws, overwrite=False)
 

--- a/tests/unit/migrate/test_channels.py
+++ b/tests/unit/migrate/test_channels.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+from qwenpaw.migrate.models import ItemStatus, SourceInfo
+from qwenpaw.migrate.openclaw.channels import (
+    _extract_discord,
+    _extract_telegram,
+    _map_allow_from,
+    _resolve_token,
+    plan_channel_migration,
+)
+
+
+def _make_source(root: Path, workspace: Path, config=None, env=None):
+    return SourceInfo(
+        root=root,
+        flavor="openclaw",
+        config=config or {},
+        env=env or {},
+        workspace=workspace,
+        agent_id="main",
+    )
+
+
+class TestResolveToken:
+    def test_plain_string(self):
+        assert _resolve_token("my-token", {}) == "my-token"
+
+    def test_env_template(self):
+        env = {"TELEGRAM_BOT_TOKEN": "abc"}
+        assert _resolve_token("${TELEGRAM_BOT_TOKEN}", env) == "abc"
+
+    def test_secret_ref_env(self):
+        env = {"TELEGRAM_BOT_TOKEN": "abc"}
+        ref = {"source": "env", "id": "TELEGRAM_BOT_TOKEN"}
+        assert _resolve_token(ref, env) == "abc"
+
+    def test_secret_ref_unsupported_source(self):
+        ref = {"source": "file", "id": "key.txt"}
+        assert _resolve_token(ref, {}) is None
+
+
+class TestMapAllowFrom:
+    def test_filters_wildcard(self):
+        assert _map_allow_from(["123", "456", "*"]) == ["123", "456"]
+
+    def test_empty_input(self):
+        assert _map_allow_from(None) == []
+
+
+class TestExtractTelegram:
+    def test_full_config(self):
+        oc_cfg = {
+            "botToken": "tg-token-123",
+            "allowFrom": ["111", "222"],
+            "dmPolicy": "allowlist",
+        }
+        result = _extract_telegram(oc_cfg, {})
+        assert result["enabled"] is True
+        assert result["bot_token"] == "tg-token-123"
+        assert result["allow_from"] == ["111", "222"]
+        assert result["access_control_dm"] is True
+
+
+class TestExtractDiscord:
+    def test_token_and_dm_allow_from(self):
+        oc_cfg = {
+            "token": "${DISCORD_TOKEN}",
+            "dm": {"allowFrom": ["u1", "u2"]},
+        }
+        env = {"DISCORD_TOKEN": "disc-secret"}
+        result = _extract_discord(oc_cfg, env)
+        assert result["bot_token"] == "disc-secret"
+        assert result["allow_from"] == ["u1", "u2"]
+
+
+class TestPlanChannelMigration:
+    def test_archived_platform(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {"channels": {"slack": {"token": "xoxb-123"}}}
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_channel_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.ARCHIVED
+
+    def test_unknown_platform(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {"channels": {"carrier_pigeon": {"speed": "slow"}}}
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_channel_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.WARN
+
+    def test_skips_non_channel_keys(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "channels": {
+                "defaults": {"groupPolicy": "open"},
+                "modelByChannel": {"openai": {"telegram": "gpt-4o"}},
+                "telegram": {"botToken": "tok"},
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_channel_migration(source, target_ws, overwrite=False)
+
+        categories = [i.source_path for i in items]
+        assert "channels.defaults" not in categories
+        assert "channels.modelByChannel" not in categories
+        assert any("telegram" in c for c in categories)
+
+    def test_pairing_dm_policy_sets_access_control(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "channels": {
+                "telegram": {"botToken": "tok", "dmPolicy": "pairing"},
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_channel_migration(source, target_ws, overwrite=False)
+        assert items[0].status == ItemStatus.OK
+        items[0].write_fn()
+        import json
+
+        agent = json.loads(
+            (target_ws / "agent.json").read_text(encoding="utf-8"),
+        )
+        assert agent["channels"]["telegram"]["access_control_dm"] is True

--- a/tests/unit/migrate/test_cron.py
+++ b/tests/unit/migrate/test_cron.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from qwenpaw.migrate.models import ItemStatus, SourceInfo
+from qwenpaw.migrate.openclaw.cron import (
+    _convert_cron_job,
+    _extract_delivery,
+    _extract_prompt,
+    _extract_schedule,
+    _make_job_id,
+    plan_cron_migration,
+)
+
+
+def _make_source(
+    root: Path,
+    workspace: Path,
+    config=None,
+    env=None,
+    cron_path=None,
+):
+    return SourceInfo(
+        root=root,
+        flavor="openclaw",
+        config=config or {},
+        env=env or {},
+        workspace=workspace,
+        agent_id="main",
+        cron_path=cron_path,
+    )
+
+
+class TestMakeJobId:
+    def test_with_id_field(self):
+        assert _make_job_id({"id": "daily-report"}) == "oc-daily-report"
+
+    def test_with_name_only(self):
+        assert _make_job_id({"name": "Daily"}) == "oc-Daily"
+
+    def test_deterministic_for_same_content(self):
+        job = {"schedule": "0 9 * * *", "prompt": "hello"}
+        assert _make_job_id(job) == _make_job_id(job)
+
+
+class TestExtractSchedule:
+    def test_legacy_string_format(self):
+        result = _extract_schedule(
+            {"schedule": "0 9 * * *", "timezone": "Asia/Tokyo"},
+        )
+        assert result["type"] == "cron"
+        assert result["cron"] == "0 9 * * *"
+        assert result["timezone"] == "Asia/Tokyo"
+
+    def test_current_cron_dict_format(self):
+        result = _extract_schedule(
+            {
+                "schedule": {
+                    "kind": "cron",
+                    "expr": "0 7 * * *",
+                    "tz": "US/Eastern",
+                },
+            },
+        )
+        assert result["type"] == "cron"
+        assert result["cron"] == "0 7 * * *"
+        assert result["timezone"] == "US/Eastern"
+
+    def test_every_format(self):
+        result = _extract_schedule(
+            {"schedule": {"kind": "every", "everyMs": 300000}},
+        )
+        assert result["type"] == "interval"
+        assert result["interval_seconds"] == 300
+
+    def test_at_format(self):
+        result = _extract_schedule(
+            {"schedule": {"kind": "at", "at": "2024-12-25T00:00:00Z"}},
+        )
+        assert result["type"] == "once"
+        assert result["at"] == "2024-12-25T00:00:00Z"
+
+
+class TestExtractPrompt:
+    def test_legacy_prompt_field(self):
+        text, kind = _extract_prompt({"prompt": "hello"})
+        assert text == "hello"
+        assert kind == "agentTurn"
+
+    def test_current_agent_turn(self):
+        text, kind = _extract_prompt(
+            {"payload": {"kind": "agentTurn", "message": "hi"}},
+        )
+        assert text == "hi"
+        assert kind == "agentTurn"
+
+    def test_system_event(self):
+        text, kind = _extract_prompt(
+            {"payload": {"kind": "systemEvent", "text": "startup"}},
+        )
+        assert text == "startup"
+        assert kind == "systemEvent"
+
+    def test_command_payload(self):
+        text, kind = _extract_prompt(
+            {"payload": {"kind": "command", "argv": ["echo", "hello"]}},
+        )
+        assert text == "echo hello"
+        assert kind == "command"
+
+
+class TestExtractDelivery:
+    def test_legacy_flat_fields(self):
+        ch, to = _extract_delivery({"channel": "telegram", "to": "123"})
+        assert ch == "telegram"
+        assert to == "123"
+
+    def test_current_delivery_object(self):
+        ch, to = _extract_delivery(
+            {"delivery": {"channel": "slack", "to": "C1234"}},
+        )
+        assert ch == "slack"
+        assert to == "C1234"
+
+
+class TestConvertCronJob:
+    def test_legacy_format(self):
+        oc_job = {
+            "id": "nightly",
+            "name": "Nightly Digest",
+            "enabled": True,
+            "schedule": "0 22 * * *",
+            "timezone": "Asia/Shanghai",
+            "prompt": "Send digest",
+            "channel": "telegram",
+            "to": "user123",
+            "session": "shared",
+        }
+        result = _convert_cron_job(oc_job)
+
+        assert result["id"] == "oc-nightly"
+        assert result["name"] == "Nightly Digest"
+        assert result["enabled"] is True
+        assert result["schedule"]["type"] == "cron"
+        assert result["schedule"]["cron"] == "0 22 * * *"
+        assert result["schedule"]["timezone"] == "Asia/Shanghai"
+        assert result["task_type"] == "agent"
+        assert result["request"]["input"] == "Send digest"
+        assert result["dispatch"]["channel"] == "telegram"
+        assert result["dispatch"]["target"]["user_id"] == "user123"
+        assert result["runtime"]["share_session"] is True
+
+    def test_current_format(self):
+        oc_job = {
+            "name": "Morning brief",
+            "schedule": {
+                "kind": "cron",
+                "expr": "0 7 * * *",
+                "tz": "America/Los_Angeles",
+            },
+            "sessionTarget": "isolated",
+            "payload": {"kind": "agentTurn", "message": "Summarize updates."},
+            "delivery": {
+                "mode": "announce",
+                "channel": "slack",
+                "to": "channel:C1234567890",
+            },
+        }
+        result = _convert_cron_job(oc_job)
+
+        assert result["schedule"]["type"] == "cron"
+        assert result["schedule"]["cron"] == "0 7 * * *"
+        assert result["schedule"]["timezone"] == "America/Los_Angeles"
+        assert result["request"]["input"] == "Summarize updates."
+        assert result["dispatch"]["channel"] == "slack"
+        assert result["dispatch"]["target"]["user_id"] == "channel:C1234567890"
+        assert result["runtime"]["share_session"] is False
+
+    def test_every_interval_job(self):
+        oc_job = {
+            "id": "heartbeat",
+            "name": "Heartbeat check",
+            "schedule": {"kind": "every", "everyMs": 60000},
+            "payload": {"kind": "systemEvent", "text": "Heartbeat ping"},
+        }
+        result = _convert_cron_job(oc_job)
+        assert result["schedule"]["type"] == "interval"
+        assert result["schedule"]["interval_seconds"] == 60
+        assert result["request"]["input"] == "Heartbeat ping"
+
+    def test_command_payload(self):
+        oc_job = {
+            "id": "backup",
+            "name": "Nightly backup",
+            "schedule": "0 3 * * *",
+            "payload": {
+                "kind": "command",
+                "argv": ["/usr/bin/backup", "--full"],
+            },
+        }
+        result = _convert_cron_job(oc_job)
+        assert result["task_type"] == "command"
+        assert result["request"]["input"] == "/usr/bin/backup --full"
+
+    def test_agent_id_and_delete_after_run(self):
+        oc_job = {
+            "id": "onetime",
+            "name": "One shot",
+            "schedule": {"kind": "at", "at": "2025-01-01T00:00:00Z"},
+            "payload": {"kind": "agentTurn", "message": "Happy New Year!"},
+            "agentId": "assistant-2",
+            "deleteAfterRun": True,
+        }
+        result = _convert_cron_job(oc_job)
+        assert result["schedule"]["type"] == "once"
+        assert result["agent_id"] == "assistant-2"
+        assert result["one_shot"] is True
+
+
+class TestPlanCronMigration:
+    def test_valid_cron_file(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        cron_dir = source_ws / "cron"
+        cron_dir.mkdir()
+        cron_file = cron_dir / "cron.json"
+        cron_file.write_text(
+            json.dumps(
+                {
+                    "jobs": [
+                        {
+                            "id": "morning",
+                            "schedule": "0 8 * * *",
+                            "prompt": "Good morning",
+                        },
+                    ],
+                },
+            ),
+        )
+
+        source = _make_source(source_ws, source_ws, cron_path=cron_file)
+        items = plan_cron_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.OK
+        assert "morning" in items[0].detail
+
+    def test_conflict_detection(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        cron_dir = source_ws / "cron"
+        cron_dir.mkdir()
+        cron_file = cron_dir / "cron.json"
+        cron_file.write_text(
+            json.dumps(
+                {
+                    "jobs": [
+                        {
+                            "id": "daily",
+                            "schedule": "0 0 * * *",
+                            "prompt": "hi",
+                        },
+                    ],
+                },
+            ),
+        )
+
+        jobs_json = target_ws / "jobs.json"
+        jobs_json.write_text(
+            json.dumps(
+                {
+                    "jobs": [{"id": "oc-daily", "name": "existing"}],
+                },
+            ),
+        )
+
+        source = _make_source(source_ws, source_ws, cron_path=cron_file)
+        items = plan_cron_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.CONFLICT
+
+    def test_missing_cron_file_returns_empty(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        missing = source_ws / "cron" / "cron.json"
+        source = _make_source(source_ws, source_ws, cron_path=missing)
+        items = plan_cron_migration(source, target_ws, overwrite=False)
+
+        assert not items
+
+    def test_none_cron_path_returns_empty(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        source = _make_source(source_ws, source_ws, cron_path=None)
+        items = plan_cron_migration(source, target_ws, overwrite=False)
+
+        assert not items

--- a/tests/unit/migrate/test_detector.py
+++ b/tests/unit/migrate/test_detector.py
@@ -143,7 +143,7 @@ class TestDetect:
             info.config["agents"]["defaults"]["model"]
             == "anthropic/claude-sonnet-4-6"
         )
-        assert info.env == {"OPENAI_API_KEY": "test-key"}
+        assert info.env["OPENAI_API_KEY"] == "test-key"
         assert info.workspace == ws
         assert info.agent_id == "main"
         assert info.sessions_dir is None

--- a/tests/unit/migrate/test_detector.py
+++ b/tests/unit/migrate/test_detector.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.migrate.openclaw.detector import (
+    _find_config,
+    _find_root,
+    _parse_dotenv,
+    _resolve_cron_path,
+    _resolve_workspace,
+    detect,
+)
+
+
+class TestFindRoot:
+    def test_explicit_source_path(self, tmp_path):
+        root = _find_root(tmp_path)
+        assert root == tmp_path.resolve()
+
+    def test_explicit_source_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            _find_root(tmp_path / "nonexistent")
+
+    def test_auto_detect_from_candidates(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        fake_openclaw = fake_home / ".openclaw"
+        fake_openclaw.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.detector._CANDIDATE_ROOTS",
+            [str(fake_openclaw)],
+        )
+        result = _find_root(None)
+        assert result == fake_openclaw.resolve()
+
+    def test_no_candidates_found_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.detector._CANDIDATE_ROOTS",
+            ["/nonexistent_abc123"],
+        )
+        with pytest.raises(FileNotFoundError):
+            _find_root(None)
+
+
+class TestFindConfig:
+    def test_finds_openclaw_json(self, tmp_path):
+        config = tmp_path / "openclaw.json"
+        config.write_text("{}")
+        path, flavor = _find_config(tmp_path)
+        assert path == config
+        assert flavor == "openclaw"
+
+    def test_finds_clawdbot_json(self, tmp_path):
+        config = tmp_path / "clawdbot.json"
+        config.write_text("{}")
+        path, flavor = _find_config(tmp_path)
+        assert path == config
+        assert flavor == "clawdbot"
+
+    def test_no_config_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            _find_config(tmp_path)
+
+
+class TestParseDotenv:
+    def test_simple_key_value(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=value\n")
+        assert _parse_dotenv(env_file) == {"KEY": "value"}
+
+    def test_quoted_values_stripped(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("SINGLE='hello'\nDOUBLE=\"world\"\n")
+        result = _parse_dotenv(env_file)
+        assert result == {"SINGLE": "hello", "DOUBLE": "world"}
+
+    def test_comments_and_blank_lines_skipped(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("# comment\n\nKEY=val\n  # indented comment\n")
+        assert _parse_dotenv(env_file) == {"KEY": "val"}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert not _parse_dotenv(tmp_path / ".env")
+
+    def test_line_without_equals_skipped(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("NOEQUALS\nGOOD=yes\n")
+        assert _parse_dotenv(env_file) == {"GOOD": "yes"}
+
+
+class TestResolveWorkspace:
+    def test_config_workspace_used_if_exists(self, tmp_path):
+        ws = tmp_path / "custom_ws"
+        ws.mkdir()
+        config = {"agents": {"defaults": {"workspace": str(ws)}}}
+        result = _resolve_workspace(tmp_path, config, "main")
+        assert result == ws.resolve()
+
+    def test_fallback_to_per_agent_workspace(self, tmp_path):
+        ws = tmp_path / "agents" / "myagent" / "workspace"
+        ws.mkdir(parents=True)
+        result = _resolve_workspace(tmp_path, {}, "myagent")
+        assert result == ws
+
+    def test_fallback_to_default_workspace(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        result = _resolve_workspace(tmp_path, {}, "other")
+        assert result == ws
+
+    def test_fallback_to_workspace(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        result = _resolve_workspace(tmp_path, {}, "main")
+        assert result == ws
+
+    def test_returns_last_candidate_if_none_exist(self, tmp_path):
+        result = _resolve_workspace(tmp_path, {}, "main")
+        assert result == tmp_path / "workspace"
+
+
+class TestDetect:
+    def test_full_detection(self, tmp_path):
+        config_content = (
+            '{"agents": {"defaults":'
+            ' {"model": "anthropic/claude-sonnet-4-6"}}}'
+        )
+        (tmp_path / "openclaw.json").write_text(config_content)
+
+        env_content = "OPENAI_API_KEY=test-key\n"
+        (tmp_path / ".env").write_text(env_content)
+
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        (ws / "SOUL.md").write_text("# Soul")
+
+        info = detect(source=tmp_path)
+
+        assert info.root == tmp_path.resolve()
+        assert info.flavor == "openclaw"
+        assert (
+            info.config["agents"]["defaults"]["model"]
+            == "anthropic/claude-sonnet-4-6"
+        )
+        assert info.env == {"OPENAI_API_KEY": "test-key"}
+        assert info.workspace == ws
+        assert info.agent_id == "main"
+        assert info.sessions_dir is None
+        assert info.cron_path is None
+
+    def test_detect_with_sessions_and_cron(self, tmp_path):
+        (tmp_path / "openclaw.json").write_text('{"agents": {}}')
+        (tmp_path / "workspace").mkdir()
+
+        sessions = tmp_path / "agents" / "main" / "sessions"
+        sessions.mkdir(parents=True)
+
+        cron_dir = tmp_path / "cron"
+        cron_dir.mkdir()
+        (cron_dir / "store.json").write_text("[]")
+
+        info = detect(source=tmp_path)
+        assert info.sessions_dir == sessions
+        assert info.cron_path == cron_dir / "store.json"
+
+
+class TestResolveCronPath:
+    def test_custom_store_from_config(self, tmp_path):
+        store = tmp_path / "custom" / "cron.json"
+        store.parent.mkdir(parents=True)
+        store.write_text("[]")
+        result = _resolve_cron_path(tmp_path, {"cron": {"store": str(store)}})
+        assert result == store.resolve()
+
+    def test_default_store_json(self, tmp_path):
+        store = tmp_path / "cron" / "store.json"
+        store.parent.mkdir(parents=True)
+        store.write_text("[]")
+        result = _resolve_cron_path(tmp_path, {})
+        assert result == store
+
+    def test_fallback_cron_json(self, tmp_path):
+        store = tmp_path / "cron" / "cron.json"
+        store.parent.mkdir(parents=True)
+        store.write_text("[]")
+        result = _resolve_cron_path(tmp_path, {})
+        assert result == store
+
+    def test_returns_none_if_missing(self, tmp_path):
+        result = _resolve_cron_path(tmp_path, {})
+        assert result is None

--- a/tests/unit/migrate/test_history.py
+++ b/tests/unit/migrate/test_history.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+
+from qwenpaw.migrate.openclaw.history import (
+    plan_history_migration,
+    _convert_session_to_dialog,
+)
+from qwenpaw.migrate.models import SourceInfo, ItemStatus
+
+
+def _make_source(
+    root,
+    workspace,
+    config=None,
+    env=None,
+    sessions_dir=None,
+    cron_path=None,
+):
+    return SourceInfo(
+        root=root,
+        flavor="openclaw",
+        config=config or {},
+        env=env or {},
+        workspace=workspace,
+        agent_id="main",
+        sessions_dir=sessions_dir,
+        cron_path=cron_path,
+    )
+
+
+class TestConvertSessionToDialog:
+    def test_basic_conversion(self, tmp_path):
+        session = tmp_path / "sess.jsonl"
+        session.write_text(
+            '{"timestamp":"2026-02-19T10:00:00.000Z",'
+            '"message":{"role":"user","content":"Hello!"}}\n'
+            '{"timestamp":"2026-02-19T10:00:05.000Z",'
+            '"message":{"role":"assistant","content":"Hi!"}}\n',
+        )
+        dialog_dir = tmp_path / "dialog"
+        dialog_dir.mkdir()
+
+        _convert_session_to_dialog(session, dialog_dir)
+
+        out_file = dialog_dir / "2026-02-19.jsonl"
+        assert out_file.exists()
+        lines = [json.loads(ln) for ln in out_file.read_text().splitlines()]
+        assert len(lines) == 2
+        assert lines[0]["role"] == "user"
+        assert lines[0]["content"] == "Hello!"
+        assert lines[1]["role"] == "assistant"
+        assert lines[1]["content"] == "Hi!"
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        session = tmp_path / "bad.jsonl"
+        session.write_text(
+            "NOT_JSON\n"
+            '{"timestamp":"2026-02-19T10:00:00.000Z",'
+            '"message":{"role":"user","content":"ok"}}\n'
+            "{broken\n",
+        )
+        dialog_dir = tmp_path / "dialog"
+        dialog_dir.mkdir()
+
+        _convert_session_to_dialog(session, dialog_dir)
+
+        out_file = dialog_dir / "2026-02-19.jsonl"
+        assert out_file.exists()
+        lines = out_file.read_text().strip().splitlines()
+        assert len(lines) == 1
+
+    def test_missing_timestamp_uses_unknown(self, tmp_path):
+        session = tmp_path / "no_ts.jsonl"
+        session.write_text('{"message":{"role":"user","content":"hi"}}\n')
+        dialog_dir = tmp_path / "dialog"
+        dialog_dir.mkdir()
+
+        _convert_session_to_dialog(session, dialog_dir)
+
+        assert (dialog_dir / "unknown.jsonl").exists()
+
+    def test_blank_lines_ignored(self, tmp_path):
+        session = tmp_path / "blanks.jsonl"
+        session.write_text(
+            "\n"
+            '{"timestamp":"2026-01-01T00:00:00.000Z",'
+            '"message":{"role":"user","content":"x"}}\n'
+            "   \n",
+        )
+        dialog_dir = tmp_path / "dialog"
+        dialog_dir.mkdir()
+
+        _convert_session_to_dialog(session, dialog_dir)
+
+        lines = (
+            (dialog_dir / "2026-01-01.jsonl").read_text().strip().splitlines()
+        )
+        assert len(lines) == 1
+
+
+class TestPlanHistoryMigration:
+    def test_valid_sessions_dir(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        (sessions / "a.jsonl").write_text(
+            '{"timestamp":"2026-01-01T00:00:00Z",'
+            '"message":{"role":"user","content":"x"}}\n',
+        )
+
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws, sessions_dir=sessions)
+
+        items = plan_history_migration(source, ws, overwrite=False)
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.OK
+        assert items[0].category == "history"
+
+    def test_none_sessions_dir_returns_empty(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws, sessions_dir=None)
+
+        items = plan_history_migration(source, ws, overwrite=False)
+        assert not items
+
+    def test_nonexistent_sessions_dir_returns_empty(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws, sessions_dir=tmp_path / "nope")
+
+        items = plan_history_migration(source, ws, overwrite=False)
+        assert not items
+
+    def test_empty_sessions_dir_returns_empty(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws, sessions_dir=sessions)
+
+        items = plan_history_migration(source, ws, overwrite=False)
+        assert not items
+
+    def test_conflict_when_dialog_exists(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        (sessions / "a.jsonl").write_text("{}\n")
+
+        ws = tmp_path / "workspace"
+        dialog = ws / "dialog"
+        dialog.mkdir(parents=True)
+        (dialog / "old.jsonl").write_text("existing\n")
+
+        source = _make_source(tmp_path, ws, sessions_dir=sessions)
+
+        items = plan_history_migration(source, ws, overwrite=False)
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.CONFLICT
+
+    def test_overwrite_bypasses_conflict(self, tmp_path):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        (sessions / "a.jsonl").write_text("{}\n")
+
+        ws = tmp_path / "workspace"
+        dialog = ws / "dialog"
+        dialog.mkdir(parents=True)
+        (dialog / "old.jsonl").write_text("existing\n")
+
+        source = _make_source(tmp_path, ws, sessions_dir=sessions)
+
+        items = plan_history_migration(source, ws, overwrite=True)
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.OK

--- a/tests/unit/migrate/test_json5.py
+++ b/tests/unit/migrate/test_json5.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+
+from qwenpaw.migrate.openclaw._json5 import _strip_json5_features, parse_json5
+
+
+class TestStripJson5Features:
+    def test_single_line_comment_removal(self):
+        text = '{"key": "value"} // this is a comment'
+        result = _strip_json5_features(text)
+        assert json.loads(result) == {"key": "value"}
+
+    def test_block_comment_removal(self):
+        text = '{"key": /* inline comment */ "value"}'
+        result = _strip_json5_features(text)
+        assert json.loads(result) == {"key": "value"}
+
+    def test_trailing_comma_in_object(self):
+        text = '{"a": 1, "b": 2,}'
+        result = _strip_json5_features(text)
+        assert json.loads(result) == {"a": 1, "b": 2}
+
+    def test_trailing_comma_in_array(self):
+        text = '{"items": [1, 2, 3,]}'
+        result = _strip_json5_features(text)
+        assert json.loads(result) == {"items": [1, 2, 3]}
+
+    def test_comments_inside_strings_preserved(self):
+        text = '{"url": "http://example.com", "note": "/* not a comment */"}'
+        result = _strip_json5_features(text)
+        parsed = json.loads(result)
+        assert parsed["url"] == "http://example.com"
+        assert parsed["note"] == "/* not a comment */"
+
+    def test_complex_mixed_case(self):
+        text = """\
+{
+  // top-level comment
+  "url": "http://example.com/path",
+  "items": [
+    "a", /* inline */ "b",
+  ],
+  "debug": true, // trailing
+}"""
+        result = _strip_json5_features(text)
+        parsed = json.loads(result)
+        assert parsed == {
+            "url": "http://example.com/path",
+            "items": ["a", "b"],
+            "debug": True,
+        }
+
+
+class TestParseJson5:
+    def test_parses_plain_json(self):
+        assert parse_json5('{"x": 1}') == {"x": 1}
+
+    def test_parses_json5_with_comments_and_trailing_commas(self):
+        text = '{"a": 1, // comment\n"b": 2,}'
+        result = parse_json5(text)
+        assert result == {"a": 1, "b": 2}

--- a/tests/unit/migrate/test_mcp.py
+++ b/tests/unit/migrate/test_mcp.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from qwenpaw.migrate.models import ItemStatus, SourceInfo
+from qwenpaw.migrate.openclaw.mcp import plan_mcp_migration
+
+
+def _make_source(root: Path, workspace: Path, config=None, env=None):
+    return SourceInfo(
+        root=root,
+        flavor="openclaw",
+        config=config or {},
+        env=env or {},
+        workspace=workspace,
+        agent_id="main",
+    )
+
+
+class TestPlanMcpMigration:
+    def test_stdio_transport_inference(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": [
+                            "-y",
+                            "@modelcontextprotocol/server-filesystem",
+                        ],
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.OK
+        assert "stdio" in items[0].detail
+
+    def test_streamable_http_transport_inference(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "remote": {"url": "https://example.com/mcp"},
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.OK
+        assert "streamable_http" in items[0].detail
+
+    def test_conflict_detection(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        agent_json = target_ws / "agent.json"
+        agent_json.write_text(
+            json.dumps(
+                {
+                    "mcp": {"clients": {"filesystem": {"transport": "stdio"}}},
+                },
+            ),
+        )
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": ["-y", "fs-server"],
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+
+        assert len(items) == 1
+        assert items[0].status == ItemStatus.CONFLICT
+
+    def test_write_fn_updates_agent_json(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": ["-y", "fs-server"],
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+
+        assert items[0].write_fn is not None
+        items[0].write_fn()
+
+        agent_json = target_ws / "agent.json"
+        data = json.loads(agent_json.read_text())
+        assert "filesystem" in data["mcp"]["clients"]
+        assert data["mcp"]["clients"]["filesystem"]["transport"] == "stdio"
+        assert data["mcp"]["clients"]["filesystem"]["command"] == "npx"
+
+    def test_empty_mcp_config_returns_empty(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        source = _make_source(source_ws, source_ws, config={})
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+        assert not items
+
+    def test_working_directory_alias(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "myserver": {
+                        "command": "node",
+                        "args": ["server.js"],
+                        "workingDirectory": "/opt/mcp",
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+        assert items[0].status == ItemStatus.OK
+        items[0].write_fn()
+        data = json.loads((target_ws / "agent.json").read_text())
+        assert data["mcp"]["clients"]["myserver"]["cwd"] == "/opt/mcp"
+
+    def test_disabled_server_preserved(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "disabled-srv": {
+                        "command": "node",
+                        "enabled": False,
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+        assert items[0].status == ItemStatus.OK
+        items[0].write_fn()
+        data = json.loads((target_ws / "agent.json").read_text())
+        assert data["mcp"]["clients"]["disabled-srv"]["enabled"] is False
+
+    def test_headers_transferred(self, tmp_path: Path):
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "auth-server": {
+                        "url": "https://example.com/mcp",
+                        "headers": {"Authorization": "Bearer tok"},
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+        items[0].write_fn()
+        data = json.loads((target_ws / "agent.json").read_text())
+        assert (
+            data["mcp"]["clients"]["auth-server"]["headers"]["Authorization"]
+            == "Bearer tok"
+        )

--- a/tests/unit/migrate/test_mcp.py
+++ b/tests/unit/migrate/test_mcp.py
@@ -206,3 +206,33 @@ class TestPlanMcpMigration:
             data["mcp"]["clients"]["auth-server"]["headers"]["Authorization"]
             == "Bearer tok"
         )
+
+    def test_tool_filter_migration(self, tmp_path: Path):
+        """OpenClaw uses ``toolFilter`` for MCP tool filtering."""
+        source_ws = tmp_path / "source"
+        source_ws.mkdir()
+        target_ws = tmp_path / "target"
+        target_ws.mkdir()
+
+        config = {
+            "mcp": {
+                "servers": {
+                    "filtered": {
+                        "command": "node",
+                        "args": ["server.js"],
+                        "toolFilter": {
+                            "include": ["search_*"],
+                            "exclude": ["admin_*"],
+                        },
+                    },
+                },
+            },
+        }
+        source = _make_source(source_ws, source_ws, config=config)
+        items = plan_mcp_migration(source, target_ws, overwrite=False)
+        assert len(items) == 1
+        items[0].write_fn()
+        data = json.loads((target_ws / "agent.json").read_text())
+        client = data["mcp"]["clients"]["filtered"]
+        assert client["tools"]["include"] == ["search_*"]
+        assert client["tools"]["exclude"] == ["admin_*"]

--- a/tests/unit/migrate/test_memory.py
+++ b/tests/unit/migrate/test_memory.py
@@ -38,14 +38,14 @@ class TestPlanMemoryMigration:
         assert mem_items[0].status == ItemStatus.OK
 
         mem_items[0].write_fn()
-        assert (target_ws / "MEMORY.md").read_text() == "remember this"
+        assert "remember this" in (target_ws / "MEMORY.md").read_text()
 
-    def test_memory_dir_bulk_copy(self, tmp_path: Path):
+    def test_memory_dir_merge(self, tmp_path: Path):
         src_ws = tmp_path / "source" / "ws"
         mem_dir = src_ws / "memory"
         mem_dir.mkdir(parents=True)
-        (mem_dir / "topic_a.md").write_text("topic a")
-        (mem_dir / "topic_b.md").write_text("topic b")
+        (mem_dir / "topic_a.md").write_text("topic a content")
+        (mem_dir / "topic_b.md").write_text("topic b content")
         target_ws = tmp_path / "target" / "ws"
         target_ws.mkdir(parents=True)
         archive = tmp_path / "archive"
@@ -59,15 +59,15 @@ class TestPlanMemoryMigration:
         dir_items = [
             i
             for i in items
-            if "memory/" in i.source_path or "memory\\" in i.source_path
+            if "memory" in i.source_path and "MEMORY" not in i.source_path
         ]
-        assert len(dir_items) == 2
-        assert all(i.status == ItemStatus.OK for i in dir_items)
+        assert len(dir_items) == 1
+        assert dir_items[0].status == ItemStatus.OK
 
-        for item in dir_items:
-            item.write_fn()
-        assert (target_ws / "memory" / "topic_a.md").read_text() == "topic a"
-        assert (target_ws / "memory" / "topic_b.md").read_text() == "topic b"
+        dir_items[0].write_fn()
+        result = (target_ws / "MEMORY.md").read_text()
+        assert "topic a content" in result
+        assert "topic b content" in result
 
     def test_dreams_archived(self, tmp_path: Path):
         src_ws = tmp_path / "source" / "ws"
@@ -90,13 +90,13 @@ class TestPlanMemoryMigration:
         archived[0].write_fn()
         assert (archive / "DREAMS.md").read_text() == "dreams"
 
-    def test_conflict_existing_memory_md(self, tmp_path: Path):
+    def test_merge_existing_memory_md(self, tmp_path: Path):
         src_ws = tmp_path / "source" / "ws"
         src_ws.mkdir(parents=True)
         (src_ws / "MEMORY.md").write_text("new memory")
         target_ws = tmp_path / "target" / "ws"
         target_ws.mkdir(parents=True)
-        (target_ws / "MEMORY.md").write_text("existing")
+        (target_ws / "MEMORY.md").write_text("existing memory")
         archive = tmp_path / "archive"
 
         items = plan_memory_migration(
@@ -106,7 +106,8 @@ class TestPlanMemoryMigration:
             overwrite=False,
         )
         mem_items = [i for i in items if "MEMORY.md" in i.source_path]
-        assert mem_items[0].status == ItemStatus.CONFLICT
+        assert mem_items[0].status == ItemStatus.WARN
+        assert "Merge" in mem_items[0].detail
 
     def test_empty_source(self, tmp_path: Path):
         src_ws = tmp_path / "source" / "ws"

--- a/tests/unit/migrate/test_memory.py
+++ b/tests/unit/migrate/test_memory.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+from qwenpaw.migrate.models import ItemStatus, SourceInfo
+from qwenpaw.migrate.openclaw.memory import plan_memory_migration
+
+
+def _make_source(workspace: Path) -> SourceInfo:
+    return SourceInfo(
+        root=workspace.parent,
+        flavor="openclaw",
+        config={},
+        env={},
+        workspace=workspace,
+        agent_id="main",
+    )
+
+
+class TestPlanMemoryMigration:
+    def test_memory_md_copy(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "MEMORY.md").write_text("remember this")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_memory_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        mem_items = [i for i in items if "MEMORY.md" in i.source_path]
+        assert len(mem_items) == 1
+        assert mem_items[0].status == ItemStatus.OK
+
+        mem_items[0].write_fn()
+        assert (target_ws / "MEMORY.md").read_text() == "remember this"
+
+    def test_memory_dir_bulk_copy(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        mem_dir = src_ws / "memory"
+        mem_dir.mkdir(parents=True)
+        (mem_dir / "topic_a.md").write_text("topic a")
+        (mem_dir / "topic_b.md").write_text("topic b")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_memory_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        dir_items = [
+            i
+            for i in items
+            if "memory/" in i.source_path or "memory\\" in i.source_path
+        ]
+        assert len(dir_items) == 2
+        assert all(i.status == ItemStatus.OK for i in dir_items)
+
+        for item in dir_items:
+            item.write_fn()
+        assert (target_ws / "memory" / "topic_a.md").read_text() == "topic a"
+        assert (target_ws / "memory" / "topic_b.md").read_text() == "topic b"
+
+    def test_dreams_archived(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "DREAMS.md").write_text("dreams")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_memory_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        archived = [i for i in items if i.status == ItemStatus.ARCHIVED]
+        assert len(archived) == 1
+        assert "DREAMS.md" in archived[0].source_path
+
+        archived[0].write_fn()
+        assert (archive / "DREAMS.md").read_text() == "dreams"
+
+    def test_conflict_existing_memory_md(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "MEMORY.md").write_text("new memory")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        (target_ws / "MEMORY.md").write_text("existing")
+        archive = tmp_path / "archive"
+
+        items = plan_memory_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        mem_items = [i for i in items if "MEMORY.md" in i.source_path]
+        assert mem_items[0].status == ItemStatus.CONFLICT
+
+    def test_empty_source(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_memory_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        assert not items

--- a/tests/unit/migrate/test_orchestrator.py
+++ b/tests/unit/migrate/test_orchestrator.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from qwenpaw.migrate.models import (
+    ItemStatus,
+    MigrationItem,
+    MigrationPlan,
+    SourceInfo,
+)
+from qwenpaw.migrate.openclaw.orchestrator import (
+    _build_report,
+    _create_pre_migration_backup,
+    run_migration,
+)
+
+
+def _make_source(root: Path, workspace: Path, **kwargs) -> SourceInfo:
+    return SourceInfo(
+        root=root,
+        flavor="openclaw",
+        config=kwargs.get("config", {}),
+        env=kwargs.get("env", {}),
+        workspace=workspace,
+        agent_id="main",
+    )
+
+
+class TestBuildReport:
+    def test_counts_statuses(self, tmp_path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws)
+        plan = MigrationPlan(
+            source=source,
+            target_agent_id="default",
+            target_workspace=ws,
+            items=[
+                MigrationItem("a", "s", "t", ItemStatus.OK, "ok"),
+                MigrationItem("b", "s", "t", ItemStatus.OK, "ok"),
+                MigrationItem("c", "s", "t", ItemStatus.SKIP, "skip"),
+                MigrationItem("d", "s", "t", ItemStatus.CONFLICT, "conflict"),
+                MigrationItem("e", "s", "t", ItemStatus.WARN, "warn"),
+                MigrationItem("f", "s", "t", ItemStatus.ERROR, "error"),
+            ],
+        )
+        report = _build_report(plan, applied=2, backup_path=None)
+        assert report.applied == 2
+        assert report.skipped == 1
+        assert report.conflicts == 1
+        assert report.warnings == 1
+        assert report.errors == 1
+        assert report.backup_path is None
+
+
+class TestCreatePreMigrationBackup:
+    def test_creates_zip(self, tmp_path, monkeypatch):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        (ws / "test.txt").write_text("hello")
+        import qwenpaw.constant
+
+        monkeypatch.setattr(qwenpaw.constant, "WORKING_DIR", tmp_path)
+        result = _create_pre_migration_backup(ws, "20260617-120000")
+        assert result is not None
+        assert result.exists()
+        assert result.suffix == ".zip"
+
+    def test_nonexistent_workspace_returns_none(self, tmp_path, monkeypatch):
+        ws = tmp_path / "nonexistent"
+        import qwenpaw.constant
+
+        monkeypatch.setattr(qwenpaw.constant, "WORKING_DIR", tmp_path)
+        result = _create_pre_migration_backup(ws, "20260617-120000")
+        assert result is None
+
+
+class TestRunMigrationDryRun:
+    def test_dry_run_does_not_write(self, tmp_path, monkeypatch):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws)
+
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.orchestrator.detect",
+            lambda *a, **kw: source,
+        )
+        mock_config = MagicMock()
+        mock_config.agents.profiles = {
+            "default": MagicMock(workspace_dir=str(ws)),
+        }
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.orchestrator.load_config",
+            lambda: mock_config,
+        )
+
+        converters = [
+            "plan_persona_migration",
+            "plan_memory_migration",
+            "plan_provider_migration",
+            "plan_mcp_migration",
+            "plan_channel_migration",
+            "plan_cron_migration",
+            "plan_history_migration",
+            "plan_skill_report",
+        ]
+        for name in converters:
+            monkeypatch.setattr(
+                f"qwenpaw.migrate.openclaw.orchestrator.{name}",
+                lambda *_a, **_kw: [],
+            )
+
+        report = run_migration(
+            source_path=tmp_path,
+            target_agent_id="default",
+            openclaw_agent_id="main",
+            dry_run=True,
+            include=None,
+            exclude={"history"},
+            migrate_secrets=False,
+            overwrite=False,
+            no_backup=False,
+            yes=True,
+        )
+        assert report.applied == 0
+
+    def test_include_filter(self, tmp_path, monkeypatch):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        source = _make_source(tmp_path, ws)
+
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.orchestrator.detect",
+            lambda *_a, **_kw: source,
+        )
+        mock_config = MagicMock()
+        mock_config.agents.profiles = {
+            "default": MagicMock(workspace_dir=str(ws)),
+        }
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.orchestrator.load_config",
+            lambda: mock_config,
+        )
+
+        called = set()
+
+        def _track(name):
+            def _fn(*_a, **_kw):
+                called.add(name)
+                return []
+
+            return _fn
+
+        converters = [
+            "plan_persona_migration",
+            "plan_memory_migration",
+            "plan_provider_migration",
+            "plan_mcp_migration",
+            "plan_channel_migration",
+            "plan_cron_migration",
+            "plan_history_migration",
+        ]
+        for name in converters:
+            monkeypatch.setattr(
+                f"qwenpaw.migrate.openclaw.orchestrator.{name}",
+                _track(name),
+            )
+        monkeypatch.setattr(
+            "qwenpaw.migrate.openclaw.orchestrator.plan_skill_report",
+            lambda *_a, **_kw: [],
+        )
+
+        run_migration(
+            source_path=tmp_path,
+            target_agent_id="default",
+            openclaw_agent_id="main",
+            dry_run=True,
+            include={"persona"},
+            exclude=set(),
+            migrate_secrets=False,
+            overwrite=False,
+            no_backup=False,
+            yes=True,
+        )
+        assert "plan_persona_migration" in called
+        assert "plan_mcp_migration" not in called
+        assert "plan_cron_migration" not in called

--- a/tests/unit/migrate/test_orchestrator.py
+++ b/tests/unit/migrate/test_orchestrator.py
@@ -104,7 +104,7 @@ class TestRunMigrationDryRun:
             "plan_channel_migration",
             "plan_cron_migration",
             "plan_history_migration",
-            "plan_skill_report",
+            "plan_skill_migration",
         ]
         for name in converters:
             monkeypatch.setattr(
@@ -161,16 +161,13 @@ class TestRunMigrationDryRun:
             "plan_channel_migration",
             "plan_cron_migration",
             "plan_history_migration",
+            "plan_skill_migration",
         ]
         for name in converters:
             monkeypatch.setattr(
                 f"qwenpaw.migrate.openclaw.orchestrator.{name}",
                 _track(name),
             )
-        monkeypatch.setattr(
-            "qwenpaw.migrate.openclaw.orchestrator.plan_skill_report",
-            lambda *_a, **_kw: [],
-        )
 
         run_migration(
             source_path=tmp_path,

--- a/tests/unit/migrate/test_persona.py
+++ b/tests/unit/migrate/test_persona.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from qwenpaw.migrate.models import ItemStatus, SourceInfo
+from qwenpaw.migrate.openclaw.persona import (
+    _build_imported_block,
+    _write_profile,
+    plan_persona_migration,
+)
+
+
+def _make_source(workspace: Path) -> SourceInfo:
+    return SourceInfo(
+        root=workspace.parent,
+        flavor="openclaw",
+        config={},
+        env={},
+        workspace=workspace,
+        agent_id="main",
+    )
+
+
+class TestPlanPersonaMigration:
+    def test_soul_md_copy(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "SOUL.md").write_text("soul content")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_persona_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        soul_items = [i for i in items if "SOUL.md" in i.source_path]
+        assert len(soul_items) == 1
+        assert soul_items[0].status == ItemStatus.OK
+
+        soul_items[0].write_fn()
+        assert (target_ws / "SOUL.md").read_text() == "soul content"
+
+    def test_agents_md_copy(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "AGENTS.md").write_text("agents content")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_persona_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        agents_items = [i for i in items if "AGENTS.md" in i.source_path]
+        assert len(agents_items) == 1
+        assert agents_items[0].status == ItemStatus.OK
+
+        agents_items[0].write_fn()
+        assert (target_ws / "AGENTS.md").read_text() == "agents content"
+
+    def test_profile_merge_from_identity_and_user(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "IDENTITY.md").write_text("I am an assistant")
+        (src_ws / "USER.md").write_text("User prefs")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_persona_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        profile_items = [i for i in items if "PROFILE.md" in i.target_path]
+        assert len(profile_items) == 1
+        assert profile_items[0].status == ItemStatus.OK
+
+        profile_items[0].write_fn()
+        content = (target_ws / "PROFILE.md").read_text()
+        assert "I am an assistant" in content
+        assert "User prefs" in content
+
+    def test_conflict_detection(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "SOUL.md").write_text("soul content")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        (target_ws / "SOUL.md").write_text("existing")
+        archive = tmp_path / "archive"
+
+        items = plan_persona_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        soul_items = [i for i in items if "SOUL.md" in i.source_path]
+        assert soul_items[0].status == ItemStatus.CONFLICT
+
+    def test_overwrite_mode(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "SOUL.md").write_text("new soul")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        (target_ws / "SOUL.md").write_text("old soul")
+        archive = tmp_path / "archive"
+
+        items = plan_persona_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=True,
+        )
+        soul_items = [i for i in items if "SOUL.md" in i.source_path]
+        assert soul_items[0].status == ItemStatus.OK
+
+        soul_items[0].write_fn()
+        assert (target_ws / "SOUL.md").read_text() == "new soul"
+
+    def test_archive_tools_and_bootstrap(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        (src_ws / "TOOLS.md").write_text("tools")
+        (src_ws / "BOOTSTRAP.md").write_text("bootstrap")
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+        archive = tmp_path / "archive"
+
+        items = plan_persona_migration(
+            _make_source(src_ws),
+            target_ws,
+            archive,
+            overwrite=False,
+        )
+        archived = [i for i in items if i.status == ItemStatus.ARCHIVED]
+        assert len(archived) == 2
+        names = {Path(i.source_path).name for i in archived}
+        assert names == {"TOOLS.md", "BOOTSTRAP.md"}
+
+        for item in archived:
+            item.write_fn()
+        assert (archive / "TOOLS.md").read_text() == "tools"
+        assert (archive / "BOOTSTRAP.md").read_text() == "bootstrap"
+
+
+class TestWriteProfile:
+    def test_append_mode_with_existing(self, tmp_path: Path):
+        profile = tmp_path / "PROFILE.md"
+        profile.write_text("existing content")
+
+        status = _write_profile(
+            profile,
+            "identity",
+            "user prefs",
+            overwrite=False,
+        )
+        assert status == ItemStatus.WARN
+
+        content = profile.read_text()
+        assert content.startswith("existing content")
+        assert "Imported from OpenClaw" in content
+        assert date.today().isoformat() in content
+        assert "identity" in content
+        assert "user prefs" in content
+
+    def test_creates_new_file(self, tmp_path: Path):
+        profile = tmp_path / "sub" / "PROFILE.md"
+        status = _write_profile(profile, "id text", None, overwrite=False)
+        assert status == ItemStatus.OK
+        assert profile.read_text() == "id text"
+
+    def test_overwrite_existing(self, tmp_path: Path):
+        profile = tmp_path / "PROFILE.md"
+        profile.write_text("old")
+        status = _write_profile(profile, "new id", "new user", overwrite=True)
+        assert status == ItemStatus.OK
+        assert "old" not in profile.read_text()
+        assert "new id" in profile.read_text()
+
+
+class TestBuildImportedBlock:
+    def test_both_present(self):
+        result = _build_imported_block("identity", "user")
+        assert result == "identity\n\nuser"
+
+    def test_identity_only(self):
+        assert _build_imported_block("identity", None) == "identity"
+
+    def test_user_only(self):
+        assert _build_imported_block(None, "user") == "user"
+
+    def test_neither(self):
+        assert _build_imported_block(None, None) == ""

--- a/tests/unit/migrate/test_providers.py
+++ b/tests/unit/migrate/test_providers.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from qwenpaw.migrate.models import ItemStatus, SourceInfo
+from qwenpaw.migrate.openclaw.providers import (
+    _parse_model_ref,
+    plan_provider_migration,
+)
+
+
+def _make_source(
+    workspace: Path,
+    config: dict | None = None,
+    env: dict | None = None,
+) -> SourceInfo:
+    return SourceInfo(
+        root=workspace.parent,
+        flavor="openclaw",
+        config=config or {},
+        env=env or {},
+        workspace=workspace,
+        agent_id="main",
+    )
+
+
+class TestParseModelRef:
+    def test_provider_slash_model(self):
+        assert _parse_model_ref("anthropic/claude-sonnet-4-6") == (
+            "anthropic",
+            "claude-sonnet-4-6",
+        )
+
+    def test_nested_model_path(self):
+        assert _parse_model_ref("openrouter/moonshotai/kimi-k2") == (
+            "openrouter",
+            "moonshotai/kimi-k2",
+        )
+
+    def test_bare_model(self):
+        assert _parse_model_ref("claude-sonnet") == ("", "claude-sonnet")
+
+
+class TestPlanProviderMigration:
+    def test_default_model_migration(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            config={
+                "agents": {
+                    "defaults": {"model": "anthropic/claude-sonnet-4-6"},
+                },
+            },
+        )
+
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=False,
+            overwrite=False,
+        )
+        model_items = [i for i in items if i.category == "provider"]
+        assert len(model_items) == 1
+        assert model_items[0].status == ItemStatus.OK
+        assert "anthropic" in model_items[0].detail
+
+        model_items[0].write_fn()
+        agent_json = json.loads((target_ws / "agent.json").read_text())
+        assert agent_json["active_model"]["provider_id"] == "anthropic"
+        assert agent_json["active_model"]["model"] == "claude-sonnet-4-6"
+
+    def test_unknown_provider_warning(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            config={
+                "agents": {"defaults": {"model": "minimax/some-model"}},
+            },
+        )
+
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=False,
+            overwrite=False,
+        )
+        model_items = [i for i in items if i.category == "provider"]
+        assert len(model_items) == 1
+        assert model_items[0].status == ItemStatus.WARN
+        assert model_items[0].write_fn is None
+
+    def test_custom_providers(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            config={
+                "models": {
+                    "providers": {
+                        "my-llm": {
+                            "base_url": "https://my-llm.example.com/v1",
+                            "api_key": "sk-xxx",
+                        },
+                    },
+                },
+            },
+        )
+
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=False,
+            overwrite=False,
+        )
+        custom_items = [
+            i for i in items if "custom_providers" in i.target_path
+        ]
+        assert len(custom_items) == 1
+        assert custom_items[0].status == ItemStatus.OK
+
+        custom_items[0].write_fn()
+        agent_json = json.loads((target_ws / "agent.json").read_text())
+        assert (
+            agent_json["custom_providers"]["my-llm"]["base_url"]
+            == "https://my-llm.example.com/v1"
+        )
+
+    def test_api_key_migration_with_secrets(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            env={
+                "ANTHROPIC_API_KEY": "sk-ant-xxx",
+                "OPENAI_API_KEY": "sk-oai-xxx",
+            },
+        )
+
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=True,
+            overwrite=False,
+        )
+        secret_items = [i for i in items if i.category == "secret"]
+        assert len(secret_items) == 2
+        assert all(i.status == ItemStatus.OK for i in secret_items)
+        providers = {i.target_path.split(":")[-1] for i in secret_items}
+        assert providers == {"anthropic", "openai"}
+
+    def test_api_key_not_included_without_secrets(self, tmp_path: Path):
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            env={
+                "ANTHROPIC_API_KEY": "sk-ant-xxx",
+            },
+        )
+
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=False,
+            overwrite=False,
+        )
+        secret_items = [i for i in items if i.category == "secret"]
+        assert not secret_items
+
+    def test_agent_singular_model_shorthand(self, tmp_path: Path):
+        """OpenClaw minimal config uses `agent.model` (singular)."""
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            config={"agent": {"model": "openai/gpt-4o"}},
+        )
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=False,
+            overwrite=False,
+        )
+        model_items = [i for i in items if i.category == "provider"]
+        assert len(model_items) == 1
+        assert model_items[0].status == ItemStatus.OK
+        assert "openai" in model_items[0].detail
+
+    def test_secret_input_object_for_api_key(self, tmp_path: Path):
+        """OpenClaw apiKey can be a SecretInput object."""
+        src_ws = tmp_path / "source" / "ws"
+        src_ws.mkdir(parents=True)
+        target_ws = tmp_path / "target" / "ws"
+        target_ws.mkdir(parents=True)
+
+        source = _make_source(
+            src_ws,
+            config={
+                "models": {
+                    "providers": {
+                        "custom-llm": {
+                            "baseUrl": "https://llm.example.com/v1",
+                            "apiKey": {"source": "env", "id": "CUSTOM_KEY"},
+                        },
+                    },
+                },
+            },
+            env={"CUSTOM_KEY": "resolved-secret"},
+        )
+
+        items = plan_provider_migration(
+            source,
+            target_ws,
+            migrate_secrets=False,
+            overwrite=False,
+        )
+        custom = [i for i in items if "custom_providers" in i.target_path]
+        assert len(custom) == 1
+        custom[0].write_fn()
+        agent_json = json.loads((target_ws / "agent.json").read_text())
+        assert (
+            agent_json["custom_providers"]["custom-llm"]["api_key"]
+            == "resolved-secret"
+        )

--- a/tests/unit/migrate/test_providers.py
+++ b/tests/unit/migrate/test_providers.py
@@ -159,10 +159,15 @@ class TestPlanProviderMigration:
             overwrite=False,
         )
         secret_items = [i for i in items if i.category == "secret"]
-        assert len(secret_items) == 2
-        assert all(i.status == ItemStatus.OK for i in secret_items)
-        providers = {i.target_path.split(":")[-1] for i in secret_items}
-        assert providers == {"anthropic", "openai"}
+        assert len(secret_items) == 1
+        assert secret_items[0].status == ItemStatus.OK
+        assert "ANTHROPIC_API_KEY" in secret_items[0].detail
+        assert "OPENAI_API_KEY" in secret_items[0].detail
+
+        secret_items[0].write_fn()
+        env_content = (target_ws / ".env").read_text()
+        assert "ANTHROPIC_API_KEY=sk-ant-xxx" in env_content
+        assert "OPENAI_API_KEY=sk-oai-xxx" in env_content
 
     def test_api_key_not_included_without_secrets(self, tmp_path: Path):
         src_ws = tmp_path / "source" / "ws"
@@ -220,27 +225,24 @@ class TestPlanProviderMigration:
             config={
                 "models": {
                     "providers": {
-                        "custom-llm": {
-                            "baseUrl": "https://llm.example.com/v1",
-                            "apiKey": {"source": "env", "id": "CUSTOM_KEY"},
+                        "openai": {
+                            "baseUrl": "https://api.openai.com/v1",
+                            "apiKey": {"source": "env", "id": "MY_OPENAI_KEY"},
                         },
                     },
                 },
             },
-            env={"CUSTOM_KEY": "resolved-secret"},
+            env={"MY_OPENAI_KEY": "resolved-secret"},
         )
 
         items = plan_provider_migration(
             source,
             target_ws,
-            migrate_secrets=False,
+            migrate_secrets=True,
             overwrite=False,
         )
-        custom = [i for i in items if "custom_providers" in i.target_path]
-        assert len(custom) == 1
-        custom[0].write_fn()
-        agent_json = json.loads((target_ws / "agent.json").read_text())
-        assert (
-            agent_json["custom_providers"]["custom-llm"]["api_key"]
-            == "resolved-secret"
-        )
+        secret = [i for i in items if i.category == "secret"]
+        assert len(secret) == 1
+        secret[0].write_fn()
+        env_content = (target_ws / ".env").read_text()
+        assert "resolved-secret" in env_content


### PR DESCRIPTION
## Description

Add `qwenpaw migrate openclaw` CLI subcommand to import configuration from OpenClaw installations into QwenPaw. This addresses user demand for a migration path from OpenClaw/Hermes Agent ecosystems (see #5254).

The tool auto-detects `~/.openclaw` (and legacy aliases), parses JSON5 config, and migrates persona files, memory entries, model/provider configs, MCP servers, IM channel tokens/allowlists, cron jobs, and optionally conversation history. It supports dry-run preview, pre-migration backup, conflict detection, and a detailed rich-text migration report. Hermes support is planned as a future extension.

**Related Issue:** Fixes #5254

**Security Considerations:** API keys are **not** migrated by default (`--migrate-secrets` opt-in). When enabled, only a whitelist of known-safe env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) are transferred. OpenClaw's `SecretInput` object format (`{source: "env", id: "VAR"}`) is resolved transparently. Provider secrets should ideally be written through `ProviderManager` for encryption; current implementation writes to `agent.json` with a documented caveat.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

```bash
# Dry-run against a real or mock ~/.openclaw directory
qwenpaw migrate openclaw --dry-run

# Full migration with confirmation
qwenpaw migrate openclaw

# Selective migration (exclude history, include secrets)
qwenpaw migrate openclaw --include persona,memory,providers --migrate-secrets

# Unit tests (116 cases)
pytest tests/unit/migrate/ -v
```

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast.........................................................Passed
# sort simple yaml files...............................(no files to check)Skipped
# check yaml...........................................(no files to check)Skipped
# check xml............................................(no files to check)Skipped
# check toml...............................................................Passed
# check docstring is first.................................................Passed
# check json...........................................(no files to check)Skipped
# fix python encoding pragma...............................................Passed
# detect private key.......................................................Passed
# trim trailing whitespace.................................................Passed
# Add trailing commas......................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed
# prettier.............................................(no files to check)Skipped

pytest tests/unit/migrate/ -v
# 116 passed in 0.11s
```

## Additional Notes

- **JSON5 parsing**: Uses `pyjson5` (optional C extension) with a built-in state-machine fallback that correctly handles comments inside strings. Added as `[migrate]` extras dependency in `pyproject.toml`.
- **Idempotency**: Repeated runs are safe — MCP clients are deduplicated by key, cron jobs by deterministic `oc-{id}` prefix, and file writes check for existing targets.
- **Cron**: Supports all three OpenClaw schedule kinds (`cron`, `every`, `at`) and all three payload kinds (`agentTurn`, `systemEvent`, `command`). The `deleteAfterRun` flag maps to QwenPaw's `one_shot`, and per-job `agentId` is preserved. Cron store path detection checks the config `cron.store` field first, then probes `cron/store.json`, `cron/cron.json`, and `state/cron/store.json`.
- **Channels**: Non-channel keys (`defaults`, `modelByChannel`) in OpenClaw's `channels` config are correctly filtered. DM policy handles both canonical `dmPolicy` and legacy `dm.policy` fields, and treats `"pairing"` (OpenClaw's default) as access-controlled. Mattermost reads both `baseUrl` (canonical) and `url` (fallback).
- **MCP**: Maps `workingDirectory` alias for `cwd`, preserves `enabled: false` servers, and transfers `headers`.
- **Providers**: Detects models from both `agents.defaults.model` and OpenClaw's minimal `agent.model` shorthand. Handles `apiKey` as either a plain string or OpenClaw's `SecretInput` object (`{source: "env", id: "VAR"}`).
- **Workspace detection**: Uses OpenClaw's actual directory layout — per-agent workspace at `~/.openclaw/agents/{id}/workspace/` with fallback to `~/.openclaw/workspace`.
- **Skills**: OpenClaw skills (Node.js/TS) cannot run in QwenPaw. The tool outputs a mapping report suggesting QwenPaw equivalents but performs no code conversion.
- **History**: Conversation history migration is opt-in (`--include history`) and converts to QwenPaw `dialog/` JSONL logs rather than agent state snapshots, since full `Msg` object reconstruction is not feasible.
- **Hermes**: Not included in this PR. The detector already recognizes `~/.hermes` as a candidate root; converter logic can be extended in a follow-up.