### PR TITLE
bump: version to 2.0.0a1

### DIFF
--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.1.10b1"
+__version__ = "2.0.0a1"


### PR DESCRIPTION
## Summary
- Bump version from `1.1.10b1` to `2.0.0a1` for the agentscope 2.0 alpha milestone

## Changes
- `src/qwenpaw/__version__.py`: `1.1.10b1` → `2.0.0a1`


Made with [Cursor](https://cursor.com)