### PR TITLE
fix: explicitly configure SSL certificates for DingTalk channel HTTP client

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -31,7 +31,10 @@ from typing import (
 from uuid import uuid4
 from urllib.parse import unquote, urlparse
 
+import ssl
+
 import aiohttp
+import certifi
 import dingtalk_stream
 from dingtalk_stream import ChatbotMessage
 from alibabacloud_tea_openapi import models as open_api_models
@@ -2656,7 +2659,9 @@ class DingTalkChannel(BaseChannel):
         )
         self._stream_thread.start()
         if self._http is None:
-            self._http = aiohttp.ClientSession()
+            ssl_context = ssl.create_default_context(cafile=certifi.where())
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            self._http = aiohttp.ClientSession(connector=connector)
 
         # Initialize DingTalk OpenAPI SDK clients
         sdk_config = open_api_models.Config()


### PR DESCRIPTION
## Description

When QwenPaw is installed via `uv tool install`, the DingTalk channel fails to communicate because `aiohttp.ClientSession()` is created without explicit SSL certificate configuration. In `uv`-managed virtual environments on Windows, the default SSL certificate store may not be correctly resolved, causing HTTPS requests to DingTalk APIs to fail with SSL verification errors.

This fix explicitly configures the SSL context using `certifi`'s CA bundle when creating the `aiohttp.ClientSession`, ensuring consistent SSL certificate resolution regardless of the installation method (uv vs. Windows installer).

**Related Issue:** Fixes #5237

**Security Considerations:** No security impact. The change uses `certifi`'s Mozilla CA bundle (already a transitive dependency) for certificate verification — this is the standard, secure approach. No certificates are weakened or bypassed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_dingtalk_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_dingtalk.py` for complex internal logic

## Testing

1. Install QwenPaw via `uv tool install qwenpaw` on Windows
2. Configure DingTalk channel with valid `client_id` and `client_secret`
3. Start QwenPaw and send a message to the DingTalk bot
4. Verify the bot responds normally (previously would fail with SSL certificate errors)
5. Verify that the Windows installer installation still works as before (no regression)

### Root Cause

In `DingTalkChannel.start()`, the HTTP client was created as:
```python
self._http = aiohttp.ClientSession()
```

Without explicit SSL configuration, `aiohttp` relies on the system's default certificate store. In `uv`-managed virtual environments, the Python SSL module may not correctly locate the system CA certificates on Windows, causing all HTTPS requests to DingTalk APIs (sessionWebhook, Open API, media upload) to fail.

### Fix

```python
ssl_context = ssl.create_default_context(cafile=certifi.where())
connector = aiohttp.TCPConnector(ssl=ssl_context)
self._http = aiohttp.ClientSession(connector=connector)
```

`certifi` provides a curated Mozilla CA bundle and is already a transitive dependency (via `httpx`/`requests`). This ensures SSL certificate resolution works consistently across all installation methods and platforms.

### Workaround (for users on affected versions)

Users can work around this issue by setting the `SSL_CERT_FILE` environment variable:
```powershell
$env:SSL_CERT_FILE = "<path-to-uv-env>\Lib\site-packages\certifi\cacert.pem"
```