### PR TITLE
feat(models): batch test & batch delete models (#5294)

### DIFF
--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -14,6 +14,9 @@ import type {
   TestConnectionResponse,
   TestProviderRequest,
   TestModelRequest,
+  BatchTestModelsRequest,
+  BatchTestModelsResponse,
+  BatchDeleteModelsRequest,
   DiscoverModelsResponse,
   ProbeMultimodalResponse,
   SeriesResponse,
@@ -143,6 +146,26 @@ export const providerApi = {
   testModelConnection: (providerId: string, body: TestModelRequest) =>
     request<TestConnectionResponse>(
       `/models/${encodeURIComponent(providerId)}/models/test`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+    ),
+
+  /* ---- Batch operations ---- */
+
+  batchTestModels: (providerId: string, body: BatchTestModelsRequest) =>
+    request<BatchTestModelsResponse>(
+      `/models/${encodeURIComponent(providerId)}/models/batch-test`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+    ),
+
+  batchDeleteModels: (providerId: string, body: BatchDeleteModelsRequest) =>
+    request<ProviderInfo>(
+      `/models/${encodeURIComponent(providerId)}/models/batch-delete`,
       {
         method: "POST",
         body: JSON.stringify(body),

--- a/console/src/api/modules/provider.ts
+++ b/console/src/api/modules/provider.ts
@@ -17,6 +17,7 @@ import type {
   BatchTestModelsRequest,
   BatchTestModelsResponse,
   BatchDeleteModelsRequest,
+  BatchDeleteModelsResponse,
   DiscoverModelsResponse,
   ProbeMultimodalResponse,
   SeriesResponse,
@@ -164,7 +165,7 @@ export const providerApi = {
     ),
 
   batchDeleteModels: (providerId: string, body: BatchDeleteModelsRequest) =>
-    request<ProviderInfo>(
+    request<BatchDeleteModelsResponse>(
       `/models/${encodeURIComponent(providerId)}/models/batch-delete`,
       {
         method: "POST",

--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -220,6 +220,17 @@ export interface BatchDeleteModelsRequest {
   model_ids: string[];
 }
 
+export interface SingleDeleteResult {
+  model_id: string;
+  success: boolean;
+  message: string;
+}
+
+export interface BatchDeleteModelsResponse {
+  results: SingleDeleteResult[];
+  provider_info: ProviderInfo;
+}
+
 export interface DiscoverModelsResponse {
   success: boolean;
   message: string;

--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -202,6 +202,24 @@ export interface TestModelRequest {
   model_id: string;
 }
 
+export interface BatchTestModelsRequest {
+  model_ids: string[];
+}
+
+export interface SingleTestResult {
+  model_id: string;
+  success: boolean;
+  message: string;
+}
+
+export interface BatchTestModelsResponse {
+  results: SingleTestResult[];
+}
+
+export interface BatchDeleteModelsRequest {
+  model_ids: string[];
+}
+
 export interface DiscoverModelsResponse {
   success: boolean;
   message: string;

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -14,7 +14,8 @@ import {
   Tag,
   Tooltip,
 } from "@agentscope-ai/design";
-import { AutoComplete } from "antd";
+import { AutoComplete, Checkbox } from "antd";
+import type { CheckboxChangeEvent } from "antd/es/checkbox";
 import {
   DeleteOutlined,
   PlusOutlined,
@@ -380,6 +381,11 @@ export function RemoteModelManageModal({
   const [loadingDiscoveredModels, setLoadingDiscoveredModels] = useState(false);
   const PAGE_SIZE = 30;
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [selectedModelIds, setSelectedModelIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [batchTesting, setBatchTesting] = useState(false);
+  const [batchDeleting, setBatchDeleting] = useState(false);
 
   // For custom providers ALL models are deletable.
   // For built-in providers only extra_models are deletable.
@@ -534,10 +540,122 @@ export function RemoteModelManageModal({
     });
   };
 
+  // ---- Batch operations ----
+
+  const isModelDeletable = useCallback(
+    (modelId: string) => provider.is_custom || extraModelIds.has(modelId),
+    [provider.is_custom, extraModelIds],
+  );
+
+  const handleSelectModel = useCallback(
+    (modelId: string, checked: boolean) => {
+      setSelectedModelIds((prev) => {
+        const next = new Set(prev);
+        if (checked) {
+          next.add(modelId);
+        } else {
+          next.delete(modelId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const handleSelectAll = useCallback((checked: boolean) => {
+    if (checked) {
+      setSelectedModelIds(
+        new Set(
+          filteredModels
+            .filter(
+              (m) => provider.is_custom || extraModelIds.has(m.id),
+            )
+            .map((m) => m.id),
+        ),
+      );
+    } else {
+      setSelectedModelIds(new Set());
+    }
+  }, [filteredModels, provider.is_custom, extraModelIds]);
+
+  const handleBatchTest = async () => {
+    if (selectedModelIds.size === 0) return;
+    setBatchTesting(true);
+    try {
+      const result = await api.batchTestModels(provider.id, {
+        model_ids: Array.from(selectedModelIds),
+      });
+      const passed = result.results.filter((r) => r.success).length;
+      const failed = result.results.filter((r) => !r.success).length;
+      message.success(
+        t("models.batchTestDone", {
+          total: result.results.length,
+          passed,
+          failed,
+          defaultValue: `Batch test done: ${passed} passed, ${failed} failed`,
+        }),
+      );
+      // Show individual failures
+      for (const r of result.results) {
+        if (!r.success) {
+          message.warning(`${r.model_id}: ${r.message}`);
+        }
+      }
+      await onSaved();
+    } catch (error) {
+      const errMsg =
+        error instanceof Error
+          ? error.message
+          : t("models.batchTestFailed", "Batch test failed");
+      message.error(errMsg);
+    } finally {
+      setBatchTesting(false);
+    }
+  };
+
+  const handleBatchDelete = () => {
+    if (selectedModelIds.size === 0) return;
+    Modal.confirm({
+      title: t("models.batchRemoveModel", "Batch Delete Models"),
+      content: t("models.batchRemoveModelConfirm", {
+        count: selectedModelIds.size,
+        defaultValue: `Are you sure you want to delete ${selectedModelIds.size} models?`,
+      }),
+      okText: t("common.delete"),
+      okButtonProps: { danger: true },
+      cancelText: t("models.cancel"),
+      onOk: async () => {
+        setBatchDeleting(true);
+        try {
+          await api.batchDeleteModels(provider.id, {
+            model_ids: Array.from(selectedModelIds),
+          });
+          message.success(
+            t("models.batchModelsRemoved", {
+              count: selectedModelIds.size,
+              defaultValue: `${selectedModelIds.size} models deleted`,
+            }),
+          );
+          setSelectedModelIds(new Set());
+          await onSaved();
+        } catch (error) {
+          const errMsg =
+            error instanceof Error
+              ? error.message
+              : t("models.batchRemoveFailed", "Batch delete failed");
+          message.error(errMsg);
+        } finally {
+          setBatchDeleting(false);
+        }
+      },
+    });
+  };
+
   const handleClose = () => {
     setAdding(false);
     setConfigOpenModelId(null);
     setModelSearchQuery("");
+    setSelectedModelIds(new Set());
     setVisibleCount(PAGE_SIZE);
     form.resetFields();
     onClose();
@@ -721,6 +839,84 @@ export function RemoteModelManageModal({
         allowClear
       />
 
+      {/* Batch toolbar */}
+      {filteredModels.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            margin: "8px 0 0",
+            padding: "4px 0",
+            borderTop: isDark
+              ? "1px solid rgba(255,255,255,0.08)"
+              : "1px solid #f0f0f0",
+            borderBottom: isDark
+              ? "1px solid rgba(255,255,255,0.08)"
+              : "1px solid #f0f0f0",
+            minHeight: 36,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Checkbox
+              indeterminate={
+                selectedModelIds.size > 0 &&
+                selectedModelIds.size <
+                  filteredModels.filter(
+                    (m) => provider.is_custom || extraModelIds.has(m.id),
+                  ).length
+              }
+              checked={
+                selectedModelIds.size > 0 &&
+                selectedModelIds.size ===
+                  filteredModels.filter(
+                    (m) => provider.is_custom || extraModelIds.has(m.id),
+                  ).length
+              }
+              onChange={(e: CheckboxChangeEvent) =>
+                handleSelectAll(e.target.checked)
+              }
+            />
+            <span
+              style={{
+                fontSize: 12,
+                color: isDark
+                  ? "rgba(255,255,255,0.5)"
+                  : "#888",
+              }}
+            >
+              {selectedModelIds.size > 0
+                ? t("models.selectedCount", {
+                    count: selectedModelIds.size,
+                    defaultValue: `${selectedModelIds.size} selected`,
+                  })
+                : t("models.selectHint", "Select models...")}
+            </span>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <Button
+              size="small"
+              icon={<ApiOutlined />}
+              disabled={selectedModelIds.size === 0}
+              loading={batchTesting}
+              onClick={handleBatchTest}
+            >
+              {t("models.batchTest", "Batch Test")}
+            </Button>
+            <Button
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              disabled={selectedModelIds.size === 0}
+              loading={batchDeleting}
+              onClick={handleBatchDelete}
+            >
+              {t("models.batchDelete", "Batch Delete")}
+            </Button>
+          </div>
+        </div>
+      )}
+
       {/* Model list */}
       <div className={styles.modelList}>
         {filteredModels.length === 0 ? (
@@ -733,6 +929,13 @@ export function RemoteModelManageModal({
               return (
                 <div key={m.id}>
                   <div className={styles.modelListItem}>
+                    <Checkbox
+                      checked={selectedModelIds.has(m.id)}
+                      onChange={(e: CheckboxChangeEvent) =>
+                        handleSelectModel(m.id, e.target.checked)
+                      }
+                      style={{ marginRight: 8 }}
+                    />
                     <div className={styles.modelListItemInfo}>
                       <span className={styles.modelListItemName}>{m.name}</span>
                       <span className={styles.modelListItemId}>{m.id}</span>

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -640,15 +640,22 @@ export function RemoteModelManageModal({
       onOk: async () => {
         setBatchDeleting(true);
         try {
-          await api.batchDeleteModels(provider.id, {
+          const result = await api.batchDeleteModels(provider.id, {
             model_ids: Array.from(selectedModelIds),
           });
-          message.success(
-            t("models.batchModelsRemoved", {
-              count: selectedModelIds.size,
-              defaultValue: `${selectedModelIds.size} models deleted`,
-            }),
-          );
+          const succeeded = result.results.filter((r) => r.success).length;
+          const failed = result.results.filter((r) => !r.success);
+          if (succeeded > 0) {
+            message.success(
+              t("models.batchModelsRemoved", {
+                count: succeeded,
+                defaultValue: `${succeeded} models deleted`,
+              }),
+            );
+          }
+          for (const f of failed) {
+            message.error(`${f.model_id}: ${f.message}`);
+          }
           setSelectedModelIds(new Set());
           await onSaved();
         } catch (error) {
@@ -922,6 +929,7 @@ export function RemoteModelManageModal({
                   <div className={styles.modelListItem}>
                     <Checkbox
                       checked={selectedModelIds.has(m.id)}
+                      disabled={!isDeletable}
                       onChange={(e: CheckboxChangeEvent) =>
                         handleSelectModel(m.id, e.target.checked)
                       }

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -542,11 +542,6 @@ export function RemoteModelManageModal({
 
   // ---- Batch operations ----
 
-  const isModelDeletable = useCallback(
-    (modelId: string) => provider.is_custom || extraModelIds.has(modelId),
-    [provider.is_custom, extraModelIds],
-  );
-
   const handleSelectModel = useCallback(
     (modelId: string, checked: boolean) => {
       setSelectedModelIds((prev) => {
@@ -561,6 +556,26 @@ export function RemoteModelManageModal({
     },
     [],
   );
+
+  const deferredSearchQuery = useDeferredValue(modelSearchQuery);
+
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [deferredSearchQuery]);
+
+  const filteredModels = useMemo(() => {
+    const all_models = [
+      ...(provider.extra_models ?? []),
+      ...(provider.models ?? []),
+    ];
+    const q = deferredSearchQuery.trim().toLowerCase();
+    if (!q) return all_models;
+    return all_models.filter(
+      (m) => m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q),
+    );
+  }, [provider.models, provider.extra_models, deferredSearchQuery]);
+
+  const colors = tagColors(isDark);
 
   const handleSelectAll = useCallback((checked: boolean) => {
     if (checked) {
@@ -801,26 +816,6 @@ export function RemoteModelManageModal({
     setAdding(false);
     form.resetFields();
   }, [adding, form, isOpenRouter]);
-
-  const deferredSearchQuery = useDeferredValue(modelSearchQuery);
-
-  useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [deferredSearchQuery]);
-
-  const filteredModels = useMemo(() => {
-    const all_models = [
-      ...(provider.extra_models ?? []),
-      ...(provider.models ?? []),
-    ];
-    const q = deferredSearchQuery.trim().toLowerCase();
-    if (!q) return all_models;
-    return all_models.filter(
-      (m) => m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q),
-    );
-  }, [provider.models, provider.extra_models, deferredSearchQuery]);
-
-  const colors = tagColors(isDark);
 
   return (
     <Modal

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -542,20 +542,17 @@ export function RemoteModelManageModal({
 
   // ---- Batch operations ----
 
-  const handleSelectModel = useCallback(
-    (modelId: string, checked: boolean) => {
-      setSelectedModelIds((prev) => {
-        const next = new Set(prev);
-        if (checked) {
-          next.add(modelId);
-        } else {
-          next.delete(modelId);
-        }
-        return next;
-      });
-    },
-    [],
-  );
+  const handleSelectModel = useCallback((modelId: string, checked: boolean) => {
+    setSelectedModelIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(modelId);
+      } else {
+        next.delete(modelId);
+      }
+      return next;
+    });
+  }, []);
 
   const deferredSearchQuery = useDeferredValue(modelSearchQuery);
 
@@ -577,21 +574,22 @@ export function RemoteModelManageModal({
 
   const colors = tagColors(isDark);
 
-  const handleSelectAll = useCallback((checked: boolean) => {
-    if (checked) {
-      setSelectedModelIds(
-        new Set(
-          filteredModels
-            .filter(
-              (m) => provider.is_custom || extraModelIds.has(m.id),
-            )
-            .map((m) => m.id),
-        ),
-      );
-    } else {
-      setSelectedModelIds(new Set());
-    }
-  }, [filteredModels, provider.is_custom, extraModelIds]);
+  const handleSelectAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setSelectedModelIds(
+          new Set(
+            filteredModels
+              .filter((m) => provider.is_custom || extraModelIds.has(m.id))
+              .map((m) => m.id),
+          ),
+        );
+      } else {
+        setSelectedModelIds(new Set());
+      }
+    },
+    [filteredModels, provider.is_custom, extraModelIds],
+  );
 
   const handleBatchTest = async () => {
     if (selectedModelIds.size === 0) return;
@@ -875,9 +873,7 @@ export function RemoteModelManageModal({
             <span
               style={{
                 fontSize: 12,
-                color: isDark
-                  ? "rgba(255,255,255,0.5)"
-                  : "#888",
+                color: isDark ? "rgba(255,255,255,0.5)" : "#888",
               }}
             >
               {selectedModelIds.size > 0

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -535,7 +535,8 @@ async def batch_delete_models(
             )
         except (ValueError, AppBaseException) as exc:
             logger.warning(
-                "Batch delete: failed to remove model '%s' from provider '%s': %s",
+                # ponytail: kept < 79 chars for flake8
+                "Batch delete: failed to remove '%s' from '%s': %s",
                 model_id,
                 provider_id,
                 exc,

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -313,6 +313,23 @@ class BatchDeleteModelsRequest(BaseModel):
     )
 
 
+class SingleDeleteResult(BaseModel):
+    model_id: str = Field(..., description="Model ID that was deleted")
+    success: bool = Field(..., description="Whether the deletion succeeded")
+    message: str = Field(..., description="Result message")
+
+
+class BatchDeleteModelsResponse(BaseModel):
+    results: List[SingleDeleteResult] = Field(
+        ...,
+        description="Per-model deletion results",
+    )
+    provider_info: ProviderInfo = Field(
+        ...,
+        description="Updated provider info after deletion",
+    )
+
+
 class DiscoverModelsRequest(BaseModel):
     api_key: Optional[str] = Field(
         default=None,
@@ -518,20 +535,28 @@ async def batch_test_models(
 
 @router.post(
     "/{provider_id}/models/batch-delete",
-    response_model=ProviderInfo,
+    response_model=BatchDeleteModelsResponse,
     summary="Batch delete multiple models",
 )
 async def batch_delete_models(
     manager: ProviderManager = Depends(get_provider_manager),
     provider_id: str = Path(...),
     body: BatchDeleteModelsRequest = Body(...),
-) -> ProviderInfo:
+) -> BatchDeleteModelsResponse:
     """Delete multiple models from a provider in sequence."""
+    results = []
     for model_id in body.model_ids:
         try:
             await manager.delete_model_from_provider(
                 provider_id=provider_id,
                 model_id=model_id,
+            )
+            results.append(
+                SingleDeleteResult(
+                    model_id=model_id,
+                    success=True,
+                    message="Model deleted successfully",
+                ),
             )
         except (ValueError, AppBaseException) as exc:
             logger.warning(
@@ -541,17 +566,23 @@ async def batch_delete_models(
                 provider_id,
                 exc,
             )
-            raise HTTPException(
-                status_code=400,
-                detail=f"Failed to delete model '{model_id}': {exc!s}",
-            ) from exc
+            results.append(
+                SingleDeleteResult(
+                    model_id=model_id,
+                    success=False,
+                    message=str(exc),
+                ),
+            )
     provider_info = await manager.get_provider_info(provider_id)
     if provider_info is None:
         raise HTTPException(
             status_code=404,
             detail=f"Provider '{provider_id}' not found",
         )
-    return provider_info
+    return BatchDeleteModelsResponse(
+        results=results,
+        provider_info=provider_info,
+    )
 
 
 @router.delete(

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Dict, List, Literal, Optional
 from fastapi import (
@@ -285,6 +286,33 @@ class TestModelRequest(BaseModel):
     model_id: str = Field(..., description="Model ID to test")
 
 
+class BatchTestModelsRequest(BaseModel):
+    model_ids: List[str] = Field(
+        ...,
+        description="List of model IDs to test",
+    )
+
+
+class SingleTestResult(BaseModel):
+    model_id: str = Field(..., description="Model ID that was tested")
+    success: bool = Field(..., description="Whether the test passed")
+    message: str = Field(..., description="Result message")
+
+
+class BatchTestModelsResponse(BaseModel):
+    results: List[SingleTestResult] = Field(
+        ...,
+        description="Per-model test results",
+    )
+
+
+class BatchDeleteModelsRequest(BaseModel):
+    model_ids: List[str] = Field(
+        ...,
+        description="List of model IDs to delete",
+    )
+
+
 class DiscoverModelsRequest(BaseModel):
     api_key: Optional[str] = Field(
         default=None,
@@ -443,6 +471,80 @@ async def test_model(
         )
     except (ValueError, AppBaseException) as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.post(
+    "/{provider_id}/models/batch-test",
+    response_model=BatchTestModelsResponse,
+    summary="Batch test multiple models",
+)
+async def batch_test_models(
+    manager: ProviderManager = Depends(get_provider_manager),
+    provider_id: str = Path(...),
+    body: BatchTestModelsRequest = Body(...),
+) -> BatchTestModelsResponse:
+    """Test multiple models in parallel against the configured provider."""
+    provider = manager.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Provider '{provider_id}' not found.",
+        )
+
+    async def _test_one(model_id: str) -> SingleTestResult:
+        try:
+            ok, msg = await provider.check_model_connection(
+                model_id=model_id,
+            )
+            return SingleTestResult(
+                model_id=model_id,
+                success=ok,
+                message="Model connection successful"
+                if ok
+                else f"Model connection failed: {msg}",
+            )
+        except Exception as exc:
+            return SingleTestResult(
+                model_id=model_id,
+                success=False,
+                message=f"Error: {exc!s}",
+            )
+
+    results = await asyncio.gather(
+        *[_test_one(mid) for mid in body.model_ids],
+    )
+    return BatchTestModelsResponse(results=list(results))
+
+
+@router.post(
+    "/{provider_id}/models/batch-delete",
+    response_model=ProviderInfo,
+    summary="Batch delete multiple models",
+)
+async def batch_delete_models(
+    manager: ProviderManager = Depends(get_provider_manager),
+    provider_id: str = Path(...),
+    body: BatchDeleteModelsRequest = Body(...),
+) -> ProviderInfo:
+    """Delete multiple models from a provider in sequence."""
+    for model_id in body.model_ids:
+        try:
+            await manager.delete_model_from_provider(
+                provider_id=provider_id,
+                model_id=model_id,
+            )
+        except (ValueError, AppBaseException) as exc:
+            logger.warning(
+                "Batch delete: failed to remove model '%s' from provider '%s': %s",
+                model_id,
+                provider_id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=f"Failed to delete model '{model_id}': {exc!s}",
+            ) from exc
+    return await manager.get_provider_info(provider_id)
 
 
 @router.delete(

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -544,7 +544,13 @@ async def batch_delete_models(
                 status_code=400,
                 detail=f"Failed to delete model '{model_id}': {exc!s}",
             ) from exc
-    return await manager.get_provider_info(provider_id)
+    provider_info = await manager.get_provider_info(provider_id)
+    if provider_info is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Provider '{provider_id}' not found",
+        )
+    return provider_info
 
 
 @router.delete(


### PR DESCRIPTION
## Summary
Batch test and batch delete models in the provider model management dialog. Addresses issue #5294.

## Changes

### Backend
- `POST /{provider_id}/models/batch-test` — test N models in parallel (via `asyncio.gather`)
- `POST /{provider_id}/models/batch-delete` — delete N models in sequence
- New Pydantic models: `BatchTestModelsRequest`, `SingleTestResult`, `BatchTestModelsResponse`, `BatchDeleteModelsRequest`

### Frontend
- `api.batchTestModels()` and `api.batchDeleteModels()` in API client
- Checkbox per model row + select-all checkbox
- Batch toolbar with 'Batch Test' and 'Batch Delete' buttons
- Delete confirmation dialog before batch delete

### Files Changed
1. `src/qwenpaw/app/routers/providers.py`
2. `console/src/api/modules/provider.ts`
3. `console/src/api/types/provider.ts`
4. `console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx`
