### PR TITLE
fix(token_usage): use active model's max_input_length for context usage display (#5300)

### DIFF
--- a/src/qwenpaw/token_usage/turn_usage.py
+++ b/src/qwenpaw/token_usage/turn_usage.py
@@ -27,12 +27,13 @@ async def snapshot_context_usage_for_memory(
 ) -> dict[str, Any] | None:
     """Estimate token totals from a loaded memory object."""
     try:
-        from ..config.config import load_agent_config
-
-        max_input_length = int(
-            getattr(load_agent_config(agent_id).running, "max_input_length", 0)
-            or 0,
+        from ..config.config import (
+            load_agent_config,
+            get_model_max_input_length,
         )
+
+        agent_config = load_agent_config(agent_id)
+        max_input_length = int(get_model_max_input_length(agent_config) or 0)
         if max_input_length <= 0:
             return None
 


### PR DESCRIPTION
Closes #5300  fix(token_usage): use active model's max_input_length for context usage display (#5300)  The Web chat context usage indicator was reading \`agent.running.max_input_length\` instead of the active model's actual \`max_input_length\`. This caused incorrect context usage ratios when the model's max_input_length (e.g. 480000 for MiniMax-M3) differs from the running config default (131072).  Replace with \`get_model_max_input_length(agent_config)\` which correctly resolves the current active model's max_input_length.