### PR TITLE
fix chat turn context denominator

### DIFF
--- a/src/qwenpaw/token_usage/turn_usage.py
+++ b/src/qwenpaw/token_usage/turn_usage.py
@@ -27,12 +27,13 @@ async def snapshot_context_usage_for_memory(
 ) -> dict[str, Any] | None:
     """Estimate token totals from a loaded memory object."""
     try:
-        from ..config.config import load_agent_config
-
-        max_input_length = int(
-            getattr(load_agent_config(agent_id).running, "max_input_length", 0)
-            or 0,
+        from ..config.config import (
+            get_model_max_input_length,
+            load_agent_config,
         )
+
+        agent_config = load_agent_config(agent_id)
+        max_input_length = int(get_model_max_input_length(agent_config) or 0)
         if max_input_length <= 0:
             return None
 


### PR DESCRIPTION
## Description

Fix Console chat turn **context usage popover** using the improper context window size.

`snapshot_context_usage_for_memory()` previously read `agent.running.max_input_length`, while context management and model settings use the **active model’s** `max_input_length` via `get_model_max_input_length()`. That made the popover denominator and usage ratio too high when the model window is larger.

**Related Issue:** Fixes #5300 or Relates to #5300

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
