### PR TITLE
feat(sandbox): add bubblewrap Linux sandbox with mount namespace isolation

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -475,6 +475,13 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         action=GovernanceAction.ALLOW,
         reason="Allow all browser access",
     ),
+    # ── /tmp ──
+    # Allow all tool access under /tmp without prompting.
+    GovernanceRule(
+        match="*(/tmp/**)",
+        action=GovernanceAction.ALLOW,
+        reason="Scratch directory access for tmp",
+    ),
 ]
 
 

--- a/src/qwenpaw/governance/resource_governor.py
+++ b/src/qwenpaw/governance/resource_governor.py
@@ -188,11 +188,21 @@ class ResourceGovernor:
         # trace policy evaluation results without querying audit.db.
         # ``target`` is truncated to keep log lines bounded.
         target_repr = (tc_spec.target or "")[:120]
+        # sandbox backend actually used for this call: the compiled
+        # config's mode (bubblewrap/landlock/...), or "-" when the
+        # decision does not route through a sandbox.
+        sandbox_mode = (
+            decision.sandbox_config.mode.value
+            if decision.sandbox_config is not None
+            else "-"
+        )
         logger.info(
-            "governance decision: tool=%s target=%r action=%s reason=%s",
+            "governance decision: tool=%s target=%r action=%s sandbox=%s "
+            "reason=%s",
             tc_spec.tool_name,
             target_repr,
             decision.action.value,
+            sandbox_mode,
             decision.reason,
         )
         return decision

--- a/src/qwenpaw/sandbox/__init__.py
+++ b/src/qwenpaw/sandbox/__init__.py
@@ -32,16 +32,16 @@ from .config import (
     SandboxCapability,
     SandboxConfig,
     SandboxMode,
+    create_sandbox,
     detect_platform_mode,
     probe_sandbox_support,
 )
 from .bubblewrap_sandbox import BubblewrapSandbox
 from .local_sandbox import (
     LocalSandbox,
-    MacOSSandbox,
     NoneSandbox,
-    create_sandbox,
 )
+from .macos_sandbox import MacOSSandbox
 from .windows_sandbox import WindowsSandbox
 
 __all__ = [

--- a/src/qwenpaw/sandbox/__init__.py
+++ b/src/qwenpaw/sandbox/__init__.py
@@ -2,10 +2,11 @@
 """Sandbox — lightweight local execution isolation.
 
 Supported modes:
-  - SEATBELT: macOS sandbox-exec kernel isolation
-  - LANDLOCK: Linux Landlock LSM kernel isolation (5.13+)
-  - WSL2:     Windows WSL2 delegated execution + Landlock isolation
-  - NONE:     no isolation, direct execution
+  - SEATBELT:    macOS sandbox-exec kernel isolation
+  - BUBBLEWRAP:  Linux bubblewrap mount-namespace isolation (preferred)
+  - LANDLOCK:    Linux Landlock LSM kernel isolation (5.13+, fallback)
+  - WSL2:        Windows WSL2 delegated execution + Landlock isolation
+  - NONE:        no isolation, direct execution
 
 Lifecycle: per-tool-call (created and destroyed for each invocation).
 
@@ -34,6 +35,7 @@ from .config import (
     detect_platform_mode,
     probe_sandbox_support,
 )
+from .bubblewrap_sandbox import BubblewrapSandbox
 from .local_sandbox import (
     LocalSandbox,
     MacOSSandbox,
@@ -43,6 +45,7 @@ from .local_sandbox import (
 from .windows_sandbox import WindowsSandbox
 
 __all__ = [
+    "BubblewrapSandbox",
     "ExecutionResult",
     "LocalSandbox",
     "MacOSSandbox",

--- a/src/qwenpaw/sandbox/bubblewrap_sandbox.py
+++ b/src/qwenpaw/sandbox/bubblewrap_sandbox.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+"""Linux bubblewrap sandbox implementation.
+
+Uses bubblewrap (bwrap) to construct a mount-namespace-based filesystem view.
+This provides stronger isolation than Landlock alone:
+  - deny_paths are truly invisible (not mounted at all)
+  - /dev is a minimal synthetic devtmpfs (null, zero, urandom, tty, etc.)
+  - PID namespace isolation via --unshare-pid
+  - No HOME enumeration hacks needed for deny_paths
+
+Architecture:
+    bwrap constructs the filesystem view, then execs the user command.
+    The parent process waits for completion and captures stdout/stderr.
+
+Reference:
+    https://github.com/containers/bubblewrap
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import signal
+import time
+from typing import List, Optional
+
+from .config import ExecutionResult
+from .local_sandbox import LocalSandbox
+
+logger = logging.getLogger(__name__)
+
+# Regex to detect sandbox violations in stderr output.
+_BWRAP_VIOLATION_RE = re.compile(
+    r"\bPermission denied\b"
+    r"|^bwrap:\s"
+    r"|\bOperation not permitted\b"
+    r"|\bEACCES\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class BubblewrapSandbox(LocalSandbox):
+    """Linux bubblewrap sandbox using mount namespaces.
+
+    deny-default whitelist model:
+      - Filesystem is read-only by default (--ro-bind / /) when
+        allow_read_all=True, or starts empty (--tmpfs /) otherwise.
+      - /dev is always a minimal synthetic devtmpfs (--dev /dev).
+      - /tmp is always writable.
+      - workspace_dir and mounts are layered with appropriate permissions.
+      - deny_paths are masked with --tmpfs (invisible to sandboxed process).
+      - PID namespace is isolated (--unshare-pid + --proc /proc).
+    """
+
+    def _find_bwrap(self) -> str:
+        """Locate the bwrap binary.
+
+        Raises:
+            FileNotFoundError: if bwrap is not on PATH.
+        """
+        bwrap = shutil.which("bwrap")
+        if not bwrap:
+            raise FileNotFoundError(
+                "bubblewrap (bwrap) not found on PATH; "
+                "install it or switch to Landlock mode",
+            )
+        return bwrap
+
+    def _build_bwrap_args(  # pylint: disable=too-many-branches
+        self,
+        cmd: str,
+        cwd: str,
+    ) -> List[str]:
+        """Build the full bwrap command-line argument list.
+
+        The mount order follows Codex conventions:
+        1. Base filesystem (--ro-bind / / or --tmpfs /)
+        2. --dev /dev (minimal device nodes)
+        3. Always-writable paths (/tmp, /dev/shm)
+        4. Writable mounts from config (workspace, etc.)
+        5. Read-only mounts from config
+        6. deny_paths masks (--tmpfs to hide)
+        7. Namespace isolation (--unshare-user, --unshare-pid, --proc)
+        8. -- /bin/sh -c <cmd>
+        """
+        config = self._config
+        args: List[str] = []
+
+        # Session and lifecycle
+        args.extend(["--new-session", "--die-with-parent"])
+
+        # --- Base filesystem ---
+        if config.allow_read_all:
+            # Full disk readable (deny-list mode)
+            args.extend(["--ro-bind", "/", "/"])
+        else:
+            # Empty filesystem (allow-list mode)
+            args.extend(["--tmpfs", "/"])
+            # Mount system paths for basic operation
+            system_paths = [
+                "/usr",
+                "/lib",
+                "/lib64",
+                "/bin",
+                "/sbin",
+                "/etc",
+                "/proc",
+                "/sys",
+                "/run",
+            ]
+            for sp in system_paths:
+                if os.path.exists(sp):
+                    args.extend(["--ro-bind", sp, sp])
+            # Mount declared read-only mounts
+            for mount in config.mounts:
+                if not mount.writable and os.path.exists(mount.path):
+                    args.extend(["--ro-bind", mount.path, mount.path])
+
+        # --- Minimal /dev ---
+        args.extend(["--dev", "/dev"])
+
+        # --- Always-writable paths ---
+        always_writable = ["/tmp"]
+        if os.path.exists("/dev/shm"):
+            always_writable.append("/dev/shm")
+        for p in always_writable:
+            if os.path.exists(p):
+                args.extend(["--bind", p, p])
+
+        # --- Writable mounts (workspace + config mounts) ---
+        for mount in config.mounts:
+            if mount.writable and os.path.exists(mount.path):
+                args.extend(["--bind", mount.path, mount.path])
+
+        # --- deny_paths: mask with --tmpfs ---
+        if config.deny_paths:
+            for dp in config.deny_paths:
+                expanded = os.path.expanduser(dp)
+                if os.path.exists(expanded):
+                    if os.path.isdir(expanded):
+                        args.extend(["--tmpfs", expanded])
+                    else:
+                        # For files, bind /dev/null over them
+                        args.extend(
+                            ["--ro-bind", "/dev/null", expanded],
+                        )
+
+        # --- Namespace isolation ---
+        args.extend(["--unshare-user", "--unshare-pid"])
+
+        # --- Fresh /proc ---
+        args.extend(["--proc", "/proc"])
+
+        # --- Working directory ---
+        if cwd and os.path.isdir(cwd):
+            args.extend(["--chdir", cwd])
+
+        # --- Command ---
+        shell = os.environ.get("SHELL", "/bin/sh")
+        if not os.path.exists(shell):
+            shell = "/bin/sh"
+        args.extend(["--", shell, "-c", cmd])
+
+        return args
+
+    async def execute(
+        self,
+        cmd: str,
+        cwd: Optional[str] = None,
+    ) -> ExecutionResult:
+        """Execute a command inside the bubblewrap sandbox."""
+        cwd_resolved = cwd or self._config.workspace_dir
+        if not os.path.isdir(cwd_resolved):
+            cwd_resolved = self._config.workspace_dir
+
+        start = time.monotonic()
+
+        try:
+            bwrap = self._find_bwrap()
+        except FileNotFoundError as e:
+            return ExecutionResult(
+                exit_code=-1,
+                stdout="",
+                stderr=str(e),
+                duration_ms=0,
+            )
+
+        bwrap_args = self._build_bwrap_args(cmd, cwd_resolved)
+        full_cmd = [bwrap] + bwrap_args
+
+        # Build subprocess environment
+        env = dict(os.environ)
+        if self._config.env_vars:
+            env.update(self._config.env_vars)
+
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *full_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                start_new_session=True,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                self._process.communicate(),
+                timeout=self._config.timeout_seconds,
+            )
+            duration_ms = int((time.monotonic() - start) * 1000)
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+            # Detect sandbox violation
+            violation = None
+            if self._process.returncode != 0 and _BWRAP_VIOLATION_RE.search(
+                stderr,
+            ):
+                violation = stderr.strip()
+
+            return ExecutionResult(
+                exit_code=self._process.returncode or 0,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=False,
+                duration_ms=duration_ms,
+                sandbox_violation=violation,
+            )
+        except asyncio.TimeoutError:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            await self.stop()
+            return ExecutionResult(
+                exit_code=-1,
+                stdout="",
+                stderr="Command timed out",
+                timed_out=True,
+                duration_ms=duration_ms,
+            )
+        except Exception as e:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return ExecutionResult(
+                exit_code=-1,
+                stdout="",
+                stderr=str(e),
+                duration_ms=duration_ms,
+            )
+
+    async def stop(self) -> None:
+        """Kill any running subprocess."""
+        if self._process and self._process.returncode is None:
+            try:
+                os.killpg(
+                    os.getpgid(self._process.pid),
+                    signal.SIGKILL,
+                )
+            except (ProcessLookupError, OSError):
+                pass

--- a/src/qwenpaw/sandbox/bubblewrap_sandbox.py
+++ b/src/qwenpaw/sandbox/bubblewrap_sandbox.py
@@ -2,11 +2,18 @@
 """Linux bubblewrap sandbox implementation.
 
 Uses bubblewrap (bwrap) to construct a mount-namespace-based filesystem view.
-This provides stronger isolation than Landlock alone:
+This provides stronger filesystem isolation than Landlock alone:
   - deny_paths are truly invisible (not mounted at all)
   - /dev is a minimal synthetic devtmpfs (null, zero, urandom, tty, etc.)
   - PID namespace isolation via --unshare-pid
   - No HOME enumeration hacks needed for deny_paths
+
+Limitations (current version):
+  - Network is NOT isolated (no --unshare-net). Sandboxed processes have
+    full network access. Network namespace isolation is planned for a
+    future iteration.
+  - deny_paths for individual files uses --ro-bind /dev/null (file appears
+    empty rather than ENOENT). Directory-level deny uses --tmpfs (invisible).
 
 Architecture:
     bwrap constructs the filesystem view, then execs the user command.
@@ -149,7 +156,11 @@ class BubblewrapSandbox(LocalSandbox):
                         )
 
         # --- Namespace isolation ---
-        args.extend(["--unshare-user", "--unshare-pid"])
+        # --unshare-user creates a user namespace; bwrap automatically
+        # maps the calling uid/gid to uid 0/gid 0 inside the sandbox.
+        # We add explicit --uid/--gid for clarity and cross-distro safety.
+        args.extend(["--unshare-user", "--uid", "0", "--gid", "0"])
+        args.extend(["--unshare-pid"])
 
         # --- Fresh /proc ---
         args.extend(["--proc", "/proc"])
@@ -159,10 +170,9 @@ class BubblewrapSandbox(LocalSandbox):
             args.extend(["--chdir", cwd])
 
         # --- Command ---
-        shell = os.environ.get("SHELL", "/bin/sh")
-        if not os.path.exists(shell):
-            shell = "/bin/sh"
-        args.extend(["--", shell, "-c", cmd])
+        # Hardcode /bin/sh (POSIX-guaranteed) to avoid injection via
+        # SHELL env var and ensure consistent cross-shell semantics.
+        args.extend(["--", "/bin/sh", "-c", cmd])
 
         return args
 
@@ -247,12 +257,16 @@ class BubblewrapSandbox(LocalSandbox):
             )
 
     async def stop(self) -> None:
-        """Kill any running subprocess."""
+        """Kill any running subprocess and reap zombie."""
         if self._process and self._process.returncode is None:
             try:
                 os.killpg(
                     os.getpgid(self._process.pid),
                     signal.SIGKILL,
                 )
+            except (ProcessLookupError, OSError):
+                pass
+            try:
+                await self._process.wait()
             except (ProcessLookupError, OSError):
                 pass

--- a/src/qwenpaw/sandbox/config.py
+++ b/src/qwenpaw/sandbox/config.py
@@ -12,7 +12,8 @@ class SandboxMode(str, Enum):
     """Sandbox isolation mode."""
 
     SEATBELT = "seatbelt"  # macOS sandbox-exec
-    LANDLOCK = "landlock"  # Linux (future)
+    BUBBLEWRAP = "bubblewrap"  # Linux bubblewrap (preferred)
+    LANDLOCK = "landlock"  # Linux Landlock LSM (fallback)
     WSL2 = "wsl2"  # Windows (future)
     NONE = "none"  # No isolation, direct execution
 
@@ -315,18 +316,90 @@ def _probe_windows_wsl2() -> SandboxCapability:
     )
 
 
+def _probe_linux_bubblewrap() -> SandboxCapability:
+    """Probe bubblewrap (bwrap) availability on Linux.
+
+    Detection steps:
+        1. bwrap binary exists on PATH
+        2. User namespaces work (test run with --unshare-user)
+    """
+    import shutil
+    import subprocess
+
+    bwrap = shutil.which("bwrap")
+    if not bwrap:
+        return SandboxCapability(
+            supported=False,
+            mode=SandboxMode.NONE,
+            reason="bwrap not found on PATH",
+        )
+    # Probe: attempt a trivial sandboxed execution to confirm
+    # user namespace and mount namespace work.
+    try:
+        result = subprocess.run(  # noqa: S603, pylint: disable=W1510
+            [
+                bwrap,
+                "--ro-bind",
+                "/",
+                "/",
+                "--dev",
+                "/dev",
+                "--unshare-user",
+                "--unshare-pid",
+                "--proc",
+                "/proc",
+                "--",
+                "/bin/true",
+            ],
+            capture_output=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return SandboxCapability(
+                supported=True,
+                mode=SandboxMode.BUBBLEWRAP,
+                reason="bubblewrap available with user namespaces",
+            )
+        stderr = result.stderr.decode("utf-8", errors="replace")
+        return SandboxCapability(
+            supported=False,
+            mode=SandboxMode.NONE,
+            reason=(
+                f"bwrap probe failed (rc={result.returncode}): "
+                f"{stderr[:200]}"
+            ),
+        )
+    except subprocess.TimeoutExpired:
+        return SandboxCapability(
+            supported=False,
+            mode=SandboxMode.NONE,
+            reason="bwrap probe timed out",
+        )
+    except (FileNotFoundError, OSError) as e:
+        return SandboxCapability(
+            supported=False,
+            mode=SandboxMode.NONE,
+            reason=f"bwrap probe error: {e}",
+        )
+
+
 def probe_sandbox_support() -> SandboxCapability:
     """Probe current platform sandbox support at startup.
 
     Returns a SandboxCapability describing whether sandbox isolation is
     available. If unsupported, mode is NONE and callers should block
     the SANDBOX_FALLBACK path.
+
+    On Linux the priority is: bubblewrap > Landlock > NONE.
     """
     import sys
 
     if sys.platform == "darwin":
         return _probe_macos_seatbelt()
     elif sys.platform == "linux":
+        cap = _probe_linux_bubblewrap()
+        if cap.supported:
+            return cap
         return _probe_linux_landlock()
     elif sys.platform == "win32":
         # Windows sandbox (WSL2 + Landlock) is currently disabled because the

--- a/src/qwenpaw/sandbox/config.py
+++ b/src/qwenpaw/sandbox/config.py
@@ -30,6 +30,8 @@ Typical usage:
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -275,8 +277,6 @@ def _probe_linux_landlock() -> (
 
 def _probe_macos_seatbelt() -> SandboxCapability:
     """Probe macOS Seatbelt (sandbox-exec) support."""
-    import shutil
-
     if shutil.which("sandbox-exec"):
         return SandboxCapability(
             supported=True,
@@ -350,9 +350,6 @@ def _probe_linux_bubblewrap() -> SandboxCapability:
         1. bwrap binary exists on PATH
         2. User namespaces work (test run with --unshare-user)
     """
-    import shutil
-    import subprocess
-
     bwrap = shutil.which("bwrap")
     if not bwrap:
         return SandboxCapability(

--- a/src/qwenpaw/sandbox/config.py
+++ b/src/qwenpaw/sandbox/config.py
@@ -1,5 +1,32 @@
 # -*- coding: utf-8 -*-
-"""Sandbox configuration and result types."""
+"""Sandbox — configuration, capability probing, and factory (entry point).
+
+This is the natural entry point into the :mod:`qwenpaw.sandbox` package:
+it defines the constraint vocabulary (modes, mounts, ports), probes what
+the current platform actually supports, and ships the factory that maps a
+``SandboxConfig`` to a concrete backend.
+
+Backend layout (``create_sandbox`` dispatches to these by ``SandboxMode``):
+  - SEATBELT   → :mod:`qwenpaw.sandbox.macos_sandbox`      (MacOSSandbox)
+  - BUBBLEWRAP → :mod:`qwenpaw.sandbox.bubblewrap_sandbox` (BubblewrapSandbox)
+  - LANDLOCK   → :mod:`qwenpaw.sandbox.linux_sandbox`      (LinuxSandbox)
+  - WSL2       → :mod:`qwenpaw.sandbox.windows_sandbox`    (WindowsSandbox)
+  - NONE       → :mod:`qwenpaw.sandbox.local_sandbox`      (NoneSandbox)
+
+Shared base class for all backends:
+  - :class:`qwenpaw.sandbox.local_sandbox.LocalSandbox`
+
+Typical usage:
+    from .sandbox import create_sandbox, SandboxConfig, SandboxMode, MountSpec
+    config = SandboxConfig(
+        mode=SandboxMode.BUBBLEWRAP,
+        workspace_dir="/path/to/project",
+        mounts=[MountSpec(path="/path/to/project", writable=True)],
+    )
+    async with create_sandbox(config) as sandbox:
+        result = await sandbox.execute("echo hello")
+        print(result.stdout)
+"""
 
 from __future__ import annotations
 
@@ -429,3 +456,44 @@ def detect_platform_mode() -> SandboxMode:
     """
     cap = probe_sandbox_support()
     return cap.mode
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Factory
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def create_sandbox(config: SandboxConfig) -> Any:
+    """Create a sandbox instance based on ``config.mode``.
+
+    Supported modes:
+      - SEATBELT    → MacOSSandbox
+      - BUBBLEWRAP  → BubblewrapSandbox (Linux preferred)
+      - LANDLOCK    → LinuxSandbox (Linux fallback)
+      - NONE        → NoneSandbox
+      - WSL2        → WindowsSandbox (currently disabled at probe time;
+                     Re-enable in ``probe_sandbox_support`` when the
+                     Windows sandbox path is production-ready.)
+    """
+    if config.mode == SandboxMode.SEATBELT:
+        from .macos_sandbox import MacOSSandbox
+
+        return MacOSSandbox(config)
+    elif config.mode == SandboxMode.NONE:
+        from .local_sandbox import NoneSandbox
+
+        return NoneSandbox(config)
+    elif config.mode == SandboxMode.BUBBLEWRAP:
+        from .bubblewrap_sandbox import BubblewrapSandbox
+
+        return BubblewrapSandbox(config)
+    elif config.mode == SandboxMode.LANDLOCK:
+        from .linux_sandbox import LinuxSandbox
+
+        return LinuxSandbox(config)
+    elif config.mode == SandboxMode.WSL2:
+        from .windows_sandbox import WindowsSandbox
+
+        return WindowsSandbox(config)
+    else:
+        raise ValueError(f"Unknown sandbox mode: {config.mode}")

--- a/src/qwenpaw/sandbox/local_sandbox.py
+++ b/src/qwenpaw/sandbox/local_sandbox.py
@@ -464,17 +464,22 @@ def create_sandbox(config: SandboxConfig) -> Any:
     """Create a sandbox instance based on ``config.mode``.
 
     Supported modes:
-      - SEATBELT → MacOSSandbox
-      - LANDLOCK → LinuxSandbox
-      - NONE     → NoneSandbox
-      - WSL2     → WindowsSandbox (currently disabled at probe time;
-                   Re-enable in ``probe_sandbox_support`` when the
-                   Windows sandbox path is production-ready.)
+      - SEATBELT    → MacOSSandbox
+      - BUBBLEWRAP  → BubblewrapSandbox (Linux preferred)
+      - LANDLOCK    → LinuxSandbox (Linux fallback)
+      - NONE        → NoneSandbox
+      - WSL2        → WindowsSandbox (currently disabled at probe time;
+                     Re-enable in ``probe_sandbox_support`` when the
+                     Windows sandbox path is production-ready.)
     """
     if config.mode == SandboxMode.SEATBELT:
         return MacOSSandbox(config)
     elif config.mode == SandboxMode.NONE:
         return NoneSandbox(config)
+    elif config.mode == SandboxMode.BUBBLEWRAP:
+        from .bubblewrap_sandbox import BubblewrapSandbox
+
+        return BubblewrapSandbox(config)
     elif config.mode == SandboxMode.LANDLOCK:
         from .linux_sandbox import LinuxSandbox
 

--- a/src/qwenpaw/sandbox/local_sandbox.py
+++ b/src/qwenpaw/sandbox/local_sandbox.py
@@ -1,25 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Local sandbox — macOS Seatbelt + None mode.
+"""Local sandbox — abstract base + None passthrough.
 
-Only two modes are implemented:
-  - SEATBELT: macOS sandbox-exec kernel isolation
-  - NONE: passthrough, no isolation (trusted scenarios)
-
-Usage:
-    from qwenpaw.sandbox import (
-        create_sandbox, SandboxConfig, SandboxMode, MountSpec,
-    )
-
-    config = SandboxConfig(
-        mode=SandboxMode.SEATBELT,
-        workspace_dir="/path/to/project",
-        mounts=[MountSpec(path="/path/to/project", writable=True)],
-        network_allow=["*"],
-    )
-    sandbox = create_sandbox(config)
-    result = await sandbox.execute("ls -la")
-    print(result.stdout)
-    await sandbox.stop()
+Implementation layer for the sandbox package. Hosts the shared
+:class:`LocalSandbox` ABC that every platform backend subclasses, plus the
+:class:`NoneSandbox` passthrough used for trusted / no-isolation execution.
 """
 
 from __future__ import annotations
@@ -27,16 +11,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import re
 import signal
 import time
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Optional
 
 from .config import (
     ExecutionResult,
     SandboxConfig,
-    SandboxMode,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,27 +27,6 @@ logger = logging.getLogger(__name__)
 # ═══════════════════════════════════════════════════════════════════════════════
 # Abstract base
 # ═══════════════════════════════════════════════════════════════════════════════
-
-
-# Seatbelt violation patterns. Substring matching against generic words
-# like ``"deny"`` or ``"sandbox"`` is far too lossy — application logs
-# routinely contain those tokens and would be mis-flagged as sandbox
-# violations. Match the actual diagnostic shapes emitted by
-# ``sandbox-exec`` / the Seatbelt kernel:
-#   - ``deny(1) file-read-data ...``  / ``deny(1) network-outbound ...``
-#   - ``Sandbox: <bin>(<pid>) deny(1) ...``
-#   - ``sandbox-exec: <error message>``
-#   - ``Operation not permitted`` (full phrase, case-insensitive)
-# TODO: this remains a heuristic. A robust solution would be to read
-#   structured violation events via Endpoint Security or an audit log
-#   stream rather than scraping stderr.
-_SEATBELT_VIOLATION_RE = re.compile(
-    r"\bdeny\(\d+\)"  # `deny(1)`, `deny(2)` ...
-    r"|^Sandbox:\s"  # macOS kernel violation line prefix
-    r"|^sandbox-exec:\s"  # sandbox-exec error prefix
-    r"|\bOperation not permitted\b",
-    re.IGNORECASE | re.MULTILINE,
-)
 
 
 class LocalSandbox(ABC):
@@ -100,289 +61,6 @@ class LocalSandbox(ABC):
 
     async def __aexit__(self, exc_type, exc, tb):
         await self.stop()
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# macOS — Seatbelt / sandbox-exec
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-class MacOSSandbox(LocalSandbox):
-    """macOS sandbox using sandbox-exec (Seatbelt profiles).
-
-    deny-default whitelist model:
-      - Basic system paths are read-only (/System, /usr/lib, /usr/share,
-        /Library, /dev)
-      - workspace_dir is read-write
-      - Paths declared in mounts are ro/rw based on ``writable``
-      - Network access is governed by ``network_allow``
-      - Sensitive paths such as ~/.ssh are explicitly denied
-    """
-
-    @staticmethod
-    def _sanitize_seatbelt_path(path: str) -> str:
-        """Sanitize a filesystem path for safe embedding in a Seatbelt profile.
-
-        Prevents Seatbelt rule injection by escaping characters that could
-        break out of the S-expression string literal (double-quote,
-        backslash, newlines, and parentheses).
-
-        Raises:
-            ValueError: if the path contains control characters other than
-                common whitespace (tab).
-        """
-        # Reject newlines — no valid filesystem path contains them and they
-        # can break the profile grammar.
-        if "\n" in path or "\r" in path:
-            raise ValueError(
-                "Seatbelt path contains newlines "
-                f"(possible injection): {path!r}",
-            )
-        # Escape backslash first (order matters), then double-quote.
-        path = path.replace("\\", "\\\\")
-        path = path.replace('"', '\\"')
-        return path
-
-    def _compile_seatbelt_profile(  # noqa: E501  pylint: disable=too-many-branches,too-many-statements
-        self,
-    ) -> str:
-        """Build the Seatbelt .sb policy string."""
-        config = self._config
-        _san = self._sanitize_seatbelt_path  # shorthand
-        lines = [
-            "(version 1)",
-            "",
-            "(deny default)",
-            "",
-            "; Basic system operations",
-            "(allow process-exec*)",
-            "(allow process-fork)",
-            "(allow signal)",
-            "(allow sysctl-read)",
-            "",
-            "; System file access (readonly)",
-            "(allow file-read*",
-            '  (subpath "/System")',
-            '  (subpath "/usr/lib")',
-            '  (subpath "/usr/share")',
-            '  (subpath "/Library")',
-            '  (subpath "/private/var/db/timezone")',
-            '  (literal "/dev/null")',
-            '  (literal "/dev/zero")',
-            '  (literal "/dev/random")',
-            '  (literal "/dev/urandom")',
-            '  (literal "/dev/tty")',
-            '  (literal "/dev/dtracehelper")',
-            ")",
-            "",
-            "; Mach operations",
-            "(allow mach-lookup)",
-            "(allow ipc-posix-shm)",
-            "",
-            "; Sysctl operations",
-            "(allow sysctl-read",
-            '  (sysctl-name-prefix "hw.")',
-            '  (sysctl-name-prefix "kern.")',
-            '  (sysctl-name-prefix "machdep.cpu.")',
-            ")",
-        ]
-
-        # Network
-        lines.append("")
-        lines.append("; Network")
-        if config.network_allow and ("*" in config.network_allow):
-            lines.append(
-                "; WARNING: Domain-level filtering not implemented",
-            )
-            domains = [d for d in config.network_allow if d != "*"]
-            if domains:
-                lines.append(
-                    "; The following domains are in allowedDomains "
-                    "but not enforced:",
-                )
-                for d in domains:
-                    lines.append(f";   - {d}")
-            lines.append("; All network access is allowed")
-            lines.append("(allow network*)")
-        elif config.network_allow:
-            lines.append(
-                "; Partial network (domain filtering not enforceable)",
-            )
-            lines.append("(allow network*)")
-        else:
-            lines.append("(deny network*)")
-
-        # File read paths
-        lines.append("")
-        lines.append("; File read")
-        if config.allow_read_all:
-            # deny-list mode: allow reading everything, then deny
-            # specific paths
-            lines.append("(allow file-read*)")
-        else:
-            # allow-list mode: only allow reading declared mounts
-            for mount in config.mounts:
-                lines.append("(allow file-read*")
-                lines.append(f'  (subpath "{_san(mount.path)}"))')
-
-        # Deny sensitive paths (read + write)
-        if config.deny_paths:
-            lines.append("")
-            lines.append("; Denied sensitive paths")
-            for p in config.deny_paths:
-                expanded = _san(os.path.expanduser(p))
-                lines.append("(deny file-read*")
-                lines.append(f'  (subpath "{expanded}"))')
-                lines.append("(deny file-write*")
-                lines.append(f'  (subpath "{expanded}"))')
-
-        # File write paths (whitelist)
-        lines.append("")
-        lines.append("; File write")
-        # Always allow /dev/null, /dev/zero, /dev/tty, /tmp
-        write_always = [
-            "/dev/null",
-            "/dev/zero",
-            "/dev/tty",
-            "/tmp",
-            "/private/tmp",
-        ]
-        for p in write_always:
-            lines.append("(allow file-write*")
-            lines.append(f'  (subpath "{p}"))')
-
-        # Workspace and explicit mounts
-        for mount in config.mounts:
-            if mount.writable:
-                lines.append("(allow file-write*")
-                lines.append(f'  (subpath "{_san(mount.path)}"))')
-
-        # Executable control
-        non_exec_mounts = [m for m in config.mounts if not m.executable]
-        if non_exec_mounts:
-            lines.append("")
-            lines.append("; Deny execution in specific paths")
-            for mount in non_exec_mounts:
-                lines.append("(deny process-exec*")
-                lines.append(f'  (subpath "{_san(mount.path)}")')
-
-        # Platform hints: extra seatbelt rules
-        # WARNING: seatbelt_extra_rules is an ADMIN-ONLY escape hatch.
-        # Content is embedded verbatim — it MUST NOT come from user input
-        # or untrusted approval flows.
-        extra_rules = config.platform_hints.get("seatbelt_extra_rules")
-        if extra_rules:
-            if "\n" in str(extra_rules):
-                logger.warning(
-                    "MacOSSandbox: seatbelt_extra_rules contains newlines; "
-                    "verify this is from a trusted admin source.",
-                )
-            lines.append("")
-            lines.append(
-                "; Platform hints: extra rules (admin-only, verbatim)",
-            )
-            lines.append(str(extra_rules))
-
-        # Log warnings for unsupported features on macOS
-        if config.max_processes is not None:
-            logger.warning(
-                "MacOSSandbox: max_processes=%d is not supported by "
-                "Seatbelt; ignoring.",
-                config.max_processes,
-            )
-        if config.max_memory_mb is not None:
-            logger.warning(
-                "MacOSSandbox: max_memory_mb=%d is not supported by "
-                "Seatbelt; ignoring.",
-                config.max_memory_mb,
-            )
-        if config.network_ports:
-            logger.warning(
-                "MacOSSandbox: network_ports (port-level filtering) is not "
-                "supported by Seatbelt; ignoring.",
-            )
-
-        return "\n".join(lines)
-
-    async def execute(
-        self,
-        cmd: str,
-        cwd: Optional[str] = None,
-    ) -> ExecutionResult:
-        """Execute via ``sandbox-exec -p '<profile>' /bin/bash -c '<cmd>'``."""
-        profile = self._compile_seatbelt_profile()
-        cwd = cwd or self._config.workspace_dir
-
-        # Find shell
-        shell = os.environ.get("SHELL", "/bin/bash")
-        if not os.path.exists(shell):
-            shell = "/bin/bash"
-
-        # Build subprocess env: inherit + apply env_vars (overrides)
-        env = dict(os.environ)
-        if self._config.env_vars:
-            env.update(self._config.env_vars)
-
-        start = time.monotonic()
-        try:
-            self._process = await asyncio.create_subprocess_exec(
-                "sandbox-exec",
-                "-p",
-                profile,
-                shell,
-                "-c",
-                cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-                start_new_session=True,
-            )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                self._process.communicate(),
-                timeout=self._config.timeout_seconds,
-            )
-            duration_ms = int((time.monotonic() - start) * 1000)
-            stdout = stdout_bytes.decode("utf-8", errors="replace")
-            stderr = stderr_bytes.decode("utf-8", errors="replace")
-
-            # Detect sandbox violation from stderr.
-            # Use precise regex against Seatbelt's actual diagnostic
-            # shapes so legitimate application output containing
-            # tokens like "deny" or "sandbox" is not mis-flagged.
-            violation = None
-            if (
-                self._process.returncode != 0
-                and _SEATBELT_VIOLATION_RE.search(stderr)
-            ):
-                violation = stderr.strip()
-
-            return ExecutionResult(
-                exit_code=self._process.returncode or 0,
-                stdout=stdout,
-                stderr=stderr,
-                timed_out=False,
-                duration_ms=duration_ms,
-                sandbox_violation=violation,
-            )
-        except asyncio.TimeoutError:
-            duration_ms = int((time.monotonic() - start) * 1000)
-            await self.stop()
-            return ExecutionResult(
-                exit_code=-1,
-                stdout="",
-                stderr="Command timed out",
-                timed_out=True,
-                duration_ms=duration_ms,
-            )
-        except Exception as e:
-            duration_ms = int((time.monotonic() - start) * 1000)
-            return ExecutionResult(
-                exit_code=-1,
-                stdout="",
-                stderr=str(e),
-                duration_ms=duration_ms,
-            )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -453,40 +131,3 @@ class NoneSandbox(LocalSandbox):
                 stderr=str(e),
                 duration_ms=duration_ms,
             )
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Factory
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-def create_sandbox(config: SandboxConfig) -> Any:
-    """Create a sandbox instance based on ``config.mode``.
-
-    Supported modes:
-      - SEATBELT    → MacOSSandbox
-      - BUBBLEWRAP  → BubblewrapSandbox (Linux preferred)
-      - LANDLOCK    → LinuxSandbox (Linux fallback)
-      - NONE        → NoneSandbox
-      - WSL2        → WindowsSandbox (currently disabled at probe time;
-                     Re-enable in ``probe_sandbox_support`` when the
-                     Windows sandbox path is production-ready.)
-    """
-    if config.mode == SandboxMode.SEATBELT:
-        return MacOSSandbox(config)
-    elif config.mode == SandboxMode.NONE:
-        return NoneSandbox(config)
-    elif config.mode == SandboxMode.BUBBLEWRAP:
-        from .bubblewrap_sandbox import BubblewrapSandbox
-
-        return BubblewrapSandbox(config)
-    elif config.mode == SandboxMode.LANDLOCK:
-        from .linux_sandbox import LinuxSandbox
-
-        return LinuxSandbox(config)
-    elif config.mode == SandboxMode.WSL2:
-        from .windows_sandbox import WindowsSandbox
-
-        return WindowsSandbox(config)
-    else:
-        raise ValueError(f"Unknown sandbox mode: {config.mode}")

--- a/src/qwenpaw/sandbox/macos_sandbox.py
+++ b/src/qwenpaw/sandbox/macos_sandbox.py
@@ -1,0 +1,328 @@
+# -*- coding: utf-8 -*-
+"""macOS Seatbelt sandbox implementation.
+
+Uses ``sandbox-exec`` (the Seatbelt profile language) to construct a
+deny-default filesystem + network policy for command isolation.
+
+Architecture:
+    - Parent process compiles a Seatbelt ``.sb`` profile from
+      ``SandboxConfig``.
+    - ``sandbox-exec -p '<profile>' <shell> -c '<cmd>'`` enforces the
+      policy in-kernel while exec'ing the user command.
+    - The parent waits for completion and captures stdout/stderr.
+
+Reference:
+    https://developer.apple.com/library/archive/documentation/Security/Conceptual/SeatBeltBook/SeatBeltBook.html
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from typing import Optional
+
+from .config import ExecutionResult
+from .local_sandbox import LocalSandbox
+
+logger = logging.getLogger(__name__)
+
+# Seatbelt violation patterns. Substring matching against generic words
+# like ``"deny"`` or ``"sandbox"`` is far too lossy — application logs
+# routinely contain those tokens and would be mis-flagged as sandbox
+# violations. Match the actual diagnostic shapes emitted by
+# ``sandbox-exec`` / the Seatbelt kernel:
+#   - ``deny(1) file-read-data ...``  / ``deny(1) network-outbound ...``
+#   - ``Sandbox: <bin>(<pid>) deny(1) ...``
+#   - ``sandbox-exec: <error message>``
+#   - ``Operation not permitted`` (full phrase, case-insensitive)
+# TODO: this remains a heuristic. A robust solution would be to read
+#   structured violation events via Endpoint Security or an audit log
+#   stream rather than scraping stderr.
+_SEATBELT_VIOLATION_RE = re.compile(
+    r"\bdeny\(\d+\)"  # `deny(1)`, `deny(2)` ...
+    r"|^Sandbox:\s"  # macOS kernel violation line prefix
+    r"|^sandbox-exec:\s"  # sandbox-exec error prefix
+    r"|\bOperation not permitted\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class MacOSSandbox(LocalSandbox):
+    """macOS sandbox using sandbox-exec (Seatbelt profiles).
+
+    deny-default whitelist model:
+      - Basic system paths are read-only (/System, /usr/lib, /usr/share,
+        /Library, /dev)
+      - workspace_dir is read-write
+      - Paths declared in mounts are ro/rw based on ``writable``
+      - Network access is governed by ``network_allow``
+      - Sensitive paths such as ~/.ssh are explicitly denied
+    """
+
+    @staticmethod
+    def _sanitize_seatbelt_path(path: str) -> str:
+        """Sanitize a filesystem path for safe embedding in a Seatbelt profile.
+
+        Prevents Seatbelt rule injection by escaping characters that could
+        break out of the S-expression string literal (double-quote,
+        backslash, newlines, and parentheses).
+
+        Raises:
+            ValueError: if the path contains control characters other than
+                common whitespace (tab).
+        """
+        # Reject newlines — no valid filesystem path contains them and they
+        # can break the profile grammar.
+        if "\n" in path or "\r" in path:
+            raise ValueError(
+                "Seatbelt path contains newlines "
+                f"(possible injection): {path!r}",
+            )
+        # Escape backslash first (order matters), then double-quote.
+        path = path.replace("\\", "\\\\")
+        path = path.replace('"', '\\"')
+        return path
+
+    def _compile_seatbelt_profile(  # noqa: E501  pylint: disable=too-many-branches,too-many-statements
+        self,
+    ) -> str:
+        """Build the Seatbelt .sb policy string."""
+        config = self._config
+        _san = self._sanitize_seatbelt_path  # shorthand
+        lines = [
+            "(version 1)",
+            "",
+            "(deny default)",
+            "",
+            "; Basic system operations",
+            "(allow process-exec*)",
+            "(allow process-fork)",
+            "(allow signal)",
+            "(allow sysctl-read)",
+            "",
+            "; System file access (readonly)",
+            "(allow file-read*",
+            '  (subpath "/System")',
+            '  (subpath "/usr/lib")',
+            '  (subpath "/usr/share")',
+            '  (subpath "/Library")',
+            '  (subpath "/private/var/db/timezone")',
+            '  (literal "/dev/null")',
+            '  (literal "/dev/zero")',
+            '  (literal "/dev/random")',
+            '  (literal "/dev/urandom")',
+            '  (literal "/dev/tty")',
+            '  (literal "/dev/dtracehelper")',
+            ")",
+            "",
+            "; Mach operations",
+            "(allow mach-lookup)",
+            "(allow ipc-posix-shm)",
+            "",
+            "; Sysctl operations",
+            "(allow sysctl-read",
+            '  (sysctl-name-prefix "hw.")',
+            '  (sysctl-name-prefix "kern.")',
+            '  (sysctl-name-prefix "machdep.cpu.")',
+            ")",
+        ]
+
+        # Network
+        lines.append("")
+        lines.append("; Network")
+        if config.network_allow and ("*" in config.network_allow):
+            lines.append(
+                "; WARNING: Domain-level filtering not implemented",
+            )
+            domains = [d for d in config.network_allow if d != "*"]
+            if domains:
+                lines.append(
+                    "; The following domains are in allowedDomains "
+                    "but not enforced:",
+                )
+                for d in domains:
+                    lines.append(f";   - {d}")
+            lines.append("; All network access is allowed")
+            lines.append("(allow network*)")
+        elif config.network_allow:
+            lines.append(
+                "; Partial network (domain filtering not enforceable)",
+            )
+            lines.append("(allow network*)")
+        else:
+            lines.append("(deny network*)")
+
+        # File read paths
+        lines.append("")
+        lines.append("; File read")
+        if config.allow_read_all:
+            # deny-list mode: allow reading everything, then deny
+            # specific paths
+            lines.append("(allow file-read*)")
+        else:
+            # allow-list mode: only allow reading declared mounts
+            for mount in config.mounts:
+                lines.append("(allow file-read*")
+                lines.append(f'  (subpath "{_san(mount.path)}")')
+
+        # Deny sensitive paths (read + write)
+        if config.deny_paths:
+            lines.append("")
+            lines.append("; Denied sensitive paths")
+            for p in config.deny_paths:
+                expanded = _san(os.path.expanduser(p))
+                lines.append("(deny file-read*")
+                lines.append(f'  (subpath "{expanded}")')
+                lines.append("(deny file-write*")
+                lines.append(f'  (subpath "{expanded}")')
+
+        # File write paths (whitelist)
+        lines.append("")
+        lines.append("; File write")
+        # Always allow /dev/null, /dev/zero, /dev/tty, /tmp
+        write_always = [
+            "/dev/null",
+            "/dev/zero",
+            "/dev/tty",
+            "/tmp",
+            "/private/tmp",
+        ]
+        for p in write_always:
+            lines.append("(allow file-write*")
+            lines.append(f'  (subpath "{p}"))')
+
+        # Workspace and explicit mounts
+        for mount in config.mounts:
+            if mount.writable:
+                lines.append("(allow file-write*")
+                lines.append(f'  (subpath "{_san(mount.path)}")')
+
+        # Executable control
+        non_exec_mounts = [m for m in config.mounts if not m.executable]
+        if non_exec_mounts:
+            lines.append("")
+            lines.append("; Deny execution in specific paths")
+            for mount in non_exec_mounts:
+                lines.append("(deny process-exec*")
+                lines.append(f'  (subpath "{_san(mount.path)}")')
+
+        # Platform hints: extra seatbelt rules
+        # WARNING: seatbelt_extra_rules is an ADMIN-ONLY escape hatch.
+        # Content is embedded verbatim — it MUST NOT come from user input
+        # or untrusted approval flows.
+        extra_rules = config.platform_hints.get("seatbelt_extra_rules")
+        if extra_rules:
+            if "\n" in str(extra_rules):
+                logger.warning(
+                    "MacOSSandbox: seatbelt_extra_rules contains newlines; "
+                    "verify this is from a trusted admin source.",
+                )
+            lines.append("")
+            lines.append(
+                "; Platform hints: extra rules (admin-only, verbatim)",
+            )
+            lines.append(str(extra_rules))
+
+        # Log warnings for unsupported features on macOS
+        if config.max_processes is not None:
+            logger.warning(
+                "MacOSSandbox: max_processes=%d is not supported by "
+                "Seatbelt; ignoring.",
+                config.max_processes,
+            )
+        if config.max_memory_mb is not None:
+            logger.warning(
+                "MacOSSandbox: max_memory_mb=%d is not supported by "
+                "Seatbelt; ignoring.",
+                config.max_memory_mb,
+            )
+        if config.network_ports:
+            logger.warning(
+                "MacOSSandbox: network_ports (port-level filtering) is not "
+                "supported by Seatbelt; ignoring.",
+            )
+
+        return "\n".join(lines)
+
+    async def execute(
+        self,
+        cmd: str,
+        cwd: Optional[str] = None,
+    ) -> ExecutionResult:
+        """Execute via ``sandbox-exec -p '<profile>' /bin/bash -c '<cmd>'``."""
+        profile = self._compile_seatbelt_profile()
+        cwd = cwd or self._config.workspace_dir
+
+        # Find shell
+        shell = os.environ.get("SHELL", "/bin/bash")
+        if not os.path.exists(shell):
+            shell = "/bin/bash"
+
+        # Build subprocess env: inherit + apply env_vars (overrides)
+        env = dict(os.environ)
+        if self._config.env_vars:
+            env.update(self._config.env_vars)
+
+        start = time.monotonic()
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                "sandbox-exec",
+                "-p",
+                profile,
+                shell,
+                "-c",
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+                start_new_session=True,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                self._process.communicate(),
+                timeout=self._config.timeout_seconds,
+            )
+            duration_ms = int((time.monotonic() - start) * 1000)
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+            # Detect sandbox violation from stderr.
+            # Use precise regex against Seatbelt's actual diagnostic
+            # shapes so legitimate application output containing
+            # tokens like "deny" or "sandbox" is not mis-flagged.
+            violation = None
+            if (
+                self._process.returncode != 0
+                and _SEATBELT_VIOLATION_RE.search(stderr)
+            ):
+                violation = stderr.strip()
+
+            return ExecutionResult(
+                exit_code=self._process.returncode or 0,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=False,
+                duration_ms=duration_ms,
+                sandbox_violation=violation,
+            )
+        except asyncio.TimeoutError:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            await self.stop()
+            return ExecutionResult(
+                exit_code=-1,
+                stdout="",
+                stderr="Command timed out",
+                timed_out=True,
+                duration_ms=duration_ms,
+            )
+        except Exception as e:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            return ExecutionResult(
+                exit_code=-1,
+                stdout="",
+                stderr=str(e),
+                duration_ms=duration_ms,
+            )

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -344,6 +344,12 @@ class TestGovernancePolicyEvaluate:
         decision = policy.evaluate(tc)
         assert decision.action == GovernanceAction.ASK
 
+    def test_write_tmp_file_allow(self, policy):
+        """Writing a file directly under /tmp should be ALLOW."""
+        tc = _tc("Write", "/tmp/a.txt")
+        decision = policy.evaluate(tc)
+        assert decision.action == GovernanceAction.ALLOW
+
 
 # ---------------------------------------------------------------------------
 # Test: ResourceGovernor assert_policy with sandbox fallback escalation

--- a/tests/unit/sandbox/test_bubblewrap_sandbox.py
+++ b/tests/unit/sandbox/test_bubblewrap_sandbox.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
+"""Unit tests for Linux bubblewrap sandbox."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qwenpaw.sandbox import (
+    MountSpec,
+    SandboxCapability,
+    SandboxConfig,
+    SandboxMode,
+    create_sandbox,
+)
+from qwenpaw.sandbox.bubblewrap_sandbox import (
+    BubblewrapSandbox,
+    _BWRAP_VIOLATION_RE,
+)
+from qwenpaw.sandbox.config import _probe_linux_bubblewrap
+
+
+# ============================================================================
+# _build_bwrap_args() — parameter generation
+# ============================================================================
+
+
+class TestBuildBwrapArgs:
+    """Test bwrap command-line argument generation."""
+
+    def _make_sandbox(self, **kwargs) -> BubblewrapSandbox:
+        defaults = {
+            "mode": SandboxMode.BUBBLEWRAP,
+            "workspace_dir": "/tmp/ws",
+        }
+        defaults.update(kwargs)
+        config = SandboxConfig(**defaults)
+        return BubblewrapSandbox(config)
+
+    def test_allow_read_all_generates_ro_bind_root(self):
+        sb = self._make_sandbox(allow_read_all=True)
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        assert "--ro-bind" in args
+        # Verify the root bind: --ro-bind / /
+        idx = args.index("--ro-bind")
+        assert args[idx + 1] == "/"
+        assert args[idx + 2] == "/"
+
+    def test_allow_read_all_false_generates_tmpfs_root(self):
+        sb = self._make_sandbox(allow_read_all=False)
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        # First filesystem arg should be --tmpfs /
+        idx = args.index("--tmpfs")
+        assert args[idx + 1] == "/"
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isdir", return_value=True)
+    def test_deny_paths_generate_tmpfs_for_dirs(self, mock_isdir, mock_exists):
+        sb = self._make_sandbox(deny_paths=["/home/user/.ssh"])
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        # Find --tmpfs for the deny_path
+        tmpfs_indices = [i for i, x in enumerate(args) if x == "--tmpfs"]
+        deny_found = any(
+            args[i + 1] == "/home/user/.ssh" for i in tmpfs_indices
+        )
+        assert deny_found, f"deny_path not masked with --tmpfs, args={args}"
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isdir", return_value=False)
+    def test_deny_paths_generate_ro_bind_devnull_for_files(
+        self,
+        mock_isdir,
+        mock_exists,
+    ):
+        sb = self._make_sandbox(deny_paths=["/etc/secret.conf"])
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        # Should bind /dev/null over the file
+        for i, x in enumerate(args):
+            if x == "--ro-bind" and i + 2 < len(args):
+                if args[i + 2] == "/etc/secret.conf":
+                    assert args[i + 1] == "/dev/null"
+                    break
+        else:
+            pytest.fail(
+                f"deny_path file not masked with /dev/null, args={args}",
+            )
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isdir", return_value=True)
+    def test_writable_mount_generates_bind(self, mock_isdir, mock_exists):
+        sb = self._make_sandbox(
+            mounts=[MountSpec(path="/workspace/project", writable=True)],
+        )
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        # Find --bind for writable mount
+        bind_indices = [i for i, x in enumerate(args) if x == "--bind"]
+        writable_found = any(
+            args[i + 1] == "/workspace/project" for i in bind_indices
+        )
+        assert writable_found, f"writable mount not found, args={args}"
+
+    def test_dev_always_present(self):
+        sb = self._make_sandbox()
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        assert "--dev" in args
+        idx = args.index("--dev")
+        assert args[idx + 1] == "/dev"
+
+    def test_unshare_pid_and_user(self):
+        sb = self._make_sandbox()
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        assert "--unshare-user" in args
+        assert "--unshare-pid" in args
+
+    def test_proc_mount(self):
+        sb = self._make_sandbox()
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        assert "--proc" in args
+        idx = args.index("--proc")
+        assert args[idx + 1] == "/proc"
+
+    def test_command_at_end(self):
+        sb = self._make_sandbox()
+        args = sb._build_bwrap_args("echo hello", "/tmp/ws")
+        # Should end with: -- <shell> -c <cmd>
+        assert "--" in args
+        separator_idx = args.index("--")
+        # After -- there should be: shell, -c, cmd
+        remaining = args[separator_idx + 1 :]
+        assert remaining[-2] == "-c"
+        assert remaining[-1] == "echo hello"
+
+    @patch("os.path.isdir", return_value=True)
+    def test_chdir_when_cwd_valid(self, mock_isdir):
+        sb = self._make_sandbox()
+        args = sb._build_bwrap_args("ls", "/workspace")
+        assert "--chdir" in args
+        idx = args.index("--chdir")
+        assert args[idx + 1] == "/workspace"
+
+    def test_new_session_and_die_with_parent(self):
+        sb = self._make_sandbox()
+        args = sb._build_bwrap_args("echo hi", "/tmp/ws")
+        assert "--new-session" in args
+        assert "--die-with-parent" in args
+
+
+# ============================================================================
+# Violation detection regex
+# ============================================================================
+
+
+class TestBwrapViolationRegex:
+    """Test violation detection regex patterns."""
+
+    def test_permission_denied(self):
+        assert _BWRAP_VIOLATION_RE.search("Permission denied")
+
+    def test_bwrap_error_prefix(self):
+        assert _BWRAP_VIOLATION_RE.search("bwrap: No such file or directory")
+
+    def test_operation_not_permitted(self):
+        assert _BWRAP_VIOLATION_RE.search("Operation not permitted")
+
+    def test_eacces(self):
+        assert _BWRAP_VIOLATION_RE.search("open failed: EACCES")
+
+    def test_normal_output_no_match(self):
+        assert _BWRAP_VIOLATION_RE.search("hello world") is None
+
+    def test_partial_word_no_match(self):
+        # "Permission denied" should match as whole word boundary
+        assert _BWRAP_VIOLATION_RE.search("PermissionDenied") is None
+
+
+# ============================================================================
+# Probe logic
+# ============================================================================
+
+
+class TestProbeLinuxBubblewrap:
+    """Test _probe_linux_bubblewrap() probe function."""
+
+    @patch("shutil.which", return_value=None)
+    def test_bwrap_not_found(self, mock_which):
+        result = _probe_linux_bubblewrap()
+        assert result.supported is False
+        assert result.mode == SandboxMode.NONE
+        assert "not found" in result.reason
+
+    @patch("shutil.which", return_value="/usr/bin/bwrap")
+    @patch("subprocess.run")
+    def test_bwrap_probe_success(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(returncode=0)
+        result = _probe_linux_bubblewrap()
+        assert result.supported is True
+        assert result.mode == SandboxMode.BUBBLEWRAP
+        assert "bubblewrap available" in result.reason
+
+    @patch("shutil.which", return_value="/usr/bin/bwrap")
+    @patch("subprocess.run")
+    def test_bwrap_probe_fails_nonzero(self, mock_run, mock_which):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr=b"bwrap: No permissions for user namespace",
+        )
+        result = _probe_linux_bubblewrap()
+        assert result.supported is False
+        assert result.mode == SandboxMode.NONE
+
+    @patch("shutil.which", return_value="/usr/bin/bwrap")
+    @patch("subprocess.run", side_effect=OSError("exec failed"))
+    def test_bwrap_probe_oserror(self, mock_run, mock_which):
+        result = _probe_linux_bubblewrap()
+        assert result.supported is False
+        assert "error" in result.reason.lower()
+
+
+# ============================================================================
+# probe_sandbox_support — Linux routing (bwrap > landlock > none)
+# ============================================================================
+
+
+class TestProbeSandboxSupportLinuxBwrap:
+    """Test that probe_sandbox_support on Linux tries bwrap first."""
+
+    @patch("sys.platform", "linux")
+    @patch(
+        "qwenpaw.sandbox.config._probe_linux_bubblewrap",
+        return_value=SandboxCapability(
+            supported=True,
+            mode=SandboxMode.BUBBLEWRAP,
+            reason="bubblewrap available with user namespaces",
+        ),
+    )
+    @patch("qwenpaw.sandbox.config._probe_linux_landlock")
+    def test_bwrap_available_skips_landlock(
+        self,
+        mock_landlock,
+        mock_bwrap,
+    ):
+        from qwenpaw.sandbox import probe_sandbox_support
+
+        result = probe_sandbox_support()
+        assert result.mode == SandboxMode.BUBBLEWRAP
+        mock_landlock.assert_not_called()
+
+    @patch("sys.platform", "linux")
+    @patch(
+        "qwenpaw.sandbox.config._probe_linux_bubblewrap",
+        return_value=SandboxCapability(
+            supported=False,
+            mode=SandboxMode.NONE,
+            reason="bwrap not found on PATH",
+        ),
+    )
+    @patch(
+        "qwenpaw.sandbox.config._probe_linux_landlock",
+        return_value=SandboxCapability(
+            supported=True,
+            mode=SandboxMode.LANDLOCK,
+            reason="Kernel 6.5, Landlock ABI v4",
+            landlock_abi_version=4,
+        ),
+    )
+    def test_bwrap_unavailable_falls_to_landlock(
+        self,
+        mock_landlock,
+        mock_bwrap,
+    ):
+        from qwenpaw.sandbox import probe_sandbox_support
+
+        result = probe_sandbox_support()
+        assert result.mode == SandboxMode.LANDLOCK
+
+
+# ============================================================================
+# Factory — create_sandbox()
+# ============================================================================
+
+
+class TestCreateSandboxBubblewrap:
+    """Test create_sandbox returns BubblewrapSandbox for BUBBLEWRAP mode."""
+
+    def test_create_sandbox_bubblewrap(self):
+        config = SandboxConfig(
+            mode=SandboxMode.BUBBLEWRAP,
+            workspace_dir="/tmp/ws",
+        )
+        sb = create_sandbox(config)
+        assert isinstance(sb, BubblewrapSandbox)
+
+    def test_create_sandbox_unknown_mode_raises(self):
+        config = SandboxConfig(
+            mode=SandboxMode.BUBBLEWRAP,
+            workspace_dir="/tmp/ws",
+        )
+        # Temporarily force an invalid mode
+        config.mode = "bogus_mode"
+        with pytest.raises(ValueError, match="Unknown sandbox mode"):
+            create_sandbox(config)

--- a/tests/unit/sandbox/test_config.py
+++ b/tests/unit/sandbox/test_config.py
@@ -187,7 +187,7 @@ class TestUnsupportedFeaturesLogging:
                 max_processes=10,
             ),
         )
-        with patch("qwenpaw.sandbox.local_sandbox.logger") as mock_logger:
+        with patch("qwenpaw.sandbox.macos_sandbox.logger") as mock_logger:
             sandbox._compile_seatbelt_profile()
 
         assert mock_logger.warning.called
@@ -204,7 +204,7 @@ class TestUnsupportedFeaturesLogging:
                 max_memory_mb=512,
             ),
         )
-        with patch("qwenpaw.sandbox.local_sandbox.logger") as mock_logger:
+        with patch("qwenpaw.sandbox.macos_sandbox.logger") as mock_logger:
             sandbox._compile_seatbelt_profile()
 
         assert mock_logger.warning.called
@@ -221,7 +221,7 @@ class TestUnsupportedFeaturesLogging:
                 network_ports=[PortRule(port=443)],
             ),
         )
-        with patch("qwenpaw.sandbox.local_sandbox.logger") as mock_logger:
+        with patch("qwenpaw.sandbox.macos_sandbox.logger") as mock_logger:
             sandbox._compile_seatbelt_profile()
 
         assert mock_logger.warning.called
@@ -237,7 +237,7 @@ class TestUnsupportedFeaturesLogging:
                 mounts=[MountSpec(path="/tmp/ws", writable=True)],
             ),
         )
-        with patch("qwenpaw.sandbox.local_sandbox.logger") as mock_logger:
+        with patch("qwenpaw.sandbox.macos_sandbox.logger") as mock_logger:
             sandbox._compile_seatbelt_profile()
 
         mock_logger.warning.assert_not_called()

--- a/tests/unit/sandbox/test_config.py
+++ b/tests/unit/sandbox/test_config.py
@@ -12,7 +12,7 @@ from qwenpaw.sandbox import (
     SandboxConfig,
     SandboxMode,
 )
-from qwenpaw.sandbox.local_sandbox import MacOSSandbox
+from qwenpaw.sandbox.macos_sandbox import MacOSSandbox
 
 # ============================================================================
 # Task 5.1: test_sandbox_config_defaults

--- a/tests/unit/sandbox/test_linux_sandbox.py
+++ b/tests/unit/sandbox/test_linux_sandbox.py
@@ -35,9 +35,10 @@ class TestProbeSandboxSupport:
         assert result.mode == SandboxMode.SEATBELT
 
     @patch("sys.platform", "linux")
+    @patch("shutil.which", return_value=None)  # bwrap not found
     @patch("os.uname")
-    def test_linux_delegates_to_landlock(self, mock_uname):
-        # Will fail kernel check but that's fine — we just verify routing
+    def test_linux_delegates_to_landlock(self, mock_uname, mock_which):
+        # bwrap not found → falls through to Landlock → kernel too old
         mock_uname.return_value = MagicMock(release="4.0.0")
         result = probe_sandbox_support()
         # Should go through _probe_linux_landlock and fail on kernel version


### PR DESCRIPTION
## Description

Add bubblewrap (bwrap) as the preferred Linux sandbox backend, providing mount-namespace-based filesystem isolation that is stronger than Landlock alone:
- **deny_paths are truly invisible** — masked with `--tmpfs`, not "visible but access-denied"
- **Minimal /dev** — synthetic devtmpfs with only null, zero, urandom, tty
- **PID namespace isolation** — `--unshare-pid` limits process visibility
- **Automatic fallback** — probe tries bwrap first, falls back to Landlock if unavailable (e.g. Docker without user namespaces)

Also includes:
- Split MacOSSandbox into its own `macos_sandbox.py` module (per-platform file convention)
- Move `create_sandbox()` factory into `config.py` (type/probe/factory co-located)
- Governance logging now includes sandbox backend mode (`sandbox=bubblewrap/landlock/...`)
- Default ALLOW rule for `/tmp/**` scratch directory

**Related Issue:** Relates to sandbox hardening initiative

**Security Considerations:**
- Shell hardcoded to `/bin/sh` (no SHELL env var injection)
- Explicit `--uid 0 --gid 0` mapping for cross-distro user namespace safety
- Network isolation is NOT included in this version (documented limitation, planned follow-up with `--unshare-net`)
- Integration-tested on Linux 5.15 (Ubuntu) with real bwrap execution

## Type of Change

- [x] New feature
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- **Unit tests**: 79 sandbox tests pass (including 25 new bubblewrap tests covering `_build_bwrap_args`, violation regex, probe logic, factory dispatch)
- **Integration tests**: 8/8 pass on Linux 5.15 server with real bwrap (echo, deny_paths, writable mount, readonly root, PID isolation, timeout, restricted fs write)

## Local Verification Evidence

```bash
pre-commit run --all-files
# All passed (ast, yaml, trailing-comma, mypy, black, flake8, pylint, prettier)

pytest tests/unit/sandbox/ -q
# 79 passed, 2 warnings in 0.13s

# Remote Linux integration (ssh 121.41.21.21):
# 8/8 passed — basic echo, deny_paths, writable mount, readonly root,
# PID isolation, violation regex, timeout, restricted fs