### PR TITLE
feat(discord): add streaming responses via message edit and typing indicator

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -19,6 +19,7 @@ export interface DiscordConfig extends BaseChannelConfig {
   http_proxy: string;
   http_proxy_auth: string;
   accept_bot_messages?: boolean;
+  streaming_enabled?: boolean;
 }
 
 export interface DingTalkConfig extends BaseChannelConfig {

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1436,7 +1436,8 @@ export function ChannelDrawer({
           {(activeKey === "wecom" ||
             activeKey === "telegram" ||
             activeKey === "dingtalk" ||
-            activeKey === "feishu") && (
+            activeKey === "feishu" ||
+            activeKey === "discord") && (
             <Form.Item
               name="streaming_enabled"
               label={t("channels.streamingEnabled")}

--- a/src/qwenpaw/app/channels/discord_/channel.py
+++ b/src/qwenpaw/app/channels/discord_/channel.py
@@ -38,12 +38,15 @@ logger = logging.getLogger(__name__)
 # Regex that matches a code-fence opening/closing line (``` or ~~~).
 _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
 
+_STREAM_PLACEHOLDER = "..."
+
 
 class DiscordChannel(BaseChannel):
     channel = "discord"
     uses_manager_queue = True
     _DISCORD_MAX_LEN: int = 2000
     _MAX_CACHED_MESSAGE_IDS: int = 500
+    _STREAM_DELTA_MIN_INTERVAL_S: float = 1.0
 
     def __init__(
         self,
@@ -63,6 +66,7 @@ class DiscordChannel(BaseChannel):
         deny_message: str = "",
         require_mention: bool = False,
         accept_bot_messages: bool = False,
+        streaming_enabled: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
     ):
@@ -77,6 +81,7 @@ class DiscordChannel(BaseChannel):
             allow_from=allow_from,
             deny_message=deny_message,
             require_mention=require_mention,
+            streaming_enabled=streaming_enabled,
             access_control_dm=access_control_dm,
             access_control_group=access_control_group,
         )
@@ -94,6 +99,10 @@ class DiscordChannel(BaseChannel):
         # detection when thread creation and first message arrive
         # simultaneously.
         self._recent_thread_starts: dict[str, str] = {}
+        # Typing indicator tasks: channel_id (str) -> Task
+        self._typing_tasks: dict[str, asyncio.Task] = {}
+        # Track which to_handles are currently processing
+        self._is_processing: dict[str, bool] = {}
 
         if self.enabled:
             import discord  # type: ignore
@@ -354,9 +363,18 @@ class DiscordChannel(BaseChannel):
             group_policy=os.getenv("DISCORD_GROUP_POLICY", "open"),
             allow_from=allow_from,
             deny_message=os.getenv("DISCORD_DENY_MESSAGE", ""),
-            require_mention=os.getenv("DISCORD_REQUIRE_MENTION", "0") == "1",
+            require_mention=os.getenv(
+                "DISCORD_REQUIRE_MENTION",
+                "0",
+            )
+            == "1",
             accept_bot_messages=os.getenv(
                 "DISCORD_ACCEPT_BOT_MESSAGES",
+                "0",
+            )
+            == "1",
+            streaming_enabled=os.getenv(
+                "DISCORD_STREAMING_ENABLED",
                 "0",
             )
             == "1",
@@ -389,6 +407,7 @@ class DiscordChannel(BaseChannel):
             deny_message=config.deny_message or "",
             require_mention=config.require_mention,
             accept_bot_messages=config.accept_bot_messages,
+            streaming_enabled=config.streaming_enabled,
             access_control_dm=bool(
                 getattr(config, "access_control_dm", False),
             ),
@@ -679,6 +698,11 @@ class DiscordChannel(BaseChannel):
     async def stop(self) -> None:
         if not self.enabled:
             return
+        # Cancel all typing indicator tasks
+        for task in self._typing_tasks.values():
+            if task and not task.done():
+                task.cancel()
+        self._typing_tasks.clear()
         if self._task:
             self._task.cancel()
             try:
@@ -732,6 +756,246 @@ class DiscordChannel(BaseChannel):
 
     def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
         return session_id
+
+    # ------------------------------------------------------------------
+    # Typing indicator (discord.py context manager + hook lifecycle)
+    # ------------------------------------------------------------------
+
+    async def _typing_keepalive(self, channel_id: int) -> None:
+        """Keep typing indicator alive via async with ch.typing().
+
+        discord.py auto-refreshes typing inside the context manager.
+        Cancelling this task exits the context, stopping typing.
+        """
+        try:
+            ch = self._client.get_channel(channel_id)
+            if not ch:
+                return
+            async with ch.typing():
+                while self._client and self._client.is_ready():
+                    await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            pass
+
+    def _start_typing(self, channel_id: int) -> None:
+        """Start typing indicator (idempotent)."""
+        key = str(channel_id)
+        existing = self._typing_tasks.get(key)
+        if existing and not existing.done():
+            return
+        self._typing_tasks[key] = asyncio.create_task(
+            self._typing_keepalive(channel_id),
+        )
+
+    def _stop_typing(self, channel_id: int) -> None:
+        """Stop typing by cancelling the keepalive task."""
+        key = str(channel_id)
+        task = self._typing_tasks.pop(key, None)
+        if task and not task.done():
+            task.cancel()
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks (align with yuanbao pattern)
+    # ------------------------------------------------------------------
+
+    async def _before_consume_process(
+        self,
+        request: Any,
+    ) -> None:
+        """Start typing before agent processes the request."""
+        meta = getattr(request, "channel_meta", None) or {}
+        channel_id = meta.get("channel_id", "")
+        if channel_id:
+            to_handle = self.get_to_handle_from_request(request)
+            self._is_processing[to_handle] = True
+            try:
+                self._start_typing(int(channel_id))
+            except (ValueError, TypeError):
+                pass
+
+    async def _on_process_completed(
+        self,
+        request: Any,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Stop typing after all processing completes."""
+        self._is_processing.pop(to_handle, None)
+        channel_id = (send_meta or {}).get("channel_id", "")
+        if channel_id:
+            try:
+                self._stop_typing(int(channel_id))
+            except (ValueError, TypeError):
+                pass
+        await super()._on_process_completed(
+            request,
+            to_handle,
+            send_meta,
+        )
+
+    async def _on_consume_error(
+        self,
+        request: Any,
+        to_handle: str,
+        err_text: str,
+    ) -> None:
+        """Stop typing on error."""
+        self._is_processing.pop(to_handle, None)
+        meta = getattr(request, "channel_meta", None) or {}
+        channel_id = meta.get("channel_id", "")
+        if channel_id:
+            try:
+                self._stop_typing(int(channel_id))
+            except (ValueError, TypeError):
+                pass
+        await super()._on_consume_error(
+            request,
+            to_handle,
+            err_text,
+        )
+
+    # ------------------------------------------------------------------
+    # Streaming hooks (Post + Edit, aligned with Telegram)
+    # ------------------------------------------------------------------
+
+    def _get_discord_stream_state(
+        self,
+        send_meta: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Get or create per-request Discord streaming state."""
+        state = send_meta.get("_discord_stream")
+        if state is None:
+            state = {"message": None}
+            send_meta["_discord_stream"] = state
+        return state
+
+    def _build_stream_display_text(
+        self,
+        stream_type: str,
+        text: str,
+        send_meta: Dict[str, Any],
+    ) -> str:
+        """Build display text with bot_prefix and thinking emoji."""
+        prefix = send_meta.get("bot_prefix") or self.bot_prefix or ""
+        if stream_type == "reasoning" and text:
+            if prefix:
+                return f"{prefix}  💭 {text}"
+            return f"💭 {text}"
+        if prefix and text:
+            return f"{prefix}  {text}"
+        return text
+
+    def _resolve_discord_channel(
+        self,
+        send_meta: Dict[str, Any],
+    ) -> Any:
+        """Resolve Discord channel from send_meta['channel_id']."""
+        channel_id = send_meta.get("channel_id", "")
+        if not channel_id or not self._client:
+            return None
+        try:
+            return self._client.get_channel(int(channel_id))
+        except (ValueError, TypeError):
+            return None
+
+    async def on_streaming_start(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Send placeholder message and cache for streaming."""
+        if not self.streaming_enabled:
+            return
+        ch = self._resolve_discord_channel(send_meta)
+        if not ch:
+            return
+        state = self._get_discord_stream_state(send_meta)
+        placeholder = self._build_stream_display_text(
+            stream_type,
+            "...",
+            send_meta,
+        )
+        try:
+            msg = await ch.send(placeholder)
+            state["message"] = msg
+        except Exception:
+            logger.debug(
+                "discord: failed to send streaming placeholder",
+            )
+
+    async def on_streaming_delta(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Edit placeholder with accumulated text."""
+        state = send_meta.get("_discord_stream")
+        if not state:
+            return
+        msg = state.get("message")
+        if not msg:
+            return
+        display = self._build_stream_display_text(
+            stream_type,
+            accumulated_text,
+            send_meta,
+        )
+        # Show tail portion when exceeding Discord's message limit
+        if len(display) > self._DISCORD_MAX_LEN:
+            display = "..." + display[-(self._DISCORD_MAX_LEN - 4) :]
+        try:
+            await msg.edit(content=display)
+        except Exception:
+            logger.debug(
+                "discord: streaming delta edit failed",
+            )
+
+    async def on_streaming_end(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        """Final edit or fallback to chunked send."""
+        state = send_meta.pop("_discord_stream", None)
+        msg = state.get("message") if state else None
+        final_text = self._build_stream_display_text(
+            stream_type,
+            accumulated_text,
+            send_meta,
+        )
+
+        if not msg:
+            # Placeholder was never sent; fall back to normal send
+            if final_text:
+                await self.send(to_handle, final_text, send_meta)
+            return
+
+        if len(final_text) <= self._DISCORD_MAX_LEN:
+            try:
+                await msg.edit(content=final_text)
+            except Exception:
+                logger.debug(
+                    "discord: streaming end edit failed",
+                )
+        else:
+            # Text too long: delete placeholder, use chunked send
+            try:
+                await msg.delete()
+            except Exception:
+                pass
+            await self.send(to_handle, final_text, send_meta)
 
     def _route_from_handle(self, to_handle: str) -> dict:
         # to_handle format: discord:ch:<channel_id> or discord:dm:<user_id>

--- a/src/qwenpaw/cli/channels_cmd.py
+++ b/src/qwenpaw/cli/channels_cmd.py
@@ -295,6 +295,12 @@ def configure_discord(current_config: DiscordConfig) -> DiscordConfig:
         current_config.http_proxy = ""
         current_config.http_proxy_auth = ""
 
+    streaming_enabled = prompt_confirm(
+        "Enable streaming?",
+        default=current_config.streaming_enabled,
+    )
+    current_config.streaming_enabled = streaming_enabled
+
     return current_config
 
 
@@ -334,6 +340,12 @@ def configure_dingtalk(current_config: DingTalkConfig) -> DingTalkConfig:
         type=str,
     )
     current_config.client_secret = client_secret
+
+    streaming_enabled = prompt_confirm(
+        "Enable streaming?",
+        default=current_config.streaming_enabled,
+    )
+    current_config.streaming_enabled = streaming_enabled
 
     return current_config
 
@@ -384,6 +396,12 @@ def configure_feishu(current_config: FeishuConfig) -> FeishuConfig:
         type=str,
     )
     current_config.app_secret = app_secret
+
+    streaming_enabled = prompt_confirm(
+        "Enable streaming?",
+        default=current_config.streaming_enabled,
+    )
+    current_config.streaming_enabled = streaming_enabled
 
     return current_config
 
@@ -558,6 +576,12 @@ def configure_telegram(current_config: TelegramConfig) -> TelegramConfig:
     else:
         current_config.http_proxy = ""
         current_config.http_proxy_auth = ""
+
+    streaming_enabled = prompt_confirm(
+        "Enable streaming?",
+        default=current_config.streaming_enabled,
+    )
+    current_config.streaming_enabled = streaming_enabled
 
     return current_config
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -224,6 +224,7 @@ class DiscordConfig(BaseChannelConfig):
     http_proxy: str = ""
     http_proxy_auth: str = ""
     accept_bot_messages: bool = False
+    streaming_enabled: bool = False
 
 
 class DingTalkConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

## Summary

Add streaming response support to the Discord channel. When enabled, a
placeholder message is sent immediately and edited in-place as tokens
arrive, with a persistent typing indicator shown while the agent is
working. Streaming is opt-in (`streaming_enabled: false` by default)
and fully backward-compatible.

## What's New

- **Discord streaming**: Post + Edit model (aligned with Telegram) —
  `on_streaming_start` sends a placeholder, `on_streaming_delta` edits
  it with accumulated text (throttled via base class at 1.0s), and
  `on_streaming_end` applies the final text or falls back to chunked
  send when exceeding Discord's 2000-char limit.

- **Typing indicator**: Uses discord.py's `async with channel.typing()`
  context manager, managed by `_before_consume_process` /
  `_on_process_completed` / `_on_consume_error` hooks (yuanbao pattern).

- **`streaming_enabled` config** for Discord: config file, env var
  (`DISCORD_STREAMING_ENABLED`), CLI prompt, and Console UI switch.

- **CLI fix**: Added missing `streaming_enabled` prompts for Telegram,
  DingTalk, and Feishu configurators.

**Related Issue:** Fixes #1296 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
