### PR TITLE
feat(plan): add native todo_write progress panel for multi-step agent tasks

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -17,7 +17,13 @@ export function toDisplayUrl(url: string): string {
   if (url.startsWith("http://") || url.startsWith("https://")) return url;
   if (url.startsWith("data:")) return url;
   if (url.startsWith("file://")) url = url.replace("file://", "");
-  return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
+  // ponytail: normalize Windows backslashes to forward slashes
+  // so paths like C:\Users\... work in HTTP URLs.
+  // ceiling: if we need more URL sanitisation, extract into a helper.
+  const normalized = url.replace(/\\/g, "/");
+  return chatApi.filePreviewUrl(
+    normalized.startsWith("/") ? normalized : `/${normalized}`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { IconButton } from "@agentscope-ai/design";
 import {
   SparkHistoryLine,
@@ -6,11 +6,15 @@ import {
   SparkSearchLine,
 } from "@agentscope-ai/icons";
 import { ExpandAltOutlined, CompressOutlined } from "@ant-design/icons";
-import { useChatAnywhereSessions } from "@agentscope-ai/chat";
+import {
+  useChatAnywhereSessions,
+  useChatAnywhereSessionsState,
+} from "@agentscope-ai/chat";
 import { useTranslation } from "react-i18next";
 import { Flex, Tooltip } from "antd";
 import ChatSearchPanel from "../ChatSearchPanel";
 import PlanPanel from "../../../../components/PlanPanel";
+import { planApi, subscribePlanUpdates } from "../../../../api/modules/plan";
 
 const PlanIcon = () => (
   <svg
@@ -49,11 +53,49 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
 
   const [searchOpen, setSearchOpen] = useState(false);
   const [planOpen, setPlanOpen] = useState(false);
+  const [hasActivePlan, setHasActivePlan] = useState(false);
+  const prevHasPlanRef = useRef(false);
+
   const { createSession } = useChatAnywhereSessions();
+  const { currentSessionId } = useChatAnywhereSessionsState();
+
+  // Fetch initial plan status when session changes
+  useEffect(() => {
+    const checkPlan = async () => {
+      const sid = (window as any).currentSessionId || "";
+      try {
+        const data = await planApi.getCurrentPlan(sid || undefined);
+        const hasPlan = data !== null;
+        setHasActivePlan(hasPlan);
+        prevHasPlanRef.current = hasPlan;
+      } catch {
+        // ignore
+      }
+    };
+    checkPlan();
+  }, [currentSessionId]);
+
+  // Subscribe to real-time plan updates
+  useEffect(() => {
+    const unsub = subscribePlanUpdates((updatedPlan, eventSessionId) => {
+      const mySid = (window as any).currentSessionId || "";
+      if (eventSessionId && mySid && eventSessionId !== mySid) return;
+
+      const hasPlan = updatedPlan !== null;
+      setHasActivePlan(hasPlan);
+
+      if (hasPlan && !prevHasPlanRef.current) {
+        setPlanOpen(true);
+      }
+      prevHasPlanRef.current = hasPlan;
+    });
+
+    return unsub;
+  }, []);
 
   return (
     <Flex gap={8} align="center">
-      {planEnabled && (
+      {(planEnabled || hasActivePlan) && (
         <Tooltip title={t("plan.title", "Plan")} mouseEnterDelay={0.5}>
           <IconButton
             bordered={false}
@@ -105,7 +147,7 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
         </Tooltip>
       )}
       <ChatSearchPanel open={searchOpen} onClose={() => setSearchOpen(false)} />
-      {planEnabled && (
+      {(planEnabled || hasActivePlan) && (
         <PlanPanel open={planOpen} onClose={() => setPlanOpen(false)} />
       )}
     </Flex>

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -61,6 +61,8 @@ from .tools import (
     set_user_timezone,
     view_image,
     view_video,
+    todo_write,
+    TodoWrite,
     write_file,
 )
 from .utils import process_file_and_media_blocks_in_message
@@ -308,6 +310,8 @@ class QwenPawAgent(CodingModeMixin, ToolGuardMixin, ReActAgent):
             "check_agent_task": check_agent_task,
             "spawn_subagent": spawn_subagent,
             "run_tool_batch": run_tool_batch,
+            "todo_write": todo_write,
+            "TodoWrite": TodoWrite,
             # Register only when the `make-skill` skill is enabled.
             **(
                 {"materialize_skill": materialize_skill}

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -35,6 +35,7 @@ from .delegate_external_agent import delegate_external_agent
 # __all__ so it's always enabled, not gated on agent config.
 from .make_skill_tools import materialize_skill  # noqa: F401
 from .run_tool_batch import run_tool_batch  # noqa: F401
+from .todo_write import todo_write, TodoWrite  # noqa: F401
 
 __all__ = [
     "execute_python_code",

--- a/src/qwenpaw/agents/tools/todo_write.py
+++ b/src/qwenpaw/agents/tools/todo_write.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""Tool for writing and updating a task todo list.
+
+Shows real-time progress.
+"""
+
+import logging
+from typing import List, Dict, Any
+
+from agentscope.message import TextBlock
+from agentscope.tool import ToolResponse
+from agentscope.plan import SubTask
+
+logger = logging.getLogger(__name__)
+
+
+async def todo_write(
+    todos: List[Dict[str, Any]],
+    plan_name: str = "Agent Task",
+    plan_description: str = "Execution progress tracker",
+) -> ToolResponse:
+    """Update or create the agent's active task progress list.
+
+    Displays to the user in the right-side panel.
+
+    Use this tool whenever you start a multi-step task or want to report
+    your execution plan and progress to the user. This updates a
+    persistent Todo list panel.
+
+    Args:
+        todos: A list of dicts representing the tasks/steps. Each dict
+            must contain:
+            - 'title' (str): Short name/description of the step
+              (e.g. "Clone repository", "Run tests").
+            - 'status' (Literal['todo', 'in_progress', 'done',
+              'abandoned']): Current status of this step.
+            - 'result' (str, optional): The outcome or result of the step
+              if finished.
+        plan_name: The overall title of the multi-step task (e.g. "Fixing
+            bug in repository").
+        plan_description: A brief summary of what the overall task does.
+
+    Returns:
+        `ToolResponse`: A confirmation message.
+    """
+    from ...app.agent_context import get_current_plan_notebook
+
+    nb = get_current_plan_notebook()
+    if nb is None:
+        logger.warning(
+            "todo_write called but plan_notebook is not set in context",
+        )
+        return ToolResponse(
+            content=[
+                TextBlock(
+                    type="text",
+                    text=(
+                        "Error: Progress panel / Plan notebook is not "
+                        "initialized in the current context."
+                    ),
+                ),
+            ],
+        )
+
+    subtasks = []
+    for idx, t in enumerate(todos):
+        title = t.get("title") or t.get("name") or f"Step {idx + 1}"
+        desc = t.get("description") or ""
+
+        # ponytail: simple state mapping for ease of agent use
+        # Map statuses:
+        # done/completed/finished -> done
+        # in_progress/running -> in_progress
+        # abandoned/failed/skipped -> abandoned
+        # todo/pending -> todo
+        status_val = (
+            str(
+                t.get("status") or t.get("state") or "todo",
+            )
+            .lower()
+            .strip()
+        )
+        if status_val in ("completed", "done", "finished", "success"):
+            state = "done"
+        elif status_val in ("in_progress", "running", "active", "started"):
+            state = "in_progress"
+        elif status_val in ("abandoned", "failed", "skipped", "error"):
+            state = "abandoned"
+        else:
+            state = "todo"
+
+        result = t.get("result") or t.get("outcome") or ""
+        expected = t.get("expected_outcome") or "Step completed"
+
+        subtasks.append(
+            SubTask(
+                name=title,
+                description=desc,
+                expected_outcome=expected,
+                state=state,
+                outcome=result if state in ("done", "abandoned") else None,
+            ),
+        )
+
+    # Await create_plan to write/overwrite it
+    await nb.create_plan(
+        name=plan_name,
+        description=plan_description,
+        expected_outcome="All tasks completed",
+        subtasks=subtasks,
+    )
+
+    # Check if all subtasks are finished (done or abandoned)
+    # to auto-finish the plan
+    if len(subtasks) > 0 and all(
+        st.state in ("done", "abandoned") for st in subtasks
+    ):
+        # Mark plan as finished/done
+        await nb.finish_plan(
+            state="done",
+            outcome="All tasks completed successfully.",
+        )
+
+    return ToolResponse(
+        content=[
+            TextBlock(
+                type="text",
+                text=(
+                    "Successfully updated progress panel with "
+                    f"{len(todos)} tasks."
+                ),
+            ),
+        ],
+    )
+
+
+# Alias for compatibility with PascalCase issue naming
+TodoWrite = todo_write

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -5,7 +5,7 @@ Provides utilities to get the correct agent instance for each request.
 """
 from contextvars import ContextVar
 from pathlib import Path
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Any
 from fastapi import Request
 from .multi_agent_manager import MultiAgentManager
 from ..config.utils import load_config
@@ -228,3 +228,19 @@ def set_current_channel(channel: Optional[str]) -> None:
 def get_current_channel() -> Optional[str]:
     """Get current channel from context."""
     return _current_channel.get()
+
+
+_current_plan_notebook: ContextVar[Optional[Any]] = ContextVar(
+    "current_plan_notebook",
+    default=None,
+)
+
+
+def set_current_plan_notebook(nb: Optional[Any]) -> None:
+    """Set current plan notebook in context."""
+    _current_plan_notebook.set(nb)
+
+
+def get_current_plan_notebook() -> Optional[Any]:
+    """Get current plan notebook from context."""
+    return _current_plan_notebook.get()

--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -88,4 +88,12 @@ async def preview_file(
 
     if not os.access(path, os.R_OK):
         raise HTTPException(status_code=500, detail="Permission denied")
-    return FileResponse(path, filename=path.name)
+    return FileResponse(
+        path,
+        filename=path.name,
+        # ponytail: FileResponse uses "attachment" by default;
+        # browsers download instead of inline display.
+        # ceiling: if per-file download-vs-preview logic is needed, extract
+        # into a helper parameter.
+        content_disposition_type="inline",
+    )

--- a/src/qwenpaw/app/runner/runner.py
+++ b/src/qwenpaw/app/runner/runner.py
@@ -424,6 +424,7 @@ class AgentRunner(Runner):
             set_current_root_session_id,
             set_current_user_id,
             set_current_channel,
+            set_current_plan_notebook,
         )
 
         set_current_agent_id(self.agent_id)
@@ -655,14 +656,14 @@ class AgentRunner(Runner):
                 "enabled",
                 False,
             )
-            if plan_enabled:
-                try:
-                    from agentscope.plan import (
-                        PlanNotebook,
-                        InMemoryPlanStorage,
-                    )
-                    from ...plan.hints import SimplePlanToHint, set_plan_gate
+            try:
+                from agentscope.plan import (
+                    PlanNotebook,
+                    InMemoryPlanStorage,
+                )
+                from ...plan.hints import SimplePlanToHint, set_plan_gate
 
+                if plan_enabled:
                     hint_gen = SimplePlanToHint()
                     plan_notebook = PlanNotebook(
                         plan_to_hint=hint_gen,
@@ -683,61 +684,70 @@ class AgentRunner(Runner):
                                 "Plan mode: /plan gate set, desc=%s",
                                 plan_desc[:60],
                             )
+                else:
+                    plan_notebook = PlanNotebook(
+                        # ponytail: use empty dummy lambda to prevent
+                        # system prompt pollution while allowing todo_write
+                        plan_to_hint=lambda plan: None,
+                        storage=InMemoryPlanStorage(),
+                    )
 
-                    # Register SSE broadcast hook + state tracking
-                    from ...plan.broadcast import broadcast_plan_update
-                    from ...plan.schemas import plan_to_response
+                # Register SSE broadcast hook + state tracking
+                from ...plan.broadcast import broadcast_plan_update
+                from ...plan.schemas import plan_to_response
 
-                    def _on_plan_change(  # pylint: disable=protected-access
-                        nb,
-                        plan,
-                    ):
-                        if getattr(nb, "_loading_from_state", False):
-                            nb._qp_had_plan = plan is not None
-                            nb._qp_prev_plan_id = (
-                                plan.id if plan is not None else None
-                            )
-                            return
-
-                        had_plan = getattr(nb, "_qp_had_plan", False)
-                        prev_id = getattr(nb, "_qp_prev_plan_id", None)
-
-                        if plan is not None:
-                            cur_id = plan.id
-                            if not had_plan or cur_id != prev_id:
-                                nb._plan_just_mutated = True
-                            nb._qp_prev_plan_id = cur_id
-                        else:
-                            if had_plan:
-                                nb._plan_recently_finished = True
-                                nb._plan_awaiting_user_confirm = False
-                            nb._qp_prev_plan_id = None
+                def _on_plan_change(  # pylint: disable=protected-access
+                    nb,
+                    plan,
+                ):
+                    if getattr(nb, "_loading_from_state", False):
                         nb._qp_had_plan = plan is not None
-
-                        payload = {
-                            "type": "plan_update",
-                            "plan": (
-                                plan_to_response(plan).model_dump()
-                                if plan is not None
-                                else None
-                            ),
-                        }
-                        broadcast_plan_update(
-                            self.agent_id,
-                            payload,
-                            session_id=session_id,
+                        nb._qp_prev_plan_id = (
+                            plan.id if plan is not None else None
                         )
+                        return
 
-                    plan_notebook.register_plan_change_hook(
-                        "broadcast",
-                        _on_plan_change,
+                    had_plan = getattr(nb, "_qp_had_plan", False)
+                    prev_id = getattr(nb, "_qp_prev_plan_id", None)
+
+                    if plan is not None:
+                        cur_id = plan.id
+                        if not had_plan or cur_id != prev_id:
+                            nb._plan_just_mutated = True
+                        nb._qp_prev_plan_id = cur_id
+                    else:
+                        if had_plan:
+                            nb._plan_recently_finished = True
+                            nb._plan_awaiting_user_confirm = False
+                        nb._qp_prev_plan_id = None
+                    nb._qp_had_plan = plan is not None
+
+                    payload = {
+                        "type": "plan_update",
+                        "plan": (
+                            plan_to_response(plan).model_dump()
+                            if plan is not None
+                            else None
+                        ),
+                    }
+                    broadcast_plan_update(
+                        self.agent_id,
+                        payload,
+                        session_id=session_id,
                     )
-                except Exception:
-                    logger.warning(
-                        "Failed to create PlanNotebook",
-                        exc_info=True,
-                    )
-                    plan_notebook = None
+
+                plan_notebook.register_plan_change_hook(
+                    "broadcast",
+                    _on_plan_change,
+                )
+                set_current_plan_notebook(plan_notebook)
+            except Exception:
+                logger.warning(
+                    "Failed to create PlanNotebook",
+                    exc_info=True,
+                )
+                plan_notebook = None
+                set_current_plan_notebook(None)
 
             agent = QwenPawAgent(
                 agent_config=agent_config,

--- a/tests/unit/agents/tools/test_todo_write.py
+++ b/tests/unit/agents/tools/test_todo_write.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+
+import pytest
+from agentscope.plan import PlanNotebook, InMemoryPlanStorage
+
+from qwenpaw.agents.tools.todo_write import todo_write
+
+
+@pytest.mark.asyncio
+async def test_todo_write_basic():
+    notebook = PlanNotebook(storage=InMemoryPlanStorage())
+
+    with patch(
+        "qwenpaw.app.agent_context.get_current_plan_notebook",
+        return_value=notebook,
+    ):
+        todos = [
+            {"title": "Step 1", "status": "done", "result": "Result 1"},
+            {"title": "Step 2", "status": "in_progress"},
+            {"title": "Step 3", "status": "todo"},
+        ]
+
+        response = await todo_write(
+            todos=todos,
+            plan_name="Test Task",
+            plan_description="Testing todo_write",
+        )
+
+        assert response is not None
+        assert (
+            "Successfully updated progress panel"
+            in response.content[0]["text"]
+        )
+
+        plan = notebook.current_plan
+        assert plan is not None
+        assert plan.name == "Test Task"
+        assert plan.description == "Testing todo_write"
+        assert len(plan.subtasks) == 3
+        assert plan.subtasks[0].name == "Step 1"
+        assert plan.subtasks[0].state == "done"
+        assert plan.subtasks[0].outcome == "Result 1"
+        assert plan.subtasks[1].state == "in_progress"
+        assert plan.subtasks[2].state == "todo"


### PR DESCRIPTION
Closes #5318. Adds a native todo_write / TodoWrite tool for updating real-time plan execution progress, and updates the frontend console panel to auto-open and display plan details whenever a plan is active.