### PR TITLE
fix(files): use inline content-disposition for file preview (#5320)

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -17,7 +17,13 @@ export function toDisplayUrl(url: string): string {
   if (url.startsWith("http://") || url.startsWith("https://")) return url;
   if (url.startsWith("data:")) return url;
   if (url.startsWith("file://")) url = url.replace("file://", "");
-  return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
+  // ponytail: normalize Windows backslashes to forward slashes
+  // so paths like C:\Users\... work in HTTP URLs.
+  // ceiling: if we need more URL sanitisation, extract into a helper.
+  const normalized = url.replace(/\\/g, "/");
+  return chatApi.filePreviewUrl(
+    normalized.startsWith("/") ? normalized : `/${normalized}`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -320,8 +320,7 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
     fast_elapsed = time.time() - startup_start_time
     logger.info(
-        f"Server ready in {fast_elapsed:.3f}s "
-        f"(agents loading in background)",
+        f"Server ready in {fast_elapsed:.3f}s " f"(agents loading in background)",
     )
 
     # ================================================================
@@ -489,8 +488,7 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
             startup_elapsed = time.time() - startup_start_time
             logger.info(
-                "Background startup completed in "
-                f"{startup_elapsed:.3f} seconds",
+                "Background startup completed in " f"{startup_elapsed:.3f} seconds",
             )
 
             # Print server URL again so it's visible after background logs
@@ -666,7 +664,9 @@ logger.info(f"STATIC_DIR: {_CONSOLE_STATIC_DIR}")
 @app.get("/")
 def read_root():
     if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-        return FileResponse(_CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"})
+        return FileResponse(
+            _CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"}
+        )
     return {
         "message": (
             f"{PROJECT_NAME} web console is not available. "
@@ -727,7 +727,9 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
 
     def _serve_console_index():
         if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-            return FileResponse(_CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"})
+            return FileResponse(
+                _CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"}
+            )
 
         raise HTTPException(status_code=404, detail="Not Found")
 
@@ -768,6 +770,8 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
             if not Path(full_path).is_absolute():
                 static_file = _console_path / full_path
                 if static_file.is_file():
-                    return FileResponse(static_file, headers={"X-Content-Type-Options": "nosniff"})
+                    return FileResponse(
+                        static_file, headers={"X-Content-Type-Options": "nosniff"}
+                    )
 
         return _serve_console_index()

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -320,7 +320,8 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
     fast_elapsed = time.time() - startup_start_time
     logger.info(
-        f"Server ready in {fast_elapsed:.3f}s " f"(agents loading in background)",
+        f"Server ready in {fast_elapsed:.3f}s "
+        f"(agents loading in background)",
     )
 
     # ================================================================
@@ -488,7 +489,8 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
 
             startup_elapsed = time.time() - startup_start_time
             logger.info(
-                "Background startup completed in " f"{startup_elapsed:.3f} seconds",
+                "Background startup completed in "
+                f"{startup_elapsed:.3f} seconds",
             )
 
             # Print server URL again so it's visible after background logs
@@ -665,7 +667,8 @@ logger.info(f"STATIC_DIR: {_CONSOLE_STATIC_DIR}")
 def read_root():
     if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
         return FileResponse(
-            _CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"}
+            _CONSOLE_INDEX,
+            headers={"X-Content-Type-Options": "nosniff"},
         )
     return {
         "message": (
@@ -728,7 +731,8 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
     def _serve_console_index():
         if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
             return FileResponse(
-                _CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"}
+                _CONSOLE_INDEX,
+                headers={"X-Content-Type-Options": "nosniff"},
             )
 
         raise HTTPException(status_code=404, detail="Not Found")
@@ -771,7 +775,8 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
                 static_file = _console_path / full_path
                 if static_file.is_file():
                     return FileResponse(
-                        static_file, headers={"X-Content-Type-Options": "nosniff"}
+                        static_file,
+                        headers={"X-Content-Type-Options": "nosniff"},
                     )
 
         return _serve_console_index()

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -666,7 +666,7 @@ logger.info(f"STATIC_DIR: {_CONSOLE_STATIC_DIR}")
 @app.get("/")
 def read_root():
     if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-        return FileResponse(_CONSOLE_INDEX)
+        return FileResponse(_CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"})
     return {
         "message": (
             f"{PROJECT_NAME} web console is not available. "
@@ -727,7 +727,7 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
 
     def _serve_console_index():
         if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-            return FileResponse(_CONSOLE_INDEX)
+            return FileResponse(_CONSOLE_INDEX, headers={"X-Content-Type-Options": "nosniff"})
 
         raise HTTPException(status_code=404, detail="Not Found")
 
@@ -768,6 +768,6 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
             if not Path(full_path).is_absolute():
                 static_file = _console_path / full_path
                 if static_file.is_file():
-                    return FileResponse(static_file)
+                    return FileResponse(static_file, headers={"X-Content-Type-Options": "nosniff"})
 
         return _serve_console_index()

--- a/src/qwenpaw/app/routers/backup.py
+++ b/src/qwenpaw/app/routers/backup.py
@@ -319,4 +319,5 @@ async def export_backup_route(backup_id: str):
         path=zip_path,
         media_type="application/zip",
         filename=filename,
+        headers={"X-Content-Type-Options": "nosniff"},
     )

--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -91,7 +91,7 @@ async def preview_file(
         raise HTTPException(status_code=500, detail="Permission denied")
 
     content_type, _ = mimetypes.guess_type(path)
-    # ponytail: Keep inline only for known-safe media types (image/video/audio/pdf)
+    # ponytail: Keep inline only for safe media types (image/video/audio/pdf)
     # and exclude dangerous ones like text/html, image/svg+xml, or XML.
     is_safe = False
     if content_type:

--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -88,4 +88,12 @@ async def preview_file(
 
     if not os.access(path, os.R_OK):
         raise HTTPException(status_code=500, detail="Permission denied")
-    return FileResponse(path, filename=path.name)
+    return FileResponse(
+        path,
+        filename=path.name,
+        # ponytail: FileResponse uses "attachment" by default;
+        # browsers download instead of inline display.
+        # ceiling: if per-file download-vs-preview logic is needed, extract
+        # into a helper parameter.
+        content_disposition_type="inline",
+    )

--- a/src/qwenpaw/app/routers/files.py
+++ b/src/qwenpaw/app/routers/files.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import mimetypes
 import os
 from pathlib import Path
 from urllib.parse import unquote
@@ -88,12 +89,30 @@ async def preview_file(
 
     if not os.access(path, os.R_OK):
         raise HTTPException(status_code=500, detail="Permission denied")
+
+    content_type, _ = mimetypes.guess_type(path)
+    # ponytail: Keep inline only for known-safe media types (image/video/audio/pdf)
+    # and exclude dangerous ones like text/html, image/svg+xml, or XML.
+    is_safe = False
+    if content_type:
+        ct_lower = content_type.lower()
+        if (
+            ct_lower.startswith("image/")
+            or ct_lower.startswith("video/")
+            or ct_lower.startswith("audio/")
+            or ct_lower == "application/pdf"
+        ):
+            if (
+                "svg" not in ct_lower
+                and "xml" not in ct_lower
+                and "html" not in ct_lower
+            ):
+                is_safe = True
+
+    content_disposition_type = "inline" if is_safe else "attachment"
     return FileResponse(
         path,
+        headers={"X-Content-Type-Options": "nosniff"},
+        content_disposition_type=content_disposition_type,
         filename=path.name,
-        # ponytail: FileResponse uses "attachment" by default;
-        # browsers download instead of inline display.
-        # ceiling: if per-file download-vs-preview logic is needed, extract
-        # into a helper parameter.
-        content_disposition_type="inline",
     )

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -878,9 +878,16 @@ async def serve_plugin_ui_file(
         content_type = "text/css"
 
     if content_type:
-        return FileResponse(str(full_path), media_type=content_type)
+        return FileResponse(
+            str(full_path),
+            media_type=content_type,
+            headers={"X-Content-Type-Options": "nosniff"},
+        )
 
-    return FileResponse(str(full_path))
+    return FileResponse(
+        str(full_path),
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
 
 
 # ── Plugin market proxy ───────────────────────────────────────────────────

--- a/tests/integration/test_messages_files.py
+++ b/tests/integration/test_messages_files.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Integration tests for messages and files APIs."""
+
 from __future__ import annotations
 
 from urllib.parse import quote
@@ -403,4 +404,3 @@ def test_files_preview_security_hardening(app_server, tmp_path) -> None:
     assert resp.status_code == 200
     assert resp.headers.get("x-content-type-options") == "nosniff"
     assert "attachment" in resp.headers.get("content-disposition", "")
-

--- a/tests/integration/test_messages_files.py
+++ b/tests/integration/test_messages_files.py
@@ -358,3 +358,49 @@ def test_files_preview_directory_path_returns_404(
     )
     assert resp.status_code == 404, app_server.logs_tail()
     assert resp.json().get("detail") == "Not found"
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_files_preview_security_hardening(app_server, tmp_path) -> None:
+    """Test purpose:
+    - Verify files preview endpoint returns X-Content-Type-Options: nosniff,
+      and only serves safe media types (image, video, audio, pdf) inline,
+      while dangerous types (html, svg, xml) fall back to attachment.
+    """
+    # 1. Test image file (png) -> inline, with nosniff
+    png_file = tmp_path / "test.png"
+    png_file.write_bytes(b"dummy png content")
+    encoded_png = quote(str(png_file), safe="")
+    resp = app_server.client.get(
+        f"{app_server.base_url}/api/files/preview/{encoded_png}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert "inline" in resp.headers.get("content-disposition", "")
+
+    # 2. Test HTML file (html) -> attachment, with nosniff
+    html_file = tmp_path / "test.html"
+    html_file.write_bytes(b"<html>dummy</html>")
+    encoded_html = quote(str(html_file), safe="")
+    resp = app_server.client.get(
+        f"{app_server.base_url}/api/files/preview/{encoded_html}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert "attachment" in resp.headers.get("content-disposition", "")
+
+    # 3. Test SVG file (svg) -> attachment, with nosniff
+    svg_file = tmp_path / "test.svg"
+    svg_file.write_bytes(b"<svg></svg>")
+    encoded_svg = quote(str(svg_file), safe="")
+    resp = app_server.client.get(
+        f"{app_server.base_url}/api/files/preview/{encoded_svg}",
+        timeout=_MESSAGES_FILES_TIMEOUT,
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert "attachment" in resp.headers.get("content-disposition", "")
+


### PR DESCRIPTION
Closes #5320  
  
FileResponse defaults to content_disposition_type="attachment", causing  
browsers to download files instead of displaying them inline. This  
broke send_file_to_user image display after v1.1.12 (switched from  
Response+bytes to FileResponse in PR #5115).  
  
## Root Cause  
  
In Starlette's FileResponse, the default content_disposition_type is  
"attachment" when a filename is provided. This means browsers treat  
the response as a download, not an inline image. The previous code  
used Response(content=bytes, headers={"content-disposition":  
"inline; ..."}) which displayed images correctly.  
  
## Changes  
  
- **files.py**: Add content_disposition_type="inline" to FileResponse  
- **utils.ts**: Normalize Windows backslashes to forward slashes in toDisplayUrl() 
