### PR TITLE
fix(console): yield failed response event on exception to prevent stuck UI (#5333)

### DIFF
--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -25,12 +25,14 @@ from agentscope_runtime.engine.schemas.agent_schemas import (
     MessageType,
     Message,
     RunStatus,
+    AgentResponse,
+    Error,
 )
 
 from ....config.config import ConsoleConfig as ConsoleChannelConfig
 from ...console_push_store import append as push_store_append
 from ....constant import DEFAULT_MEDIA_DIR
-from ....exceptions import ModelQuotaExceededException
+from ....exceptions import ModelQuotaExceededException, convert_model_exception
 from ..base import (
     BaseChannel,
     AudioContent,
@@ -492,10 +494,57 @@ class ConsoleChannel(BaseChannel):
             )
             yield f"data: {rl_event}\n\n"
             self._print_error(str(e).strip())
+
+            # Yield failed response to avoid stuck UI
+            error_obj = Error(
+                code="MODEL_QUOTA_EXCEEDED",
+                message=str(e).strip(),
+            )
+            req_id = getattr(request, "id", None)
+            failed_resp = AgentResponse(
+                id=req_id,
+                session_id=session_id,
+            ).failed(error_obj)
+            data = self._serialize_event_for_sse(failed_resp)
+            yield f"data: {data}\n\n"
+
         except Exception as e:
             logger.exception("console process/reply failed")
             err_msg = str(e).strip() or "An error occurred while processing."
             self._print_error(err_msg)
+
+            # Yield failed response to avoid stuck UI
+            from agentscope_runtime.engine.schemas.exception import (
+                AgentRuntimeErrorException,
+            )
+
+            if isinstance(e, AgentRuntimeErrorException):
+                converted = e
+            else:
+                model_name = None
+                if self._workspace is not None and hasattr(
+                    self._workspace,
+                    "runner",
+                ):
+                    runner = self._workspace.runner
+                    if runner is not None:
+                        agent = getattr(runner, "agent", None)
+                        if agent and hasattr(agent, "model"):
+                            model_name = getattr(
+                                agent.model,
+                                "model_name",
+                                None,
+                            )
+                converted = convert_model_exception(e, model_name)
+
+            error_obj = Error(code=converted.code, message=converted.message)
+            req_id = getattr(request, "id", None)
+            failed_resp = AgentResponse(
+                id=req_id,
+                session_id=session_id,
+            ).failed(error_obj)
+            data = self._serialize_event_for_sse(failed_resp)
+            yield f"data: {data}\n\n"
 
     async def consume_one(self, payload: Any) -> None:
         """Process one payload; drain stream_one (queue/terminal)."""


### PR DESCRIPTION
Closes #5333.

### Description
After a model execution error occurs on the backend, the SSE connection closed but no error or failure response event was yielded. This left the UI in a waiting state, but with the input field active for new messages.

This PR fixes the issue by catching all exceptions in the console channel \stream_one\ method and yielding a properly formatted \ailed\ response event, resolving the stuck UI state.

### Verification
- Unit and integration tests passed.
- Verified that failed responses are correctly sent and handled.