### PR TITLE
fix(providers): use plain string content for OpenAIProvider check_model_connection (#5330)

### DIFF
--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -125,12 +125,7 @@ class OpenAIProvider(Provider):
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": "ping",
-                            },
-                        ],
+                        "content": "ping",
                     },
                 ],
                 timeout=timeout,


### PR DESCRIPTION
Closes #5330.

### Description
In Zhipu AI's (Z.AI) completions endpoint, structured multimodal list message content (e.g. `[{"type": "text", "text": "ping"}]`) is not supported for text models, which caused Zhipu model connection tests to always fail even though the provider-level test succeeded.

This PR fixes it by using a plain string `"content": "ping"` in `OpenAIProvider.check_model_connection`, which is OpenAI-compatible and widely supported by all OpenAI-compatible endpoints (and already used by other providers like OpenRouter and Anthropic in the codebase).

### Verification
- Ran format/quality checks via pre-commit, all passed.
- Unit and integration tests for providers and provider switching passed cleanly.
