### PR TITLE
fix(providers): use plain string content for check_model_connection (#5330)

### DIFF
--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -120,33 +120,37 @@ class OpenAIProvider(Provider):
 
         try:
             client = self._client(timeout=timeout)
+            # ponytail: string content works for all OpenAI-compatible APIs for
+            # text-only calls; array format only needed for multimodal messages
+            # ceiling: if a provider requires multimodal array format, switch
+            # upgrade: use "content": [{"type": "text", "text": "ping"}]
             res = await client.chat.completions.create(
                 model=model_id,
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": "ping",
-                            },
-                        ],
+                        "content": "ping",
                     },
                 ],
                 timeout=timeout,
-                max_tokens=20,
+                max_tokens=64,
                 stream=True,
             )
             # consume the stream to ensure the model is actually responsive
             async for _ in res:
                 break
             return True, ""
-        except APIError:
-            return False, f"API error when connecting to model '{model_id}'"
-        except Exception:
+        except APIError as exc:
+            msg = exc.message or str(exc)
             return (
                 False,
-                f"Unknown exception when connecting to model '{model_id}'",
+                f"API error when connecting to model '{model_id}': {msg}",
+            )
+        except Exception as exc:
+            return (
+                False,
+                f"Unknown exception when connecting to model "
+                f"'{model_id}': {exc}",
             )
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:


### PR DESCRIPTION
## Description

Fix #5330 — Zhipu AI provider model-level connection tests failing for all models.

### Root Cause

The `check_model_connection` method in `OpenAIProvider` sends the chat message content as an **array** (`[{"type": "text", "text": "ping"}]`). While this conforms to the OpenAI API specification for multimodal messages, some OpenAI-compatible providers (notably **Zhipu AI's API**) **do not accept the array format** for `content` and return an API error.

The provider-level test (`check_connection`) calls `client.models.list()` which uses a different endpoint (`GET /models`) and succeeds regardless.

### Changes

**`src/qwenpaw/providers/openai_provider.py`:**

1. **Content format**: Changed `"content": [{"type": "text", "text": "ping"}]` → `"content": "ping"`. Plain string content is universally supported by all OpenAI-compatible APIs for text-only messages; the array format is only needed for multimodal content.

2. **max_tokens**: Increased from 20 → 64 to stay safely above any provider minimum requirements and produce reliable responses.

3. **Error details**: `except APIError` and `except Exception` now include the actual error message from the provider (`exc.message` / `str(exc)`) instead of a generic string, aiding future debugging.

4. **Ponytail comment**: Documents the ceiling (multimodal requirement) and upgrade path (switch to array format).

### Testing

- [x] flake8 ✅
- [x] mypy ✅
- [x] black ✅
- [x] pylint ✅
- [x] AST validation ✅
