### PR TITLE
fix(providers): use plain string content for check_model_connection (#5330)

### DIFF
--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -120,33 +120,37 @@ class OpenAIProvider(Provider):
 
         try:
             client = self._client(timeout=timeout)
+            # ponytail: string content works for all OpenAI-compatible APIs for
+            # text-only calls; array format only needed for multimodal messages
+            # ceiling: if a provider requires multimodal array format, switch
+            # upgrade: use "content": [{"type": "text", "text": "ping"}]
             res = await client.chat.completions.create(
                 model=model_id,
                 messages=[
                     {
                         "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": "ping",
-                            },
-                        ],
+                        "content": "ping",
                     },
                 ],
                 timeout=timeout,
-                max_tokens=20,
+                max_tokens=64,
                 stream=True,
             )
             # consume the stream to ensure the model is actually responsive
             async for _ in res:
                 break
             return True, ""
-        except APIError:
-            return False, f"API error when connecting to model '{model_id}'"
-        except Exception:
+        except APIError as exc:
+            msg = exc.message or str(exc)
             return (
                 False,
-                f"Unknown exception when connecting to model '{model_id}'",
+                f"API error when connecting to model '{model_id}': {msg}",
+            )
+        except Exception as exc:
+            return (
+                False,
+                f"Unknown exception when connecting to model "
+                f"'{model_id}': {exc}",
             )
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -141,7 +141,7 @@ class OpenAIProvider(Provider):
                 break
             return True, ""
         except APIError as exc:
-            msg = exc.message or str(exc)
+            msg = getattr(exc, "message", None) or str(exc)
             return (
                 False,
                 f"API error when connecting to model '{model_id}': {msg}",

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -122,7 +122,7 @@ async def test_check_model_connection_success(monkeypatch) -> None:
     assert len(captured) == 1
     assert captured[0]["model"] == "gpt-4o-mini"
     assert captured[0]["timeout"] == 4
-    assert captured[0]["max_tokens"] == 20
+    assert captured[0]["max_tokens"] == 64
     assert captured[0]["stream"] is True
 
 
@@ -145,7 +145,65 @@ async def test_check_model_connection_api_error_returns_false(
     ok, msg = await provider.check_model_connection("gpt-4o-mini", timeout=4)
 
     assert ok is False
-    assert msg == "API error when connecting to model 'gpt-4o-mini'"
+    assert "API error when connecting to model 'gpt-4o-mini'" in msg
+
+
+async def test_check_model_connection_zhipu_group_success(monkeypatch) -> None:
+    provider = _make_provider()
+    provider.provider_group = "zhipu"
+    captured: list[dict] = []
+
+    class FakeStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.append(kwargs)
+            return FakeStream()
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+    monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
+
+    ok, _ = await provider.check_model_connection("glm-4", timeout=4)
+
+    assert ok is True
+    assert len(captured) == 1
+    assert captured[0]["messages"][0]["content"] == "ping"
+
+
+async def test_check_model_connection_zhipu_id_success(monkeypatch) -> None:
+    provider = _make_provider()
+    provider.id = "zhipu-something"
+    captured: list[dict] = []
+
+    class FakeStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.append(kwargs)
+            return FakeStream()
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+    monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
+
+    ok, _ = await provider.check_model_connection("glm-4", timeout=4)
+
+    assert ok is True
+    assert len(captured) == 1
+    assert captured[0]["messages"][0]["content"] == "ping"
 
 
 async def test_update_config_updates_non_none_values_and_get_info() -> None:


### PR DESCRIPTION
## Description

Fix #5330 — Zhipu AI provider model-level connection tests failing for all models.

### Root Cause

The `check_model_connection` method in `OpenAIProvider` sends the chat message content as an **array** (`[{"type": "text", "text": "ping"}]`). While this conforms to the OpenAI API specification for multimodal messages, some OpenAI-compatible providers (notably **Zhipu AI's API**) **do not accept the array format** and return an API error.

The provider-level test (`check_connection`) calls `client.models.list()` which uses a different endpoint (`GET /models`) and succeeds regardless.

### Changes

**`src/qwenpaw/providers/openai_provider.py`:**

1. **Content format**: Array → plain string "ping"
2. **max_tokens**: 20 → 64
3. **Error details**: Include actual `exc.message` from API
4. **Ponytail comment**: Documents ceiling & upgrade path

### Testing

- [x] flake8 &#10003;
- [x] mypy &#10003;
- [x] black &#10003;
- [x] pylint &#10003;
- [x] AST validation &#10003;
