### PR TITLE
fix(tools): constrain file tools to the agent workspace

### DIFF
--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -21,23 +21,80 @@ from ...config.context import (
 from ...constant import WORKING_DIR, TRUNCATION_NOTICE_MARKER
 
 
+class PathContainmentError(ValueError):
+    """Raised when a tool-supplied path resolves outside the workspace."""
+
+
+# Operators who intentionally need the built-in file tools to reach paths
+# outside the agent workspace can opt out of containment by setting this
+# env var to a truthy value. Containment is on by default (fail-closed).
+_ALLOW_OUTSIDE_WORKSPACE_ENV = "QWENPAW_ALLOW_FILE_TOOLS_OUTSIDE_WORKSPACE"
+
+
+def _file_tools_allow_outside_workspace() -> bool:
+    """Return True when workspace containment for file tools is disabled."""
+    value = os.environ.get(_ALLOW_OUTSIDE_WORKSPACE_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _path_error_response(error: PathContainmentError) -> ToolResponse:
+    """Wrap a containment violation as a fail-closed tool error."""
+    return ToolResponse(
+        content=[
+            TextBlock(type="text", text=str(error)),
+        ],
+    )
+
+
 def _resolve_file_path(file_path: str) -> str:
     """Resolve file path: use absolute path as-is,
     resolve relative path from current workspace or WORKING_DIR.
+
+    When an agent workspace directory is set in context (the case for
+    model-driven tool calls in a ReAct turn), the resolved path is
+    constrained to that workspace so a tool-supplied ``file_path`` cannot
+    escape it via ``..`` segments, symlinks, or an absolute path. Set
+    ``QWENPAW_ALLOW_FILE_TOOLS_OUTSIDE_WORKSPACE=1`` to opt out. When no
+    workspace is configured the legacy behavior (resolve relative to
+    ``WORKING_DIR``, absolute paths as-is) is preserved.
 
     Args:
         file_path: The input file path (absolute or relative).
 
     Returns:
         The resolved absolute file path as string.
+
+    Raises:
+        PathContainmentError: If a workspace is configured and the
+            resolved path escapes it (and the opt-out env var is not set).
     """
+    # Workspace directory the model-driven agent is confined to, if any.
+    workspace_dir = get_current_workspace_dir()
     path = Path(file_path).expanduser()
     if path.is_absolute():
-        return str(path)
+        resolved = path
     else:
-        # Use current workspace_dir from context, fallback to WORKING_DIR
-        workspace_dir = get_current_workspace_dir() or WORKING_DIR
-        return str(workspace_dir / file_path)
+        resolved = Path(workspace_dir or WORKING_DIR) / path
+
+    # Only enforce containment when an agent workspace is set. Without one,
+    # the caller is the trusted local operator (direct/library use) and the
+    # legacy resolution behavior is preserved.
+    if workspace_dir is None or _file_tools_allow_outside_workspace():
+        return str(resolved)
+
+    # realpath collapses ``..`` and resolves symlinks so containment cannot
+    # be defeated by traversal or links pointing outside the workspace.
+    real_resolved = os.path.realpath(str(resolved))
+    real_root = os.path.realpath(str(workspace_dir))
+    if (
+        real_resolved != real_root
+        and os.path.commonpath([real_root, real_resolved]) != real_root
+    ):
+        raise PathContainmentError(
+            f"Error: file_path {file_path!r} resolves outside the "
+            f"workspace directory {real_root!r}.",
+        )
+    return str(resolved)
 
 
 def _get_encoding_for_file(file_path: str) -> str:
@@ -110,7 +167,10 @@ async def read_file(  # pylint: disable=too-many-return-statements
                 ],
             )
 
-    file_path = _resolve_file_path(file_path)
+    try:
+        file_path = _resolve_file_path(file_path)
+    except PathContainmentError as exc:
+        return _path_error_response(exc)
 
     if not os.path.exists(file_path):
         return ToolResponse(
@@ -229,7 +289,10 @@ async def write_file(
             ],
         )
 
-    file_path = _resolve_file_path(file_path)
+    try:
+        file_path = _resolve_file_path(file_path)
+    except PathContainmentError as exc:
+        return _path_error_response(exc)
     encoding = _get_encoding_for_file(file_path)
 
     try:
@@ -282,7 +345,10 @@ async def edit_file(
             ],
         )
 
-    resolved_path = _resolve_file_path(file_path)
+    try:
+        resolved_path = _resolve_file_path(file_path)
+    except PathContainmentError as exc:
+        return _path_error_response(exc)
 
     if not os.path.exists(resolved_path):
         return ToolResponse(
@@ -371,7 +437,10 @@ async def append_file(
             ],
         )
 
-    file_path = _resolve_file_path(file_path)
+    try:
+        file_path = _resolve_file_path(file_path)
+    except PathContainmentError as exc:
+        return _path_error_response(exc)
     encoding = _get_encoding_for_file(file_path)
 
     try:

--- a/tests/unit/agents/tools/test_file_io.py
+++ b/tests/unit/agents/tools/test_file_io.py
@@ -276,3 +276,141 @@ class TestAppendFile:
             "No" in result.content[0]["text"]
             and "file_path" in result.content[0]["text"]
         )
+
+
+# ---------------------------------------------------------------------------
+# Workspace containment (path traversal via model-supplied file_path)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceContainment:
+    """Regression tests for workspace-containment of model file tools.
+
+    A model-driven tool call must not read/write outside the agent's
+    configured workspace via ``..`` segments or an absolute path. The
+    guard lives in ``_resolve_file_path`` and is shared by read_file,
+    write_file, edit_file and append_file. On the unpatched code every
+    assertion below would fail (the escaping path would be accepted and
+    the file would be created outside the workspace).
+    """
+
+    @pytest.fixture
+    def workspace(self, tmp_path):
+        """An isolated agent workspace plus an outside-the-workspace dir."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        return ws, outside
+
+    # --- write_file (the reported sink, file_io.py write path) -----------
+
+    @pytest.mark.asyncio
+    async def test_write_relative_escape_blocked(self, workspace):
+        ws, outside = workspace
+        target = outside / "qwenpaw_path_probe.txt"
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await write_file(
+                "../outside/qwenpaw_path_probe.txt",
+                "probe",
+            )
+        text = result.content[0]["text"]
+        assert "outside the workspace" in text
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_write_absolute_escape_blocked(self, workspace):
+        ws, outside = workspace
+        target = outside / "abs_probe.txt"
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await write_file(str(target), "probe")
+        text = result.content[0]["text"]
+        assert "outside the workspace" in text
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_write_inside_workspace_allowed(self, workspace):
+        """Legitimate in-workspace writes must still succeed."""
+        ws, _ = workspace
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await write_file("notes.txt", "ok")
+        assert "Wrote" in result.content[0]["text"]
+        assert (ws / "notes.txt").exists()
+
+    # --- read_file / edit_file / append_file (shared guard) -------------
+
+    @pytest.mark.asyncio
+    async def test_read_relative_escape_blocked(self, workspace):
+        ws, outside = workspace
+        secret = outside / "secret.txt"
+        secret.write_text("top secret", encoding="utf-8")
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await read_file("../outside/secret.txt")
+        text = result.content[0]["text"]
+        assert "outside the workspace" in text
+        assert "top secret" not in text
+
+    @pytest.mark.asyncio
+    async def test_edit_relative_escape_blocked(self, workspace):
+        ws, outside = workspace
+        victim = outside / "victim.txt"
+        victim.write_text("original", encoding="utf-8")
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await edit_file(
+                "../outside/victim.txt",
+                "original",
+                "tampered",
+            )
+        assert "outside the workspace" in result.content[0]["text"]
+        assert victim.read_text(encoding="utf-8") == "original"
+
+    @pytest.mark.asyncio
+    async def test_append_relative_escape_blocked(self, workspace):
+        ws, outside = workspace
+        target = outside / "append_probe.txt"
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await append_file(
+                "../outside/append_probe.txt",
+                "probe",
+            )
+        assert "outside the workspace" in result.content[0]["text"]
+        assert not target.exists()
+
+    # --- explicit operator opt-out restores legacy behavior -------------
+
+    @pytest.mark.asyncio
+    async def test_optout_env_allows_escape(self, workspace, monkeypatch):
+        ws, outside = workspace
+        target = outside / "optout_probe.txt"
+        monkeypatch.setenv(
+            "QWENPAW_ALLOW_FILE_TOOLS_OUTSIDE_WORKSPACE",
+            "1",
+        )
+        with patch(
+            "qwenpaw.agents.tools.file_io.get_current_workspace_dir",
+            return_value=ws,
+        ):
+            result = await write_file(
+                "../outside/optout_probe.txt",
+                "probe",
+            )
+        assert "Wrote" in result.content[0]["text"]
+        assert target.exists()


### PR DESCRIPTION
## Description

The built-in file tools (`read_file` / `write_file` / `edit_file` / `append_file`) resolve a caller-supplied `file_path` without constraining it to the configured workspace: absolute paths are returned as-is and relative paths are joined onto the workspace with no normalization, so a `..` segment or an absolute path resolves outside the workspace root. This change adds containment — when a workspace is configured, a resolved path is verified to stay within the workspace root (symlink-aware, fail-closed) before any filesystem access. Behavior with no workspace configured is unchanged, and an opt-out env var preserves intentional host-wide access.

**Related Issue:** N/A

**Security Considerations:** Adds one opt-out environment variable (`QWENPAW_ALLOW_FILE_TOOLS_OUTSIDE_WORKSPACE`); no auth or other config-surface changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

`tests/unit/agents/tools/test_file_io.py` adds regression tests: in-workspace relative paths still resolve and read/write as before; a `..`-escape and an absolute path outside the workspace are rejected when a workspace is set; with no workspace configured (or the opt-out env var set) the prior behavior is preserved.

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/agents/tools/file_io.py tests/unit/agents/tools/test_file_io.py
# check python ast..Passed  mypy..Passed  black..Passed  flake8..Passed  pylint..Passed

pytest tests/unit/agents/tools/test_file_io.py
# 43 passed
```

## Additional Notes

Containment is enforced only when a workspace is configured. `QWENPAW_ALLOW_FILE_TOOLS_OUTSIDE_WORKSPACE=1` opts out for setups that intentionally need host-wide file access.