### PR TITLE
fix(crons): drop invalid jobs.json entries on startup (migration)

### DIFF
--- a/src/qwenpaw/app/crons/repo/json_repo.py
+++ b/src/qwenpaw/app/crons/repo/json_repo.py
@@ -10,8 +10,10 @@ import uuid
 from pathlib import Path
 from urllib.parse import quote
 
+from pydantic import ValidationError
+
 from .base import BaseJobRepository
-from ..models import CronExecutionRecord, JobsFile
+from ..models import CronExecutionRecord, CronJobSpec, JobsFile
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +199,80 @@ def migrate_legacy_weixin_jobs_file(jobs_path: Path | str) -> None:
         logger.error(
             "Failed to migrate legacy 'weixin' cron dispatch targets in "
             "%s: %s",
+            path,
+            exc,
+        )
+
+
+def migrate_invalid_jobs(jobs_path: Path | str) -> None:
+    """Drop jobs.json entries that fail validation, on workspace start.
+
+    A single invalid job makes ``JobsFile`` validation fail for the whole
+    file, so the cron manager cannot start and the workspace hangs
+    (issue #4835). Invalid entries can appear after an upgrade that changed
+    the cron job schema, or from a manual edit / interrupted write.
+
+    Each job is validated individually; valid jobs are kept verbatim and
+    invalid ones are dropped. The original file is backed up before any
+    rewrite, and nothing is changed when every job is already valid.
+    Idempotent.
+    """
+    path = (
+        Path(jobs_path).expanduser()
+        if isinstance(jobs_path, str)
+        else jobs_path
+    )
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        return
+
+    valid_jobs: list = []
+    dropped = 0
+    for job in jobs:
+        try:
+            CronJobSpec.model_validate(job)
+        except ValidationError:
+            dropped += 1
+            continue
+        valid_jobs.append(job)
+
+    if dropped == 0:
+        return
+
+    try:
+        backup_path = path.with_suffix(
+            path.suffix + f".{uuid.uuid4().hex[:8]}.invalid-jobs.bak",
+        )
+        shutil.copy2(path, backup_path)
+        data["jobs"] = valid_jobs
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        # newline="\n" keeps Windows from translating LF -> CRLF on rewrite.
+        tmp_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+            newline="\n",
+        )
+        # os.replace is the documented atomic-overwrite primitive on all
+        # supported platforms (POSIX rename + Windows ReplaceFile).
+        os.replace(tmp_path, path)
+        logger.warning(
+            "Dropped %d invalid job(s) from %s (backup: %s)",
+            dropped,
+            path,
+            backup_path,
+        )
+    except OSError as exc:
+        logger.error(
+            "Failed to drop invalid jobs in %s: %s",
             path,
             exc,
         )

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -410,7 +410,10 @@ class Workspace:
         Each step is guarded so a failure logs a warning instead of
         blocking startup; affected files stay in their legacy state.
         """
-        from ..crons.repo.json_repo import migrate_legacy_weixin_jobs_file
+        from ..crons.repo.json_repo import (
+            migrate_invalid_jobs,
+            migrate_legacy_weixin_jobs_file,
+        )
         from ..runner.repo.json_repo import migrate_legacy_weixin_chats_file
         from ..runner.session import migrate_legacy_weixin_session_files
 
@@ -434,6 +437,17 @@ class Workspace:
             logger.warning(
                 "weixin->wechat jobs.json migration failed for "
                 "agent %s: %s",
+                self.agent_id,
+                exc,
+            )
+
+        try:
+            migrate_invalid_jobs(
+                self.workspace_dir / "jobs.json",
+            )
+        except Exception as exc:
+            logger.warning(
+                "invalid-jobs migration failed for agent %s: %s",
                 self.agent_id,
                 exc,
             )


### PR DESCRIPTION
Fixes #4835

The migration approach discussed in #5040 (root-cause cleanup rather than runtime tolerance).

## What

`migrate_invalid_jobs()` runs on workspace start — right after the existing weixin→wechat jobs migration, **before `cron_manager` loads**. It validates each job in `jobs.json`, keeps the valid ones **verbatim**, drops invalid ones, and **backs up the original** before rewriting.

## Why

A single invalid job (e.g. one missing `dispatch.target.session_id`) makes `JobsFile.model_validate` fail for the whole file, so `cron_manager` can't start and the workspace hangs.

As traced in #5040, such entries don't arise from normal operation — writes always serialize a validated `JobsFile`. They come from a **schema change across upgrades**, or a manual edit / interrupted write, and `migration.py` had no content migration for them. This adds it.

Relative to #5040 (which tolerates invalid jobs at *load* time), this **cleans the file once on upgrade** — the root-cause fix you preferred — backing up the original so nothing is lost. The two are complementary; happy to keep either or both.

## Behaviour

- All jobs valid → no-op (no rewrite, no backup).
- Some invalid → drop them, back up original to `jobs.json.<hex>.invalid-jobs.bak`, atomically rewrite the cleaned file. Idempotent.

## Verification

- `black==23.3.0`, `flake8==6.1.0`, `pylint==3.0.2` (repo args) — clean (10/10)
- Ran it directly: a `jobs.json` with one valid + one invalid job (which makes `JobsFile.model_validate` raise) → after migration the invalid job is dropped, the valid one kept verbatim, `JobsFile.model_validate` succeeds, the original (incl. the dropped job) is backed up, and a re-run on the clean file is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
