### PR TITLE
feat(runner): freeze env_context date per session to preserve KV cache prefix

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -67,6 +67,7 @@ def build_env_context(
     add_hint: bool = True,
     default_shell: Optional[str] = None,
     project_dir: Optional[str] = None,
+    frozen_now: Optional[datetime] = None,
 ) -> str:
     """
     Build environment context with current request context prepended.
@@ -86,18 +87,26 @@ def build_env_context(
             directory" line is replaced with an explicit
             "Project directory" + "Agent workspace (internal)" pair
             so the LLM stops treating the workspace as home.
+        frozen_now: Optional datetime to use for the current date line.
+            When provided, the date is frozen to this value instead
+            of being generated from the current time. This allows
+            caller-side session-level date freezing to preserve
+            KV cache prefix across turns within a session.
 
     Returns:
         Formatted environment context string
     """
     parts = []
     user_tz = load_config().user_timezone or "UTC"
-    try:
-        now = datetime.now(ZoneInfo(user_tz))
-    except (ZoneInfoNotFoundError, KeyError):
-        logger.warning("Invalid timezone %r, falling back to UTC", user_tz)
-        now = datetime.now(timezone.utc)
-        user_tz = "UTC"
+    if frozen_now is not None:
+        now = frozen_now
+    else:
+        try:
+            now = datetime.now(ZoneInfo(user_tz))
+        except (ZoneInfoNotFoundError, KeyError):
+            logger.warning("Invalid timezone %r, falling back to UTC", user_tz)
+            now = datetime.now(timezone.utc)
+            user_tz = "UTC"
 
     if session_id is not None:
         parts.append(f"- Session ID: {session_id}")

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1203,6 +1203,14 @@ class AgentProfileConfig(BaseModel):
         default_factory=CodingModeConfig,
         description="Coding Mode configuration for this agent",
     )
+    freeze_env_context_date: bool = Field(
+        default=False,
+        description=(
+            "Freeze date in env_context per session to preserve "
+            "KV cache prefix. When enabled, the date remains stable "
+            "across turns within a session and refreshes on session switch."
+        ),
+    )
 
 
 class AgentsConfig(BaseModel):

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -11,9 +11,17 @@ injects all dependencies into the agent constructor.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any, Iterable
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 _logger = logging.getLogger(__name__)
+
+# Per-session date freezing: keep system prompt stable across turns
+# to preserve KV cache prefix. Refreshed on session switch.
+# Module-level globals are safe for single-worker deployment.
+_env_context_session_id: str | None = None
+_env_context_frozen_now: datetime | None = None
 
 
 class AgentBuilder:
@@ -363,6 +371,7 @@ class AgentBuilder:
         import os
         import sys
         from ..app.chats.utils import build_env_context
+        from ..config import load_config
         from ..constant import WORKING_DIR
 
         workspace_dir = getattr(ctx, "workspace_dir", None)
@@ -385,6 +394,25 @@ class AgentBuilder:
             or ("cmd.exe" if sys.platform == "win32" else "/bin/sh")
         )
         request = getattr(ctx, "request", None)
+
+        # Freeze date per session to preserve KV cache prefix
+        frozen_now = None
+        if getattr(agent_config, "freeze_env_context_date", False):
+            global _env_context_session_id, _env_context_frozen_now
+            session_id = getattr(ctx, "session_id", "")
+            if session_id != _env_context_session_id:
+                _env_context_session_id = session_id
+                _user_tz = load_config().user_timezone or "UTC"
+                try:
+                    _env_context_frozen_now = datetime.now(
+                        ZoneInfo(_user_tz),
+                    )
+                except (ZoneInfoNotFoundError, KeyError):
+                    _env_context_frozen_now = datetime.now(
+                        ZoneInfo("UTC"),
+                    )
+            frozen_now = _env_context_frozen_now
+
         return build_env_context(
             session_id=getattr(ctx, "session_id", ""),
             user_id=(getattr(request, "user_id", None) if request else None),
@@ -393,6 +421,7 @@ class AgentBuilder:
             working_dir=ws,
             default_shell=_default_shell,
             project_dir=_project_dir,
+            frozen_now=frozen_now,
         )
 
     @staticmethod


### PR DESCRIPTION
## Description

The System Prompt injects `Current date: YYYY-MM-DD` via `build_env_context()`. This date is computed on every request. When the date changes (for example, crossing midnight), the System Prompt prefix changes. This invalidates the entire KV Cache. As a result, tokens are re-computed and responses get slower for sessions that span across day boundaries.

This PR freezes the date at the session level. The date is captured once when a session starts, and reused for all turns in that session. The frozen date is refreshed only when the user switches to a different session.

**Related Issue:** Relates to #3891

**Security Considerations:** N/A — no user data is exposed, no external calls are added.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- [x] Manually tested: the date stays the same across turns within a session. It refreshes correctly when switching to another session.
- The second commit (`fix: add global declaration for module-level variables in query_handler`) is a fix discovered during testing. It has been resolved and verified.

## Additional Notes

- **Main benefit scenario:** Local self-hosted LLM with long context tasks that span across days. This optimization matters most for self-hosted setups where KV cache is managed by the deployment itself.
- Module-level globals are safe for single-worker deployment. The check-and-set has no `await` between the comparison and the assignment. This makes it atomic under Python's single-threaded asyncio event loop.
- Session switching refreshes the date. A new session always gets a fresh frozen datetime.
- Timezone is respected. The frozen datetime uses the user's configured timezone (from `load_config().user_timezone`), and falls back to UTC on invalid timezone.
- Backward compatible: `build_env_context()` defaults `frozen_now=None`. Existing behavior is preserved when the parameter is not passed.