### PR TITLE
agent重新加载后，chanel会跟着old_instance stop，不会启动。

### DIFF
--- a/src/qwenpaw/app/channels/registry.py
+++ b/src/qwenpaw/app/channels/registry.py
@@ -173,9 +173,13 @@ def register_custom_channel_routes(app) -> None:
             hook = getattr(mod, "register_app_routes", None)
             if not callable(hook):
                 continue
-            prev_routes = {r.path for r in app.routes}
+            prev_routes = {r.path for r in app.routes if hasattr(r,'path')}
+            last_route = app.routes[-1]
             hook(app)
-            new_routes = {r.path for r in app.routes} - prev_routes
+            new_routes = {r.path for r in app.routes if hasattr(r,'path')} - prev_routes
+            if not new_routes and last_route != app.routes[-1]: # last _IncludedRouter
+                last_route = app.routes[-1]
+                new_routes = {r.path for r in last_route.original_router.routes if hasattr(r,'path')}
             non_api = {p for p in new_routes if not p.startswith("/api/")}
             if non_api:
                 logger.warning(
@@ -185,8 +189,8 @@ def register_custom_channel_routes(app) -> None:
                     name,
                     non_api,
                 )
-        except Exception:
-            logger.exception("Failed to load custom channel routes: %s", name)
+        except Exception as e:
+            logger.exception("Failed to load custom channel routes: %s, error: %s", name,e)
 
 
 def get_channel_registry() -> dict[str, type[BaseChannel]]:

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -391,6 +391,10 @@ class MultiAgentManager:
                     f"{list(reusable.keys())}",
                 )
 
+            # Step 5: Gracefully stop old instance (outside lock)
+            # Delegates to helper method to avoid too-many-statements
+            await self._graceful_stop_old_instance(old_instance, agent_id)
+
         try:
             await new_instance.start()
             new_instance.set_manager(self)  # Set manager reference
@@ -423,10 +427,6 @@ class MultiAgentManager:
             old_instance = self.agents[agent_id]
             self.agents[agent_id] = new_instance
             logger.info(f"Workspace instance replaced: {agent_id}")
-
-        # Step 5: Gracefully stop old instance (outside lock)
-        # Delegates to helper method to avoid too-many-statements
-        await self._graceful_stop_old_instance(old_instance, agent_id)
 
         return True
 


### PR DESCRIPTION
## Description

1. agent重新加载后，chanel会跟着old_instance stop，不会启动。

2. chanel实现了register_app_routes，raise  '_IncludedRouter' object has no attribute 'path'

## Type of Change

- [ ] Bug fix

## Component(s) Affected

- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)


## Checklist
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Ready for review


