### PR TITLE
fix(console): improve ModelSelector dropdown mobile responsiveness

### DIFF
--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -61,6 +61,15 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  @media (max-width: 768px) {
+    width: calc(100vw - 32px);
+    max-width: 360px;
+    max-height: 60vh;
+    position: fixed !important;
+    left: 50% !important;
+    transform: translateX(-50%) !important;
+  }
 }
 
 /* ---- Search box ---- */

--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -195,6 +195,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
+  min-width: 0;
 }
 
 .collapseIcon {
@@ -243,6 +244,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
+  min-width: 0;
 }
 
 .modelTags {

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -698,7 +698,9 @@ export default function ModelSelector() {
       <Dropdown
         open={open}
         onOpenChange={handleOpenChange}
-        popupRender={() => dropdownContent}
+        popupRender={() => (
+          <div style={{ transform: "translateY(0)" }}>{dropdownContent}</div>
+        )}
         trigger={["click"]}
         placement="bottomLeft"
       >

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -117,7 +117,20 @@
 
 @media (max-width: 900px) {
   .historyPanel {
-    display: none;
+    position: fixed;
+    top: 90px;
+    right: 0;
+    bottom: 0;
+    width: min(330px, 85vw);
+    z-index: 1000;
+    box-shadow: -4px 0 12px rgba(0, 0, 0, 0.15);
+    border-radius: 12px 0 0 12px;
+  }
+  .historyPanelMask {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 999;
   }
 }
 

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2963,13 +2963,19 @@ export default function ChatPage() {
 
       {/* Right-side history panel (full mode only) */}
       {isFullMode && historyPanelOpen && (
-        <div className={styles.historyPanel}>
-          <ChatSessionDrawer
-            open={historyPanelOpen}
-            onClose={toggleHistoryPanel}
-            embedded
+        <>
+          <div
+            className={styles.historyPanelMask}
+            onClick={toggleHistoryPanel}
           />
-        </div>
+          <div className={styles.historyPanel}>
+            <ChatSessionDrawer
+              open={historyPanelOpen}
+              onClose={toggleHistoryPanel}
+              embedded
+            />
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

This PR improves mobile responsiveness of the Chat page header and history panel.

**Changes:**

1. **ModelSelector dropdown mobile fix** — The dropdown panel was partially obscured by the top navigation bar and clipped on the left side on mobile devices (< 768px). Now it is fully visible and horizontally centered.

2. **History panel mobile fix** — The right-side history panel was completely hidden on mobile (`display: none` at max-width: 900px). It is now shown as a slide-out drawer from the right side with a mask overlay, so users can access chat history on mobile.

**Related Issues:** #5334, #5350

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- Open Chat page on mobile viewport (< 768px width)
- Verify ModelSelector dropdown appears centered and fully visible
- Verify history panel opens as a right-side drawer with mask overlay
- Verify clicking the mask closes the history panel

## Local Verification Evidence

Tested on QwenPaw instance (fnOS) with embedded mode:
- ModelSelector dropdown: no navbar overlap, no left-side clipping, centered horizontally
- History panel: slide-out from right, border-radius 12px left side, mask overlay works

## Merge Compatibility

This PR is based on `fa98ae90` (main) and has been tested for merge compatibility with:
- #5350 (feat/mobile-chat-header-clean) — no conflicts
- #5357 (fix/issue-5354-session-switch) — no conflicts