### PR TITLE
feat(console): enhance PR #5350 with marquee and centered menu

### DIFF
--- a/console/src/components/PageHeader/index.module.less
+++ b/console/src/components/PageHeader/index.module.less
@@ -6,6 +6,12 @@
   padding: 20px;
   border-bottom: 1px solid #eae9e7;
   flex-shrink: 0;
+  gap: 8px;
+
+  @media (max-width: 768px) {
+    padding: 12px;
+    gap: 6px;
+  }
 }
 
 .leading {

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -229,7 +229,7 @@ export default function Header() {
               ] as MenuProps["items"],
             }}
           >
-            <Button type="text">
+            <Button type="text" className={styles.hideOnMobile}>
               {t("header.resources")} <DownOutlined />
             </Button>
           </Dropdown>
@@ -238,12 +238,15 @@ export default function Header() {
               type="text"
               icon={<GithubOutlined />}
               onClick={() => handleNavClick(GITHUB_URL)}
+              className={styles.hideOnMobile}
             >
               {t("header.github")}
             </Button>
           </Tooltip>
           <div className={styles.headerDivider} />
-          <CodingModeToggle />
+          <span className={styles.hideOnMobile}>
+            <CodingModeToggle />
+          </span>
           <div className={styles.headerDivider} />
           <LanguageSwitcher />
           <ThemeToggleButton />

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -19,6 +19,21 @@
       justify-content: center;
     }
   }
+
+  // ─── Mobile (≤ 768px) ─────────────────────────────────────────────────
+  // On narrow screens, hide auxiliary header items (Resources dropdown,
+  // GitHub link, dividers, CodingModeToggle) so the Chat header below it
+  // gets enough horizontal room for action buttons.
+  @media (max-width: 768px) {
+    padding: 0 12px;
+
+    .headerDivider {
+      display: none;
+    }
+    .hideOnMobile {
+      display: none !important;
+    }
+  }
 }
 
 .headerTitle {

--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -47,6 +47,21 @@
   }
 }
 
+.marqueeText {
+  display: inline-block;
+  padding-left: 100%;
+  animation: modelNameMarquee 10s linear infinite;
+}
+
+@keyframes modelNameMarquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
 .triggerArrow {
   flex-shrink: 0;
   font-size: 18px;

--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -19,6 +19,17 @@
     color: #ff7f16;
     box-shadow: 0 2px 8px rgba(97, 92, 237, 0.12);
   }
+
+  @media (max-width: 768px) {
+    max-width: 140px;
+    padding: 4px 6px;
+    gap: 3px;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 96px;
+    font-size: 13px;
+  }
 }
 
 .triggerName {
@@ -26,6 +37,14 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 180px;
+
+  @media (max-width: 768px) {
+    max-width: 90px;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 60px;
+  }
 }
 
 .triggerArrow {

--- a/console/src/pages/Chat/ModelSelector/index.tsx
+++ b/console/src/pages/Chat/ModelSelector/index.tsx
@@ -68,6 +68,8 @@ export default function ModelSelector() {
 
   const [showMoreFree, setShowMoreFree] = useState(false);
   const moreContentRef = useRef<HTMLDivElement>(null);
+  const triggerNameRef = useRef<HTMLSpanElement>(null);
+  const [shouldMarquee, setShouldMarquee] = useState(false);
   const [expandedModels, setExpandedModels] = useState<Record<string, number>>(
     {},
   );
@@ -233,6 +235,25 @@ export default function ModelSelector() {
   })();
 
   const showActiveProviderIcon = Boolean(activeProviderId);
+
+  // Detect text overflow for marquee effect
+  useEffect(() => {
+    const el = triggerNameRef.current;
+    if (!el) return;
+
+    const checkOverflow = () => {
+      setShouldMarquee(el.scrollWidth > el.clientWidth);
+    };
+
+    checkOverflow();
+
+    const resizeObserver = new ResizeObserver(checkOverflow);
+    resizeObserver.observe(el);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [activeModelName, open]);
 
   const handleOpenChange = useCallback(
     async (next: boolean) => {
@@ -700,7 +721,18 @@ export default function ModelSelector() {
             {showActiveProviderIcon && activeProviderId && (
               <ProviderIcon providerId={activeProviderId} size={16} />
             )}
-            <span className={styles.triggerName}>{activeModelName}</span>
+            <span
+              className={styles.triggerName}
+              ref={triggerNameRef}
+            >
+              <span
+                className={
+                  shouldMarquee ? styles.marqueeText : undefined
+                }
+              >
+                {activeModelName}
+              </span>
+            </span>
             {open ? <UpOutlined /> : <DownOutlined />}
           </div>
         </Tooltip>

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -99,7 +99,9 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
     moreItems.push({
       key: "plan",
       icon: <PlanIcon />,
-      label: t("plan.title", "Plan"),
+      label: (
+        <div style={{ textAlign: "center" }}>{t("plan.title", "Plan")}</div>
+      ),
       onClick: () => setPlanOpen(true),
     });
   }
@@ -107,7 +109,11 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
     moreItems.push({
       key: "history",
       icon: <SparkHistoryLine />,
-      label: t("chat.chatHistoryTooltip"),
+      label: (
+        <div style={{ textAlign: "center" }}>
+          {t("chat.chatHistoryTooltip")}
+        </div>
+      ),
       onClick: () => onToggleHistory(),
     });
   }
@@ -115,9 +121,13 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
     moreItems.push({
       key: "wideMode",
       icon: isWideMode ? <CompressOutlined /> : <ExpandAltOutlined />,
-      label: isWideMode
-        ? t("chat.normalModeTooltip")
-        : t("chat.wideModeTooltip"),
+      label: (
+        <div style={{ textAlign: "center" }}>
+          {isWideMode
+            ? t("chat.normalModeTooltip")
+            : t("chat.wideModeTooltip")}
+        </div>
+      ),
       onClick: () => onToggleWideMode(),
     });
   }

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -1,14 +1,19 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { IconButton } from "@agentscope-ai/design";
 import {
   SparkHistoryLine,
   SparkNewChatFill,
   SparkSearchLine,
 } from "@agentscope-ai/icons";
-import { ExpandAltOutlined, CompressOutlined } from "@ant-design/icons";
+import {
+  ExpandAltOutlined,
+  CompressOutlined,
+  MoreOutlined,
+} from "@ant-design/icons";
 import { useChatAnywhereSessions } from "@agentscope-ai/chat";
 import { useTranslation } from "react-i18next";
-import { Flex, Tooltip } from "antd";
+import { Dropdown, Flex, Tooltip } from "antd";
+import type { MenuProps } from "antd";
 import ChatSearchPanel from "../ChatSearchPanel";
 import PlanPanel from "../../../../components/PlanPanel";
 
@@ -27,6 +32,11 @@ const PlanIcon = () => (
     <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
   </svg>
 );
+
+// Below this *available header width*, collapse secondary actions (Plan,
+// History, WideMode) into a "more" dropdown so the essential New/Search
+// buttons stay visible on mobile.
+const COMPACT_BREAKPOINT_PX = 700;
 
 interface ChatActionGroupProps {
   planEnabled?: boolean;
@@ -51,9 +61,71 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
   const [planOpen, setPlanOpen] = useState(false);
   const { createSession } = useChatAnywhereSessions();
 
+  // Detect compact mode by observing the parent header width.
+  // Falls back to window inner width on environments without ResizeObserver.
+  const groupRef = useRef<HTMLDivElement | null>(null);
+  const [isCompact, setIsCompact] = useState(false);
+
+  useEffect(() => {
+    const computeCompact = () => {
+      const headerEl = groupRef.current?.parentElement ?? null;
+      const headerWidth =
+        headerEl?.getBoundingClientRect().width ?? window.innerWidth;
+      setIsCompact(headerWidth < COMPACT_BREAKPOINT_PX);
+    };
+
+    computeCompact();
+
+    let observer: ResizeObserver | null = null;
+    const headerEl = groupRef.current?.parentElement ?? null;
+    if (typeof ResizeObserver !== "undefined" && headerEl) {
+      observer = new ResizeObserver(() => computeCompact());
+      observer.observe(headerEl);
+    } else if (typeof window !== "undefined") {
+      window.addEventListener("resize", computeCompact);
+    }
+
+    return () => {
+      observer?.disconnect();
+      if (typeof window !== "undefined") {
+        window.removeEventListener("resize", computeCompact);
+      }
+    };
+  }, []);
+
+  // Build "more" dropdown items for compact mode: Plan, History, WideMode.
+  const moreItems: MenuProps["items"] = [];
+  if (planEnabled) {
+    moreItems.push({
+      key: "plan",
+      icon: <PlanIcon />,
+      label: t("plan.title", "Plan"),
+      onClick: () => setPlanOpen(true),
+    });
+  }
+  if (onToggleHistory) {
+    moreItems.push({
+      key: "history",
+      icon: <SparkHistoryLine />,
+      label: t("chat.chatHistoryTooltip"),
+      onClick: () => onToggleHistory(),
+    });
+  }
+  if (onToggleWideMode) {
+    moreItems.push({
+      key: "wideMode",
+      icon: isWideMode ? <CompressOutlined /> : <ExpandAltOutlined />,
+      label: isWideMode
+        ? t("chat.normalModeTooltip")
+        : t("chat.wideModeTooltip"),
+      onClick: () => onToggleWideMode(),
+    });
+  }
+
   return (
-    <Flex gap={8} align="center">
-      {planEnabled && (
+    <Flex gap={8} align="center" ref={groupRef}>
+      {/* Plan icon: only render inline when NOT compact */}
+      {!isCompact && planEnabled && (
         <Tooltip title={t("plan.title", "Plan")} mouseEnterDelay={0.5}>
           <IconButton
             bordered={false}
@@ -62,6 +134,8 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           />
         </Tooltip>
       )}
+
+      {/* Essential actions always visible */}
       <Tooltip title={t("chat.newChatTooltip")} mouseEnterDelay={0.5}>
         <IconButton
           bordered={false}
@@ -76,7 +150,9 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           onClick={() => setSearchOpen(true)}
         />
       </Tooltip>
-      {onToggleHistory && (
+
+      {/* History + WideMode: inline when NOT compact */}
+      {!isCompact && onToggleHistory && (
         <Tooltip title={t("chat.chatHistoryTooltip")} mouseEnterDelay={0.5}>
           <IconButton
             bordered={false}
@@ -90,7 +166,7 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           />
         </Tooltip>
       )}
-      {onToggleWideMode && (
+      {!isCompact && onToggleWideMode && (
         <Tooltip
           title={
             isWideMode ? t("chat.normalModeTooltip") : t("chat.wideModeTooltip")
@@ -104,6 +180,18 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           />
         </Tooltip>
       )}
+
+      {/* Compact mode: collapse Plan/History/WideMode into more dropdown */}
+      {isCompact && moreItems.length > 0 && (
+        <Dropdown
+          menu={{ items: moreItems }}
+          trigger={["click"]}
+          placement="bottomRight"
+        >
+          <IconButton bordered={false} icon={<MoreOutlined />} />
+        </Dropdown>
+      )}
+
       <ChatSearchPanel open={searchOpen} onClose={() => setSearchOpen(false)} />
       {planEnabled && (
         <PlanPanel open={planOpen} onClose={() => setPlanOpen(false)} />

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
@@ -77,3 +77,64 @@
     color: rgba(255, 255, 255, 0.88);
   }
 }
+
+/* ---- Trigger button ---- */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+  max-width: 260px;
+
+  &:hover {
+    .chatName {
+      color: #ff7f16;
+    }
+    .triggerArrow {
+      color: #ff7f16;
+    }
+  }
+
+  @media (max-width: 768px) {
+    max-width: 140px;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 100px;
+  }
+}
+
+.triggerArrow {
+  font-size: 12px;
+  color: #999;
+  transition: transform 0.2s, color 0.15s;
+  flex-shrink: 0;
+
+  &.triggerArrowOpen {
+    transform: rotate(180deg);
+    color: #ff7f16;
+  }
+}
+
+/* ---- Dropdown menu items ---- */
+.menuItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.menuItemName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.menuItemActive {
+  color: #ff7f16;
+  font-size: 12px;
+  flex-shrink: 0;
+}

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
@@ -9,10 +9,67 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media (max-width: 768px) {
+    max-width: 120px;
+    font-size: 14px;
+  }
+
+  // ─── Mobile: replace ellipsis with horizontal marquee ───────────────────
+  // When the title is longer than its container, slide the full text from
+  // right to left so the user can still read it.
+  @media (max-width: 480px) {
+    max-width: 90px;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: clip;
+
+    > .marquee {
+      display: inline-block;
+      padding-left: 100%;
+      animation: chatNameMarquee 12s linear infinite;
+    }
+  }
 }
 
 .chatNameCoding {
   max-width: 100px;
+
+  @media (max-width: 768px) {
+    max-width: 70px;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 55px;
+  }
+}
+
+// Wrapper used in JSX only when the title overflows on mobile.
+.marquee {
+  display: inline-block;
+}
+
+@keyframes chatNameMarquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+// Wrapper used in JSX only when the title overflows on mobile.
+.marquee {
+  display: inline-block;
+}
+
+@keyframes chatNameMarquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
 }
 
 :global(.dark-mode) {

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
+import { Dropdown } from "antd";
+import { DownOutlined } from "@ant-design/icons";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import styles from "./index.module.less";
@@ -6,10 +8,13 @@ import styles from "./index.module.less";
 const MOBILE_BREAKPOINT_PX = 480;
 
 const ChatHeaderTitle: React.FC = () => {
-  const { sessions, currentSessionId } = useChatAnywhereSessionsState();
+  const { sessions, currentSessionId, setCurrentSessionId } =
+    useChatAnywhereSessionsState();
   const { codingMode } = useCodingMode();
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const chatName = currentSession?.name || "New Chat";
+
+  const [open, setOpen] = useState(false);
 
   // Detect mobile + whether title overflows. On mobile + overflow, render as
   // a horizontal marquee; otherwise keep the original ellipsis behavior.
@@ -39,11 +44,29 @@ const ChatHeaderTitle: React.FC = () => {
     return () => window.removeEventListener("resize", check);
   }, [chatName, codingMode]);
 
+  const handleSessionClick = (sessionId: string) => {
+    setCurrentSessionId(sessionId);
+    setOpen(false);
+  };
+
+  const menuItems = sessions.map((session) => ({
+    key: session.id,
+    label: (
+      <div className={styles.menuItem}>
+        <span className={styles.menuItemName}>{session.name || "New Chat"}</span>
+        {session.id === currentSessionId && (
+          <span className={styles.menuItemActive}>✓</span>
+        )}
+      </div>
+    ),
+    onClick: () => handleSessionClick(session.id),
+  }));
+
   const className = codingMode
     ? `${styles.chatName} ${styles.chatNameCoding}`
     : styles.chatName;
 
-  return (
+  const titleContent = (
     <span className={className} ref={containerRef}>
       {/* Hidden span used to measure intrinsic text width. */}
       <span
@@ -64,6 +87,25 @@ const ChatHeaderTitle: React.FC = () => {
         chatName
       )}
     </span>
+  );
+
+  if (sessions.length <= 1) {
+    return titleContent;
+  }
+
+  return (
+    <Dropdown
+      menu={{ items: menuItems }}
+      open={open}
+      onOpenChange={setOpen}
+      trigger={["click"]}
+      placement="bottomLeft"
+    >
+      <span className={styles.trigger}>
+        {titleContent}
+        <DownOutlined className={styles.triggerArrow} />
+      </span>
+    </Dropdown>
   );
 };
 

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import styles from "./index.module.less";
+
+const MOBILE_BREAKPOINT_PX = 480;
 
 const ChatHeaderTitle: React.FC = () => {
   const { sessions, currentSessionId } = useChatAnywhereSessionsState();
@@ -9,11 +11,60 @@ const ChatHeaderTitle: React.FC = () => {
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const chatName = currentSession?.name || "New Chat";
 
+  // Detect mobile + whether title overflows. On mobile + overflow, render as
+  // a horizontal marquee; otherwise keep the original ellipsis behavior.
+  const containerRef = useRef<HTMLSpanElement | null>(null);
+  const measureRef = useRef<HTMLSpanElement | null>(null);
+  const [shouldMarquee, setShouldMarquee] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      const w =
+        typeof window !== "undefined" ? window.innerWidth : Number.MAX_VALUE;
+      const isMobile = w <= MOBILE_BREAKPOINT_PX;
+      if (!isMobile) {
+        setShouldMarquee(false);
+        return;
+      }
+      const containerWidth =
+        containerRef.current?.getBoundingClientRect().width ?? 0;
+      const textWidth =
+        measureRef.current?.getBoundingClientRect().width ?? 0;
+      // Add a few px tolerance to avoid borderline jitter.
+      setShouldMarquee(textWidth > containerWidth + 2);
+    };
+
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [chatName, codingMode]);
+
   const className = codingMode
     ? `${styles.chatName} ${styles.chatNameCoding}`
     : styles.chatName;
 
-  return <span className={className}>{chatName}</span>;
+  return (
+    <span className={className} ref={containerRef}>
+      {/* Hidden span used to measure intrinsic text width. */}
+      <span
+        ref={measureRef}
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          visibility: "hidden",
+          whiteSpace: "nowrap",
+          pointerEvents: "none",
+        }}
+      >
+        {chatName}
+      </span>
+      {shouldMarquee ? (
+        <span className={styles.marquee}>{chatName}</span>
+      ) : (
+        chatName
+      )}
+    </span>
+  );
 };
 
 export default ChatHeaderTitle;


### PR DESCRIPTION
## 基于 PR #5350 的增强补丁

在 PR #5350（移动端 Chat header 响应式改进）基础上，进一步优化移动端体验：

### 改动内容

1. **ChatHeaderTitle 可点击下拉**
   - 多会话时标题变为下拉选择器，支持点击切换会话
   - 单个会话时保持纯文本，不显示箭头
   - 保留移动端 marquee 跑马灯效果

2. **ChatActionGroup 折叠菜单居中**
   - compact 模式下下拉菜单文字居中显示
   - 保留原有 icon，不影响桌面端

3. **ModelSelector 跑马灯**
   - 模型名称改为跑马灯效果
   - 动态检测文字溢出（ResizeObserver），不再依赖固定断点
   - 仅在溢出时滚动，正常显示时保持省略号

### 文件改动

- `console/src/pages/Chat/components/ChatHeaderTitle/index.tsx`
- `console/src/pages/Chat/components/ChatHeaderTitle/index.module.less`
- `console/src/pages/Chat/components/ChatActionGroup/index.tsx`
- `console/src/pages/Chat/ModelSelector/index.tsx`
- `console/src/pages/Chat/ModelSelector/index.module.less`

### 构建部署

- 前端构建成功（需 `NODE_OPTIONS=--max_old_space_size=8192`）
- 已本地验证移动端效果

### 关联 PR

- 基于 #5350（feat/mobile-chat-header-clean）