### PR TITLE
fix(console): improve mobile responsiveness of settings/agents page

### DIFF
--- a/console/src/pages/Settings/Agents/components/AgentCards.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentCards.tsx
@@ -1,0 +1,159 @@
+import { Button, Popconfirm, Tag, Tooltip, Space } from "antd";
+import { useTranslation } from "react-i18next";
+import {
+  EditOutlined,
+  DeleteOutlined,
+  RobotOutlined,
+} from "@ant-design/icons";
+import { EyeOff, Eye } from "lucide-react";
+import type { AgentSummary } from "../../../../api/types/agents";
+import { getAgentDisplayName } from "../../../../utils/agentDisplayName";
+import { providerIcon } from "../../Models/components/providerIcon";
+import styles from "../index.module.less";
+
+interface AgentCardsProps {
+  agents: AgentSummary[];
+  loading: boolean;
+  onEdit: (agent: AgentSummary) => void;
+  onDelete: (agentId: string) => void;
+  onToggle: (agentId: string, currentEnabled: boolean) => void;
+}
+
+export function AgentCards({
+  agents,
+  loading: _loading,
+  onEdit,
+  onDelete,
+  onToggle,
+}: AgentCardsProps) {
+  const { t } = useTranslation();
+
+  if (!agents.length) {
+    return null;
+  }
+
+  return (
+    <div className={styles.agentCardList}>
+      {agents.map((agent) => (
+        <div
+          key={agent.id}
+          className={`${styles.agentCardItem} ${!agent.enabled ? styles.agentCardDisabled : ""}`}
+        >
+          {/* Header: icon + name + status */}
+          <div className={styles.agentCardHeader}>
+            <RobotOutlined className={styles.agentCardIcon} />
+            <span className={styles.agentCardName}>
+              {getAgentDisplayName(agent, t)}
+            </span>
+            {!agent.enabled && (
+              <Tag color="error" className={styles.agentCardTag}>
+                {t("agent.disabled")}
+              </Tag>
+            )}
+          </div>
+
+          {/* Info rows */}
+          <div className={styles.agentCardBody}>
+            <div className={styles.agentCardRow}>
+              <span className={styles.agentCardLabel}>{t("agent.id")}:</span>
+              <code className={styles.agentCardValue}>{agent.id}</code>
+            </div>
+            {agent.description && (
+              <div className={styles.agentCardRow}>
+                <span className={styles.agentCardLabel}>
+                  {t("agent.description")}:
+                </span>
+                <span className={styles.agentCardValue}>
+                  {agent.description}
+                </span>
+              </div>
+            )}
+            {agent.workspace_dir && (
+              <div className={styles.agentCardRow}>
+                <span className={styles.agentCardLabel}>
+                  {t("agent.workspace")}:
+                </span>
+                <code className={`${styles.agentCardValue} ${styles.agentCardMono}`}>
+                  {agent.workspace_dir}
+                </code>
+              </div>
+            )}
+            <div className={styles.agentCardRow}>
+              <span className={styles.agentCardLabel}>
+                {t("agent.modelColumn")}:
+              </span>
+              {agent.active_model ? (
+                <Space size={4} className={styles.agentCardValue}>
+                  <img
+                    src={providerIcon(agent.active_model.provider_id)}
+                    alt=""
+                    className={styles.agentCardProviderIcon}
+                  />
+                  <Tooltip title={agent.active_model.model}>
+                    <span>{agent.active_model.model}</span>
+                  </Tooltip>
+                </Space>
+              ) : (
+                <span className={`${styles.agentCardValue} ${styles.agentCardPlaceholder}`}>
+                  {t("agent.modelPlaceholder")}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Action buttons */}
+          <div className={styles.agentCardActions}>
+            <Button
+              type="text"
+              size="small"
+              icon={<EditOutlined />}
+              onClick={() => onEdit(agent)}
+              disabled={agent.id === "default"}
+            />
+            <Popconfirm
+              title={
+                agent.enabled
+                  ? t("agent.disableConfirm")
+                  : t("agent.enableConfirm")
+              }
+              description={
+                agent.enabled
+                  ? t("agent.disableConfirmDesc")
+                  : t("agent.enableConfirmDesc")
+              }
+              onConfirm={() => onToggle(agent.id, agent.enabled)}
+              disabled={agent.id === "default"}
+              okText={t("common.confirm")}
+              cancelText={t("common.cancel")}
+            >
+              <Button
+                type="text"
+                size="small"
+                icon={
+                  agent.enabled ? <EyeOff size={14} /> : <Eye size={14} />
+                }
+                disabled={agent.id === "default"}
+              />
+            </Popconfirm>
+            <Popconfirm
+              title={t("agent.deleteConfirm")}
+              description={t("agent.deleteConfirmDesc")}
+              onConfirm={() => onDelete(agent.id)}
+              disabled={agent.id === "default"}
+              okText={t("common.confirm")}
+              cancelText={t("common.cancel")}
+            >
+              <Button
+                type="link"
+                size="small"
+                danger
+                icon={<DeleteOutlined />}
+                disabled={agent.id === "default"}
+              />
+            </Popconfirm>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/console/src/pages/Settings/Agents/components/AgentTable.tsx
+++ b/console/src/pages/Settings/Agents/components/AgentTable.tsx
@@ -74,6 +74,7 @@ export function AgentTable({
       key: "sort",
       width: 56,
       align: "center",
+      responsive: ["lg"],
       render: () => (
         <Tooltip title={t("agent.dragHandleTooltip")}>
           <span>
@@ -106,24 +107,28 @@ export function AgentTable({
       title: t("agent.id"),
       dataIndex: "id",
       key: "id",
+      responsive: ["lg"],
     },
     {
       title: t("agent.description"),
       dataIndex: "description",
       key: "description",
       ellipsis: true,
+      responsive: ["md"],
     },
     {
       title: t("agent.workspace"),
       dataIndex: "workspace_dir",
       key: "workspace_dir",
       ellipsis: true,
+      responsive: ["lg"],
     },
     {
       title: t("agent.modelColumn"),
       key: "active_model",
       width: 260,
       ellipsis: true,
+      responsive: ["sm"],
       render: (_: any, record: AgentSummary) => {
         if (!record.active_model) {
           return (
@@ -234,6 +239,7 @@ export function AgentTable({
             columns={columns}
             loading={loading}
             rowKey="id"
+            scroll={{ x: "max-content" }}
             components={{
               body: {
                 row: SortableAgentRow,

--- a/console/src/pages/Settings/Agents/components/index.ts
+++ b/console/src/pages/Settings/Agents/components/index.ts
@@ -1,2 +1,3 @@
 export { AgentTable } from "./AgentTable";
+export { AgentCards } from "./AgentCards";
 export { AgentModal } from "./AgentModal";

--- a/console/src/pages/Settings/Agents/index.module.less
+++ b/console/src/pages/Settings/Agents/index.module.less
@@ -310,3 +310,195 @@
   color: rgba(255, 255, 255, 0.25) !important;
   opacity: 1 !important;
 }
+
+/* ─── Mobile agent cards ────────────────────────────────────────────────────── */
+.agentCardList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agentCardItem {
+  background: #fff;
+  border-radius: 14px;
+  border: 1px solid #e8e8e8;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: border-color 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    border-color: rgba(97, 92, 237, 0.3);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.agentCardDisabled {
+  opacity: 0.6;
+}
+
+.agentCardHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.agentCardIcon {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.agentCardName {
+  font-weight: 600;
+  font-size: 15px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #1a1a1a;
+}
+
+.agentCardTag {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.agentCardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  color: #666;
+}
+
+.agentCardRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  line-height: 1.5;
+}
+
+.agentCardLabel {
+  font-weight: 500;
+  white-space: nowrap;
+  flex-shrink: 0;
+  color: #888;
+}
+
+.agentCardValue {
+  word-break: break-all;
+  color: #444;
+}
+
+.agentCardMono {
+  font-size: 11px;
+}
+
+.agentCardPlaceholder {
+  opacity: 0.45;
+}
+
+.agentCardProviderIcon {
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+}
+
+.agentCardActions {
+  display: flex;
+  gap: 4px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+  padding-top: 10px;
+}
+
+/* Dark mode agent cards */
+:global(.dark-mode) {
+  .agentCardItem {
+    background: #1e1e1e;
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
+
+    &:hover {
+      border-color: rgba(99, 102, 241, 0.3);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    }
+  }
+
+  .agentCardName {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .agentCardBody {
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .agentCardLabel {
+    color: rgba(255, 255, 255, 0.4);
+  }
+
+  .agentCardValue {
+    color: rgba(255, 255, 255, 0.75);
+  }
+
+  .agentCardActions {
+    border-top-color: rgba(255, 255, 255, 0.08);
+  }
+}
+
+/* ─── Desktop-only: table ──────────────────────────────────────────────────── */
+.desktopTableOnly {
+  display: block;
+}
+
+.mobileCardsOnly {
+  display: none;
+}
+
+/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .agentsPage {
+    height: auto;
+    min-height: auto;
+    padding-bottom: 16px;
+  }
+
+  .pageHeader {
+    padding: 12px 16px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .tableCard {
+    margin-bottom: 16px;
+  }
+
+  .tableCard :global(.ant-card-body) {
+    padding: 12px;
+  }
+
+  .desktopTableOnly {
+    display: none;
+  }
+
+  .mobileCardsOnly {
+    display: block;
+  }
+
+  :global {
+    .qwenpaw-table-cell {
+      padding: 4px 8px !important;
+    }
+
+    .qwenpaw-table-wrapper
+      .qwenpaw-table-container
+      .qwenpaw-table-thead
+      > tr
+      > th {
+      padding: 4px 8px !important;
+    }
+  }
+}

--- a/console/src/pages/Settings/Agents/index.tsx
+++ b/console/src/pages/Settings/Agents/index.tsx
@@ -8,7 +8,7 @@ import { invalidateSkillCache, skillApi } from "../../../api/modules/skill";
 import type { AgentSummary } from "../../../api/types/agents";
 import { useAgentStore } from "../../../stores/agentStore";
 import { useAgents } from "./useAgents";
-import { AgentTable, AgentModal } from "./components";
+import { AgentTable, AgentCards, AgentModal } from "./components";
 import { PageHeader } from "@/components/PageHeader";
 import { reorderAgents } from "./reorder";
 import styles from "./index.module.less";
@@ -190,15 +190,26 @@ export default function AgentsPage() {
       />
 
       <Card className={styles.tableCard}>
-        <AgentTable
-          agents={agents}
-          loading={loading || reordering}
-          reordering={reordering}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onToggle={handleToggle}
-          onReorder={handleReorder}
-        />
+        <div className={styles.desktopTableOnly}>
+          <AgentTable
+            agents={agents}
+            loading={loading || reordering}
+            reordering={reordering}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onToggle={handleToggle}
+            onReorder={handleReorder}
+          />
+        </div>
+        <div className={styles.mobileCardsOnly}>
+          <AgentCards
+            agents={agents}
+            loading={loading || reordering}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onToggle={handleToggle}
+          />
+        </div>
       </Card>
 
       <AgentModal


### PR DESCRIPTION
﻿## Description

The "Settings / Agents" page was nearly unusable on mobile — the table overflowed horizontally, content was clipped on the right side, and excessive whitespace was left at the bottom after removing the header.

This PR replaces the antd Table with a **card-based layout** on narrow viewports (< 768px), showing all agent information (name, id, description, workspace, model, actions) in stacked cards that fit the screen width naturally. The desktop version retains the full table with drag-reorder and responsive column hiding.

### Issues Fixed

1. **Horizontal overflow**: Table columns (sort, id, name, description, workspace, model, actions) were too wide for mobile — content clipped
2. **Bottom whitespace**: Fixed `height: calc(100vh - ...)` left empty space on mobile
3. **Desktop table also improved**: Added `responsive` props to hide non-essential columns on smaller desktop viewports (sort/id/workspace at lg+, description at md+)
4. **Table scroll**: Added `scroll={{ x: "max-content" }}` for graceful horizontal scroll fallback

### Changes

| File | Change |
|------|--------|
| `AgentCards.tsx` | **New** — Card-based mobile layout showing all agent fields |
| `index.ts` | Export `AgentCards` |
| `index.tsx` | Render both Table + Cards, CSS-toggled by `@media (max-width: 768px)` |
| `index.module.less` | Card styles with QwenPaw visual design (solid bg, shadow, dark mode) + mobile breakpoints |
| `AgentTable.tsx` | Added `scroll={{ x: "max-content" }}` and `responsive` column props |

### Desktop Column Responsiveness

| Column | Visible From |
|--------|-------------|
| Sort handle | lg (≥ 992px) |
| Name | always |
| ID | lg (≥ 992px) |
| Description | md (≥ 768px) |
| Workspace | lg (≥ 992px) |
| Model | sm (≥ 576px) |
| Actions | always |

### Mobile Card Layout

```
┌──────────────────────────────────┐
│ 🤖 Agent Name            [禁用]  │
│                                  │
│ ID:         default               │
│ 描述:      xxxxxx                 │
│ 工作目录:   /path/to/workspace    │
│ 模型:       provider/gpt-4        │
│                                  │
│ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ── │
│  ✏️编辑     👁禁用     🗑删除     │
└──────────────────────────────────┘
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Testing

1. Open Settings / Agents on a desktop browser — full table with all columns visible at lg+
2. Resize to < 768px or use DevTools mobile mode — cards appear, no overflow
3. Verify all fields (id, description, workspace, model) are visible on each card
4. Verify edit/toggle/delete actions work on mobile cards
5. Toggle dark mode — cards render correctly
6. Resize to intermediate widths (768-992px, 576-768px) — columns hide/show as expected

## Local Verification

```bash
cd console && NODE_OPTIONS="--max-old-space-size=4096" npm run build
# ✓ built in 32.50s
```

## Additional Notes

Cards use solid background + shadow for clear visual separation on plain backgrounds (backdrop-filter glass effect was tried but barely visible on solid backgrounds). The desktop table is completely unaffected — all mobile styles are wrapped in `@media (max-width: 768px)` and `responsive` column props.