### PR TITLE
feat(console): mobile responsive layout for Agent Config page

### DIFF
--- a/console/src/pages/Agent/Config/index.module.less
+++ b/console/src/pages/Agent/Config/index.module.less
@@ -259,3 +259,54 @@
     }
   }
 }
+
+/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 12px 16px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .tabContent {
+    padding: 0 12px;
+  }
+
+  .reactAgentRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .reactAgentField {
+    margin-bottom: 12px !important;
+  }
+
+  .llmRetryRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .llmRetryField {
+    margin-bottom: 12px !important;
+  }
+
+  .formCard {
+    margin-bottom: 16px;
+  }
+
+  .footerActions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px 16px;
+    justify-content: center;
+  }
+
+  .footerActions :global(.ant-btn) {
+    flex: 1;
+    min-width: 120px;
+    max-width: 200px;
+  }
+}


### PR DESCRIPTION
## Summary

Add mobile responsive CSS for the Agent Config page (workspace → run configuration → ReAct agent / LLM retry / rate limiter tabs).

## Changes

### `console/src/pages/Agent/Config/index.module.less`

Added a `@media (max-width: 768px)` block that:

- **Page header**: reduced padding from 20px to 12px 16px, title font from 20px to 16px
- **Tab content**: reduced side padding from 16px to 12px
- **Form rows** (`.reactAgentRow`, `.llmRetryRow`): switched from 3-column `grid-template-columns: repeat(3, 1fr)` to single-column `1fr`
- **Form fields** (`.reactAgentField`, `.llmRetryField`): added `margin-bottom: 12px` so fields don't stick together in stacked layout
- **Card**: added bottom margin (16px)
- **Footer actions**: kept horizontal flex with wrap, buttons use `flex: 1` capped at 200px max-width – prevents full-width accidental taps
- **Desktop: 0 impact** – all changes are wrapped in `@media (max-width: 768px)`

Applies to all three tabs under Agent Config: ReAct Agent, LLM Retry, and Rate Limiter.
