### PR TITLE
feat(console): mobile responsive layout for Agent Config page

### DIFF
--- a/console/src/pages/Agent/Config/index.module.less
+++ b/console/src/pages/Agent/Config/index.module.less
@@ -309,4 +309,16 @@
     min-width: 120px;
     max-width: 200px;
   }
+
+  .mainTabs {
+    :global(.qwenpaw-tabs-nav) {
+      overflow-x: auto;
+      white-space: nowrap;
+      -webkit-overflow-scrolling: touch;
+    }
+    :global(.qwenpaw-tabs-nav-list) {
+      display: inline-flex;
+      white-space: nowrap;
+    }
+  }
 }

--- a/console/src/pages/Agent/Config/index.module.less
+++ b/console/src/pages/Agent/Config/index.module.less
@@ -259,3 +259,54 @@
     }
   }
 }
+
+/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 12px 16px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .tabContent {
+    padding: 0 12px;
+  }
+
+  .reactAgentRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .reactAgentField {
+    margin-bottom: 12px !important;
+  }
+
+  .llmRetryRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .llmRetryField {
+    margin-bottom: 12px !important;
+  }
+
+  .formCard {
+    margin-bottom: 16px;
+  }
+
+  .footerActions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px 16px;
+    justify-content: center;
+  }
+
+  .footerActions :global(.ant-btn) {
+    flex: 1;
+    min-width: 120px;
+    max-width: 200px;
+  }
+}


### PR DESCRIPTION
## Description

Add mobile responsive CSS for the Agent Config page (workspace → run configuration → ReAct agent / LLM retry / rate limiter tabs).

**Related Issue:** Relates to #(mobile_responsive_improvements)

**Security Considerations:** No security impact - CSS only changes.

## Type of Change

- [x] Bug fix (mobile layout overflow / misalignment)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

On a mobile viewport (≤768px width):
1. Open QwenPaw Console → 工作区 → 运行配置
2. Verify the 3-column form rows stack into a single column
3. Verify form fields have proper vertical spacing (12px margin)
4. Verify page header padding is reduced
5. Verify tab content side padding is reduced
6. Verify footer action buttons wrap horizontally instead of stretching full-width
7. Verify desktop view (≥769px) is unchanged

## Local Verification Evidence

```bash
# Console build completed successfully
npm run build
# ✓ built in 32.54s

# Deployed to local venv
rsync -a --delete console/dist/ /var/apps/com.dustinky.qwenpaw/home/venv/lib/python3.12/site-packages/qwenpaw/console/
```

## Additional Notes

All changes are wrapped in `@media (max-width: 768px)` to ensure zero impact on desktop layouts.
