### PR TITLE
feat(console): mobile responsive layout for Security page

### DIFF
--- a/console/src/pages/Agent/Config/index.module.less
+++ b/console/src/pages/Agent/Config/index.module.less
@@ -259,3 +259,54 @@
     }
   }
 }
+
+/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 12px 16px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .tabContent {
+    padding: 0 12px;
+  }
+
+  .reactAgentRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .reactAgentField {
+    margin-bottom: 12px !important;
+  }
+
+  .llmRetryRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .llmRetryField {
+    margin-bottom: 12px !important;
+  }
+
+  .formCard {
+    margin-bottom: 16px;
+  }
+
+  .footerActions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px 16px;
+    justify-content: center;
+  }
+
+  .footerActions :global(.ant-btn) {
+    flex: 1;
+    min-width: 120px;
+    max-width: 200px;
+  }
+}

--- a/console/src/pages/Settings/Security/components/RuleTable.tsx
+++ b/console/src/pages/Settings/Security/components/RuleTable.tsx
@@ -245,6 +245,7 @@ export function RuleTable({
           pagination={false}
           size="small"
           className={styles.ruleTable}
+          scroll={{ x: 600 }}
         />
       ),
     };

--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -732,3 +732,103 @@
     padding-bottom: 16px;
   }
 }
+
+/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 12px 16px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .content {
+    padding: 0 12px;
+  }
+
+  .mainTabs {
+    :global(.qwenpaw-tabs-tab) {
+      padding: 8px 2px;
+      font-size: 13px;
+    }
+
+    :global(.qwenpaw-tabs-tab-active .qwenpaw-tabs-tab-btn) {
+      font-weight: 600;
+    }
+  }
+
+  .tabDescription {
+    margin-bottom: 12px;
+    font-size: 13px;
+  }
+
+  .toolGuardRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .formCard {
+    margin-bottom: 12px;
+  }
+
+  .sectionHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 0;
+    margin-bottom: 12px;
+  }
+
+  .sectionTitle {
+    font-size: 15px;
+  }
+
+  .shellEvasionGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .skillScannerConfig {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .skillScannerConfigItem {
+    border-left: none !important;
+    padding-right: 0 !important;
+  }
+
+  .skillScannerConfigItem + .skillScannerConfigItem {
+    border-left: none !important;
+  }
+
+  .footerButtons {
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px;
+  }
+
+  .footerButtons :global(.ant-btn) {
+    width: 100%;
+  }
+
+  .tableCard {
+    margin-bottom: 12px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tableCard :global(.ant-table) {
+    min-width: 600px;
+  }
+
+  .tableCard :global(.ant-table-thead > tr > th),
+  .tableCard :global(.ant-table-tbody > tr > td) {
+    padding: 10px 8px !important;
+    font-size: 13px;
+  }
+
+  .sectionConfigureContainer {
+    padding-bottom: 16px;
+  }
+}

--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -726,94 +726,6 @@
 
   .tableCard {
     margin-bottom: 12px;
-  }
-
-  .sectionConfigureContainer {
-    padding-bottom: 16px;
-  }
-}
-
-/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
-@media (max-width: 768px) {
-  .pageHeader {
-    padding: 12px 16px;
-  }
-
-  .breadcrumbCurrent {
-    font-size: 16px;
-  }
-
-  .content {
-    padding: 0 12px;
-  }
-
-  .mainTabs {
-    :global(.qwenpaw-tabs-tab) {
-      padding: 8px 2px;
-      font-size: 13px;
-    }
-
-    :global(.qwenpaw-tabs-tab-active .qwenpaw-tabs-tab-btn) {
-      font-weight: 600;
-    }
-  }
-
-  .tabDescription {
-    margin-bottom: 12px;
-    font-size: 13px;
-  }
-
-  .toolGuardRow {
-    grid-template-columns: 1fr;
-    gap: 0;
-  }
-
-  .formCard {
-    margin-bottom: 12px;
-  }
-
-  .sectionHeader {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 0;
-    margin-bottom: 12px;
-  }
-
-  .sectionTitle {
-    font-size: 15px;
-  }
-
-  .shellEvasionGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .skillScannerConfig {
-    grid-template-columns: 1fr;
-    gap: 12px;
-  }
-
-  .skillScannerConfigItem {
-    border-left: none !important;
-    padding-right: 0 !important;
-  }
-
-  .skillScannerConfigItem + .skillScannerConfigItem {
-    border-left: none !important;
-  }
-
-  .footerButtons {
-    flex-direction: column;
-    gap: 8px;
-    padding: 12px 16px;
-  }
-
-  .footerButtons :global(.ant-btn) {
-    width: 100%;
-  }
-
-  .tableCard {
-    margin-bottom: 12px;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
   }
@@ -826,6 +738,10 @@
   .tableCard :global(.ant-table-tbody > tr > td) {
     padding: 10px 8px !important;
     font-size: 13px;
+  }
+
+  .ruleCollapse :global(.qwenpaw-collapse-item) {
+    overflow: visible;
   }
 
   .sectionConfigureContainer {

--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -643,3 +643,92 @@
   display: inline-flex;
   align-items: center;
 }
+
+
+/* ─── Mobile responsive ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 12px 16px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .content {
+    padding: 0 12px;
+  }
+
+  .mainTabs {
+    :global(.qwenpaw-tabs-tab) {
+      padding: 8px 2px;
+      font-size: 13px;
+    }
+
+    :global(.qwenpaw-tabs-tab-active .qwenpaw-tabs-tab-btn) {
+      font-weight: 600;
+    }
+  }
+
+  .tabDescription {
+    margin-bottom: 12px;
+    font-size: 13px;
+  }
+
+  .toolGuardRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .formCard {
+    margin-bottom: 12px;
+  }
+
+  .sectionHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 0;
+    margin-bottom: 12px;
+  }
+
+  .sectionTitle {
+    font-size: 15px;
+  }
+
+  .shellEvasionGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .skillScannerConfig {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .skillScannerConfigItem {
+    border-left: none !important;
+    padding-right: 0 !important;
+  }
+
+  .skillScannerConfigItem + .skillScannerConfigItem {
+    border-left: none !important;
+  }
+
+  .footerButtons {
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px;
+  }
+
+  .footerButtons :global(.ant-btn) {
+    width: 100%;
+  }
+
+  .tableCard {
+    margin-bottom: 12px;
+  }
+
+  .sectionConfigureContainer {
+    padding-bottom: 16px;
+  }
+}

--- a/console/src/pages/Settings/SkillPool/index.module.less
+++ b/console/src/pages/Settings/SkillPool/index.module.less
@@ -1155,10 +1155,85 @@
   .pageHeader {
     flex-direction: column;
     align-items: stretch;
+    padding: 16px;
+    gap: 12px;
+  }
+
+  .headerRight {
+    flex-direction: column;
+    gap: 10px;
   }
 
   .headerActionsLeft,
-  .headerActionsRight {
+  .headerActionsRight,
+  .batchActions {
     flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .primaryTransferButton,
+  .primaryActionButton {
+    min-width: unset;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    padding: 12px 12px 0;
+  }
+
+  .searchContainer {
+    max-width: unset;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .searchInput {
+    height: 36px;
+    font-size: 14px;
+  }
+
+  .tagSelect {
+    min-width: unset;
+    max-width: unset;
+    width: 100%;
+
+    :global {
+      .ant-select-selector {
+        height: 36px !important;
+      }
+    }
+  }
+
+  .toolbarRight {
+    align-self: flex-end;
+  }
+
+  .viewToggleBtn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .skillsGrid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .skillsList {
+    padding: 12px;
+  }
+
+  .listItemRight {
+    margin-left: 0;
+    margin-top: 8px;
+  }
+
+  .listItemHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
   }
 }


### PR DESCRIPTION
## Description

Add mobile responsive CSS for the Security settings page (设置 → 安全).

**Related Issue:** Relates to #(mobile_responsive_improvements)

**Security Considerations:** No security impact - CSS only changes.

## Type of Change

- [x] Bug fix (mobile layout overflow / misalignment)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

On a mobile viewport (≤768px width):
1. Open QwenPaw Console → 设置 → 安全
2. Verify the tool guard form rows stack into a single column
3. Verify shell evasion check cards stack vertically
4. Verify skill scanner config items stack vertically
5. Verify section header (title + add button) stacks vertically
6. Verify footer action buttons are full-width
7. Verify page header and content padding are reduced
8. Verify rule table is horizontally scrollable if content overflows
9. Verify table cell padding and font size are reduced on mobile
10. Verify desktop view (≥769px) is unchanged

## Local Verification Evidence

```bash
# Console build completed successfully
npm run build
# ✓ built in 1m 19s

# Deployed to local venv
rsync -a --delete console/dist/ /var/apps/com.dustinky.qwenpaw/home/venv/lib/python3.12/site-packages/qwenpaw/console/
```

## Additional Notes

All changes are wrapped in `@media (max-width: 768px)` to ensure zero impact on desktop layouts.

### Table Overflow Fix (Updated)
Initial CSS-only fix (`overflow-x: auto` on `.tableCard`) did not take effect due to antd Table's internal scroll container structure.

Final fix: Added `scroll={{ x: 600 }}` directly to the `<Table>` component in `RuleTable.tsx`. This uses antd's native horizontal scroll support, which creates a proper scroll wrapper around the table body. Combined with reduced cell padding (10px 8px) and smaller font (13px) on mobile for better readability.
