### PR TITLE
fix(queue): bind agent ID at enqueue time to prevent cross-agent deli…

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1683,10 +1683,6 @@ export default function ChatPage() {
       if (!textarea) return;
       const val = textarea.value.trim();
       if (!val) return;
-      // Slash commands (e.g. /clear, /compact) must always be handled by the
-      // slash-command system, never enqueued as plain messages — even when
-      // the chat is loading or the queue is busy.
-      if (val.startsWith("/")) return;
       e.preventDefault();
       e.stopPropagation();
       if (!chatId) {
@@ -2261,9 +2257,6 @@ export default function ChatPage() {
           ?.querySelector("textarea") as HTMLTextAreaElement | null;
         const val = textarea?.value.trim() ?? "";
         if (!val) return false;
-        // Slash commands must not be enqueued; let the slash-command
-        // system handle them locally.
-        if (val.startsWith("/")) return true;
         if (!chatId) {
           return false;
         }

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -287,9 +287,8 @@ async function startBackgroundQueue(
       let fetchSucceeded = false;
       // True once fetch() has resolved with an HTTP response. For a streaming
       // chat endpoint, this means the backend has already accepted the
-      // request and started generating — a subsequent abort only severs
-      // OUR read stream; the backend keeps producing the turn and the
-      // foreground SDK's reconnect will pick it up.
+      // request and started generating — the backend keeps producing the turn
+      // and the foreground SDK's reconnect will pick it up.
       let fetchStarted = false;
       try {
         const authHeaders = buildAuthHeaders();
@@ -298,6 +297,10 @@ async function startBackgroundQueue(
         if (item.agentId) {
           authHeaders["X-Agent-Id"] = item.agentId;
         }
+        // Intentionally do NOT pass ctrl.signal to fetch. This keeps the
+        // HTTP connection alive even when the queue loop is aborted (e.g.
+        // foreground takes over). The server finishes generating and
+        // persists the turn so no message is lost and no re-send occurs.
         const res = await fetch(getApiUrl("/console/chat"), {
           method: "POST",
           headers: {
@@ -319,7 +322,6 @@ async function startBackgroundQueue(
             channel: DEFAULT_CHANNEL,
             stream: true,
           }),
-          signal: ctrl.signal,
         });
 
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -341,9 +343,9 @@ async function startBackgroundQueue(
 
       if (ctrl.signal.aborted) {
         if (fetchStarted) {
-          // Backend already accepted and is generating this turn. The
-          // foreground SDK will reconnect and render the stream — keeping
-          // the item in the queue would double-show it (queue + bubble).
+          // Server connection was NOT aborted (no signal on fetch), so the
+          // backend will finish generating and persist this turn. Safe to
+          // remove — the foreground SDK will see it in history on reconnect.
           useMessageQueueStore.getState().remove(queueKey, item.id);
         } else {
           // Request never made it out (aborted while waiting for status idle
@@ -1225,6 +1227,13 @@ export default function ChatPage() {
         if (fresh.length === 0 || fresh[0].id !== next.id) return;
         useMessageQueueStore.getState().setCurrentSendingId(next.id);
         useMessageQueueStore.getState().remove(queueSessionId, next.id);
+        // Force-set window.currentSessionId from the queue item's snapshot
+        // so customFetch uses the correct session_id, even if the global
+        // was overwritten by a recent agent switch.
+        if (next.backendSessionId) {
+          (window as unknown as { currentSessionId?: string }).currentSessionId =
+            next.backendSessionId;
+        }
         chatRef.current?.input.submit({
           query: next.text,
           fileList: buildFileList(next),
@@ -1674,6 +1683,10 @@ export default function ChatPage() {
       if (!textarea) return;
       const val = textarea.value.trim();
       if (!val) return;
+      // Slash commands (e.g. /clear, /compact) must always be handled by the
+      // slash-command system, never enqueued as plain messages — even when
+      // the chat is loading or the queue is busy.
+      if (val.startsWith("/")) return;
       e.preventDefault();
       e.stopPropagation();
       if (!chatId) {
@@ -1994,6 +2007,13 @@ export default function ChatPage() {
   useEffect(() => {
     const prevAgent = prevSelectedAgentRef.current;
     if (prevAgent !== selectedAgent && prevAgent !== undefined) {
+      // Immediately block the queue sender. window.currentSessionId is a
+      // global that still holds the PREVIOUS agent's session_id until the
+      // SDK finishes reloading. Without this guard, scheduleNextSend could
+      // fire during the reload window and send a queued item to the wrong
+      // agent's conversation.
+      setChatLoading(true);
+
       // Save current chat ID for the agent we're leaving
       const currentChatId =
         chatIdRef.current || lastSessionIdRef.current || undefined;
@@ -2241,6 +2261,9 @@ export default function ChatPage() {
           ?.querySelector("textarea") as HTMLTextAreaElement | null;
         const val = textarea?.value.trim() ?? "";
         if (!val) return false;
+        // Slash commands must not be enqueued; let the slash-command
+        // system handle them locally.
+        if (val.startsWith("/")) return true;
         if (!chatId) {
           return false;
         }

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -133,17 +133,34 @@ function stopBackgroundQueue(queueKey?: string) {
  *
  * Returns true when the chat became idle (or status is unknown / 404, which
  * we treat as idle to avoid blocking the queue forever); false if aborted.
+ *
+ * @param agentId - If provided, overrides X-Agent-Id in the status request
+ *   so that switching agents does not cause a spurious "idle" result.
  */
 async function waitForChatIdle(
   chatIdForStatus: string,
   signal: AbortSignal,
+  agentId?: string,
 ): Promise<boolean> {
   if (!chatIdForStatus) return true;
   while (!signal.aborted) {
     try {
-      const chat = await chatApi.getChat(chatIdForStatus);
+      // Use direct fetch with the correct agent ID header to avoid
+      // cross-agent status misreads when the user has switched agents.
+      const headers = buildAuthHeaders();
+      if (agentId) {
+        headers["X-Agent-Id"] = agentId;
+      }
+      const res = await fetch(
+        getApiUrl(`/chats/${encodeURIComponent(chatIdForStatus)}`),
+        { headers, signal },
+      );
+      if (!res.ok) return true; // 404 / error → treat as idle
+      const chat = await res.json();
       if (chat?.status !== "running") return true;
     } catch {
+      // If aborted, return false (not idle) so the caller breaks cleanly.
+      if (signal.aborted) return false;
       // Backend unreachable / 404 (e.g. id is still a local timestamp).
       // Treat as idle so we don't block forever.
       return true;
@@ -236,7 +253,11 @@ async function startBackgroundQueue(
       // Wait until the backend finishes the currently running task before
       // sending the next one. This preserves order task1 → task2 → task3
       // and prevents firing while task1 is still generating.
-      const idle = await waitForChatIdle(chatIdForStatus, ctrl.signal);
+      const idle = await waitForChatIdle(
+        chatIdForStatus,
+        ctrl.signal,
+        item.agentId,
+      );
       if (!idle) break;
 
       // Mark as sending — visible to other tabs and to the foreground page
@@ -271,11 +292,17 @@ async function startBackgroundQueue(
       // foreground SDK's reconnect will pick it up.
       let fetchStarted = false;
       try {
+        const authHeaders = buildAuthHeaders();
+        // Use the agent ID captured at enqueue time to prevent cross-agent
+        // delivery when the user switches agents after queueing.
+        if (item.agentId) {
+          authHeaders["X-Agent-Id"] = item.agentId;
+        }
         const res = await fetch(getApiUrl("/console/chat"), {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            ...buildAuthHeaders(),
+            ...authHeaders,
           },
           body: JSON.stringify({
             input: [

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1231,8 +1231,9 @@ export default function ChatPage() {
         // so customFetch uses the correct session_id, even if the global
         // was overwritten by a recent agent switch.
         if (next.backendSessionId) {
-          (window as unknown as { currentSessionId?: string }).currentSessionId =
-            next.backendSessionId;
+          (
+            window as unknown as { currentSessionId?: string }
+          ).currentSessionId = next.backendSessionId;
         }
         chatRef.current?.input.submit({
           query: next.text,

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -314,7 +314,7 @@ async function startBackgroundQueue(
                 ],
               },
             ],
-            session_id: backendSessionId,
+            session_id: item.backendSessionId || backendSessionId,
             user_id: DEFAULT_USER_ID,
             channel: DEFAULT_CHANNEL,
             stream: true,
@@ -413,8 +413,27 @@ function startAllBackgroundQueues(excludeSessionId?: string) {
     }
     // For background sending, resolve the actual session_id the backend
     // expects (chat.session_id), which may differ from the localStorage key
-    // (chat.id). Fall back to the key itself for locally-created sessions.
-    const backendSessionId = sessionApi.getBackendSessionId(sessionId);
+    // (chat.id). Prefer the snapshot stored in the queue item (captured at
+    // enqueue time) because the session list may have been cleared after an
+    // agent switch. Fall back to sessionApi lookup, then to the key itself.
+    let backendSessionId: string | undefined;
+    try {
+      const raw2 = localStorage.getItem(key);
+      if (raw2) {
+        const parsed2 = JSON.parse(raw2);
+        const itemsArr: Array<{ backendSessionId?: string }> = Array.isArray(
+          parsed2,
+        )
+          ? parsed2
+          : parsed2.items;
+        backendSessionId = itemsArr?.[0]?.backendSessionId || undefined;
+      }
+    } catch {
+      // ignore
+    }
+    if (!backendSessionId) {
+      backendSessionId = sessionApi.getBackendSessionId(sessionId);
+    }
     const chatIdForStatus =
       sessionApi.getRealIdForSession(sessionId) || sessionId;
     startBackgroundQueue(sessionId, backendSessionId, chatIdForStatus);

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -44,6 +44,9 @@ export interface QueueItem {
   quote?: QueueQuote;
   /** Agent ID captured at enqueue time to prevent cross-agent delivery */
   agentId?: string;
+  /** Backend session_id captured at enqueue time so background sender uses
+   *  the correct session even after agent switch clears the session list. */
+  backendSessionId?: string;
   status: QueueItemStatus;
   retryCount: number;
   errorMessage?: string;
@@ -356,6 +359,11 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
     } catch {
       // ignore
     }
+    // Capture backend session_id so background sender targets the correct
+    // session even if the session list is cleared after agent switch.
+    const backendSessionId =
+      (window as unknown as { currentSessionId?: string }).currentSessionId ||
+      undefined;
     const item: QueueItem = {
       id: nextQueueId(),
       text: input.text,
@@ -364,6 +372,7 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
       mentions: input.mentions,
       quote: input.quote,
       agentId,
+      backendSessionId,
       status: "pending",
       retryCount: 0,
       createdAt: Date.now(),

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -42,6 +42,8 @@ export interface QueueItem {
   images?: QueueImage[];
   mentions?: QueueMention[];
   quote?: QueueQuote;
+  /** Agent ID captured at enqueue time to prevent cross-agent delivery */
+  agentId?: string;
   status: QueueItemStatus;
   retryCount: number;
   errorMessage?: string;
@@ -340,6 +342,20 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
       // Queue is full, reject
       return;
     }
+    // Capture the current selected agent at enqueue time so that
+    // background sending uses the correct X-Agent-Id even after switch.
+    let agentId: string | undefined;
+    try {
+      const agentStorage =
+        sessionStorage.getItem("qwenpaw-agent-storage") ||
+        localStorage.getItem("qwenpaw-agent-storage");
+      if (agentStorage) {
+        const parsed = JSON.parse(agentStorage);
+        agentId = parsed?.state?.selectedAgent || undefined;
+      }
+    } catch {
+      // ignore
+    }
     const item: QueueItem = {
       id: nextQueueId(),
       text: input.text,
@@ -347,6 +363,7 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
       images: input.images,
       mentions: input.mentions,
       quote: input.quote,
+      agentId,
       status: "pending",
       retryCount: 0,
       createdAt: Date.now(),


### PR DESCRIPTION
- Add agentId field to QueueItem, captured from storage at enqueue time
- Override X-Agent-Id header in background sender with item.agentId
- Fix waitForChatIdle to use correct agent ID for status polling, preventing spurious idle detection after agent switch
- Handle AbortError correctly in waitForChatIdle fetch

Closes #5354

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
