### PR TITLE
fix: navigate to new chat after deleting the current session

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -6,7 +6,10 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { buildSessionPath, getSessionIdFromPath } from "../../../../utils/sessionRoute";
+import {
+  buildSessionPath,
+  getSessionIdFromPath,
+} from "../../../../utils/sessionRoute";
 import { Drawer, Spin, Tooltip } from "antd";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { IconButton } from "@agentscope-ai/design";
@@ -32,7 +35,10 @@ import {
   useContextMenu,
   type ContextMenuItem,
 } from "../../../../components/ContextMenu";
-import { syncSessionsGlobal, type ExtendedSession } from "../../../../stores/sessionListStore";
+import {
+  syncSessionsGlobal,
+  type ExtendedSession,
+} from "../../../../stores/sessionListStore";
 import styles from "./index.module.less";
 
 /** Fixed height of each session item in pixels (matches CSS min-height) */
@@ -397,7 +403,8 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       }
 
       // Fetch the updated session list after deletion
-      const freshList = (await sessionApi.getSessionList()) as ExtendedChatSession[];
+      const freshList =
+        (await sessionApi.getSessionList()) as ExtendedChatSession[];
       setSessions(freshList);
       syncSessionsGlobal(freshList as unknown as ExtendedSession[]);
 

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { buildSessionPath } from "../../../../utils/sessionRoute";
+import { buildSessionPath, getSessionIdFromPath } from "../../../../utils/sessionRoute";
 import { Drawer, Spin, Tooltip } from "antd";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { IconButton } from "@agentscope-ai/design";
@@ -32,6 +32,7 @@ import {
   useContextMenu,
   type ContextMenuItem,
 } from "../../../../components/ContextMenu";
+import { syncSessionsGlobal, type ExtendedSession } from "../../../../stores/sessionListStore";
 import styles from "./index.module.less";
 
 /** Fixed height of each session item in pixels (matches CSS min-height) */
@@ -395,26 +396,28 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         await chatApi.deleteChat(backendId);
       }
 
-      if (currentSessionId === sessionId) {
-        if (props.embedded) {
-          // In embedded mode, create a new chat via DOM event
-          // since we can't directly set the session from outside the context tree.
+      // Fetch the updated session list after deletion
+      const freshList = (await sessionApi.getSessionList()) as ExtendedChatSession[];
+      setSessions(freshList);
+      syncSessionsGlobal(freshList as unknown as ExtendedSession[]);
+
+      // Post-deletion check: if the URL's chatId no longer exists in the
+      // refreshed list, the deleted session was the one being viewed.
+      // This approach avoids all ID-format mismatch issues (timestamp vs UUID,
+      // realId vs id, multiple backend UUIDs for the same session).
+      const urlChatId = getSessionIdFromPath(location.pathname);
+      if (urlChatId) {
+        const stillExists = freshList.some(
+          (s) =>
+            s.id === urlChatId ||
+            (s as ExtendedChatSession).realId === urlChatId,
+        );
+        if (!stillExists) {
           window.dispatchEvent(new CustomEvent("qwenpaw:sidebar-new-chat"));
-        } else {
-          const next = sessions.filter((s) => s.id !== sessionId);
-          setCurrentSessionId(next[0]?.id);
         }
       }
-
-      await refreshSessions();
     },
-    [
-      sessions,
-      currentSessionId,
-      setCurrentSessionId,
-      refreshSessions,
-      props.embedded,
-    ],
+    [sessions, setSessions, location.pathname],
   );
 
   /** Enter rename mode for a session */

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
@@ -195,9 +195,28 @@ export function useSessionListData(
       const session = sessions.find((s) => s.id === sessionId);
       const backendId = session ? getBackendId(session) : null;
       if (backendId) await chatApi.deleteChat(backendId);
-      await refreshSessions();
+
+      // Fetch fresh session list after deletion
+      const freshList = (await sessionApi.getSessionList()) as ExtendedChatSession[];
+      setSessions(freshList);
+      syncSessionsGlobal(freshList);
+
+      // Post-deletion check: if the currently displayed session no longer
+      // exists in the refreshed list, navigate to a new blank chat.
+      // This avoids all ID-format mismatch issues between URL chatId,
+      // session.id, and session.realId.
+      if (currentSessionId) {
+        const stillExists = freshList.some(
+          (s) =>
+            s.id === currentSessionId ||
+            (s as ExtendedChatSession).realId === currentSessionId,
+        );
+        if (!stillExists) {
+          window.dispatchEvent(new CustomEvent("qwenpaw:sidebar-new-chat"));
+        }
+      }
     },
-    [sessions, refreshSessions],
+    [sessions, currentSessionId, setSessions],
   );
 
   const handleEditStart = useCallback(

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
@@ -197,7 +197,8 @@ export function useSessionListData(
       if (backendId) await chatApi.deleteChat(backendId);
 
       // Fetch fresh session list after deletion
-      const freshList = (await sessionApi.getSessionList()) as ExtendedChatSession[];
+      const freshList =
+        (await sessionApi.getSessionList()) as ExtendedChatSession[];
       setSessions(freshList);
       syncSessionsGlobal(freshList);
 


### PR DESCRIPTION
Use post-deletion check instead of pre-deletion ID matching to reliably detect whether the deleted session was the one currently being viewed.

After deletion, fetch the updated session list and verify if the URL's chatId still exists. If not, dispatch 'qwenpaw:sidebar-new-chat' to navigate to a blank page.

This fixes ID-format mismatch issues where URL chatId (may be timestamp, UUID or realId) didn't match the session list item's id or backendId, causing the page to stay on the deleted conversation.

Also adds syncSessionsGlobal call in ChatSessionDrawer to immediately sync sidebar store after embedded panel deletion.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
