### PR TITLE
feat(console): mobile adaptation for MCP page

### DIFF
--- a/console/src/pages/Agent/MCP/index.module.less
+++ b/console/src/pages/Agent/MCP/index.module.less
@@ -493,3 +493,37 @@
     }
   }
 }
+
+@media (max-width: 768px) {
+  .pageHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+
+    .breadcrumbHeader {
+      width: 100%;
+    }
+
+    :global(.ant-btn),
+    :global(.qwenpaw-btn) {
+      width: 100%;
+    }
+  }
+
+  .mcpGrid {
+    grid-template-columns: 1fr;
+    padding: 12px 16px;
+  }
+
+  .cardFooter {
+    flex-wrap: wrap;
+  }
+
+  .toggleButton,
+  .deleteButton,
+  .toolsButton {
+    flex: 1 1 calc(50% - 4px);
+    min-width: 0;
+  }
+}

--- a/console/src/pages/Agent/MCP/index.module.less
+++ b/console/src/pages/Agent/MCP/index.module.less
@@ -407,6 +407,19 @@
     color: rgba(255, 255, 255, 0.65);
   }
 
+  .typeBadge {
+    &.local {
+      background-color: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.45);
+    }
+
+    &.remote {
+      background-color: rgba(250, 173, 20, 0.15);
+      color: #ffd666;
+      border-color: rgba(250, 173, 20, 0.3);
+    }
+  }
+
   .cardFooter {
     border-top-color: rgba(255, 255, 255, 0.08);
   }


### PR DESCRIPTION
## Description

This PR adds mobile adaptation for the MCP Clients page in the QwenPaw console.

On narrow screens (≤768px):
- The page header switches to a vertical stack so the "Create Client" button does not overlap the breadcrumb/title.
- The client card grid becomes a single column.
- The action buttons in each card footer wrap to two per row, preventing overflow and keeping all actions tappable.

**Related Issue:** Relates to the ongoing console mobile adaptation effort.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

> **Note on pre-commit:** The current pre-commit config excludes `^console/` from the `prettier` hook, so frontend files are not auto-checked. I manually verified the changes with `tsc`, `prettier`, `eslint`, and `npm run build`.

## Testing

1. Open QwenPaw Console on a mobile browser or a narrow viewport (≤768px).
2. Navigate to **Agent → MCP Clients**.
3. Verify that:
   - The page header and "Create Client" button do not overlap.
   - Client cards display in a single column.
   - Card footer buttons (Tools / Authorize / Enable / Delete) do not overflow and remain tappable.
4. Resize to desktop width and confirm the multi-column grid and horizontal footer remain unchanged.

## Local Verification Evidence

```bash
cd console
npx tsc --noEmit
npx prettier --check "src/pages/Agent/MCP/**/*.{ts,tsx,less}"
npx eslint "src/pages/Agent/MCP/**/*.{ts,tsx}"
npm run build
# all passed
```

## Additional Notes

No TypeScript changes were required. All mobile styles are scoped inside `@media (max-width: 768px)` at the end of `index.module.less`.