### PR TITLE
feat(console): mobile adaptation for ACP page

### DIFF
--- a/console/src/pages/Agent/ACP/index.module.less
+++ b/console/src/pages/Agent/ACP/index.module.less
@@ -1,0 +1,29 @@
+@media (max-width: 768px) {
+  .pageHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+
+    [class*="leading"] {
+      width: 100%;
+    }
+
+    [class*="center"] {
+      position: static;
+      transform: none;
+      align-self: flex-start;
+    }
+
+    [class*="extra"] {
+      width: 100%;
+      justify-content: flex-start;
+    }
+  }
+
+  .channelsGridMobile {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 12px 16px 24px;
+  }
+}

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -18,6 +18,7 @@ import {
   stringifyEnv,
 } from "./components/ACPDrawer";
 import styles from "../../Control/Channels/index.module.less";
+import stylesACP from "./index.module.less";
 
 const BUILTIN_ACP_ORDER = [
   "opencode",
@@ -220,6 +221,7 @@ function ACPPage() {
   return (
     <div className={styles.channelsPage}>
       <PageHeader
+        className={stylesACP.pageHeader}
         items={[{ title: t("nav.agent") }, { title: t("acp.title") }]}
         center={
           <div className={styles.filterTabs}>
@@ -248,7 +250,7 @@ function ACPPage() {
             <span className={styles.loadingText}>{t("acp.loading")}</span>
           </div>
         ) : (
-          <div className={styles.channelsGrid}>
+          <div className={`${styles.channelsGrid} ${stylesACP.channelsGridMobile}`}>
             {cards.map(({ key, config }) => (
               <ACPCard
                 key={key}

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -250,7 +250,9 @@ function ACPPage() {
             <span className={styles.loadingText}>{t("acp.loading")}</span>
           </div>
         ) : (
-          <div className={`${styles.channelsGrid} ${stylesACP.channelsGridMobile}`}>
+          <div
+            className={`${styles.channelsGrid} ${stylesACP.channelsGridMobile}`}
+          >
             {cards.map(({ key, config }) => (
               <ACPCard
                 key={key}


### PR DESCRIPTION

## Description

This PR adds mobile adaptation for the ACP (Agent Connect Protocol) page in the QwenPaw console.

On narrow screens (≤768px), the page header now stacks vertically so the filter tabs and the "Create Custom Agent" button no longer overlap. The ACP card grid also switches to a single column layout to fit mobile viewports.

**Related Issue:** Relates to the ongoing console mobile adaptation effort.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

> **Note on pre-commit:** The current pre-commit config excludes `^console/` from the `prettier` hook, so frontend files are not auto-checked. I manually verified the changes with `tsc`, `prettier`, `eslint`, and `npm run build`.

## Testing

1. Open QwenPaw Console on a mobile browser or a narrow viewport (≤768px).
2. Navigate to **Agent → ACP**.
3. Verify that:
   - The page header stacks vertically.
   - The filter tabs (All / Built-in / Custom) and the "Create Custom Agent" button do not overlap.
   - ACP cards render in a single column.
4. Resize to desktop width and confirm the layout remains unchanged.

## Local Verification Evidence

```bash
cd console
npx tsc --noEmit
npx prettier --check "src/pages/Agent/ACP/**/*.{ts,tsx,less}"
npx eslint "src/pages/Agent/ACP/**/*.{ts,tsx}"
npm run build
# all passed
```

## Additional Notes

The changes are scoped strictly within `@media (max-width: 768px)` in the new `index.module.less` file, plus a `className` prop on `PageHeader` and a mobile helper class on the card grid. Desktop styles are not affected.
