### PR TITLE
feat(console): mobile adaptation for Inbox page

### DIFF
--- a/console/src/pages/Inbox/components/PushMessageCard.module.less
+++ b/console/src/pages/Inbox/components/PushMessageCard.module.less
@@ -87,6 +87,17 @@
   gap: 8px;
 }
 
+/* ─── Mobile ────────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .messageCard {
+    :global(.qwenpaw-card-body) {
+      height: auto !important;
+      min-height: 142px;
+      overflow: hidden;
+    }
+  }
+}
+
 /* ─── Dark mode ─────────────────────────────────────────────────────────────── */
 :global(.dark-mode) {
   .messageCard {

--- a/console/src/pages/Inbox/index.module.less
+++ b/console/src/pages/Inbox/index.module.less
@@ -512,3 +512,52 @@
     border-color: rgba(255, 255, 255, 0.15);
   }
 }
+
+@media (max-width: 768px) {
+  .pageContent {
+    padding: 0 16px 20px;
+  }
+
+  .inboxTabs {
+    :global(.ant-tabs-nav) {
+      overflow-x: auto;
+      white-space: nowrap;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    :global(.ant-tabs-tab) {
+      flex-shrink: 0;
+    }
+  }
+
+  .messagesToolbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .messagesSelectionTools {
+    flex-wrap: wrap;
+    width: 100%;
+
+    :global(.ant-select) {
+      width: 100% !important;
+    }
+
+    :global(.ant-btn) {
+      flex-shrink: 0;
+    }
+  }
+
+  .harvestGrid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .paginationWrap {
+    justify-content: center;
+  }
+}

--- a/console/src/pages/Inbox/index.module.less
+++ b/console/src/pages/Inbox/index.module.less
@@ -440,8 +440,16 @@
   .selectedCountText,
   .messageDetailLabel,
   .traceLoading,
-  .traceEmpty {
+  .traceEmpty,
+  .summaryRow {
     color: rgba(255, 255, 255, 0.55);
+  }
+
+  .messageDetailContent,
+  .messageDetailPayload {
+    background: #1f1f1f;
+    border-color: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.82);
   }
 
   .traceLoading,


### PR DESCRIPTION
## Description

This PR adds mobile adaptation for the Inbox page in the QwenPaw console.

On narrow screens (≤768px), the page content padding is reduced, the tab nav becomes horizontally scrollable, the message toolbar stacks vertically, the agent filter dropdown expands to full width, and the approvals grid switches to a single column.

**Related Issue:** Relates to the ongoing console mobile adaptation effort.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

> **Note on pre-commit:** The current pre-commit config excludes `^console/` from the `prettier` hook, so frontend files are not auto-checked. I manually verified the changes with `tsc`, `prettier`, `eslint`, and `npm run build`.

## Testing

1. Open QwenPaw Console on a mobile browser or a narrow viewport (≤768px).
2. Navigate to **Inbox**.
3. Verify that:
   - The Push Messages / Approvals tabs are usable.
   - The agent filter and batch action buttons do not overflow horizontally.
   - Approval cards render in a single column.
4. Resize to desktop width and confirm the layout remains unchanged.

## Local Verification Evidence

```bash
cd console
npx tsc --noEmit
npx prettier --check "src/pages/Inbox/**/*.{ts,tsx,less}"
npx eslint "src/pages/Inbox/**/*.{ts,tsx}"
npm run build
# all passed
```

## Additional Notes

All mobile styles are scoped inside `@media (max-width: 768px)` at the end of `index.module.less`. No React component logic was changed.