### PR TITLE
feat(console): mobile adaptation for Workspace page

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -25,6 +25,7 @@
     "contentPlaceholder": "Enter content...",
     "help": "Help",
     "close": "Close",
+    "back": "Back",
     "actions": "Actions",
     "total": "Total {{count}}",
     "clear": "Clear",
@@ -392,7 +393,10 @@
     "configUpdateFailed": "Failed to update system prompt configuration",
     "attribution": "Workspace design partly inspired by the OpenClaw project — thank you! 🐾",
     "saveSuccess": "Saved successfully",
-    "saveFailed": "Save failed"
+    "saveFailed": "Save failed",
+    "saving": "Saving...",
+    "saved": "Saved",
+    "unsaved": "Unsaved"
   },
   "agent": {
     "parent": "Settings",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -25,6 +25,7 @@
     "contentPlaceholder": "输入内容...",
     "help": "帮助",
     "close": "关闭",
+    "back": "返回",
     "actions": "操作",
     "total": "共 {{count}} 条",
     "clear": "清除",
@@ -195,7 +196,10 @@
     "configUpdateFailed": "更新系统提示词配置失败",
     "attribution": "工作区设计部分灵感源自 OpenClaw 项目，在此表示感谢 🐾",
     "saveSuccess": "保存成功",
-    "saveFailed": "保存失败"
+    "saveFailed": "保存失败",
+    "saving": "保存中...",
+    "saved": "已保存",
+    "unsaved": "未保存"
   },
   "agent": {
     "parent": "设置",

--- a/console/src/pages/Agent/Workspace/components/FileEditor.tsx
+++ b/console/src/pages/Agent/Workspace/components/FileEditor.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useMemo } from "react";
 import { Button, Card, Input, Switch } from "@agentscope-ai/design";
-import { CopyOutlined, UndoOutlined, SaveOutlined } from "@ant-design/icons";
+import {
+  CopyOutlined,
+  UndoOutlined,
+  SaveOutlined,
+  ArrowLeftOutlined,
+} from "@ant-design/icons";
 import type { MarkdownFile } from "../../../../api/types";
 import { XMarkdown } from "@ant-design/x-markdown";
 import { useTranslation } from "react-i18next";
@@ -12,25 +17,32 @@ import styles from "../index.module.less";
 interface FileEditorProps {
   selectedFile: MarkdownFile | null;
   fileContent: string;
-  loading: boolean;
   hasChanges: boolean;
+  saving?: boolean;
   onContentChange: (content: string) => void;
-  onSave: () => void;
+  onSave: () => void | Promise<void>;
   onReset: () => void;
+  onBack?: () => void;
+  compact?: boolean;
 }
 
 export const FileEditor: React.FC<FileEditorProps> = ({
   selectedFile,
   fileContent,
-  loading,
   hasChanges,
+  saving,
   onContentChange,
   onSave,
   onReset,
+  onBack,
+  compact,
 }) => {
   const { t } = useTranslation();
   const { message } = useAppMessage();
   const [showMarkdown, setShowMarkdown] = useState(true);
+  const [touchStart, setTouchStart] = useState<{ x: number; y: number } | null>(
+    null,
+  );
 
   const isMarkdownFile = selectedFile?.filename.endsWith(".md") || false;
   const markdownContent = useMemo(
@@ -62,17 +74,68 @@ export const FileEditor: React.FC<FileEditorProps> = ({
     }
   };
 
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (!onBack) return;
+    setTouchStart({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (!touchStart || !onBack) return;
+    const endX = e.changedTouches[0].clientX;
+    const endY = e.changedTouches[0].clientY;
+    const dx = endX - touchStart.x;
+    const dy = endY - touchStart.y;
+    if (dx > 80 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+      onBack();
+    }
+    setTouchStart(null);
+  };
+
   return (
-    <div className={styles.fileEditor}>
+    <div
+      className={styles.fileEditor}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
       <Card className={styles.editorCard}>
         {selectedFile ? (
           <>
-            <div className={styles.editorHeader}>
-              <div>
-                <div className={styles.fileName}>{selectedFile.filename}</div>
+            {compact && onBack && (
+              <div className={styles.mobileToolbar}>
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<ArrowLeftOutlined />}
+                  onClick={onBack}
+                >
+                  {t("common.back")}
+                </Button>
+                <span className={styles.mobileToolbarTitle}>
+                  {selectedFile.filename}
+                </span>
+              </div>
+            )}
+            <div
+              className={
+                compact
+                  ? `${styles.editorHeader} ${styles.editorHeaderCompact}`
+                  : styles.editorHeader
+              }
+            >
+              <div className={compact ? styles.fileMetaCompact : ""}>
+                {!compact && (
+                  <div className={styles.fileName}>{selectedFile.filename}</div>
+                )}
                 <div className={styles.filePath}>{selectedFile.path}</div>
               </div>
               <div className={styles.buttonGroup}>
+                <span className={styles.saveStatus}>
+                  {saving
+                    ? t("workspace.saving")
+                    : hasChanges
+                    ? t("workspace.unsaved")
+                    : t("workspace.saved")}
+                </span>
                 <Button
                   size="small"
                   onClick={onReset}
@@ -86,7 +149,7 @@ export const FileEditor: React.FC<FileEditorProps> = ({
                   size="small"
                   onClick={onSave}
                   disabled={!hasChanges}
-                  loading={loading}
+                  loading={saving}
                   icon={<SaveOutlined />}
                 >
                   {t("common.save")}
@@ -139,6 +202,11 @@ export const FileEditor: React.FC<FileEditorProps> = ({
                   onChange={(e) => onContentChange(e.target.value)}
                   className={styles.textarea}
                   placeholder={t("workspace.fileContent")}
+                  autoSize={
+                    compact
+                      ? { minRows: 15, maxRows: 40 }
+                      : { minRows: 6, maxRows: 20 }
+                  }
                 />
               )}
             </div>

--- a/console/src/pages/Agent/Workspace/components/FileItem.tsx
+++ b/console/src/pages/Agent/Workspace/components/FileItem.tsx
@@ -21,6 +21,7 @@ interface FileItemProps {
   enabled?: boolean;
   onFileClick: (file: MarkdownFile) => void;
   onDailyMemoryClick: (daily: DailyMemoryFile) => void;
+  onMemoryExpand?: () => void;
   onToggleEnabled: (filename: string) => void;
 }
 
@@ -32,6 +33,7 @@ export const FileItem: React.FC<FileItemProps> = ({
   enabled = false,
   onFileClick,
   onDailyMemoryClick,
+  onMemoryExpand,
   onToggleEnabled,
 }) => {
   const { t } = useTranslation();
@@ -87,6 +89,20 @@ export const FileItem: React.FC<FileItemProps> = ({
               <HolderOutlined />
             </div>
           )}
+          {isMemoryFile && (
+            <button
+              type="button"
+              className={styles.expandIcon}
+              aria-label={expandedMemory ? "collapse" : "expand"}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onMemoryExpand?.();
+              }}
+            >
+              {expandedMemory ? <CaretDownOutlined /> : <CaretRightOutlined />}
+            </button>
+          )}
           <div className={styles.fileInfo}>
             <div className={styles.fileItemName}>
               {enabled && <span className={styles.enabledBadge}>●</span>}
@@ -104,15 +120,6 @@ export const FileItem: React.FC<FileItemProps> = ({
                 onClick={handleToggleClick}
               />
             </Tooltip>
-            {isMemoryFile && (
-              <span className={styles.expandIcon}>
-                {expandedMemory ? (
-                  <CaretDownOutlined />
-                ) : (
-                  <CaretRightOutlined />
-                )}
-              </span>
-            )}
           </div>
         </div>
       </div>

--- a/console/src/pages/Agent/Workspace/components/FileListPanel.tsx
+++ b/console/src/pages/Agent/Workspace/components/FileListPanel.tsx
@@ -29,6 +29,7 @@ interface FileListPanelProps {
   onRefresh: () => void;
   onFileClick: (file: MarkdownFile) => void;
   onDailyMemoryClick: (daily: DailyMemoryFile) => void;
+  onMemoryExpand?: () => void;
   onToggleEnabled: (filename: string) => void;
   onReorder: (newOrder: string[]) => void;
 }
@@ -42,6 +43,7 @@ export const FileListPanel: React.FC<FileListPanelProps> = ({
   onRefresh,
   onFileClick,
   onDailyMemoryClick,
+  onMemoryExpand,
   onToggleEnabled,
   onReorder,
 }) => {
@@ -110,6 +112,7 @@ export const FileListPanel: React.FC<FileListPanelProps> = ({
                       enabled={isEnabled}
                       onFileClick={onFileClick}
                       onDailyMemoryClick={onDailyMemoryClick}
+                      onMemoryExpand={onMemoryExpand}
                       onToggleEnabled={onToggleEnabled}
                     />
                   );

--- a/console/src/pages/Agent/Workspace/components/useAgentsData.ts
+++ b/console/src/pages/Agent/Workspace/components/useAgentsData.ts
@@ -156,6 +156,15 @@ export const useAgentsData = () => {
   };
 
   const handleFileClick = async (file: MarkdownFile) => {
+    if (file.filename === "MEMORY.md") {
+      setExpandedMemory((prev) => {
+        if (!prev) {
+          fetchDailyMemories();
+        }
+        return !prev;
+      });
+    }
+
     setSelectedFile(file);
     setLoading(true);
     try {

--- a/console/src/pages/Agent/Workspace/components/useAgentsData.ts
+++ b/console/src/pages/Agent/Workspace/components/useAgentsData.ts
@@ -156,16 +156,6 @@ export const useAgentsData = () => {
   };
 
   const handleFileClick = async (file: MarkdownFile) => {
-    if (file.filename === "MEMORY.md") {
-      if (expandedMemory && selectedFile?.filename === "MEMORY.md") {
-        setExpandedMemory(false);
-        return;
-      } else {
-        setExpandedMemory(true);
-        fetchDailyMemories();
-      }
-    }
-
     setSelectedFile(file);
     setLoading(true);
     try {
@@ -288,6 +278,14 @@ export const useAgentsData = () => {
     fetchDailyMemories,
     handleFileClick,
     handleDailyMemoryClick,
+    toggleExpandedMemory: () => {
+      setExpandedMemory((v) => {
+        if (!v) {
+          fetchDailyMemories();
+        }
+        return !v;
+      });
+    },
     handleSave,
     handleReset,
     handleToggleFileEnabled,

--- a/console/src/pages/Agent/Workspace/index.module.less
+++ b/console/src/pages/Agent/Workspace/index.module.less
@@ -238,9 +238,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
   height: 20px;
-  white-space: nowrap;
 }
 
 .markdownViewer {
@@ -367,21 +365,10 @@
   cursor: pointer;
   background-color: #fff;
   transition: all 0.2s;
-  touch-action: manipulation;
-
-  &,
-  * {
-    -webkit-tap-highlight-color: transparent !important;
-    outline: none;
-  }
 
   &:hover:not(.selected) {
     border-color: #d9d9d9;
     background-color: #fafafa;
-  }
-
-  &:active:not(.selected) {
-    background-color: #f0f0f0;
   }
 
   &.selected {
@@ -462,18 +449,10 @@
   font-size: 12px;
   color: #999;
   margin-left: 8px;
+  background: transparent;
+  border: none;
+  padding: 0;
   cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
-  transition: background-color 0.2s;
-
-  &:active {
-    background-color: rgba(0, 0, 0, 0.08);
-  }
 }
 
 .dailyMemoryList {
@@ -490,21 +469,10 @@
   cursor: pointer;
   background-color: #fff;
   transition: all 0.2s;
-  touch-action: manipulation;
-
-  &,
-  * {
-    -webkit-tap-highlight-color: transparent !important;
-    outline: none;
-  }
 
   &:hover:not(.selected) {
     border-color: #d9d9d9;
     background-color: #fafafa;
-  }
-
-  &:active:not(.selected) {
-    background-color: #f0f0f0;
   }
 
   &.selected {
@@ -567,10 +535,6 @@
       background-color: #333;
     }
 
-    &:active:not(.selected) {
-      background-color: #3a3a3a;
-    }
-
     &.selected {
       border-color: #ff7f16;
       background-color: rgba(97, 92, 237, 0.15);
@@ -611,10 +575,6 @@
     &:hover:not(.selected) {
       border-color: rgba(255, 255, 255, 0.2);
       background-color: #333;
-    }
-
-    &:active:not(.selected) {
-      background-color: #3a3a3a;
     }
 
     &.selected {
@@ -776,6 +736,18 @@
     align-items: center;
   }
 
+  .fileItem {
+    touch-action: manipulation;
+
+    &:active:not(.selected) {
+      background-color: #f0f0f0;
+    }
+
+    :global(.dark-mode) &:active:not(.selected) {
+      background-color: #3a3a3a;
+    }
+  }
+
   .fileItemActions {
     align-self: center;
     display: flex;
@@ -811,6 +783,18 @@
       &:active {
         color: rgba(255, 255, 255, 0.85);
       }
+    }
+  }
+
+  .dailyMemoryItem {
+    touch-action: manipulation;
+
+    &:active:not(.selected) {
+      background-color: #f0f0f0;
+    }
+
+    :global(.dark-mode) &:active:not(.selected) {
+      background-color: #3a3a3a;
     }
   }
 
@@ -880,6 +864,8 @@
 
   .contentLabel {
     flex-wrap: nowrap;
+    gap: 8px;
+    white-space: nowrap;
 
     .buttonGroup {
       width: auto;

--- a/console/src/pages/Agent/Workspace/index.module.less
+++ b/console/src/pages/Agent/Workspace/index.module.less
@@ -61,6 +61,11 @@
   border-radius: 2px;
   background: rgba(239, 240, 243, 0.8);
   padding: 0px 4px;
+
+  :global(.dark-mode) & {
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.08);
+  }
 }
 
 .actionButtons {
@@ -233,7 +238,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
   height: 20px;
+  white-space: nowrap;
 }
 
 .markdownViewer {
@@ -360,10 +367,21 @@
   cursor: pointer;
   background-color: #fff;
   transition: all 0.2s;
+  touch-action: manipulation;
+
+  &,
+  * {
+    -webkit-tap-highlight-color: transparent !important;
+    outline: none;
+  }
 
   &:hover:not(.selected) {
     border-color: #d9d9d9;
     background-color: #fafafa;
+  }
+
+  &:active:not(.selected) {
+    background-color: #f0f0f0;
   }
 
   &.selected {
@@ -444,6 +462,18 @@
   font-size: 12px;
   color: #999;
   margin-left: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+
+  &:active {
+    background-color: rgba(0, 0, 0, 0.08);
+  }
 }
 
 .dailyMemoryList {
@@ -460,10 +490,21 @@
   cursor: pointer;
   background-color: #fff;
   transition: all 0.2s;
+  touch-action: manipulation;
+
+  &,
+  * {
+    -webkit-tap-highlight-color: transparent !important;
+    outline: none;
+  }
 
   &:hover:not(.selected) {
     border-color: #d9d9d9;
     background-color: #fafafa;
+  }
+
+  &:active:not(.selected) {
+    background-color: #f0f0f0;
   }
 
   &.selected {
@@ -526,6 +567,10 @@
       background-color: #333;
     }
 
+    &:active:not(.selected) {
+      background-color: #3a3a3a;
+    }
+
     &.selected {
       border-color: #ff7f16;
       background-color: rgba(97, 92, 237, 0.15);
@@ -568,6 +613,10 @@
       background-color: #333;
     }
 
+    &:active:not(.selected) {
+      background-color: #3a3a3a;
+    }
+
     &.selected {
       border-color: #ff7f16;
       background-color: rgba(97, 92, 237, 0.15);
@@ -599,6 +648,11 @@
     border-color: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.85);
     background: #1f1f1f;
+
+    :global(.x-markdown) {
+      background: transparent !important;
+      color: inherit !important;
+    }
 
     :global {
       pre {
@@ -650,5 +704,216 @@
     background: #2a2a2a !important;
     color: rgba(255, 255, 255, 0.85) !important;
     border-color: rgba(255, 255, 255, 0.1) !important;
+  }
+
+  /* Mobile toolbar */
+  .mobileToolbar {
+    background: #2a2a2a;
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .mobileToolbarTitle {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .saveStatus {
+    color: rgba(255, 255, 255, 0.45);
+  }
+}
+
+@media (max-width: 768px) {
+  .pageHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+
+    [class*="leading"] {
+      width: 100%;
+    }
+  }
+
+  .breadcrumbHeader {
+    flex-wrap: wrap;
+  }
+
+  .workspacePath {
+    margin-left: 0;
+    margin-top: 4px;
+    width: 100%;
+    word-break: break-all;
+    box-sizing: border-box;
+  }
+
+  .workspaceInfo {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .actionButtons {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .content {
+    flex-direction: column;
+  }
+
+  .fileListPanel {
+    width: 100%;
+    height: auto;
+    flex: 1;
+    border-right: none;
+
+    &,
+    * {
+      -webkit-tap-highlight-color: transparent !important;
+    }
+  }
+
+  .fileItemHeader {
+    gap: 4px;
+    align-items: center;
+  }
+
+  .fileItemActions {
+    align-self: center;
+    display: flex;
+    align-items: center;
+  }
+
+  .expandIcon {
+    order: -1;
+    margin-left: 0;
+    margin-right: 4px;
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    color: #999;
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: -8px;
+    }
+
+    &:active {
+      color: #333;
+    }
+
+    :global(.dark-mode) & {
+      color: rgba(255, 255, 255, 0.45);
+
+      &:active {
+        color: rgba(255, 255, 255, 0.85);
+      }
+    }
+  }
+
+  .content.mobileShowEditor {
+    .fileListPanel {
+      display: none;
+    }
+
+    > .fileEditor {
+      display: flex;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+    }
+  }
+
+  .fileEditor {
+    display: none;
+  }
+
+  .editorCard {
+    box-shadow: none !important;
+    border: none !important;
+    background: transparent !important;
+  }
+
+  .mobileToolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-bottom: 1px solid #f0f0f0;
+    flex-shrink: 0;
+    background: #fff;
+  }
+
+  .mobileToolbarTitle {
+    font-weight: 600;
+    font-size: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+
+  .editorHeaderCompact {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 10px 12px;
+  }
+
+  .fileMetaCompact {
+    width: 100%;
+  }
+
+  .filePath {
+    word-break: break-all;
+    white-space: normal;
+    line-height: 1.4;
+  }
+
+  .buttonGroup {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .contentLabel {
+    flex-wrap: nowrap;
+
+    .buttonGroup {
+      width: auto;
+      flex-shrink: 0;
+    }
+  }
+
+  .saveStatus {
+    font-size: 12px;
+    color: #8c8c8c;
+    margin-right: 8px;
+  }
+
+  .editorContent {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 10px 12px;
+    overflow: hidden;
+
+    .textarea {
+      flex: 1;
+      min-height: 240px;
+
+      textarea {
+        min-height: 240px;
+      }
+    }
+  }
+
+  .markdownViewer {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
   }
 }

--- a/console/src/pages/Agent/Workspace/index.tsx
+++ b/console/src/pages/Agent/Workspace/index.tsx
@@ -3,12 +3,13 @@ import styles from "./index.module.less";
 import { UploadOutlined, DownloadOutlined } from "@ant-design/icons";
 import { Button, Tooltip } from "@agentscope-ai/design";
 import { workspaceApi } from "../../../api/modules/workspace";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/PageHeader";
 import { useAppMessage } from "../../../hooks/useAppMessage";
 import { useUploadLimitStore } from "../../../stores/uploadLimitStore";
 import { DownloadCancelledError } from "../../../utils/downloadFileFromUrl";
+import type { MarkdownFile, DailyMemoryFile } from "../../../api/types";
 
 export default function WorkspacePage() {
   const { t } = useTranslation();
@@ -19,7 +20,6 @@ export default function WorkspacePage() {
     dailyMemories,
     expandedMemory,
     fileContent,
-    loading,
     workspacePath,
     hasChanges,
     enabledFiles,
@@ -27,6 +27,7 @@ export default function WorkspacePage() {
     fetchFiles,
     handleFileClick,
     handleDailyMemoryClick,
+    toggleExpandedMemory,
     handleSave,
     handleReset,
     handleToggleFileEnabled,
@@ -35,6 +36,50 @@ export default function WorkspacePage() {
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [downloading, setDownloading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [mobileShowEditor, setMobileShowEditor] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 768px)");
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    if (!isMobile) {
+      setMobileShowEditor(false);
+    }
+  }, [isMobile]);
+
+  const handleFileClickMobile = (file: MarkdownFile) => {
+    void handleFileClick(file);
+    if (isMobile) {
+      setMobileShowEditor(true);
+    }
+  };
+
+  const handleDailyMemoryClickMobile = (daily: DailyMemoryFile) => {
+    void handleDailyMemoryClick(daily);
+    if (isMobile) {
+      setMobileShowEditor(true);
+    }
+  };
+
+  const handleBackToFileList = () => {
+    setMobileShowEditor(false);
+  };
+
+  const handleSaveWithState = async () => {
+    setSaving(true);
+    try {
+      await handleSave();
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const handleDownload = async () => {
     if (downloading) return;
@@ -122,6 +167,7 @@ export default function WorkspacePage() {
   return (
     <div className={styles.workspacePage}>
       <PageHeader
+        className={styles.pageHeader}
         items={[{ title: t("nav.agent") }, { title: t("workspace.title") }]}
         afterBreadcrumb={
           <p className={styles.workspacePath}>
@@ -175,7 +221,13 @@ export default function WorkspacePage() {
         }
       />
 
-      <div className={styles.content}>
+      <div
+        className={
+          mobileShowEditor
+            ? `${styles.content} ${styles.mobileShowEditor}`
+            : styles.content
+        }
+      >
         <FileListPanel
           files={files}
           selectedFile={selectedFile}
@@ -184,8 +236,9 @@ export default function WorkspacePage() {
           workspacePath={workspacePath}
           enabledFiles={enabledFiles}
           onRefresh={fetchFiles}
-          onFileClick={handleFileClick}
-          onDailyMemoryClick={handleDailyMemoryClick}
+          onFileClick={handleFileClickMobile}
+          onDailyMemoryClick={handleDailyMemoryClickMobile}
+          onMemoryExpand={toggleExpandedMemory}
           onToggleEnabled={handleToggleFileEnabled}
           onReorder={handleReorderFiles}
         />
@@ -193,11 +246,13 @@ export default function WorkspacePage() {
         <FileEditor
           selectedFile={selectedFile}
           fileContent={fileContent}
-          loading={loading}
           hasChanges={hasChanges}
           onContentChange={setFileContent}
-          onSave={handleSave}
+          onSave={handleSaveWithState}
           onReset={handleReset}
+          onBack={isMobile ? handleBackToFileList : undefined}
+          compact={isMobile}
+          saving={saving}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

This PR adds mobile adaptation for the Workspace (Files) page in the QwenPaw console.

On narrow screens (≤768px):
- The page header stacks vertically and the workspace path chip wraps instead of overflowing.
- The upload/download button group wraps below the breadcrumb.
- The file list panel and file editor switch from a side-by-side layout to a full-screen page-level switch: tapping a file hides the file list and shows the editor, while a "Back" button or a right-to-left swipe returns to the file list.
- The viewport is watched with `matchMedia`, so rotating/resizing the browser automatically switches between mobile and desktop layouts.
- The editor header shows a save status label ("Saving... / Saved / Unsaved") and the save button enters a loading state during save.

**Related Issue:** Relates to the ongoing console mobile adaptation effort.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

> **Note on pre-commit:** The current pre-commit config excludes `^console/` from the `prettier` hook, so frontend files are not auto-checked. I manually verified the changes with `tsc`, `prettier`, `eslint`, and `npm run build`.

## Testing

1. Open QwenPaw Console on a mobile browser or a narrow viewport (≤768px).
2. Navigate to **Agent → Workspace (Files)**.
3. Verify that:
   - The workspace path does not overflow the screen.
   - Upload / Download buttons are accessible and do not overlap tabs.
   - Tapping a file opens the editor full-screen.
   - The "Back" button or a right-to-left swipe returns to the file list.
   - Save status is shown in the editor header.
4. Resize to desktop width and confirm the side-by-side layout remains unchanged.

## Local Verification Evidence

```bash
cd console
npx tsc --noEmit
npx prettier --check "src/pages/Agent/Workspace/**/*.{ts,tsx,less}"
npx eslint "src/pages/Agent/Workspace/**/*.{ts,tsx}"
npm run build
# all passed
```

## Additional Notes

- `PageHeader` receives `className={styles.pageHeader}`.
- New `common.back` i18n key added (`Back` / `返回`).
- `FileEditor` gained two optional props: `onBack` and `compact`, plus a `saving` state prop. All mobile styles are scoped inside `@media (max-width: 768px)` at the end of `index.module.less`.