### PR TITLE
feat(console): mobile adaptation for Environments page

### DIFF
--- a/console/src/pages/Settings/Environments/index.module.less
+++ b/console/src/pages/Settings/Environments/index.module.less
@@ -558,3 +558,107 @@
     color: rgba(255, 255, 255, 0.2);
   }
 }
+
+@media (max-width: 768px) {
+  .pageHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+
+    [class*="leading"] {
+      width: 100%;
+    }
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .toolbarLeft,
+  .toolbarRight {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .toolbarRight {
+    justify-content: flex-end;
+  }
+
+  .envRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .rowCheckbox {
+    align-self: flex-start;
+
+    :global(.ant-checkbox-inner),
+    :global(.qwenpaw-checkbox-inner) {
+      border-color: #999;
+    }
+
+    :global(.ant-checkbox-checked .ant-checkbox-inner),
+    :global(.qwenpaw-checkbox-checked .qwenpaw-checkbox-inner) {
+      background-color: #69b1ff;
+      border-color: #69b1ff;
+    }
+  }
+
+  .fieldsWrap {
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+  }
+
+  .inputGroup {
+    width: 100%;
+    min-width: auto;
+    height: 44px;
+    min-height: 44px;
+  }
+
+  .inputLabel {
+    min-width: 56px;
+    line-height: 44px;
+  }
+
+  .inputField {
+    display: flex !important;
+    align-items: center;
+    height: 100% !important;
+    min-height: 42px !important;
+
+    :global(.ant-input),
+    :global(.qwenpaw-input) {
+      height: 100% !important;
+      min-height: 42px !important;
+    }
+  }
+
+  .rowActions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .rowIconBtn {
+    width: 40px;
+    height: 40px;
+    font-size: 18px;
+    color: #8c8c8c;
+    background: #f5f5f5;
+
+    &:hover {
+      background: #e8e8e8;
+    }
+  }
+
+  .rowIconBtnDanger:hover {
+    background: #fff1f0;
+  }
+}

--- a/console/src/pages/Settings/Environments/index.module.less
+++ b/console/src/pages/Settings/Environments/index.module.less
@@ -557,6 +557,24 @@
   .emptyState {
     color: rgba(255, 255, 255, 0.2);
   }
+
+  /* Mobile overrides must beat the non-dark media-query rules */
+  @media (max-width: 768px) {
+    .rowIconBtn {
+      color: rgba(255, 255, 255, 0.2);
+      background: transparent;
+
+      &:hover {
+        color: #ff7f16;
+        background: rgba(97, 92, 237, 0.12);
+      }
+    }
+
+    .rowIconBtnDanger:hover {
+      color: #ff7875;
+      background: rgba(255, 77, 79, 0.12);
+    }
+  }
 }
 
 @media (max-width: 768px) {

--- a/console/src/pages/Settings/Environments/index.tsx
+++ b/console/src/pages/Settings/Environments/index.tsx
@@ -264,6 +264,7 @@ function EnvironmentsPage() {
       <PageHeader
         parent={t("environments.parent")}
         current={t("environments.environments")}
+        className={styles.pageHeader}
       />
 
       {/* ---- Content ---- */}

--- a/console/src/pages/Settings/Environments/index.tsx
+++ b/console/src/pages/Settings/Environments/index.tsx
@@ -151,7 +151,7 @@ function EnvironmentsPage() {
         },
       });
     },
-    [workingRows, ensureLocal, envVars.length, fetchAll],
+    [workingRows, ensureLocal, envVars.length, fetchAll, message, t],
   );
 
   const removeSelected = useCallback(() => {


### PR DESCRIPTION
## Description

This PR adds mobile adaptation for the Settings → Environments page in the QwenPaw console.

On narrow screens (≤768px):
- The page header stacks vertically.
- The toolbar (select-all checkbox / action buttons) stacks vertically.
- Each environment variable row switches from a horizontal Key/Value layout to a stacked vertical layout with full-width inputs.
- Input height is preserved on mobile by forcing the antd Input wrapper to `display: flex` so that `height: 100%` applies correctly to the inner input, including inputs with a suffix (eye icon).
- Row action buttons (+ insert / delete) are enlarged and given a light background so they remain visible and tappable.
- The checkbox fill color is lightened for better visibility.

**Related Issue:** Relates to the ongoing console mobile adaptation effort.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

> **Note on pre-commit:** The current pre-commit config excludes `^console/` from the `prettier` hook, so frontend files are not auto-checked. I manually verified the changes with `tsc`, `prettier`, `eslint`, and `npm run build`.

## Testing

1. Open QwenPaw Console on a mobile browser or a narrow viewport (≤768px).
2. Navigate to **Settings → Environments**.
3. Verify that:
   - The page header and toolbar do not overflow horizontally.
   - Each row shows Key and Value stacked vertically with usable input heights.
   - Inputs with the eye icon (password values) are not collapsed.
   - Row action buttons (+ / delete) are clearly visible.
   - Checkboxes are easy to see.
4. Resize to desktop width and confirm the horizontal row layout remains unchanged.

## Local Verification Evidence

```bash
cd console
npx tsc --noEmit
npx prettier --check "src/pages/Settings/Environments/**/*.{ts,tsx,less}"
npx eslint "src/pages/Settings/Environments/**/*.{ts,tsx}"
npm run build
# all passed
```

## Additional Notes

Only `PageHeader` receives `className={styles.pageHeader}`. All mobile styles are scoped inside `@media (max-width: 768px)` at the end of `index.module.less`. The desktop light-mode `.inputField` styles are left untouched; mobile overrides live inside the media query.