### PR TITLE
fix(console): use QueueItem userId/channel in background queue sender

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -288,8 +288,8 @@ async function startBackgroundQueue(
               },
             ],
             session_id: backendSessionId,
-            user_id: DEFAULT_USER_ID,
-            channel: DEFAULT_CHANNEL,
+            user_id: item.userId || DEFAULT_USER_ID,
+            channel: item.channel || DEFAULT_CHANNEL,
             stream: true,
           }),
           signal: ctrl.signal,
@@ -1649,6 +1649,8 @@ export default function ChatPage() {
                 size: f.size,
               }))
             : undefined,
+        userId: window.currentUserId || DEFAULT_USER_ID,
+        channel: window.currentChannel || DEFAULT_CHANNEL,
       });
       // Clear tracked attachments after enqueuing
       pendingFileListRef.current = [];
@@ -2216,6 +2218,8 @@ export default function ChatPage() {
                   size: f.size,
                 }))
               : undefined,
+          userId: window.currentUserId || DEFAULT_USER_ID,
+          channel: window.currentChannel || DEFAULT_CHANNEL,
         });
         pendingFileListRef.current = [];
         if (textarea) setTextareaValue(textarea, "");
@@ -2548,7 +2552,8 @@ export default function ChatPage() {
           }
 
           if (payload.type === "turn_usage") {
-            return null;
+            // Return a heartbeat so the SDK's handle() safely skips this chunk
+            return { object: "message", type: "heartbeat" };
           }
 
           if (payload.type === "rate_limited") {
@@ -2556,7 +2561,7 @@ export default function ChatPage() {
               (payload.alternatives as typeof rateLimitAlternatives) || [];
             setRateLimitAlternatives(alts);
             message.warning(t("chat.rateLimitHit"));
-            return null;
+            return { object: "message", type: "heartbeat" };
           }
 
           if (payloadRequestsHistoryClear(payload)) {

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -42,6 +42,8 @@ export interface QueueItem {
   images?: QueueImage[];
   mentions?: QueueMention[];
   quote?: QueueQuote;
+  userId?: string;
+  channel?: string;
   status: QueueItemStatus;
   retryCount: number;
   errorMessage?: string;
@@ -55,6 +57,8 @@ export interface QueueItemInput {
   images?: QueueImage[];
   mentions?: QueueMention[];
   quote?: QueueQuote;
+  userId?: string;
+  channel?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -347,6 +351,8 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
       images: input.images,
       mentions: input.mentions,
       quote: input.quote,
+      userId: input.userId,
+      channel: input.channel,
       status: "pending",
       retryCount: 0,
       createdAt: Date.now(),


### PR DESCRIPTION
Previously startBackgroundQueue hardcoded user_id and channel to DEFAULT_USER_ID/DEFAULT_CHANNEL, causing DingTalk queue messages to create new sessions due to channel mismatch.

- Add userId and channel fields to QueueItem/QueueItemInput interfaces
- Inject userId/channel from window context at enqueue time
- Use item.userId/item.channel in background fetch request body

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
