### PR TITLE
fix(console): move Inbox menu item to the global section

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -235,8 +235,11 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   );
 
   const settingsMenuItems = useMemo(
-    () => toAntdItems(settingsMenu, { collapsed }),
-    [settingsMenu, collapsed],
+    () => toAntdItems(settingsMenu, { collapsed, decorateLabel }),
+    // hasInboxUnread closure inside decorateLabel — listed as dep explicitly
+    // (inbox lives in the settings menu, so its unread badge is decorated here).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [settingsMenu, collapsed, hasInboxUnread],
   );
 
   const openKeys = useMemo(

--- a/console/src/layouts/registry/builtinMenu.ts
+++ b/console/src/layouts/registry/builtinMenu.ts
@@ -56,15 +56,6 @@ const navLabel = (key: string, defaultValue?: string) => (): string =>
 
 export const BUILTIN_MENU: MenuItem[] = [
   // ── Agent-scoped (Sidebar Menu #1) ───────────────────────────────────────
-  {
-    id: "core.inbox",
-    location: "primary.agentScoped",
-    label: navLabel("nav.inbox"),
-    icon: SparkEmailLine,
-    route: "core.inbox",
-    order: 10,
-  },
-
   // control-group
   {
     id: "core.control-group",
@@ -183,6 +174,18 @@ export const BUILTIN_MENU: MenuItem[] = [
   },
 
   // ── Settings (Sidebar Menu #2) ───────────────────────────────────────────
+  // Inbox is global (shows push messages across all agents, with an in-page
+  // agent filter), so it lives in the global menu rather than the agent-scoped
+  // one. Standalone item above the Settings group, mirroring its prior
+  // standalone placement.
+  {
+    id: "core.inbox",
+    location: "primary.settings",
+    label: navLabel("nav.inbox"),
+    icon: SparkEmailLine,
+    route: "core.inbox",
+    order: 5,
+  },
   {
     id: "core.settings-group",
     location: "primary.settings",

--- a/console/src/plugins/registry/types.ts
+++ b/console/src/plugins/registry/types.ts
@@ -65,8 +65,8 @@ export function resolveLocalized<T>(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type MenuLocation =
-  | "primary.agentScoped" // Sidebar Menu #1 (agent-bound entries: inbox, control, agent-group)
-  | "primary.settings" //   Sidebar Menu #2 (global settings + plugins-group)
+  | "primary.agentScoped" // Sidebar Menu #1 (agent-bound entries: control, agent-group)
+  | "primary.settings" //   Sidebar Menu #2 (global entries: inbox, settings + plugins-group)
   | "userMenu"; //          Reserved for future avatar-dropdown items
 
 export interface MenuItem {


### PR DESCRIPTION
## Description

The **Inbox** menu item was registered under `primary.agentScoped`, so it rendered right next to the `AgentSelector` in the agent-scoped sidebar — visually implying the Inbox is scoped to the *currently selected agent*.

In reality the Inbox is **global**:
- `useInboxData` fetches via `api.getInboxEvents({ limit: 200 })` — no `agent_id`, so it returns push messages across **all** agents (`console/src/pages/Inbox/hooks/useInboxData.ts`).
- The Inbox page offers an in-page agent filter dropdown that filters client-side over the already-global result set (`console/src/pages/Inbox/index.tsx`).
- The route is a plain `/inbox` with no agent parameter (`console/src/layouts/registry/builtinRoutes.tsx`).

Placement (agent-scoped) and behavior (global) contradicted each other. This PR moves the Inbox into the global menu section to match its actual behavior.

**Related Issue:** None — no existing issue/PR/discussion covers this placement inconsistency (searched issues, PRs, and discussions).

**Security Considerations:** None — UI menu placement only; no change to data access, auth, or the API query.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Changes

- `console/src/layouts/registry/builtinMenu.ts` — move the `core.inbox` entry from `primary.agentScoped` to `primary.settings` as a standalone item (`order: 5`) above the Settings group.
- `console/src/layouts/Sidebar.tsx` — apply the unread-badge `decorateLabel` to `settingsMenuItems` as well, so the unread badge survives the move. Simple mode (`SIMPLE_MODE_WHITELIST` + `simpleFlatNav`) and collapsed mode already iterate both menus and keep working.
- `console/src/plugins/registry/types.ts` — update the `MenuLocation` doc comment.

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran the relevant checks locally and they pass — see evidence below (console-only change)
- [ ] Documentation updated (if needed)
- [x] Ready for review

> Note on `pre-commit`: the repo's `.pre-commit-config.yaml` excludes `^console/` from the `prettier` hook, and its Python hooks (black / flake8 / pylint / mypy) only target `.py`, so none apply to these `.tsx` files. The console's own toolchain (tsc / eslint / prettier) is authoritative for this change and is run below.

## Testing

1. Open the console sidebar — **Inbox** now appears in the global section (second menu, above the Settings group) instead of beside the agent selector.
2. Confirm the unread badge still shows on the Inbox label in expanded mode, and the unread dot still shows in collapsed and simple modes.
3. Confirm the Inbox still opens at `/inbox` and lists push messages from all agents with the in-page agent filter.

## Local Verification Evidence

```bash
$ npx tsc -b --noEmit          # in console/
# exit 0 — no errors

$ npx eslint src/layouts/Sidebar.tsx \
             src/layouts/registry/builtinMenu.ts \
             src/plugins/registry/types.ts
# exit 0 — no problems

$ npx prettier --check src/layouts/Sidebar.tsx \
                       src/layouts/registry/builtinMenu.ts \
                       src/plugins/registry/types.ts
# Checking formatting...
# All matched files use Prettier code style!
# exit 0
```

## Additional Notes

This is a pure menu-placement fix; the alternative (scoping the Inbox query to the current agent and removing the in-page filter) was considered but rejected as more invasive and a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
