### PR TITLE
feat(console): mobile card layout for Backups page

### DIFF
--- a/console/src/pages/Settings/Backups/index.module.less
+++ b/console/src/pages/Settings/Backups/index.module.less
@@ -12,10 +12,6 @@
   overflow-y: auto;
 }
 
-.pageHeader {
-  /* desktop defaults keep PageHeader original layout */
-}
-
 .pageHeader [class*="leading"] {
   min-width: 0;
 }

--- a/console/src/pages/Settings/Backups/index.module.less
+++ b/console/src/pages/Settings/Backups/index.module.less
@@ -12,10 +12,50 @@
   overflow-y: auto;
 }
 
+.pageHeader {
+  /* desktop defaults keep PageHeader original layout */
+}
+
+.pageHeader [class*="leading"] {
+  min-width: 0;
+}
+
+.pageHeader [class*="extra"] {
+  flex-shrink: 0;
+}
+
 .headerRight {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .pageHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .pageHeader [class*="leading"] {
+    width: 100%;
+  }
+
+  .pageHeader [class*="extra"] {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .pageHeader [class*="center"] {
+    position: static;
+    transform: none;
+    align-self: flex-start;
+  }
+
+  .content {
+    padding: 16px;
+  }
 }
 
 .centerState {

--- a/console/src/pages/Settings/Backups/index.tsx
+++ b/console/src/pages/Settings/Backups/index.tsx
@@ -74,6 +74,7 @@ export default function BackupsPage() {
   return (
     <div className={styles.page}>
       <PageHeader
+        className={styles.pageHeader}
         parent={t("nav.settings")}
         current={t("backup.title")}
         extra={

--- a/console/src/pages/Settings/Backups/list/BackupTable.module.less
+++ b/console/src/pages/Settings/Backups/list/BackupTable.module.less
@@ -17,3 +17,79 @@
   display: flex;
   gap: 4px;
 }
+
+.mobileCards {
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mobileCard {
+  :global {
+    .qwenpaw-card-head {
+      min-height: unset;
+      padding: 0 12px;
+    }
+    .qwenpaw-card-head-title {
+      padding: 8px 0;
+    }
+    .qwenpaw-card-body {
+      padding: 12px !important;
+    }
+  }
+}
+
+.mobileCardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mobileId {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--ant-color-text-secondary);
+  word-break: break-all;
+}
+
+.mobileTime {
+  font-size: 12px;
+  color: var(--ant-color-text-tertiary);
+}
+
+.mobileRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.mobileLabel {
+  font-size: 12px;
+  color: var(--ant-color-text-secondary);
+}
+
+.mobileValue {
+  font-size: 14px;
+  color: var(--ant-color-text);
+}
+
+.mobileActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .tableCard {
+    display: none;
+  }
+
+  .mobileCards {
+    display: flex;
+  }
+}

--- a/console/src/pages/Settings/Backups/list/BackupTable.module.less
+++ b/console/src/pages/Settings/Backups/list/BackupTable.module.less
@@ -41,27 +41,30 @@
 
 .mobileCardHeader {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  gap: 8px;
 }
 
 .mobileId {
+  flex: 1;
+  min-width: 0;
   font-family: monospace;
   font-size: 12px;
   color: var(--ant-color-text-secondary);
-  word-break: break-all;
 }
 
 .mobileTime {
+  flex-shrink: 0;
   font-size: 12px;
   color: var(--ant-color-text-tertiary);
+  text-align: right;
 }
 
 .mobileRow {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 
   &:last-child {
     margin-bottom: 0;

--- a/console/src/pages/Settings/Backups/list/BackupTable.module.less
+++ b/console/src/pages/Settings/Backups/list/BackupTable.module.less
@@ -84,6 +84,12 @@
   flex-wrap: wrap;
 }
 
+.mobilePagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
+}
+
 @media (max-width: 768px) {
   .tableCard {
     display: none;

--- a/console/src/pages/Settings/Backups/list/BackupTable.tsx
+++ b/console/src/pages/Settings/Backups/list/BackupTable.tsx
@@ -51,7 +51,6 @@ export default function BackupTable({
   }, [backups, searchQuery]);
 
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(PAGE_SIZE);
 
   // Keep mobile cards sorted by created time (desc) to match the desktop table default.
   const sortedFilteredBackups = useMemo(() => {
@@ -65,12 +64,12 @@ export default function BackupTable({
   }, [searchQuery]);
 
   const totalBackups = sortedFilteredBackups.length;
-  const maxPage = Math.max(1, Math.ceil(totalBackups / pageSize));
+  const maxPage = Math.max(1, Math.ceil(totalBackups / PAGE_SIZE));
   const currentPage = Math.min(page, maxPage);
-  const startIndex = (currentPage - 1) * pageSize;
+  const startIndex = (currentPage - 1) * PAGE_SIZE;
   const paginatedBackups = sortedFilteredBackups.slice(
     startIndex,
-    startIndex + pageSize,
+    startIndex + PAGE_SIZE,
   );
 
   /** Deletes a single backup by ID and refreshes the list on success. */
@@ -260,31 +259,17 @@ export default function BackupTable({
           />
         ) : (
           <>
-            <Pagination
-              current={currentPage}
-              pageSize={pageSize}
-              total={totalBackups}
-              showSizeChanger
-              showTotal={(count) => t("backup.total", { count })}
-              pageSizeOptions={["10", "20", "50"]}
-              onChange={(p, size) => {
-                setPage(p);
-                setPageSize(size);
-              }}
-            />
             {paginatedBackups.map(renderMobileCard)}
-            <Pagination
-              current={currentPage}
-              pageSize={pageSize}
-              total={totalBackups}
-              showSizeChanger
-              showTotal={(count) => t("backup.total", { count })}
-              pageSizeOptions={["10", "20", "50"]}
-              onChange={(p, size) => {
-                setPage(p);
-                setPageSize(size);
-              }}
-            />
+            <div className={styles.mobilePagination}>
+              <Pagination
+                current={currentPage}
+                pageSize={PAGE_SIZE}
+                total={totalBackups}
+                size="small"
+                simple
+                onChange={(p) => setPage(p)}
+              />
+            </div>
           </>
         )}
       </div>

--- a/console/src/pages/Settings/Backups/list/BackupTable.tsx
+++ b/console/src/pages/Settings/Backups/list/BackupTable.tsx
@@ -8,7 +8,17 @@
  * Restore delegates to the parent via onRestore (handled by useRestoreFlow).
  */
 import { useEffect, useMemo, useState } from "react";
-import { Button, Card, Empty, Modal, Pagination, Popconfirm, Table, Tooltip, Typography } from "antd";
+import {
+  Button,
+  Card,
+  Empty,
+  Modal,
+  Pagination,
+  Popconfirm,
+  Table,
+  Tooltip,
+  Typography,
+} from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
@@ -196,7 +206,9 @@ export default function BackupTable({
       </div>
       {backup.description ? (
         <div className={styles.mobileRow}>
-          <span className={styles.mobileLabel}>{t("backup.descriptionLabel")}</span>
+          <span className={styles.mobileLabel}>
+            {t("backup.descriptionLabel")}
+          </span>
           <Typography.Text
             ellipsis={{ tooltip: true }}
             className={styles.mobileValue}
@@ -210,7 +222,12 @@ export default function BackupTable({
         <ScopeTags scope={backup.scope} agentCount={backup.agent_count} />
       </div>
       <div className={styles.mobileActions}>
-        <Button type="primary" size="small" ghost onClick={() => onRestore(backup)}>
+        <Button
+          type="primary"
+          size="small"
+          ghost
+          onClick={() => onRestore(backup)}
+        >
           {t("backup.restore")}
         </Button>
         <Button size="small" onClick={() => handleExport(backup)}>

--- a/console/src/pages/Settings/Backups/list/BackupTable.tsx
+++ b/console/src/pages/Settings/Backups/list/BackupTable.tsx
@@ -7,8 +7,8 @@
  * Delete calls the API directly and triggers onRefresh on success.
  * Restore delegates to the parent via onRestore (handled by useRestoreFlow).
  */
-import { useMemo } from "react";
-import { Button, Card, Empty, Modal, Popconfirm, Table, Tooltip } from "antd";
+import { useEffect, useMemo, useState } from "react";
+import { Button, Card, Empty, Modal, Pagination, Popconfirm, Table, Tooltip, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
@@ -49,6 +49,29 @@ export default function BackupTable({
       (s) => s.name.toLowerCase().includes(q) || s.id.toLowerCase().includes(q),
     );
   }, [backups, searchQuery]);
+
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+  // Keep mobile cards sorted by created time (desc) to match the desktop table default.
+  const sortedFilteredBackups = useMemo(() => {
+    return [...filteredBackups].sort(
+      (a, b) => dayjs(b.created_at).unix() - dayjs(a.created_at).unix(),
+    );
+  }, [filteredBackups]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery]);
+
+  const totalBackups = sortedFilteredBackups.length;
+  const maxPage = Math.max(1, Math.ceil(totalBackups / pageSize));
+  const currentPage = Math.min(page, maxPage);
+  const startIndex = (currentPage - 1) * pageSize;
+  const paginatedBackups = sortedFilteredBackups.slice(
+    startIndex,
+    startIndex + pageSize,
+  );
 
   /** Deletes a single backup by ID and refreshes the list on success. */
   const handleDelete = async (id: string) => {
@@ -149,27 +172,122 @@ export default function BackupTable({
     },
   ];
 
-  return (
-    <Card className={styles.tableCard}>
-      {backups.length === 0 ? (
-        <Empty
-          description={t("backup.noBackups")}
-          style={{ padding: "40px 0" }}
-        />
-      ) : (
-        <Table<BackupMeta>
-          rowKey="id"
-          dataSource={filteredBackups}
-          columns={columns}
-          size="middle"
-          pagination={{
-            pageSize: PAGE_SIZE,
-            showSizeChanger: true,
-            showTotal: (total) => t("backup.total", { count: total }),
-            pageSizeOptions: ["10", "20", "50"],
-          }}
-        />
-      )}
+  const renderMobileCard = (backup: BackupMeta) => (
+    <Card
+      key={backup.id}
+      className={styles.mobileCard}
+      size="small"
+      title={
+        <div className={styles.mobileCardHeader}>
+          <span className={styles.mobileId}>{backup.id}</span>
+          <span className={styles.mobileTime}>
+            {dayjs(backup.created_at).format("YYYY-MM-DD HH:mm")}
+          </span>
+        </div>
+      }
+    >
+      <div className={styles.mobileRow}>
+        <span className={styles.mobileLabel}>{t("backup.name")}</span>
+        <Typography.Text
+          ellipsis={{ tooltip: true }}
+          className={styles.mobileValue}
+        >
+          {backup.name}
+        </Typography.Text>
+      </div>
+      {backup.description ? (
+        <div className={styles.mobileRow}>
+          <span className={styles.mobileLabel}>{t("backup.descriptionLabel")}</span>
+          <Typography.Text
+            ellipsis={{ tooltip: true }}
+            className={styles.mobileValue}
+          >
+            {backup.description}
+          </Typography.Text>
+        </div>
+      ) : null}
+      <div className={styles.mobileRow}>
+        <span className={styles.mobileLabel}>{t("backup.scopeSummary")}</span>
+        <ScopeTags scope={backup.scope} agentCount={backup.agent_count} />
+      </div>
+      <div className={styles.mobileActions}>
+        <Button type="primary" size="small" ghost onClick={() => onRestore(backup)}>
+          {t("backup.restore")}
+        </Button>
+        <Button size="small" onClick={() => handleExport(backup)}>
+          {t("backup.export")}
+        </Button>
+        <Popconfirm
+          title={t("backup.deleteConfirm")}
+          onConfirm={() => handleDelete(backup.id)}
+        >
+          <Button size="small" danger>
+            {t("backup.delete")}
+          </Button>
+        </Popconfirm>
+      </div>
     </Card>
+  );
+
+  return (
+    <>
+      <Card className={styles.tableCard}>
+        {backups.length === 0 ? (
+          <Empty
+            description={t("backup.noBackups")}
+            style={{ padding: "40px 0" }}
+          />
+        ) : (
+          <Table<BackupMeta>
+            rowKey="id"
+            dataSource={filteredBackups}
+            columns={columns}
+            size="middle"
+            pagination={{
+              pageSize: PAGE_SIZE,
+              showSizeChanger: true,
+              showTotal: (total) => t("backup.total", { count: total }),
+              pageSizeOptions: ["10", "20", "50"],
+            }}
+          />
+        )}
+      </Card>
+      <div className={styles.mobileCards}>
+        {totalBackups === 0 ? (
+          <Empty
+            description={t("backup.noBackups")}
+            style={{ padding: "40px 0" }}
+          />
+        ) : (
+          <>
+            <Pagination
+              current={currentPage}
+              pageSize={pageSize}
+              total={totalBackups}
+              showSizeChanger
+              showTotal={(count) => t("backup.total", { count })}
+              pageSizeOptions={["10", "20", "50"]}
+              onChange={(p, size) => {
+                setPage(p);
+                setPageSize(size);
+              }}
+            />
+            {paginatedBackups.map(renderMobileCard)}
+            <Pagination
+              current={currentPage}
+              pageSize={pageSize}
+              total={totalBackups}
+              showSizeChanger
+              showTotal={(count) => t("backup.total", { count })}
+              pageSizeOptions={["10", "20", "50"]}
+              onChange={(p, size) => {
+                setPage(p);
+                setPageSize(size);
+              }}
+            />
+          </>
+        )}
+      </div>
+    </>
   );
 }

--- a/console/src/pages/Settings/Backups/list/BackupTable.tsx
+++ b/console/src/pages/Settings/Backups/list/BackupTable.tsx
@@ -188,7 +188,12 @@ export default function BackupTable({
       size="small"
       title={
         <div className={styles.mobileCardHeader}>
-          <span className={styles.mobileId}>{backup.id}</span>
+          <Typography.Text
+            ellipsis={{ tooltip: true }}
+            className={styles.mobileId}
+          >
+            {backup.id}
+          </Typography.Text>
           <span className={styles.mobileTime}>
             {dayjs(backup.created_at).format("YYYY-MM-DD HH:mm")}
           </span>
@@ -219,7 +224,11 @@ export default function BackupTable({
       ) : null}
       <div className={styles.mobileRow}>
         <span className={styles.mobileLabel}>{t("backup.scopeSummary")}</span>
-        <ScopeTags scope={backup.scope} agentCount={backup.agent_count} />
+        <ScopeTags
+          scope={backup.scope}
+          agentCount={backup.agent_count}
+          compact
+        />
       </div>
       <div className={styles.mobileActions}>
         <Button

--- a/console/src/pages/Settings/Backups/list/BackupToolbar.module.less
+++ b/console/src/pages/Settings/Backups/list/BackupToolbar.module.less
@@ -7,3 +7,9 @@
 .searchInput {
   max-width: 320px;
 }
+
+@media (max-width: 768px) {
+  .searchInput {
+    max-width: 100%;
+  }
+}

--- a/console/src/pages/Settings/Backups/list/ScopeTags.module.less
+++ b/console/src/pages/Settings/Backups/list/ScopeTags.module.less
@@ -3,3 +3,9 @@
   gap: 4px;
   flex-wrap: wrap;
 }
+
+.compactTag {
+  padding: 0 4px !important;
+  font-size: 11px !important;
+  line-height: 18px !important;
+}

--- a/console/src/pages/Settings/Backups/list/ScopeTags.tsx
+++ b/console/src/pages/Settings/Backups/list/ScopeTags.tsx
@@ -22,7 +22,9 @@ export default function ScopeTags({ scope, agentCount }: Props) {
       ) : null}
       {scope.include_global_config && <Tag>{t("backup.globalConfig")}</Tag>}
       {scope.include_skill_pool && <Tag>{t("backup.skillPool")}</Tag>}
-      {scope.include_secrets && <Tag color="orange">{t("backup.secrets")}</Tag>}
+      {scope.include_secrets && (
+        <Tag color="warning">{t("backup.secrets")}</Tag>
+      )}
     </div>
   );
 }

--- a/console/src/pages/Settings/Backups/list/ScopeTags.tsx
+++ b/console/src/pages/Settings/Backups/list/ScopeTags.tsx
@@ -11,19 +11,29 @@ import styles from "./ScopeTags.module.less";
 interface Props {
   scope: BackupMeta["scope"];
   agentCount?: number;
+  compact?: boolean;
 }
 
-export default function ScopeTags({ scope, agentCount }: Props) {
+export default function ScopeTags({ scope, agentCount, compact }: Props) {
   const { t } = useTranslation();
+  const tagClass = compact ? styles.compactTag : undefined;
   return (
     <div className={styles.scopeTags}>
       {scope.include_agents && agentCount ? (
-        <Tag>{t("backup.agents", { count: agentCount })}</Tag>
+        <Tag className={tagClass}>
+          {t("backup.agents", { count: agentCount })}
+        </Tag>
       ) : null}
-      {scope.include_global_config && <Tag>{t("backup.globalConfig")}</Tag>}
-      {scope.include_skill_pool && <Tag>{t("backup.skillPool")}</Tag>}
+      {scope.include_global_config && (
+        <Tag className={tagClass}>{t("backup.globalConfig")}</Tag>
+      )}
+      {scope.include_skill_pool && (
+        <Tag className={tagClass}>{t("backup.skillPool")}</Tag>
+      )}
       {scope.include_secrets && (
-        <Tag color="warning">{t("backup.secrets")}</Tag>
+        <Tag className={tagClass} color="warning">
+          {t("backup.secrets")}
+        </Tag>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

This PR adds a responsive mobile layout for the **Backups** settings page.
On viewports `<= 768px`, the backup list is rendered as cards instead of the desktop table, making it usable on phones while keeping the existing table experience unchanged on larger screens.

- Each card shows ID, name, description, scope tags, creation time, and Restore / Export / Delete actions.
- Mobile cards are sorted by created time (descending) and paginated with a compact `simple` Pagination.
- Long IDs and names use `Typography.Text ellipsis` with tooltips to avoid overflow.
- PageHeader stacks vertically on mobile via `className` + `[class*="leading"]`, `[class*="extra"]`, `[class*="center"]` selectors.
- All mobile-specific text colors use antd CSS variables (`--ant-color-text*`) for automatic dark-mode support.

**Related Issue:** Relates to mobile console adaptation.

**Security Considerations:** None.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Console (frontend web UI)

## Checklist

- [x] I ran `pre-commit` equivalent checks (`eslint`, `prettier`) locally and they pass
- [x] I ran `npm run build` locally and it passes
- [ ] Documentation updated (if needed)

## Testing

1. Open the Backups page on a viewport `<= 768px`.
2. Verify backups appear as cards with ID, name, description, scope tags, and actions.
3. Verify pagination works and defaults to the latest backups first.
4. Switch to desktop width and confirm the original table is still shown.

## Local Verification Evidence

```bash
cd console
npx eslint src/pages/Settings/Backups --max-warnings 0
npx prettier --check src/pages/Settings/Backups
npm run build
# all passed
```

## Additional Notes

- Branch: `yaozy2020/QwenPaw-1:mobile-backups-cards-rebase`
- Target: `agentscope-ai/QwenPaw:main`
