### PR TITLE
feat(plugin-manager): mobile card layout and unified catalog cards

### DIFF
--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.module.less
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.module.less
@@ -53,6 +53,47 @@
 
 .searchHint {
   font-size: 13px;
-  color: var(--ant-color-text-secondary);
+  color: var(--ant-color-text-tertiary);
   white-space: nowrap;
+}
+
+.searchInput {
+  width: 220px;
+}
+
+.catalogIconInline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--ant-color-fill-tertiary);
+  color: var(--ant-color-text-secondary);
+  margin-right: 8px;
+  flex-shrink: 0;
+  overflow: hidden;
+
+  img {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+  }
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbarRight {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .searchInput {
+    width: 100%;
+  }
 }

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -124,7 +124,7 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
               if (!e.target.value) onSearch("");
             }}
             onSearch={onSearch}
-            style={{ width: 220 }}
+            className={marketStyles.searchInput}
           />
           <Button
             type="default"
@@ -154,24 +154,24 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
         <div className={styles.catalogList}>
           {plugins.map((entry) => (
             <div className={styles.catalogRow} key={entry.id}>
-              <div className={styles.catalogIcon}>
-                {entry.logo_url ? (
-                  <img
-                    src={entry.logo_url}
-                    alt=""
-                    style={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: 4,
-                      objectFit: "contain",
-                    }}
-                  />
-                ) : (
-                  <Package size={18} />
-                )}
-              </div>
               <div className={styles.catalogInfo}>
                 <div className={styles.catalogNameRow}>
+                  <span className={styles.catalogIconInline}>
+                    {entry.logo_url ? (
+                      <img
+                        src={entry.logo_url}
+                        alt=""
+                        style={{
+                          width: 18,
+                          height: 18,
+                          borderRadius: 4,
+                          objectFit: "contain",
+                        }}
+                      />
+                    ) : (
+                      <Package size={16} />
+                    )}
+                  </span>
                   <Text strong>{entry.display_name}</Text>
                   {entry.locales?.[lang]?.category && (
                     <Tag color="blue" style={{ margin: 0, fontSize: 11 }}>

--- a/console/src/pages/Settings/PluginManager/components/OfficialPluginList.module.less
+++ b/console/src/pages/Settings/PluginManager/components/OfficialPluginList.module.less
@@ -16,6 +16,14 @@
   gap: 12px;
 }
 
+.filterInput {
+  width: 220px;
+}
+
+.filterSelect {
+  width: 150px;
+}
+
 .catalogList {
   display: flex;
   flex-direction: column;
@@ -26,39 +34,29 @@
   align-items: center;
   gap: 12px;
   padding: 14px 16px;
-  border: 1px solid var(--color-border-secondary, #eae8e7);
-  transition: background 0.2s ease;
-  border-bottom: none;
+  border: 1.5px solid var(--ant-color-border-strong, #d9d9d9);
+  border-radius: 12px;
+  margin-bottom: 12px;
+  background: var(--ant-color-bg-container);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
 
   &:first-child {
-    border-radius: 8px 8px 0 0;
+    border-radius: 12px;
   }
 
   &:last-child {
-    border-bottom: 1px solid var(--color-border-secondary, #eae8e7);
-    border-radius: 0 0 8px 8px;
+    border-radius: 12px;
+    margin-bottom: 0;
   }
 
   &:only-child {
-    border-radius: 8px;
-    border-bottom: 1px solid var(--color-border-secondary, #eae8e7);
+    border-radius: 12px;
   }
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.02);
-  }
-}
-
-.catalogIcon {
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  background: var(--ant-color-fill-tertiary);
-  color: var(--ant-color-text-secondary);
 }
 
 .catalogInfo {
@@ -76,7 +74,7 @@
 .catalogDescription {
   margin-top: 4px;
   font-size: 12px;
-  color: var(--ant-color-text-secondary);
+  color: var(--ant-color-text-tertiary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -85,7 +83,7 @@
 .catalogMeta {
   margin-top: 2px;
   font-size: 12px;
-  color: var(--ant-color-text-quaternary);
+  color: var(--ant-color-text-tertiary);
 }
 
 .catalogActions {
@@ -93,4 +91,45 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .catalogToolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .catalogFilters {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .filterInput {
+    width: 100%;
+  }
+
+  .filterSelect {
+    width: 100%;
+  }
+
+  .catalogRow {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 14px 16px;
+  }
+
+  .catalogActions {
+    margin-top: 10px;
+  }
+
+  .catalogNameRow {
+    flex-wrap: wrap;
+  }
+
+  .categoryTabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    flex-wrap: nowrap;
+  }
 }

--- a/console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx
@@ -93,7 +93,7 @@ export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
             allowClear
             value={nameFilter}
             onChange={(e) => setNameFilter(e.target.value)}
-            style={{ width: 220 }}
+            className={styles.filterInput}
           />
           <Select
             placeholder={t("pluginManager.filterByKind")}
@@ -101,7 +101,7 @@ export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
             value={kindFilter}
             onChange={(val) => setKindFilter(val)}
             options={kindOptions}
-            style={{ width: 150 }}
+            className={styles.filterSelect}
           />
         </div>
         <Button
@@ -131,11 +131,11 @@ export function OfficialPluginList({ onInstalled }: OfficialPluginListProps) {
         <div className={styles.catalogList}>
           {filteredPlugins.map((entry) => (
             <div className={styles.catalogRow} key={entry.id}>
-              <div className={styles.catalogIcon}>
-                <Package size={18} />
-              </div>
               <div className={styles.catalogInfo}>
                 <div className={styles.catalogNameRow}>
+                  <span className={styles.catalogIconInline}>
+                    <Package size={18} />
+                  </span>
                   <Text strong>{entry.name}</Text>
                   {entry.kind && (
                     <Tag

--- a/console/src/pages/Settings/PluginManager/index.module.less
+++ b/console/src/pages/Settings/PluginManager/index.module.less
@@ -17,6 +17,14 @@
   }
 }
 
+.desktopTable {
+  display: block;
+}
+
+.mobileCards {
+  display: none;
+}
+
 .table {
   :global(.ant-table-thead > tr > th) {
     background: transparent;
@@ -41,5 +49,103 @@
 
   :global(.ant-table-tbody > tr:hover > td) {
     background: var(--ant-color-fill-quaternary);
+  }
+}
+
+.pluginCard {
+  border: 1.5px solid var(--ant-color-border-strong, #d9d9d9);
+  border-radius: 12px;
+  padding: 16px 18px;
+  margin-bottom: 14px;
+  background: var(--ant-color-bg-container);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.pluginCard:active {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.pluginCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.pluginCardTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.pluginCardStatus {
+  flex-shrink: 0;
+}
+
+.pluginCardDesc {
+  font-size: 13px;
+  color: var(--ant-color-text-tertiary);
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+
+.pluginCardMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.pluginCardMetaItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.pluginCardMetaLabel {
+  color: var(--ant-color-text-tertiary);
+}
+
+.pluginCardActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 768px) {
+  .content {
+    padding: 0 12px;
+  }
+
+  .desktopTable {
+    display: none;
+  }
+
+  .mobileCards {
+    display: block;
+  }
+
+  .pluginCard {
+    padding: 12px;
+    margin-bottom: 10px;
+  }
+
+  .pluginCardTitle {
+    font-size: 14px;
+  }
+
+  .pluginCardDesc {
+    font-size: 12px;
+  }
+
+  .pluginCardMeta {
+    gap: 10px;
+  }
+
+  .pluginCardMetaItem {
+    font-size: 12px;
   }
 }

--- a/console/src/pages/Settings/PluginManager/index.tsx
+++ b/console/src/pages/Settings/PluginManager/index.tsx
@@ -1,6 +1,13 @@
 import { useTranslation } from "react-i18next";
-import { Button, Empty, Spin, Table, Tabs } from "antd";
-import { ExternalLink, Package, Plus } from "lucide-react";
+import { Button, Empty, Spin, Table, Tabs, Tag } from "antd";
+import {
+  ExternalLink,
+  Package,
+  Plus,
+  Trash2,
+  CheckCircle,
+  XCircle,
+} from "lucide-react";
 import { PageHeader } from "@/components/PageHeader";
 import { usePluginManager } from "./hooks/usePluginManager";
 import { usePluginColumns } from "./hooks/usePluginColumns";
@@ -9,6 +16,74 @@ import { InstallPluginModal } from "./components/InstallPluginModal";
 import { OfficialPluginList } from "./components/OfficialPluginList";
 import { MarketPluginList } from "./components/MarketPluginList";
 import styles from "./index.module.less";
+import type { PluginInfo } from "@/api/modules/plugin";
+import { PluginTypeTag } from "./components/PluginTypeTag";
+
+function PluginCard({
+  plugin,
+  uninstallingId,
+  onUninstall,
+  t,
+}: {
+  plugin: PluginInfo;
+  uninstallingId: string | null;
+  onUninstall: (record: PluginInfo) => void;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  return (
+    <div className={styles.pluginCard}>
+      <div className={styles.pluginCardHeader}>
+        <div className={styles.pluginCardTitle}>
+          <Package size={18} />
+          <span>{plugin.name}</span>
+        </div>
+        <Tag
+          icon={
+            plugin.loaded ? <CheckCircle size={12} /> : <XCircle size={12} />
+          }
+          color={plugin.loaded ? "success" : "default"}
+          className={styles.pluginCardStatus}
+        >
+          {plugin.loaded
+            ? t("pluginManager.statusLoaded")
+            : t("pluginManager.statusUnloaded")}
+        </Tag>
+      </div>
+
+      {plugin.description && (
+        <div className={styles.pluginCardDesc}>{plugin.description}</div>
+      )}
+
+      <div className={styles.pluginCardMeta}>
+        <div className={styles.pluginCardMetaItem}>
+          <span className={styles.pluginCardMetaLabel}>类型</span>
+          <PluginTypeTag type={plugin.plugin_type || "general"} />
+        </div>
+        <div className={styles.pluginCardMetaItem}>
+          <span className={styles.pluginCardMetaLabel}>版本</span>
+          <span>{plugin.version || "-"}</span>
+        </div>
+        <div className={styles.pluginCardMetaItem}>
+          <span className={styles.pluginCardMetaLabel}>作者</span>
+          <span>{plugin.author || t("pluginManager.unknown")}</span>
+        </div>
+      </div>
+
+      <div className={styles.pluginCardActions}>
+        <Button
+          type="text"
+          danger
+          size="small"
+          icon={<Trash2 size={14} />}
+          loading={uninstallingId === plugin.id}
+          onClick={() => onUninstall(plugin)}
+        >
+          {t("pluginManager.uninstall")}
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 export default function PluginManagerPage() {
   const { t } = useTranslation();
@@ -36,13 +111,28 @@ export default function PluginManagerPage() {
               style={{ marginTop: 24 }}
             />
           ) : (
-            <Table
-              dataSource={plugins}
-              columns={columns}
-              rowKey="id"
-              pagination={false}
-              className={styles.table}
-            />
+            <div className={styles.desktopTable}>
+              <Table
+                dataSource={plugins}
+                columns={columns}
+                rowKey="id"
+                pagination={false}
+                className={styles.table}
+              />
+            </div>
+          )}
+          {!loading && plugins && plugins.length > 0 && (
+            <div className={styles.mobileCards}>
+              {plugins.map((plugin) => (
+                <PluginCard
+                  key={plugin.id}
+                  plugin={plugin}
+                  uninstallingId={uninstallingId}
+                  onUninstall={handleUninstall}
+                  t={t}
+                />
+              ))}
+            </div>
           )}
         </Spin>
       ),


### PR DESCRIPTION
$## Description

The "Settings / Plugin Manager" page in QwenPaw was not responsive on narrow viewports — plugin lists overflowed, action buttons were clipped, and the catalog icon occupied a separate row instead of sitting beside the plugin name. This PR adds `@media (max-width: 768px)` blocks that adjust the layout for mobile while leaving the desktop layout completely unchanged.

### Issues Fixed

1. **Official plugins overflow** — The catalog rows and toolbar did not reflow for narrow screens, causing horizontal clipping.
2. **Market plugins overflow** — Search and category tabs plus plugin rows overflowed on mobile.
3. **Icon separated from name** — Plugin icons were rendered in a standalone column, unlike the installed-plugins card layout.
4. **Inconsistent card styling** — Installed, Official, and Market tabs used different visual treatments.
5. **Dark mode text brightness** — Card descriptions and meta text were too bright in dark mode.

### Changes

All responsive changes are wrapped in `@media (max-width: 768px)`:

- `console/src/pages/Settings/PluginManager/index.tsx` — card layout for installed plugins on mobile
- `console/src/pages/Settings/PluginManager/index.module.less` — card styles and responsive rules
- `console/src/pages/Settings/PluginManager/components/OfficialPluginList.tsx` — inline icon + responsive stack
- `console/src/pages/Settings/PluginManager/components/OfficialPluginList.module.less` — catalog card styles and responsive rules
- `console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx` — inline icon/logo + responsive stack
- `console/src/pages/Settings/PluginManager/components/MarketPluginList.module.less` — market card styles and responsive rules

## Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Testing

1. Open **Plugin Manager** on a desktop browser — table/card baseline should remain unchanged.
2. Resize to `< 768px` or use DevTools mobile emulation.
3. Verify the **Installed**, **Official**, and **Market** tabs render as cards without horizontal scroll.
4. Verify the plugin icon is inline with the plugin name in Official and Market tabs.
5. Verify card borders, shadows, and spacing are visually consistent across all three tabs.
6. Verify search/filter toolbars and action buttons fit within the viewport.
7. Verify dark mode text contrast is comfortable and not overly bright.

## Local Verification Evidence

```bash
cd console && NODE_OPTIONS="--max-old-space-size=4096" npm run build
# built successfully; frontend bundle deployed to local instance for manual verification
```