### PR TITLE
fix(runtime): respect configured workspace prompt files

### DIFF
--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -3,7 +3,7 @@
 
 Each contributor is responsible for one fragment of the system prompt.
 ``build_default_prompt_manager`` assembles a :class:`PromptManager`
-pre-loaded with all 7 contributors, ready for ``build_sync(ctx)``.
+pre-loaded with the built-in contributors, ready for ``build_sync(ctx)``.
 
 Contributors read configuration from ``ctx.extras``:
 
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SYSTEM_PROMPT_FILES = ("AGENTS.md", "SOUL.md", "PROFILE.md")
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
@@ -52,10 +54,18 @@ def _read_prompt_file(workspace_dir: Path, filename: str) -> str | None:
     Returns ``None`` when the file does not exist or is empty after
     stripping.
     """
-    path = workspace_dir / filename
-    if not path.exists():
-        return None
     try:
+        workspace_root = workspace_dir.resolve()
+        path = (workspace_root / filename).resolve()
+        if path == workspace_root or not path.is_relative_to(workspace_root):
+            logger.warning(
+                "Prompt file %s resolves outside workspace, skipping",
+                filename,
+            )
+            return None
+        if not path.is_file():
+            return None
+
         from ..agents.utils.file_handling import (
             read_text_file_with_encoding_fallback,
         )
@@ -69,6 +79,22 @@ def _read_prompt_file(workspace_dir: Path, filename: str) -> str | None:
     except Exception:
         logger.warning("Failed to read %s, skipping", filename)
         return None
+
+
+def _system_prompt_files(ctx: "HookContext") -> list[str]:
+    """Return prompt files configured for the current agent.
+
+    ``None`` means the profile predates the field, so use the historical
+    defaults. An empty list is meaningful and disables workspace prompt files.
+    """
+    extras = getattr(ctx, "extras", {}) or {}
+    agent_config = extras.get("agent_config")
+    if agent_config is None:
+        return list(DEFAULT_SYSTEM_PROMPT_FILES)
+    files = getattr(agent_config, "system_prompt_files", None)
+    if files is None:
+        return list(DEFAULT_SYSTEM_PROMPT_FILES)
+    return [str(filename) for filename in files]
 
 
 def _process_heartbeat_section(content: str, enabled: bool) -> str:
@@ -184,6 +210,51 @@ class ProfileMdContributor(SyncPromptContributor):
         return f"# PROFILE.md\n\n{content}"
 
 
+class WorkspacePromptFilesContributor(SyncPromptContributor):
+    """Load configured workspace markdown files in UI-configured order."""
+
+    name = "workspace_prompt_files"
+    priority = 10
+
+    def contribute_sync(self, ctx: "HookContext") -> str | None:
+        wd = getattr(ctx, "workspace_dir", None)
+        if not wd:
+            return None
+
+        workspace_dir = Path(wd)
+        extras = getattr(ctx, "extras", {}) or {}
+        parts: list[str] = []
+        for filename in _system_prompt_files(ctx):
+            content = _read_prompt_file(workspace_dir, filename)
+            if not content:
+                continue
+            if filename == "AGENTS.md":
+                content = self._process_agents_md(content, extras)
+            if not content:
+                continue
+            parts.append(f"# {filename}\n\n{content}")
+        return "\n\n".join(parts) or None
+
+    @staticmethod
+    def _process_agents_md(content: str, extras: dict[str, Any]) -> str:
+        heartbeat_enabled = extras.get("heartbeat_enabled", False)
+        try:
+            content = _process_heartbeat_section(content, heartbeat_enabled)
+        except Exception as e:
+            logger.warning("Failed to process heartbeat: %s", e)
+        memory_manager = extras.get("memory_manager")
+        language = extras.get("language", "zh")
+        try:
+            content = _process_memory_section(
+                content,
+                memory_manager,
+                language,
+            )
+        except Exception as e:
+            logger.warning("Failed to process memory section: %s", e)
+        return content
+
+
 class MultimodalHintContributor(SyncPromptContributor):
     """Inject multimodal capability awareness hint."""
 
@@ -273,9 +344,7 @@ class DriverPolicyHintContributor(SyncPromptContributor):
 
 _ALL_CONTRIBUTORS = (
     AgentIdentityContributor,
-    AgentsMdContributor,
-    SoulMdContributor,
-    ProfileMdContributor,
+    WorkspacePromptFilesContributor,
     MultimodalHintContributor,
     CodingModeContributor,
     DriverPolicyHintContributor,
@@ -296,6 +365,7 @@ __all__ = [
     "AgentsMdContributor",
     "SoulMdContributor",
     "ProfileMdContributor",
+    "WorkspacePromptFilesContributor",
     "MultimodalHintContributor",
     "CodingModeContributor",
     "DriverPolicyHintContributor",

--- a/tests/unit/runtime/test_prompt_contributors.py
+++ b/tests/unit/runtime/test_prompt_contributors.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""Tests for runtime prompt contributors."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.runtime.prompt_contributors import (
+    WorkspacePromptFilesContributor,
+    build_default_prompt_manager,
+)
+
+
+def _ctx(tmp_path, system_prompt_files):
+    return SimpleNamespace(
+        workspace_dir=str(tmp_path),
+        agent_id="test_agent",
+        extras={
+            "agent_config": SimpleNamespace(
+                system_prompt_files=system_prompt_files,
+                language="en",
+            ),
+            "heartbeat_enabled": False,
+            "language": "en",
+            "memory_manager": None,
+        },
+    )
+
+
+def test_workspace_prompt_files_respects_disabled_files(tmp_path):
+    """Configured prompt file list gates SOUL.md and PROFILE.md."""
+    (tmp_path / "AGENTS.md").write_text("agents body", encoding="utf-8")
+    (tmp_path / "SOUL.md").write_text("soul body", encoding="utf-8")
+    (tmp_path / "PROFILE.md").write_text("profile body", encoding="utf-8")
+
+    prompt = build_default_prompt_manager().build_sync(
+        _ctx(tmp_path, ["AGENTS.md"]),
+    )
+
+    assert "# AGENTS.md" in prompt
+    assert "agents body" in prompt
+    assert "# SOUL.md" not in prompt
+    assert "soul body" not in prompt
+    assert "# PROFILE.md" not in prompt
+    assert "profile body" not in prompt
+
+
+def test_workspace_prompt_files_empty_list_disables_workspace_markdown(
+    tmp_path,
+):
+    """An empty configured list is meaningful and disables markdown files."""
+    (tmp_path / "AGENTS.md").write_text("agents body", encoding="utf-8")
+    (tmp_path / "SOUL.md").write_text("soul body", encoding="utf-8")
+    (tmp_path / "PROFILE.md").write_text("profile body", encoding="utf-8")
+
+    fragment = WorkspacePromptFilesContributor().contribute_sync(
+        _ctx(tmp_path, []),
+    )
+
+    assert fragment is None
+
+
+def test_workspace_prompt_files_preserves_configured_order_and_custom_files(
+    tmp_path,
+):
+    """Configured file order is the rendered prompt order."""
+    (tmp_path / "AGENTS.md").write_text("agents body", encoding="utf-8")
+    (tmp_path / "PROFILE.md").write_text("profile body", encoding="utf-8")
+    (tmp_path / "CUSTOM.md").write_text("custom body", encoding="utf-8")
+
+    fragment = WorkspacePromptFilesContributor().contribute_sync(
+        _ctx(tmp_path, ["PROFILE.md", "CUSTOM.md", "AGENTS.md"]),
+    )
+
+    assert fragment is not None
+    assert fragment.index("# PROFILE.md") < fragment.index("# CUSTOM.md")
+    assert fragment.index("# CUSTOM.md") < fragment.index("# AGENTS.md")
+
+
+def test_workspace_prompt_files_skips_parent_traversal(tmp_path):
+    """Configured prompt files cannot escape the workspace via ``..``."""
+    outside = tmp_path.parent / f"{tmp_path.name}_secret.md"
+    outside.write_text("secret body", encoding="utf-8")
+    (tmp_path / "AGENTS.md").write_text("agents body", encoding="utf-8")
+
+    fragment = WorkspacePromptFilesContributor().contribute_sync(
+        _ctx(tmp_path, [f"../{outside.name}", "AGENTS.md"]),
+    )
+
+    assert fragment is not None
+    assert "secret body" not in fragment
+    assert "agents body" in fragment
+
+
+def test_workspace_prompt_files_skips_symlink_escape(tmp_path):
+    """Configured prompt files cannot escape through symlinks."""
+    outside = tmp_path.parent / f"{tmp_path.name}_symlink_secret.md"
+    outside.write_text("secret body", encoding="utf-8")
+    link = tmp_path / "LINK.md"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are not available on this platform")
+
+    fragment = WorkspacePromptFilesContributor().contribute_sync(
+        _ctx(tmp_path, ["LINK.md"]),
+    )
+
+    assert fragment is None

--- a/tests/unit/runtime/test_prompt_contributors.py
+++ b/tests/unit/runtime/test_prompt_contributors.py
@@ -88,8 +88,9 @@ def test_workspace_prompt_files_skips_parent_traversal(tmp_path):
     )
 
     assert fragment is not None
-    assert "secret body" not in fragment
-    assert "agents body" in fragment
+    body = str(fragment)
+    assert "secret body" not in body
+    assert "agents body" in body
 
 
 def test_workspace_prompt_files_skips_symlink_escape(tmp_path):


### PR DESCRIPTION
## Description

Fixes runtime system prompt assembly so workspace markdown prompt files are loaded from the agent's configured `system_prompt_files` list instead of always loading `AGENTS.md`, `SOUL.md`, and `PROFILE.md` when those files exist.

The root cause was that the default prompt manager registered separate unconditional contributors for each built-in markdown file. This change replaces those registrations with a single workspace prompt-files contributor that preserves the configured order, supports custom files, and treats an empty list as disabling workspace markdown prompt files.

**Related Issue:** N/A

**Security Considerations:** No new auth, network, or environment handling. The change narrows prompt injection surface by respecting disabled workspace prompt files.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the focused runtime prompt contributor tests:

```bash
uv run pytest tests/unit/runtime/test_prompt_contributors.py
```

## Local Verification Evidence

```bash
uv run pytest tests/unit/runtime/test_prompt_contributors.py
# 5 passed, 1 warning in 0.41s
```

## Additional Notes

This PR targets the active runtime prompt-manager path used by `AgentBuilder.build_prompt()`. Legacy migration/fallback behavior is unchanged.
