### PR TITLE
feat(console): adapt Settings-Models page for mobile view

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/LocalModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/LocalModelManageModal.tsx
@@ -859,6 +859,7 @@ export function LocalModelManageModal({
       onCancel={handleClose}
       footer={null}
       width={800}
+      className={styles.modelManageModal}
       destroyOnHidden
     >
       {(loadingLocal || loadingStatus || loadingLocalConfig) &&

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -609,6 +609,7 @@ export function ProviderConfigModal({
   return (
     <Modal
       width={800}
+      className={styles.modelManageModal}
       title={t("models.configureProvider", { name: provider.name })}
       open={open}
       onCancel={onClose}

--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -711,6 +711,7 @@ export function RemoteModelManageModal({
       onCancel={handleClose}
       footer={null}
       width={800}
+      className={styles.modelManageModal}
       destroyOnHidden
     >
       <Input

--- a/console/src/pages/Settings/Models/index.module.less
+++ b/console/src/pages/Settings/Models/index.module.less
@@ -2373,3 +2373,258 @@
     opacity: 0.8;
   }
 }
+
+/* ─── Mobile responsive ───────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 12px 16px;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .breadcrumbHeader {
+    flex-wrap: wrap;
+    gap: 4px 8px;
+  }
+
+  .breadcrumbParent {
+    font-size: 14px;
+  }
+
+  .breadcrumbSeparator {
+    margin: 0 4px;
+  }
+
+  .breadcrumbCurrent {
+    font-size: 16px;
+  }
+
+  .sectionHeaderRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .headerRight {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    padding: 0 16px;
+  }
+
+  .providersPageHeader {
+    padding: 12px 16px;
+  }
+
+  .llmPill {
+    justify-content: space-between;
+    width: 100%;
+    padding: 6px 10px;
+    font-size: 13px;
+  }
+
+  .llmPillLabel {
+    font-size: 13px;
+  }
+
+  .llmPillValue {
+    font-size: 12px;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .searchRow {
+    margin: 0;
+    width: 100%;
+  }
+
+  .searchInput {
+    max-width: unset;
+    width: 100%;
+  }
+
+  .addProviderBtn {
+    margin-right: 0;
+    width: 100%;
+  }
+
+  .tabsNav {
+    margin: 0 12px 12px;
+    overflow-x: auto;
+    gap: 0;
+  }
+
+  .tabItem {
+    padding: 8px 14px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .section {
+    margin-bottom: 24px;
+  }
+
+  .sectionTitle {
+    font-size: 20px;
+  }
+
+  .sectionDesc {
+    margin: 0 0 16px;
+    font-size: 13px;
+  }
+
+  .providersBlock {
+    margin-top: 16px;
+  }
+
+  .providerGroup {
+    padding: 0 12px;
+  }
+
+  .providerGroupTitle {
+    font-size: 13px;
+    margin: 0 0 8px;
+  }
+
+  .providerCards {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .providerCard {
+    padding: 16px;
+    padding-bottom: 56px;
+    border-radius: 12px;
+  }
+
+  .cardName {
+    font-size: 14px;
+  }
+
+  .groupCardGlass {
+    padding: 16px;
+    border-radius: 12px;
+  }
+
+  .groupCardHeader {
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .groupCardName {
+    font-size: 15px;
+  }
+
+  .groupSegmented {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    gap: 0;
+    padding: 2px;
+  }
+
+  .groupSegBtn {
+    flex: 0 0 auto;
+    padding: 6px 10px;
+    font-size: 10px;
+  }
+
+  .groupCardContent {
+    gap: 8px;
+  }
+
+  .availableGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .availableItem {
+    padding: 8px 12px;
+  }
+
+  .cardActions {
+    position: static;
+    padding-top: 12px;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+    background: transparent;
+  }
+
+  .actionBtn {
+    height: 28px;
+    font-size: 12px;
+  }
+
+  .modalFooter {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .modalFooterLeft {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .modalFooterRight {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .slotSection {
+    padding: 16px;
+  }
+
+  .slotHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .slotActions {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .emptyConfigured {
+    padding: 32px 16px;
+  }
+
+  .variantItem {
+    padding: 10px 12px;
+  }
+
+  .configFieldRow {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .configFieldLabel {
+    min-width: unset;
+    width: 100%;
+  }
+
+  .configFieldValue {
+    width: 100%;
+  }
+
+  .inlineKeyInput {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .localModalIntro {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .localModalTitle {
+    font-size: 16px;
+  }
+
+  .jsonEditorHighlight,
+  .jsonEditorTextarea {
+    padding: 8px 10px;
+    font-size: 12px;
+    min-height: 120px;
+  }
+}

--- a/console/src/pages/Settings/Models/index.module.less
+++ b/console/src/pages/Settings/Models/index.module.less
@@ -2535,6 +2535,40 @@
     gap: 8px;
   }
 
+  .groupCardMono {
+    font-size: 11px;
+    padding: 6px 10px;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .groupCardKeyInput {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .groupCardActions {
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-top: 10px;
+  }
+
+  .groupCardActBtn {
+    flex: 1;
+    min-width: 0;
+    padding: 6px 10px;
+    font-size: 11px;
+    text-align: center;
+  }
+
+  .groupCardField {
+    gap: 3px;
+  }
+
+  .groupCardFieldValue {
+    font-size: 12px;
+  }
+
   .availableGrid {
     grid-template-columns: 1fr;
   }

--- a/console/src/pages/Settings/Models/index.module.less
+++ b/console/src/pages/Settings/Models/index.module.less
@@ -2508,6 +2508,11 @@
     border-radius: 12px;
   }
 
+  .groupCardGlass,
+  .providerCard {
+    min-width: 0;
+  }
+
   .groupCardHeader {
     flex-wrap: wrap;
     gap: 8px;
@@ -2538,7 +2543,6 @@
   .groupCardMono {
     font-size: 11px;
     padding: 6px 10px;
-    flex-wrap: wrap;
     gap: 4px;
   }
 
@@ -2660,5 +2664,60 @@
     padding: 8px 10px;
     font-size: 12px;
     min-height: 120px;
+  }
+
+  /* ─── Model Management Modal ─── */
+  .modelList {
+    max-height: 320px;
+  }
+
+  .modelListItem {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 8px 12px;
+    gap: 6px;
+  }
+
+  .modelListItemInfo {
+    flex: none;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .modelListItemName {
+    font-size: 13px;
+  }
+
+  .modelListItemId {
+    font-size: 11px;
+  }
+
+  .modelListItemActions {
+    gap: 4px;
+    flex-shrink: 0;
+    margin-left: 0;
+    justify-content: flex-start;
+  }
+
+  .modelListItemStatusButton {
+    height: 22px;
+    padding: 0 8px;
+    font-size: 11px;
+  }
+
+  .modelListCount {
+    font-size: 11px;
+  }
+
+  .modelManageModal {
+    :global {
+      .ant-modal {
+        max-width: calc(100vw - 32px);
+      }
+      .ant-modal-content {
+        max-height: 90vh;
+        overflow-y: auto;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

Mobile responsive adaptation for the Settings → Models page. Improves the layout and usability of model management on narrow screens.

## Changes

- **Provider cards**: stack description and action buttons vertically on mobile
- **Group cards**: prevent content overflow with `min-width: 0`
- **Search/action row**: full-width search input, refresh + add buttons wrap to next line
- **Tabs**: reduce padding to prevent text overflow
- **Model list items**: stack model info and action buttons vertically (two-row layout) so model names are fully visible
- **Model management modals**: restrict modal width to viewport on mobile, limit content height with scroll
- **Default LLM pill**: compact display on mobile, hide redundant labels

All changes are scoped to `@media (max-width: 768px)`. Desktop layout is completely unaffected.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Configuration change
- [x] CSS/Layout improvement
- [ ] Documentation update

## Component(s) affected

- [x] Console (Frontend)
- [ ] Backend (Python)
- [ ] Documentation
- [ ] Other

## Testing

- Built and deployed locally on FnOS NAS
- Verified on desktop (no regression)
- Verified via user-provided mobile screenshots

## Local Verification

Tested on `localhost:19901`, desktop + mobile viewport.