### PR TITLE
feat(browser): support shared browser instance for multi session with page isolation

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -268,6 +268,7 @@ def _make_fresh_state(workspace_id: str, workspace_dir: str) -> dict[str, Any]:
         "pending_file_choosers": {},  # page_id -> FileChooser list
         "headless": True,
         "session_pages": {},
+        "_active_session_id": None,
         "_lock": asyncio.Lock(),
         "page_counter": 0,
         "last_activity_time": 0.0,  # monotonic timestamp of last browser activity
@@ -298,8 +299,12 @@ def _get_workspace_state(
     return _workspace_states[workspace_id]
 
 
+def _get_active_session_id(state: dict) -> str:
+    return str(state.get("_active_session_id") or "default")
+
+
 def _get_session_data(state: dict, session_id: str | None = None) -> dict:
-    session_id = session_id or "default"
+    session_id = session_id or _get_active_session_id(state)
     sp = state.setdefault("session_pages", {})
     return sp.setdefault(
         session_id,
@@ -365,13 +370,6 @@ def _real_page_is_referenced(state: dict, real_page_id: str) -> bool:
         if real_page_id in sd.get("map", {}).values():
             return True
     return False
-
-
-def _find_session_for_real_page(state: dict, real_page_id: str) -> str | None:
-    for sid, sd in state.get("session_pages", {}).items():
-        if real_page_id in sd.get("map", {}).values():
-            return sid
-    return None
 
 
 def _replace_page_id_values(
@@ -481,6 +479,7 @@ def _reset_browser_state(state: dict) -> None:
     state["pending_dialogs"].clear()
     state["pending_file_choosers"].clear()
     state["session_pages"].clear()
+    state["_active_session_id"] = None
     state["page_counter"] = 0
     state["last_activity_time"] = 0.0
     state["headless"] = True
@@ -1092,26 +1091,12 @@ def _attach_context_listeners(state: dict, context) -> None:
     def on_page(page):
         new_id = _next_page_id(state)
         _register_page(state, page, new_id)
-        session_id = None
-        try:
-            opener = page.opener
-            if callable(opener):
-                opener = opener()
-            if opener:
-                for rid, p in state.get("pages", {}).items():
-                    if p is opener:
-                        session_id = _find_session_for_real_page(state, rid)
-                        break
-        except Exception:
-            pass
-        if not session_id:
-            session_id = "default"
-        vid = _session_add_page(state, new_id, session_id)
+        vid = _session_add_page(state, new_id)
         logger.debug(
             "New tab opened by page, real_id=%s, virtual_id=%s, session=%s",
             new_id,
             vid,
-            session_id,
+            _get_active_session_id(state),
         )
 
     context.on("page", on_page)
@@ -4863,6 +4848,7 @@ async def browser_use(  # pylint: disable=R0911,R0912
     }
 
     async with state["_lock"]:
+        state["_active_session_id"] = _session_id
         if action in _NO_PAGE_ACTIONS:
             pass
         elif action == "open":

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -267,8 +267,10 @@ def _make_fresh_state(workspace_id: str, workspace_dir: str) -> dict[str, Any]:
         "pending_dialogs": {},  # page_id -> dialog handlers
         "pending_file_choosers": {},  # page_id -> FileChooser list
         "headless": True,
-        "current_page_id": None,
-        "page_counter": 0,  # monotonic counter for page_N ids, avoids reuse after close
+        "session_page_maps": {},
+        "_active_session_id": None,
+        "_lock": asyncio.Lock(),
+        "page_counter": 0,
         "last_activity_time": 0.0,  # monotonic timestamp of last browser activity
         "_idle_task": None,  # background asyncio.Task for idle watchdog
         "_last_browser_error": None,  # message when launch failed (for user-facing error)
@@ -295,6 +297,223 @@ def _get_workspace_state(
             workspace_dir,
         )
     return _workspace_states[workspace_id]
+
+
+def _get_active_session_id(state: dict) -> str:
+    return str(state.get("_active_session_id") or "default")
+
+
+def _get_session_page_map(state: dict, session_id: str | None = None) -> dict:
+    session_id = session_id or _get_active_session_id(state)
+    maps = state.setdefault("session_page_maps", {})
+    return maps.setdefault(
+        session_id,
+        {
+            "alias_to_real": {},
+            "real_to_alias": {},
+            "current_page_id": None,
+            "page_counter": 0,
+        },
+    )
+
+
+def _next_local_page_id(state: dict, session_id: str | None = None) -> str:
+    m = _get_session_page_map(state, session_id)
+    while True:
+        m["page_counter"] = m.get("page_counter", 0) + 1
+        cand = f"page_{m['page_counter']}"
+        if cand not in m["alias_to_real"]:
+            return cand
+
+
+def _map_local_to_real(
+    state: dict,
+    page_id: str,
+    session_id: str | None = None,
+) -> str | None:
+    return _get_session_page_map(state, session_id)["alias_to_real"].get(
+        page_id,
+    )
+
+
+def _map_real_to_local(
+    state: dict,
+    real_id: str,
+    session_id: str | None = None,
+) -> str | None:
+    return _get_session_page_map(state, session_id)["real_to_alias"].get(
+        real_id,
+    )
+
+
+def _assign_local_page_alias(
+    state: dict,
+    real_page_id: str,
+    requested_alias: str | None = None,
+    session_id: str | None = None,
+    set_current: bool = True,
+) -> str:
+    m = _get_session_page_map(state, session_id)
+    existing = m["real_to_alias"].get(real_page_id)
+    if existing:
+        if set_current:
+            _set_current_page_for_session(state, existing, session_id)
+        return existing
+    alias = (requested_alias or "").strip()
+    if not alias or alias == "default":
+        alias = _next_local_page_id(state, session_id)
+    elif alias in m["alias_to_real"]:
+        raise ValueError(f"Page id '{alias}' already exists")
+    m["alias_to_real"][alias] = real_page_id
+    m["real_to_alias"][real_page_id] = alias
+    if set_current:
+        _set_current_page_for_session(state, alias, session_id)
+    return alias
+
+
+def _set_current_page_for_session(
+    state: dict,
+    local_page_id: str | None,
+    session_id: str | None = None,
+) -> None:
+    session_id = session_id or _get_active_session_id(state)
+    m = _get_session_page_map(state, session_id)
+    real = m["alias_to_real"].get(local_page_id) if local_page_id else None
+    m["current_page_id"] = local_page_id if real else None
+
+
+def _get_current_page_for_session(
+    state: dict,
+    session_id: str | None = None,
+) -> str | None:
+    m = _get_session_page_map(state, session_id)
+    pid = m.get("current_page_id")
+    if pid and _map_local_to_real(state, pid, session_id) in (
+        state.get("pages") or {}
+    ):
+        return pid
+    return None
+
+
+def _set_current_real_page_for_session(
+    state: dict,
+    real_page_id: str | None,
+    session_id: str | None = None,
+) -> str | None:
+    if not real_page_id:
+        _set_current_page_for_session(state, None, session_id)
+        return None
+    local = _map_real_to_local(state, real_page_id, session_id)
+    if not local:
+        local = _assign_local_page_alias(
+            state,
+            real_page_id,
+            session_id=session_id,
+            set_current=False,
+        )
+    _set_current_page_for_session(state, local, session_id)
+    return local
+
+
+def _local_page_ids_for_session(
+    state: dict,
+    session_id: str | None = None,
+) -> list[str]:
+    m = _get_session_page_map(state, session_id)
+    pages = state.get("pages") or {}
+    return [a for a, r in m["alias_to_real"].items() if r in pages]
+
+
+def _real_page_is_referenced(state: dict, real_page_id: str) -> bool:
+    for m in state.get("session_page_maps", {}).values():
+        if real_page_id in m.get("real_to_alias", {}):
+            return True
+    return False
+
+
+def _detach_local_page_alias(
+    state: dict,
+    local_page_id: str,
+    session_id: str | None = None,
+) -> str | None:
+    m = _get_session_page_map(state, session_id)
+    real = m["alias_to_real"].pop(local_page_id, None)
+    if real:
+        m["real_to_alias"].pop(real, None)
+    if m.get("current_page_id") == local_page_id:
+        remaining = _local_page_ids_for_session(state, session_id)
+        m["current_page_id"] = remaining[0] if remaining else None
+    return real
+
+
+def _replace_page_id_values(
+    value: Any,
+    state: dict,
+    session_id: str | None = None,
+    drop_unmapped_dict: bool = False,
+) -> Any:
+    if isinstance(value, str):
+        local = _map_real_to_local(state, value, session_id)
+        if local:
+            return local
+        return None if re.fullmatch(r"real_page_\d+", value) else value
+    if isinstance(value, list):
+        out = []
+        for item in value:
+            r = _replace_page_id_values(
+                item,
+                state,
+                session_id,
+                drop_unmapped_dict,
+            )
+            if r is not None:
+                out.append(r)
+        return out
+    if isinstance(value, dict):
+        out = {}
+        for k, v in value.items():
+            if k == "page_id" and isinstance(v, str):
+                v = _replace_page_id_values(v, state, session_id)
+                if v is None:
+                    return None if drop_unmapped_dict else {}
+                out[k] = v
+            elif k in {
+                "tabs",
+                "pages",
+                "tab_list",
+                "current_page_id",
+                "session_current_page_id",
+                "results",
+            }:
+                out[k] = _replace_page_id_values(
+                    v,
+                    state,
+                    session_id,
+                    drop_unmapped_dict=(k == "tab_list"),
+                )
+            else:
+                out[k] = v
+        return out
+    return value
+
+
+def _localize_tool_response(
+    state: dict,
+    resp: ToolResponse,
+    session_id: str | None = None,
+) -> ToolResponse:
+    try:
+        block = resp.content[0]
+        raw = block["text"] if isinstance(block, dict) else block.text
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return resp
+    except Exception:
+        return resp
+    localized = _replace_page_id_values(data, state, session_id)
+    if not isinstance(localized, dict):
+        return resp
+    return _tool_response(json.dumps(localized, ensure_ascii=False, indent=2))
 
 
 # Stop the browser after this many seconds of inactivity (default 10 minutes).
@@ -333,7 +552,8 @@ def _reset_browser_state(state: dict) -> None:
     state["network_requests"].clear()
     state["pending_dialogs"].clear()
     state["pending_file_choosers"].clear()
-    state["current_page_id"] = None
+    state["session_page_maps"].clear()
+    state["_active_session_id"] = None
     state["page_counter"] = 0
     state["last_activity_time"] = 0.0
     state["headless"] = True
@@ -673,13 +893,16 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
             for page in context.pages:
                 page_id = _next_page_id(state)
                 _register_page(state, page, page_id)
-                if state["current_page_id"] is None:
-                    state["current_page_id"] = page_id
+                _assign_local_page_alias(
+                    state,
+                    page_id,
+                    set_current=_get_current_page_for_session(state) is None,
+                )
             if not state["pages"]:
                 page = await context.new_page()
                 page_id = _next_page_id(state)
                 _register_page(state, page, page_id)
-                state["current_page_id"] = page_id
+                _set_current_real_page_for_session(state, page_id)
     except Exception:
         await _stop_playwright_instance(pw)
         try:
@@ -820,6 +1043,17 @@ async def _get_tab_info_list(state: dict) -> list[dict[str, str]]:
     return tab_list
 
 
+async def _get_session_tab_info_list(state: dict) -> list[dict[str, str]]:
+    real_tabs = await _get_tab_info_list(state)
+    out: list[dict[str, str]] = []
+    for item in real_tabs:
+        local = _map_real_to_local(state, item.get("page_id", ""))
+        if not local:
+            continue
+        out.append({**item, "page_id": local})
+    return out
+
+
 def _get_context(state: dict):
     """Return the active browser context regardless of sync/async mode."""
     return state["context"] or state.get("_sync_context")
@@ -910,7 +1144,7 @@ def _next_page_id(state: dict) -> str:
     """Return a unique page_id (page_N).
     Uses monotonic counter so IDs are not reused after close."""
     state["page_counter"] = state.get("page_counter", 0) + 1
-    return f"page_{state['page_counter']}"
+    return f"real_page_{state['page_counter']}"
 
 
 def _register_page(state: dict, page, page_id: str) -> None:
@@ -931,10 +1165,17 @@ def _attach_context_listeners(state: dict, context) -> None:
     def on_page(page):
         new_id = _next_page_id(state)
         _register_page(state, page, new_id)
-        state["current_page_id"] = new_id
-        logger.debug(
-            "New tab opened by page, registered as page_id=%s",
+        session_id = _get_active_session_id(state)
+        local_id = _assign_local_page_alias(
+            state,
             new_id,
+            session_id=session_id,
+        )
+        logger.debug(
+            "New tab opened by page, real_id=%s, local_id=%s, session=%s",
+            new_id,
+            local_id,
+            session_id,
         )
 
     context.on("page", on_page)
@@ -1408,7 +1649,12 @@ async def _action_stop(state: dict) -> ToolChunk:
     )
 
 
-async def _action_open(state: dict, url: str, page_id: str) -> ToolChunk:
+async def _action_open(
+    state: dict,
+    url: str,
+    page_id: str,
+    local_page_id: str | None = None,
+) -> ToolChunk:
     url = (url or "").strip()
     if not url:
         return _tool_response(
@@ -1441,6 +1687,11 @@ async def _action_open(state: dict, url: str, page_id: str) -> ToolChunk:
             page = await state["context"].new_page()
 
         _register_page(state, page, page_id)
+        exposed_id = _assign_local_page_alias(
+            state,
+            page_id,
+            requested_alias=local_page_id,
+        )
         await _configure_download_behavior(state)
 
         if _USE_SYNC_PLAYWRIGHT:
@@ -1453,13 +1704,13 @@ async def _action_open(state: dict, url: str, page_id: str) -> ToolChunk:
             await page.goto(url)
 
         state["pages"][page_id] = page
-        state["current_page_id"] = page_id
+        _set_current_page_for_session(state, exposed_id)
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
                     "message": f"Opened {url}",
-                    "page_id": page_id,
+                    "page_id": exposed_id,
                     "url": url,
                 },
                 ensure_ascii=False,
@@ -1508,7 +1759,7 @@ async def _action_navigate(
             )
         else:
             await page.goto(url)
-        state["current_page_id"] = page_id
+        _set_current_real_page_for_session(state, page_id)
         return _tool_response(
             json.dumps(
                 {
@@ -2038,37 +2289,66 @@ async def _action_pdf(state: dict, page_id: str, path: str) -> ToolChunk:
         )
 
 
-async def _action_close(state: dict, page_id: str) -> ToolChunk:
+async def _action_close(
+    state: dict,
+    page_id: str,
+    local_page_id: str | None = None,
+) -> ToolChunk:
     page = _get_page(state, page_id)
     if not page:
         return _tool_response(
             json.dumps(
-                {"ok": False, "error": f"Page '{page_id}' not found"},
+                {
+                    "ok": False,
+                    "error": f"Page '{local_page_id or page_id}' not found",
+                },
                 ensure_ascii=False,
                 indent=2,
             ),
         )
+    local_page_id = (
+        local_page_id or _map_real_to_local(state, page_id) or page_id
+    )
     try:
-        if _USE_SYNC_PLAYWRIGHT:
-            await _run_sync(page.close)
-        else:
-            await page.close()
-        del state["pages"][page_id]
-        for key in (
-            "refs",
-            "refs_frame",
-            "console_logs",
-            "network_requests",
-            "pending_dialogs",
-            "pending_file_choosers",
-        ):
-            state[key].pop(page_id, None)
-        if state.get("current_page_id") == page_id:
-            remaining = list(state["pages"].keys())
-            state["current_page_id"] = remaining[0] if remaining else None
+        detached_real = _detach_local_page_alias(state, local_page_id)
+        if detached_real != page_id:
+            return _tool_response(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": f"Page '{local_page_id}' not found",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+            )
+        closed_real = False
+        if not _real_page_is_referenced(state, page_id):
+            if _USE_SYNC_PLAYWRIGHT:
+                await _run_sync(page.close)
+            else:
+                await page.close()
+            del state["pages"][page_id]
+            for key in (
+                "refs",
+                "refs_frame",
+                "console_logs",
+                "network_requests",
+                "pending_dialogs",
+                "pending_file_choosers",
+            ):
+                state[key].pop(page_id, None)
+            closed_real = True
         return _tool_response(
             json.dumps(
-                {"ok": True, "message": f"Closed page '{page_id}'"},
+                {
+                    "ok": True,
+                    "message": f"Closed page '{local_page_id}'",
+                    "page_id": local_page_id,
+                    "closed_real_page": closed_real,
+                    "current_page_id": _get_current_page_for_session(state),
+                    "tabs": _local_page_ids_for_session(state),
+                },
                 ensure_ascii=False,
                 indent=2,
             ),
@@ -3436,6 +3716,7 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
     page_id: str,
     tab_action: str,
     index: int,
+    local_page_id: str | None = None,
 ) -> ToolChunk:
     tab_action = (tab_action or "").strip().lower()
     if not tab_action:
@@ -3449,16 +3730,18 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                 indent=2,
             ),
         )
-    pages = state["pages"]
-    page_ids = list(pages.keys())
+    local_ids = _local_page_ids_for_session(state)
     if tab_action == "list":
+        cur = _get_current_page_for_session(state)
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "tabs": page_ids,
-                    "tab_list": await _get_tab_info_list(state),
-                    "count": len(page_ids),
+                    "tabs": local_ids,
+                    "tab_list": await _get_session_tab_info_list(state),
+                    "count": len(local_ids),
+                    "current_page_id": cur,
+                    "session_current_page_id": cur,
                 },
                 ensure_ascii=False,
                 indent=2,
@@ -3502,15 +3785,15 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                 page = await state["context"].new_page()
             new_id = _next_page_id(state)
             _register_page(state, page, new_id)
-            state["current_page_id"] = new_id
+            exposed_id = _assign_local_page_alias(state, new_id)
             await _configure_download_behavior(state)
             return _tool_response(
                 json.dumps(
                     {
                         "ok": True,
-                        "page_id": new_id,
-                        "tabs": list(state["pages"].keys()),
-                        "tab_list": await _get_tab_info_list(state),
+                        "page_id": exposed_id,
+                        "tabs": _local_page_ids_for_session(state),
+                        "tab_list": await _get_session_tab_info_list(state),
                     },
                     ensure_ascii=False,
                     indent=2,
@@ -3525,17 +3808,38 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                 ),
             )
     if tab_action == "close":
-        target_id = page_ids[index] if 0 <= index < len(page_ids) else page_id
-        return await _action_close(state, target_id)
+        target_local = (
+            local_ids[index] if 0 <= index < len(local_ids) else local_page_id
+        )
+        target_real = _map_local_to_real(state, target_local or "") or page_id
+        return await _action_close(
+            state,
+            target_real,
+            local_page_id=target_local,
+        )
     if tab_action == "select":
-        target_id = page_ids[index] if 0 <= index < len(page_ids) else page_id
-        state["current_page_id"] = target_id
+        target_local = (
+            local_ids[index] if 0 <= index < len(local_ids) else local_page_id
+        )
+        target_real = _map_local_to_real(state, target_local or "")
+        if not target_local or not target_real:
+            return _tool_response(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": f"Page '{target_local or local_page_id}' not found",
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+            )
+        _set_current_page_for_session(state, target_local)
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "message": f"Use page_id={target_id} for later actions",
-                    "page_id": target_id,
+                    "message": f"Use page_id={target_local} for later actions",
+                    "page_id": target_local,
                 },
                 ensure_ascii=False,
                 indent=2,
@@ -3799,7 +4103,23 @@ async def _action_batch(  # pylint: disable=too-many-nested-blocks
                 ),
             )
 
-        sub_page_id = act.get("page_id") or page_id
+        req_sub = act.get("page_id")
+        if req_sub:
+            sub_page_id = _map_local_to_real(state, str(req_sub))
+            if not sub_page_id:
+                results.append(
+                    {
+                        "step": idx,
+                        "action": sub_action,
+                        "ok": False,
+                        "error": f"Page '{req_sub}' not found in this session",
+                    },
+                )
+                if act.get("stop_on_error", True):
+                    break
+                continue
+        else:
+            sub_page_id = page_id
         sub_wait: float = act.get("wait", 0)  # seconds
         stop_on_error = act.get("stop_on_error", True)
 
@@ -4141,13 +4461,16 @@ async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolChunk:
         for page in context.pages:
             page_id = _next_page_id(state)
             _register_page(state, page, page_id)
-            if state["current_page_id"] is None:
-                state["current_page_id"] = page_id
+            _assign_local_page_alias(
+                state,
+                page_id,
+                set_current=_get_current_page_for_session(state) is None,
+            )
         if not state["pages"]:
             page = await context.new_page()
             page_id = _next_page_id(state)
             _register_page(state, page, page_id)
-            state["current_page_id"] = page_id
+            _set_current_real_page_for_session(state, page_id)
         _touch_activity(state)
         _start_idle_watchdog(state)
         await _configure_download_behavior(state)
@@ -4498,13 +4821,17 @@ async def browser_use(  # pylint: disable=R0911,R0912
             Defaults to 10000 when not specified.
     """
     # Resolve per-workspace state using context var set by react_agent.py
-    from ...config.context import get_current_workspace_dir as _get_cwd
+    from ...config.context import (
+        get_current_session_id as _get_session_id,
+        get_current_workspace_dir as _get_cwd,
+    )
 
     _cwd = _get_cwd()
     _ws_id = _cwd.name if _cwd else "default"
     _ws_dir = str(_cwd) if _cwd else ""
     state = _get_workspace_state(_ws_id, _ws_dir)
     _touch_activity(state)
+    _session_id = _get_session_id() or "default"
 
     action = (action or "").strip().lower()
     if not action:
@@ -4517,12 +4844,61 @@ async def browser_use(  # pylint: disable=R0911,R0912
         )
 
     page_id = (page_id or "default").strip() or "default"
-    current = state.get("current_page_id")
-    pages = state.get("pages") or {}
-    if page_id == "default" and current and current in pages:
-        page_id = current
+    requested_page_id = page_id
+    local_page_id = requested_page_id
 
-    try:
+    _NO_PAGE_ACTIONS = {
+        "start",
+        "stop",
+        "connect_cdp",
+        "list_cdp_targets",
+        "tabs",
+        "install",
+        "cookies_get",
+        "cookies_set",
+        "cookies_clear",
+        "clear_browser_cache",
+    }
+
+    async with state["_lock"]:
+        state["_active_session_id"] = _session_id
+        if action in _NO_PAGE_ACTIONS:
+            pass
+        elif action == "open":
+            page_id = _next_page_id(state)
+            if requested_page_id == "default":
+                local_page_id = "default"
+        else:
+            current = _get_current_page_for_session(state, _session_id)
+            if requested_page_id == "default" and current:
+                local_page_id = current
+                page_id = _map_local_to_real(state, current, _session_id)
+            elif requested_page_id == "default" and not current:
+                page_id = None
+            else:
+                local_page_id = requested_page_id
+                page_id = _map_local_to_real(state, local_page_id, _session_id)
+            if not page_id:
+                return _tool_response(
+                    json.dumps(
+                        {
+                            "ok": False,
+                            "error": f"Page '{local_page_id}' not found in this session",
+                            "tabs": _local_page_ids_for_session(
+                                state,
+                                _session_id,
+                            ),
+                            "current_page_id": _get_current_page_for_session(
+                                state,
+                                _session_id,
+                            ),
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    ),
+                )
+
+    async def _dispatch() -> ToolResponse:
         if action == "start":
             return await _action_start(
                 state,
@@ -4539,7 +4915,12 @@ async def browser_use(  # pylint: disable=R0911,R0912
         if action == "list_cdp_targets":
             return await _action_list_cdp_targets(port, port_min, port_max)
         if action == "open":
-            return await _action_open(state, url, page_id)
+            return await _action_open(
+                state,
+                url,
+                page_id,
+                local_page_id=local_page_id,
+            )
         if action == "navigate":
             return await _action_navigate(state, url, page_id)
         if action == "navigate_back":
@@ -4673,7 +5054,13 @@ async def browser_use(  # pylint: disable=R0911,R0912
                 frame_selector,
             )
         if action == "tabs":
-            return await _action_tabs(state, page_id, tab_action, index)
+            return await _action_tabs(
+                state,
+                page_id,
+                tab_action,
+                index,
+                local_page_id=local_page_id,
+            )
         if action == "wait_for":
             return await _action_wait_for(
                 state,
@@ -4685,7 +5072,11 @@ async def browser_use(  # pylint: disable=R0911,R0912
         if action == "pdf":
             return await _action_pdf(state, page_id, path)
         if action == "close":
-            return await _action_close(state, page_id)
+            return await _action_close(
+                state,
+                page_id,
+                local_page_id=local_page_id,
+            )
         if action == "cookies_get":
             ctx = _get_context(state)
             if not ctx:
@@ -4828,12 +5219,16 @@ async def browser_use(  # pylint: disable=R0911,R0912
                 indent=2,
             ),
         )
+
+    try:
+        resp = await _dispatch()
     except Exception as e:
         logger.error("Browser tool error: %s", e, exc_info=True)
-        return _tool_response(
+        resp = _tool_response(
             json.dumps(
                 {"ok": False, "error": str(e)},
                 ensure_ascii=False,
                 indent=2,
             ),
         )
+    return _localize_tool_response(state, resp, _session_id)

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -268,7 +268,6 @@ def _make_fresh_state(workspace_id: str, workspace_dir: str) -> dict[str, Any]:
         "pending_file_choosers": {},  # page_id -> FileChooser list
         "headless": True,
         "session_pages": {},
-        "_active_session_id": None,
         "_lock": asyncio.Lock(),
         "page_counter": 0,
         "last_activity_time": 0.0,  # monotonic timestamp of last browser activity
@@ -299,28 +298,39 @@ def _get_workspace_state(
     return _workspace_states[workspace_id]
 
 
-def _get_active_session_id(state: dict) -> str:
-    return str(state.get("_active_session_id") or "default")
-
-
 def _get_session_data(state: dict, session_id: str | None = None) -> dict:
-    session_id = session_id or _get_active_session_id(state)
+    session_id = session_id or "default"
     sp = state.setdefault("session_pages", {})
-    return sp.setdefault(session_id, {"map": {}, "counter": 0, "current": None})
+    return sp.setdefault(
+        session_id,
+        {"map": {}, "counter": 0, "current": None},
+    )
 
 
-def _resolve_page(state: dict, virtual_id: str, session_id: str | None = None) -> str | None:
+def _resolve_page(
+    state: dict,
+    virtual_id: str,
+    session_id: str | None = None,
+) -> str | None:
     return _get_session_data(state, session_id)["map"].get(virtual_id)
 
 
-def _virtual_page_id(state: dict, real_id: str, session_id: str | None = None) -> str | None:
+def _virtual_page_id(
+    state: dict,
+    real_id: str,
+    session_id: str | None = None,
+) -> str | None:
     for v, r in _get_session_data(state, session_id)["map"].items():
         if r == real_id:
             return v
     return None
 
 
-def _session_add_page(state: dict, real_id: str, session_id: str | None = None) -> str:
+def _session_add_page(
+    state: dict,
+    real_id: str,
+    session_id: str | None = None,
+) -> str:
     sd = _get_session_data(state, session_id)
     existing = _virtual_page_id(state, real_id, session_id)
     if existing:
@@ -333,7 +343,11 @@ def _session_add_page(state: dict, real_id: str, session_id: str | None = None) 
     return vid
 
 
-def _session_remove_page(state: dict, real_id: str, session_id: str | None = None) -> str | None:
+def _session_remove_page(
+    state: dict,
+    real_id: str,
+    session_id: str | None = None,
+) -> str | None:
     sd = _get_session_data(state, session_id)
     vid = _virtual_page_id(state, real_id, session_id)
     if not vid:
@@ -353,8 +367,17 @@ def _real_page_is_referenced(state: dict, real_page_id: str) -> bool:
     return False
 
 
+def _find_session_for_real_page(state: dict, real_page_id: str) -> str | None:
+    for sid, sd in state.get("session_pages", {}).items():
+        if real_page_id in sd.get("map", {}).values():
+            return sid
+    return None
+
+
 def _replace_page_id_values(
-    value: Any, state: dict, session_id: str | None = None,
+    value: Any,
+    state: dict,
+    session_id: str | None = None,
     drop_unmapped_dict: bool = False,
 ) -> Any:
     if isinstance(value, str):
@@ -365,7 +388,12 @@ def _replace_page_id_values(
     if isinstance(value, list):
         out = []
         for item in value:
-            r = _replace_page_id_values(item, state, session_id, drop_unmapped_dict)
+            r = _replace_page_id_values(
+                item,
+                state,
+                session_id,
+                drop_unmapped_dict,
+            )
             if r is not None:
                 out.append(r)
         return out
@@ -377,10 +405,19 @@ def _replace_page_id_values(
                 if v is None:
                     return None if drop_unmapped_dict else {}
                 out[k] = v
-            elif k in {"tabs", "pages", "tab_list", "current_page_id",
-                        "session_current_page_id", "results"}:
+            elif k in {
+                "tabs",
+                "pages",
+                "tab_list",
+                "current_page_id",
+                "session_current_page_id",
+                "results",
+            }:
                 out[k] = _replace_page_id_values(
-                    v, state, session_id, drop_unmapped_dict=(k == "tab_list"),
+                    v,
+                    state,
+                    session_id,
+                    drop_unmapped_dict=(k == "tab_list"),
                 )
             else:
                 out[k] = v
@@ -389,7 +426,9 @@ def _replace_page_id_values(
 
 
 def _localize_tool_response(
-    state: dict, resp: ToolChunk, session_id: str | None = None,
+    state: dict,
+    resp: ToolChunk,
+    session_id: str | None = None,
 ) -> ToolChunk:
     try:
         block = resp.content[0]
@@ -442,7 +481,6 @@ def _reset_browser_state(state: dict) -> None:
     state["pending_dialogs"].clear()
     state["pending_file_choosers"].clear()
     state["session_pages"].clear()
-    state["_active_session_id"] = None
     state["page_counter"] = 0
     state["last_activity_time"] = 0.0
     state["headless"] = True
@@ -929,7 +967,10 @@ async def _get_tab_info_list(state: dict) -> list[dict[str, str]]:
     return tab_list
 
 
-async def _get_session_tab_info_list(state: dict, session_id: str | None = None) -> list[dict[str, str]]:
+async def _get_session_tab_info_list(
+    state: dict,
+    session_id: str | None = None,
+) -> list[dict[str, str]]:
     real_tabs = await _get_tab_info_list(state)
     out: list[dict[str, str]] = []
     for item in real_tabs:
@@ -1051,10 +1092,26 @@ def _attach_context_listeners(state: dict, context) -> None:
     def on_page(page):
         new_id = _next_page_id(state)
         _register_page(state, page, new_id)
-        vid = _session_add_page(state, new_id)
+        session_id = None
+        try:
+            opener = page.opener
+            if callable(opener):
+                opener = opener()
+            if opener:
+                for rid, p in state.get("pages", {}).items():
+                    if p is opener:
+                        session_id = _find_session_for_real_page(state, rid)
+                        break
+        except Exception:
+            pass
+        if not session_id:
+            session_id = "default"
+        vid = _session_add_page(state, new_id, session_id)
         logger.debug(
             "New tab opened by page, real_id=%s, virtual_id=%s, session=%s",
-            new_id, vid, _get_active_session_id(state),
+            new_id,
+            vid,
+            session_id,
         )
 
     context.on("page", on_page)
@@ -1245,11 +1302,18 @@ async def _action_start(
             cur = sd.get("current")
             result: dict[str, Any] = {
                 "ok": True,
-                "message": "Browser already running. If the current browser state meets your requirements, please proceed with actions on it directly.",
+                "message": (
+                    "Browser already running. If the current browser"
+                    " state meets your requirements, please proceed"
+                    " with actions on it directly."
+                ),
                 "headed": not current_headless,
                 "tabs": tabs,
                 "current_page_id": cur,
-                "tab_list": await _get_session_tab_info_list(state, session_id),
+                "tab_list": await _get_session_tab_info_list(
+                    state,
+                    session_id,
+                ),
             }
             if current_headless:
                 result["headless_warning"] = _HEADLESS_VERIFICATION_WARNING
@@ -1423,11 +1487,17 @@ async def _action_start(
         )
 
 
-async def _action_stop(state: dict, *, force: bool = False, session_id: str | None = None) -> ToolChunk:
+async def _action_stop(
+    state: dict,
+    *,
+    force: bool = False,
+    session_id: str | None = None,
+) -> ToolChunk:
     session_id = session_id or _get_active_session_id(state)
     sd = _get_session_data(state, session_id)
     other_sessions = [
-        sid for sid, sdata in state.get("session_pages", {}).items()
+        sid
+        for sid, sdata in state.get("session_pages", {}).items()
         if sid != session_id and sdata.get("map")
     ]
     if other_sessions and _is_browser_running(state) and not force:
@@ -1435,21 +1505,28 @@ async def _action_stop(state: dict, *, force: bool = False, session_id: str | No
         for vid, real in list(sd["map"].items()):
             _session_remove_page(state, real, session_id)
             closed_vids.append(vid)
-            if not _real_page_is_referenced(state, real):
-                page = _get_page(state, real)
-                if page:
-                    try:
-                        if _USE_SYNC_PLAYWRIGHT:
-                            await _run_sync(page.close)
-                        else:
-                            await page.close()
-                    except Exception:
-                        pass
-                    state["pages"].pop(real, None)
-                    for key in ("refs", "refs_frame", "console_logs",
-                                "network_requests", "pending_dialogs",
-                                "pending_file_choosers"):
-                        state[key].pop(real, None)
+            if _real_page_is_referenced(state, real):
+                continue
+            page = _get_page(state, real)
+            if not page:
+                continue
+            try:
+                if _USE_SYNC_PLAYWRIGHT:
+                    await _run_sync(page.close)
+                else:
+                    await page.close()
+            except Exception:
+                pass
+            state["pages"].pop(real, None)
+            for key in (
+                "refs",
+                "refs_frame",
+                "console_logs",
+                "network_requests",
+                "pending_dialogs",
+                "pending_file_choosers",
+            ):
+                state[key].pop(real, None)
         return _tool_response(
             json.dumps(
                 {
@@ -1583,7 +1660,12 @@ async def _action_stop(state: dict, *, force: bool = False, session_id: str | No
     )
 
 
-async def _action_open(state: dict, url: str, page_id: str, session_id: str | None = None) -> ToolChunk:
+async def _action_open(
+    state: dict,
+    url: str,
+    page_id: str,
+    session_id: str | None = None,
+) -> ToolChunk:
     url = (url or "").strip()
     if not url:
         return _tool_response(
@@ -1607,7 +1689,7 @@ async def _action_open(state: dict, url: str, page_id: str, session_id: str | No
             loop = asyncio.get_event_loop()
             page = await loop.run_in_executor(
                 _get_executor(),
-                lambda: state["_sync_context"].new_page(),
+                state["_sync_context"].new_page,
             )
         else:
             page = await state["context"].new_page()
@@ -2214,7 +2296,11 @@ async def _action_pdf(state: dict, page_id: str, path: str) -> ToolChunk:
         )
 
 
-async def _action_close(state: dict, page_id: str, session_id: str | None = None) -> ToolChunk:
+async def _action_close(
+    state: dict,
+    page_id: str,
+    session_id: str | None = None,
+) -> ToolChunk:
     page = _get_page(state, page_id)
     if not page:
         return _tool_response(
@@ -2235,8 +2321,12 @@ async def _action_close(state: dict, page_id: str, session_id: str | None = None
                 await page.close()
             del state["pages"][page_id]
             for key in (
-                "refs", "refs_frame", "console_logs", "network_requests",
-                "pending_dialogs", "pending_file_choosers",
+                "refs",
+                "refs_frame",
+                "console_logs",
+                "network_requests",
+                "pending_dialogs",
+                "pending_file_choosers",
             ):
                 state[key].pop(page_id, None)
             closed_real = True
@@ -3625,7 +3715,10 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
     if not tab_action:
         return _tool_response(
             json.dumps(
-                {"ok": False, "error": "tab_action required (list, new, close, select)"},
+                {
+                    "ok": False,
+                    "error": "tab_action required (list, new, close, select)",
+                },
                 ensure_ascii=False,
                 indent=2,
             ),
@@ -3640,7 +3733,10 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                 {
                     "ok": True,
                     "tabs": vids,
-                    "tab_list": await _get_session_tab_info_list(state, session_id),
+                    "tab_list": await _get_session_tab_info_list(
+                        state,
+                        session_id,
+                    ),
                     "count": len(vids),
                     "current_page_id": cur,
                     "session_current_page_id": cur,
@@ -3654,17 +3750,31 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
             if not state["_sync_context"]:
                 ok = await _ensure_browser(state, session_id)
                 if not ok:
-                    err = state.get("_last_browser_error") or "Browser not started"
+                    err = (
+                        state.get("_last_browser_error")
+                        or "Browser not started"
+                    )
                     return _tool_response(
-                        json.dumps({"ok": False, "error": err}, ensure_ascii=False, indent=2),
+                        json.dumps(
+                            {"ok": False, "error": err},
+                            ensure_ascii=False,
+                            indent=2,
+                        ),
                     )
         else:
             if not state["context"]:
                 ok = await _ensure_browser(state, session_id)
                 if not ok:
-                    err = state.get("_last_browser_error") or "Browser not started"
+                    err = (
+                        state.get("_last_browser_error")
+                        or "Browser not started"
+                    )
                     return _tool_response(
-                        json.dumps({"ok": False, "error": err}, ensure_ascii=False, indent=2),
+                        json.dumps(
+                            {"ok": False, "error": err},
+                            ensure_ascii=False,
+                            indent=2,
+                        ),
                     )
         try:
             if _USE_SYNC_PLAYWRIGHT:
@@ -3680,8 +3790,15 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                     {
                         "ok": True,
                         "page_id": vid,
-                        "tabs": [v for v, r in sd["map"].items() if r in state.get("pages", {})],
-                        "tab_list": await _get_session_tab_info_list(state, session_id),
+                        "tabs": [
+                            v
+                            for v, r in sd["map"].items()
+                            if r in state.get("pages", {})
+                        ],
+                        "tab_list": await _get_session_tab_info_list(
+                            state,
+                            session_id,
+                        ),
                     },
                     ensure_ascii=False,
                     indent=2,
@@ -3713,7 +3830,8 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
             return _tool_response(
                 json.dumps(
                     {"ok": False, "error": "Page not found"},
-                    ensure_ascii=False, indent=2,
+                    ensure_ascii=False,
+                    indent=2,
                 ),
             )
         sd["current"] = target_vid
@@ -4732,13 +4850,19 @@ async def browser_use(  # pylint: disable=R0911,R0912
     requested_page_id = page_id
 
     _NO_PAGE_ACTIONS = {
-        "start", "stop", "connect_cdp", "list_cdp_targets",
-        "tabs", "install", "cookies_get", "cookies_set",
-        "cookies_clear", "clear_browser_cache",
+        "start",
+        "stop",
+        "connect_cdp",
+        "list_cdp_targets",
+        "tabs",
+        "install",
+        "cookies_get",
+        "cookies_set",
+        "cookies_clear",
+        "clear_browser_cache",
     }
 
     async with state["_lock"]:
-        state["_active_session_id"] = _session_id
         if action in _NO_PAGE_ACTIONS:
             pass
         elif action == "open":
@@ -4746,7 +4870,11 @@ async def browser_use(  # pylint: disable=R0911,R0912
         else:
             sd = _get_session_data(state, _session_id)
             if requested_page_id == "default":
-                page_id = _resolve_page(state, sd.get("current", ""), _session_id)
+                page_id = _resolve_page(
+                    state,
+                    sd.get("current", ""),
+                    _session_id,
+                )
             else:
                 page_id = _resolve_page(state, requested_page_id, _session_id)
             if not page_id:
@@ -4756,7 +4884,9 @@ async def browser_use(  # pylint: disable=R0911,R0912
                         {
                             "ok": False,
                             "error": f"Page '{requested_page_id}' not found in this session",
-                            "tabs": [v for v, r in sd["map"].items() if r in pages],
+                            "tabs": [
+                                v for v, r in sd["map"].items() if r in pages
+                            ],
                             "current_page_id": sd.get("current"),
                         },
                         ensure_ascii=False,
@@ -4788,7 +4918,12 @@ async def browser_use(  # pylint: disable=R0911,R0912
         if action == "open":
             return await _action_open(state, url, page_id, _session_id)
         if action == "navigate":
-            return await _action_navigate(state, url, page_id, session_id=_session_id)
+            return await _action_navigate(
+                state,
+                url,
+                page_id,
+                session_id=_session_id,
+            )
         if action == "navigate_back":
             return await _action_navigate_back(state, page_id)
         if action in ("screenshot", "take_screenshot"):
@@ -4920,7 +5055,13 @@ async def browser_use(  # pylint: disable=R0911,R0912
                 frame_selector,
             )
         if action == "tabs":
-            return await _action_tabs(state, page_id, tab_action, index, session_id=_session_id)
+            return await _action_tabs(
+                state,
+                page_id,
+                tab_action,
+                index,
+                session_id=_session_id,
+            )
         if action == "wait_for":
             return await _action_wait_for(
                 state,
@@ -5065,7 +5206,12 @@ async def browser_use(  # pylint: disable=R0911,R0912
                     ),
                 )
         if action == "batch":
-            return await _action_batch(state, page_id, actions_json, session_id=_session_id)
+            return await _action_batch(
+                state,
+                page_id,
+                actions_json,
+                session_id=_session_id,
+            )
         if action == "clear_browser_cache":
             return await _action_clear_browser_cache(state)
         return _tool_response(

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -755,6 +755,23 @@ async def _wait_for_cdp_ready(
     )
 
 
+async def _ensure_initial_page(state, context, session_id):
+    """Register existing context pages or create one if none exist."""
+    for page in context.pages:
+        page_id = _next_page_id(state)
+        _register_page(state, page, page_id)
+        _session_add_page(state, page_id, session_id)
+    if not state["pages"]:
+        state["_creating_page"] = True
+        try:
+            page = await context.new_page()
+        finally:
+            state["_creating_page"] = False
+        page_id = _next_page_id(state)
+        _register_page(state, page, page_id)
+        _session_add_page(state, page_id, session_id)
+
+
 async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     state: dict,
     cdp_port: int = 0,
@@ -818,19 +835,7 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
         state["browser_pid"] = proc.pid
         state["browser_process"] = proc
         if ensure_pages:
-            for page in context.pages:
-                page_id = _next_page_id(state)
-                _register_page(state, page, page_id)
-                _session_add_page(state, page_id, session_id)
-            if not state["pages"]:
-                state["_creating_page"] = True
-                try:
-                    page = await context.new_page()
-                finally:
-                    state["_creating_page"] = False
-                page_id = _next_page_id(state)
-                _register_page(state, page, page_id)
-                _session_add_page(state, page_id, session_id)
+            await _ensure_initial_page(state, context, session_id)
     except Exception:
         await _stop_playwright_instance(pw)
         try:
@@ -4464,20 +4469,7 @@ async def _action_connect_cdp(
         state["owned_browser_process"] = False
         state["browser_pid"] = None
         state["browser_process"] = None
-        # Register existing pages
-        for page in context.pages:
-            page_id = _next_page_id(state)
-            _register_page(state, page, page_id)
-            _session_add_page(state, page_id, session_id)
-        if not state["pages"]:
-            state["_creating_page"] = True
-            try:
-                page = await context.new_page()
-            finally:
-                state["_creating_page"] = False
-            page_id = _next_page_id(state)
-            _register_page(state, page, page_id)
-            _session_add_page(state, page_id, session_id)
+        await _ensure_initial_page(state, context, session_id)
         _touch_activity(state)
         _start_idle_watchdog(state)
         await _configure_download_behavior(state)

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -269,6 +269,7 @@ def _make_fresh_state(workspace_id: str, workspace_dir: str) -> dict[str, Any]:
         "headless": True,
         "session_pages": {},
         "_active_session_id": None,
+        "_creating_page": False,
         "_lock": asyncio.Lock(),
         "page_counter": 0,
         "last_activity_time": 0.0,  # monotonic timestamp of last browser activity
@@ -822,7 +823,11 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
                 _register_page(state, page, page_id)
                 _session_add_page(state, page_id, session_id)
             if not state["pages"]:
-                page = await context.new_page()
+                state["_creating_page"] = True
+                try:
+                    page = await context.new_page()
+                finally:
+                    state["_creating_page"] = False
                 page_id = _next_page_id(state)
                 _register_page(state, page, page_id)
                 _session_add_page(state, page_id, session_id)
@@ -1089,6 +1094,8 @@ def _attach_context_listeners(state: dict, context) -> None:
     register it and set as current."""
 
     def on_page(page):
+        if state.get("_creating_page"):
+            return
         new_id = _next_page_id(state)
         _register_page(state, page, new_id)
         vid = _session_add_page(state, new_id)
@@ -1670,14 +1677,18 @@ async def _action_open(
             ),
         )
     try:
-        if _USE_SYNC_PLAYWRIGHT:
-            loop = asyncio.get_event_loop()
-            page = await loop.run_in_executor(
-                _get_executor(),
-                state["_sync_context"].new_page,
-            )
-        else:
-            page = await state["context"].new_page()
+        state["_creating_page"] = True
+        try:
+            if _USE_SYNC_PLAYWRIGHT:
+                loop = asyncio.get_event_loop()
+                page = await loop.run_in_executor(
+                    _get_executor(),
+                    state["_sync_context"].new_page,
+                )
+            else:
+                page = await state["context"].new_page()
+        finally:
+            state["_creating_page"] = False
 
         _register_page(state, page, page_id)
         _session_add_page(state, page_id, session_id)
@@ -3762,10 +3773,14 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                         ),
                     )
         try:
-            if _USE_SYNC_PLAYWRIGHT:
-                page = await _run_sync(state["_sync_context"].new_page)
-            else:
-                page = await state["context"].new_page()
+            state["_creating_page"] = True
+            try:
+                if _USE_SYNC_PLAYWRIGHT:
+                    page = await _run_sync(state["_sync_context"].new_page)
+                else:
+                    page = await state["context"].new_page()
+            finally:
+                state["_creating_page"] = False
             new_id = _next_page_id(state)
             _register_page(state, page, new_id)
             vid = _session_add_page(state, new_id, session_id)
@@ -4455,7 +4470,11 @@ async def _action_connect_cdp(
             _register_page(state, page, page_id)
             _session_add_page(state, page_id, session_id)
         if not state["pages"]:
-            page = await context.new_page()
+            state["_creating_page"] = True
+            try:
+                page = await context.new_page()
+            finally:
+                state["_creating_page"] = False
             page_id = _next_page_id(state)
             _register_page(state, page, page_id)
             _session_add_page(state, page_id, session_id)

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -267,7 +267,7 @@ def _make_fresh_state(workspace_id: str, workspace_dir: str) -> dict[str, Any]:
         "pending_dialogs": {},  # page_id -> dialog handlers
         "pending_file_choosers": {},  # page_id -> FileChooser list
         "headless": True,
-        "session_page_maps": {},
+        "session_pages": {},
         "_active_session_id": None,
         "_lock": asyncio.Lock(),
         "page_counter": 0,
@@ -303,169 +303,69 @@ def _get_active_session_id(state: dict) -> str:
     return str(state.get("_active_session_id") or "default")
 
 
-def _get_session_page_map(state: dict, session_id: str | None = None) -> dict:
+def _get_session_data(state: dict, session_id: str | None = None) -> dict:
     session_id = session_id or _get_active_session_id(state)
-    maps = state.setdefault("session_page_maps", {})
-    return maps.setdefault(
-        session_id,
-        {
-            "alias_to_real": {},
-            "real_to_alias": {},
-            "current_page_id": None,
-            "page_counter": 0,
-        },
-    )
+    sp = state.setdefault("session_pages", {})
+    return sp.setdefault(session_id, {"map": {}, "counter": 0, "current": None})
 
 
-def _next_local_page_id(state: dict, session_id: str | None = None) -> str:
-    m = _get_session_page_map(state, session_id)
-    while True:
-        m["page_counter"] = m.get("page_counter", 0) + 1
-        cand = f"page_{m['page_counter']}"
-        if cand not in m["alias_to_real"]:
-            return cand
+def _resolve_page(state: dict, virtual_id: str, session_id: str | None = None) -> str | None:
+    return _get_session_data(state, session_id)["map"].get(virtual_id)
 
 
-def _map_local_to_real(
-    state: dict,
-    page_id: str,
-    session_id: str | None = None,
-) -> str | None:
-    return _get_session_page_map(state, session_id)["alias_to_real"].get(
-        page_id,
-    )
-
-
-def _map_real_to_local(
-    state: dict,
-    real_id: str,
-    session_id: str | None = None,
-) -> str | None:
-    return _get_session_page_map(state, session_id)["real_to_alias"].get(
-        real_id,
-    )
-
-
-def _assign_local_page_alias(
-    state: dict,
-    real_page_id: str,
-    requested_alias: str | None = None,
-    session_id: str | None = None,
-    set_current: bool = True,
-) -> str:
-    m = _get_session_page_map(state, session_id)
-    existing = m["real_to_alias"].get(real_page_id)
-    if existing:
-        if set_current:
-            _set_current_page_for_session(state, existing, session_id)
-        return existing
-    alias = (requested_alias or "").strip()
-    if not alias or alias == "default":
-        alias = _next_local_page_id(state, session_id)
-    elif alias in m["alias_to_real"]:
-        raise ValueError(f"Page id '{alias}' already exists")
-    m["alias_to_real"][alias] = real_page_id
-    m["real_to_alias"][real_page_id] = alias
-    if set_current:
-        _set_current_page_for_session(state, alias, session_id)
-    return alias
-
-
-def _set_current_page_for_session(
-    state: dict,
-    local_page_id: str | None,
-    session_id: str | None = None,
-) -> None:
-    session_id = session_id or _get_active_session_id(state)
-    m = _get_session_page_map(state, session_id)
-    real = m["alias_to_real"].get(local_page_id) if local_page_id else None
-    m["current_page_id"] = local_page_id if real else None
-
-
-def _get_current_page_for_session(
-    state: dict,
-    session_id: str | None = None,
-) -> str | None:
-    m = _get_session_page_map(state, session_id)
-    pid = m.get("current_page_id")
-    if pid and _map_local_to_real(state, pid, session_id) in (
-        state.get("pages") or {}
-    ):
-        return pid
+def _virtual_page_id(state: dict, real_id: str, session_id: str | None = None) -> str | None:
+    for v, r in _get_session_data(state, session_id)["map"].items():
+        if r == real_id:
+            return v
     return None
 
 
-def _set_current_real_page_for_session(
-    state: dict,
-    real_page_id: str | None,
-    session_id: str | None = None,
-) -> str | None:
-    if not real_page_id:
-        _set_current_page_for_session(state, None, session_id)
+def _session_add_page(state: dict, real_id: str, session_id: str | None = None) -> str:
+    sd = _get_session_data(state, session_id)
+    existing = _virtual_page_id(state, real_id, session_id)
+    if existing:
+        sd["current"] = existing
+        return existing
+    sd["counter"] += 1
+    vid = f"page_{sd['counter']}"
+    sd["map"][vid] = real_id
+    sd["current"] = vid
+    return vid
+
+
+def _session_remove_page(state: dict, real_id: str, session_id: str | None = None) -> str | None:
+    sd = _get_session_data(state, session_id)
+    vid = _virtual_page_id(state, real_id, session_id)
+    if not vid:
         return None
-    local = _map_real_to_local(state, real_page_id, session_id)
-    if not local:
-        local = _assign_local_page_alias(
-            state,
-            real_page_id,
-            session_id=session_id,
-            set_current=False,
-        )
-    _set_current_page_for_session(state, local, session_id)
-    return local
-
-
-def _local_page_ids_for_session(
-    state: dict,
-    session_id: str | None = None,
-) -> list[str]:
-    m = _get_session_page_map(state, session_id)
-    pages = state.get("pages") or {}
-    return [a for a, r in m["alias_to_real"].items() if r in pages]
+    del sd["map"][vid]
+    if sd["current"] == vid:
+        pages = state.get("pages") or {}
+        remaining = [v for v, r in sd["map"].items() if r in pages]
+        sd["current"] = remaining[-1] if remaining else None
+    return vid
 
 
 def _real_page_is_referenced(state: dict, real_page_id: str) -> bool:
-    for m in state.get("session_page_maps", {}).values():
-        if real_page_id in m.get("real_to_alias", {}):
+    for sd in state.get("session_pages", {}).values():
+        if real_page_id in sd.get("map", {}).values():
             return True
     return False
 
 
-def _detach_local_page_alias(
-    state: dict,
-    local_page_id: str,
-    session_id: str | None = None,
-) -> str | None:
-    m = _get_session_page_map(state, session_id)
-    real = m["alias_to_real"].pop(local_page_id, None)
-    if real:
-        m["real_to_alias"].pop(real, None)
-    if m.get("current_page_id") == local_page_id:
-        remaining = _local_page_ids_for_session(state, session_id)
-        m["current_page_id"] = remaining[0] if remaining else None
-    return real
-
-
 def _replace_page_id_values(
-    value: Any,
-    state: dict,
-    session_id: str | None = None,
+    value: Any, state: dict, session_id: str | None = None,
     drop_unmapped_dict: bool = False,
 ) -> Any:
     if isinstance(value, str):
-        local = _map_real_to_local(state, value, session_id)
-        if local:
-            return local
+        v = _virtual_page_id(state, value, session_id)
+        if v:
+            return v
         return None if re.fullmatch(r"real_page_\d+", value) else value
     if isinstance(value, list):
         out = []
         for item in value:
-            r = _replace_page_id_values(
-                item,
-                state,
-                session_id,
-                drop_unmapped_dict,
-            )
+            r = _replace_page_id_values(item, state, session_id, drop_unmapped_dict)
             if r is not None:
                 out.append(r)
         return out
@@ -477,19 +377,10 @@ def _replace_page_id_values(
                 if v is None:
                     return None if drop_unmapped_dict else {}
                 out[k] = v
-            elif k in {
-                "tabs",
-                "pages",
-                "tab_list",
-                "current_page_id",
-                "session_current_page_id",
-                "results",
-            }:
+            elif k in {"tabs", "pages", "tab_list", "current_page_id",
+                        "session_current_page_id", "results"}:
                 out[k] = _replace_page_id_values(
-                    v,
-                    state,
-                    session_id,
-                    drop_unmapped_dict=(k == "tab_list"),
+                    v, state, session_id, drop_unmapped_dict=(k == "tab_list"),
                 )
             else:
                 out[k] = v
@@ -498,10 +389,8 @@ def _replace_page_id_values(
 
 
 def _localize_tool_response(
-    state: dict,
-    resp: ToolResponse,
-    session_id: str | None = None,
-) -> ToolResponse:
+    state: dict, resp: ToolChunk, session_id: str | None = None,
+) -> ToolChunk:
     try:
         block = resp.content[0]
         raw = block["text"] if isinstance(block, dict) else block.text
@@ -552,7 +441,7 @@ def _reset_browser_state(state: dict) -> None:
     state["network_requests"].clear()
     state["pending_dialogs"].clear()
     state["pending_file_choosers"].clear()
-    state["session_page_maps"].clear()
+    state["session_pages"].clear()
     state["_active_session_id"] = None
     state["page_counter"] = 0
     state["last_activity_time"] = 0.0
@@ -587,7 +476,7 @@ async def _idle_watchdog(
                     idle,
                     idle_seconds,
                 )
-                await _action_stop(state)
+                await _action_stop(state, force=True)
                 return
     except asyncio.CancelledError:
         pass
@@ -834,6 +723,7 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     ensure_pages: bool = False,
     browser_args: str = "",
     executable_path: str = "",
+    session_id: str | None = None,
 ) -> None:
     default_kind, exe = _resolve_chromium_launch_target()
     explicit_exe = bool(executable_path)
@@ -893,16 +783,12 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
             for page in context.pages:
                 page_id = _next_page_id(state)
                 _register_page(state, page, page_id)
-                _assign_local_page_alias(
-                    state,
-                    page_id,
-                    set_current=_get_current_page_for_session(state) is None,
-                )
+                _session_add_page(state, page_id, session_id)
             if not state["pages"]:
                 page = await context.new_page()
                 page_id = _next_page_id(state)
                 _register_page(state, page, page_id)
-                _set_current_real_page_for_session(state, page_id)
+                _session_add_page(state, page_id, session_id)
     except Exception:
         await _stop_playwright_instance(pw)
         try:
@@ -1043,14 +929,14 @@ async def _get_tab_info_list(state: dict) -> list[dict[str, str]]:
     return tab_list
 
 
-async def _get_session_tab_info_list(state: dict) -> list[dict[str, str]]:
+async def _get_session_tab_info_list(state: dict, session_id: str | None = None) -> list[dict[str, str]]:
     real_tabs = await _get_tab_info_list(state)
     out: list[dict[str, str]] = []
     for item in real_tabs:
-        local = _map_real_to_local(state, item.get("page_id", ""))
-        if not local:
+        vid = _virtual_page_id(state, item.get("page_id", ""), session_id)
+        if not vid:
             continue
-        out.append({**item, "page_id": local})
+        out.append({**item, "page_id": vid})
     return out
 
 
@@ -1165,17 +1051,10 @@ def _attach_context_listeners(state: dict, context) -> None:
     def on_page(page):
         new_id = _next_page_id(state)
         _register_page(state, page, new_id)
-        session_id = _get_active_session_id(state)
-        local_id = _assign_local_page_alias(
-            state,
-            new_id,
-            session_id=session_id,
-        )
+        vid = _session_add_page(state, new_id)
         logger.debug(
-            "New tab opened by page, real_id=%s, local_id=%s, session=%s",
-            new_id,
-            local_id,
-            session_id,
+            "New tab opened by page, real_id=%s, virtual_id=%s, session=%s",
+            new_id, vid, _get_active_session_id(state),
         )
 
     context.on("page", on_page)
@@ -1184,6 +1063,7 @@ def _attach_context_listeners(state: dict, context) -> None:
 # pylint: disable=too-many-branches,too-many-statements
 async def _ensure_browser(
     state: dict,
+    session_id: str | None = None,
 ) -> bool:
     """Start browser if not running. Return True if ready, False on failure."""
     # CDP-connected mode: verify the connection is still alive; never auto-restart.
@@ -1267,6 +1147,7 @@ async def _ensure_browser(
                     ensure_pages=True,
                     browser_args=state.get("_browser_args", ""),
                     executable_path=state.get("_executable_path", ""),
+                    session_id=session_id,
                 )
             except Exception:
                 await _action_start(
@@ -1275,6 +1156,7 @@ async def _ensure_browser(
                     private_mode=True,
                     browser_args=state.get("_browser_args", ""),
                     executable_path=state.get("_executable_path", ""),
+                    session_id=session_id,
                 )
         state["_last_browser_error"] = None
         _touch_activity(state)
@@ -1316,6 +1198,7 @@ async def _action_start(
     private_mode: bool = False,
     browser_args: str = "",
     executable_path: str = "",
+    session_id: str | None = None,
 ) -> ToolChunk:
     _validate_executable_path(executable_path)
     # Check browser state based on mode
@@ -1352,13 +1235,21 @@ async def _action_start(
         if headed and current_headless:
             _cancel_idle_watchdog(state)
             try:
-                await _action_stop(state)
+                await _action_stop(state, force=True)
             except Exception:
                 pass
         else:
+            sd = _get_session_data(state, session_id)
+            pages = state.get("pages") or {}
+            tabs = [v for v, r in sd["map"].items() if r in pages]
+            cur = sd.get("current")
             result: dict[str, Any] = {
                 "ok": True,
-                "message": "Browser already running",
+                "message": "Browser already running. If the current browser state meets your requirements, please proceed with actions on it directly.",
+                "headed": not current_headless,
+                "tabs": tabs,
+                "current_page_id": cur,
+                "tab_list": await _get_session_tab_info_list(state, session_id),
             }
             if current_headless:
                 result["headless_warning"] = _HEADLESS_VERIFICATION_WARNING
@@ -1394,6 +1285,7 @@ async def _action_start(
                 ensure_pages=True,
                 browser_args=browser_args,
                 executable_path=executable_path,
+                session_id=session_id,
             )
         elif _USE_SYNC_PLAYWRIGHT:
             loop = asyncio.get_event_loop()
@@ -1531,7 +1423,49 @@ async def _action_start(
         )
 
 
-async def _action_stop(state: dict) -> ToolChunk:
+async def _action_stop(state: dict, *, force: bool = False, session_id: str | None = None) -> ToolChunk:
+    session_id = session_id or _get_active_session_id(state)
+    sd = _get_session_data(state, session_id)
+    other_sessions = [
+        sid for sid, sdata in state.get("session_pages", {}).items()
+        if sid != session_id and sdata.get("map")
+    ]
+    if other_sessions and _is_browser_running(state) and not force:
+        closed_vids = []
+        for vid, real in list(sd["map"].items()):
+            _session_remove_page(state, real, session_id)
+            closed_vids.append(vid)
+            if not _real_page_is_referenced(state, real):
+                page = _get_page(state, real)
+                if page:
+                    try:
+                        if _USE_SYNC_PLAYWRIGHT:
+                            await _run_sync(page.close)
+                        else:
+                            await page.close()
+                    except Exception:
+                        pass
+                    state["pages"].pop(real, None)
+                    for key in ("refs", "refs_frame", "console_logs",
+                                "network_requests", "pending_dialogs",
+                                "pending_file_choosers"):
+                        state[key].pop(real, None)
+        return _tool_response(
+            json.dumps(
+                {
+                    "ok": True,
+                    "message": (
+                        "Browser is shared by other sessions. "
+                        "Closed all pages opened by this session."
+                    ),
+                    "closed_pages": closed_vids,
+                    "other_sessions_count": len(other_sessions),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
+
     _cancel_idle_watchdog(state)
 
     # Check browser state based on mode
@@ -1649,12 +1583,7 @@ async def _action_stop(state: dict) -> ToolChunk:
     )
 
 
-async def _action_open(
-    state: dict,
-    url: str,
-    page_id: str,
-    local_page_id: str | None = None,
-) -> ToolChunk:
+async def _action_open(state: dict, url: str, page_id: str, session_id: str | None = None) -> ToolChunk:
     url = (url or "").strip()
     if not url:
         return _tool_response(
@@ -1664,7 +1593,7 @@ async def _action_open(
                 indent=2,
             ),
         )
-    if not await _ensure_browser(state):
+    if not await _ensure_browser(state, session_id):
         err = state.get("_last_browser_error") or "Browser not started"
         return _tool_response(
             json.dumps(
@@ -1675,23 +1604,16 @@ async def _action_open(
         )
     try:
         if _USE_SYNC_PLAYWRIGHT:
-            # Hybrid mode: create page in thread pool
             loop = asyncio.get_event_loop()
-            # pylint: disable=unnecessary-lambda
             page = await loop.run_in_executor(
                 _get_executor(),
                 lambda: state["_sync_context"].new_page(),
             )
         else:
-            # Standard async mode
             page = await state["context"].new_page()
 
         _register_page(state, page, page_id)
-        exposed_id = _assign_local_page_alias(
-            state,
-            page_id,
-            requested_alias=local_page_id,
-        )
+        _session_add_page(state, page_id, session_id)
         await _configure_download_behavior(state)
 
         if _USE_SYNC_PLAYWRIGHT:
@@ -1704,13 +1626,12 @@ async def _action_open(
             await page.goto(url)
 
         state["pages"][page_id] = page
-        _set_current_page_for_session(state, exposed_id)
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
                     "message": f"Opened {url}",
-                    "page_id": exposed_id,
+                    "page_id": page_id,
                     "url": url,
                 },
                 ensure_ascii=False,
@@ -1731,6 +1652,7 @@ async def _action_navigate(
     state: dict,
     url: str,
     page_id: str,
+    session_id: str | None = None,
 ) -> ToolChunk:
     url = (url or "").strip()
     if not url:
@@ -1759,7 +1681,10 @@ async def _action_navigate(
             )
         else:
             await page.goto(url)
-        _set_current_real_page_for_session(state, page_id)
+        sd = _get_session_data(state, session_id)
+        vid = _virtual_page_id(state, page_id, session_id)
+        if vid:
+            sd["current"] = vid
         return _tool_response(
             json.dumps(
                 {
@@ -2289,39 +2214,19 @@ async def _action_pdf(state: dict, page_id: str, path: str) -> ToolChunk:
         )
 
 
-async def _action_close(
-    state: dict,
-    page_id: str,
-    local_page_id: str | None = None,
-) -> ToolChunk:
+async def _action_close(state: dict, page_id: str, session_id: str | None = None) -> ToolChunk:
     page = _get_page(state, page_id)
     if not page:
         return _tool_response(
             json.dumps(
-                {
-                    "ok": False,
-                    "error": f"Page '{local_page_id or page_id}' not found",
-                },
+                {"ok": False, "error": f"Page '{page_id}' not found"},
                 ensure_ascii=False,
                 indent=2,
             ),
         )
-    local_page_id = (
-        local_page_id or _map_real_to_local(state, page_id) or page_id
-    )
+    vid = _virtual_page_id(state, page_id, session_id) or page_id
     try:
-        detached_real = _detach_local_page_alias(state, local_page_id)
-        if detached_real != page_id:
-            return _tool_response(
-                json.dumps(
-                    {
-                        "ok": False,
-                        "error": f"Page '{local_page_id}' not found",
-                    },
-                    ensure_ascii=False,
-                    indent=2,
-                ),
-            )
+        _session_remove_page(state, page_id, session_id)
         closed_real = False
         if not _real_page_is_referenced(state, page_id):
             if _USE_SYNC_PLAYWRIGHT:
@@ -2330,24 +2235,22 @@ async def _action_close(
                 await page.close()
             del state["pages"][page_id]
             for key in (
-                "refs",
-                "refs_frame",
-                "console_logs",
-                "network_requests",
-                "pending_dialogs",
-                "pending_file_choosers",
+                "refs", "refs_frame", "console_logs", "network_requests",
+                "pending_dialogs", "pending_file_choosers",
             ):
                 state[key].pop(page_id, None)
             closed_real = True
+        sd = _get_session_data(state, session_id)
+        pages = state.get("pages") or {}
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "message": f"Closed page '{local_page_id}'",
-                    "page_id": local_page_id,
+                    "message": f"Closed page '{vid}'",
+                    "page_id": vid,
                     "closed_real_page": closed_real,
-                    "current_page_id": _get_current_page_for_session(state),
-                    "tabs": _local_page_ids_for_session(state),
+                    "current_page_id": sd.get("current"),
+                    "tabs": [v for v, r in sd["map"].items() if r in pages],
                 },
                 ensure_ascii=False,
                 indent=2,
@@ -3716,30 +3619,29 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
     page_id: str,
     tab_action: str,
     index: int,
-    local_page_id: str | None = None,
+    session_id: str | None = None,
 ) -> ToolChunk:
     tab_action = (tab_action or "").strip().lower()
     if not tab_action:
         return _tool_response(
             json.dumps(
-                {
-                    "ok": False,
-                    "error": "tab_action required (list, new, close, select)",
-                },
+                {"ok": False, "error": "tab_action required (list, new, close, select)"},
                 ensure_ascii=False,
                 indent=2,
             ),
         )
-    local_ids = _local_page_ids_for_session(state)
+    sd = _get_session_data(state, session_id)
+    pages = state.get("pages") or {}
+    vids = [v for v, r in sd["map"].items() if r in pages]
     if tab_action == "list":
-        cur = _get_current_page_for_session(state)
+        cur = sd.get("current")
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "tabs": local_ids,
-                    "tab_list": await _get_session_tab_info_list(state),
-                    "count": len(local_ids),
+                    "tabs": vids,
+                    "tab_list": await _get_session_tab_info_list(state, session_id),
+                    "count": len(vids),
                     "current_page_id": cur,
                     "session_current_page_id": cur,
                 },
@@ -3750,33 +3652,19 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
     if tab_action == "new":
         if _USE_SYNC_PLAYWRIGHT:
             if not state["_sync_context"]:
-                ok = await _ensure_browser(state)
+                ok = await _ensure_browser(state, session_id)
                 if not ok:
-                    err = (
-                        state.get("_last_browser_error")
-                        or "Browser not started"
-                    )
+                    err = state.get("_last_browser_error") or "Browser not started"
                     return _tool_response(
-                        json.dumps(
-                            {"ok": False, "error": err},
-                            ensure_ascii=False,
-                            indent=2,
-                        ),
+                        json.dumps({"ok": False, "error": err}, ensure_ascii=False, indent=2),
                     )
         else:
             if not state["context"]:
-                ok = await _ensure_browser(state)
+                ok = await _ensure_browser(state, session_id)
                 if not ok:
-                    err = (
-                        state.get("_last_browser_error")
-                        or "Browser not started"
-                    )
+                    err = state.get("_last_browser_error") or "Browser not started"
                     return _tool_response(
-                        json.dumps(
-                            {"ok": False, "error": err},
-                            ensure_ascii=False,
-                            indent=2,
-                        ),
+                        json.dumps({"ok": False, "error": err}, ensure_ascii=False, indent=2),
                     )
         try:
             if _USE_SYNC_PLAYWRIGHT:
@@ -3785,15 +3673,15 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                 page = await state["context"].new_page()
             new_id = _next_page_id(state)
             _register_page(state, page, new_id)
-            exposed_id = _assign_local_page_alias(state, new_id)
+            vid = _session_add_page(state, new_id, session_id)
             await _configure_download_behavior(state)
             return _tool_response(
                 json.dumps(
                     {
                         "ok": True,
-                        "page_id": exposed_id,
-                        "tabs": _local_page_ids_for_session(state),
-                        "tab_list": await _get_session_tab_info_list(state),
+                        "page_id": vid,
+                        "tabs": [v for v, r in sd["map"].items() if r in state.get("pages", {})],
+                        "tab_list": await _get_session_tab_info_list(state, session_id),
                     },
                     ensure_ascii=False,
                     indent=2,
@@ -3808,38 +3696,33 @@ async def _action_tabs(  # pylint: disable=too-many-return-statements
                 ),
             )
     if tab_action == "close":
-        target_local = (
-            local_ids[index] if 0 <= index < len(local_ids) else local_page_id
-        )
-        target_real = _map_local_to_real(state, target_local or "") or page_id
-        return await _action_close(
-            state,
-            target_real,
-            local_page_id=target_local,
-        )
+        if 0 <= index < len(vids):
+            target_vid = vids[index]
+            target_real = sd["map"].get(target_vid, page_id)
+        else:
+            target_real = page_id
+        return await _action_close(state, target_real, session_id)
     if tab_action == "select":
-        target_local = (
-            local_ids[index] if 0 <= index < len(local_ids) else local_page_id
-        )
-        target_real = _map_local_to_real(state, target_local or "")
-        if not target_local or not target_real:
+        if 0 <= index < len(vids):
+            target_vid = vids[index]
+            target_real = sd["map"].get(target_vid)
+        else:
+            target_vid = _virtual_page_id(state, page_id, session_id)
+            target_real = page_id if target_vid else None
+        if not target_vid or not target_real:
             return _tool_response(
                 json.dumps(
-                    {
-                        "ok": False,
-                        "error": f"Page '{target_local or local_page_id}' not found",
-                    },
-                    ensure_ascii=False,
-                    indent=2,
+                    {"ok": False, "error": "Page not found"},
+                    ensure_ascii=False, indent=2,
                 ),
             )
-        _set_current_page_for_session(state, target_local)
+        sd["current"] = target_vid
         return _tool_response(
             json.dumps(
                 {
                     "ok": True,
-                    "message": f"Use page_id={target_local} for later actions",
-                    "page_id": target_local,
+                    "message": f"Use page_id={target_vid} for later actions",
+                    "page_id": target_vid,
                 },
                 ensure_ascii=False,
                 indent=2,
@@ -4051,6 +3934,7 @@ async def _action_batch(  # pylint: disable=too-many-nested-blocks
     state: dict,
     page_id: str,
     actions_json: str,
+    session_id: str | None = None,
 ) -> ToolChunk:
     """Execute multiple browser actions sequentially.
 
@@ -4105,7 +3989,7 @@ async def _action_batch(  # pylint: disable=too-many-nested-blocks
 
         req_sub = act.get("page_id")
         if req_sub:
-            sub_page_id = _map_local_to_real(state, str(req_sub))
+            sub_page_id = _resolve_page(state, str(req_sub), session_id)
             if not sub_page_id:
                 results.append(
                     {
@@ -4138,6 +4022,7 @@ async def _action_batch(  # pylint: disable=too-many-nested-blocks
                     state,
                     url=(act.get("url") or "").strip(),
                     page_id=sub_page_id,
+                    session_id=session_id,
                 )
 
             # --- click ---
@@ -4392,7 +4277,11 @@ async def _action_list_cdp_targets(
     )
 
 
-async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolChunk:
+async def _action_connect_cdp(
+    state: dict,
+    cdp_url: str,
+    session_id: str | None = None,
+) -> ToolChunk:
     """Connect Playwright to a running Chrome via CDP."""
     if not cdp_url:
         return _tool_response(
@@ -4461,16 +4350,12 @@ async def _action_connect_cdp(state: dict, cdp_url: str) -> ToolChunk:
         for page in context.pages:
             page_id = _next_page_id(state)
             _register_page(state, page, page_id)
-            _assign_local_page_alias(
-                state,
-                page_id,
-                set_current=_get_current_page_for_session(state) is None,
-            )
+            _session_add_page(state, page_id, session_id)
         if not state["pages"]:
             page = await context.new_page()
             page_id = _next_page_id(state)
             _register_page(state, page, page_id)
-            _set_current_real_page_for_session(state, page_id)
+            _session_add_page(state, page_id, session_id)
         _touch_activity(state)
         _start_idle_watchdog(state)
         await _configure_download_behavior(state)
@@ -4525,7 +4410,7 @@ async def stop_all_browsers() -> None:
     for state in list(_workspace_states.values()):
         if _is_browser_running(state):
             try:
-                await _action_stop(state)
+                await _action_stop(state, force=True)
             except Exception as e:
                 logger.error(
                     "Failed to stop browser for workspace %s: %s",
@@ -4555,7 +4440,7 @@ async def stop_browsers_for_workspace_dirs(
             continue
         if _is_browser_running(state):
             try:
-                await _action_stop(state)
+                await _action_stop(state, force=True)
             except Exception as e:
                 logger.error(
                     "Failed to stop browser for workspace %s before "
@@ -4845,19 +4730,11 @@ async def browser_use(  # pylint: disable=R0911,R0912
 
     page_id = (page_id or "default").strip() or "default"
     requested_page_id = page_id
-    local_page_id = requested_page_id
 
     _NO_PAGE_ACTIONS = {
-        "start",
-        "stop",
-        "connect_cdp",
-        "list_cdp_targets",
-        "tabs",
-        "install",
-        "cookies_get",
-        "cookies_set",
-        "cookies_clear",
-        "clear_browser_cache",
+        "start", "stop", "connect_cdp", "list_cdp_targets",
+        "tabs", "install", "cookies_get", "cookies_set",
+        "cookies_clear", "clear_browser_cache",
     }
 
     async with state["_lock"]:
@@ -4866,39 +4743,28 @@ async def browser_use(  # pylint: disable=R0911,R0912
             pass
         elif action == "open":
             page_id = _next_page_id(state)
-            if requested_page_id == "default":
-                local_page_id = "default"
         else:
-            current = _get_current_page_for_session(state, _session_id)
-            if requested_page_id == "default" and current:
-                local_page_id = current
-                page_id = _map_local_to_real(state, current, _session_id)
-            elif requested_page_id == "default" and not current:
-                page_id = None
+            sd = _get_session_data(state, _session_id)
+            if requested_page_id == "default":
+                page_id = _resolve_page(state, sd.get("current", ""), _session_id)
             else:
-                local_page_id = requested_page_id
-                page_id = _map_local_to_real(state, local_page_id, _session_id)
+                page_id = _resolve_page(state, requested_page_id, _session_id)
             if not page_id:
+                pages = state.get("pages") or {}
                 return _tool_response(
                     json.dumps(
                         {
                             "ok": False,
-                            "error": f"Page '{local_page_id}' not found in this session",
-                            "tabs": _local_page_ids_for_session(
-                                state,
-                                _session_id,
-                            ),
-                            "current_page_id": _get_current_page_for_session(
-                                state,
-                                _session_id,
-                            ),
+                            "error": f"Page '{requested_page_id}' not found in this session",
+                            "tabs": [v for v, r in sd["map"].items() if r in pages],
+                            "current_page_id": sd.get("current"),
                         },
                         ensure_ascii=False,
                         indent=2,
                     ),
                 )
 
-    async def _dispatch() -> ToolResponse:
+    async def _dispatch() -> ToolChunk:
         if action == "start":
             return await _action_start(
                 state,
@@ -4907,22 +4773,22 @@ async def browser_use(  # pylint: disable=R0911,R0912
                 private_mode=private_mode,
                 browser_args=browser_args,
                 executable_path=executable_path,
+                session_id=_session_id,
             )
         if action == "stop":
-            return await _action_stop(state)
+            return await _action_stop(state, session_id=_session_id)
         if action == "connect_cdp":
-            return await _action_connect_cdp(state, cdp_url)
+            return await _action_connect_cdp(
+                state,
+                cdp_url,
+                session_id=_session_id,
+            )
         if action == "list_cdp_targets":
             return await _action_list_cdp_targets(port, port_min, port_max)
         if action == "open":
-            return await _action_open(
-                state,
-                url,
-                page_id,
-                local_page_id=local_page_id,
-            )
+            return await _action_open(state, url, page_id, _session_id)
         if action == "navigate":
-            return await _action_navigate(state, url, page_id)
+            return await _action_navigate(state, url, page_id, session_id=_session_id)
         if action == "navigate_back":
             return await _action_navigate_back(state, page_id)
         if action in ("screenshot", "take_screenshot"):
@@ -5054,13 +4920,7 @@ async def browser_use(  # pylint: disable=R0911,R0912
                 frame_selector,
             )
         if action == "tabs":
-            return await _action_tabs(
-                state,
-                page_id,
-                tab_action,
-                index,
-                local_page_id=local_page_id,
-            )
+            return await _action_tabs(state, page_id, tab_action, index, session_id=_session_id)
         if action == "wait_for":
             return await _action_wait_for(
                 state,
@@ -5072,11 +4932,7 @@ async def browser_use(  # pylint: disable=R0911,R0912
         if action == "pdf":
             return await _action_pdf(state, page_id, path)
         if action == "close":
-            return await _action_close(
-                state,
-                page_id,
-                local_page_id=local_page_id,
-            )
+            return await _action_close(state, page_id, _session_id)
         if action == "cookies_get":
             ctx = _get_context(state)
             if not ctx:
@@ -5209,7 +5065,7 @@ async def browser_use(  # pylint: disable=R0911,R0912
                     ),
                 )
         if action == "batch":
-            return await _action_batch(state, page_id, actions_json)
+            return await _action_batch(state, page_id, actions_json, session_id=_session_id)
         if action == "clear_browser_cache":
             return await _action_clear_browser_cache(state)
         return _tool_response(


### PR DESCRIPTION
## Description

Add session-level page isolation for the browser use tool, so that multiple sessions (or subagents) sharing the same browser instance no longer interfere with each other.

Previously, all sessions shared a flat `page_id` namespace (`page_1`, `page_2`, ...) and a single `current_page_id`. This meant one sub-agent opening, closing, or switching tabs would silently affect other sub-agents' state — leading to "page not found" errors, wrong-page operations, or unexpected tab switches.

This PR introduces a two-layer page ID mapping:
- **Internal IDs** (`real_page_N`): used by Playwright, globally unique across the browser instance.
- **Session-local aliases** (`page_1`, `page_2`, ...): each session maintains its own alias namespace with independent counters, so every sub-agent sees `page_1` as its first page regardless of what other sessions have opened.
- 
### Key design decisions

- **No shared mutable session state**: removed `state["current_page_id"]` entirely — `session_id` is passed explicitly through function parameters to eliminate cross-session race conditions under concurrent asyncio coroutines.
- **`on_page` callback uses opener-based session lookup**: when the browser opens a new tab (e.g. `window.open`), the callback traces the opener page to determine which session it belongs to via `_find_session_for_real_page`, rather than relying on a shared mutable field.
- **`_action_stop` multi-session awareness**: when a session calls `stop` while other sessions are using the browser, only that session's pages are closed; the browser stays running. System-level callers (idle watchdog, `stop_all_browsers`) use `force=True` to bypass this check.
- **`_localize_tool_response` as output gate**: all action functions return real page IDs; a single post-processing step at the `browser_use` exit converts them to session-local virtual IDs, keeping action function internals session-agnostic.
- **`_dispatch()` closure pattern**: `browser_use` entry splits into lock-protected page_id resolution + lock-free `_dispatch()` inner function. The lock only covers virtual→real ID translation (fast, no I/O); actual browser operations run outside the lock to avoid blocking other sessions. `_session_id` is captured in the closure and passed explicitly to all action functions.
- **`_ensure_browser` session-aware**: auto-restart (when browser process dies) now passes `session_id` through to `_start_managed_cdp_browser` / `_action_start`, so newly created pages register to the correct session.


**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Single agent session: verify behavior is identical to main branch — `open`, `click`, `navigate`, `close`, `tabs list` all work as before.
2. Multiple sub-agents: start two sub-agents sharing the same workspace. Each opens its own pages. Verify:
   - Each sub-agent sees only its own tabs in `tabs list`.
   - One sub-agent closing a page does not affect the other.
   - Page IDs are independently numbered (`page_1`, `page_2`, ...) per session.
   - JS-triggered new tabs (`window.open`) are registered in the active session only.
3. Stop behavior with multiple sessions:
   - Sub-agent A calls `stop` while sub-agent B is still using the browser -> only A's pages are closed, browser stays running.
   - After all sessions close their pages, `stop` shuts down the browser normally.
   - `force=True` (idle watchdog, `stop_all_browsers`) bypasses session check and stops unconditionally.
4. Start behavior:
   - `start` with `headed=True` correctly opens a visible browser window.
   - `start` when browser is already running returns session-specific tab info.
5. Edge cases:
   - Sub-agent calls `click` without ever opening a page -> returns "page not found" error.
   - Browser `stop` with `force=True` / reset clears all session mappings.



