### PR TITLE
fix(cron): record APScheduler misfires in history and raise default misfire grace to 600s

### DIFF
--- a/console/src/pages/Control/CronJobs/components/JobDrawer.tsx
+++ b/console/src/pages/Control/CronJobs/components/JobDrawer.tsx
@@ -723,7 +723,7 @@ export function JobDrawer({
           label={t("cronJobs.runtimeMisfireGraceSeconds")}
           tooltip={t("cronJobs.misfireGraceSecondsTooltip")}
         >
-          <InputNumber min={0} style={{ width: "100%" }} placeholder="60" />
+          <InputNumber min={0} style={{ width: "100%" }} placeholder="600" />
         </Form.Item>
       </Form>
     </Drawer>

--- a/console/src/pages/Control/CronJobs/components/constants.ts
+++ b/console/src/pages/Control/CronJobs/components/constants.ts
@@ -37,6 +37,6 @@ export const DEFAULT_FORM_VALUES = {
     share_session: true,
     max_concurrency: 1,
     timeout_seconds: 120,
-    misfire_grace_seconds: 60,
+    misfire_grace_seconds: 600,
   },
 };

--- a/console/src/pages/Control/CronJobs/components/templates.ts
+++ b/console/src/pages/Control/CronJobs/components/templates.ts
@@ -32,7 +32,7 @@ const buildRuntime = () => ({
   share_session: true,
   max_concurrency: 1,
   timeout_seconds: 120,
-  misfire_grace_seconds: 60,
+  misfire_grace_seconds: 600,
 });
 
 const createCustomCronTemplate = (

--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -7,6 +7,12 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Literal, Optional, Union
 
+from apscheduler.events import (
+    EVENT_JOB_MAX_INSTANCES,
+    EVENT_JOB_MISSED,
+    JobExecutionEvent,
+    JobSubmissionEvent,
+)
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
@@ -29,6 +35,7 @@ from .repo.base import BaseJobRepository
 
 HEARTBEAT_JOB_ID = "_heartbeat"
 DREAM_JOB_ID = "_dream"
+INTERNAL_JOB_IDS = frozenset({HEARTBEAT_JOB_ID, DREAM_JOB_ID})
 CRON_HISTORY_LIMIT = 50
 
 logger = logging.getLogger(__name__)
@@ -75,6 +82,7 @@ class CronManager:
             }
             await self._repo.prune_orphan_history(valid_job_ids)
 
+            self._register_scheduler_listeners()
             self._scheduler.start()
             for job in jobs_file.jobs:
                 try:
@@ -340,6 +348,95 @@ class CronManager:
                 )
 
     # ----- internal -----
+
+    def _register_scheduler_listeners(self) -> None:
+        mask = EVENT_JOB_MISSED | EVENT_JOB_MAX_INSTANCES
+        self._scheduler.add_listener(self._on_scheduler_event, mask=mask)
+
+    def _on_scheduler_event(self, event) -> None:
+        if event.code == EVENT_JOB_MISSED:
+            asyncio.ensure_future(self._handle_job_missed(event))
+        elif event.code == EVENT_JOB_MAX_INSTANCES:
+            asyncio.ensure_future(self._handle_job_max_instances(event))
+
+    async def _handle_job_missed(self, event: JobExecutionEvent) -> None:
+        job_id = event.job_id
+        if job_id in INTERNAL_JOB_IDS:
+            return
+
+        job = await self._repo.get_job(job_id)
+        if not job:
+            return
+
+        scheduled = event.scheduled_run_time
+        if scheduled.tzinfo is None:
+            scheduled = scheduled.replace(tzinfo=timezone.utc)
+        late_seconds = max(
+            0,
+            int((datetime.now(timezone.utc) - scheduled).total_seconds()),
+        )
+        grace = job.runtime.misfire_grace_seconds
+        error_msg = (
+            f"missed scheduled run at {scheduled.isoformat()}: "
+            f"late by {late_seconds}s, grace={grace}s"
+        )
+        await self._record_skipped(job, error_msg)
+
+    async def _handle_job_max_instances(
+        self,
+        event: JobSubmissionEvent,
+    ) -> None:
+        job_id = event.job_id
+        if job_id in INTERNAL_JOB_IDS:
+            return
+
+        job = await self._repo.get_job(job_id)
+        if not job:
+            return
+
+        scheduled_times = event.scheduled_run_times or []
+        if scheduled_times:
+            scheduled = scheduled_times[-1]
+            if scheduled.tzinfo is None:
+                scheduled = scheduled.replace(tzinfo=timezone.utc)
+            scheduled_text = scheduled.isoformat()
+        else:
+            scheduled_text = "unknown"
+        error_msg = (
+            f"skipped scheduled run at {scheduled_text}: "
+            f"maximum running instances reached "
+            f"({job.runtime.max_concurrency})"
+        )
+        await self._record_skipped(job, error_msg)
+
+    async def _record_skipped(self, job: CronJobSpec, error_msg: str) -> None:
+        assert job.id is not None
+        logger.warning(
+            "cron job skipped: job_id=%s name=%s %s",
+            job.id,
+            job.name,
+            error_msg,
+        )
+
+        st = self._states.get(job.id, CronJobState())
+        st.last_status = "skipped"
+        st.last_error = error_msg
+        aps_job = self._scheduler.get_job(job.id)
+        st.next_run_at = aps_job.next_run_time if aps_job else st.next_run_at
+        self._states[job.id] = st
+
+        record = CronExecutionRecord(
+            run_at=datetime.now(timezone.utc),
+            status="skipped",
+            error=error_msg,
+            trigger="scheduled",
+        )
+        records = await self._repo.append_history(
+            job.id,
+            record,
+            limit=CRON_HISTORY_LIMIT,
+        )
+        self._history[job.id] = records
 
     async def _register_or_update(self, spec: CronJobSpec) -> None:
         # Validate and build trigger first. If schedule is invalid, fail fast

--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -353,11 +353,14 @@ class CronManager:
         mask = EVENT_JOB_MISSED | EVENT_JOB_MAX_INSTANCES
         self._scheduler.add_listener(self._on_scheduler_event, mask=mask)
 
-    def _on_scheduler_event(self, event) -> None:
+    def _on_scheduler_event(
+        self,
+        event: JobExecutionEvent | JobSubmissionEvent,
+    ) -> None:
         if event.code == EVENT_JOB_MISSED:
-            asyncio.ensure_future(self._handle_job_missed(event))
+            asyncio.create_task(self._handle_job_missed(event))
         elif event.code == EVENT_JOB_MAX_INSTANCES:
-            asyncio.ensure_future(self._handle_job_max_instances(event))
+            asyncio.create_task(self._handle_job_max_instances(event))
 
     async def _handle_job_missed(self, event: JobExecutionEvent) -> None:
         job_id = event.job_id
@@ -396,6 +399,8 @@ class CronManager:
 
         scheduled_times = event.scheduled_run_times or []
         if scheduled_times:
+            # coalesce may queue multiple due times;
+            # [-1] is the latest skipped slot.
             scheduled = scheduled_times[-1]
             if scheduled.tzinfo is None:
                 scheduled = scheduled.replace(tzinfo=timezone.utc)
@@ -410,7 +415,11 @@ class CronManager:
         await self._record_skipped(job, error_msg)
 
     async def _record_skipped(self, job: CronJobSpec, error_msg: str) -> None:
-        assert job.id is not None
+        if job.id is None:
+            logger.error(
+                "cron _record_skipped: job.id is None, skipping record",
+            )
+            return
         logger.warning(
             "cron job skipped: job_id=%s name=%s %s",
             job.id,

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -154,7 +154,7 @@ class DispatchSpec(BaseModel):
 class JobRuntimeSpec(BaseModel):
     max_concurrency: int = Field(default=1, ge=1)
     timeout_seconds: int = Field(default=120, ge=1)
-    misfire_grace_seconds: int = Field(default=60, ge=0)
+    misfire_grace_seconds: int = Field(default=600, ge=0)
     share_session: bool = Field(
         default=True,
         description=(

--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -256,7 +256,7 @@ def _build_spec_from_cli(
         "share_session": share_session,
         "max_concurrency": 1,
         "timeout_seconds": timeout_seconds,
-        "misfire_grace_seconds": 60,
+        "misfire_grace_seconds": 600,
     }
     if task_type == "text":
         if not (text and text.strip()):

--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -188,6 +188,28 @@ def setup_logger(level: int | str = logging.INFO):
     return logger
 
 
+def _attach_logger_file_handler(
+    logger_name: str,
+    file_handler: logging.Handler,
+    *,
+    level: int,
+) -> None:
+    """Attach a shared file handler to another logger namespace."""
+    target = logging.getLogger(logger_name)
+    target.setLevel(level)
+    target.propagate = False
+    base = getattr(file_handler, "baseFilename", None)
+    for handler in target.handlers:
+        handler_base = getattr(handler, "baseFilename", None)
+        if (
+            base is not None
+            and handler_base is not None
+            and Path(handler_base).resolve() == Path(base).resolve()
+        ):
+            return
+    target.addHandler(file_handler)
+
+
 def add_project_file_handler(log_path: Path) -> None:
     """Add a rotating file handler to the project logger for daemon logs.
 
@@ -208,6 +230,11 @@ def add_project_file_handler(log_path: Path) -> None:
     for handler in logger.handlers:
         base = getattr(handler, "baseFilename", None)
         if base is not None and Path(base).resolve() == log_path:
+            _attach_logger_file_handler(
+                "apscheduler",
+                handler,
+                level=logging.WARNING,
+            )
             return
 
     file_handler = _SafeRotatingFileHandler(
@@ -223,3 +250,8 @@ def add_project_file_handler(log_path: Path) -> None:
         PlainFormatter("%(asctime)s | %(message)s", "%Y-%m-%d %H:%M:%S"),
     )
     logger.addHandler(file_handler)
+    _attach_logger_file_handler(
+        "apscheduler",
+        file_handler,
+        level=logging.WARNING,
+    )

--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -194,10 +194,13 @@ def _attach_logger_file_handler(
     *,
     level: int,
 ) -> None:
-    """Attach a shared file handler to another logger namespace."""
+    """Attach a shared file handler to another logger namespace.
+
+    Keeps ``propagate`` enabled so records still reach the root logger
+    (stderr / journald) while also being written to ``qwenpaw.log``.
+    """
     target = logging.getLogger(logger_name)
     target.setLevel(level)
-    target.propagate = False
     base = getattr(file_handler, "baseFilename", None)
     for handler in target.handlers:
         handler_base = getattr(handler, "baseFilename", None)


### PR DESCRIPTION

Fixes cron jobs appearing to "silently stop" when APScheduler drops overdue runs.

- Listen for `EVENT_JOB_MISSED` and `EVENT_JOB_MAX_INSTANCES`; persist `skipped` records to cron history/state and log via `qwenpaw` logger.
- Route APScheduler WARNING logs (e.g. `was missed by …`) into `qwenpaw.log`.
- Increase default `misfire_grace_seconds` from **60 → 600** for new jobs (model, CLI, Console defaults).


## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
