### PR TITLE
fix(dream): set the default misfire time to 600s for dream.

### DIFF
--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -35,6 +35,8 @@ from .repo.base import BaseJobRepository
 
 HEARTBEAT_JOB_ID = "_heartbeat"
 DREAM_JOB_ID = "_dream"
+HEARTBEAT_MISFIRE_GRACE_SECONDS = 60
+DREAM_MISFIRE_GRACE_SECONDS = 600
 INTERNAL_JOB_IDS = frozenset({HEARTBEAT_JOB_ID, DREAM_JOB_ID})
 CRON_HISTORY_LIMIT = 50
 
@@ -119,6 +121,7 @@ class CronManager:
                     self._heartbeat_callback,
                     trigger=trigger,
                     id=HEARTBEAT_JOB_ID,
+                    misfire_grace_time=HEARTBEAT_MISFIRE_GRACE_SECONDS,
                     replace_existing=True,
                 )
                 logger.info(
@@ -139,6 +142,7 @@ class CronManager:
                         self._dream_callback,
                         trigger=trigger,
                         id=DREAM_JOB_ID,
+                        misfire_grace_time=DREAM_MISFIRE_GRACE_SECONDS,
                         replace_existing=True,
                     )
                     logger.info(
@@ -229,6 +233,7 @@ class CronManager:
                     self._heartbeat_callback,
                     trigger=trigger,
                     id=HEARTBEAT_JOB_ID,
+                    misfire_grace_time=HEARTBEAT_MISFIRE_GRACE_SECONDS,
                     replace_existing=True,
                 )
                 logger.info(
@@ -276,6 +281,7 @@ class CronManager:
                         self._dream_callback,
                         trigger=trigger,
                         id=DREAM_JOB_ID,
+                        misfire_grace_time=DREAM_MISFIRE_GRACE_SECONDS,
                         replace_existing=True,
                     )
                     logger.info(


### PR DESCRIPTION
## Description

Set the default misfire time for dream(600s) and heartbeat(60s).

**Related Issue:** Fixes #5402 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
