### PR TITLE
feat(ci): end-to-end UI verification for desktop releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,6 +25,7 @@ jobs:
   # and emit a misleading "PASS". Forks / manual dispatch are allowed
   # to run without the secret (UI-load checks still execute).
   check-release-secrets:
+    name: Check release secrets (release only)
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -508,7 +508,8 @@ jobs:
           python scripts/verify/desktop_verify.py `
             --base-url $env:BASE_URL `
             --ui-mode tauri-windows `
-            --headed
+            --headed `
+            --cdp-url $env:CDP_URL
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server (Tauri Windows)

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -191,7 +191,8 @@ jobs:
           #    stays untouched.
           & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py `
             --base-url http://127.0.0.1:8088 `
-            --ui-mode legacy
+            --ui-mode legacy `
+            --headed
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server (Legacy Windows)
@@ -375,7 +376,8 @@ jobs:
           #    that ships to users.
           "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
             --base-url http://127.0.0.1:8088 \
-            --ui-mode legacy
+            --ui-mode legacy \
+            --headed
 
       - name: Stop desktop server (Legacy macOS)
         if: always()
@@ -502,76 +504,11 @@ jobs:
           QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
           PYTHONIOENCODING: utf-8
         run: |
-          $ErrorActionPreference = "Stop"
-
-          # 1. Locate the sidecar binary in the build tree (skip NSIS
-          #    install — the sidecar runs standalone).
-          $sidecar = "console\src-tauri\binaries\qwenpaw-backend\qwenpaw-backend.exe"
-          if (-not (Test-Path $sidecar)) {
-            throw "Sidecar not found at $sidecar"
-          }
-
-          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
-          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
-
-          # 2. Start the sidecar. It auto-inits the workspace and picks
-          #    its own random free port (entry.py takes no arguments).
-          #    Start-Process detaches naturally (no disown needed).
-          $proc = Start-Process -PassThru -NoNewWindow `
-            -FilePath $sidecar `
-            -RedirectStandardOutput $stdoutLog `
-            -RedirectStandardError $stderrLog
-          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
-
-          # 3. Parse the random port from the startup banner.
-          #    Banner: "Address: http://127.0.0.1:NNNN"
-          $port = $null
-          $deadline = (Get-Date).AddSeconds(120)
-          while ((Get-Date) -lt $deadline) {
-            $match = Select-String -Path $stdoutLog -Pattern 'Address: http://127\.0\.0\.1:(\d+)' -ErrorAction SilentlyContinue |
-              Select-Object -First 1
-            if ($match) {
-              $port = $match.Matches[0].Groups[1].Value
-              Write-Host "Sidecar bound to port $port"
-              break
-            }
-            Start-Sleep -Seconds 2
-          }
-          if (-not $port) {
-            Write-Host "::error::Sidecar did not advertise a port within 120s"
-            Get-Content $stdoutLog -Tail 50 -ErrorAction SilentlyContinue
-            Get-Content $stderrLog -Tail 50 -ErrorAction SilentlyContinue
-            exit 1
-          }
-          $baseUrl = "http://127.0.0.1:$port"
-
-          # 4. Drop BOOTSTRAP.md (sidecar auto-init already created it).
-          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
-          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
-
-          # 5. Wait for /api/version.
-          $ready = $false
-          for ($i = 1; $i -le 60; $i++) {
-            try {
-              $resp = Invoke-WebRequest -Uri "$baseUrl/api/version" `
-                -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
-              if ($resp.StatusCode -eq 200) {
-                Write-Host "Server up after ~$([int]($i*2))s"
-                $ready = $true
-                break
-              }
-            } catch { Start-Sleep -Seconds 2 }
-          }
-          if (-not $ready) {
-            Write-Host "::error::Server did not respond within 120s"
-            exit 1
-          }
-
-          # 6. Run the shared verifier with Chromium (same engine
-          #    family as Tauri's WebView2 on Windows).
+          . scripts/verify/launch_tauri_windows.ps1
           python scripts/verify/desktop_verify.py `
-            --base-url $baseUrl `
-            --ui-mode tauri-windows
+            --base-url $env:BASE_URL `
+            --ui-mode tauri-windows `
+            --headed
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server (Tauri Windows)
@@ -579,14 +516,16 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Continue"
-          $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
-          if (Test-Path $pidFile) {
-            $pidValue = (Get-Content $pidFile | Select-Object -First 1).Trim()
-            if ($pidValue) {
-              taskkill /F /PID $pidValue 2>$null | Out-Null
-              taskkill /F /T /PID $pidValue 2>$null | Out-Null
-            }
-          }
+          # Kill the Tauri shell and its sidecar subprocess by name.
+          Get-Process -Name "qwenpaw-desktop" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name "qwenpaw-backend" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 2
+          Get-Process -Name "qwenpaw-desktop" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name "qwenpaw-backend" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
           exit 0
 
       - name: Upload desktop verify logs (Tauri Windows)
@@ -597,6 +536,7 @@ jobs:
           path: |
             ${{ runner.temp }}/qwenpaw-desktop-stdout.log
             ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+            ~/AppData/Local/com.qwenpaw.desktop/logs/
           if-no-files-found: ignore
           retention-days: 7
 
@@ -678,103 +618,22 @@ jobs:
           QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
         run: |
           set -euo pipefail
-
-          # 1. Unpack the freshly built Tauri zip.
-          mkdir -p dist/verify-tauri
-          unzip -q dist/QwenPaw-Tauri-*-macOS.zip -d dist/verify-tauri
-          APP="$(find dist/verify-tauri -maxdepth 3 -name '*.app' -type d | head -1)"
-          if [ -z "$APP" ]; then
-            echo "::error::Tauri .app not found inside zip"
-            exit 1
-          fi
-
-          # 2. Remove macOS quarantine (CI download marks it).
-          xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
-
-          # 3. Locate the PyInstaller sidecar binary. Unlike the
-          #    Legacy desktop's `qwenpaw` CLI, this sidecar entry
-          #    (src/qwenpaw/tauri/entry.py) takes NO arguments —
-          #    it auto-inits the workspace and picks its own random
-          #    free port. We have to parse the port back out of its
-          #    startup banner.
-          SIDECAR="$APP/Contents/Resources/binaries/qwenpaw-backend/qwenpaw-backend"
-          if [ ! -f "$SIDECAR" ]; then
-            echo "::error::Sidecar not found at $SIDECAR"
-            exit 1
-          fi
-          chmod +x "$SIDECAR"
-
-          STDOUT_LOG="$RUNNER_TEMP/qwenpaw-desktop-stdout.log"
-          STDERR_LOG="$RUNNER_TEMP/qwenpaw-desktop-stderr.log"
-          : > "$STDOUT_LOG"
-          : > "$STDERR_LOG"
-
-          # 4. Start the sidecar detached so the GitHub Actions step
-          #    doesn't wait for the background process to finish.
-          #    Redirect stdin from /dev/null + disown to fully decouple.
-          nohup "$SIDECAR" \
-            >"$STDOUT_LOG" 2>"$STDERR_LOG" </dev/null &
-          SIDECAR_PID=$!
-          disown "$SIDECAR_PID" 2>/dev/null || true
-          echo "$SIDECAR_PID" > "$RUNNER_TEMP/qwenpaw-desktop.pid"
-
-          # 5. Parse the random port out of the startup banner.
-          #    Banner line: "Address: http://127.0.0.1:NNNN"
-          PORT=""
-          for i in $(seq 1 60); do
-            PORT="$(grep -oE 'Address: http://127\.0\.0\.1:[0-9]+' "$STDOUT_LOG" 2>/dev/null | head -1 | grep -oE '[0-9]+$' || true)"
-            if [ -n "$PORT" ]; then
-              echo "Sidecar bound to port $PORT after ~$((i*2))s"
-              break
-            fi
-            sleep 2
-          done
-          if [ -z "$PORT" ]; then
-            echo "::error::Sidecar did not advertise a port within 120s"
-            tail -50 "$STDOUT_LOG" || true
-            tail -50 "$STDERR_LOG" || true
-            exit 1
-          fi
-          BASE_URL="http://127.0.0.1:$PORT"
-          echo "BASE_URL=$BASE_URL" >> "$GITHUB_ENV"
-
-          # 6. Drop BOOTSTRAP.md so the agent answers in plain QA
-          #    mode (sidecar auto-init has already created it).
-          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
-
-          # 7. Wait for /api/version to actually respond.
-          for i in $(seq 1 60); do
-            if curl -sf "$BASE_URL/api/version" >/dev/null; then
-              echo "Server up after ~$((i*2))s"
-              break
-            fi
-            if [ "$i" = "60" ]; then
-              echo "::error::Server did not respond within 120s"
-              exit 1
-            fi
-            sleep 2
-          done
-
-          # 8. Run the shared verifier with WebKit (same engine as
-          #    the Tauri webview on macOS).
+          source scripts/verify/launch_tauri_macos.sh
           python scripts/verify/desktop_verify.py \
             --base-url "$BASE_URL" \
-            --ui-mode tauri-macos
+            --ui-mode tauri-macos \
+            --headed
 
       - name: Stop desktop server (Tauri macOS)
         if: always()
         run: |
-          if [ -f "$RUNNER_TEMP/qwenpaw-desktop.pid" ]; then
-            SIDECAR_PID="$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")"
-            kill "$SIDECAR_PID" 2>/dev/null || true
-            # Give it a moment, then SIGKILL stragglers from the
-            # same process group.
-            sleep 2
-            kill -9 "$SIDECAR_PID" 2>/dev/null || true
-          fi
-          # Best-effort: kill anything sitting on the detected port
-          # (fall back gracefully when BASE_URL never made it into
-          # $GITHUB_ENV).
+          # Kill the Tauri shell and its sidecar subprocess.
+          pkill -f "QwenPaw Desktop" 2>/dev/null || true
+          pkill -f "qwenpaw-backend" 2>/dev/null || true
+          sleep 2
+          pkill -9 -f "QwenPaw Desktop" 2>/dev/null || true
+          pkill -9 -f "qwenpaw-backend" 2>/dev/null || true
+          # Best-effort: kill anything sitting on the detected port.
           if [ -n "${BASE_URL:-}" ]; then
             PORT="${BASE_URL##*:}"
             lsof -ti:"$PORT" | xargs kill 2>/dev/null || true
@@ -789,6 +648,7 @@ jobs:
           path: |
             ${{ runner.temp }}/qwenpaw-desktop-stdout.log
             ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+            ~/Library/Logs/com.qwenpaw.desktop/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -84,6 +84,165 @@ jobs:
             Get-ChildItem -Path dist\win-unpacked -ErrorAction SilentlyContinue | Select-Object -First 30 | ForEach-Object { $_.Name }
           }
 
+      - name: Set up runner Python for verification
+        id: runner-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install verify deps (Playwright + Chromium)
+        shell: pwsh
+        env:
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          & $env:RUNNER_PYTHON -m pip install --upgrade pip
+          & $env:RUNNER_PYTHON -m pip install -r scripts/verify/requirements-verify.txt
+          & $env:RUNNER_PYTHON -m playwright install chromium --with-deps
+
+      - name: Verify desktop (Legacy Windows)
+        timeout-minutes: 10
+        shell: pwsh
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+          PYTHONIOENCODING: utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          # 1. Locate the freshly built NSIS installer.
+          $installer = Get-ChildItem dist/QwenPaw-Setup-*.exe |
+            Select-Object -First 1
+          if (-not $installer) { throw "No QwenPaw-Setup-*.exe found in dist/" }
+
+          # 2. Silent install to a deterministic ASCII path under RUNNER_TEMP
+          #    so we don't need to reverse-lookup the install location.
+          #    NSIS requires /D=<path> to be the LAST argument and unquoted.
+          $installDir = Join-Path $env:RUNNER_TEMP "QwenPaw-Verify"
+          if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
+          $nsisArgs = "/S /D=$installDir"
+          Write-Host "Installer: $($installer.FullName)"
+          Write-Host "Install dir: $installDir"
+          Start-Process -FilePath $installer.FullName -ArgumentList $nsisArgs -Wait
+
+          # 3. NSIS runs asynchronously even with -Wait; poll for python.exe.
+          $bundledPython = Join-Path $installDir "python.exe"
+          $deadline = (Get-Date).AddSeconds(120)
+          while (-not (Test-Path $bundledPython)) {
+            if ((Get-Date) -gt $deadline) {
+              throw "python.exe not present at $bundledPython after 120s"
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Host "Bundled interpreter located: $bundledPython"
+
+          # 4. Initialise workspace and start the desktop backend in the
+          #    background. Use the bundled python so dependencies match the
+          #    actual installed env users will use.
+          $env:PYTHONNOUSERSITE = "1"
+          & $bundledPython -m qwenpaw init --defaults --accept-security
+          if ($LASTEXITCODE -ne 0) { throw "qwenpaw init failed ($LASTEXITCODE)" }
+
+          # Skip the BootstrapHook onboarding script so the verifier
+          # can drive the agent in normal QA mode (see
+          # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
+          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
+          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
+
+          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
+          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
+          $proc = Start-Process -PassThru -NoNewWindow `
+            -FilePath $bundledPython `
+            -ArgumentList "-m","qwenpaw","app","--host","127.0.0.1","--port","8088" `
+            -RedirectStandardOutput $stdoutLog `
+            -RedirectStandardError $stderrLog
+          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
+
+          # 5. Wait for /api/version (~120s budget).
+          $ready = $false
+          for ($i = 1; $i -le 60; $i++) {
+            try {
+              $resp = Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version `
+                -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+              if ($resp.StatusCode -eq 200) {
+                Write-Host "Server up after ~$([int]($i*2))s"
+                $ready = $true
+                break
+              }
+            } catch { Start-Sleep -Seconds 2 }
+          }
+          if (-not $ready) {
+            Write-Host "::error::Server did not respond within 120s"
+            exit 1
+          }
+
+          # 6. Cross-version sanity: backend version must match source.
+          $expected = "${{ steps.version.outputs.version }}"
+          $payload = (Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version `
+            -UseBasicParsing -TimeoutSec 10).Content | ConvertFrom-Json
+          $actual = $payload.version
+          if ($actual -ne $expected) {
+            Write-Host "::error::Desktop version mismatch: expected=$expected actual=$actual"
+            exit 1
+          }
+
+          # 7. Run the shared verifier with the runner's python (where
+          #    Playwright + Chromium are installed) so the installed env
+          #    stays untouched.
+          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py `
+            --base-url http://127.0.0.1:8088 `
+            --ui-mode legacy
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stop desktop server (Legacy Windows)
+        if: always()
+        shell: pwsh
+        run: |
+          $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
+          if (Test-Path $pidFile) {
+            $pidValue = (Get-Content $pidFile | Select-Object -First 1).Trim()
+            if ($pidValue) {
+              taskkill /F /PID $pidValue 2>$null | Out-Null
+            }
+          }
+
+          # Best-effort port-based fallback (kill anything still on 8088).
+          $line = netstat -ano 2>$null | Select-String -Pattern ':8088 .*LISTENING' |
+            Select-Object -First 1
+          if ($line) {
+            $owner = ($line.ToString() -split '\s+')[-1].Trim()
+            if ($owner) { taskkill /F /PID $owner 2>$null | Out-Null }
+          }
+
+          # Uninstall to leave the runner clean.
+          $installDir = Join-Path $env:RUNNER_TEMP "QwenPaw-Verify"
+          $uninstaller = Join-Path $installDir "Uninstall.exe"
+          if (Test-Path $uninstaller) {
+            Start-Process -FilePath $uninstaller -ArgumentList "/S" -Wait `
+              -ErrorAction SilentlyContinue
+          }
+          exit 0
+
+      - name: Upload desktop verify logs (Legacy Windows)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-logs-legacy-windows-${{ steps.version.outputs.version }}
+          path: |
+            ${{ runner.temp }}/qwenpaw-desktop-stdout.log
+            ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload verify screenshots (Legacy Windows)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-screenshots-legacy-windows-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/verify-screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
@@ -127,6 +286,125 @@ jobs:
         run: |
           chmod +x scripts/pack/build_macos.sh
           conda run -n qwenpaw-build bash -c 'CREATE_ZIP=1 ./scripts/pack/build_macos.sh'
+
+      - name: Set up runner Python for verification
+        id: runner-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install verify deps (Playwright + Chromium)
+        env:
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+        run: |
+          set -euo pipefail
+          "$RUNNER_PYTHON" -m pip install --upgrade pip
+          "$RUNNER_PYTHON" -m pip install \
+            -r scripts/verify/requirements-verify.txt
+          "$RUNNER_PYTHON" -m playwright install chromium --with-deps
+
+      - name: Verify desktop (Legacy macOS)
+        timeout-minutes: 10
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+        run: |
+          set -euo pipefail
+
+          # 1. Unpack the freshly built zip into an isolated verify dir.
+          mkdir -p dist/verify-legacy
+          unzip -q dist/QwenPaw-*-macOS.zip -d dist/verify-legacy
+          APP="$(find dist/verify-legacy -maxdepth 2 -name '*.app' -type d | head -1)"
+          if [ -z "$APP" ]; then
+            echo "::error::QwenPaw.app not found inside zip"
+            exit 1
+          fi
+          ENV_DIR="$APP/Contents/Resources/env"
+          PYTHON="$ENV_DIR/bin/python"
+
+          # 2. Fix conda-pack paths (mandatory or python crashes on launch).
+          (cd "$ENV_DIR" && ./bin/conda-unpack 2>/dev/null || true)
+
+          # 3. Force the bundled interpreter to ignore user site-packages.
+          export PYTHONHOME="$ENV_DIR"
+          export PYTHONNOUSERSITE=1
+          export PATH="$ENV_DIR/bin:$PATH"
+
+          # 4. SSL certificates — required for DashScope HTTPS calls.
+          CERT_FILE="$("$PYTHON" -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
+          if [ -n "${CERT_FILE:-}" ] && [ -f "$CERT_FILE" ]; then
+            export SSL_CERT_FILE="$CERT_FILE"
+            export REQUESTS_CA_BUNDLE="$CERT_FILE"
+          fi
+
+          # 5. Init workspace and start the desktop backend in the background.
+          "$PYTHON" -m qwenpaw init --defaults --accept-security
+          # Skip the BootstrapHook onboarding script so the verifier
+          # can drive the agent in normal QA mode (see
+          # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
+          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
+          nohup "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
+            > "$RUNNER_TEMP/qwenpaw-desktop-stdout.log" \
+            2> "$RUNNER_TEMP/qwenpaw-desktop-stderr.log" &
+          echo $! > "$RUNNER_TEMP/qwenpaw-desktop.pid"
+
+          # 6. Wait for /api/version (~120s budget).
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8088/api/version >/dev/null; then
+              echo "Server up after ~$((i*2))s"
+              break
+            fi
+            if [ "$i" = "60" ]; then
+              echo "::error::Server did not respond within 120s"
+              exit 1
+            fi
+            sleep 2
+          done
+
+          # 7. Cross-version sanity: backend version must match source.
+          expected="${{ steps.version.outputs.version }}"
+          actual="$(curl -sf http://127.0.0.1:8088/api/version | "$RUNNER_PYTHON" -c 'import sys,json; print(json.load(sys.stdin)["version"])')"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Desktop version mismatch: expected=$expected actual=$actual"
+            exit 1
+          fi
+
+          # 8. Run the shared verifier with the runner's python (where
+          #    Playwright + Chromium are installed). The bundled conda-pack
+          #    python stays untouched so we don't pollute the actual env
+          #    that ships to users.
+          "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
+            --base-url http://127.0.0.1:8088 \
+            --ui-mode legacy
+
+      - name: Stop desktop server (Legacy macOS)
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/qwenpaw-desktop.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")" 2>/dev/null || true
+          fi
+          lsof -ti:8088 | xargs kill 2>/dev/null || true
+          rm -rf dist/verify-legacy
+
+      - name: Upload desktop verify logs (Legacy macOS)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-logs-legacy-macos-${{ steps.version.outputs.version }}
+          path: |
+            ${{ runner.temp }}/qwenpaw-desktop-stdout.log
+            ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload verify screenshots (Legacy macOS)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-screenshots-legacy-macos-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/verify-screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
@@ -209,6 +487,128 @@ jobs:
           Copy-Item -Force $installer.FullName $target
           Write-Host "Staged Tauri Windows installer: $target"
 
+      - name: Install verify deps (Playwright + Chromium)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          python -m pip install --upgrade pip
+          python -m pip install -r scripts/verify/requirements-verify.txt
+          python -m playwright install chromium --with-deps
+
+      - name: Verify desktop (Tauri Windows)
+        timeout-minutes: 10
+        shell: pwsh
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          PYTHONIOENCODING: utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          # 1. Locate the sidecar binary in the build tree (skip NSIS
+          #    install — the sidecar runs standalone).
+          $sidecar = "console\src-tauri\binaries\qwenpaw-backend\qwenpaw-backend.exe"
+          if (-not (Test-Path $sidecar)) {
+            throw "Sidecar not found at $sidecar"
+          }
+
+          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
+          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
+
+          # 2. Start the sidecar. It auto-inits the workspace and picks
+          #    its own random free port (entry.py takes no arguments).
+          #    Start-Process detaches naturally (no disown needed).
+          $proc = Start-Process -PassThru -NoNewWindow `
+            -FilePath $sidecar `
+            -RedirectStandardOutput $stdoutLog `
+            -RedirectStandardError $stderrLog
+          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
+
+          # 3. Parse the random port from the startup banner.
+          #    Banner: "Address: http://127.0.0.1:NNNN"
+          $port = $null
+          $deadline = (Get-Date).AddSeconds(120)
+          while ((Get-Date) -lt $deadline) {
+            $match = Select-String -Path $stdoutLog -Pattern 'Address: http://127\.0\.0\.1:(\d+)' -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+            if ($match) {
+              $port = $match.Matches[0].Groups[1].Value
+              Write-Host "Sidecar bound to port $port"
+              break
+            }
+            Start-Sleep -Seconds 2
+          }
+          if (-not $port) {
+            Write-Host "::error::Sidecar did not advertise a port within 120s"
+            Get-Content $stdoutLog -Tail 50 -ErrorAction SilentlyContinue
+            Get-Content $stderrLog -Tail 50 -ErrorAction SilentlyContinue
+            exit 1
+          }
+          $baseUrl = "http://127.0.0.1:$port"
+
+          # 4. Drop BOOTSTRAP.md (sidecar auto-init already created it).
+          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
+          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
+
+          # 5. Wait for /api/version.
+          $ready = $false
+          for ($i = 1; $i -le 60; $i++) {
+            try {
+              $resp = Invoke-WebRequest -Uri "$baseUrl/api/version" `
+                -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+              if ($resp.StatusCode -eq 200) {
+                Write-Host "Server up after ~$([int]($i*2))s"
+                $ready = $true
+                break
+              }
+            } catch { Start-Sleep -Seconds 2 }
+          }
+          if (-not $ready) {
+            Write-Host "::error::Server did not respond within 120s"
+            exit 1
+          }
+
+          # 6. Run the shared verifier with Chromium (same engine
+          #    family as Tauri's WebView2 on Windows).
+          python scripts/verify/desktop_verify.py `
+            --base-url $baseUrl `
+            --ui-mode tauri-windows
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stop desktop server (Tauri Windows)
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
+          if (Test-Path $pidFile) {
+            $pidValue = (Get-Content $pidFile | Select-Object -First 1).Trim()
+            if ($pidValue) {
+              taskkill /F /PID $pidValue 2>$null | Out-Null
+              taskkill /F /T /PID $pidValue 2>$null | Out-Null
+            }
+          }
+          exit 0
+
+      - name: Upload desktop verify logs (Tauri Windows)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-logs-tauri-windows-${{ steps.version.outputs.version }}
+          path: |
+            ${{ runner.temp }}/qwenpaw-desktop-stdout.log
+            ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload verify screenshots (Tauri Windows)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-screenshots-tauri-windows-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/verify-screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload Tauri Windows artifact
         uses: actions/upload-artifact@v4
         with:
@@ -264,6 +664,142 @@ jobs:
         run: |
           chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
           bash scripts/pack-tauri/build_macos_pyinstaller.sh
+
+      - name: Install verify deps (Playwright + WebKit)
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r scripts/verify/requirements-verify.txt
+          python -m playwright install webkit --with-deps
+
+      - name: Verify desktop (Tauri macOS)
+        timeout-minutes: 10
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          # 1. Unpack the freshly built Tauri zip.
+          mkdir -p dist/verify-tauri
+          unzip -q dist/QwenPaw-Tauri-*-macOS.zip -d dist/verify-tauri
+          APP="$(find dist/verify-tauri -maxdepth 3 -name '*.app' -type d | head -1)"
+          if [ -z "$APP" ]; then
+            echo "::error::Tauri .app not found inside zip"
+            exit 1
+          fi
+
+          # 2. Remove macOS quarantine (CI download marks it).
+          xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
+
+          # 3. Locate the PyInstaller sidecar binary. Unlike the
+          #    Legacy desktop's `qwenpaw` CLI, this sidecar entry
+          #    (src/qwenpaw/tauri/entry.py) takes NO arguments —
+          #    it auto-inits the workspace and picks its own random
+          #    free port. We have to parse the port back out of its
+          #    startup banner.
+          SIDECAR="$APP/Contents/Resources/binaries/qwenpaw-backend/qwenpaw-backend"
+          if [ ! -f "$SIDECAR" ]; then
+            echo "::error::Sidecar not found at $SIDECAR"
+            exit 1
+          fi
+          chmod +x "$SIDECAR"
+
+          STDOUT_LOG="$RUNNER_TEMP/qwenpaw-desktop-stdout.log"
+          STDERR_LOG="$RUNNER_TEMP/qwenpaw-desktop-stderr.log"
+          : > "$STDOUT_LOG"
+          : > "$STDERR_LOG"
+
+          # 4. Start the sidecar detached so the GitHub Actions step
+          #    doesn't wait for the background process to finish.
+          #    Redirect stdin from /dev/null + disown to fully decouple.
+          nohup "$SIDECAR" \
+            >"$STDOUT_LOG" 2>"$STDERR_LOG" </dev/null &
+          SIDECAR_PID=$!
+          disown "$SIDECAR_PID" 2>/dev/null || true
+          echo "$SIDECAR_PID" > "$RUNNER_TEMP/qwenpaw-desktop.pid"
+
+          # 5. Parse the random port out of the startup banner.
+          #    Banner line: "Address: http://127.0.0.1:NNNN"
+          PORT=""
+          for i in $(seq 1 60); do
+            PORT="$(grep -oE 'Address: http://127\.0\.0\.1:[0-9]+' "$STDOUT_LOG" 2>/dev/null | head -1 | grep -oE '[0-9]+$' || true)"
+            if [ -n "$PORT" ]; then
+              echo "Sidecar bound to port $PORT after ~$((i*2))s"
+              break
+            fi
+            sleep 2
+          done
+          if [ -z "$PORT" ]; then
+            echo "::error::Sidecar did not advertise a port within 120s"
+            tail -50 "$STDOUT_LOG" || true
+            tail -50 "$STDERR_LOG" || true
+            exit 1
+          fi
+          BASE_URL="http://127.0.0.1:$PORT"
+          echo "BASE_URL=$BASE_URL" >> "$GITHUB_ENV"
+
+          # 6. Drop BOOTSTRAP.md so the agent answers in plain QA
+          #    mode (sidecar auto-init has already created it).
+          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
+
+          # 7. Wait for /api/version to actually respond.
+          for i in $(seq 1 60); do
+            if curl -sf "$BASE_URL/api/version" >/dev/null; then
+              echo "Server up after ~$((i*2))s"
+              break
+            fi
+            if [ "$i" = "60" ]; then
+              echo "::error::Server did not respond within 120s"
+              exit 1
+            fi
+            sleep 2
+          done
+
+          # 8. Run the shared verifier with WebKit (same engine as
+          #    the Tauri webview on macOS).
+          python scripts/verify/desktop_verify.py \
+            --base-url "$BASE_URL" \
+            --ui-mode tauri-macos
+
+      - name: Stop desktop server (Tauri macOS)
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/qwenpaw-desktop.pid" ]; then
+            SIDECAR_PID="$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")"
+            kill "$SIDECAR_PID" 2>/dev/null || true
+            # Give it a moment, then SIGKILL stragglers from the
+            # same process group.
+            sleep 2
+            kill -9 "$SIDECAR_PID" 2>/dev/null || true
+          fi
+          # Best-effort: kill anything sitting on the detected port
+          # (fall back gracefully when BASE_URL never made it into
+          # $GITHUB_ENV).
+          if [ -n "${BASE_URL:-}" ]; then
+            PORT="${BASE_URL##*:}"
+            lsof -ti:"$PORT" | xargs kill 2>/dev/null || true
+          fi
+          rm -rf dist/verify-tauri
+
+      - name: Upload desktop verify logs (Tauri macOS)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-logs-tauri-macos-${{ steps.version.outputs.version }}
+          path: |
+            ${{ runner.temp }}/qwenpaw-desktop-stdout.log
+            ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload verify screenshots (Tauri macOS)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-screenshots-tauri-macos-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/verify-screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload Tauri macOS artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -20,7 +20,30 @@ permissions:
   contents: read
 
 jobs:
+  # On release events, fail fast if the DashScope secret is missing.
+  # Without it, the verifier would silently skip the LLM chat round
+  # and emit a misleading "PASS". Forks / manual dispatch are allowed
+  # to run without the secret (UI-load checks still execute).
+  check-release-secrets:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure DashScope secret is configured
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+        run: |
+          if [ -z "$QWENPAW_DASHSCOPE_API_KEY" ]; then
+            echo "::error::QWENPAW_DASHSCOPE_API_KEY is not set; release verification cannot validate the LLM chat round. Configure the repo secret before publishing."
+            exit 1
+          fi
+          echo "DashScope secret present"
+
   build-windows:
+    needs: [check-release-secrets]
+    if: |
+      always() &&
+      (needs.check-release-secrets.result == 'success' ||
+       needs.check-release-secrets.result == 'skipped')
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -251,6 +274,11 @@ jobs:
           path: dist/QwenPaw-Setup-*.exe
 
   build-macos:
+    needs: [check-release-secrets]
+    if: |
+      always() &&
+      (needs.check-release-secrets.result == 'success' ||
+       needs.check-release-secrets.result == 'skipped')
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -415,6 +443,11 @@ jobs:
           path: dist/QwenPaw-*.zip
 
   build-tauri-windows:
+    needs: [check-release-secrets]
+    if: |
+      always() &&
+      (needs.check-release-secrets.result == 'success' ||
+       needs.check-release-secrets.result == 'skipped')
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -557,6 +590,11 @@ jobs:
           path: dist/QwenPaw-Tauri-*-Windows-setup.exe
 
   build-tauri-macos:
+    needs: [check-release-secrets]
+    if: |
+      always() &&
+      (needs.check-release-secrets.result == 'success' ||
+       needs.check-release-secrets.result == 'skipped')
     runs-on: macos-14
     steps:
       - name: Checkout

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -380,7 +380,8 @@ jobs:
           python scripts/verify/desktop_verify.py `
             --base-url $env:BASE_URL `
             --ui-mode tauri-windows `
-            --headed
+            --headed `
+            --cdp-url $env:CDP_URL
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -118,7 +118,7 @@ jobs:
             sleep 2
           done
           "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
-            --base-url http://127.0.0.1:8088 --ui-mode legacy
+            --base-url http://127.0.0.1:8088 --ui-mode legacy --headed
 
       - name: Stop desktop server
         if: always()
@@ -230,7 +230,7 @@ jobs:
             } catch { Start-Sleep -Seconds 2 }
           }
           if (-not $ready) { Write-Host "::error::Server timeout"; exit 1 }
-          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py --base-url http://127.0.0.1:8088 --ui-mode legacy
+          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py --base-url http://127.0.0.1:8088 --ui-mode legacy --headed
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server
@@ -299,44 +299,17 @@ jobs:
           QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
         run: |
           set -euo pipefail
-          mkdir -p dist/verify-tauri
-          unzip -q dist/QwenPaw-Tauri-*-macOS.zip -d dist/verify-tauri
-          APP="$(find dist/verify-tauri -maxdepth 3 -name '*.app' -type d | head -1)"
-          if [ -z "$APP" ]; then echo "::error::Tauri .app not found"; exit 1; fi
-          xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
-          SIDECAR="$APP/Contents/Resources/binaries/qwenpaw-backend/qwenpaw-backend"
-          if [ ! -f "$SIDECAR" ]; then echo "::error::Sidecar not found"; exit 1; fi
-          chmod +x "$SIDECAR"
-          STDOUT_LOG="$RUNNER_TEMP/qwenpaw-desktop-stdout.log"
-          STDERR_LOG="$RUNNER_TEMP/qwenpaw-desktop-stderr.log"
-          : > "$STDOUT_LOG"; : > "$STDERR_LOG"
-          nohup "$SIDECAR" >"$STDOUT_LOG" 2>"$STDERR_LOG" </dev/null &
-          SIDECAR_PID=$!; disown "$SIDECAR_PID" 2>/dev/null || true
-          echo "$SIDECAR_PID" > "$RUNNER_TEMP/qwenpaw-desktop.pid"
-          PORT=""
-          for i in $(seq 1 60); do
-            PORT="$(grep -oE 'Address: http://127\.0\.0\.1:[0-9]+' "$STDOUT_LOG" 2>/dev/null | head -1 | grep -oE '[0-9]+$' || true)"
-            if [ -n "$PORT" ]; then echo "Sidecar port $PORT"; break; fi
-            sleep 2
-          done
-          if [ -z "$PORT" ]; then echo "::error::No port advertised"; exit 1; fi
-          BASE_URL="http://127.0.0.1:$PORT"
-          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
-          for i in $(seq 1 60); do
-            if curl -sf "$BASE_URL/api/version" >/dev/null; then echo "Server up"; break; fi
-            if [ "$i" = "60" ]; then echo "::error::Server timeout"; exit 1; fi
-            sleep 2
-          done
-          python scripts/verify/desktop_verify.py --base-url "$BASE_URL" --ui-mode tauri-macos
+          source scripts/verify/launch_tauri_macos.sh
+          python scripts/verify/desktop_verify.py --base-url "$BASE_URL" --ui-mode tauri-macos --headed
 
       - name: Stop desktop server
         if: always()
         run: |
-          if [ -f "$RUNNER_TEMP/qwenpaw-desktop.pid" ]; then
-            kill "$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")" 2>/dev/null || true
-            sleep 2
-            kill -9 "$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")" 2>/dev/null || true
-          fi
+          pkill -f "QwenPaw Desktop" 2>/dev/null || true
+          pkill -f "qwenpaw-backend" 2>/dev/null || true
+          sleep 2
+          pkill -9 -f "QwenPaw Desktop" 2>/dev/null || true
+          pkill -9 -f "qwenpaw-backend" 2>/dev/null || true
 
   tauri-windows:
     if: >-
@@ -403,44 +376,25 @@ jobs:
           QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
           PYTHONIOENCODING: utf-8
         run: |
-          $ErrorActionPreference = "Stop"
-          $sidecar = "console\src-tauri\binaries\qwenpaw-backend\qwenpaw-backend.exe"
-          if (-not (Test-Path $sidecar)) { throw "Sidecar not found" }
-          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
-          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
-          $proc = Start-Process -PassThru -NoNewWindow -FilePath $sidecar `
-            -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
-          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
-          $port = $null
-          $deadline = (Get-Date).AddSeconds(120)
-          while ((Get-Date) -lt $deadline) {
-            $match = Select-String -Path $stdoutLog -Pattern 'Address: http://127\.0\.0\.1:(\d+)' -ErrorAction SilentlyContinue |
-              Select-Object -First 1
-            if ($match) { $port = $match.Matches[0].Groups[1].Value; Write-Host "Sidecar port $port"; break }
-            Start-Sleep -Seconds 2
-          }
-          if (-not $port) { Write-Host "::error::No port advertised"; exit 1 }
-          $baseUrl = "http://127.0.0.1:$port"
-          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
-          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
-          $ready = $false
-          for ($i = 1; $i -le 60; $i++) {
-            try {
-              $r = Invoke-WebRequest -Uri "$baseUrl/api/version" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
-              if ($r.StatusCode -eq 200) { Write-Host "Server up"; $ready = $true; break }
-            } catch { Start-Sleep -Seconds 2 }
-          }
-          if (-not $ready) { Write-Host "::error::Server timeout"; exit 1 }
-          python scripts/verify/desktop_verify.py --base-url $baseUrl --ui-mode tauri-windows
+          . scripts/verify/launch_tauri_windows.ps1
+          python scripts/verify/desktop_verify.py `
+            --base-url $env:BASE_URL `
+            --ui-mode tauri-windows `
+            --headed
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server
         if: always()
         shell: pwsh
         run: |
-          $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
-          if (Test-Path $pidFile) {
-            $pid = (Get-Content $pidFile | Select-Object -First 1).Trim()
-            if ($pid) { taskkill /F /T /PID $pid 2>$null | Out-Null }
-          }
+          $ErrorActionPreference = "Continue"
+          Get-Process -Name "qwenpaw-desktop" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name "qwenpaw-backend" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 2
+          Get-Process -Name "qwenpaw-desktop" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name "qwenpaw-backend" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
           exit 0

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -1,0 +1,446 @@
+# One-click desktop release verification for fork repositories.
+# Builds each desktop flavour and runs the end-to-end UI verification
+# (Playwright + headless browser) against the freshly built product.
+#
+# Unlike desktop-release.yml this workflow does NOT upload artifacts to
+# a GitHub Release or OSS — it only verifies that the build + LLM chain
+# works. Use it to validate packaging changes before opening a PR.
+#
+# Usage: Actions → Fork Desktop Release Verification → Run workflow.
+
+name: Fork Desktop Release Verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: 'Which platforms to verify'
+        required: false
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - 'legacy-only'
+          - 'tauri-only'
+          - 'macos-only'
+          - 'windows-only'
+
+permissions:
+  contents: read
+
+jobs:
+  legacy-macos:
+    if: >-
+      inputs.platforms == 'all' ||
+      inputs.platforms == 'legacy-only' ||
+      inputs.platforms == 'macos-only'
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: "3.10"
+          activate-environment: "qwenpaw-build"
+          condarc-file: .github/condarc
+          conda-remove-defaults: false
+
+      - name: Build macOS .app
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+        run: |
+          chmod +x scripts/pack/build_macos.sh
+          conda run -n qwenpaw-build bash -c 'CREATE_ZIP=1 ./scripts/pack/build_macos.sh'
+
+      - name: Set up runner Python for verification
+        id: runner-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install verify deps (Playwright + Chromium)
+        env:
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+        run: |
+          set -euo pipefail
+          "$RUNNER_PYTHON" -m pip install --upgrade pip
+          "$RUNNER_PYTHON" -m pip install \
+            -r scripts/verify/requirements-verify.txt
+          "$RUNNER_PYTHON" -m playwright install chromium --with-deps
+
+      - name: Verify desktop (Legacy macOS)
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/verify-legacy
+          unzip -q dist/QwenPaw-*-macOS.zip -d dist/verify-legacy
+          APP="$(find dist/verify-legacy -maxdepth 2 -name '*.app' -type d | head -1)"
+          if [ -z "$APP" ]; then echo "::error::QwenPaw.app not found"; exit 1; fi
+          ENV_DIR="$APP/Contents/Resources/env"
+          PYTHON="$ENV_DIR/bin/python"
+          (cd "$ENV_DIR" && ./bin/conda-unpack 2>/dev/null || true)
+          export PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1
+          export PATH="$ENV_DIR/bin:$PATH"
+          CERT_FILE="$("$PYTHON" -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
+          if [ -n "${CERT_FILE:-}" ] && [ -f "$CERT_FILE" ]; then
+            export SSL_CERT_FILE="$CERT_FILE" REQUESTS_CA_BUNDLE="$CERT_FILE"
+          fi
+          "$PYTHON" -m qwenpaw init --defaults --accept-security
+          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
+          nohup "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
+            > "$RUNNER_TEMP/qwenpaw-desktop-stdout.log" \
+            2> "$RUNNER_TEMP/qwenpaw-desktop-stderr.log" &
+          echo $! > "$RUNNER_TEMP/qwenpaw-desktop.pid"
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8088/api/version >/dev/null; then
+              echo "Server up after ~$((i*2))s"; break
+            fi
+            if [ "$i" = "60" ]; then echo "::error::Server timeout"; exit 1; fi
+            sleep 2
+          done
+          "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
+            --base-url http://127.0.0.1:8088 --ui-mode legacy
+
+      - name: Stop desktop server
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/qwenpaw-desktop.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")" 2>/dev/null || true
+          fi
+          lsof -ti:8088 | xargs kill 2>/dev/null || true
+
+  legacy-windows:
+    if: >-
+      inputs.platforms == 'all' ||
+      inputs.platforms == 'legacy-only' ||
+      inputs.platforms == 'windows-only'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        shell: pwsh
+        run: |
+          $content = Get-Content src/qwenpaw/__version__.py -Raw
+          if ($content -match '__version__\s*=\s*"([^"]+)"') {
+            $v = $Matches[1]
+          } else { throw "Failed to extract version" }
+          "version<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $v | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: "3.10"
+          activate-environment: "qwenpaw-build"
+          condarc-file: .github/condarc
+          conda-remove-defaults: false
+
+      - name: Install NSIS
+        uses: negrutiu/nsis-install@v2
+
+      - name: Build Windows installer
+        shell: pwsh
+        run: conda run -n qwenpaw-build pwsh -File ./scripts/pack/build_win.ps1
+
+      - name: Set up runner Python for verification
+        id: runner-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install verify deps (Playwright + Chromium)
+        shell: pwsh
+        env:
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          & $env:RUNNER_PYTHON -m pip install --upgrade pip
+          & $env:RUNNER_PYTHON -m pip install -r scripts/verify/requirements-verify.txt
+          & $env:RUNNER_PYTHON -m playwright install chromium --with-deps
+
+      - name: Verify desktop (Legacy Windows)
+        shell: pwsh
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
+          PYTHONIOENCODING: utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installer = Get-ChildItem dist/QwenPaw-Setup-*.exe | Select-Object -First 1
+          if (-not $installer) { throw "No installer found" }
+          $installDir = Join-Path $env:RUNNER_TEMP "QwenPaw-Verify"
+          if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
+          Start-Process -FilePath $installer.FullName -ArgumentList "/S /D=$installDir" -Wait
+          $bundledPython = Join-Path $installDir "python.exe"
+          $deadline = (Get-Date).AddSeconds(120)
+          while (-not (Test-Path $bundledPython)) {
+            if ((Get-Date) -gt $deadline) { throw "python.exe not found after 120s" }
+            Start-Sleep -Seconds 2
+          }
+          $env:PYTHONNOUSERSITE = "1"
+          & $bundledPython -m qwenpaw init --defaults --accept-security
+          if ($LASTEXITCODE -ne 0) { throw "init failed" }
+          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
+          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
+          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
+          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
+          $proc = Start-Process -PassThru -NoNewWindow -FilePath $bundledPython `
+            -ArgumentList "-m","qwenpaw","app","--host","127.0.0.1","--port","8088" `
+            -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
+          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
+          $ready = $false
+          for ($i = 1; $i -le 60; $i++) {
+            try {
+              $r = Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+              if ($r.StatusCode -eq 200) { Write-Host "Server up"; $ready = $true; break }
+            } catch { Start-Sleep -Seconds 2 }
+          }
+          if (-not $ready) { Write-Host "::error::Server timeout"; exit 1 }
+          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py --base-url http://127.0.0.1:8088 --ui-mode legacy
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stop desktop server
+        if: always()
+        shell: pwsh
+        run: |
+          $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
+          if (Test-Path $pidFile) {
+            $pid = (Get-Content $pidFile | Select-Object -First 1).Trim()
+            if ($pid) { taskkill /F /PID $pid 2>$null | Out-Null }
+          }
+          exit 0
+
+  tauri-macos:
+    if: >-
+      inputs.platforms == 'all' ||
+      inputs.platforms == 'tauri-only' ||
+      inputs.platforms == 'macos-only'
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Tauri macOS package
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+        run: |
+          chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
+          bash scripts/pack-tauri/build_macos_pyinstaller.sh
+
+      - name: Install verify deps (Playwright + WebKit)
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r scripts/verify/requirements-verify.txt
+          python -m playwright install webkit --with-deps
+
+      - name: Verify desktop (Tauri macOS)
+        timeout-minutes: 10
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/verify-tauri
+          unzip -q dist/QwenPaw-Tauri-*-macOS.zip -d dist/verify-tauri
+          APP="$(find dist/verify-tauri -maxdepth 3 -name '*.app' -type d | head -1)"
+          if [ -z "$APP" ]; then echo "::error::Tauri .app not found"; exit 1; fi
+          xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
+          SIDECAR="$APP/Contents/Resources/binaries/qwenpaw-backend/qwenpaw-backend"
+          if [ ! -f "$SIDECAR" ]; then echo "::error::Sidecar not found"; exit 1; fi
+          chmod +x "$SIDECAR"
+          STDOUT_LOG="$RUNNER_TEMP/qwenpaw-desktop-stdout.log"
+          STDERR_LOG="$RUNNER_TEMP/qwenpaw-desktop-stderr.log"
+          : > "$STDOUT_LOG"; : > "$STDERR_LOG"
+          nohup "$SIDECAR" >"$STDOUT_LOG" 2>"$STDERR_LOG" </dev/null &
+          SIDECAR_PID=$!; disown "$SIDECAR_PID" 2>/dev/null || true
+          echo "$SIDECAR_PID" > "$RUNNER_TEMP/qwenpaw-desktop.pid"
+          PORT=""
+          for i in $(seq 1 60); do
+            PORT="$(grep -oE 'Address: http://127\.0\.0\.1:[0-9]+' "$STDOUT_LOG" 2>/dev/null | head -1 | grep -oE '[0-9]+$' || true)"
+            if [ -n "$PORT" ]; then echo "Sidecar port $PORT"; break; fi
+            sleep 2
+          done
+          if [ -z "$PORT" ]; then echo "::error::No port advertised"; exit 1; fi
+          BASE_URL="http://127.0.0.1:$PORT"
+          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
+          for i in $(seq 1 60); do
+            if curl -sf "$BASE_URL/api/version" >/dev/null; then echo "Server up"; break; fi
+            if [ "$i" = "60" ]; then echo "::error::Server timeout"; exit 1; fi
+            sleep 2
+          done
+          python scripts/verify/desktop_verify.py --base-url "$BASE_URL" --ui-mode tauri-macos
+
+      - name: Stop desktop server
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/qwenpaw-desktop.pid" ]; then
+            kill "$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")" 2>/dev/null || true
+            sleep 2
+            kill -9 "$(cat "$RUNNER_TEMP/qwenpaw-desktop.pid")" 2>/dev/null || true
+          fi
+
+  tauri-windows:
+    if: >-
+      inputs.platforms == 'all' ||
+      inputs.platforms == 'tauri-only' ||
+      inputs.platforms == 'windows-only'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        shell: pwsh
+        run: |
+          $content = Get-Content src/qwenpaw/__version__.py -Raw
+          if ($content -match '__version__\s*=\s*"([^"]+)"') {
+            $v = $Matches[1]
+          } else { throw "Failed to extract version" }
+          "version<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $v | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install NSIS
+        uses: negrutiu/nsis-install@v2
+
+      - name: Build Tauri Windows package
+        shell: pwsh
+        run: ./scripts/pack-tauri/build_win_pyinstaller.ps1
+
+      - name: Install verify deps (Playwright + Chromium)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          python -m pip install --upgrade pip
+          python -m pip install -r scripts/verify/requirements-verify.txt
+          python -m playwright install chromium --with-deps
+
+      - name: Verify desktop (Tauri Windows)
+        timeout-minutes: 10
+        shell: pwsh
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          PYTHONIOENCODING: utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+          $sidecar = "console\src-tauri\binaries\qwenpaw-backend\qwenpaw-backend.exe"
+          if (-not (Test-Path $sidecar)) { throw "Sidecar not found" }
+          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
+          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
+          $proc = Start-Process -PassThru -NoNewWindow -FilePath $sidecar `
+            -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
+          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
+          $port = $null
+          $deadline = (Get-Date).AddSeconds(120)
+          while ((Get-Date) -lt $deadline) {
+            $match = Select-String -Path $stdoutLog -Pattern 'Address: http://127\.0\.0\.1:(\d+)' -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+            if ($match) { $port = $match.Matches[0].Groups[1].Value; Write-Host "Sidecar port $port"; break }
+            Start-Sleep -Seconds 2
+          }
+          if (-not $port) { Write-Host "::error::No port advertised"; exit 1 }
+          $baseUrl = "http://127.0.0.1:$port"
+          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
+          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
+          $ready = $false
+          for ($i = 1; $i -le 60; $i++) {
+            try {
+              $r = Invoke-WebRequest -Uri "$baseUrl/api/version" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+              if ($r.StatusCode -eq 200) { Write-Host "Server up"; $ready = $true; break }
+            } catch { Start-Sleep -Seconds 2 }
+          }
+          if (-not $ready) { Write-Host "::error::Server timeout"; exit 1 }
+          python scripts/verify/desktop_verify.py --base-url $baseUrl --ui-mode tauri-windows
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stop desktop server
+        if: always()
+        shell: pwsh
+        run: |
+          $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
+          if (Test-Path $pidFile) {
+            $pid = (Get-Content $pidFile | Select-Object -First 1).Trim()
+            if ($pid) { taskkill /F /T /PID $pid 2>$null | Out-Null }
+          }
+          exit 0

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -118,7 +118,7 @@ jobs:
             sleep 2
           done
           "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
-            --base-url http://127.0.0.1:8088 --ui-mode legacy --headed
+            --base-url http://127.0.0.1:8088 --ui-mode legacy --headed --allow-flaky-llm
 
       - name: Stop desktop server
         if: always()
@@ -230,7 +230,7 @@ jobs:
             } catch { Start-Sleep -Seconds 2 }
           }
           if (-not $ready) { Write-Host "::error::Server timeout"; exit 1 }
-          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py --base-url http://127.0.0.1:8088 --ui-mode legacy --headed
+          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py --base-url http://127.0.0.1:8088 --ui-mode legacy --headed --allow-flaky-llm
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server
@@ -300,7 +300,7 @@ jobs:
         run: |
           set -euo pipefail
           source scripts/verify/launch_tauri_macos.sh
-          python scripts/verify/desktop_verify.py --base-url "$BASE_URL" --ui-mode tauri-macos --headed
+          python scripts/verify/desktop_verify.py --base-url "$BASE_URL" --ui-mode tauri-macos --headed --allow-flaky-llm
 
       - name: Stop desktop server
         if: always()
@@ -381,7 +381,8 @@ jobs:
             --base-url $env:BASE_URL `
             --ui-mode tauri-windows `
             --headed `
-            --cdp-url $env:CDP_URL
+            --cdp-url $env:CDP_URL `
+            --allow-flaky-llm
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stop desktop server

--- a/scripts/verify/__init__.py
+++ b/scripts/verify/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-"""Release verification helpers for desktop builds."""

--- a/scripts/verify/__init__.py
+++ b/scripts/verify/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Release verification helpers for desktop builds."""

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -250,6 +250,7 @@ class PlaywrightDriver(UIDriver):
         self,
         browser: str = "chromium",
         screenshot_dir: Optional[str] = None,
+        headless: bool = True,
     ) -> None:
         self._screenshot_dir = screenshot_dir
         if screenshot_dir:
@@ -270,7 +271,7 @@ class PlaywrightDriver(UIDriver):
                 raise UIDriverInitError(
                     f"playwright has no browser '{browser}'",
                 )
-            self._browser = launcher.launch(headless=True)
+            self._browser = launcher.launch(headless=headless)
             self._context = self._browser.new_context()
             self._page = self._context.new_page()
         except UIDriverInitError:
@@ -611,14 +612,15 @@ UI_MODES = ("legacy", "tauri-macos", "tauri-windows")
 def make_driver(
     ui_mode: str,
     screenshot_dir: Optional[str] = None,
+    headless: bool = True,
 ) -> UIDriver:
     """Build a concrete ``UIDriver`` for the requested mode."""
     if ui_mode == "legacy":
-        return PlaywrightDriver("chromium", screenshot_dir)
+        return PlaywrightDriver("chromium", screenshot_dir, headless)
     if ui_mode == "tauri-macos":
-        return PlaywrightDriver("webkit", screenshot_dir)
+        return PlaywrightDriver("webkit", screenshot_dir, headless)
     if ui_mode == "tauri-windows":
-        return PlaywrightDriver("chromium", screenshot_dir)
+        return PlaywrightDriver("chromium", screenshot_dir, headless)
     raise UIDriverInitError(f"unknown ui-mode: {ui_mode!r}")
 
 
@@ -742,6 +744,12 @@ def main() -> int:
         "env RUNNER_TEMP (set by GitHub Actions). Empty = no "
         "screenshots.",
     )
+    parser.add_argument(
+        "--headed",
+        action="store_true",
+        help="Run the browser in headed mode (visible window) "
+        "instead of headless. Requires a display server.",
+    )
     args = parser.parse_args()
 
     base_url = args.base_url.rstrip("/")
@@ -785,7 +793,11 @@ def main() -> int:
                     if args.screenshot_dir
                     else None
                 )
-                driver = make_driver(args.ui_mode, ss_dir)
+                driver = make_driver(
+                    args.ui_mode,
+                    ss_dir,
+                    headless=not args.headed,
+                )
             except UIDriverInitError as exc:
                 print(f"FAIL  UI driver init: {exc}", file=sys.stderr)
                 return 3

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -51,14 +51,12 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from typing import Optional
 
 DEFAULT_MODEL = "qwen3.6-plus"
 DEFAULT_PROVIDER = "dashscope"
 DEFAULT_TIMEOUT = 120
 SESSION_ID = "release-verify-session"
 USER_ID = "release-verify-user"
-TIGER_NAME = "Tiger"
 
 # Selectors come straight from e2e/pages/chat_page.py so they stay in sync
 # with what the real UI tests expect.
@@ -76,7 +74,7 @@ SEL_AI_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-start"
 def _http(
     method: str,
     url: str,
-    body: Optional[dict] = None,
+    body: dict | None = None,
     timeout: int = 30,
 ) -> str:
     """Issue an HTTP request and return the decoded body text.
@@ -188,9 +186,21 @@ def ensure_model(
         )
         print(f"PASS  registered model '{model}' on '{provider_id}'")
     except RuntimeError as exc:
-        # Already-registered or duplicate add -> downgrade to info log
-        # because set_active_model below will surface any real failure.
-        print(f"INFO  add-model returned: {exc}")
+        # 4xx (e.g. 409 already-registered) is expected and downgraded
+        # to info; 5xx and others are likely real failures and surface
+        # as warnings so they show up in CI logs.
+        msg = str(exc)
+        is_4xx = (
+            any(
+                f" {code} " in f" {msg} " or f"HTTP {code}" in msg
+                for code in (400, 401, 403, 404, 409, 422)
+            )
+            or "already" in msg.lower()
+        )
+        if is_4xx:
+            print(f"INFO  add-model: {exc}")
+        else:
+            print(f"WARN  add-model unexpected: {exc}", file=sys.stderr)
 
 
 def set_active_model(
@@ -250,7 +260,7 @@ class PlaywrightDriver(UIDriver):
     def __init__(
         self,
         browser: str = "chromium",
-        screenshot_dir: Optional[str] = None,
+        screenshot_dir: str | None = None,
         headless: bool = True,
         cdp_url: str = "",
     ) -> None:
@@ -271,12 +281,17 @@ class PlaywrightDriver(UIDriver):
             self._pw = sync_playwright().start()
             if cdp_url:
                 self._browser = self._pw.chromium.connect_over_cdp(cdp_url)
-                for _ in range(60):
+                for i in range(60):
                     if (
                         self._browser.contexts
                         and self._browser.contexts[0].pages
                     ):
                         break
+                    if i and i % 10 == 0:
+                        print(
+                            f"  CDP: waiting for page "
+                            f"({i * 0.5:.0f}s elapsed)...",
+                        )
                     time.sleep(0.5)
                 if (
                     not self._browser.contexts
@@ -427,6 +442,9 @@ class PlaywrightDriver(UIDriver):
         if (cache.text !== raw) {
           window[key] = { text: raw, since: now };
         } else if ((now - cache.since) >= 2500) {
+          // 2500ms is empirical — long enough to ride out SSE chunk
+          // gaps on a busy CI runner, short enough to avoid extending
+          // the verify step. Revisit if streaming cadence changes.
           contentStable = true;
         }
       }
@@ -452,39 +470,36 @@ class PlaywrightDriver(UIDriver):
         if self._page.locator(SEL_USER_BUBBLE).count() == 0:
             return
         try:
-            _idle_js = (
-                "() => {\n"
-                "  const btn = document.querySelector("
-                "'button.qwenpaw-sender-actions-btn"
-                ".qwenpaw-btn-primary'"
-                ");\n"
-                "  if (btn) {\n"
-                "    const cls = btn.className || '';\n"
-                "    const disabledByCls = "
-                "/qwenpaw-btn-disabled|qwenpaw-btn-loading"
-                "|is-disabled|is-loading/.test(cls);\n"
-                "    const disabledByAttr = btn.disabled === true\n"
-                "      || btn.hasAttribute('disabled')\n"
-                "      || btn.getAttribute('aria-disabled')"
-                " === 'true';\n"
-                "    if (!disabledByAttr && !disabledByCls) "
-                "return true;\n"
-                "  }\n"
-                "  const aiMsgs = document.querySelectorAll("
-                "'.qwenpaw-bubble.qwenpaw-bubble-start');\n"
-                "  if (aiMsgs.length === 0) return true;\n"
-                "  const last = aiMsgs[aiMsgs.length - 1];\n"
-                "  const raw = (last.innerText || '').trim();\n"
-                "  const key = '__qwenpaw_send_idle_cache__';\n"
-                "  const now = Date.now();\n"
-                "  const cache = window[key] || {};\n"
-                "  if (cache.text !== raw) {\n"
-                "    window[key] = { text: raw, since: now };\n"
-                "    return false;\n"
-                "  }\n"
-                "  return (now - cache.since) >= 1500;\n"
-                "}"
-            )
+            _idle_js = """() => {
+  const btn = document.querySelector(
+    'button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary',
+  );
+  if (btn) {
+    const cls = btn.className || '';
+    const disabledByCls =
+      /qwenpaw-btn-disabled|qwenpaw-btn-loading|is-disabled|is-loading/.test(cls);
+    const disabledByAttr = btn.disabled === true
+      || btn.hasAttribute('disabled')
+      || btn.getAttribute('aria-disabled') === 'true';
+    if (!disabledByAttr && !disabledByCls) return true;
+  }
+  const aiMsgs = document.querySelectorAll(
+    '.qwenpaw-bubble.qwenpaw-bubble-start',
+  );
+  if (aiMsgs.length === 0) return true;
+  const last = aiMsgs[aiMsgs.length - 1];
+  const raw = (last.innerText || '').trim();
+  const key = '__qwenpaw_send_idle_cache__';
+  const now = Date.now();
+  const cache = window[key] || {};
+  if (cache.text !== raw) {
+    window[key] = { text: raw, since: now };
+    return false;
+  }
+  // 1500ms is empirical — tuned against real CI runners. May need
+  // adjustment if SSE chunk cadence changes.
+  return (now - cache.since) >= 1500;
+}"""
             self._page.wait_for_function(_idle_js, timeout=8000)
         except Exception:  # noqa: BLE001
             pass
@@ -641,7 +656,7 @@ UI_MODES = ("legacy", "tauri-macos", "tauri-windows")
 
 def make_driver(
     ui_mode: str,
-    screenshot_dir: Optional[str] = None,
+    screenshot_dir: str | None = None,
     headless: bool = True,
     cdp_url: str = "",
 ) -> UIDriver:
@@ -730,7 +745,7 @@ def _run_llm_with_retry(
 ) -> int:
     """Run the LLM chat round with retries; return process exit code."""
     attempts = max(1, retries + 1)
-    last_err: Optional[BaseException] = None
+    last_err: BaseException | None = None
     for attempt in range(1, attempts + 1):
         try:
             verify_ui_chat(driver, timeout)
@@ -743,7 +758,9 @@ def _run_llm_with_retry(
                 file=sys.stderr,
             )
             if attempt < attempts:
-                time.sleep(5)
+                backoff = 5 * (2 ** (attempt - 1))
+                print(f"  retrying in {backoff}s...")
+                time.sleep(backoff)
     if allow_flaky:
         print(
             "::warning::LLM verification failed after "
@@ -842,9 +859,10 @@ def main() -> int:
     parser.add_argument(
         "--llm-retries",
         type=int,
-        default=2,
-        help="Retries for the single LLM round on transient "
-        "failures (DashScope 5xx / SSE jitter). Default: 2.",
+        default=3,
+        help="Retries for the LLM round on transient failures "
+        "(DashScope 5xx / SSE jitter). Uses exponential backoff "
+        "(5s, 10s, 20s, ...). Default: 3.",
     )
     parser.add_argument(
         "--allow-flaky-llm",
@@ -860,7 +878,7 @@ def main() -> int:
     skip_chat = args.skip_chat or not args.api_key
 
     started = time.monotonic()
-    driver: Optional[UIDriver] = None
+    driver: UIDriver | None = None
     try:
         # ---- API-level checks (always run, no key needed) ----
         health_check(base_url)

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -665,29 +665,40 @@ def make_driver(
 # =============================================================================
 
 
-def verify_ui_chat(
+def verify_ui_loaded(
     driver: UIDriver,
     base_url: str,
-    timeout: int,
     skip_navigate: bool = False,
 ) -> None:
-    """Drive the real SPA with one factual question to prove LLM works.
+    """Verify the SPA loads and the chat input becomes visible.
 
-    Uses a single-round factual question ("tallest mountain") rather
-    than multi-turn context retention. Reasons:
-
-    - One round eliminates multi-turn SPA timing races that plagued
-      earlier iterations (chat/stop cancellations, button-disabled
-      state-machine fights, etc.).
-    - A factual question with universally known answers (Everest /
-      珠穆朗玛峰 / 8848m / 8849m) gives a deterministic assertion
-      that any LLM will satisfy.
-    - Still proves the full UI path: SPA loaded -> textarea filled ->
-      send clicked -> backend received -> LLM invoked -> SSE streamed
-      -> AI bubble rendered with real content.
+    Runs without an API key — proves the desktop bundle's frontend
+    is wired up correctly. Catches broken Vite bundles, missing
+    asset paths, CSP misconfigurations, and Tauri webview load
+    failures even when LLM credentials are unavailable.
     """
-    # Any of these substrings in the reply proves the LLM answered
-    # correctly. Covers English, Chinese, altitude variants.
+    if skip_navigate:
+        print("--> CDP mode: waiting for SPA on existing page")
+        driver.wait_for_input()
+    else:
+        print(f"--> opening UI at {base_url}")
+        driver.open(base_url)
+    print("PASS  UI loaded, chat input visible")
+
+
+def verify_ui_chat(
+    driver: UIDriver,
+    timeout: int,
+) -> None:
+    """Drive the loaded SPA with one factual question to prove LLM works.
+
+    Assumes the SPA is already loaded by ``verify_ui_loaded``. Uses a
+    single-round factual question ("tallest mountain") to avoid
+    multi-turn SPA timing races. Any of Everest / 珠穆朗玛 / 8848 in
+    the reply proves the full path:
+    textarea filled -> send clicked -> backend received -> LLM
+    invoked -> SSE streamed -> AI bubble rendered with real content.
+    """
     expected_any = (
         "Everest",
         "everest",
@@ -696,14 +707,6 @@ def verify_ui_chat(
         "8848",
         "8849",
     )
-
-    if skip_navigate:
-        print("--> CDP mode: waiting for SPA on existing page")
-        driver.wait_for_input()
-    else:
-        print(f"--> opening UI at {base_url}")
-        driver.open(base_url)
-    print("PASS  UI loaded, chat input visible")
 
     question = "What is the tallest mountain in the world?"
     print(f"--> sending: {question!r}")
@@ -717,6 +720,43 @@ def verify_ui_chat(
             f"Got: {reply[:500]}",
         )
     print("PASS  LLM responded with correct factual answer")
+
+
+def _run_llm_with_retry(
+    driver: UIDriver,
+    timeout: int,
+    retries: int,
+    allow_flaky: bool,
+) -> int:
+    """Run the LLM chat round with retries; return process exit code."""
+    attempts = max(1, retries + 1)
+    last_err: Optional[BaseException] = None
+    for attempt in range(1, attempts + 1):
+        try:
+            verify_ui_chat(driver, timeout)
+            return 0
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            print(
+                f"WARN  LLM round attempt {attempt}/{attempts} "
+                f"failed: {exc}",
+                file=sys.stderr,
+            )
+            if attempt < attempts:
+                time.sleep(5)
+    if allow_flaky:
+        print(
+            "::warning::LLM verification failed after "
+            f"{attempts} attempts but --allow-flaky-llm is set; "
+            f"continuing. Last error: {last_err}",
+        )
+        return 0
+    print(
+        f"FAIL  LLM verification failed after {attempts} attempts: "
+        f"{last_err}",
+        file=sys.stderr,
+    )
+    return 1
 
 
 # =============================================================================
@@ -769,8 +809,9 @@ def main() -> int:
     parser.add_argument(
         "--skip-ui",
         action="store_true",
-        help="Skip only the UI driver portion (still configure provider "
-        "via API). Useful for environments without a browser.",
+        help="Skip the UI driver portion entirely (no SPA load "
+        "check, no chat round). API-level checks still run. "
+        "Useful for environments without a browser.",
     )
     parser.add_argument(
         "--timeout",
@@ -798,6 +839,21 @@ def main() -> int:
         "When set, connects to the existing WebView2 via CDP "
         "instead of launching a new Playwright browser.",
     )
+    parser.add_argument(
+        "--llm-retries",
+        type=int,
+        default=2,
+        help="Retries for the single LLM round on transient "
+        "failures (DashScope 5xx / SSE jitter). Default: 2.",
+    )
+    parser.add_argument(
+        "--allow-flaky-llm",
+        action="store_true",
+        help="If all LLM retries fail, emit a warning and exit 0 "
+        "instead of failing. Use for fork CI where a flaky LLM "
+        "should not block release. Release pipelines should NOT "
+        "set this — they need the assertion.",
+    )
     args = parser.parse_args()
 
     base_url = args.base_url.rstrip("/")
@@ -806,31 +862,15 @@ def main() -> int:
     started = time.monotonic()
     driver: Optional[UIDriver] = None
     try:
-        # ---- API-level checks (always run) ----
+        # ---- API-level checks (always run, no key needed) ----
         health_check(base_url)
         verify_frontend(base_url)
 
-        if skip_chat:
-            reason = (
-                "explicit --skip-chat"
-                if args.skip_chat
-                else "no DashScope API key provided"
-            )
-            print(f"SKIP  LLM verification ({reason})")
-            elapsed = time.monotonic() - started
-            print(
-                f"OK    desktop verification completed in {elapsed:.1f}s",
-            )
-            return 0
-
-        # ---- LLM provider setup via API ----
-        configure_provider(base_url, args.provider, args.api_key)
-        ensure_model(base_url, args.provider, args.model)
-        set_active_model(base_url, args.provider, args.model)
-
-        # ---- UI three-round conversation ----
+        # ---- UI load (always run unless --skip-ui, no key needed) ----
+        # This catches broken Vite bundles, missing assets, CSP issues,
+        # and Tauri webview load failures even without LLM credentials.
         if args.skip_ui:
-            print("SKIP  UI chat verification (--skip-ui)")
+            print("SKIP  UI verification (--skip-ui)")
         else:
             try:
                 ss_dir = (
@@ -850,12 +890,35 @@ def main() -> int:
             except UIDriverInitError as exc:
                 print(f"FAIL  UI driver init: {exc}", file=sys.stderr)
                 return 3
-            verify_ui_chat(
+            verify_ui_loaded(
                 driver,
                 base_url,
-                args.timeout,
                 skip_navigate=bool(args.cdp_url),
             )
+
+        # ---- LLM chat round (only when key is available) ----
+        if skip_chat:
+            reason = (
+                "explicit --skip-chat"
+                if args.skip_chat
+                else "no DashScope API key provided"
+            )
+            print(f"SKIP  LLM verification ({reason})")
+        elif driver is None:
+            # --skip-ui was set; nothing to drive.
+            print("SKIP  LLM verification (--skip-ui)")
+        else:
+            configure_provider(base_url, args.provider, args.api_key)
+            ensure_model(base_url, args.provider, args.model)
+            set_active_model(base_url, args.provider, args.model)
+            rc = _run_llm_with_retry(
+                driver,
+                args.timeout,
+                args.llm_retries,
+                args.allow_flaky_llm,
+            )
+            if rc != 0:
+                return rc
     except RuntimeError as exc:
         print(f"FAIL  {exc}", file=sys.stderr)
         return 1

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -40,6 +40,7 @@ Exit codes:
     2  argument / configuration error
     3  UI driver could not be initialised (missing browser / driver)
 """
+
 from __future__ import annotations
 
 import abc
@@ -251,6 +252,7 @@ class PlaywrightDriver(UIDriver):
         browser: str = "chromium",
         screenshot_dir: Optional[str] = None,
         headless: bool = True,
+        cdp_url: str = "",
     ) -> None:
         self._screenshot_dir = screenshot_dir
         if screenshot_dir:
@@ -261,19 +263,39 @@ class PlaywrightDriver(UIDriver):
         except ImportError as exc:
             raise UIDriverInitError(
                 "playwright is not installed; "
-                "run 'pip install -r scripts/verify/requirements-verify.txt'",
+                "run 'pip install -r scripts/verify/"
+                "requirements-verify.txt'",
             ) from exc
 
         try:
             self._pw = sync_playwright().start()
-            launcher = getattr(self._pw, browser, None)
-            if launcher is None:
-                raise UIDriverInitError(
-                    f"playwright has no browser '{browser}'",
-                )
-            self._browser = launcher.launch(headless=headless)
-            self._context = self._browser.new_context()
-            self._page = self._context.new_page()
+            if cdp_url:
+                self._browser = self._pw.chromium.connect_over_cdp(cdp_url)
+                for _ in range(60):
+                    if (
+                        self._browser.contexts
+                        and self._browser.contexts[0].pages
+                    ):
+                        break
+                    time.sleep(0.5)
+                if (
+                    not self._browser.contexts
+                    or not self._browser.contexts[0].pages
+                ):
+                    raise UIDriverInitError(
+                        "CDP connected but no page appeared within 30s",
+                    )
+                self._context = self._browser.contexts[0]
+                self._page = self._context.pages[0]
+            else:
+                launcher = getattr(self._pw, browser, None)
+                if launcher is None:
+                    raise UIDriverInitError(
+                        f"playwright has no browser '{browser}'",
+                    )
+                self._browser = launcher.launch(headless=headless)
+                self._context = self._browser.new_context()
+                self._page = self._context.new_page()
         except UIDriverInitError:
             raise
         except Exception as exc:  # noqa: BLE001
@@ -294,6 +316,14 @@ class PlaywrightDriver(UIDriver):
 
     def open(self, url: str) -> None:
         self._page.goto(url, timeout=self.NAVIGATE_TIMEOUT_MS)
+        self._page.locator(SEL_INPUT).first.wait_for(
+            state="visible",
+            timeout=self.INPUT_VISIBLE_TIMEOUT_MS,
+        )
+        self._screenshot("01-page-loaded")
+
+    def wait_for_input(self) -> None:
+        """Wait for chat input on the current page (no navigation)."""
         self._page.locator(SEL_INPUT).first.wait_for(
             state="visible",
             timeout=self.INPUT_VISIBLE_TIMEOUT_MS,
@@ -613,6 +643,7 @@ def make_driver(
     ui_mode: str,
     screenshot_dir: Optional[str] = None,
     headless: bool = True,
+    cdp_url: str = "",
 ) -> UIDriver:
     """Build a concrete ``UIDriver`` for the requested mode."""
     if ui_mode == "legacy":
@@ -620,7 +651,12 @@ def make_driver(
     if ui_mode == "tauri-macos":
         return PlaywrightDriver("webkit", screenshot_dir, headless)
     if ui_mode == "tauri-windows":
-        return PlaywrightDriver("chromium", screenshot_dir, headless)
+        return PlaywrightDriver(
+            "chromium",
+            screenshot_dir,
+            headless,
+            cdp_url,
+        )
     raise UIDriverInitError(f"unknown ui-mode: {ui_mode!r}")
 
 
@@ -633,6 +669,7 @@ def verify_ui_chat(
     driver: UIDriver,
     base_url: str,
     timeout: int,
+    skip_navigate: bool = False,
 ) -> None:
     """Drive the real SPA with one factual question to prove LLM works.
 
@@ -660,8 +697,12 @@ def verify_ui_chat(
         "8849",
     )
 
-    print(f"--> opening UI at {base_url}")
-    driver.open(base_url)
+    if skip_navigate:
+        print("--> CDP mode: waiting for SPA on existing page")
+        driver.wait_for_input()
+    else:
+        print(f"--> opening UI at {base_url}")
+        driver.open(base_url)
     print("PASS  UI loaded, chat input visible")
 
     question = "What is the tallest mountain in the world?"
@@ -750,6 +791,13 @@ def main() -> int:
         help="Run the browser in headed mode (visible window) "
         "instead of headless. Requires a display server.",
     )
+    parser.add_argument(
+        "--cdp-url",
+        default="",
+        help="CDP endpoint URL (e.g. http://127.0.0.1:9222). "
+        "When set, connects to the existing WebView2 via CDP "
+        "instead of launching a new Playwright browser.",
+    )
     args = parser.parse_args()
 
     base_url = args.base_url.rstrip("/")
@@ -797,11 +845,17 @@ def main() -> int:
                     args.ui_mode,
                     ss_dir,
                     headless=not args.headed,
+                    cdp_url=args.cdp_url,
                 )
             except UIDriverInitError as exc:
                 print(f"FAIL  UI driver init: {exc}", file=sys.stderr)
                 return 3
-            verify_ui_chat(driver, base_url, args.timeout)
+            verify_ui_chat(
+                driver,
+                base_url,
+                args.timeout,
+                skip_navigate=bool(args.cdp_url),
+            )
     except RuntimeError as exc:
         print(f"FAIL  {exc}", file=sys.stderr)
         return 1

--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -1,0 +1,806 @@
+# -*- coding: utf-8 -*-
+"""Desktop release verification script.
+
+Drives a running QwenPaw desktop backend (any of the four packaging flavours:
+legacy-win / legacy-mac / tauri-win / tauri-mac) end-to-end:
+
+1. ``GET /api/version`` — health + version match.
+2. ``GET /``           — frontend HTML served.
+3. ``PUT /api/models/<provider>/config``            — install API key.
+4. ``POST /api/models/<provider>/models``           — register the chat model
+                                                       (newer aliases like
+                                                       qwen3.6-plus aren't in
+                                                       the built-in catalogue).
+5. ``PUT /api/models/active``                       — mark it active globally.
+6. **UI single-round factual Q&A**                  — drive the real SPA:
+   - Open the page and wait for the chat input to render.
+   - Send "What is the tallest mountain in the world?" via the
+     input box.
+   - Assert the AI bubble mentions "Everest".
+
+   This proves the full path: install package -> launch -> render UI ->
+   send message via input box -> receive bubble back with correct answer.
+
+UI flavours:
+- ``--ui-mode legacy``         Playwright + headless Chromium, points at
+                               ``http://127.0.0.1:<port>/`` (Legacy Win/Mac).
+- ``--ui-mode tauri-macos``    Playwright + headless WebKit (same engine as
+                               the Tauri webview on macOS).
+- ``--ui-mode tauri-windows``  Playwright + headless Chromium (same engine
+                               family as Tauri's WebView2 on Windows).
+
+Designed to be invoked by ``.github/workflows/desktop-release.yml`` after the
+desktop server has been booted on ``--base-url``. The API layer uses only
+the Python standard library; UI drivers lazy-import Playwright so callers
+without it installed can still use ``--skip-ui``.
+
+Exit codes:
+    0  all assertions pass
+    1  assertion / HTTP / UI failure
+    2  argument / configuration error
+    3  UI driver could not be initialised (missing browser / driver)
+"""
+from __future__ import annotations
+
+import abc
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Optional
+
+DEFAULT_MODEL = "qwen3.6-plus"
+DEFAULT_PROVIDER = "dashscope"
+DEFAULT_TIMEOUT = 120
+SESSION_ID = "release-verify-session"
+USER_ID = "release-verify-user"
+TIGER_NAME = "Tiger"
+
+# Selectors come straight from e2e/pages/chat_page.py so they stay in sync
+# with what the real UI tests expect.
+SEL_INPUT = "textarea.qwenpaw-sender-input"
+SEL_SEND_BTN = "button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary"
+SEL_USER_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-end"
+SEL_AI_BUBBLE = ".qwenpaw-bubble.qwenpaw-bubble-start"
+
+
+# =============================================================================
+# HTTP helper
+# =============================================================================
+
+
+def _http(
+    method: str,
+    url: str,
+    body: Optional[dict] = None,
+    timeout: int = 30,
+) -> str:
+    """Issue an HTTP request and return the decoded body text.
+
+    Raises ``RuntimeError`` with a readable message on any failure so callers
+    can surface it directly via ``::error::`` annotations.
+    """
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            pass
+        raise RuntimeError(
+            f"HTTP {exc.code} {method} {url}: {detail[:300]}",
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Network error {method} {url}: {exc.reason}",
+        ) from exc
+
+
+# =============================================================================
+# API-level verification
+# =============================================================================
+
+
+def health_check(base_url: str) -> str:
+    """Verify ``/api/version`` and return the reported version string."""
+    body = _http("GET", f"{base_url}/api/version")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"/api/version returned non-JSON: {body[:200]}",
+        ) from exc
+    version = payload.get("version") or ""
+    if not version:
+        raise RuntimeError(
+            f"/api/version missing 'version' field: {body[:200]}",
+        )
+    print(f"PASS  /api/version -> {version}")
+    return version
+
+
+def verify_frontend(base_url: str) -> None:
+    """Verify the bundled console frontend is served at ``/``."""
+    body = _http("GET", f"{base_url}/")
+    lower = body.lower()
+    if "<html" not in lower:
+        raise RuntimeError(
+            f"Frontend root did not return HTML (first 200 chars): "
+            f"{body[:200]}",
+        )
+    if "qwenpaw" not in lower:
+        raise RuntimeError(
+            "Frontend HTML does not mention QwenPaw — wrong bundle?",
+        )
+    print("PASS  GET / -> frontend HTML served")
+
+
+def configure_provider(
+    base_url: str,
+    provider_id: str,
+    api_key: str,
+) -> None:
+    """Write the DashScope API key into ProviderManager."""
+    _http(
+        "PUT",
+        f"{base_url}/api/models/{provider_id}/config",
+        body={"api_key": api_key},
+    )
+    print(f"PASS  configured provider '{provider_id}'")
+
+
+def ensure_model(
+    base_url: str,
+    provider_id: str,
+    model: str,
+) -> None:
+    """Register ``model`` on ``provider_id`` if it isn't already known.
+
+    DashScope ships only a few model ids in the built-in catalogue
+    (``qwen3-max`` / ``deepseek-v3.2`` / ...), so verifying against newer
+    aliases like ``qwen3.6-plus`` requires an explicit add first. The
+    endpoint returns 201 on first add; later runs may 4xx because the model
+    already exists — both outcomes are fine for our purposes.
+    """
+    try:
+        _http(
+            "POST",
+            f"{base_url}/api/models/{provider_id}/models",
+            body={"id": model, "name": model},
+        )
+        print(f"PASS  registered model '{model}' on '{provider_id}'")
+    except RuntimeError as exc:
+        # Already-registered or duplicate add -> downgrade to info log
+        # because set_active_model below will surface any real failure.
+        print(f"INFO  add-model returned: {exc}")
+
+
+def set_active_model(
+    base_url: str,
+    provider_id: str,
+    model: str,
+) -> None:
+    """Mark ``provider_id/model`` as the global active LLM."""
+    _http(
+        "PUT",
+        f"{base_url}/api/models/active",
+        body={
+            "provider_id": provider_id,
+            "model": model,
+            "scope": "global",
+        },
+    )
+    print(f"PASS  active model -> {provider_id}/{model}")
+
+
+# =============================================================================
+# UI driver abstraction
+# =============================================================================
+
+
+class UIDriverInitError(RuntimeError):
+    """Raised when a UI driver cannot start (missing browser / driver)."""
+
+
+class UIDriver(abc.ABC):
+    """High-level interface implemented by each platform-specific driver."""
+
+    @abc.abstractmethod
+    def open(self, url: str) -> None:
+        """Navigate to ``url`` and wait until the chat input is visible."""
+
+    @abc.abstractmethod
+    def chat_one_round(self, message: str, timeout: int) -> str:
+        """Send ``message`` and return the resulting AI bubble's full text."""
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Tear down browser / webdriver resources (best effort)."""
+
+
+class PlaywrightDriver(UIDriver):
+    """Headless browser driver backed by Playwright.
+
+    Supports both Chromium (for Legacy desktop) and WebKit (for Tauri
+    macOS — same engine as the Tauri webview). The ``browser`` arg
+    selects which backend to launch.
+    """
+
+    INPUT_VISIBLE_TIMEOUT_MS = 60_000
+    NAVIGATE_TIMEOUT_MS = 60_000
+
+    def __init__(
+        self,
+        browser: str = "chromium",
+        screenshot_dir: Optional[str] = None,
+    ) -> None:
+        self._screenshot_dir = screenshot_dir
+        if screenshot_dir:
+            os.makedirs(screenshot_dir, exist_ok=True)
+
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise UIDriverInitError(
+                "playwright is not installed; "
+                "run 'pip install -r scripts/verify/requirements-verify.txt'",
+            ) from exc
+
+        try:
+            self._pw = sync_playwright().start()
+            launcher = getattr(self._pw, browser, None)
+            if launcher is None:
+                raise UIDriverInitError(
+                    f"playwright has no browser '{browser}'",
+                )
+            self._browser = launcher.launch(headless=True)
+            self._context = self._browser.new_context()
+            self._page = self._context.new_page()
+        except UIDriverInitError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            raise UIDriverInitError(
+                f"failed to start {browser}: {exc}",
+            ) from exc
+
+    def _screenshot(self, name: str) -> None:
+        """Best-effort screenshot. Never raises."""
+        if not self._screenshot_dir:
+            return
+        try:
+            path = os.path.join(self._screenshot_dir, f"{name}.png")
+            self._page.screenshot(path=path, full_page=True)
+            print(f"  [screenshot] {path}")
+        except Exception:  # noqa: BLE001
+            pass
+
+    def open(self, url: str) -> None:
+        self._page.goto(url, timeout=self.NAVIGATE_TIMEOUT_MS)
+        self._page.locator(SEL_INPUT).first.wait_for(
+            state="visible",
+            timeout=self.INPUT_VISIBLE_TIMEOUT_MS,
+        )
+        self._screenshot("01-page-loaded")
+
+    # Same 4-channel disabled detection as e2e/pages/chat_page.py:
+    #   1. button.disabled property
+    #   2. disabled attribute
+    #   3. aria-disabled="true"
+    #   4. framework-injected disabled / loading class
+    _JS_SEND_DISABLED = """() => {
+      const btn = document.querySelector(
+        'button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary'
+      );
+      if (!btn) return true;
+      if (btn.disabled === true) return true;
+      if (btn.hasAttribute('disabled')) return true;
+      if (btn.getAttribute('aria-disabled') === 'true') return true;
+      const cls = btn.className || '';
+      if (/qwenpaw-btn-disabled|qwenpaw-btn-loading|is-disabled|is-loading/.test(cls)) {
+        return true;
+      }
+      return false;
+    }"""
+
+    def _wait_for_send_enabled(self, timeout: int) -> None:
+        """Block until the send button is clickable (or timeout).
+
+        The chat UI throttles the button while a previous round is still
+        streaming. Trying to fill+click during that window produces a
+        no-op and leaves the verifier waiting on a bubble that never
+        comes.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            disabled = self._page.evaluate(self._JS_SEND_DISABLED)
+            if not disabled:
+                return
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"Send button never became enabled within {timeout}s",
+        )
+
+    # End-of-streaming detection JS shared with e2e/pages/chat_page.py.
+    # Two paths, whichever fires first releases the wait:
+    #   Path A: send button went through a disabled -> enabled transition
+    #           (we must have seen disabled at least once during this
+    #           round, then seen it come back to enabled) AND the last
+    #           AI bubble has at least 2 real characters after stripping
+    #           "Thinking" / "Loading" placeholders.
+    #   Path B: last AI bubble content has been unchanged for >= 2500ms
+    #           and has at least 2 real characters (fallback for the
+    #           known "button stays forever disabled" bug). With
+    #           bootstrap pre-skipped (see verify_ui_chat docstring),
+    #           rounds are short single-step replies; 2.5s is plenty.
+    _JS_BUBBLE_READY = """(expectedCount) => {
+      const btn = document.querySelector(
+        'button.qwenpaw-sender-actions-btn.qwenpaw-btn-primary'
+      );
+      let btnDisabled = true;
+      if (btn) {
+        const cls = btn.className || '';
+        const disabledByCls = /qwenpaw-btn-disabled|qwenpaw-btn-loading|is-disabled|is-loading/.test(cls);
+        const disabledByAttr = btn.disabled === true
+          || btn.hasAttribute('disabled')
+          || btn.getAttribute('aria-disabled') === 'true';
+        btnDisabled = disabledByAttr || disabledByCls;
+      }
+
+      // Track whether we have ever seen the button in the disabled
+      // state during this round. Path A only fires after a full
+      // disabled -> enabled transition, not when the button simply
+      // hasn't been disabled yet (which looks the same as "enabled").
+      const stateKey = '__qwenpaw_btn_was_disabled__';
+      if (btnDisabled) {
+        window[stateKey] = true;
+      }
+      const sawDisabled = !!window[stateKey];
+      const btnRecovered = sawDisabled && !btnDisabled;
+
+      const aiMsgs = document.querySelectorAll(
+        '.qwenpaw-bubble.qwenpaw-bubble-start'
+      );
+      if (aiMsgs.length <= expectedCount) {
+        return false;
+      }
+      const last = aiMsgs[aiMsgs.length - 1];
+      const raw = (last.innerText || '').trim();
+      const stripped = raw
+        .replace(/Thinking/gi, '')
+        .replace(/Loading/gi, '')
+        .trim();
+      const hasRealText = stripped.length >= 2;
+
+      let contentStable = false;
+      if (hasRealText) {
+        const key = '__qwenpaw_ai_stable_cache__';
+        const now = Date.now();
+        const cache = window[key] || {};
+        if (cache.text !== raw) {
+          window[key] = { text: raw, since: now };
+        } else if ((now - cache.since) >= 2500) {
+          contentStable = true;
+        }
+      }
+
+      if (btnRecovered && hasRealText) {
+        return true;
+      }
+      if (contentStable) {
+        return true;
+      }
+      return false;
+    }"""
+
+    def _wait_previous_round_idle(self) -> None:
+        """Wait for any prior round's streaming to finish.
+
+        Runs the same dual-path JS as
+        ``e2e/pages/chat_page.py::send_message``: button recovered to
+        enabled **or** last AI bubble content stable for 1500ms.  Uses
+        a separate cache key so it doesn't clobber Gate 2's cache.
+        Best-effort: timeouts (8s) are swallowed.
+        """
+        if self._page.locator(SEL_USER_BUBBLE).count() == 0:
+            return
+        try:
+            _idle_js = (
+                "() => {\n"
+                "  const btn = document.querySelector("
+                "'button.qwenpaw-sender-actions-btn"
+                ".qwenpaw-btn-primary'"
+                ");\n"
+                "  if (btn) {\n"
+                "    const cls = btn.className || '';\n"
+                "    const disabledByCls = "
+                "/qwenpaw-btn-disabled|qwenpaw-btn-loading"
+                "|is-disabled|is-loading/.test(cls);\n"
+                "    const disabledByAttr = btn.disabled === true\n"
+                "      || btn.hasAttribute('disabled')\n"
+                "      || btn.getAttribute('aria-disabled')"
+                " === 'true';\n"
+                "    if (!disabledByAttr && !disabledByCls) "
+                "return true;\n"
+                "  }\n"
+                "  const aiMsgs = document.querySelectorAll("
+                "'.qwenpaw-bubble.qwenpaw-bubble-start');\n"
+                "  if (aiMsgs.length === 0) return true;\n"
+                "  const last = aiMsgs[aiMsgs.length - 1];\n"
+                "  const raw = (last.innerText || '').trim();\n"
+                "  const key = '__qwenpaw_send_idle_cache__';\n"
+                "  const now = Date.now();\n"
+                "  const cache = window[key] || {};\n"
+                "  if (cache.text !== raw) {\n"
+                "    window[key] = { text: raw, since: now };\n"
+                "    return false;\n"
+                "  }\n"
+                "  return (now - cache.since) >= 1500;\n"
+                "}"
+            )
+            self._page.wait_for_function(_idle_js, timeout=8000)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            try:
+                self._page.evaluate(
+                    "() => { try { delete window."
+                    "__qwenpaw_send_idle_cache__; } catch(e) {} }",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
+    def chat_one_round(self, message: str, timeout: int) -> str:
+        self._wait_previous_round_idle()
+
+        ai_count_before = self._page.locator(SEL_AI_BUBBLE).count()
+        user_count_before = self._page.locator(SEL_USER_BUBBLE).count()
+
+        # Defensive input flow borrowed from e2e/pages/chat_page.py:
+        # focus the textarea, clear any leftover text, fill the new
+        # message, then click send (or fall back to Enter).
+        input_box = self._page.locator(SEL_INPUT).first
+        input_box.click()
+        time.sleep(0.2)
+        input_box.fill("")
+        time.sleep(0.2)
+        input_box.fill(message)
+        time.sleep(0.5)
+
+        # Reset Gate 2 state-machine caches so a fresh round starts
+        # from a clean slate (prior round's disabled-flag / content
+        # stable cache must not carry over).
+        try:
+            self._page.evaluate(
+                "() => { delete window.__qwenpaw_btn_was_disabled__;"
+                " delete window.__qwenpaw_ai_stable_cache__; }",
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+        send_btn = self._page.locator(SEL_SEND_BTN).first
+        if send_btn.is_visible() and send_btn.is_enabled():
+            send_btn.click()
+        else:
+            input_box.press("Enter")
+
+        # Gold-standard "message actually sent" check: a new user bubble
+        # must appear. Treating button-disabled as the signal turns out
+        # to be racy (e2e/ tried it and dropped it); the user bubble
+        # showing up is what the SPA actually does once the request was
+        # accepted.
+        send_timeout_ms = min(30, timeout) * 1000
+        try:
+            self._page.wait_for_function(
+                """(expected) => {
+                  const msgs = document.querySelectorAll(
+                    '.qwenpaw-bubble.qwenpaw-bubble-end'
+                  );
+                  return msgs.length > expected;
+                }""",
+                arg=user_count_before,
+                timeout=send_timeout_ms,
+            )
+        except Exception:  # noqa: BLE001
+            # Fall back to pressing Enter — some layouts ignore the
+            # send button click but accept Enter on the textarea.
+            try:
+                input_box.click()
+                time.sleep(0.2)
+                input_box.press("Enter")
+                self._page.wait_for_function(
+                    """(expected) => {
+                      const msgs = document.querySelectorAll(
+                        '.qwenpaw-bubble.qwenpaw-bubble-end'
+                      );
+                      return msgs.length > expected;
+                    }""",
+                    arg=user_count_before,
+                    timeout=send_timeout_ms,
+                )
+            except Exception as exc:  # noqa: BLE001
+                raise RuntimeError(
+                    f"User bubble never appeared for: {message!r}",
+                ) from exc
+
+        self._screenshot("02-message-sent")
+        timeout_ms = timeout * 1000
+
+        # Gate 1: a new AI bubble appears in the DOM.
+        try:
+            self._page.wait_for_function(
+                """(expectedCount) => {
+                  const aiMsgs = document.querySelectorAll(
+                    '.qwenpaw-bubble.qwenpaw-bubble-start'
+                  );
+                  return aiMsgs.length > expectedCount;
+                }""",
+                arg=ai_count_before,
+                timeout=timeout_ms,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                f"No new AI bubble within {timeout}s for: {message!r}",
+            ) from exc
+
+        # Gate 2: streaming actually finished. Path A (button enabled +
+        # real text) or Path B (content stable >= 2500ms + real text)
+        # may release first; whichever fires accepts the round.
+        try:
+            self._page.wait_for_function(
+                self._JS_BUBBLE_READY,
+                arg=ai_count_before,
+                timeout=timeout_ms,
+            )
+        except Exception:  # noqa: BLE001
+            # Don't fail outright — return whatever text we have so the
+            # caller's substring assertion can still succeed when most
+            # of the streaming arrived but the end-of-stream signal was
+            # lost (a known SPA quirk e2e/ also tolerates).
+            pass
+
+        self._screenshot("03-reply-received")
+        last_locator = self._page.locator(SEL_AI_BUBBLE).last
+        try:
+            raw = (last_locator.inner_text() or "").strip()
+        except Exception:  # noqa: BLE001
+            return ""
+        # Strip placeholders so callers don't accidentally satisfy a
+        # substring assertion on the loading indicator.
+        return raw.replace("Thinking", "").replace("Loading", "").strip()
+
+    def close(self) -> None:
+        for closer in (
+            getattr(self, "_page", None),
+            getattr(self, "_context", None),
+            getattr(self, "_browser", None),
+        ):
+            if closer is None:
+                continue
+            try:
+                closer.close()
+            except Exception:  # noqa: BLE001
+                pass
+        pw = getattr(self, "_pw", None)
+        if pw is not None:
+            try:
+                pw.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+UI_MODES = ("legacy", "tauri-macos", "tauri-windows")
+
+
+def make_driver(
+    ui_mode: str,
+    screenshot_dir: Optional[str] = None,
+) -> UIDriver:
+    """Build a concrete ``UIDriver`` for the requested mode."""
+    if ui_mode == "legacy":
+        return PlaywrightDriver("chromium", screenshot_dir)
+    if ui_mode == "tauri-macos":
+        return PlaywrightDriver("webkit", screenshot_dir)
+    if ui_mode == "tauri-windows":
+        return PlaywrightDriver("chromium", screenshot_dir)
+    raise UIDriverInitError(f"unknown ui-mode: {ui_mode!r}")
+
+
+# =============================================================================
+# UI-level verification (three-round conversation)
+# =============================================================================
+
+
+def verify_ui_chat(
+    driver: UIDriver,
+    base_url: str,
+    timeout: int,
+) -> None:
+    """Drive the real SPA with one factual question to prove LLM works.
+
+    Uses a single-round factual question ("tallest mountain") rather
+    than multi-turn context retention. Reasons:
+
+    - One round eliminates multi-turn SPA timing races that plagued
+      earlier iterations (chat/stop cancellations, button-disabled
+      state-machine fights, etc.).
+    - A factual question with universally known answers (Everest /
+      珠穆朗玛峰 / 8848m / 8849m) gives a deterministic assertion
+      that any LLM will satisfy.
+    - Still proves the full UI path: SPA loaded -> textarea filled ->
+      send clicked -> backend received -> LLM invoked -> SSE streamed
+      -> AI bubble rendered with real content.
+    """
+    # Any of these substrings in the reply proves the LLM answered
+    # correctly. Covers English, Chinese, altitude variants.
+    expected_any = (
+        "Everest",
+        "everest",
+        "珠穆朗玛",
+        "Chomolungma",
+        "8848",
+        "8849",
+    )
+
+    print(f"--> opening UI at {base_url}")
+    driver.open(base_url)
+    print("PASS  UI loaded, chat input visible")
+
+    question = "What is the tallest mountain in the world?"
+    print(f"--> sending: {question!r}")
+    reply = driver.chat_one_round(question, timeout)
+    preview = reply.replace("\n", " ")[:200]
+    print(f"<-- agent: {preview}...")
+
+    if not any(kw in reply for kw in expected_any):
+        raise RuntimeError(
+            f"LLM reply does not mention Everest / 珠穆朗玛 / 8848. "
+            f"Got: {reply[:500]}",
+        )
+    print("PASS  LLM responded with correct factual answer")
+
+
+# =============================================================================
+# main
+# =============================================================================
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a running QwenPaw desktop backend end-to-end: API "
+            "health + provider config + single-round UI chat."
+        ),
+    )
+    parser.add_argument(
+        "--base-url",
+        required=True,
+        help="Base URL of the running desktop backend, e.g. "
+        "http://127.0.0.1:8088",
+    )
+    parser.add_argument(
+        "--ui-mode",
+        choices=UI_MODES,
+        default="legacy",
+        help="UI driver flavour. 'legacy' uses Playwright + Chromium; "
+        "'tauri-macos' / 'tauri-windows' use platform webdrivers.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("QWENPAW_DASHSCOPE_API_KEY", ""),
+        help="DashScope API key. Falls back to env "
+        "QWENPAW_DASHSCOPE_API_KEY. Empty value -> auto skip-chat.",
+    )
+    parser.add_argument(
+        "--provider",
+        default=DEFAULT_PROVIDER,
+        help=f"Provider id (default: {DEFAULT_PROVIDER})",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Model id (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--skip-chat",
+        action="store_true",
+        help="Skip the entire LLM chain (provider config + UI chat). "
+        "Implied when no API key is available.",
+    )
+    parser.add_argument(
+        "--skip-ui",
+        action="store_true",
+        help="Skip only the UI driver portion (still configure provider "
+        "via API). Useful for environments without a browser.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Per-chat timeout in seconds (default: {DEFAULT_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--screenshot-dir",
+        default=os.environ.get("RUNNER_TEMP", ""),
+        help="Directory to save UI screenshots. Defaults to "
+        "env RUNNER_TEMP (set by GitHub Actions). Empty = no "
+        "screenshots.",
+    )
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+    skip_chat = args.skip_chat or not args.api_key
+
+    started = time.monotonic()
+    driver: Optional[UIDriver] = None
+    try:
+        # ---- API-level checks (always run) ----
+        health_check(base_url)
+        verify_frontend(base_url)
+
+        if skip_chat:
+            reason = (
+                "explicit --skip-chat"
+                if args.skip_chat
+                else "no DashScope API key provided"
+            )
+            print(f"SKIP  LLM verification ({reason})")
+            elapsed = time.monotonic() - started
+            print(
+                f"OK    desktop verification completed in {elapsed:.1f}s",
+            )
+            return 0
+
+        # ---- LLM provider setup via API ----
+        configure_provider(base_url, args.provider, args.api_key)
+        ensure_model(base_url, args.provider, args.model)
+        set_active_model(base_url, args.provider, args.model)
+
+        # ---- UI three-round conversation ----
+        if args.skip_ui:
+            print("SKIP  UI chat verification (--skip-ui)")
+        else:
+            try:
+                ss_dir = (
+                    os.path.join(
+                        args.screenshot_dir,
+                        "verify-screenshots",
+                    )
+                    if args.screenshot_dir
+                    else None
+                )
+                driver = make_driver(args.ui_mode, ss_dir)
+            except UIDriverInitError as exc:
+                print(f"FAIL  UI driver init: {exc}", file=sys.stderr)
+                return 3
+            verify_ui_chat(driver, base_url, args.timeout)
+    except RuntimeError as exc:
+        print(f"FAIL  {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if driver is not None:
+            driver.close()
+
+    elapsed = time.monotonic() - started
+    print(f"OK    desktop verification completed in {elapsed:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify/launch_tauri_macos.sh
+++ b/scripts/verify/launch_tauri_macos.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Unpack, launch the Tauri macOS shell, and wait for the backend to be ready.
+# Outputs BASE_URL to $GITHUB_ENV for subsequent steps.
+set -euo pipefail
+
+# 1. Unpack the freshly built Tauri zip.
+echo "[launch_tauri_macos] Unpacking zip..."
+mkdir -p dist/verify-tauri
+unzip -q dist/QwenPaw-Tauri-*-macOS.zip -d dist/verify-tauri
+APP="$(find dist/verify-tauri -maxdepth 3 -name '*.app' -type d | head -1)"
+if [ -z "$APP" ]; then
+  echo "::error::Tauri .app not found inside zip"
+  exit 1
+fi
+echo "[launch_tauri_macos] Found app: $APP"
+
+# 2. Remove macOS quarantine (CI download marks it).
+xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
+
+# 3. Pre-delete BOOTSTRAP.md so the agent answers in plain QA mode.
+mkdir -p "$HOME/.qwenpaw/workspaces/default"
+rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
+
+# 4. Launch the full Tauri shell (matches real user double-click).
+echo "[launch_tauri_macos] Launching Tauri shell..."
+open "$APP"
+echo "[launch_tauri_macos] open exit=$?"
+sleep 3
+echo "[launch_tauri_macos] Process snapshot after launch:"
+ps -ef | grep -iE "qwenpaw|tauri" | grep -v grep || echo "  (no matching processes)"
+
+# 5. Wait for the sidecar to write the port file and respond.
+#    The sidecar writes desktop_port at WORKING_DIR root (~/.qwenpaw),
+#    not inside the workspace dir.
+PORT_FILE="$HOME/.qwenpaw/desktop_port"
+PORT=""
+for i in $(seq 1 60); do
+  if [ -f "$PORT_FILE" ]; then
+    PORT="$(cat "$PORT_FILE" | tr -d '[:space:]')"
+    if [ -n "$PORT" ] && curl -sf "http://127.0.0.1:$PORT/api/version" >/dev/null; then
+      echo "[launch_tauri_macos] Tauri app ready on port $PORT after ~$((i*2))s"
+      break
+    fi
+  fi
+  if [ "$i" = "60" ]; then
+    echo "::error::Tauri app did not start within 120s"
+    echo "[debug] PORT_FILE=$PORT_FILE exists=$([ -f "$PORT_FILE" ] && echo yes || echo no)"
+    echo "[debug] WORKING_DIR (~/.qwenpaw) contents:"
+    ls -la "$HOME/.qwenpaw/" 2>/dev/null || echo "  (missing)"
+    echo "[debug] All qwenpaw-related files under HOME (top 30):"
+    find "$HOME/.qwenpaw" -maxdepth 4 -type f 2>/dev/null | head -30 || true
+    echo "[debug] desktop.log tail (if exists):"
+    tail -50 "$HOME/.qwenpaw/desktop.log" 2>/dev/null || echo "  (no desktop.log)"
+    echo "[debug] Process list:"
+    ps -ef | grep -iE "qwenpaw|tauri" | grep -v grep || echo "  (no matching processes)"
+    exit 1
+  fi
+  sleep 2
+done
+
+export BASE_URL="http://127.0.0.1:$PORT"
+echo "BASE_URL=$BASE_URL" >> "$GITHUB_ENV"
+echo "$BASE_URL"

--- a/scripts/verify/launch_tauri_windows.ps1
+++ b/scripts/verify/launch_tauri_windows.ps1
@@ -68,13 +68,27 @@ if (-not $tauriExe) {
 }
 Write-Host "Installed at: $tauriExe"
 
+# 2b. Verify WebView2 bootstrapper is bundled in the install.
+$installRoot = Split-Path $tauriExe -Parent
+$wv2Files = Get-ChildItem -Path $installRoot -Filter "*WebView2*" `
+  -Recurse -Depth 3 -ErrorAction SilentlyContinue
+if ($wv2Files) {
+  Write-Host "WebView2 bootstrapper present: $($wv2Files[0].Name)"
+} else {
+  Write-Host "::warning::WebView2 bootstrapper not found in install dir"
+}
+
 # 3. Pre-delete BOOTSTRAP.md so the agent answers in plain QA mode.
 $wsDir = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default"
 New-Item -ItemType Directory -Force -Path $wsDir | Out-Null
 $bootstrapMd = Join-Path $wsDir "BOOTSTRAP.md"
 if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
 
-# 4. Launch the full Tauri shell (matches real user double-click).
+# 4. Launch the full Tauri shell with CDP debugging enabled.
+#    This makes WebView2 expose a Chrome DevTools Protocol port so
+#    Playwright can connect_over_cdp() to the real embedded webview.
+$cdpPort = 9222
+$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$cdpPort"
 Start-Process -FilePath $tauriExe
 
 # 5. Wait for the sidecar to write the port file and respond.
@@ -104,7 +118,29 @@ if (-not $port) {
   exit 1
 }
 
+# 6. Wait for CDP endpoint to become available.
+$cdpUrl = "http://127.0.0.1:$cdpPort"
+$cdpReady = $false
+for ($i = 1; $i -le 30; $i++) {
+  try {
+    $r = Invoke-WebRequest -Uri "$cdpUrl/json/version" `
+      -UseBasicParsing -TimeoutSec 3 -ErrorAction Stop
+    if ($r.StatusCode -eq 200) {
+      Write-Host "CDP ready at $cdpUrl"
+      $cdpReady = $true
+      break
+    }
+  } catch { Start-Sleep -Seconds 2 }
+}
+if (-not $cdpReady) {
+  Write-Host "::warning::CDP not available, falling back to standalone browser"
+  $cdpUrl = ""
+}
+
 $baseUrl = "http://127.0.0.1:$port"
 $env:BASE_URL = $baseUrl
+$env:CDP_URL = $cdpUrl
 "BASE_URL=$baseUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-Write-Host $baseUrl
+"CDP_URL=$cdpUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+Write-Host "BASE_URL=$baseUrl"
+Write-Host "CDP_URL=$cdpUrl"

--- a/scripts/verify/launch_tauri_windows.ps1
+++ b/scripts/verify/launch_tauri_windows.ps1
@@ -19,50 +19,53 @@ if ($proc.ExitCode -ne 0) {
 Start-Sleep -Seconds 5
 
 # 2. Locate the installed Tauri exe.
-#    Tauri NSIS may install to versioned subdirs, so search recursively
-#    inside each candidate root.
-$candidateRoots = @(
-  (Join-Path $env:LOCALAPPDATA "QwenPaw Desktop"),
-  (Join-Path $env:LOCALAPPDATA "Programs\QwenPaw Desktop"),
-  (Join-Path $env:ProgramFiles "QwenPaw Desktop"),
-  (Join-Path ${env:ProgramFiles(x86)} "QwenPaw Desktop")
-)
+#    Priority: registry InstallLocation (canonical) → known candidate dirs.
 $tauriExe = $null
-foreach ($root in $candidateRoots) {
-  if (Test-Path $root) {
-    $found = Get-ChildItem -Path $root -Filter "qwenpaw-desktop.exe" `
-      -Recurse -Depth 3 -ErrorAction SilentlyContinue |
-      Select-Object -First 1
-    if ($found) { $tauriExe = $found.FullName; break }
-  }
-}
-if (-not $tauriExe) {
-  foreach ($hive in @("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
-                      "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
-                      "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall")) {
-    $reg = Get-ChildItem $hive -ErrorAction SilentlyContinue |
-      Where-Object { (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName -match "QwenPaw" } |
-      Select-Object -First 1
-    if ($reg) {
-      $loc = (Get-ItemProperty $reg.PSPath).InstallLocation
-      if ($loc -and (Test-Path $loc)) {
-        $found = Get-ChildItem -Path $loc -Filter "qwenpaw-desktop.exe" `
-          -Recurse -Depth 3 -ErrorAction SilentlyContinue |
-          Select-Object -First 1
-        if ($found) { $tauriExe = $found.FullName; break }
-      }
+
+# Try registry first — Tauri NSIS always writes InstallLocation.
+foreach ($hive in @("HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+                    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+                    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall")) {
+  $reg = Get-ChildItem $hive -ErrorAction SilentlyContinue |
+    Where-Object { (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName -match "QwenPaw" } |
+    Select-Object -First 1
+  if ($reg) {
+    $loc = (Get-ItemProperty $reg.PSPath).InstallLocation
+    if ($loc -and (Test-Path $loc)) {
+      $found = Get-ChildItem -Path $loc -Filter "qwenpaw-desktop.exe" `
+        -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+      if ($found) { $tauriExe = $found.FullName; break }
     }
   }
 }
+
+# Fallback: search known install candidate directories.
+if (-not $tauriExe) {
+  $candidateRoots = @(
+    (Join-Path $env:LOCALAPPDATA "QwenPaw Desktop"),
+    (Join-Path $env:LOCALAPPDATA "Programs\QwenPaw Desktop"),
+    (Join-Path $env:ProgramFiles "QwenPaw Desktop"),
+    (Join-Path ${env:ProgramFiles(x86)} "QwenPaw Desktop")
+  )
+  foreach ($root in $candidateRoots) {
+    if (Test-Path $root) {
+      $found = Get-ChildItem -Path $root -Filter "qwenpaw-desktop.exe" `
+        -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+      if ($found) { $tauriExe = $found.FullName; break }
+    }
+  }
+}
+
 if (-not $tauriExe) {
   Write-Host "=== DEBUG: install location not found ==="
-  foreach ($root in $candidateRoots) {
-    Write-Host "Candidate: $root  exists=$([bool](Test-Path $root))"
-    if (Test-Path $root) {
-      Write-Host "  Contents (depth 2):"
-      Get-ChildItem -Path $root -Recurse -Depth 2 -ErrorAction SilentlyContinue |
-        Select-Object -First 30 | ForEach-Object { Write-Host "    $($_.FullName)" }
-    }
+  Write-Host "Registry entries matching QwenPaw:"
+  foreach ($hive in @("HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+                      "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall")) {
+    Get-ChildItem $hive -ErrorAction SilentlyContinue |
+      Where-Object { (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName -match "QwenPaw" } |
+      ForEach-Object { Write-Host "  $((Get-ItemProperty $_.PSPath).InstallLocation)" }
   }
   throw "Tauri exe not found after NSIS install"
 }

--- a/scripts/verify/launch_tauri_windows.ps1
+++ b/scripts/verify/launch_tauri_windows.ps1
@@ -1,0 +1,110 @@
+# Install Tauri via NSIS, launch the shell, and wait for the backend.
+# Outputs BASE_URL to $env:GITHUB_ENV for subsequent steps.
+$ErrorActionPreference = "Stop"
+
+# 1. Run NSIS silent install (matches real user installer).
+#    /S = silent, run the installer to completion before continuing.
+$installer = Get-ChildItem dist/QwenPaw-Tauri-*-Windows-setup.exe |
+  Select-Object -First 1
+if (-not $installer) { throw "NSIS installer not found in dist/" }
+Write-Host "Installing $($installer.Name) silently..."
+$proc = Start-Process -FilePath $installer.FullName -ArgumentList "/S" `
+  -Wait -PassThru -NoNewWindow
+Write-Host "Installer exited with code $($proc.ExitCode)"
+if ($proc.ExitCode -ne 0) {
+  throw "NSIS installer failed (exit $($proc.ExitCode))"
+}
+# Tauri NSIS spawns elevated child + finishes immediately; allow time for
+# files to settle.
+Start-Sleep -Seconds 5
+
+# 2. Locate the installed Tauri exe.
+#    Tauri NSIS may install to versioned subdirs, so search recursively
+#    inside each candidate root.
+$candidateRoots = @(
+  (Join-Path $env:LOCALAPPDATA "QwenPaw Desktop"),
+  (Join-Path $env:LOCALAPPDATA "Programs\QwenPaw Desktop"),
+  (Join-Path $env:ProgramFiles "QwenPaw Desktop"),
+  (Join-Path ${env:ProgramFiles(x86)} "QwenPaw Desktop")
+)
+$tauriExe = $null
+foreach ($root in $candidateRoots) {
+  if (Test-Path $root) {
+    $found = Get-ChildItem -Path $root -Filter "qwenpaw-desktop.exe" `
+      -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+      Select-Object -First 1
+    if ($found) { $tauriExe = $found.FullName; break }
+  }
+}
+if (-not $tauriExe) {
+  foreach ($hive in @("HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+                      "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+                      "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall")) {
+    $reg = Get-ChildItem $hive -ErrorAction SilentlyContinue |
+      Where-Object { (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName -match "QwenPaw" } |
+      Select-Object -First 1
+    if ($reg) {
+      $loc = (Get-ItemProperty $reg.PSPath).InstallLocation
+      if ($loc -and (Test-Path $loc)) {
+        $found = Get-ChildItem -Path $loc -Filter "qwenpaw-desktop.exe" `
+          -Recurse -Depth 3 -ErrorAction SilentlyContinue |
+          Select-Object -First 1
+        if ($found) { $tauriExe = $found.FullName; break }
+      }
+    }
+  }
+}
+if (-not $tauriExe) {
+  Write-Host "=== DEBUG: install location not found ==="
+  foreach ($root in $candidateRoots) {
+    Write-Host "Candidate: $root  exists=$([bool](Test-Path $root))"
+    if (Test-Path $root) {
+      Write-Host "  Contents (depth 2):"
+      Get-ChildItem -Path $root -Recurse -Depth 2 -ErrorAction SilentlyContinue |
+        Select-Object -First 30 | ForEach-Object { Write-Host "    $($_.FullName)" }
+    }
+  }
+  throw "Tauri exe not found after NSIS install"
+}
+Write-Host "Installed at: $tauriExe"
+
+# 3. Pre-delete BOOTSTRAP.md so the agent answers in plain QA mode.
+$wsDir = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default"
+New-Item -ItemType Directory -Force -Path $wsDir | Out-Null
+$bootstrapMd = Join-Path $wsDir "BOOTSTRAP.md"
+if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
+
+# 4. Launch the full Tauri shell (matches real user double-click).
+Start-Process -FilePath $tauriExe
+
+# 5. Wait for the sidecar to write the port file and respond.
+#    The sidecar writes desktop_port at WORKING_DIR root (~/.qwenpaw),
+#    not inside the workspace dir.
+$portFile = Join-Path $env:USERPROFILE ".qwenpaw\desktop_port"
+$port = $null
+$deadline = (Get-Date).AddSeconds(120)
+while ((Get-Date) -lt $deadline) {
+  if (Test-Path $portFile) {
+    $port = (Get-Content $portFile -ErrorAction SilentlyContinue).Trim()
+    if ($port) {
+      try {
+        $r = Invoke-WebRequest -Uri "http://127.0.0.1:$port/api/version" `
+          -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        if ($r.StatusCode -eq 200) {
+          Write-Host "Tauri app ready on port $port"
+          break
+        }
+      } catch {}
+    }
+  }
+  Start-Sleep -Seconds 2
+}
+if (-not $port) {
+  Write-Host "::error::Tauri app did not start within 120s"
+  exit 1
+}
+
+$baseUrl = "http://127.0.0.1:$port"
+$env:BASE_URL = $baseUrl
+"BASE_URL=$baseUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+Write-Host $baseUrl

--- a/scripts/verify/requirements-verify.txt
+++ b/scripts/verify/requirements-verify.txt
@@ -4,9 +4,6 @@
 # layer; the drivers below are imported lazily so callers using --skip-ui
 # don't have to install them.
 
-# Legacy Win/Mac: Playwright + Chromium for headless browser automation.
+# All platforms: Playwright drives Chromium (Legacy + Tauri Win) or
+# WebKit (Tauri macOS) for headed/headless browser automation.
 playwright>=1.40
-
-# Tauri Win/Mac: Selenium drives platform webviews (msedgedriver via
-# tauri-driver on Windows, safaridriver on macOS).
-selenium>=4.20

--- a/scripts/verify/requirements-verify.txt
+++ b/scripts/verify/requirements-verify.txt
@@ -1,0 +1,12 @@
+# Dependencies for scripts/verify/desktop_verify.py UI drivers.
+# Installed by .github/workflows/desktop-release.yml on each runner before
+# the verify step runs. The verifier itself only needs stdlib for the API
+# layer; the drivers below are imported lazily so callers using --skip-ui
+# don't have to install them.
+
+# Legacy Win/Mac: Playwright + Chromium for headless browser automation.
+playwright>=1.40
+
+# Tauri Win/Mac: Selenium drives platform webviews (msedgedriver via
+# tauri-driver on Windows, safaridriver on macOS).
+selenium>=4.20


### PR DESCRIPTION
## Description

Adds end-to-end UI verification to QwenPaw's desktop release pipeline.
Today `desktop-release.yml` builds 4 desktop flavours (Legacy Win/Mac
+ Tauri Win/Mac) and uploads them straight to GitHub Release / OSS
with no automated checks — broken installers, sidecar startup
failures, frontend bundle issues, or LLM chat regressions only
surface after users hit them. This PR closes that gap.

### What gets verified

For each of the 4 build jobs, between the `Build` step and the
`Upload artifact` step, a new `Verify desktop` step runs the full
real-user path:

```
Build → Install/extract artifact → Launch the actual shell users
launch → Backend ready → Playwright drives the SPA → Configure
DashScope → Register model → Send factual question → Assert AI
bubble contains the expected answer → PASS
```

Coverage matrix:

| Flavour | Runner | Launch path | UI engine |
|---------|--------|-------------|-----------|
| Legacy Windows | windows-latest | NSIS `/S /D=...` install + start backend | Playwright Chromium (headed) |
| Legacy macOS | macos-14 | conda-pack unzip + start backend | Playwright Chromium (headed) |
| Tauri Windows | windows-latest | NSIS `/S` install + Start-Process the installed exe | **Playwright connected to the real WebView2 via CDP** |
| Tauri macOS | macos-14 | unzip + `open <APP>` (matches user double-click) | Playwright WebKit (headed) — same engine as the embedded WKWebView |

Tauri Windows is the highest-fidelity path: WebView2 is launched
with `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port`
and Playwright `connect_over_cdp()`s into the real embedded webview,
so the verifier exercises the same engine, same `tauri://localhost`
frontend entry, and same CSP / IPC bridge as a real install.

### Files

- `scripts/verify/desktop_verify.py` — shared verifier (API health,
  frontend load, provider config, model registration, Playwright UI
  chat with single-round factual Q&A)
- `scripts/verify/launch_tauri_macos.sh` /
  `scripts/verify/launch_tauri_windows.ps1` — install + launch +
  port-file / CDP discovery, shared between both workflows
- `scripts/verify/requirements-verify.txt` — Playwright dep
- `.github/workflows/desktop-release.yml` — wires verify into each
  build job (between build and upload)
- `.github/workflows/fork-verify-desktop.yml` — standalone
  `workflow_dispatch` for fork-side smoke testing across all 4
  platforms (`platforms: all|legacy-only|tauri-only|macos-only|windows-only`)

### CI time impact

Verify runs in the same job as build (sequential), so it only
extends per-job wall time — build parallelism is unchanged.
Numbers from the latest CI run:

| Flavour | Build | Verify total | Per-job delta |
|---------|-------|--------------|---------------|
| Legacy macOS | 7.1m | +3.1m | +44% |
| Legacy Windows | 21.5m | +6.2m | +29% |
| Tauri macOS | 14.9m | +1.3m | +9% |
| Tauri Windows | 24.9m | +5.4m | +22% |

Most of the verify cost on Windows is `pip install` +
`playwright install chromium` (~3.5m). Wall-clock for the whole
release workflow grows from ~25m to ~31m (longest job).

### Graceful degradation

- `QWENPAW_DASHSCOPE_API_KEY` missing → auto `--skip-chat`,
  still validates install + launch + frontend load (forks without
  the secret can run the workflow)
- CDP unavailable on Tauri Windows → falls back to standalone
  Playwright Chromium (so a CDP regression doesn't block release)
- All verify failures surface screenshots and logs as artifacts

### Stability

CI has been green 4 consecutive runs across all 4 flavours
(16/16 jobs):

- https://github.com/yutai78786/QwenPaw/actions/runs/28009289748
- https://github.com/yutai78786/QwenPaw/actions/runs/28011798153
- https://github.com/yutai78786/QwenPaw/actions/runs/28011803077
- https://github.com/yutai78786/QwenPaw/actions/runs/28015115986

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] CI/CD
- [x] Scripts / Deploy

## Testing

The 4 fork CI runs above exercise every code path:

- All 4 build flavours
- Headed Playwright on both macOS and Windows
- CDP `connect_over_cdp()` against real WebView2
- NSIS silent install + recursive exe lookup
- Tauri shell launch via `open` (macOS) / `Start-Process` (Windows)
- Port-file discovery at `~/.qwenpaw/desktop_port`
- Single-round factual chat with DashScope `qwen3.6-plus`

## Additional Notes

3 commits, intended to be reviewed in order:

1. Core verifier + workflow plumbing
2. Move Tauri verify to real install + shell launch + headed mode
3. CDP direct connection for Tauri Windows real-WebView2 driving