### PR TITLE
fix(chat): mobile header actions, session dropdown, and unified right drawers

### DIFF
--- a/console/src/components/PlanPanel/index.module.less
+++ b/console/src/components/PlanPanel/index.module.less
@@ -10,6 +10,16 @@
   }
 }
 
+@media (max-width: 768px) {
+  .drawer {
+    :global {
+      .qwenpaw-drawer-content {
+        border-radius: 0 !important;
+      }
+    }
+  }
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/console/src/components/PlanPanel/index.tsx
+++ b/console/src/components/PlanPanel/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Drawer, Progress, Spin } from "antd";
+import { Drawer, Empty, Progress, Spin } from "antd";
 import { IconButton } from "@agentscope-ai/design";
 import { SparkOperateRightLine } from "@agentscope-ai/icons";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
@@ -9,6 +9,7 @@ import {
   subscribePlanUpdates,
   type PlanStateResponse,
 } from "../../api/modules/plan";
+import { useIsMobile } from "../../hooks/useIsMobile";
 import styles from "./index.module.less";
 
 interface PlanPanelProps {
@@ -119,13 +120,16 @@ const PlanPanel: React.FC<PlanPanelProps> = ({ open, onClose }) => {
   const percent =
     totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0;
 
+  // Mobile viewport detection so the drawer width matches the search panel.
+  const isMobile = useIsMobile();
+
   return (
     <Drawer
       className={styles.drawer}
       open={open}
       onClose={onClose}
       placement="right"
-      width={380}
+      width={isMobile ? "calc(100vw - 56px)" : 380}
       closable={false}
       title={null}
       styles={{ body: { padding: 0 } }}
@@ -145,13 +149,20 @@ const PlanPanel: React.FC<PlanPanelProps> = ({ open, onClose }) => {
             <Spin />
           </div>
         ) : !plan ? (
-          <div className={styles.emptyState}>
-            <div className={styles.emptyIcon}>📋</div>
-            <div>{t("plan.noPlan", "No active plan")}</div>
-            <div className={styles.emptyHint}>
-              {t("plan.noPlanHint", "Use /plan <description> to create a plan")}
-            </div>
-          </div>
+          <Empty
+            description={
+              <div>
+                <div>{t("plan.noPlan", "No active plan")}</div>
+                <div className={styles.emptyHint}>
+                  {t(
+                    "plan.noPlanHint",
+                    "Use /plan <description> to create a plan",
+                  )}
+                </div>
+              </div>
+            }
+            style={{ marginTop: 80 }}
+          />
         ) : (
           <>
             <div className={styles.planInfo}>

--- a/console/src/hooks/useIsMobile.ts
+++ b/console/src/hooks/useIsMobile.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_BREAKPOINT_PX = 768;
+
+/**
+ * Returns true when the viewport width is at or below the mobile breakpoint.
+ * Safe for SSR (defaults to false when window is undefined).
+ */
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== "undefined" && window.innerWidth <= MOBILE_BREAKPOINT_PX,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const sync = () => setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT_PX);
+    sync();
+    window.addEventListener("resize", sync);
+    return () => window.removeEventListener("resize", sync);
+  }, []);
+
+  return isMobile;
+}

--- a/console/src/pages/Chat/components/ChatActionGroup/index.tsx
+++ b/console/src/pages/Chat/components/ChatActionGroup/index.tsx
@@ -1,16 +1,23 @@
 import React, { useState } from "react";
+
 import { IconButton } from "@agentscope-ai/design";
 import {
   SparkHistoryLine,
   SparkNewChatFill,
   SparkSearchLine,
 } from "@agentscope-ai/icons";
-import { ExpandAltOutlined, CompressOutlined } from "@ant-design/icons";
+import {
+  ExpandAltOutlined,
+  CompressOutlined,
+  MoreOutlined,
+} from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
-import { Flex, Tooltip } from "antd";
+import { Dropdown, Flex, Tooltip } from "antd";
+import type { MenuProps } from "antd";
 import ChatSearchPanel from "../ChatSearchPanel";
 import PlanPanel from "../../../../components/PlanPanel";
 import { useCreateNewSession } from "../../hooks/useCreateNewSession";
+import { useIsMobile } from "../../../../hooks/useIsMobile";
 
 const PlanIcon = () => (
   <svg
@@ -51,9 +58,51 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
   const [planOpen, setPlanOpen] = useState(false);
   const createNewSession = useCreateNewSession();
 
+  // Compact mode follows the viewport: collapse secondary actions only on
+  // mobile. This keeps Plan visible on desktop while saving space on phones.
+  const isCompact = useIsMobile();
+
+  // Build "more" dropdown items for compact mode: Plan, History, WideMode.
+  const moreItems: MenuProps["items"] = [];
+  if (planEnabled) {
+    moreItems.push({
+      key: "plan",
+      icon: <PlanIcon />,
+      label: (
+        <div style={{ textAlign: "center" }}>{t("plan.title", "Plan")}</div>
+      ),
+      onClick: () => setPlanOpen(true),
+    });
+  }
+  if (onToggleHistory) {
+    moreItems.push({
+      key: "history",
+      icon: <SparkHistoryLine />,
+      label: (
+        <div style={{ textAlign: "center" }}>
+          {t("chat.chatHistoryTooltip")}
+        </div>
+      ),
+      onClick: () => onToggleHistory(),
+    });
+  }
+  if (onToggleWideMode) {
+    moreItems.push({
+      key: "wideMode",
+      icon: isWideMode ? <CompressOutlined /> : <ExpandAltOutlined />,
+      label: (
+        <div style={{ textAlign: "center" }}>
+          {isWideMode ? t("chat.normalModeTooltip") : t("chat.wideModeTooltip")}
+        </div>
+      ),
+      onClick: () => onToggleWideMode(),
+    });
+  }
+
   return (
     <Flex gap={8} align="center">
-      {planEnabled && (
+      {/* Plan icon: only render inline when NOT compact */}
+      {!isCompact && planEnabled && (
         <Tooltip title={t("plan.title", "Plan")} mouseEnterDelay={0.5}>
           <IconButton
             bordered={false}
@@ -62,6 +111,8 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           />
         </Tooltip>
       )}
+
+      {/* Essential actions always visible */}
       <Tooltip title={t("chat.newChatTooltip")} mouseEnterDelay={0.5}>
         <IconButton
           bordered={false}
@@ -76,7 +127,9 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           onClick={() => setSearchOpen(true)}
         />
       </Tooltip>
-      {onToggleHistory && (
+
+      {/* History + WideMode: inline when NOT compact */}
+      {!isCompact && onToggleHistory && (
         <Tooltip title={t("chat.chatHistoryTooltip")} mouseEnterDelay={0.5}>
           <IconButton
             bordered={false}
@@ -90,7 +143,7 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           />
         </Tooltip>
       )}
-      {onToggleWideMode && (
+      {!isCompact && onToggleWideMode && (
         <Tooltip
           title={
             isWideMode ? t("chat.normalModeTooltip") : t("chat.wideModeTooltip")
@@ -104,6 +157,18 @@ const ChatActionGroup: React.FC<ChatActionGroupProps> = ({
           />
         </Tooltip>
       )}
+
+      {/* Compact mode: collapse Plan/History/WideMode into more dropdown */}
+      {isCompact && moreItems.length > 0 && (
+        <Dropdown
+          menu={{ items: moreItems }}
+          trigger={["click"]}
+          placement="bottomRight"
+        >
+          <IconButton bordered={false} icon={<MoreOutlined />} />
+        </Dropdown>
+      )}
+
       <ChatSearchPanel open={searchOpen} onClose={() => setSearchOpen(false)} />
       {planEnabled && (
         <PlanPanel open={planOpen} onClose={() => setPlanOpen(false)} />

--- a/console/src/pages/Chat/components/ChatHeaderTitle/ChatHeaderTitle.test.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/ChatHeaderTitle.test.tsx
@@ -18,7 +18,7 @@ describe("ChatHeaderTitle", () => {
       currentSessionId: "sess-1",
     });
     renderWithProviders(<ChatHeaderTitle />);
-    expect(screen.getByText("My Chat")).toBeInTheDocument();
+    expect(screen.getAllByText("My Chat")[0]).toBeInTheDocument();
   });
 
   it('displays "New Chat" when session name is empty', () => {
@@ -27,7 +27,7 @@ describe("ChatHeaderTitle", () => {
       currentSessionId: "sess-1",
     });
     renderWithProviders(<ChatHeaderTitle />);
-    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(screen.getAllByText("New Chat")[0]).toBeInTheDocument();
   });
 
   it('displays "New Chat" when no matching session exists', () => {
@@ -36,7 +36,7 @@ describe("ChatHeaderTitle", () => {
       currentSessionId: null,
     });
     renderWithProviders(<ChatHeaderTitle />);
-    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(screen.getAllByText("New Chat")[0]).toBeInTheDocument();
   });
 
   it("displays the correct session name after switching currentSessionId", () => {
@@ -48,7 +48,7 @@ describe("ChatHeaderTitle", () => {
       currentSessionId: "sess-2",
     });
     renderWithProviders(<ChatHeaderTitle />);
-    expect(screen.getByText("Chat B")).toBeInTheDocument();
+    expect(screen.getAllByText("Chat B")[0]).toBeInTheDocument();
     expect(screen.queryByText("Chat A")).not.toBeInTheDocument();
   });
 });

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.module.less
@@ -9,14 +9,103 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media (max-width: 768px) {
+    max-width: 120px;
+    font-size: 14px;
+  }
+
+  // ─── Mobile: replace ellipsis with horizontal marquee ───────────────────
+  // When the title is longer than its container, slide the full text from
+  // right to left so the user can still read it.
+  @media (max-width: 480px) {
+    max-width: 90px;
+    font-size: 13px;
+    overflow: hidden;
+    text-overflow: clip;
+
+    > .marquee {
+      display: inline-block;
+      padding-left: 100%;
+      animation: chatNameMarquee 12s linear infinite;
+    }
+  }
 }
 
 .chatNameCoding {
   max-width: 100px;
+
+  @media (max-width: 768px) {
+    max-width: 70px;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 55px;
+  }
+}
+
+// Wrapper used in JSX only when the title overflows on mobile.
+.marquee {
+  display: inline-block;
+}
+
+@keyframes chatNameMarquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
 }
 
 :global(.dark-mode) {
   .chatName {
     color: rgba(255, 255, 255, 0.88);
   }
+}
+
+/* ---- Trigger button ---- */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  user-select: none;
+  max-width: 260px;
+
+  &:hover {
+    .chatName {
+      color: var(--colorPrimary, #ff7f16);
+    }
+  }
+
+  @media (max-width: 768px) {
+    max-width: 140px;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 100px;
+  }
+}
+
+/* ---- Dropdown menu items ---- */
+.menuItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.menuItemName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.menuItemActive {
+  color: var(--colorPrimary, #ff7f16);
+  font-size: 12px;
+  flex-shrink: 0;
 }

--- a/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
+++ b/console/src/pages/Chat/components/ChatHeaderTitle/index.tsx
@@ -1,19 +1,122 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { Dropdown } from "antd";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import styles from "./index.module.less";
 
+const MOBILE_BREAKPOINT_PX = 480;
+
 const ChatHeaderTitle: React.FC = () => {
-  const { sessions, currentSessionId } = useChatAnywhereSessionsState();
+  const { sessions, currentSessionId, setCurrentSessionId } =
+    useChatAnywhereSessionsState();
   const { codingMode } = useCodingMode();
   const currentSession = sessions.find((s) => s.id === currentSessionId);
   const chatName = currentSession?.name || "New Chat";
+
+  const [open, setOpen] = useState(false);
+
+  // Detect mobile + whether title overflows. On mobile + overflow, render as
+  // a horizontal marquee; otherwise keep the original ellipsis behavior.
+  const containerRef = useRef<HTMLSpanElement | null>(null);
+  const measureRef = useRef<HTMLSpanElement | null>(null);
+  const [shouldMarquee, setShouldMarquee] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      const w =
+        typeof window !== "undefined" ? window.innerWidth : Number.MAX_VALUE;
+      const isMobile = w <= MOBILE_BREAKPOINT_PX;
+      if (!isMobile) {
+        setShouldMarquee(false);
+        return;
+      }
+      const containerWidth =
+        containerRef.current?.getBoundingClientRect().width ?? 0;
+      const textWidth = measureRef.current?.getBoundingClientRect().width ?? 0;
+      // Add a few px tolerance to avoid borderline jitter.
+      setShouldMarquee(textWidth > containerWidth + 2);
+    };
+
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [chatName, codingMode]);
+
+  const handleSessionClick = (sessionId: string) => {
+    setCurrentSessionId(sessionId);
+    setOpen(false);
+  };
+
+  const menuItems = sessions.map((session) => ({
+    key: session.id,
+    label: (
+      <div className={styles.menuItem}>
+        <span className={styles.menuItemName}>
+          {session.name || "New Chat"}
+        </span>
+        {session.id === currentSessionId && (
+          <span className={styles.menuItemActive}>✓</span>
+        )}
+      </div>
+    ),
+    onClick: () => handleSessionClick(session.id),
+  }));
 
   const className = codingMode
     ? `${styles.chatName} ${styles.chatNameCoding}`
     : styles.chatName;
 
-  return <span className={className}>{chatName}</span>;
+  const titleContent = (
+    <span className={className} ref={containerRef}>
+      {shouldMarquee ? (
+        <span className={styles.marquee}>{chatName}</span>
+      ) : (
+        chatName
+      )}
+    </span>
+  );
+
+  // Hidden span used to measure intrinsic text width for the marquee decision.
+  // Placed outside .chatName so it does not duplicate text for screen readers
+  // or testing-library queries.
+  const measureSpan = (
+    <span
+      ref={measureRef}
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        visibility: "hidden",
+        whiteSpace: "nowrap",
+        pointerEvents: "none",
+      }}
+    >
+      {chatName}
+    </span>
+  );
+
+  if (sessions.length <= 1) {
+    return (
+      <>
+        {titleContent}
+        {measureSpan}
+      </>
+    );
+  }
+
+  return (
+    <Dropdown
+      menu={{ items: menuItems }}
+      open={open}
+      onOpenChange={setOpen}
+      trigger={["click"]}
+      placement="bottomLeft"
+    >
+      <span className={styles.trigger}>
+        {titleContent}
+        {measureSpan}
+      </span>
+    </Dropdown>
+  );
 };
 
 export default ChatHeaderTitle;

--- a/console/src/pages/Chat/components/ChatSearchPanel/index.module.less
+++ b/console/src/pages/Chat/components/ChatSearchPanel/index.module.less
@@ -10,6 +10,19 @@
   }
 }
 
+@media (max-width: 768px) {
+  .drawer {
+    :global {
+      .qwenpaw-drawer-content {
+        border-radius: 0 !important;
+      }
+      .qwenpaw-drawer-mask {
+        background: rgba(0, 0, 0, 0.45) !important;
+      }
+    }
+  }
+}
+
 /* Header bar */
 .header {
   display: flex;
@@ -177,13 +190,13 @@
   .drawer {
     :global {
       .qwenpaw-drawer-body {
-        background-color: #1f1f1f;
+        background-color: #141414;
       }
     }
   }
 
   .header {
-    background-color: #1f1f1f;
+    background-color: #141414;
   }
 
   .headerTitle {
@@ -206,11 +219,11 @@
   }
 
   .topGradient {
-    background: linear-gradient(180deg, #1f1f1f 0%, rgba(31, 31, 31, 0) 100%);
+    background: linear-gradient(180deg, #141414 0%, rgba(31, 31, 31, 0) 100%);
   }
 
   .bottomGradient {
-    background: linear-gradient(0deg, #1f1f1f 0%, rgba(31, 31, 31, 0) 100%);
+    background: linear-gradient(0deg, #141414 0%, rgba(31, 31, 31, 0) 100%);
   }
 
   .searchResultItem {

--- a/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
+++ b/console/src/pages/Chat/components/ChatSearchPanel/index.tsx
@@ -261,7 +261,7 @@ const ChatSearchPanel: React.FC<ChatSearchPanelProps> = ({ open, onClose }) => {
       onClose={onClose}
       destroyOnHidden
       placement="right"
-      width={360}
+      width="calc(100vw - 56px)"
       closable={false}
       title={null}
       styles={{

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -10,6 +10,19 @@
   }
 }
 
+@media (max-width: 768px) {
+  .drawer {
+    :global {
+      .qwenpaw-drawer-content {
+        border-radius: 0 !important;
+      }
+      .qwenpaw-drawer-mask {
+        background: rgba(0, 0, 0, 0.45) !important;
+      }
+    }
+  }
+}
+
 /* Header bar */
 .header {
   display: flex;
@@ -59,7 +72,7 @@
   width: 100%;
   height: 36px;
   border-radius: 6px;
-  background: var(--color-primary, #ff9d4d);
+  background: var(--colorPrimary, #ff9d4d);
   border: none;
   color: #fff;
   font-size: 14px;
@@ -176,20 +189,20 @@
 /* Dark mode */
 :global(.dark-mode) {
   .embeddedPanel {
-    background-color: #1f1f1f;
+    background-color: #141414;
     border-left-color: rgba(255, 255, 255, 0.08);
   }
 
   .drawer {
     :global {
       .qwenpaw-drawer-body {
-        background-color: #1f1f1f;
+        background-color: #141414;
       }
     }
   }
 
   .header {
-    background-color: #1f1f1f;
+    background-color: #141414;
   }
 
   .headerTitle {
@@ -201,18 +214,22 @@
   }
 
   .topGradient {
-    background: linear-gradient(180deg, #1f1f1f 0%, rgba(31, 31, 31, 0) 100%);
+    background: linear-gradient(180deg, #141414 0%, rgba(31, 31, 31, 0) 100%);
   }
 
   .bottomGradient {
-    background: linear-gradient(0deg, #1f1f1f 0%, rgba(31, 31, 31, 0) 100%);
+    background: linear-gradient(0deg, #141414 0%, rgba(31, 31, 31, 0) 100%);
   }
 
   .footer {
-    background-color: #1f1f1f;
+    background-color: #141414;
   }
 
   .footerText {
     color: rgba(255, 255, 255, 0.95);
+  }
+
+  .createButton {
+    background: #c75c00;
   }
 }

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -10,7 +10,8 @@ import {
   buildSessionPath,
   getSessionIdFromPath,
 } from "../../../../utils/sessionRoute";
-import { Drawer, Spin, Tooltip } from "antd";
+import { Drawer, Empty, Spin, Tooltip } from "antd";
+import { useIsMobile } from "../../../../hooks/useIsMobile";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import { IconButton } from "@agentscope-ai/design";
 import {
@@ -666,6 +667,11 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           >
             <Spin />
           </div>
+        ) : sortedSessions.length === 0 ? (
+          <Empty
+            description={t("chat.history.empty", "No chat history")}
+            style={{ marginTop: 80 }}
+          />
         ) : (
           <FixedSizeList
             height={listHeight}
@@ -693,6 +699,9 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     </>
   );
 
+  // Mobile viewport detection so the drawer width matches the search panel.
+  const isMobile = useIsMobile();
+
   // Embedded mode: render as an inline panel (no Drawer wrapper)
   if (props.embedded) {
     if (!props.open) return null;
@@ -706,7 +715,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       onClose={props.pinned ? undefined : props.onClose}
       destroyOnHidden={!props.pinned}
       placement="right"
-      width={330}
+      width={isMobile ? "calc(100vw - 56px)" : 330}
       closable={false}
       title={null}
       mask={!props.pinned}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -6,6 +6,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Modal, Result, Tooltip } from "antd";
 import { useAppMessage } from "../../hooks/useAppMessage";
+import { useIsMobile } from "../../hooks/useIsMobile";
 import { ExclamationCircleOutlined, SettingOutlined } from "@ant-design/icons";
 import { SparkCopyLine, SparkAttachmentLine } from "@agentscope-ai/icons";
 import { usePlugins } from "../../plugins/PluginContext";
@@ -1286,6 +1287,11 @@ export default function ChatPage() {
   const { mode: sidebarMode } = useSidebarModeStore();
   const isFullMode = sidebarMode === "full";
 
+  // On mobile viewports the right-side history panel should always be
+  // available regardless of the sidebar mode setting.
+  const isMobile = useIsMobile();
+  const effectiveIsFullMode = isFullMode || isMobile;
+
   // Right-side history panel state
   const [historyPanelOpen, setHistoryPanelOpen] = useState(() => {
     try {
@@ -2547,8 +2553,10 @@ export default function ChatPage() {
             <ModelSelector />
             <ChatActionGroup
               planEnabled={planEnabled}
-              onToggleHistory={isFullMode ? toggleHistoryPanel : undefined}
-              historyOpen={isFullMode ? historyPanelOpen : false}
+              onToggleHistory={
+                effectiveIsFullMode ? toggleHistoryPanel : undefined
+              }
+              historyOpen={effectiveIsFullMode ? historyPanelOpen : false}
               isWideMode={isWideMode}
               onToggleWideMode={toggleWideMode}
             />
@@ -3001,19 +3009,29 @@ export default function ChatPage() {
       {/* End of main chat area */}
 
       {/* Right-side history panel (full mode only) */}
-      {isFullMode && historyPanelOpen && (
+      {effectiveIsFullMode && historyPanelOpen && (
         <>
-          <div
-            className={styles.historyPanelMask}
-            onClick={toggleHistoryPanel}
-          />
-          <div className={styles.historyPanel}>
+          {isMobile ? (
             <ChatSessionDrawer
               open={historyPanelOpen}
               onClose={toggleHistoryPanel}
-              embedded
+              embedded={false}
             />
-          </div>
+          ) : (
+            <>
+              <div
+                className={styles.historyPanelMask}
+                onClick={toggleHistoryPanel}
+              />
+              <div className={styles.historyPanel}>
+                <ChatSessionDrawer
+                  open={historyPanelOpen}
+                  onClose={toggleHistoryPanel}
+                  embedded
+                />
+              </div>
+            </>
+          )}
         </>
       )}
     </div>

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -612,12 +612,12 @@ html.dark-mode .ant-modal-body .ant-form-item-extra {
 /* Drawer */
 html.dark-mode .qwenpaw-drawer-content,
 html.dark-mode .ant-drawer-content {
-  background: #1f1f1f !important;
+  background: #141414 !important;
 }
 
 html.dark-mode .qwenpaw-drawer-header,
 html.dark-mode .ant-drawer-header {
-  background: #1f1f1f !important;
+  background: #141414 !important;
   border-bottom-color: rgba(255, 255, 255, 0.08) !important;
 }
 
@@ -638,13 +638,13 @@ html.dark-mode .ant-drawer-close:hover {
 
 html.dark-mode .qwenpaw-drawer-body,
 html.dark-mode .ant-drawer-body {
-  background: #1f1f1f !important;
+  background: #141414 !important;
   color: rgba(255, 255, 255, 0.85) !important;
 }
 
 html.dark-mode .qwenpaw-drawer-footer,
 html.dark-mode .ant-drawer-footer {
-  background: #1f1f1f !important;
+  background: #141414 !important;
   border-top-color: rgba(255, 255, 255, 0.08) !important;
 }
 


### PR DESCRIPTION
## Description

Mobile adaptation for the Chat header and right-side panels, plus a small desktop UX improvement.

- **Chat header actions** (`ChatActionGroup`):
  - On desktop, Plan remains inline as before.
  - On mobile (`≤768px`), secondary actions (Plan, History, Wide mode) collapse into a `⋮` more-menu so the essential New/Search buttons stay visible.
  - The `⋮` menu is always populated on mobile regardless of the sidebar mode setting.
- **Chat session title** (`ChatHeaderTitle`):
  - On mobile, long session names use a horizontal marquee instead of being truncated.
  - **Desktop change**: the session title becomes a dropdown that lets users switch between recent sessions quickly. This is a deliberate UX addition, not just a mobile fix.
- **Right-side panels** (`ChatSessionDrawer`, `ChatSearchPanel`, `PlanPanel`):
  - Unified mobile width to `calc(100vw - 56px)` (the remaining space beside the collapsed sidebar) so all three panels look consistent across phone sizes.
  - Drawer border radius is removed on mobile for a full-height sheet feel.
  - Dark-mode background unified with the global `#141414` page background.
- **Shared hook**: introduces `console/src/hooks/useIsMobile.ts` to replace duplicated viewport detection logic.

**Related Issue:** Relates to mobile responsiveness improvements.

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

_Not applicable._

## Testing

1. Open the chat page on a desktop viewport: Plan should be inline, title hover shows the primary color, and clicking the title opens a session switcher dropdown.
2. Switch to mobile (`≤768px`): the `⋮` menu should appear and contain History/Plan/Wide mode entries.
3. Open History, Search, and Plan panels: all three should share the same width and align flush with the collapsed sidebar.
4. Switch to dark mode: the three panels should match the main content background color.

## Local Verification Evidence

```bash
cd console
npm run build
# ✓ built successfully
```

## Additional Notes

- The desktop title-dropdown behavior was explicitly requested and retained after audit.
- `useIsMobile` is introduced in this PR; future mobile work can rely on it once this merges.