### PR TITLE
fix(channel): yield failed AgentResponse on console errors to unblock UI

### DIFF
--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -4,9 +4,10 @@
 
 A lightweight channel that prints all agent responses to stdout.
 
-Messages are sent to the agent via POST /api/console/chat. This channel
-handles the **output** side: whenever a completed message event or a
-proactive send arrives, it is pretty-printed to the terminal.
+Messages are sent to the agent via the standard AgentApp ``/agent/process``
+endpoint or via POST /console/chat. This channel handles the **output** side:
+whenever a completed message event or a proactive send arrives, it is
+pretty-printed to the terminal.
 """
 
 from __future__ import annotations
@@ -20,16 +21,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
-from qwenpaw.schemas import (
+from agentscope_runtime.engine.schemas.agent_schemas import (
     MessageType,
     Message,
     RunStatus,
+    AgentResponse,
+    Error,
 )
 
 from ....config.config import ConsoleConfig as ConsoleChannelConfig
 from ...console_push_store import append as push_store_append
 from ....constant import DEFAULT_MEDIA_DIR
-from ....exceptions import ModelQuotaExceededException
+from ....exceptions import ModelQuotaExceededException, convert_model_exception
 from ..base import (
     BaseChannel,
     AudioContent,
@@ -64,8 +67,8 @@ def _ts() -> str:
 class ConsoleChannel(BaseChannel):
     """Console Channel: prints agent responses to stdout.
 
-    Input is handled by ``POST /api/console/chat``; this channel only
-    takes care of output (printing to the terminal).
+    Input is handled by AgentApp's ``/agent/process`` endpoint; this
+    channel only takes care of output (printing to the terminal).
 
     Supports filtering options via config:
         - show_tool_details: Display tool execution details
@@ -314,9 +317,7 @@ class ConsoleChannel(BaseChannel):
                     type=MessageType.MESSAGE,
                     role="assistant",
                     content=new_parts,
-                    status=RunStatus.Completed,
                 )
-                media_message.object = "message"
         return media_message
 
     def _build_trailing_usage_sse(self, session_id: str) -> str | None:
@@ -493,10 +494,57 @@ class ConsoleChannel(BaseChannel):
             )
             yield f"data: {rl_event}\n\n"
             self._print_error(str(e).strip())
+
+            # Yield failed response to avoid stuck UI
+            error_obj = Error(
+                code="MODEL_QUOTA_EXCEEDED",
+                message=str(e).strip(),
+            )
+            req_id = getattr(request, "id", None)
+            failed_resp = AgentResponse(
+                id=req_id,
+                session_id=session_id,
+            ).failed(error_obj)
+            data = self._serialize_event_for_sse(failed_resp)
+            yield f"data: {data}\n\n"
+
         except Exception as e:
             logger.exception("console process/reply failed")
             err_msg = str(e).strip() or "An error occurred while processing."
             self._print_error(err_msg)
+
+            # Yield failed response to avoid stuck UI
+            from agentscope_runtime.engine.schemas.exception import (
+                AgentRuntimeErrorException,
+            )
+
+            if isinstance(e, AgentRuntimeErrorException):
+                converted = e
+            else:
+                model_name = None
+                if self._workspace is not None and hasattr(
+                    self._workspace,
+                    "runner",
+                ):
+                    runner = self._workspace.runner
+                    if runner is not None:
+                        agent = getattr(runner, "agent", None)
+                        if agent and hasattr(agent, "model"):
+                            model_name = getattr(
+                                agent.model,
+                                "model_name",
+                                None,
+                            )
+                converted = convert_model_exception(e, model_name)
+
+            error_obj = Error(code=converted.code, message=converted.message)
+            req_id = getattr(request, "id", None)
+            failed_resp = AgentResponse(
+                id=req_id,
+                session_id=session_id,
+            ).failed(error_obj)
+            data = self._serialize_event_for_sse(failed_resp)
+            yield f"data: {data}\n\n"
 
     async def consume_one(self, payload: Any) -> None:
         """Process one payload; drain stream_one (queue/terminal)."""


### PR DESCRIPTION
## Description

Fixes the console channel leaving the UI in a perpetual waiting state when a model or runtime error occurs.

Previously, `ConsoleChannel.process_reply` caught `ModelQuotaExceededException` and generic `Exception`, printed the error, and yielded an SSE error line, but never yielded a terminal `AgentResponse` with a failed status. The chat UI would keep showing the loading indicator because no final response arrived.

This change:

- Builds an `Error` object from the exception.
- Yields a failed `AgentResponse` via the existing `_serialize_event_for_sse` path.
- Converts generic exceptions through `convert_model_exception` to preserve meaningful error codes where applicable.

**Related Issue:** Relates to console channel reliability / UI unblocking.

**Security Considerations:** Error messages are the stripped `str(e)` or converted exception messages; no internal traceback is sent to the client. Model name is read from the workspace runner only when available.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Trigger a model quota exceeded error in the console channel.
2. Observe the SSE stream: a failed `AgentResponse` should arrive, allowing the UI to stop the loading spinner and display the error.
3. Repeat with a generic runtime exception: the UI should receive a failed response with a meaningful code/message.

## Local Verification Evidence

```bash
# Backend change; frontend build not required.
# Syntax/import check:
python3 -c "from src.qwenpaw.app.channels.console.channel import ConsoleChannel; print('OK')"
```

## Additional Notes

- This is intentionally split out from the UI mobile-adaptation PRs because it is an independent backend fix.