### PR TITLE
feat(console): mobile adaptation for Debug page

### DIFF
--- a/console/src/pages/Settings/Debug/index.module.less
+++ b/console/src/pages/Settings/Debug/index.module.less
@@ -36,6 +36,18 @@
   flex-wrap: wrap;
 }
 
+.levelSelect {
+  width: 160px;
+}
+
+.searchInput {
+  width: 320px;
+}
+
+.updatedAt {
+  font-size: 12px;
+}
+
 .toolbarRight {
   display: flex;
   align-items: center;
@@ -104,5 +116,59 @@
 
   .highlight {
     background: rgba(255, 214, 102, 0.35);
+  }
+}
+
+/* ─── Mobile Adaptation ──────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .content {
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .cardExtra {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .toolbarLeft {
+    width: 100%;
+  }
+
+  .levelSelect {
+    flex: 0 0 auto;
+    width: 120px !important;
+  }
+
+  .searchInput {
+    flex: 1 1 auto;
+    width: auto !important;
+    min-width: 0;
+  }
+
+  .updatedAt {
+    width: 100%;
+  }
+
+  .toolbarRight {
+    width: 100%;
+    justify-content: stretch;
+
+    > * {
+      flex: 1;
+    }
+  }
+
+  .logPath {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
   }
 }

--- a/console/src/pages/Settings/Debug/index.tsx
+++ b/console/src/pages/Settings/Debug/index.tsx
@@ -57,7 +57,7 @@ export default function DebugPage() {
         <Card
           title={t("debug.backend.title", "Backend logs")}
           extra={
-            <Space size="middle">
+            <Space size="middle" className={styles.cardExtra}>
               <Text type="secondary">
                 {t("debug.backend.newestFirst", "Newest first")}
               </Text>
@@ -76,7 +76,7 @@ export default function DebugPage() {
             <div className={styles.toolbar}>
               <div className={styles.toolbarLeft}>
                 <Select
-                  style={{ width: 160 }}
+                  className={styles.levelSelect}
                   value={backendLevel}
                   onChange={(v) => setBackendLevel(v)}
                   options={[
@@ -106,7 +106,7 @@ export default function DebugPage() {
                   ]}
                 />
                 <Input
-                  style={{ width: 320 }}
+                  className={styles.searchInput}
                   value={backendQuery}
                   onChange={(e) => setBackendQuery(e.target.value)}
                   placeholder={t(
@@ -116,7 +116,7 @@ export default function DebugPage() {
                   allowClear
                 />
                 {backendLogs?.updated_at && (
-                  <Text type="secondary">
+                  <Text type="secondary" className={styles.updatedAt}>
                     {t("debug.backend.updatedAt", "Updated at")}:{" "}
                     {dayjs(backendLogs.updated_at * 1000).format(
                       "YYYY-MM-DD HH:mm:ss",


### PR DESCRIPTION
## Description

Adds mobile responsive styling to the **Settings → Debug** page so the backend-log toolbar and card controls no longer overflow on narrow viewports.

The main overflow was caused by the fixed-width search input (`320px`) and the horizontal toolbar layout, which together exceeded the available screen width on phones. This PR stacks the controls vertically on mobile while preserving the existing desktop layout.

**Related Issue:** Relates to ongoing mobile console adaptation work.

**Security Considerations:** None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open the **Settings → Debug** page on a mobile device or narrow browser viewport (≤768px).
2. Confirm:
   - The “Newest first” / “Auto refresh” switches in the card header stack vertically instead of pushing the title.
   - The level select, search input, updated-at text, and action buttons stack vertically without horizontal overflow.
   - The search input fills the available width on mobile.
   - The log-file path label and value stack vertically on mobile.
3. Resize back to desktop width and confirm the original horizontal layout is unchanged.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run test:run
# Test Files  49 passed (49)
# Tests       496 passed (496)

npm run build
# ✓ built in 17.21s
```

## Additional Notes

- All mobile-only rules are scoped inside `@media (max-width: 768px)` to avoid affecting the desktop layout.
- The fixed `style={{ width: 320 }}` on the search input was moved to CSS so the width can be overridden cleanly in the media query.
