### PR TITLE
feat(console): mobile adaptation for Security page

### DIFF
--- a/console/src/pages/Settings/Security/index.module.less
+++ b/console/src/pages/Settings/Security/index.module.less
@@ -643,3 +643,99 @@
   display: inline-flex;
   align-items: center;
 }
+
+/* ─── Mobile Adaptation ──────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .mainTabs {
+    :global {
+      .qwenpaw-tabs-nav {
+        overflow-x: auto;
+        scrollbar-width: none;
+
+        &::-webkit-scrollbar {
+          display: none;
+        }
+      }
+
+      .qwenpaw-tabs-nav-wrap {
+        overflow-x: auto !important;
+        white-space: nowrap;
+      }
+
+      .qwenpaw-tabs-nav-list {
+        display: inline-flex;
+        white-space: nowrap;
+      }
+
+      .qwenpaw-tabs-tab {
+        flex-shrink: 0;
+        white-space: nowrap;
+      }
+    }
+  }
+
+  .content {
+    padding: 0 12px;
+  }
+
+  .sectionConfigureContainer {
+    padding-bottom: 16px;
+  }
+
+  .formCard {
+    :global(.ant-card-body) {
+      padding: 16px;
+    }
+  }
+
+  .toolGuardRow {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .sectionHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px 12px 0;
+  }
+
+  .ruleTable,
+  .tableCard {
+    overflow-x: auto;
+
+    :global(.ant-table),
+    :global(.qwenpaw-table) {
+      min-width: 600px;
+    }
+  }
+
+  .ruleCollapse {
+    :global(.qwenpaw-collapse-header) {
+      padding: 10px 12px !important;
+    }
+  }
+
+  .shellEvasionGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .skillScannerConfig {
+    grid-template-columns: 1fr;
+  }
+
+  .skillScannerConfigItem {
+    padding-right: 0;
+  }
+
+  .skillScannerConfigItem + .skillScannerConfigItem {
+    border-left: none;
+    border-top: 1px solid var(--ant-color-border, #f0f0f0);
+    padding-top: 12px;
+    margin-top: 12px;
+  }
+
+  .footerButtons {
+    padding: 12px 16px;
+  }
+}


### PR DESCRIPTION
## Description

Adds mobile responsive styling to the **Settings → Security** page so the tab bar, tool-guard form, rule tables, and footer actions no longer overflow or get truncated on narrow viewports.

**Key issues fixed:**
- The three main tabs (`Tool Guard`, `Skill Scanner`, `Allow-No-Auth Hosts`) had long labels that were truncated on phones; they now scroll horizontally.
- The `Guarded Tools` / `Denied Tools` selects were side-by-side in a 2-column grid and got squeezed/overlapped; they now stack vertically.
- Rule tables and table cards have many columns with fixed widths; they now scroll horizontally on mobile instead of pushing the page width.
- Section headers with a title + action button, shell-evasion check grids, and skill-scanner config grids are re-flowed for narrow screens.
- Footer action buttons keep their original horizontal layout on mobile; only padding is slightly reduced.

**Related Issue:** Relates to ongoing mobile console adaptation work.

**Security Considerations:** None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open the **Settings → Security** page on a mobile device or narrow browser viewport (≤768px).
2. Switch between the three tabs and confirm:
   - Tab labels are no longer truncated and the tab bar scrolls horizontally.
   - Tool Guard form stacks the `Guarded Tools` / `Denied Tools` selects vertically.
   - Rule tables scroll horizontally instead of overflowing.
   - Section headers with action buttons stack vertically.
   - Footer action buttons keep the original horizontal layout.
3. Resize back to desktop width and confirm the original horizontal layout is unchanged.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run test:run
# Test Files  49 passed (49)
# Tests       496 passed (496)

npm run build
# ✓ built in 17.13s
```

## Additional Notes

- All mobile-only rules are scoped inside `@media (max-width: 768px)` to avoid affecting the desktop layout.
- The change is limited to `console/src/pages/Settings/Security/index.module.less`.
