### PR TITLE
feat(console): mobile adaptation for Skill Pool page

### DIFF
--- a/console/src/pages/Settings/SkillPool/index.module.less
+++ b/console/src/pages/Settings/SkillPool/index.module.less
@@ -1157,8 +1157,94 @@
     align-items: stretch;
   }
 
+  .headerRight {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+  }
+
   .headerActionsLeft,
-  .headerActionsRight {
+  .headerActionsRight,
+  .batchActions {
     flex-wrap: wrap;
+    width: 100%;
+
+    > * {
+      flex: 1 0 auto;
+      min-width: 0;
+    }
+
+    :global(.qwenpaw-btn) {
+      min-width: 0;
+    }
+  }
+
+  .primaryTransferButton,
+  .primaryActionButton {
+    min-width: 0;
+  }
+
+  .importToolbar {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .searchContainer {
+    max-width: none;
+    width: 100%;
+  }
+
+  .searchInput {
+    :global(input) {
+      text-align: center;
+    }
+  }
+
+  .tagSelect {
+    :global {
+      .qwenpaw-select-selection-placeholder,
+      .ant-select-selection-placeholder {
+        text-align: center;
+      }
+
+      .qwenpaw-select-selection-overflow,
+      .ant-select-selection-overflow {
+        justify-content: center;
+      }
+    }
+  }
+
+  .toolbarRight {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .skillsGrid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .skillCard {
+    min-height: auto;
+  }
+
+  .cardTopRight {
+    gap: 6px;
+  }
+
+  .metaInfoRow {
+    flex-wrap: wrap;
+
+    .metaInfoLabel {
+      min-width: 64px;
+    }
   }
 }


### PR DESCRIPTION
## Description

Adds mobile responsive styling to the **Settings → Skill Pool** page so the dense header actions, search toolbar, and skill grid no longer overflow or get clipped on narrow viewports.

**Key issues fixed:**
- The header had two crowded rows of buttons (refresh / broadcast / import built-in on the left; upload zip / import hub / batch / create on the right). On mobile they now stack vertically and each button is allowed to wrap.
- The toolbar with the search box, tag filter, and view toggle was squeezed horizontally. On mobile it now stacks vertically with the search box filling the width.
- The skill grid used `repeat(auto-fill, minmax(320px, 1fr))`, which caused cards to be squeezed or partially off-screen. On mobile it collapses to a single column.
- Card padding and meta rows are reduced/allowed to wrap for narrow screens.

**Related Issue:** Relates to ongoing mobile console adaptation work.

**Security Considerations:** None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open the **Settings → Skill Pool** page on a mobile device or narrow browser viewport (≤768px).
2. Confirm the header action buttons stack vertically and no longer overflow the page width.
3. Confirm the search toolbar stacks vertically and the search box fills the width.
4. Confirm skill cards render in a single column and card content is readable.
5. Resize back to desktop width and confirm the original multi-column grid and horizontal toolbar are restored.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run build
# ✓ built in 16.91s
```

## Additional Notes

- All mobile-only rules are scoped inside `@media (max-width: 768px)` to avoid affecting the desktop layout.
- The change is limited to `console/src/pages/Settings/SkillPool/index.module.less`.
