### PR TITLE
fix: macos sandbox missing close bracket

### DIFF
--- a/src/qwenpaw/sandbox/macos_sandbox.py
+++ b/src/qwenpaw/sandbox/macos_sandbox.py
@@ -166,7 +166,7 @@ class MacOSSandbox(LocalSandbox):
             # allow-list mode: only allow reading declared mounts
             for mount in config.mounts:
                 lines.append("(allow file-read*")
-                lines.append(f'  (subpath "{_san(mount.path)}")')
+                lines.append(f'  (subpath "{_san(mount.path)}"))')
 
         # Deny sensitive paths (read + write)
         if config.deny_paths:
@@ -175,9 +175,9 @@ class MacOSSandbox(LocalSandbox):
             for p in config.deny_paths:
                 expanded = _san(os.path.expanduser(p))
                 lines.append("(deny file-read*")
-                lines.append(f'  (subpath "{expanded}")')
+                lines.append(f'  (subpath "{expanded}"))')
                 lines.append("(deny file-write*")
-                lines.append(f'  (subpath "{expanded}")')
+                lines.append(f'  (subpath "{expanded}"))')
 
         # File write paths (whitelist)
         lines.append("")
@@ -198,7 +198,7 @@ class MacOSSandbox(LocalSandbox):
         for mount in config.mounts:
             if mount.writable:
                 lines.append("(allow file-write*")
-                lines.append(f'  (subpath "{_san(mount.path)}")')
+                lines.append(f'  (subpath "{_san(mount.path)}"))')
 
         # Executable control
         non_exec_mounts = [m for m in config.mounts if not m.executable]
@@ -207,7 +207,7 @@ class MacOSSandbox(LocalSandbox):
             lines.append("; Deny execution in specific paths")
             for mount in non_exec_mounts:
                 lines.append("(deny process-exec*")
-                lines.append(f'  (subpath "{_san(mount.path)}")')
+                lines.append(f'  (subpath "{_san(mount.path)}"))')
 
         # Platform hints: extra seatbelt rules
         # WARNING: seatbelt_extra_rules is an ADMIN-ONLY escape hatch.


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
