### PR TITLE
fix: cap the file size of send_file_to_user

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -40,6 +40,7 @@ from .utils.message_request_normalizer import (
 )
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
+from ..providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 from ..providers.retry_chat_model import (
     RetryChatModel,
     RetryConfig,
@@ -153,6 +154,25 @@ def _anthropic_media_dedup_key(source: Any) -> str | None:
     return None
 
 
+def _video_oversize_placeholder(size: int) -> dict:
+    """Text placeholder substituted for a video that exceeds the inline cap.
+
+    Mirrors the wording used by ``capping_formatter``'s
+    ``CappingFormatterMixin._placeholder_text`` so oversized-video messages
+    are consistent across every provider path.  Tool-result videos inline
+    through these helpers bypass the capping formatters (which only see
+    ``_format_*_source``), so the cap is enforced here instead.
+    """
+    return {
+        "type": "text",
+        "text": (
+            f"[video omitted from model context: local file is "
+            f"{size} bytes, exceeds inline limit of "
+            f"{MAX_INLINE_MEDIA_BYTES} bytes]"
+        ),
+    }
+
+
 def _format_anthropic_video_data_block(block: Any) -> dict | None:
     """Format a 2.0 ``DataBlock`` of video media for Anthropic-compatible APIs.
 
@@ -163,15 +183,20 @@ def _format_anthropic_video_data_block(block: Any) -> dict | None:
     Returns the wire dict, or ``None`` if the source is unusable
     (missing file, unsupported extension, exotic scheme).
     """
+    # pylint: disable=too-many-return-statements
     source = getattr(block, "source", None)
     if source is None:
         return None
 
     media_type = getattr(source, "media_type", None) or ""
 
-    # Base64Source — pass data straight through.
+    # Base64Source — pass data straight through (after the size cap).
     data_attr = getattr(source, "data", None)
     if data_attr is not None:
+        # base64 length -> approximate raw byte count.
+        size = len(data_attr or "") * 3 // 4
+        if size > MAX_INLINE_MEDIA_BYTES:
+            return _video_oversize_placeholder(size)
         return {
             "type": "video",
             "source": {
@@ -187,6 +212,14 @@ def _format_anthropic_video_data_block(block: Any) -> dict | None:
 
     raw_url = _file_url_to_path(url_str)
     if os.path.exists(raw_url) and os.path.isfile(raw_url):
+        # Cap oversized local files before reading/encoding the whole
+        # thing into the request body (see ``capping_formatter``).
+        try:
+            size = os.path.getsize(raw_url)
+        except OSError:
+            size = 0
+        if size > MAX_INLINE_MEDIA_BYTES:
+            return _video_oversize_placeholder(size)
         ext = os.path.splitext(raw_url)[1].lower()
         resolved_media_type = (
             media_type
@@ -236,10 +269,22 @@ def _format_openai_video_block(video_block: dict) -> dict:
     source = video_block["source"]
     if source["type"] == "base64":
         media_type = source["media_type"]
+        # base64 length -> approximate raw byte count.
+        size = len(source.get("data") or "") * 3 // 4
+        if size > MAX_INLINE_MEDIA_BYTES:
+            return _video_oversize_placeholder(size)
         url = f"data:{media_type};base64,{source['data']}"
     elif source["type"] == "url":
         raw_url = _file_url_to_path(source["url"])
         if os.path.exists(raw_url) and os.path.isfile(raw_url):
+            # Cap oversized local files before reading/encoding the whole
+            # thing into the request body (see ``capping_formatter``).
+            try:
+                size = os.path.getsize(raw_url)
+            except OSError:
+                size = 0
+            if size > MAX_INLINE_MEDIA_BYTES:
+                return _video_oversize_placeholder(size)
             ext = os.path.splitext(raw_url)[1].lower()
             media_type = _SUPPORTED_VIDEO_EXTENSIONS.get(ext)
             if not media_type:

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -14,7 +14,6 @@ from agentscope.model import ChatModelBase
 import anthropic
 from pydantic import Field
 
-from qwenpaw.providers.capping_formatter import _CappingAnthropicFormatter
 from qwenpaw.providers.multimodal_prober import (
     ProbeResult,
     _PROBE_IMAGE_B64,
@@ -23,6 +22,9 @@ from qwenpaw.providers.multimodal_prober import (
     evaluate_image_probe_answer,
 )
 from qwenpaw.providers.provider import ModelInfo, Provider
+
+from .capping_formatter import _CappingAnthropicFormatter
+from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +73,7 @@ class AnthropicProvider(Provider):
     """Provider implementation for Anthropic API."""
 
     max_inline_media_bytes: int = Field(
-        default=2 * 1024 * 1024,
+        default=MAX_INLINE_MEDIA_BYTES,
         ge=0,
         description=(
             "Maximum size (in bytes) of a local media file inlined as "

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -12,7 +12,9 @@ from typing import Any, Dict, List
 import httpx
 from agentscope.model import ChatModelBase
 import anthropic
+from pydantic import Field
 
+from qwenpaw.providers.capping_formatter import _CappingAnthropicFormatter
 from qwenpaw.providers.multimodal_prober import (
     ProbeResult,
     _PROBE_IMAGE_B64,
@@ -67,6 +69,18 @@ class _StripApiKeyTransport(httpx.AsyncHTTPTransport):
 
 class AnthropicProvider(Provider):
     """Provider implementation for Anthropic API."""
+
+    max_inline_media_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=0,
+        description=(
+            "Maximum size (in bytes) of a local media file inlined as "
+            "base64 into the model request body. Media above this is "
+            "replaced with a text placeholder to avoid oversized requests "
+            "when large files (e.g. generated videos) persist in "
+            "conversation history. 0 disables capping."
+        ),
+    )
 
     # Cached AsyncClient for auth_token mode; re-created when auth_mode
     # changes so that the transport is always consistent with the current
@@ -280,6 +294,9 @@ class AnthropicProvider(Provider):
                 else None
             ),
             context_size=self._get_context_size(model_id),
+            formatter=_CappingAnthropicFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )
 
     async def probe_model_multimodal(

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Capping formatters that refuse to inline oversized local media.
+
+agentscope's chat formatters (OpenAI, Anthropic, Gemini, DashScope, …) all
+read every local ``file://`` media source off disk and base64-encode the
+*entire* file into the request body on every API call.  When a large file
+persists in conversation history (e.g. a 42 MB generated video produced by
+``send_file_to_user``) the request body balloons and the provider drops the
+connection on every subsequent turn.
+
+The model does not need such large media echoed back — it already has the
+surrounding text context — so anything above a configurable byte cap is
+substituted with a small text placeholder.  Capping operates purely on the
+ephemeral formatted output, so persisted conversation history and UI media
+rendering are unaffected.  ``max_bytes <= 0`` disables capping (everything
+is inlined, matching the base formatter).
+
+This module is the single source of truth shared by every provider; each
+provider wires the matching ``_Capping<Provider>Formatter`` into its chat
+model via the ``formatter=`` constructor kwarg.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# The capping formatters below override agentscope's ``_format_*_source``
+# methods, which are ``@staticmethod`` on the base classes, with instance
+# methods (they need ``self`` for the cap state).  Runtime dispatch goes
+# through ``self._format_*_source(...)``, so the instance override is picked
+# up and ``super()._format_*_source(source)`` calls the base static method
+# correctly — but pylint flags the signature change as ``arguments-differ``.
+# It is intentional, so silence it for the whole module.
+# pylint: disable=arguments-differ
+
+from agentscope.formatter import (
+    AnthropicChatFormatter,
+    DashScopeChatFormatter,
+    GeminiChatFormatter,
+    OpenAIChatFormatter,
+)
+from agentscope.message import Base64Source, URLSource
+from pydantic import Field
+
+# Maximum size (in bytes) of a local media file we are willing to inline as
+# base64 into the model request body.  See the module docstring for the
+# rationale.
+MAX_INLINE_MEDIA_BYTES = 2 * 1024 * 1024  # 2 MB
+
+
+def inline_media_size(source: Any) -> int | None:
+    """Return the byte size of *source* if it would be inlined locally.
+
+    Returns ``None`` for remote URLs (not read from disk here) and for
+    unrecognised source types so the caller leaves them untouched.
+    """
+    if isinstance(source, URLSource):
+        url = str(source.url)
+        if url.startswith("file://"):
+            try:
+                return os.path.getsize(url.removeprefix("file://"))
+            except OSError:
+                return None
+        return None
+    if isinstance(source, Base64Source):
+        # base64 length -> approximate raw byte count.
+        return len(source.data or "") * 3 // 4
+    return None
+
+
+class CappingFormatterMixin:  # pylint: disable=too-few-public-methods
+    """Pydantic mixin shared by every capping formatter.
+
+    Holds the configurable ``max_bytes`` cap and the placeholder logic.
+    Subclasses override the relevant ``_format_*_source`` methods to call
+    :meth:`_maybe_cap` first and defer to ``super()`` otherwise.
+    """
+
+    max_bytes: int = Field(default=MAX_INLINE_MEDIA_BYTES, ge=0)
+
+    @staticmethod
+    def _inline_media_size(source: Any) -> int | None:
+        """Byte size of *source* if inlined locally, else ``None``.
+
+        Thin wrapper over :func:`inline_media_size` kept as a staticmethod
+        so callers (and tests) can invoke it on the class.
+        """
+        return inline_media_size(source)
+
+    def _placeholder_text(self, kind: str, size: int) -> str:
+        return (
+            f"[{kind} omitted from model context: local file is "
+            f"{size} bytes, exceeds inline limit of "
+            f"{self.max_bytes} bytes]"
+        )
+
+    def _placeholder(self, kind: str, size: int) -> dict[str, Any]:
+        """Provider-shaped text placeholder for an oversized media block.
+
+        Default shape (``{"type": "text", "text": ...}``) matches the
+        OpenAI / Anthropic / DashScope wire formats; Gemini overrides this
+        to its ``{"text": ...}`` part shape.
+        """
+        return {"type": "text", "text": self._placeholder_text(kind, size)}
+
+    def _maybe_cap(self, source: Any, kind: str) -> dict[str, Any] | None:
+        """Return a placeholder dict if *source* exceeds the cap, else None.
+
+        ``None`` means "no capping decision — defer to the base formatter".
+        """
+        if self.max_bytes <= 0:
+            return None
+        size = self._inline_media_size(source)
+        if size is None or size <= self.max_bytes:
+            return None
+        return self._placeholder(kind, size)
+
+
+class _CappingOpenAIFormatter(OpenAIChatFormatter, CappingFormatterMixin):
+    """OpenAI formatter that caps oversized local image/audio media."""
+
+    def _format_image_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "image")
+        if capped is not None:
+            return capped
+        return super()._format_image_source(source)
+
+    def _format_audio_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "audio")
+        if capped is not None:
+            return capped
+        return super()._format_audio_source(source)
+
+
+class _CappingAnthropicFormatter(
+    AnthropicChatFormatter,
+    CappingFormatterMixin,
+):
+    """Anthropic formatter that caps oversized local image media."""
+
+    def _format_image_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "image")
+        if capped is not None:
+            return capped
+        return super()._format_image_source(source)
+
+
+class _CappingGeminiFormatter(GeminiChatFormatter, CappingFormatterMixin):
+    """Gemini formatter that caps oversized local media.
+
+    Gemini handles every media kind through a single
+    :meth:`_format_media_source`, and its text-part shape is ``{"text": ...}``
+    (not the ``{"type": "text", ...}`` used by OpenAI/Anthropic/DashScope),
+    so :meth:`_placeholder` is overridden accordingly.
+    """
+
+    def _placeholder(self, kind: str, size: int) -> dict[str, Any]:
+        return {"text": self._placeholder_text(kind, size)}
+
+    def _format_media_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "media")
+        if capped is not None:
+            return capped
+        return super()._format_media_source(source)
+
+
+class _CappingDashScopeFormatter(
+    DashScopeChatFormatter,
+    CappingFormatterMixin,
+):
+    """DashScope formatter capping oversized local image/video/audio media."""
+
+    def _format_video_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "video")
+        if capped is not None:
+            return capped
+        return super()._format_video_source(source)
+
+    def _format_image_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "image")
+        if capped is not None:
+            return capped
+        return super()._format_image_source(source)
+
+    def _format_audio_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "audio")
+        if capped is not None:
+            return capped
+        return super()._format_audio_source(source)

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -22,8 +22,11 @@ model via the ``formatter=`` constructor kwarg.
 
 from __future__ import annotations
 
+import base64
 import os
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 # The capping formatters below override agentscope's ``_format_*_source``
 # methods, which are ``@staticmethod`` on the base classes, with instance
@@ -58,8 +61,9 @@ def inline_media_size(source: Any) -> int | None:
     if isinstance(source, URLSource):
         url = str(source.url)
         if url.startswith("file://"):
+            path = url2pathname(urlparse(url).path)
             try:
-                return os.path.getsize(url.removeprefix("file://"))
+                return os.path.getsize(path)
             except OSError:
                 return None
         return None
@@ -116,6 +120,24 @@ class CappingFormatterMixin:  # pylint: disable=too-few-public-methods
             return None
         return self._placeholder(kind, size)
 
+    @staticmethod
+    def _local_source_to_base64(source: Any) -> Any:
+        """Convert a local ``file://`` URLSource to a Base64Source.
+
+        Non-local sources (remote URLs, already-base64 sources, anything
+        else) are returned unchanged so the base formatter handles them as
+        before.
+        """
+        if not isinstance(source, URLSource):
+            return source
+        url = str(source.url)
+        if not url.startswith("file://"):
+            return source
+        path = url2pathname(urlparse(url).path)
+        with open(path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("utf-8")
+        return Base64Source(data=encoded, media_type=source.media_type)
+
 
 class _CappingOpenAIFormatter(OpenAIChatFormatter, CappingFormatterMixin):
     """OpenAI formatter that caps oversized local image/audio media."""
@@ -124,13 +146,17 @@ class _CappingOpenAIFormatter(OpenAIChatFormatter, CappingFormatterMixin):
         capped = self._maybe_cap(source, "image")
         if capped is not None:
             return capped
-        return super()._format_image_source(source)
+        return super()._format_image_source(
+            self._local_source_to_base64(source),
+        )
 
     def _format_audio_source(self, source: Any) -> dict[str, Any]:
         capped = self._maybe_cap(source, "audio")
         if capped is not None:
             return capped
-        return super()._format_audio_source(source)
+        return super()._format_audio_source(
+            self._local_source_to_base64(source),
+        )
 
 
 class _CappingAnthropicFormatter(
@@ -143,7 +169,9 @@ class _CappingAnthropicFormatter(
         capped = self._maybe_cap(source, "image")
         if capped is not None:
             return capped
-        return super()._format_image_source(source)
+        return super()._format_image_source(
+            self._local_source_to_base64(source),
+        )
 
 
 class _CappingGeminiFormatter(GeminiChatFormatter, CappingFormatterMixin):
@@ -162,7 +190,9 @@ class _CappingGeminiFormatter(GeminiChatFormatter, CappingFormatterMixin):
         capped = self._maybe_cap(source, "media")
         if capped is not None:
             return capped
-        return super()._format_media_source(source)
+        return super()._format_media_source(
+            self._local_source_to_base64(source),
+        )
 
 
 class _CappingDashScopeFormatter(
@@ -175,16 +205,22 @@ class _CappingDashScopeFormatter(
         capped = self._maybe_cap(source, "video")
         if capped is not None:
             return capped
-        return super()._format_video_source(source)
+        return super()._format_video_source(
+            self._local_source_to_base64(source),
+        )
 
     def _format_image_source(self, source: Any) -> dict[str, Any]:
         capped = self._maybe_cap(source, "image")
         if capped is not None:
             return capped
-        return super()._format_image_source(source)
+        return super()._format_image_source(
+            self._local_source_to_base64(source),
+        )
 
     def _format_audio_source(self, source: Any) -> dict[str, Any]:
         capped = self._maybe_cap(source, "audio")
         if capped is not None:
             return capped
-        return super()._format_audio_source(source)
+        return super()._format_audio_source(
+            self._local_source_to_base64(source),
+        )

--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any, Dict
 
+from agentscope.formatter import DashScopeChatFormatter
+from agentscope.message import Base64Source, URLSource
 from agentscope.model import ChatModelBase
 from pydantic import Field
 
@@ -27,12 +30,35 @@ from .openai_provider import (
 
 logger = logging.getLogger(__name__)
 
+# Maximum size (in bytes) of a local media file that we are willing to
+# inline as base64 into the model request body.  agentscope's base
+# DashScope formatter reads every ``file://`` media source off disk and
+# base64-encodes the *entire* file on every API call — so a large file
+# persisted in conversation history (e.g. a 42 MB generated video) would
+# balloon the request body and cause the provider to drop the connection
+# on every subsequent turn.  The model does not need such large media
+# echoed back (it already has the surrounding text context), so anything
+# above this cap is substituted with a small text placeholder.
+_MAX_INLINE_MEDIA_BYTES = 2 * 1024 * 1024  # 2 MB
+
 
 class DashScopeProvider(OpenAIProvider):
     """Provider that wires the builtin DashScope endpoint to 2.0 native
     ``DashScopeChatModel``."""
 
     chat_model: str = Field(default="DashScopeChatModel")
+
+    max_inline_media_bytes: int = Field(
+        default=_MAX_INLINE_MEDIA_BYTES,
+        ge=0,
+        description=(
+            "Maximum size (in bytes) of a local media file inlined as "
+            "base64 into the model request body. Media above this is "
+            "replaced with a text placeholder to avoid oversized requests "
+            "when large files (e.g. generated videos) persist in "
+            "conversation history. 0 disables capping."
+        ),
+    )
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
         from agentscope.credential import DashScopeCredential
@@ -124,7 +150,76 @@ class DashScopeProvider(OpenAIProvider):
             context_size=self._get_context_size(model_id),
             thinking_explicitly_set=thinking_explicitly_set,
             extra_generate_kwargs=extra_generate_kwargs,
+            formatter=_CappingDashScopeFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )
+
+
+class _CappingDashScopeFormatter(DashScopeChatFormatter):
+    """DashScope formatter that refuses to inline oversized local media.
+
+    Overrides the per-source formatters to substitute a text placeholder
+    when the underlying media would exceed ``max_bytes``.  Operates purely
+    on the ephemeral formatted output, so persisted conversation history
+    and UI media rendering are unaffected.  ``max_bytes <= 0`` disables
+    capping (everything is inlined, matching the base formatter).
+    """
+
+    max_bytes: int = Field(default=_MAX_INLINE_MEDIA_BYTES)
+
+    @staticmethod
+    def _inline_media_size(source: Any) -> int | None:
+        """Return the byte size of *source* if it would be inlined locally.
+
+        Returns ``None`` for remote URLs (not read from disk here) and for
+        unrecognised source types so the caller leaves them untouched.
+        """
+        if isinstance(source, URLSource):
+            url = str(source.url)
+            if url.startswith("file://"):
+                try:
+                    return os.path.getsize(url.removeprefix("file://"))
+                except OSError:
+                    return None
+            return None
+        if isinstance(source, Base64Source):
+            # base64 length -> approximate raw byte count.
+            return len(source.data or "") * 3 // 4
+        return None
+
+    def _maybe_cap(self, source: Any, kind: str) -> dict[str, Any] | None:
+        if self.max_bytes <= 0:
+            return None
+        size = self._inline_media_size(source)
+        if size is None or size <= self.max_bytes:
+            return None
+        return {
+            "type": "text",
+            "text": (
+                f"[{kind} omitted from model context: local file is "
+                f"{size} bytes, exceeds inline limit of "
+                f"{self.max_bytes} bytes]"
+            ),
+        }
+
+    def _format_video_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "video")
+        if capped is not None:
+            return capped
+        return super()._format_video_source(source)
+
+    def _format_image_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "image")
+        if capped is not None:
+            return capped
+        return super()._format_image_source(source)
+
+    def _format_audio_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "audio")
+        if capped is not None:
+            return capped
+        return super()._format_audio_source(source)
 
 
 class _DashScopeChatModelCompat:

--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -13,14 +13,15 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import Any, Dict
 
-from agentscope.formatter import DashScopeChatFormatter
-from agentscope.message import Base64Source, URLSource
 from agentscope.model import ChatModelBase
 from pydantic import Field
 
+from .capping_formatter import (
+    MAX_INLINE_MEDIA_BYTES as _MAX_INLINE_MEDIA_BYTES,
+)
+from .capping_formatter import _CappingDashScopeFormatter
 from .openai_provider import (
     CODING_DASHSCOPE_BASE_URL,
     DASHSCOPE_BASE_URLS,
@@ -29,17 +30,6 @@ from .openai_provider import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Maximum size (in bytes) of a local media file that we are willing to
-# inline as base64 into the model request body.  agentscope's base
-# DashScope formatter reads every ``file://`` media source off disk and
-# base64-encodes the *entire* file on every API call — so a large file
-# persisted in conversation history (e.g. a 42 MB generated video) would
-# balloon the request body and cause the provider to drop the connection
-# on every subsequent turn.  The model does not need such large media
-# echoed back (it already has the surrounding text context), so anything
-# above this cap is substituted with a small text placeholder.
-_MAX_INLINE_MEDIA_BYTES = 2 * 1024 * 1024  # 2 MB
 
 
 class DashScopeProvider(OpenAIProvider):
@@ -154,72 +144,6 @@ class DashScopeProvider(OpenAIProvider):
                 max_bytes=self.max_inline_media_bytes,
             ),
         )
-
-
-class _CappingDashScopeFormatter(DashScopeChatFormatter):
-    """DashScope formatter that refuses to inline oversized local media.
-
-    Overrides the per-source formatters to substitute a text placeholder
-    when the underlying media would exceed ``max_bytes``.  Operates purely
-    on the ephemeral formatted output, so persisted conversation history
-    and UI media rendering are unaffected.  ``max_bytes <= 0`` disables
-    capping (everything is inlined, matching the base formatter).
-    """
-
-    max_bytes: int = Field(default=_MAX_INLINE_MEDIA_BYTES)
-
-    @staticmethod
-    def _inline_media_size(source: Any) -> int | None:
-        """Return the byte size of *source* if it would be inlined locally.
-
-        Returns ``None`` for remote URLs (not read from disk here) and for
-        unrecognised source types so the caller leaves them untouched.
-        """
-        if isinstance(source, URLSource):
-            url = str(source.url)
-            if url.startswith("file://"):
-                try:
-                    return os.path.getsize(url.removeprefix("file://"))
-                except OSError:
-                    return None
-            return None
-        if isinstance(source, Base64Source):
-            # base64 length -> approximate raw byte count.
-            return len(source.data or "") * 3 // 4
-        return None
-
-    def _maybe_cap(self, source: Any, kind: str) -> dict[str, Any] | None:
-        if self.max_bytes <= 0:
-            return None
-        size = self._inline_media_size(source)
-        if size is None or size <= self.max_bytes:
-            return None
-        return {
-            "type": "text",
-            "text": (
-                f"[{kind} omitted from model context: local file is "
-                f"{size} bytes, exceeds inline limit of "
-                f"{self.max_bytes} bytes]"
-            ),
-        }
-
-    def _format_video_source(self, source: Any) -> dict[str, Any]:
-        capped = self._maybe_cap(source, "video")
-        if capped is not None:
-            return capped
-        return super()._format_video_source(source)
-
-    def _format_image_source(self, source: Any) -> dict[str, Any]:
-        capped = self._maybe_cap(source, "image")
-        if capped is not None:
-            return capped
-        return super()._format_image_source(source)
-
-    def _format_audio_source(self, source: Any) -> dict[str, Any]:
-        capped = self._maybe_cap(source, "audio")
-        if capped is not None:
-            return capped
-        return super()._format_audio_source(source)
 
 
 class _DashScopeChatModelCompat:

--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -18,9 +18,7 @@ from typing import Any, Dict
 from agentscope.model import ChatModelBase
 from pydantic import Field
 
-from .capping_formatter import (
-    MAX_INLINE_MEDIA_BYTES as _MAX_INLINE_MEDIA_BYTES,
-)
+from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 from .capping_formatter import _CappingDashScopeFormatter
 from .openai_provider import (
     CODING_DASHSCOPE_BASE_URL,
@@ -39,7 +37,7 @@ class DashScopeProvider(OpenAIProvider):
     chat_model: str = Field(default="DashScopeChatModel")
 
     max_inline_media_bytes: int = Field(
-        default=_MAX_INLINE_MEDIA_BYTES,
+        default=MAX_INLINE_MEDIA_BYTES,
         ge=0,
         description=(
             "Maximum size (in bytes) of a local media file inlined as "

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -15,7 +15,6 @@ from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 from pydantic import Field
 
-from qwenpaw.providers.capping_formatter import _CappingGeminiFormatter
 from qwenpaw.providers.multimodal_prober import (
     ProbeResult,
     _PROBE_IMAGE_B64,
@@ -25,6 +24,8 @@ from qwenpaw.providers.multimodal_prober import (
     evaluate_image_probe_answer,
 )
 from qwenpaw.providers.provider import ModelInfo, Provider
+from .capping_formatter import _CappingGeminiFormatter
+from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +141,7 @@ class GeminiProvider(Provider):
     """Provider implementation for Google Gemini API."""
 
     max_inline_media_bytes: int = Field(
-        default=2 * 1024 * 1024,
+        default=MAX_INLINE_MEDIA_BYTES,
         ge=0,
         description=(
             "Maximum size (in bytes) of a local media file inlined as "

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -13,7 +13,9 @@ from agentscope.model import ChatModelBase
 from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
+from pydantic import Field
 
+from qwenpaw.providers.capping_formatter import _CappingGeminiFormatter
 from qwenpaw.providers.multimodal_prober import (
     ProbeResult,
     _PROBE_IMAGE_B64,
@@ -136,6 +138,18 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
 
 class GeminiProvider(Provider):
     """Provider implementation for Google Gemini API."""
+
+    max_inline_media_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=0,
+        description=(
+            "Maximum size (in bytes) of a local media file inlined as "
+            "base64 into the model request body. Media above this is "
+            "replaced with a text placeholder to avoid oversized requests "
+            "when large files (e.g. generated videos) persist in "
+            "conversation history. 0 disables capping."
+        ),
+    )
 
     def _build_default_headers(self) -> dict:
         return dict(self.custom_headers) if self.custom_headers else {}
@@ -291,6 +305,9 @@ class GeminiProvider(Provider):
             default_headers=headers or None,
             extra_config_kwargs=gen_kwargs or None,
             context_size=self._get_context_size(model_id),
+            formatter=_CappingGeminiFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )
 
     async def probe_model_multimodal(

--- a/src/qwenpaw/providers/ollama_provider.py
+++ b/src/qwenpaw/providers/ollama_provider.py
@@ -7,6 +7,7 @@ from typing import Any
 from agentscope.model import ChatModelBase
 from openai import AsyncOpenAI
 
+from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.openai_provider import OpenAIProvider
 
 
@@ -88,4 +89,7 @@ class OllamaProvider(OpenAIProvider):
             default_headers=self._build_default_headers() or None,
             extra_generate_kwargs=gen_kwargs or None,
             context_size=self._get_context_size(model_id),
+            formatter=_CappingOpenAIFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -14,8 +14,9 @@ from agentscope.model import ChatModelBase
 from openai import APIError
 from pydantic import Field
 
-from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.provider import ModelInfo, Provider
+from .capping_formatter import _CappingOpenAIFormatter
+from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 
 if TYPE_CHECKING:
     from qwenpaw.providers.multimodal_prober import ProbeResult
@@ -49,7 +50,7 @@ class OpenAIProvider(Provider):
     """Provider implementation for OpenAI API and compatible endpoints."""
 
     max_inline_media_bytes: int = Field(
-        default=2 * 1024 * 1024,
+        default=MAX_INLINE_MEDIA_BYTES,
         ge=0,
         description=(
             "Maximum size (in bytes) of a local media file inlined as "

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -12,7 +12,9 @@ from typing import TYPE_CHECKING, Any, List
 
 from agentscope.model import ChatModelBase
 from openai import APIError
+from pydantic import Field
 
+from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.provider import ModelInfo, Provider
 
 if TYPE_CHECKING:
@@ -45,6 +47,18 @@ else:
 
 class OpenAIProvider(Provider):
     """Provider implementation for OpenAI API and compatible endpoints."""
+
+    max_inline_media_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=0,
+        description=(
+            "Maximum size (in bytes) of a local media file inlined as "
+            "base64 into the model request body. Media above this is "
+            "replaced with a text placeholder to avoid oversized requests "
+            "when large files (e.g. generated videos) persist in "
+            "conversation history. 0 disables capping."
+        ),
+    )
 
     def _build_default_headers(self) -> dict:
         return dict(self.custom_headers) if self.custom_headers else {}
@@ -192,6 +206,9 @@ class OpenAIProvider(Provider):
             default_headers=merged_headers or None,
             extra_generate_kwargs=gen_kwargs or None,
             context_size=self._get_context_size(model_id),
+            formatter=_CappingOpenAIFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )
 
     async def probe_model_multimodal(

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -8,7 +8,9 @@ from typing import Any, List, Optional
 
 from agentscope.model import ChatModelBase
 from openai import APIError, AsyncOpenAI
+from pydantic import Field
 
+from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.provider import (
     Provider,
     ExtendedModelInfo,
@@ -18,6 +20,18 @@ from qwenpaw.providers.provider import (
 
 class OpenRouterProvider(Provider):
     """OpenRouter provider with required HTTP-Referer and X-Title headers."""
+
+    max_inline_media_bytes: int = Field(
+        default=2 * 1024 * 1024,
+        ge=0,
+        description=(
+            "Maximum size (in bytes) of a local media file inlined as "
+            "base64 into the model request body. Media above this is "
+            "replaced with a text placeholder to avoid oversized requests "
+            "when large files (e.g. generated videos) persist in "
+            "conversation history. 0 disables capping."
+        ),
+    )
 
     _OPENROUTER_CATEGORIES = (
         "cli-agent,cloud-agent,programming-app,"
@@ -358,4 +372,7 @@ class OpenRouterProvider(Provider):
             stream=True,
             default_headers=self._build_default_headers() or None,
             context_size=self._get_context_size(model_id),
+            formatter=_CappingOpenAIFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -10,19 +10,20 @@ from agentscope.model import ChatModelBase
 from openai import APIError, AsyncOpenAI
 from pydantic import Field
 
-from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.provider import (
     Provider,
     ExtendedModelInfo,
     ModelInfo,
 )
+from .capping_formatter import _CappingOpenAIFormatter
+from .capping_formatter import MAX_INLINE_MEDIA_BYTES
 
 
 class OpenRouterProvider(Provider):
     """OpenRouter provider with required HTTP-Referer and X-Title headers."""
 
     max_inline_media_bytes: int = Field(
-        default=2 * 1024 * 1024,
+        default=MAX_INLINE_MEDIA_BYTES,
         ge=0,
         description=(
             "Maximum size (in bytes) of a local media file inlined as "

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -2110,6 +2110,12 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                     builtin.auth_mode = provider.auth_mode
                 if provider.custom_headers:
                     builtin.custom_headers = provider.custom_headers
+                # Restore the configurable inline-media cap for the providers
+                # that support it (currently DashScope).
+                if hasattr(builtin, "max_inline_media_bytes"):
+                    builtin.max_inline_media_bytes = (
+                        provider.max_inline_media_bytes
+                    )
                 builtin_model_ids = {m.id for m in builtin.models}
                 builtin.extra_models = [
                     m

--- a/tests/unit/agents/test_model_factory_video_capping.py
+++ b/tests/unit/agents/test_model_factory_video_capping.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""Tests for video size capping in the model_factory video helpers.
+
+Tool-result videos inline through ``_format_openai_video_block`` and
+``_format_anthropic_video_data_block`` rather than the capping formatters
+(which only intercept ``_format_*_source``), so the inline byte cap is
+enforced inside those helpers.  These tests pin that behaviour for both
+the local-file (``file://`` / ``url``) and in-memory (``base64``) source
+shapes, for both wire formats.
+"""
+
+# pylint: disable=protected-access
+from agentscope.message import DataBlock, URLSource
+
+from qwenpaw.agents.model_factory import (
+    MAX_INLINE_MEDIA_BYTES,
+    _format_anthropic_video_data_block,
+    _format_openai_video_block,
+)
+
+
+def _write_video(tmp_path, name: str, size: int) -> str:
+    """Write a ``size``-byte file and return its ``file://`` URL."""
+    path = tmp_path / name
+    path.write_bytes(b"\x00" * size)
+    return f"file://{path}"
+
+
+# --------------------------------------------------------------------- OpenAI
+
+
+def test_openai_url_video_under_cap_is_inlined(tmp_path) -> None:
+    url = _write_video(tmp_path, "small.mp4", MAX_INLINE_MEDIA_BYTES)
+    block = {"source": {"type": "url", "url": url}}
+    out = _format_openai_video_block(block)
+    assert out["type"] == "video_url"
+    assert out["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+
+def test_openai_url_video_over_cap_is_placeholder(tmp_path) -> None:
+    url = _write_video(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
+    block = {"source": {"type": "url", "url": url}}
+    out = _format_openai_video_block(block)
+    assert out["type"] == "text"
+    assert "video omitted from model context" in out["text"]
+    assert str(MAX_INLINE_MEDIA_BYTES + 1) in out["text"]
+
+
+def test_openai_base64_video_over_cap_is_placeholder() -> None:
+    # base64 of (cap+1) raw bytes -> length * 3//4 > cap.
+    import base64
+
+    data = base64.b64encode(b"\x00" * (MAX_INLINE_MEDIA_BYTES + 1)).decode()
+    block = {
+        "source": {
+            "type": "base64",
+            "media_type": "video/mp4",
+            "data": data,
+        },
+    }
+    out = _format_openai_video_block(block)
+    assert out["type"] == "text"
+    assert "video omitted from model context" in out["text"]
+
+
+def test_openai_base64_video_under_cap_is_inlined() -> None:
+    import base64
+
+    data = base64.b64encode(b"\x00" * 16).decode()
+    block = {
+        "source": {
+            "type": "base64",
+            "media_type": "video/mp4",
+            "data": data,
+        },
+    }
+    out = _format_openai_video_block(block)
+    assert out["type"] == "video_url"
+    assert out["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+
+def test_openai_remote_url_video_is_passed_through() -> None:
+    block = {"source": {"type": "url", "url": "https://example.com/v.mp4"}}
+    out = _format_openai_video_block(block)
+    # Remote URL is not read from disk; pass through unchanged (no cap).
+    assert out["video_url"]["url"] == "https://example.com/v.mp4"
+
+
+# ------------------------------------------------------------------ Anthropic
+
+
+def test_anthropic_url_video_over_cap_is_placeholder(tmp_path) -> None:
+    url = _write_video(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
+    block = DataBlock(source=URLSource(url=url, media_type="video/mp4"))
+    out = _format_anthropic_video_data_block(block)
+    assert out["type"] == "text"
+    assert "video omitted from model context" in out["text"]
+
+
+def test_anthropic_url_video_under_cap_is_inlined(tmp_path) -> None:
+    url = _write_video(tmp_path, "small.mp4", MAX_INLINE_MEDIA_BYTES)
+    block = DataBlock(source=URLSource(url=url, media_type="video/mp4"))
+    out = _format_anthropic_video_data_block(block)
+    assert out["type"] == "video"
+    assert out["source"]["type"] == "base64"
+    assert out["source"]["media_type"] == "video/mp4"
+
+
+def test_anthropic_base64_video_over_cap_is_placeholder() -> None:
+    from agentscope.message import Base64Source
+
+    import base64
+
+    data = base64.b64encode(b"\x00" * (MAX_INLINE_MEDIA_BYTES + 1)).decode()
+    block = DataBlock(
+        source=Base64Source(type="base64", media_type="video/mp4", data=data),
+    )
+    out = _format_anthropic_video_data_block(block)
+    assert out["type"] == "text"
+    assert "video omitted from model context" in out["text"]
+
+
+def test_anthropic_base64_video_under_cap_is_inlined() -> None:
+    from agentscope.message import Base64Source
+
+    import base64
+
+    data = base64.b64encode(b"\x00" * 16).decode()
+    block = DataBlock(
+        source=Base64Source(type="base64", media_type="video/mp4", data=data),
+    )
+    out = _format_anthropic_video_data_block(block)
+    assert out["type"] == "video"
+    assert out["source"]["data"] == data
+
+
+def test_anthropic_missing_file_returns_none(tmp_path) -> None:
+    block = DataBlock(
+        source=URLSource(
+            url=f"file://{tmp_path / 'nope.mp4'}",
+            media_type="video/mp4",
+        ),
+    )
+    assert _format_anthropic_video_data_block(block) is None

--- a/tests/unit/providers/test_capping_formatter.py
+++ b/tests/unit/providers/test_capping_formatter.py
@@ -40,7 +40,7 @@ _ALL_CAPPING_FORMATTERS = [
 def _write(tmp_path, name: str, size: int) -> str:
     path = tmp_path / name
     path.write_bytes(b"\0" * size)
-    return f"file://{path}"
+    return path.as_uri()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/test_capping_formatter.py
+++ b/tests/unit/providers/test_capping_formatter.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""Tests for the shared capping-formatter module.
+
+agentscope's chat formatters (OpenAI, Anthropic, Gemini, DashScope) all read
+every local ``file://`` media source off disk and base64-encode the entire
+file into the request body on every API call.  For a large file persisted in
+conversation history this balloons the request and the provider drops the
+connection on every subsequent turn.  The shared
+:mod:`qwenpaw.providers.capping_formatter` substitutes a text placeholder for
+oversized media so the request stays small, while leaving small media,
+remote URLs, and persisted history untouched.
+
+These tests cover the shared helpers and each per-provider capping formatter
+directly; the provider-level wiring (the field reaching
+``model.formatter.max_bytes``) is covered in ``test_provider_manager.py``.
+"""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.providers.capping_formatter import (
+    MAX_INLINE_MEDIA_BYTES,
+    _CappingAnthropicFormatter,
+    _CappingDashScopeFormatter,
+    _CappingGeminiFormatter,
+    _CappingOpenAIFormatter,
+    inline_media_size,
+)
+
+_ALL_CAPPING_FORMATTERS = [
+    _CappingOpenAIFormatter,
+    _CappingAnthropicFormatter,
+    _CappingGeminiFormatter,
+    _CappingDashScopeFormatter,
+]
+
+
+def _write(tmp_path, name: str, size: int) -> str:
+    path = tmp_path / name
+    path.write_bytes(b"\0" * size)
+    return f"file://{path}"
+
+
+# ---------------------------------------------------------------------------
+# inline_media_size
+# ---------------------------------------------------------------------------
+
+
+def test_local_file_size_is_measured(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "clip.mp4", 1024)
+    source = URLSource(url=url, media_type="video/mp4")
+    assert inline_media_size(source) == 1024
+
+
+def test_remote_url_is_not_inlined() -> None:
+    from agentscope.message import URLSource
+
+    source = URLSource(url="https://example.com/v.mp4", media_type="video/mp4")
+    assert inline_media_size(source) is None
+
+
+def test_missing_file_returns_none() -> None:
+    from agentscope.message import URLSource
+
+    source = URLSource(
+        url="file:///nonexistent/does-not-exist.mp4",
+        media_type="video/mp4",
+    )
+    assert inline_media_size(source) is None
+
+
+def test_base64_source_size_approximated() -> None:
+    from agentscope.message import Base64Source
+
+    # 8 base64 chars -> ~6 raw bytes.
+    source = Base64Source(data="AAAAAAAA", media_type="image/png")
+    assert inline_media_size(source) == 6
+
+
+def test_unknown_source_returns_none() -> None:
+    assert inline_media_size(object()) is None
+
+
+# ---------------------------------------------------------------------------
+# CappingFormatterMixin._maybe_cap
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_cap_returns_none_within_limit(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "small.mp4", 1024)
+    source = URLSource(url=url, media_type="video/mp4")
+    assert _CappingDashScopeFormatter()._maybe_cap(source, "video") is None
+
+
+def test_maybe_cap_returns_placeholder_over_limit(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
+    source = URLSource(url=url, media_type="video/mp4")
+    capped = _CappingDashScopeFormatter()._maybe_cap(source, "video")
+    assert capped is not None
+    assert "omitted" in capped["text"]
+
+
+def test_maybe_cap_custom_threshold(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "clip.mp4", 4096)
+    source = URLSource(url=url, media_type="video/mp4")
+    assert _CappingDashScopeFormatter()._maybe_cap(source, "video") is None
+    assert (
+        _CappingDashScopeFormatter(max_bytes=1024)._maybe_cap(source, "video")
+        is not None
+    )
+
+
+def test_maybe_cap_zero_disables(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
+    source = URLSource(url=url, media_type="video/mp4")
+    assert (
+        _CappingDashScopeFormatter(max_bytes=0)._maybe_cap(source, "video")
+        is None
+    )
+
+
+def test_maybe_cap_remote_url_not_capped() -> None:
+    from agentscope.message import URLSource
+
+    source = URLSource(
+        url="https://cdn.example.com/v.mp4",
+        media_type="video/mp4",
+    )
+    assert _CappingDashScopeFormatter()._maybe_cap(source, "video") is None
+
+
+# ---------------------------------------------------------------------------
+# Default field on every capping formatter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", _ALL_CAPPING_FORMATTERS)
+def test_default_max_bytes(cls) -> None:
+    assert cls().max_bytes == MAX_INLINE_MEDIA_BYTES
+    assert cls(max_bytes=1024).max_bytes == 1024
+
+
+# ---------------------------------------------------------------------------
+# Per-formatter: oversized -> provider-shaped text placeholder;
+#                within-limit / remote -> passthrough to base formatter.
+# ---------------------------------------------------------------------------
+
+
+def test_openai_oversized_image_capped(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.jpg", MAX_INLINE_MEDIA_BYTES + 1)
+    out = _CappingOpenAIFormatter()._format_image_source(
+        URLSource(url=url, media_type="image/jpeg"),
+    )
+    # OpenAI wire format uses {"type": "text", "text": ...}.
+    assert out["type"] == "text"
+    assert "omitted" in out["text"]
+
+
+def test_openai_small_image_passthrough(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "thumb.jpg", 2048)
+    out = _CappingOpenAIFormatter()._format_image_source(
+        URLSource(url=url, media_type="image/jpeg"),
+    )
+    assert out["type"] == "image_url"
+    assert out["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_openai_oversized_audio_capped(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.wav", MAX_INLINE_MEDIA_BYTES + 1)
+    out = _CappingOpenAIFormatter()._format_audio_source(
+        URLSource(url=url, media_type="audio/wav"),
+    )
+    assert out["type"] == "text"
+    assert "omitted" in out["text"]
+
+
+def test_anthropic_oversized_image_capped(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.png", MAX_INLINE_MEDIA_BYTES + 1)
+    out = _CappingAnthropicFormatter()._format_image_source(
+        URLSource(url=url, media_type="image/png"),
+    )
+    # Anthropic wire format uses {"type": "text", "text": ...}.
+    assert out["type"] == "text"
+    assert "omitted" in out["text"]
+
+
+def test_anthropic_small_image_passthrough(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "thumb.png", 2048)
+    out = _CappingAnthropicFormatter()._format_image_source(
+        URLSource(url=url, media_type="image/png"),
+    )
+    assert out["type"] == "image"
+    assert out["source"]["type"] == "base64"
+
+
+def test_gemini_oversized_media_capped_with_text_part(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
+    out = _CappingGeminiFormatter()._format_media_source(
+        URLSource(url=url, media_type="video/mp4"),
+    )
+    # Gemini part shape is {"text": ...}, NOT {"type": "text", ...}.
+    assert out == {"text": out["text"]}
+    assert "omitted" in out["text"]
+    assert "type" not in out
+
+
+def test_gemini_small_media_passthrough(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "thumb.jpg", 2048)
+    out = _CappingGeminiFormatter()._format_media_source(
+        URLSource(url=url, media_type="image/jpeg"),
+    )
+    assert "inline_data" in out
+    assert out["inline_data"]["mime_type"] == "image/jpeg"
+
+
+def test_dashscope_oversized_video_capped(tmp_path) -> None:
+    from agentscope.message import URLSource
+
+    url = _write(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
+    out = _CappingDashScopeFormatter()._format_video_source(
+        URLSource(url=url, media_type="video/mp4"),
+    )
+    assert out["type"] == "text"
+    assert "omitted" in out["text"]
+
+
+def test_dashscope_remote_video_passthrough_unchanged() -> None:
+    from agentscope.message import URLSource
+
+    out = _CappingDashScopeFormatter()._format_video_source(
+        URLSource(url="https://cdn.example.com/v.mp4", media_type="video/mp4"),
+    )
+    assert out == {
+        "type": "video_url",
+        "video_url": {"url": "https://cdn.example.com/v.mp4"},
+    }

--- a/tests/unit/providers/test_dashscope_capping_formatter.py
+++ b/tests/unit/providers/test_dashscope_capping_formatter.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DashScope provider's oversized-media capping formatter.
+
+agentscope's base DashScope formatter reads every local ``file://`` media
+source off disk and base64-encodes the entire file into the request body
+on every API call.  For a large file persisted in conversation history
+(e.g. a generated video) this balloons the request and the provider drops
+the connection on every subsequent turn.  The capping formatter
+substitutes a text placeholder for oversized media so the model request
+stays small, while leaving small media and persisted history untouched.
+
+The cap threshold is the provider's configurable ``max_inline_media_bytes``
+field; ``0`` disables capping.
+"""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.providers.dashscope_provider import (
+    _CappingDashScopeFormatter,
+    _MAX_INLINE_MEDIA_BYTES,
+)
+
+
+def _write(tmp_path, name: str, size: int) -> str:
+    path = tmp_path / name
+    path.write_bytes(b"\0" * size)
+    return f"file://{path}"
+
+
+def test_local_file_size_is_measured(tmp_path) -> None:
+    url = _write(tmp_path, "clip.mp4", 1024)
+    from agentscope.message import URLSource
+
+    source = URLSource(url=url, media_type="video/mp4")
+    assert _CappingDashScopeFormatter._inline_media_size(source) == 1024
+
+
+def test_remote_url_is_not_inlined() -> None:
+    from agentscope.message import URLSource
+
+    source = URLSource(url="https://example.com/v.mp4", media_type="video/mp4")
+    assert _CappingDashScopeFormatter._inline_media_size(source) is None
+
+
+def test_oversized_video_is_replaced_with_text_placeholder(tmp_path) -> None:
+    url = _write(tmp_path, "big.mp4", _MAX_INLINE_MEDIA_BYTES + 1)
+    from agentscope.message import URLSource
+
+    out = _CappingDashScopeFormatter()._format_video_source(
+        URLSource(url=url, media_type="video/mp4"),
+    )
+    assert out["type"] == "text"
+    assert "omitted" in out["text"]
+
+
+def test_small_image_passes_through(tmp_path) -> None:
+    url = _write(tmp_path, "thumb.jpg", 2048)
+    from agentscope.message import URLSource
+
+    out = _CappingDashScopeFormatter()._format_image_source(
+        URLSource(url=url, media_type="image/jpeg"),
+    )
+    assert out["type"] == "image_url"
+    assert out["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_remote_video_passes_through_unchanged() -> None:
+    from agentscope.message import URLSource
+
+    out = _CappingDashScopeFormatter()._format_video_source(
+        URLSource(url="https://cdn.example.com/v.mp4", media_type="video/mp4"),
+    )
+    assert out == {
+        "type": "video_url",
+        "video_url": {"url": "https://cdn.example.com/v.mp4"},
+    }
+
+
+def test_missing_file_is_passed_through_to_base() -> None:
+    # A file:// URL whose target does not exist should not raise; we defer
+    # to the base formatter, which will surface a clear FileNotFoundError.
+    from agentscope.message import URLSource
+
+    source = URLSource(
+        url="file:///nonexistent/does-not-exist.mp4",
+        media_type="video/mp4",
+    )
+    assert _CappingDashScopeFormatter._inline_media_size(source) is None
+    with pytest.raises(FileNotFoundError):
+        _CappingDashScopeFormatter()._format_video_source(source)
+
+
+def test_custom_threshold_is_honored(tmp_path) -> None:
+    # A 4 KB file is well under the 2 MB default, but a 1 KB threshold
+    # should cap it — proving the per-provider threshold is honored.
+    url = _write(tmp_path, "clip.mp4", 4096)
+    from agentscope.message import URLSource
+
+    source = URLSource(url=url, media_type="video/mp4")
+    assert _CappingDashScopeFormatter()._maybe_cap(source, "video") is None
+    assert (
+        _CappingDashScopeFormatter(max_bytes=1024)._maybe_cap(source, "video")
+        is not None
+    )
+
+
+def test_zero_threshold_disables_capping(tmp_path) -> None:
+    url = _write(tmp_path, "big.mp4", _MAX_INLINE_MEDIA_BYTES + 1)
+    from agentscope.message import URLSource
+
+    source = URLSource(url=url, media_type="video/mp4")
+    # max_bytes=0 means disabled -> never capped, defer to base formatter.
+    assert (
+        _CappingDashScopeFormatter(max_bytes=0)._maybe_cap(source, "video")
+        is None
+    )
+    out = _CappingDashScopeFormatter(max_bytes=0)._format_video_source(source)
+    assert out["type"] == "video_url"

--- a/tests/unit/providers/test_dashscope_capping_formatter.py
+++ b/tests/unit/providers/test_dashscope_capping_formatter.py
@@ -19,7 +19,7 @@ import pytest
 
 from qwenpaw.providers.dashscope_provider import (
     _CappingDashScopeFormatter,
-    _MAX_INLINE_MEDIA_BYTES,
+    MAX_INLINE_MEDIA_BYTES,
 )
 
 
@@ -45,7 +45,7 @@ def test_remote_url_is_not_inlined() -> None:
 
 
 def test_oversized_video_is_replaced_with_text_placeholder(tmp_path) -> None:
-    url = _write(tmp_path, "big.mp4", _MAX_INLINE_MEDIA_BYTES + 1)
+    url = _write(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
     from agentscope.message import URLSource
 
     out = _CappingDashScopeFormatter()._format_video_source(
@@ -107,7 +107,7 @@ def test_custom_threshold_is_honored(tmp_path) -> None:
 
 
 def test_zero_threshold_disables_capping(tmp_path) -> None:
-    url = _write(tmp_path, "big.mp4", _MAX_INLINE_MEDIA_BYTES + 1)
+    url = _write(tmp_path, "big.mp4", MAX_INLINE_MEDIA_BYTES + 1)
     from agentscope.message import URLSource
 
     source = URLSource(url=url, media_type="video/mp4")

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -14,11 +14,15 @@ import qwenpaw.providers.provider_manager as provider_manager_module
 from qwenpaw.exceptions import ProviderError
 from qwenpaw.providers.anthropic_provider import AnthropicProvider
 from qwenpaw.config.config import ModelSlotConfig
+from qwenpaw.providers.capping_formatter import (
+    _CappingAnthropicFormatter,
+    _CappingGeminiFormatter,
+    _CappingOpenAIFormatter,
+)
 from qwenpaw.providers.openai_provider import OpenAIProvider
 from qwenpaw.providers.provider import ModelInfo
 from qwenpaw.providers.provider_manager import ProviderManager
 from qwenpaw.local_models.llamacpp import LlamaCppServerSetupResult
-
 
 LEGACY_PROVIDER = {
     "providers": {
@@ -669,3 +673,125 @@ def test_dashscope_max_inline_media_bytes_defaults_when_absent(
         provider.get_chat_model_instance("qwen3-max").formatter.max_bytes
         == 2 * 1024 * 1024
     )
+
+
+# ---------------------------------------------------------------------------
+# Inline-media capping for the other providers (OpenAI / Anthropic / Gemini).
+# Same oversized-request bug as DashScope: their agentscope formatters read
+# every file:// media off disk and base64-inline the whole file on every
+# call. Each provider now wires a shared capping formatter and exposes the
+# same configurable ``max_inline_media_bytes`` field, restored by
+# ``_init_from_storage`` via the generic ``hasattr`` branch.
+# ---------------------------------------------------------------------------
+
+# (provider_id, chat_model, model_id, capping_formatter_cls)
+_CAPPING_PROVIDER_CASES = [
+    ("openai", "OpenAIChatModel", "gpt-4o", _CappingOpenAIFormatter),
+    (
+        "anthropic",
+        "AnthropicChatModel",
+        "claude-3-5-sonnet",
+        _CappingAnthropicFormatter,
+    ),
+    (
+        "gemini",
+        "GeminiChatModel",
+        "gemini-2.0-flash",
+        _CappingGeminiFormatter,
+    ),
+]
+
+
+def _write_builtin_provider_json(
+    isolated_secret_dir,
+    provider_id: str,
+    chat_model: str,
+    model_id: str,
+    *,
+    with_cap: bool,
+) -> None:
+    """Write a builtin <id>.json under providers/builtin/.
+
+    ``with_cap=True`` sets a 4096-byte ``max_inline_media_bytes``;
+    ``False`` omits the key (legacy JSON) to exercise the default fallback.
+    """
+    builtin_path = isolated_secret_dir / "providers" / "builtin"
+    builtin_path.mkdir(parents=True, exist_ok=True)
+
+    data = {
+        "id": provider_id,
+        "name": provider_id.title(),
+        "base_url": "https://example.test/v1",
+        "api_key": "sk-test",
+        "chat_model": chat_model,
+        "models": [{"id": model_id, "name": model_id}],
+    }
+    if with_cap:
+        data["max_inline_media_bytes"] = 4096
+    (builtin_path / f"{provider_id}.json").write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "provider_id,chat_model,model_id,formatter_cls",
+    _CAPPING_PROVIDER_CASES,
+)
+def test_max_inline_media_bytes_loaded_from_json(
+    isolated_secret_dir,
+    provider_id,
+    chat_model,
+    model_id,
+    formatter_cls,
+) -> None:
+    """A user-set ``max_inline_media_bytes`` in <id>.json must be loaded by
+    ``_init_from_storage`` and reach the runtime capping formatter."""
+    _write_builtin_provider_json(
+        isolated_secret_dir,
+        provider_id,
+        chat_model,
+        model_id,
+        with_cap=True,
+    )
+
+    manager = ProviderManager()
+    provider = manager.get_provider(provider_id)
+    assert provider is not None
+    # Runtime builtin reflects the disk value, not the 2 MB default.
+    assert provider.max_inline_media_bytes == 4096
+
+    model = provider.get_chat_model_instance(model_id)
+    assert isinstance(model.formatter, formatter_cls)
+    assert model.formatter.max_bytes == 4096
+
+
+@pytest.mark.parametrize(
+    "provider_id,chat_model,model_id,formatter_cls",
+    _CAPPING_PROVIDER_CASES,
+)
+def test_max_inline_media_bytes_defaults_when_absent(
+    isolated_secret_dir,
+    provider_id,
+    chat_model,
+    model_id,
+    formatter_cls,
+) -> None:
+    """A legacy <id>.json without the key falls back to the 2 MB default
+    (upgrading must not silently cap at 0)."""
+    _write_builtin_provider_json(
+        isolated_secret_dir,
+        provider_id,
+        chat_model,
+        model_id,
+        with_cap=False,
+    )
+
+    manager = ProviderManager()
+    provider = manager.get_provider(provider_id)
+    assert provider is not None
+    assert provider.max_inline_media_bytes == 2 * 1024 * 1024
+
+    model = provider.get_chat_model_instance(model_id)
+    assert isinstance(model.formatter, formatter_cls)
+    assert model.formatter.max_bytes == 2 * 1024 * 1024

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -595,3 +595,77 @@ async def test_provider_group_in_get_info(isolated_secret_dir) -> None:
     assert info.provider_group == "aliyun"
     assert info.provider_group_name == "Aliyun"
     assert info.provider_variant == "dashscope"
+
+
+def test_dashscope_max_inline_media_bytes_loaded_from_json(
+    isolated_secret_dir,
+) -> None:
+    """A user-set ``max_inline_media_bytes`` in dashscope.json must be
+    loaded by ``_init_from_storage`` and actually used by the capping
+    formatter at runtime.
+
+    Writes a builtin dashscope.json with a custom threshold, boots a fresh
+    ``ProviderManager`` (which runs ``_init_from_storage``), and asserts
+    the runtime builtin instance — not just the freshly deserialized one —
+    carries the value through to the formatter.
+    """
+    builtin_path = isolated_secret_dir / "providers" / "builtin"
+    builtin_path.mkdir(parents=True, exist_ok=True)
+
+    dashscope_json = {
+        "id": "dashscope",
+        "name": "DashScope",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "api_key": "sk-test",
+        "chat_model": "DashScopeChatModel",
+        "models": [{"id": "qwen3-max", "name": "Qwen3 Max"}],
+        "max_inline_media_bytes": 4096,
+    }
+    (builtin_path / "dashscope.json").write_text(
+        json.dumps(dashscope_json, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    manager = ProviderManager()
+
+    provider = manager.get_provider("dashscope")
+    assert provider is not None
+    # The runtime builtin must reflect the value loaded from disk, not the
+    # field default (2 MB).
+    assert provider.max_inline_media_bytes == 4096
+
+    # And it must reach the capping formatter that actually guards requests.
+    model = provider.get_chat_model_instance("qwen3-max")
+    assert model.formatter.max_bytes == 4096
+
+
+def test_dashscope_max_inline_media_bytes_defaults_when_absent(
+    isolated_secret_dir,
+) -> None:
+    """An existing dashscope.json without the new key must fall back to the
+    built-in default (2 MB) — i.e. upgrading must not silently cap at 0."""
+    builtin_path = isolated_secret_dir / "providers" / "builtin"
+    builtin_path.mkdir(parents=True, exist_ok=True)
+
+    # Legacy JSON: no max_inline_media_bytes key at all.
+    dashscope_json = {
+        "id": "dashscope",
+        "name": "DashScope",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "api_key": "sk-test",
+        "chat_model": "DashScopeChatModel",
+        "models": [{"id": "qwen3-max", "name": "Qwen3 Max"}],
+    }
+    (builtin_path / "dashscope.json").write_text(
+        json.dumps(dashscope_json, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    manager = ProviderManager()
+    provider = manager.get_provider("dashscope")
+    assert provider is not None
+    assert provider.max_inline_media_bytes == 2 * 1024 * 1024
+    assert (
+        provider.get_chat_model_instance("qwen3-max").formatter.max_bytes
+        == 2 * 1024 * 1024
+    )


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
