### PR TITLE
feat(console): mobile adaptation for Agent Skills page

### DIFF
--- a/console/src/pages/Agent/Skills/components/SkillCard.tsx
+++ b/console/src/pages/Agent/Skills/components/SkillCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Card, Button, Checkbox, Tooltip } from "@agentscope-ai/design";
 import {
   CalendarFilled,
@@ -28,6 +28,21 @@ interface SkillCardProps {
   onToggleEnabled: (e: React.MouseEvent) => void;
   onDelete?: (e?: React.MouseEvent) => void;
 }
+
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== "undefined" ? window.innerWidth <= 768 : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleResize = () => setIsMobile(window.innerWidth <= 768);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return isMobile;
+};
 
 const normalizeSkillIconKey = (value: string) =>
   value
@@ -135,6 +150,7 @@ export const SkillCard = React.memo(function SkillCard({
   const { t } = useTranslation();
   const batchMode = selected !== undefined;
   const [isHover, setIsHover] = useState(false);
+  const isMobile = useIsMobile();
 
   const handleToggleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -259,8 +275,8 @@ export const SkillCard = React.memo(function SkillCard({
         <p className={styles.descriptionText}>{skill.description || "-"}</p>
       </div>
 
-      {/* Footer - only show on hover or batch mode */}
-      {(isHover || batchMode) && (
+      {/* Footer - only show on hover or batch mode, always on mobile */}
+      {(isHover || batchMode || isMobile) && (
         <div className={styles.cardFooter}>
           <Button
             type="default"

--- a/console/src/pages/Agent/Skills/index.module.less
+++ b/console/src/pages/Agent/Skills/index.module.less
@@ -618,9 +618,88 @@
     justify-content: space-between;
   }
 
+  .headerRight {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+  }
+
   .headerActionsLeft,
-  .headerActionsRight {
+  .headerActionsRight,
+  .batchActions {
     flex-wrap: wrap;
+    width: 100%;
+
+    > * {
+      flex: 1 0 auto;
+      min-width: 0;
+    }
+
+    :global(.qwenpaw-btn) {
+      min-width: 0;
+    }
+  }
+
+  .primaryTransferButton {
+    min-width: 0;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .searchContainer {
+    max-width: none;
+    width: 100%;
+  }
+
+  .searchInput {
+    :global(input) {
+      text-align: center;
+    }
+
+    &::placeholder {
+      text-align: center;
+    }
+  }
+
+  .tagSelect {
+    :global {
+      .qwenpaw-select-selection-placeholder,
+      .ant-select-selection-placeholder {
+        text-align: center;
+      }
+
+      .qwenpaw-select-selection-overflow,
+      .ant-select-selection-overflow {
+        justify-content: center;
+      }
+    }
+  }
+
+  .toolbarRight {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .skillsGrid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .skillCard {
+    min-height: auto;
+  }
+
+  .cardFooter {
+    position: static;
+    margin-top: 12px;
+    padding: 0;
+    background: transparent;
   }
 
   .descriptionContent {


### PR DESCRIPTION
## Description

Adds mobile responsive styling to the **Workspace → Skills** page so the dense header actions, search toolbar, and skill grid no longer overflow or get clipped on narrow viewports. Also fixes the hidden card action buttons on mobile.

**Key issues fixed:**
- The header had two crowded rows of buttons (refresh / download from pool / sync to pool on the left; upload zip / import hub / batch / create on the right). On mobile they now stack vertically and each button is allowed to wrap.
- The toolbar with the search box, tag filter, and view toggle was squeezed horizontally. On mobile it now stacks vertically with the search box and tag placeholder centered.
- The skill grid used `repeat(auto-fill, minmax(320px, 1fr))`, which caused cards to be squeezed or partially off-screen. On mobile it collapses to a single column.
- Card minimum height is removed on mobile so shorter cards don't leave excessive whitespace.
- The card footer buttons (enable/disable, delete) were only rendered on hover or in batch mode. Touch devices have no hover, so the buttons were effectively hidden. They are now always rendered on mobile, and the footer switches from absolute to static positioning so it no longer overlaps the description text.

**Related Issue:** Relates to ongoing mobile console adaptation work.

**Security Considerations:** None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open the **Workspace → Skills** page on a mobile device or narrow browser viewport (≤768px).
2. Confirm the header action buttons stack vertically and no longer overflow the page width.
3. Confirm the search toolbar stacks vertically and placeholder text is centered.
4. Confirm skill cards render in a single column and card content is readable.
5. Confirm each skill card shows the **Enable/Disable** and **Delete** buttons without requiring hover or entering batch mode.
6. Resize back to desktop width and confirm:
   - the original multi-column grid and horizontal toolbar are restored;
   - card footer buttons only appear on hover or in batch mode as before.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run build
# ✓ built in 17.23s
```

## Additional Notes

- All mobile-only CSS rules are scoped inside `@media (max-width: 768px)` to avoid affecting the desktop layout.
- The viewport detection hook inside `SkillCard.tsx` is local to this component to avoid cross-branch dependency conflicts on shared hooks.
