### PR TITLE
feat(console): mobile adaptation for Skill Market page

### DIFF
--- a/console/src/pages/Settings/Market/components/ResultCard.module.less
+++ b/console/src/pages/Settings/Market/components/ResultCard.module.less
@@ -104,6 +104,21 @@
   margin-left: auto;
 }
 
+/* ─── Mobile ─────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .skillCard {
+    min-height: auto;
+  }
+
+  .cardFooter {
+    position: static;
+    margin-top: 12px;
+    padding: 0;
+    background: transparent;
+    border-top: none;
+  }
+}
+
 /* ─── Dark mode ──────────────────────────────────────────────────────────── */
 :global(.dark-mode) {
   .skillCard {

--- a/console/src/pages/Settings/Market/components/ResultCard.tsx
+++ b/console/src/pages/Settings/Market/components/ResultCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { Button, Card, Tooltip } from "@agentscope-ai/design";
 import { useTranslation } from "react-i18next";
 import type { MarketResult } from "../../../../api/modules/market";
@@ -15,6 +15,21 @@ interface ResultCardProps {
   onOpenDetail: () => void;
 }
 
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== "undefined" ? window.innerWidth <= 768 : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleResize = () => setIsMobile(window.innerWidth <= 768);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return isMobile;
+};
+
 const CURSOR_STYLE = { cursor: "pointer" } as const;
 
 export const ResultCard = memo(function ResultCard({
@@ -26,6 +41,7 @@ export const ResultCard = memo(function ResultCard({
 }: ResultCardProps) {
   const { t } = useTranslation();
   const [hover, setHover] = useState(false);
+  const isMobile = useIsMobile();
 
   const showFooter = useCallback(() => setHover(true), []);
   const hideFooter = useCallback(() => setHover(false), []);
@@ -58,7 +74,7 @@ export const ResultCard = memo(function ResultCard({
         {item.description || t("market.noDescription")}
       </p>
 
-      {hover && (
+      {(hover || isMobile) && (
         <div
           className={styles.cardFooter}
           onClick={stopPropagation}

--- a/console/src/pages/Settings/Market/index.module.less
+++ b/console/src/pages/Settings/Market/index.module.less
@@ -276,3 +276,34 @@
     color: rgba(255, 255, 255, 0.88);
   }
 }
+
+/* ─── Mobile ─────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .categoryTabs {
+    width: 100%;
+  }
+
+  .searchInput {
+    width: 100%;
+
+    :global(input) {
+      text-align: center;
+    }
+  }
+
+  .resultsGrid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .queueDrawer {
+    left: 16px;
+    width: auto;
+  }
+}


### PR DESCRIPTION
## Description

Adds mobile responsive styling to the **Settings → Skill Market** page so the provider chips, category/search toolbar, result grid, install queue drawer, and card action buttons work well on narrow viewports.

**Key issues fixed:**
- The toolbar placed category tabs and the search input side-by-side. On mobile it now stacks vertically with the search input filling the width.
- The search placeholder is centered on mobile to match other mobile inputs.
- The result grid used `repeat(auto-fill, minmax(320px, 1fr))`, which caused cards to be squeezed. On mobile it collapses to a single column.
- The install queue drawer was fixed at `320px` wide in the bottom-right corner. On mobile it now spans the available width with safe margins.
- The result card footer (install target toggle + install button) only appeared on hover. Touch devices have no hover, so the buttons were hidden. They are now always rendered on mobile, and the footer switches from absolute to static positioning so it no longer overlaps the description text.

**Related Issue:** Relates to ongoing mobile console adaptation work.

**Security Considerations:** None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open the **Settings → Skill Market** page on a mobile device or narrow browser viewport (≤768px).
2. Confirm the provider chips wrap naturally and don't overflow.
3. Confirm the category tabs and search input stack vertically, with the search input filling the width.
4. Confirm skill result cards render in a single column.
5. Confirm each result card shows the **Target toggle** and **Install** buttons without requiring hover.
6. Trigger an install (or inspect the queue drawer) and confirm it spans the width on mobile instead of overflowing.
7. Resize back to desktop width and confirm:
   - the original horizontal toolbar and multi-column grid are restored;
   - result card footer buttons only appear on hover as before.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run build
# ✓ built in 17.03s
```

## Additional Notes

- All mobile-only CSS rules are scoped inside `@media (max-width: 768px)` to avoid affecting the desktop layout.
- The viewport detection hook inside `ResultCard.tsx` is local to this component to avoid cross-branch dependency conflicts on shared hooks.
