### PR TITLE
feat(console): add global responsive utility classes

### DIFF
--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -1173,3 +1173,58 @@ html.dark-mode .debug-log-path strong {
   max-height: 250px !important;
   overflow-y: auto !important;
 }
+
+/* ─── Global responsive utilities ────────────────────────────────────────── */
+/*
+ * Use these utility classes instead of writing per-page @media queries.
+ * All mobile-only rules are scoped to <= 768px so desktop layouts are untouched.
+ */
+
+/* Flex container that stacks vertically on mobile */
+@media (max-width: 768px) {
+  .mobile-stack {
+    flex-direction: column !important;
+    align-items: stretch !important;
+  }
+}
+
+/* Force 100% width on mobile */
+@media (max-width: 768px) {
+  .mobile-full-width {
+    width: 100% !important;
+  }
+}
+
+/* Horizontal scroll container for wide tables on mobile */
+@media (max-width: 768px) {
+  .mobile-scroll-x {
+    overflow-x: auto;
+  }
+
+  .mobile-scroll-x > .qwenpaw-table,
+  .mobile-scroll-x > .ant-table,
+  .mobile-scroll-x table {
+    min-width: 600px;
+  }
+}
+
+/* Single-column grid on mobile */
+@media (max-width: 768px) {
+  .mobile-grid-1 {
+    grid-template-columns: 1fr !important;
+  }
+}
+
+/* Responsive card grid: auto-wrap, single column on mobile */
+.responsive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 768px) {
+  .responsive-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+}


### PR DESCRIPTION
## Description

Introduces a set of reusable responsive utility classes in `console/src/styles/layout.css` so mobile adaptations can rely on shared patterns instead of duplicating `@media (max-width: 768px)` rules in every page module.

### New utility classes

| Class | Behavior on `<=768px` | Typical use case |
|:-----|:------|:------|
| `.mobile-stack` | `flex-direction: column; align-items: stretch;` | Toolbars / filter rows that should stack vertically on phones |
| `.mobile-full-width` | `width: 100%;` | Date pickers, inputs, buttons that need to fill the width |
| `.mobile-scroll-x` | `overflow-x: auto;` + inner table `min-width: 600px;` | Wide data tables that cannot fit a narrow viewport |
| `.mobile-grid-1` | `grid-template-columns: 1fr;` | Multi-column grids that should collapse to one column |
| `.responsive-grid` | Auto-fill card grid that collapses to 1 column on mobile | Card lists / skill grids |

All rules are scoped inside `@media (max-width: 768px)` so desktop layouts are unaffected. This commit intentionally does **not** modify any page component; follow-up PRs will migrate individual pages to these utilities.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] I ran `npm run format:check` and `npm run build` in `console/` and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Run `cd console && npm run format:check` — passes.
2. Run `cd console && npm run build` — builds successfully.
3. Verify that the new CSS only adds rules under `@media (max-width: 768px)` or in `.responsive-grid`, and does not override existing desktop styles.

## Additional Notes

This is the first PR in a planned series. Subsequent PRs depend on this one:

- `feat/console-token-usage-responsive` — uses `.mobile-scroll-x`
- `feat/console-agent-stats-responsive` — uses `.mobile-stack`, `.mobile-full-width`, `.mobile-grid-1`
- `feat/console-skillpool-responsive` — uses `.responsive-grid`

Please merge this PR before the others.
