### PR TITLE
feat(console): make TokenUsage tables horizontally scrollable on mobile

### DIFF
--- a/console/src/pages/Settings/TokenUsage/components/DataTables.tsx
+++ b/console/src/pages/Settings/TokenUsage/components/DataTables.tsx
@@ -112,23 +112,31 @@ export function DataTables({ byModelData, byDateData }: DataTablesProps) {
   return (
     <>
       {byModelData.length > 0 && (
-        <Card className={styles.tableCard} title={t("tokenUsage.byModel")}>
+        <Card
+          className={`${styles.tableCard} mobile-scroll-x`}
+          title={t("tokenUsage.byModel")}
+        >
           <Table
             columns={byModelColumns}
             dataSource={byModelData}
             pagination={{ pageSize: 10 }}
             size="small"
+            scroll={{ x: "max-content" }}
           />
         </Card>
       )}
 
       {byDateData.length > 0 && (
-        <Card className={styles.tableCard} title={t("tokenUsage.byDate")}>
+        <Card
+          className={`${styles.tableCard} mobile-scroll-x`}
+          title={t("tokenUsage.byDate")}
+        >
           <Table
             columns={byDateColumns}
             dataSource={byDateData}
             pagination={{ pageSize: 10 }}
             size="small"
+            scroll={{ x: "max-content" }}
           />
         </Card>
       )}


### PR DESCRIPTION
## Description

Improves the mobile experience of the **Settings → Token Usage** page by making the wide data tables horizontally scrollable on narrow viewports.

- Applies the shared `.mobile-scroll-x` utility class to both "by model" and "by date" table cards.
- Adds `scroll={{ x: "max-content" }}` to both tables so antd renders a fixed header with horizontal scrolling instead of compressing columns.

This change depends on the global responsive utilities introduced in the companion PR:

- **Branch:** `feat/console-global-responsive-utils`
- **Change:** adds `.mobile-scroll-x` to `console/src/styles/layout.css`

Please merge that PR before this one.

## Related Issue

Relates to the ongoing mobile console adaptation work.

## Security Considerations

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] I ran `npm run format:check` and `npm run build` in `console/` and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open **Settings → Token Usage** on a mobile viewport (≤768px).
2. Confirm both the "by model" and "by date" tables can be scrolled horizontally.
3. Confirm model names, token counts, and call counts are no longer compressed or clipped.
4. Resize back to desktop width and confirm the tables keep their original desktop layouts.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run build
# ✓ built in 16.99s
```

## Additional Notes

- Only modifies `console/src/pages/Settings/TokenUsage/components/DataTables.tsx`.
- This PR should be merged after the global responsive utilities PR that adds `.mobile-scroll-x`.
