### PR TITLE
feat(console): mobile adaptation for Skill Pool page

### DIFF
--- a/console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Card, Checkbox, Tooltip } from "@agentscope-ai/design";
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
@@ -32,8 +32,21 @@ export function PoolSkillCard({
 }: PoolSkillCardProps) {
   const { t } = useTranslation();
   const [isHover, setIsHover] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
   const syncTone = getPoolBuiltinStatusTone(skill.sync_status);
   const isBuiltin = isSkillBuiltin(skill.source);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(max-width: 768px)");
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(event.matches);
+    };
+    handleChange(mql);
+    mql.addEventListener("change", handleChange);
+    return () => {
+      mql.removeEventListener("change", handleChange);
+    };
+  }, []);
 
   return (
     <Card
@@ -126,8 +139,8 @@ export function PoolSkillCard({
         <p className={styles.descriptionText}>{skill.description || "-"}</p>
       </div>
 
-      {/* Footer - only show on hover or batch mode */}
-      {(isHover || batchModeEnabled) && (
+      {/* Footer - show on hover, batch mode, or mobile (no hover) */}
+      {(isHover || batchModeEnabled || isMobile) && (
         <div className={styles.cardFooter}>
           <Button
             className={styles.actionButton}

--- a/console/src/pages/Settings/SkillPool/index.module.less
+++ b/console/src/pages/Settings/SkillPool/index.module.less
@@ -435,9 +435,7 @@
 
 /* ─── Skills Grid ─────────────────────────────────────────────────────────── */
 .skillsGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 16px;
+  /* Layout (grid + gap) is provided by the shared .responsive-grid utility. */
   padding: 16px;
 }
 
@@ -1157,8 +1155,108 @@
     align-items: stretch;
   }
 
+  .headerRight {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+    width: 100%;
+  }
+
   .headerActionsLeft,
-  .headerActionsRight {
+  .headerActionsRight,
+  .batchActions {
     flex-wrap: wrap;
+    width: 100%;
+
+    > * {
+      flex: 1 0 auto;
+      min-width: 0;
+    }
+
+    :global(.qwenpaw-btn) {
+      min-width: 0;
+    }
+  }
+
+  .primaryTransferButton,
+  .primaryActionButton {
+    min-width: 0;
+  }
+
+  .importToolbar {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .searchContainer {
+    max-width: none;
+    width: 100%;
+  }
+
+  .searchInput {
+    :global(input) {
+      text-align: center;
+    }
+  }
+
+  .tagSelect {
+    :global {
+      .qwenpaw-select-selection-placeholder,
+      .ant-select-selection-placeholder {
+        text-align: center;
+      }
+
+      .qwenpaw-select-selection-overflow,
+      .ant-select-selection-overflow {
+        justify-content: center;
+      }
+    }
+  }
+
+  .toolbarRight {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .skillsGrid {
+    /* Grid columns/gap are handled by the shared .responsive-grid utility. */
+    padding: 12px;
+  }
+
+  .skillCard {
+    min-height: auto;
+  }
+
+  :global(.dark-mode) {
+    .descriptionText {
+      background: rgba(255, 255, 255, 0.04);
+      border-color: rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.65);
+    }
+  }
+
+  .cardFooter {
+    position: static;
+    margin-top: 12px;
+    padding: 0;
+    background: transparent;
+  }
+
+  .cardTopRight {
+    gap: 6px;
+  }
+
+  .metaInfoRow {
+    flex-wrap: wrap;
+
+    .metaInfoLabel {
+      min-width: 64px;
+    }
   }
 }

--- a/console/src/pages/Settings/SkillPool/index.tsx
+++ b/console/src/pages/Settings/SkillPool/index.tsx
@@ -245,7 +245,7 @@ function SkillPoolPage() {
             </span>
           </div>
         ) : pool.viewMode === "card" ? (
-          <div className={styles.skillsGrid}>
+          <div className={`${styles.skillsGrid} responsive-grid`}>
             {visibleSkills.map((skill: PoolSkillSpec) => (
               <PoolSkillCard
                 key={skill.name}


### PR DESCRIPTION
## Description

Adds comprehensive mobile responsive styling for the **Settings → Skill Pool** page, using the shared responsive grid utility from #5462 for the skills grid.

On viewports `<=768px`:

- Stack header action buttons vertically so they don't overflow.
- Make the toolbar (search + tag filter + view toggles) vertical and full-width.
- Center the search input placeholder text.
- Center the tag select placeholder and overflow items.
- Use the shared `.responsive-grid` utility for the skills grid, which becomes single-column on mobile.
- Reduce skill card min-height and adjust card metadata spacing.
- Always show skill card footer action buttons (broadcast/delete) on mobile, since touch devices have no hover to reveal them.
- Switch the card footer from absolute to static positioning on mobile so it does not overlap card content.
- Tone down the description text box background/border in dark mode on mobile so it blends better with the card surface.

All mobile-only rules are scoped inside `@media (max-width: 768px)` so the desktop layout remains unchanged.

## Related Issue

Relates to the ongoing mobile console adaptation work.

Depends on #5462 (`feat/console-global-responsive-utils`) — the `.responsive-grid` utility class must be merged first.

## Security Considerations

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] I ran `npm run format:check` and `npm run build` in `console/` and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open **Settings → Skill Pool** on a mobile viewport (≤768px).
2. Confirm the header action buttons stack vertically and are not cut off.
3. Confirm the search input and tag filter are full-width and placeholders are centered.
4. Confirm the skills grid is single-column and cards are readable.
5. Confirm the **Broadcast** and **Delete** buttons are visible on every skill card without hovering.
6. Resize back to desktop width and confirm the original multi-column grid, horizontal toolbar, and hover-only footer buttons are preserved.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run build
# ✓ built in 17.16s
```

## Additional Notes

- Modified files:
  - `console/src/pages/Settings/SkillPool/index.tsx`
  - `console/src/pages/Settings/SkillPool/index.module.less`
  - `console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx`
- This PR supersedes the earlier `fix/mobile-skillpool-page` mobile adaptation PR; the toolbar/header adaptations have been merged into this branch and the grid now uses the shared `.responsive-grid` utility.
- Merge order: #5462 → this PR (#5464).
