### PR TITLE
perf: parallelize shutdown to reduce close time

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -4198,17 +4198,24 @@ async def stop_all_browsers() -> None:
         return
 
     logger.info("Stopping all browser instances...")
-    # Use list() to avoid mutation during iteration if stop resets state
-    for state in list(_workspace_states.values()):
-        if _is_browser_running(state):
-            try:
-                await _action_stop(state)
-            except Exception as e:
-                logger.error(
-                    "Failed to stop browser for workspace %s: %s",
-                    state.get("workspace_id", "unknown"),
-                    e,
-                )
+
+    async def _stop_one(state: dict) -> None:
+        try:
+            await _action_stop(state)
+        except Exception as e:
+            logger.error(
+                "Failed to stop browser for workspace %s: %s",
+                state.get("workspace_id", "unknown"),
+                e,
+            )
+
+    await asyncio.gather(
+        *(
+            _stop_one(s)
+            for s in list(_workspace_states.values())
+            if _is_browser_running(s)
+        ),
+    )
 
 
 async def stop_browsers_for_workspace_dirs(

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -667,28 +667,40 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             except Exception as e:
                 logger.error(f"Error stopping MultiAgentManager: {e}")
 
-        # Stop token usage manager (drain queue and final flush)
-        logger.info("Stopping TokenUsageManager...")
-        try:
-            await token_usage_manager.stop()
-        except Exception as e:
-            logger.error(f"Error stopping TokenUsageManager: {e}")
-
-        # Stop all browser instances
+        # These three cleanup tasks are independent; run in parallel.
         from ..agents.tools.browser_control import stop_all_browsers
-
-        try:
-            await stop_all_browsers()
-        except Exception as e:
-            logger.error(f"Error stopping browsers during shutdown: {e}")
-
-        # Close the shared httpx client owned by the skills hub module.
         from ..agents.skill_system.hub import aclose_hub_client
 
-        try:
-            await aclose_hub_client()
-        except Exception as e:
-            logger.error(f"Error closing skills hub HTTP client: {e}")
+        async def _stop_token_usage():
+            logger.info("Stopping TokenUsageManager...")
+            try:
+                await token_usage_manager.stop()
+            except Exception as e:
+                logger.error(
+                    f"Error stopping TokenUsageManager: {e}",
+                )
+
+        async def _stop_browsers():
+            try:
+                await stop_all_browsers()
+            except Exception as e:
+                logger.error(
+                    f"Error stopping browsers: {e}",
+                )
+
+        async def _close_hub():
+            try:
+                await aclose_hub_client()
+            except Exception as e:
+                logger.error(
+                    f"Error closing skills hub HTTP client: {e}",
+                )
+
+        await asyncio.gather(
+            _stop_token_usage(),
+            _stop_browsers(),
+            _close_hub(),
+        )
 
         logger.info("Application shutdown complete")
 

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -473,26 +473,30 @@ class MultiAgentManager:
         logger.info("All cleanup tasks cancelled/completed")
 
     async def stop_all(self):
-        """Stop all agent instances.
+        """Stop all agent instances concurrently.
 
         Called during application shutdown to clean up resources.
-        Cancels any pending delayed cleanup tasks and stops all agents.
+        Cancels any pending delayed cleanup tasks and stops all
+        agents in parallel via asyncio.gather.
         """
-        logger.info(f"Stopping all agents ({len(self.agents)} running)...")
+        logger.info(
+            f"Stopping all agents ({len(self.agents)} running)...",
+        )
 
-        # First, cancel pending cleanup tasks to avoid orphaned instances
         await self.cancel_all_cleanup_tasks()
 
-        # Create list of agent IDs to avoid modifying dict during iteration
-        agent_ids = list(self.agents.keys())
-
-        for agent_id in agent_ids:
+        async def _stop_one(agent_id: str, instance: Workspace):
             try:
-                instance = self.agents[agent_id]
                 await instance.stop()
                 logger.debug(f"Agent stopped: {agent_id}")
             except Exception as e:
-                logger.error(f"Error stopping agent {agent_id}: {e}")
+                logger.error(
+                    f"Error stopping agent {agent_id}: {e}",
+                )
+
+        await asyncio.gather(
+            *(_stop_one(aid, inst) for aid, inst in self.agents.items()),
+        )
 
         self.agents.clear()
         logger.info("All agents stopped")


### PR DESCRIPTION
- MultiAgentManager.stop_all(): use asyncio.gather to stop all workspaces concurrently instead of serially
- stop_all_browsers(): use asyncio.gather to stop all browser instances concurrently
- App lifespan shutdown: run token_usage, browsers, and hub_client cleanup concurrently since they are independent

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
