### PR TITLE
feat(console): mobile adaptation for Voice Transcription settings page

### DIFF
--- a/console/src/pages/Settings/VoiceTranscription/index.module.less
+++ b/console/src/pages/Settings/VoiceTranscription/index.module.less
@@ -66,6 +66,35 @@
   flex-shrink: 0;
 }
 
+/* ─── Mobile ─────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .content {
+    padding: 12px;
+  }
+
+  .card {
+    margin-bottom: 12px;
+  }
+
+  .cardTitle {
+    font-size: 14px;
+  }
+
+  .cardDescription {
+    font-size: 12px;
+  }
+
+  .optionDescription {
+    display: block;
+    margin-top: 2px;
+    margin-left: 0;
+  }
+
+  .footerButtons {
+    padding: 12px 16px;
+  }
+}
+
 /* ─── Dark Mode ──────────────────────────────────────────────────────────── */
 :global(.dark-mode) {
   .cardDescription {


### PR DESCRIPTION
## Description

Adds mobile responsive styling for the **Settings → Voice Transcription** page.

On viewports `<=768px`:

- Reduce page content padding.
- Shrink card margins and title/description font sizes.
- Let radio option descriptions break to their own line for readability.
- Reduce footer button padding.

All mobile-only rules are scoped inside `@media (max-width: 768px)` so the desktop layout remains unchanged.

## Related Issue

Relates to the ongoing mobile console adaptation work.

## Security Considerations

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] I ran `npm run format:check` and `npm run build` in `console/` and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open **Settings → Voice Transcription** on a mobile viewport (≤768px).
2. Confirm the page padding, card spacing, and font sizes are comfortable on a narrow screen.
3. Confirm radio option descriptions are readable and not squeezed next to their labels.
4. Confirm the footer action buttons are accessible and not too tall.
5. Resize back to desktop width and confirm the original layout is preserved.

## Local Verification Evidence

```bash
cd console
npm run format:check
# Checking formatting...
# All matched files use Prettier code style!

npm run build
# ✓ built in 17.04s
```

## Additional Notes

- Only modifies `console/src/pages/Settings/VoiceTranscription/index.module.less`.
- This PR does **not** depend on the global responsive utilities PR; it keeps page-specific media queries because the adjustments are local font/padding changes rather than reusable layout patterns.
