### PR TITLE
fix(skill): zip metadata error handling

### DIFF
--- a/src/qwenpaw/agents/skill_system/store.py
+++ b/src/qwenpaw/agents/skill_system/store.py
@@ -251,7 +251,9 @@ def _directory_tree(directory: Path) -> dict[str, Any]:
 
 
 def extract_version(post: Any) -> str:
-    metadata = post.get("metadata") or {}
+    metadata = post.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
     for value in (
         post.get("version"),
         metadata.get("version"),
@@ -844,6 +846,11 @@ def validate_skill_content(content: str) -> tuple[str, str]:
                 "SKILL.md must include non-empty frontmatter "
                 "name and description"
             ),
+        )
+    metadata = post.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise SkillsError(
+            message="SKILL.md frontmatter 'metadata' must be a dict",
         )
     return skill_name, skill_description
 


### PR DESCRIPTION
## Description

Previously, when an error occurred while parsing skill metadata from a ZIP file, the exception was not properly caught, and no fallback value was provided. This created inconsistency with other parts of the system that handle skill metadata, which all follow a uniform format and error-handling pattern.

**Related Issue:** Fixes #5474.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review