### PR TITLE
fix(channel): restore streaming path and split multi-segment reply into separate streaming boxes

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -624,7 +624,7 @@ class BaseChannel(ABC):
                 msg_id_to_stream_type,
                 streaming_buffers,
             )
-        if obj == "content" and status == RunStatus.InProgress:
+        if obj == "content":
             return await self._on_stream_content_delta(
                 request,
                 to_handle,

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -696,6 +696,58 @@ class BaseChannel(ABC):
             return False
         if stream_type == "reasoning" and self._filter_thinking:
             return True
+
+        # Detect content index change → split into a new streaming box
+        content_index = getattr(event, "index", 0) or 0
+        index_key = f"_stream_last_index_{stream_type}"
+        last_index = send_meta.get(index_key, 0)
+        if content_index != last_index and streaming_buffers.get(
+            stream_type,
+            "",
+        ):
+            # Finalize current streaming box before starting a new one
+            flush_meta = self._get_stream_flush_meta(
+                send_meta,
+                stream_type,
+            )
+            task = flush_meta.get("task")
+            if task and not task.done():
+                try:
+                    await asyncio.wait_for(
+                        task,
+                        timeout=self._STREAM_FLUSH_TIMEOUT_S,
+                    )
+                except (
+                    asyncio.TimeoutError,
+                    asyncio.CancelledError,
+                    Exception,
+                ):
+                    task.cancel()
+            send_meta.get("_stream_flush", {}).pop(
+                stream_type,
+                None,
+            )
+            accumulated = streaming_buffers.pop(stream_type, "")
+            await self.on_streaming_end(
+                request,
+                to_handle,
+                event,
+                send_meta,
+                stream_type,
+                accumulated_text=accumulated,
+            )
+            # Start a new streaming box
+            streaming_buffers[stream_type] = ""
+            await self.on_streaming_start(
+                request,
+                to_handle,
+                event,
+                send_meta,
+                stream_type,
+                accumulated_text="",
+            )
+        send_meta[index_key] = content_index
+
         delta_text = getattr(event, "text", "") or ""
         streaming_buffers[stream_type] = (
             streaming_buffers.get(stream_type, "") + delta_text


### PR DESCRIPTION
## Problem

After the agentscope 2.0 migration (#4846), the base channel streaming path
was completely broken for all IM channels:

1. Content delta events no longer carry a `status` field (the new `_ContentBase`
   does not inherit from `Event`), causing the condition
   `obj == "content" and status == RunStatus.InProgress` to always evaluate
   `False` — streaming deltas were never dispatched.

2. In the new architecture, a single `MESSAGE`-type event spans the entire
   turn with multiple content indices (0, 1, 2…) representing text segments
   between tool calls. All segments shared one streaming box instead of
   getting independent cards/messages.

## Fix

- Remove the stale `status == RunStatus.InProgress` guard for content events;
  `_on_stream_content_delta` already filters via `delta=True/False`.
- Detect `index` changes in `_on_stream_content_delta`: when a new index
  arrives and the current buffer is non-empty, finalize the active streaming
  box (`on_streaming_end`) and start a fresh one (`on_streaming_start`).

Verified safe for all streaming channels (Feishu, WeCom, DingTalk, Telegram,
Discord) — each uses per-stream_type state that tolerates sequential
end→start cycles within a single message.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
