### PR TITLE
feat(console): navigable fullscreen image gallery for chat media

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -4,7 +4,7 @@ import {
   type IAgentScopeRuntimeWebUIRef,
 } from "@agentscope-ai/chat";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, Button, Modal, Result, Tooltip } from "antd";
+import { Alert, Button, Image, Modal, Result, Tooltip } from "antd";
 import { useAppMessage } from "../../hooks/useAppMessage";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { ExclamationCircleOutlined, SettingOutlined } from "@ant-design/icons";
@@ -2230,6 +2230,36 @@ export default function ChatPage() {
     document.addEventListener("keydown", handleShortcut);
     return () => document.removeEventListener("keydown", handleShortcut);
   }, [isChatActive, whisperEnabled]);
+
+  // Left/right arrow keys switch images while the fullscreen image preview is
+  // open. antd's Image.PreviewGroup ships the on-screen ◀ ▶ buttons but no
+  // keyboard navigation, so we drive its own switch buttons — reusing antd's
+  // built-in bounds handling (the buttons are disabled at the first/last image).
+  useEffect(() => {
+    const handleArrows = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      // Only act when a preview is actually open.
+      if (!document.querySelector(".ant-image-preview-wrap")) return;
+      const selector =
+        e.key === "ArrowLeft"
+          ? ".ant-image-preview-switch-left"
+          : ".ant-image-preview-switch-right";
+      const btn = document.querySelector<HTMLElement>(selector);
+      // Skip disabled edges so the keypress is a no-op at the ends.
+      if (
+        !btn ||
+        btn.className.includes("ant-image-preview-switch-left-disabled") ||
+        btn.className.includes("ant-image-preview-switch-right-disabled")
+      ) {
+        return;
+      }
+      e.preventDefault();
+      btn.click();
+    };
+    document.addEventListener("keydown", handleArrows);
+    return () => document.removeEventListener("keydown", handleArrows);
+  }, []);
+
   chatIdRef.current = chatId;
   navigateRef.current = navigate;
 
@@ -3572,17 +3602,22 @@ export default function ChatPage() {
               : styles.chatMessagesArea
           }
         >
-          <RichFileReferenceInputProvider
-            onOpenReference={(reference, trigger) =>
-              void openInlineFileReference(reference, trigger)
-            }
-          >
-            <AgentScopeRuntimeWebUI
-              ref={chatRef}
-              key={refreshKey}
-              options={options}
-            />
-          </RichFileReferenceInputProvider>
+          {/* PreviewGroup bundles every tool-card <Image> in the conversation
+              into one navigable gallery: click any image to open fullscreen,
+              then switch with the ◀ ▶ buttons or the left/right arrow keys. */}
+          <Image.PreviewGroup>
+            <RichFileReferenceInputProvider
+              onOpenReference={(reference, trigger) =>
+                void openInlineFileReference(reference, trigger)
+              }
+            >
+              <AgentScopeRuntimeWebUI
+                ref={chatRef}
+                key={refreshKey}
+                options={options}
+              />
+            </RichFileReferenceInputProvider>
+          </Image.PreviewGroup>
         </div>
 
         {/* Rate-limit guidance banner */}


### PR DESCRIPTION
## Description

Improves how images are **viewed** in the console chat. Each image in a tool card is an
**isolated** antd `<Image>`, so the fullscreen preview shows only that one image with no way
to move between images.

This PR wraps the conversation in a single `Image.PreviewGroup`, so clicking any image opens
a fullscreen gallery with prev/next buttons (plus zoom/rotate). User-posted images join the
same group automatically, since the chat library renders them with antd `<Image>` too.

It also adds **keyboard navigation**: left/right arrow keys switch images while the preview is
open. antd ships no built-in keyboard nav for `PreviewGroup` (long-standing request,
ant-design/ant-design#29323), so a small `keydown` handler drives antd's own switch buttons —
reusing its bounds handling (no-op at the first/last image).

**Scope note (rebase 2026-08-11):** this PR originally also made media tool cards open
expanded via a new `ToolCardShell` `defaultOpen` prop. That part is now **upstream** —
`ToolCardShell` has an `expanded` state and the four media cards pass
`defaultExpanded={Boolean(media)}`. Those changes were dropped in the rebase rather than
reimplemented, which is why the diff shrank from 6 files to 1. What remains is only the
gallery, which has no upstream equivalent.

**Related Issue:** Relates to #1211 (which is orthogonal — that PR covers the *input* side:
clipboard paste / compression / storage. This PR is purely the *viewing* side.)

**Security Considerations:** None. No changes to file access, URLs, or backend; purely
frontend rendering of already-resolved media URLs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Console (frontend web UI)

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
      <!-- console-only change: ran the frontend gate instead (see Evidence). The Python
           pre-commit hooks (black/flake8/mypy/pylint) don't apply to .tsx files. -->
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks (none needed)
- [x] I ran tests locally (frontend `vitest` suite — see Evidence) and they pass
- [ ] Documentation updated (if needed) — no user-facing docs cover this behavior
- [x] Ready for review

## Testing

Manual (in a local Docker build of this branch):
- Clicking any image opens the fullscreen gallery; **prev/next buttons and the left/right
  arrow keys** switch between all images in the conversation (tool-produced and user-posted).
- Verified the arrow keys are a no-op at the first/last image.

This is a **console-only** change; the Python `pytest` suite is not exercised by it, so the
relevant gate is the frontend toolchain below.

## Local Verification Evidence

Re-run after the rebase onto `8a7bfa13`:

```
# console-only change → frontend gate (CONTRIBUTING: `cd console && npm run format`)
tsc -b --noEmit                        # → exit 0
prettier@3.0.0 --check src/pages/Chat/index.tsx
                                       # → "All matched files use Prettier code style!"

npm run test:run       # vitest
                       # → Test Files  226 passed (226)
                       #   Tests       1725 passed (1725)
```

## Additional Notes

No new npm dependencies — uses the antd `Image.PreviewGroup` already in the project.
`PreviewGroup` wraps `RichFileReferenceInputProvider` rather than replacing it, so the
inline-file-reference behaviour added upstream is untouched.
The two nested `PreviewGroup`s inside the chat library (`AssetsPreview`, RAG card) keep their
own isolated galleries by design; this change does not affect them.
