### PR TITLE
fix(dashscope): honour extra_body generate_kwargs and avoid sending default enable_thinking

### DIFF
--- a/src/qwenpaw/providers/dashscope_provider.py
+++ b/src/qwenpaw/providers/dashscope_provider.py
@@ -54,8 +54,29 @@ class DashScopeProvider(OpenAIProvider):
         )
 
         effective = self.get_effective_generate_kwargs(model_id)
-        param_kwargs: Dict[str, Any] = {}
-        for key in (
+
+        # Back-compat: honour OpenAI-style ``extra_body`` so configs written
+        # for the old OpenAIProvider path keep working after migration to the
+        # native DashScopeChatModel.  Direct top-level keys take precedence.
+        # Mapped keys are promoted; unmapped keys stay in ``extra_body`` and
+        # are forwarded via ``extra_generate_kwargs``.
+        extra_body = effective.pop("extra_body", None)
+        if isinstance(extra_body, dict):
+            remaining_body = dict(extra_body)
+            _EXTRA_BODY_MAP = {
+                "enable_thinking": "thinking_enable",
+                "thinking_budget": "thinking_budget",
+                "top_k": "top_k",
+            }
+            for eb_key, param_key in _EXTRA_BODY_MAP.items():
+                if eb_key in remaining_body:
+                    if param_key not in effective:
+                        effective[param_key] = remaining_body[eb_key]
+                    del remaining_body[eb_key]
+            if remaining_body:
+                effective["extra_body"] = remaining_body
+
+        _PARAM_KEYS = (
             "max_tokens",
             "thinking_enable",
             "thinking_budget",
@@ -63,9 +84,18 @@ class DashScopeProvider(OpenAIProvider):
             "top_p",
             "top_k",
             "parallel_tool_calls",
-        ):
+        )
+        param_kwargs: Dict[str, Any] = {}
+        for key in _PARAM_KEYS:
             if key in effective:
-                param_kwargs[key] = effective[key]
+                param_kwargs[key] = effective.pop(key)
+
+        thinking_explicitly_set = "thinking_enable" in param_kwargs
+
+        # Remaining kwargs (e.g. seed, stop, frequency_penalty, …) are
+        # forwarded to every ``_call_api`` invocation so user-supplied
+        # generate_kwargs are not silently dropped.
+        extra_generate_kwargs = effective or None
 
         merged_headers = self._build_default_headers()
         dashscope_meta = json.dumps(
@@ -92,20 +122,36 @@ class DashScopeProvider(OpenAIProvider):
             stream=True,
             default_headers=merged_headers or None,
             context_size=self._get_context_size(model_id),
+            thinking_explicitly_set=thinking_explicitly_set,
+            extra_generate_kwargs=extra_generate_kwargs,
         )
 
 
 class _DashScopeChatModelCompat:
     """Factory that creates a ``DashScopeChatModel`` subclass with custom
-    tracking headers injected into every API call via ``extra_headers``."""
+    tracking headers injected into every API call via ``extra_headers``.
+
+    When ``thinking_explicitly_set`` is ``False`` the wrapper temporarily
+    sets ``parameters.thinking_enable`` to ``None`` before calling the
+    base ``_call_api``, so the ``is not None`` guard in
+    ``DashScopeChatModel._call_api`` skips emitting ``enable_thinking``
+    and the DashScope API uses its own model-level default.
+    """
 
     def __new__(cls, **kwargs: Any) -> Any:
         from agentscope.model import DashScopeChatModel
 
         default_headers = kwargs.pop("default_headers", None)
+        thinking_explicitly_set = kwargs.pop(
+            "thinking_explicitly_set",
+            True,
+        )
+        extra_generate_kwargs = kwargs.pop("extra_generate_kwargs", None)
 
         class _Compat(DashScopeChatModel):
             _qp_default_headers = default_headers
+            _qp_thinking_explicit = thinking_explicitly_set
+            _qp_extra_generate_kwargs = extra_generate_kwargs or {}
 
             async def _call_api(
                 self,
@@ -115,12 +161,42 @@ class _DashScopeChatModelCompat:
                 tool_choice=None,
                 **extra_kwargs,
             ):
+                if self._qp_extra_generate_kwargs:
+                    extra_kwargs = {
+                        **self._qp_extra_generate_kwargs,
+                        **extra_kwargs,
+                    }
                 if self._qp_default_headers:
                     existing = extra_kwargs.get("extra_headers") or {}
                     extra_kwargs["extra_headers"] = {
                         **self._qp_default_headers,
                         **existing,
                     }
+
+                # When the user never configured thinking, temporarily mask
+                # the default ``False`` so the base class skips sending
+                # ``enable_thinking`` to the API.
+                #
+                # Note: concurrent async calls may interleave the
+                # save/mask/restore sequence, but the race is benign —
+                # the masked value (``None``) is exactly what every call
+                # in this branch needs, so the worst-case outcome is
+                # ``thinking_enable`` staying at ``None`` between calls,
+                # which still correctly suppresses ``enable_thinking``.
+                if not self._qp_thinking_explicit:
+                    saved = self.parameters.thinking_enable
+                    self.parameters.__dict__["thinking_enable"] = None
+                    try:
+                        return await super()._call_api(
+                            model_name,
+                            messages,
+                            tools,
+                            tool_choice,
+                            **extra_kwargs,
+                        )
+                    finally:
+                        self.parameters.__dict__["thinking_enable"] = saved
+
                 return await super()._call_api(
                     model_name,
                     messages,


### PR DESCRIPTION
## Description

The DashScope provider now correctly handles `generate_kwargs` that were written for the old OpenAI-compatible code path:

- **Back-compat `extra_body` mapping**: `extra_body.enable_thinking` is promoted to `Parameters.thinking_enable`; unmapped `extra_body` keys are preserved and forwarded.
- **No implicit `enable_thinking: false`**: when the user never configures thinking, `enable_thinking` is omitted from the request so the API uses its own model-level default.
- **Full kwargs passthrough**: remaining `generate_kwargs` outside the Parameters whitelist (e.g. `seed`, `stop`) are now forwarded via `extra_generate_kwargs`, matching the `OpenAIProvider` behaviour.


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
