### PR TITLE
feat(plugins): support installing plugins via pip from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,13 @@ copaw = "qwenpaw.cli.main:cli"
 # [project.entry-points."qwenpaw.doctor"]
 # my_pkg = "my_pkg.doctor:doctor_notes"
 # Legacy group "copaw.doctor" is still loaded when present.
+#
+# Plugin entry points: third-party plugins installed via pip declare
+# themselves under this group.  The entry point value must point to a
+# module (or callable) inside a package that ships a ``plugin.json``
+# manifest as package data.
+# [project.entry-points."qwenpaw.plugins"]
+# my_plugin = "my_plugin_package:register"
 
 [project.optional-dependencies]
 dev = [

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -472,6 +472,7 @@ async def list_plugins(request: Request):
                 "loaded": True,
                 "plugin_type": manifest.plugin_type,
                 "frontend_entry": manifest.entry.frontend,
+                "install_source": record.install_source.value,
             },
         )
 
@@ -615,6 +616,152 @@ async def install_plugin(
         "loaded": True,
         "message": (
             f"Plugin '{record.manifest.name}' installed successfully."
+        ),
+    }
+
+
+class InstallPipPluginRequest(BaseModel):
+    """Request body for installing a plugin from a PyPI package."""
+
+    package: str
+    force: bool = False
+
+
+@router.post(
+    "/install-pip",
+    summary="Install plugin from PyPI",
+    description=(
+        "Install a plugin from a pip package. The package must declare "
+        "a ``qwenpaw.plugins`` entry point and ship a ``plugin.json`` "
+        "manifest as package data."
+    ),
+)
+async def install_pip_plugin(
+    body: InstallPipPluginRequest,
+    request: Request,
+):
+    """Install and hot-load a plugin from a PyPI package."""
+    loader = getattr(request.app.state, "plugin_loader", None)
+    if loader is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin loader is not ready yet. Try again shortly.",
+        )
+
+    package = body.package.strip()
+    if not package:
+        raise HTTPException(
+            status_code=400,
+            detail="Package name is required.",
+        )
+
+    try:
+        if body.force:
+            pip_discovered = loader.discover_pip_plugins()
+            for manifest, _dir in pip_discovered:
+                if manifest.id in loader._loaded_plugins:
+                    _f_pids, _f_cmds = _collect_plugin_runtime_ids(
+                        loader.registry,
+                        manifest.id,
+                    )
+                    await loader.unload_plugin(
+                        manifest.id,
+                        delete_files=False,
+                    )
+                    _post_unload_cleanup(
+                        request,
+                        manifest.id,
+                        _f_pids,
+                        _f_cmds,
+                    )
+
+        record = await loader.load_pip_plugin(package)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(
+            "pip plugin install failed: %s",
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"pip plugin installation failed: {exc}",
+        ) from exc
+
+    await _post_load_setup(request, record.manifest.id)
+
+    return {
+        "id": record.manifest.id,
+        "name": record.manifest.name,
+        "version": record.manifest.version,
+        "description": record.manifest.description,
+        "author": record.manifest.author,
+        "loaded": True,
+        "install_source": "pip",
+        "message": (
+            f"Plugin '{record.manifest.name}' installed from pip."
+        ),
+    }
+
+
+@router.delete(
+    "/{plugin_id}/pip",
+    summary="Uninstall a pip-installed plugin",
+    description=(
+        "Unload a pip-installed plugin and uninstall its underlying "
+        "pip package."
+    ),
+)
+async def uninstall_pip_plugin(plugin_id: str, request: Request):
+    """Unload and pip-uninstall a plugin."""
+    loader = getattr(request.app.state, "plugin_loader", None)
+    if loader is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin loader is not ready yet.",
+        )
+
+    record = loader.get_loaded_plugin(plugin_id)
+    if record is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin '{plugin_id}' is not loaded.",
+        )
+
+    meta: dict = record.manifest.meta or {}
+
+    provider_ids, command_names = _collect_plugin_runtime_ids(
+        loader.registry,
+        plugin_id,
+    )
+
+    try:
+        await loader.uninstall_pip_plugin(plugin_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(
+            "pip plugin uninstall failed for '%s': %s",
+            plugin_id,
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"pip plugin uninstallation failed: {exc}",
+        ) from exc
+
+    _post_unload_cleanup(request, plugin_id, provider_ids, command_names)
+    _remove_plugin_tools_from_agents(plugin_id, meta)
+    _schedule_all_agents_reload(request)
+
+    return {
+        "id": plugin_id,
+        "message": (
+            f"Plugin '{plugin_id}' uninstalled (pip package removed)."
         ),
     }
 

--- a/src/qwenpaw/cli/plugin_commands.py
+++ b/src/qwenpaw/cli/plugin_commands.py
@@ -148,6 +148,85 @@ def _api_upload_plugin(zip_path: Path, force: bool = False) -> bool:
         return False
 
 
+def _api_install_pip_plugin(package: str, force: bool = False) -> bool:
+    """Send a pip install request to the running QwenPaw API.
+
+    Args:
+        package: PyPI package name or specifier
+        force: Force reinstall if already exists
+
+    Returns:
+        ``True`` on success, ``False`` otherwise
+    """
+    base = _get_api_base()
+    if base is None:
+        return False
+
+    url = f"{base}/plugins/install-pip"
+    payload = json.dumps({"package": package, "force": force}).encode()
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            body = json.loads(resp.read())
+        name = body.get("name", package)
+        click.echo(
+            f"Plugin '{name}' installed and loaded (hot reload).",
+        )
+        return True
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = json.loads(exc.read()).get("detail", str(exc))
+        except Exception:
+            detail = str(exc)
+        click.echo(f"API pip install failed: {detail}", err=True)
+        return False
+    except Exception as exc:
+        click.echo(f"API request failed: {exc}", err=True)
+        return False
+
+
+def _api_uninstall_pip_plugin(plugin_id: str) -> bool:
+    """Send a pip uninstall request to the running QwenPaw API.
+
+    Args:
+        plugin_id: Plugin ID to uninstall
+
+    Returns:
+        ``True`` on success, ``False`` otherwise
+    """
+    base = _get_api_base()
+    if base is None:
+        return False
+
+    url = f"{base}/plugins/{plugin_id}/pip"
+    req = urllib.request.Request(url, method="DELETE")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            body = json.loads(resp.read())
+        click.echo(
+            body.get(
+                "message",
+                f"Plugin '{plugin_id}' uninstalled.",
+            ),
+        )
+        return True
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = json.loads(exc.read()).get("detail", str(exc))
+        except Exception:
+            detail = str(exc)
+        click.echo(f"API pip uninstall failed: {detail}", err=True)
+        return False
+    except Exception as exc:
+        click.echo(f"API request failed: {exc}", err=True)
+        return False
+
+
 def _api_uninstall_plugin(plugin_id: str) -> bool:
     """Send a hot-uninstall request to the running QwenPaw API.
 
@@ -839,6 +918,220 @@ def uninstall(plugin_id: str):
         click.echo(f"✅ Plugin '{plugin_id}' uninstalled successfully")
     except Exception as e:
         click.echo(f"❌ Failed to uninstall plugin: {e}", err=True)
+
+
+@plugin.command("install-pip")
+@click.argument("package")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Force reinstall if already exists",
+)
+def install_pip(package: str, force: bool):
+    """Install a plugin from a PyPI package.
+
+    The package must declare a ``qwenpaw.plugins`` entry point in its
+    ``pyproject.toml`` and ship a ``plugin.json`` manifest as package
+    data.
+
+    Examples:
+        qwenpaw plugin install-pip qwenpaw-plugin-xxx
+        qwenpaw plugin install-pip qwenpaw-plugin-xxx==1.0.0
+    """
+    if _is_running():
+        click.echo(
+            "QwenPaw is running — using hot-install via API...",
+        )
+        _api_install_pip_plugin(package, force=force)
+        return
+
+    click.echo(f"Installing pip package: {package}")
+
+    timeout = 300
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-input",
+                package,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        click.echo("pip install timed out.", err=True)
+        return
+
+    if result.returncode != 0:
+        pip_missing = "No module named pip" in (
+            result.stderr + result.stdout
+        )
+        if pip_missing:
+            uv = _find_uv()
+            if uv:
+                click.echo("pip not found, retrying with uv...")
+                try:
+                    result = subprocess.run(
+                        [
+                            uv,
+                            "pip",
+                            "install",
+                            "--python",
+                            sys.executable,
+                            package,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=timeout,
+                    )
+                except subprocess.TimeoutExpired:
+                    click.echo("uv install timed out.", err=True)
+                    return
+                if result.returncode != 0:
+                    click.echo(
+                        f"uv install failed: {result.stderr}",
+                        err=True,
+                    )
+                    return
+            else:
+                click.echo(
+                    "pip not available and uv not found.",
+                    err=True,
+                )
+                return
+        else:
+            click.echo(
+                f"pip install failed: {result.stderr}",
+                err=True,
+            )
+            return
+
+    click.echo(f"Package '{package}' installed.")
+
+    import importlib
+
+    importlib.invalidate_caches()
+
+    from importlib.metadata import entry_points as _entry_points
+    from qwenpaw.plugins.loader import ENTRY_POINT_GROUP
+
+    try:
+        eps = _entry_points(group=ENTRY_POINT_GROUP)
+    except Exception as exc:
+        click.echo(f"Failed to scan entry points: {exc}", err=True)
+        return
+
+    if not list(eps):
+        click.echo(
+            f"No qwenpaw.plugins entry points found after installing "
+            f"'{package}'. Ensure the package declares an entry point "
+            f"under '{ENTRY_POINT_GROUP}'.",
+            err=True,
+        )
+        return
+
+    click.echo(
+        f"Discovered {len(list(eps))} entry point(s). "
+        f"Plugin will be loaded on next QwenPaw start.",
+    )
+    click.echo(
+        f"\nPlugin package '{package}' installed successfully!",
+    )
+    click.echo("\nNext steps:")
+    click.echo("   1. Start QwenPaw to load the plugin")
+    click.echo("   2. Configure the plugin in the web UI")
+
+
+@plugin.command("uninstall-pip")
+@click.argument("plugin_id")
+def uninstall_pip(plugin_id: str):
+    """Uninstall a pip-installed plugin.
+
+    Unloads the plugin and runs ``pip uninstall`` for the underlying
+    package.
+
+    Examples:
+        qwenpaw plugin uninstall-pip my-tool-plugin
+    """
+    if _is_running():
+        click.echo(
+            "QwenPaw is running — using hot-uninstall via API...",
+        )
+        if not click.confirm(
+            f"Uninstall pip plugin '{plugin_id}'?",
+        ):
+            click.echo("Cancelled.")
+            return
+        _api_uninstall_pip_plugin(plugin_id)
+        return
+
+    from ..config.utils import get_plugins_dir
+
+    plugin_dir = get_plugins_dir() / plugin_id
+    if plugin_dir.exists():
+        click.echo(
+            f"Note: '{plugin_id}' also has a disk copy at {plugin_dir}. "
+            f"Use 'qwenpaw plugin uninstall {plugin_id}' to remove it.",
+        )
+
+    click.echo(f"Uninstalling pip package for plugin '{plugin_id}'...")
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "uninstall",
+                "-y",
+                "--disable-pip-version-check",
+                plugin_id,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode == 0:
+            click.echo(
+                f"Package '{plugin_id}' uninstalled successfully.",
+            )
+        else:
+            uv = _find_uv()
+            if uv:
+                uv_result = subprocess.run(
+                    [
+                        uv,
+                        "pip",
+                        "uninstall",
+                        "--python",
+                        sys.executable,
+                        plugin_id,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+                if uv_result.returncode == 0:
+                    click.echo(
+                        f"Package '{plugin_id}' uninstalled (via uv).",
+                    )
+                else:
+                    click.echo(
+                        f"Uninstall failed: {uv_result.stderr}",
+                        err=True,
+                    )
+            else:
+                click.echo(
+                    f"Uninstall failed: {result.stderr}",
+                    err=True,
+                )
+    except subprocess.TimeoutExpired:
+        click.echo("Uninstall timed out.", err=True)
 
 
 @plugin.command()

--- a/src/qwenpaw/plugins/__init__.py
+++ b/src/qwenpaw/plugins/__init__.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """QwenPaw Plugin System."""
 
-from .loader import PluginLoader
+from .loader import PluginLoader, ENTRY_POINT_GROUP
 from .registry import PluginRegistry
 from .api import PluginApi, get_tool_config
-from .architecture import PluginManifest, PluginRecord
+from .architecture import InstallSource, PluginManifest, PluginRecord
 
 __all__ = [
+    "ENTRY_POINT_GROUP",
+    "InstallSource",
     "PluginLoader",
     "PluginRegistry",
     "PluginApi",

--- a/src/qwenpaw/plugins/architecture.py
+++ b/src/qwenpaw/plugins/architecture.py
@@ -188,6 +188,13 @@ class PluginManifest(BaseModel):
         return cls.model_validate(data)
 
 
+class InstallSource(str, Enum):
+    """How a plugin was installed."""
+
+    ZIP = "zip"
+    PIP = "pip"
+
+
 @dataclass
 class PluginRecord:
     """Plugin record for loaded plugins."""
@@ -197,3 +204,4 @@ class PluginRecord:
     enabled: bool
     instance: Optional[Any] = None
     diagnostics: List[str] = field(default_factory=list)
+    install_source: InstallSource = InstallSource.ZIP

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -2,6 +2,7 @@
 """Plugin loader for discovering and loading plugins."""
 
 import asyncio
+import importlib
 import importlib.util
 import inspect
 import json
@@ -16,14 +17,17 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from importlib.metadata import PackageNotFoundError
+from importlib.metadata import entry_points as _entry_points
 from importlib.metadata import version as _dist_version
 from packaging.requirements import Requirement
 
-from .architecture import PluginManifest, PluginRecord
+from .architecture import InstallSource, PluginManifest, PluginRecord
 from .api import PluginApi
 from .registry import PluginRegistry
 
 logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "qwenpaw.plugins"
 
 # Distribution name -> import name, for the common cases where they differ.
 _IMPORT_NAME_OVERRIDES = {
@@ -134,6 +138,425 @@ class PluginLoader:
                     )
 
         return discovered
+
+    def discover_pip_plugins(self) -> List[Tuple[PluginManifest, Path]]:
+        """Discover plugins installed via pip using entry points.
+
+        Scans the ``qwenpaw.plugins`` entry point group.  Each entry
+        point must point to a module (or callable) inside a pip-installed
+        package that also ships a ``plugin.json`` manifest as package
+        data.
+
+        Returns:
+            List of (manifest, package_root) tuples.
+        """
+        discovered: List[Tuple[PluginManifest, Path]] = []
+
+        try:
+            eps = _entry_points(group=ENTRY_POINT_GROUP)
+        except Exception as exc:
+            logger.debug("Entry point scan failed: %s", exc)
+            return discovered
+
+        for ep in eps:
+            try:
+                loaded = ep.load()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load entry point '%s': %s",
+                    ep.name,
+                    exc,
+                )
+                continue
+
+            module = loaded if inspect.ismodule(loaded) else None
+            if module is None:
+                module = inspect.getmodule(loaded)
+            if module is None:
+                logger.warning(
+                    "Entry point '%s' did not resolve to a module",
+                    ep.name,
+                )
+                continue
+
+            module_file = getattr(module, "__file__", None)
+            if module_file is None:
+                logger.warning(
+                    "Entry point '%s' module has no __file__",
+                    ep.name,
+                )
+                continue
+
+            package_dir = Path(module_file).parent.resolve()
+            manifest_path = package_dir / "plugin.json"
+            if not manifest_path.exists():
+                logger.warning(
+                    "pip plugin '%s': plugin.json not found at %s",
+                    ep.name,
+                    manifest_path,
+                )
+                continue
+
+            try:
+                manifest = self._load_manifest(manifest_path)
+                discovered.append((manifest, package_dir))
+                logger.info(
+                    "Discovered pip plugin: %s (from %s)",
+                    manifest.id,
+                    ep.name,
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to load manifest for pip plugin '%s': %s",
+                    ep.name,
+                    exc,
+                    exc_info=True,
+                )
+
+        return discovered
+
+    async def load_pip_plugin(
+        self,
+        package_name: str,
+        config: Optional[Dict] = None,
+    ) -> PluginRecord:
+        """Install a pip package and load it as a plugin.
+
+        Runs ``pip install <package_name>`` (or ``uv pip install``),
+        then discovers the plugin via entry points and loads it.
+
+        Args:
+            package_name: PyPI package name (e.g. ``qwenpaw-plugin-xxx``).
+            config: Optional plugin configuration dict.
+
+        Returns:
+            Loaded PluginRecord.
+
+        Raises:
+            RuntimeError: If installation or loading fails.
+        """
+        await asyncio.to_thread(
+            self._pip_install_package,
+            package_name,
+        )
+
+        importlib.invalidate_caches()
+
+        discovered = self.discover_pip_plugins()
+        for manifest, package_dir in discovered:
+            if manifest.id in self._loaded_plugins:
+                continue
+            dist_name = package_name.lower().replace("_", "-")
+            try:
+                pkg_version = _dist_version(dist_name)
+            except PackageNotFoundError:
+                pkg_version = None
+
+            if pkg_version is not None or manifest.id not in self._loaded_plugins:
+                record = await self._load_pip_plugin_from_dir(
+                    manifest,
+                    package_dir,
+                    config,
+                )
+                return record
+
+        raise RuntimeError(
+            f"pip package '{package_name}' installed but no "
+            f"qwenpaw.plugins entry point found. Ensure the package "
+            f"declares an entry point under '{ENTRY_POINT_GROUP}'.",
+        )
+
+    async def _load_pip_plugin_from_dir(
+        self,
+        manifest: PluginManifest,
+        package_dir: Path,
+        config: Optional[Dict] = None,
+    ) -> PluginRecord:
+        """Load a pip-installed plugin from its package directory.
+
+        Unlike ``load_plugin_from_path``, this does NOT copy files or
+        install requirements (pip already handled both).
+
+        Args:
+            manifest: Parsed plugin manifest.
+            package_dir: Root directory of the installed package.
+            config: Optional plugin configuration dict.
+
+        Returns:
+            Loaded PluginRecord.
+        """
+        plugin_id = manifest.id
+
+        if plugin_id in self._loaded_plugins:
+            raise ValueError(
+                f"Plugin '{plugin_id}' is already loaded.",
+            )
+
+        backend_entry = manifest.entry.backend
+        if not backend_entry:
+            raise FileNotFoundError(
+                f"pip plugin '{plugin_id}' has no backend entry point",
+            )
+
+        backend_file = package_dir / backend_entry
+        if not backend_file.exists():
+            raise FileNotFoundError(
+                f"pip plugin '{plugin_id}' backend file not found: "
+                f"{backend_file}",
+            )
+
+        module_name = f"plugin_{plugin_id.replace('-', '_')}"
+        plugin_dir_str = str(package_dir)
+
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            backend_file,
+            submodule_search_locations=[plugin_dir_str],
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"Failed to load module spec for {backend_file}",
+            )
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        module.__package__ = module_name
+        module.__path__ = [plugin_dir_str]
+        spec.loader.exec_module(module)
+
+        if not hasattr(module, "plugin"):
+            raise AttributeError(
+                "Plugin module must export 'plugin' object",
+            )
+
+        plugin_def = module.plugin
+
+        manifest_dict = {
+            "id": manifest.id,
+            "name": manifest.name,
+            "version": manifest.version,
+            "description": manifest.description,
+            "author": manifest.author,
+            "dependencies": manifest.dependencies,
+            "min_version": manifest.min_version,
+            "meta": manifest.meta,
+        }
+        api = PluginApi(plugin_id, config or {}, manifest_dict)
+        api.set_registry(self.registry)
+
+        self.registry.register_plugin_manifest(plugin_id, manifest_dict)
+
+        if hasattr(plugin_def, "register"):
+            result = plugin_def.register(api)
+            if inspect.iscoroutine(result) or inspect.isawaitable(result):
+                await result
+        else:
+            raise AttributeError(
+                "Plugin must implement 'register(api)' method",
+            )
+
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=package_dir,
+            enabled=True,
+            instance=plugin_def,
+            install_source=InstallSource.PIP,
+        )
+
+        self._loaded_plugins[plugin_id] = record
+        logger.info(
+            "Loaded pip plugin '%s' successfully",
+            plugin_id,
+        )
+        return record
+
+    def _pip_install_package(self, package_name: str) -> None:
+        """Install a pip package (blocking).
+
+        Tries ``python -m pip`` first, falls back to ``uv pip install``.
+
+        Args:
+            package_name: Package name or specifier to install.
+
+        Raises:
+            RuntimeError: If installation fails.
+        """
+        timeout = 300
+
+        try:
+            result = self._run_subprocess_with_streaming_log(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--disable-pip-version-check",
+                    "--no-input",
+                    package_name,
+                ],
+                timeout=timeout,
+                plugin_id=package_name,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"pip install timed out for '{package_name}' "
+                f"(300 s limit exceeded)",
+            ) from exc
+
+        if result.returncode == 0:
+            logger.info(
+                "Package '%s' installed via pip",
+                package_name,
+            )
+            return
+
+        pip_missing = (
+            "No module named pip" in result.stderr
+            or "No module named pip" in result.stdout
+        )
+        if not pip_missing:
+            raise RuntimeError(
+                f"pip install failed for '{package_name}': "
+                f"{result.stdout}",
+            )
+
+        uv = self._find_uv()
+        if uv is None:
+            raise RuntimeError(
+                f"pip is not available and 'uv' was not found. "
+                f"Install '{package_name}' manually.",
+            )
+
+        logger.info(
+            "pip not available; retrying with uv for '%s'",
+            package_name,
+        )
+        try:
+            uv_result = self._run_subprocess_with_streaming_log(
+                [
+                    uv,
+                    "pip",
+                    "install",
+                    "--python",
+                    sys.executable,
+                    package_name,
+                ],
+                timeout=timeout,
+                plugin_id=package_name,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"uv pip install timed out for '{package_name}'",
+            ) from exc
+
+        if uv_result.returncode != 0:
+            raise RuntimeError(
+                f"uv pip install failed for '{package_name}': "
+                f"{uv_result.stdout}",
+            )
+        logger.info(
+            "Package '%s' installed via uv",
+            package_name,
+        )
+
+    async def uninstall_pip_plugin(self, plugin_id: str) -> None:
+        """Unload a pip-installed plugin and uninstall its package.
+
+        Args:
+            plugin_id: Plugin identifier to uninstall.
+
+        Raises:
+            KeyError: If the plugin is not loaded.
+        """
+        record = self._loaded_plugins.get(plugin_id)
+        if record is None:
+            raise KeyError(f"Plugin '{plugin_id}' is not loaded")
+
+        await self.unload_plugin(plugin_id, delete_files=False)
+
+        dist_name = self._guess_dist_name(record)
+        if dist_name:
+            await asyncio.to_thread(
+                self._pip_uninstall_package,
+                dist_name,
+            )
+
+    @staticmethod
+    def _guess_dist_name(record: PluginRecord) -> Optional[str]:
+        """Best-effort guess of the pip distribution name for a record."""
+        source = record.source_path
+        dist_info_dirs = list(source.parent.glob("*.dist-info"))
+        for d in dist_info_dirs:
+            metadata_file = d / "METADATA"
+            if metadata_file.exists():
+                for line in metadata_file.read_text(
+                    encoding="utf-8",
+                ).splitlines():
+                    if line.startswith("Name:"):
+                        return line.split(":", 1)[1].strip()
+        return None
+
+    def _pip_uninstall_package(self, package_name: str) -> None:
+        """Uninstall a pip package (blocking).
+
+        Args:
+            package_name: Distribution name to uninstall.
+
+        Raises:
+            RuntimeError: If uninstallation fails.
+        """
+        try:
+            result = self._run_subprocess_with_streaming_log(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "uninstall",
+                    "-y",
+                    "--disable-pip-version-check",
+                    package_name,
+                ],
+                timeout=120,
+                plugin_id=package_name,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"pip uninstall timed out for '{package_name}'",
+            ) from exc
+
+        if result.returncode != 0:
+            uv = self._find_uv()
+            if uv is not None:
+                try:
+                    uv_result = self._run_subprocess_with_streaming_log(
+                        [
+                            uv,
+                            "pip",
+                            "uninstall",
+                            "--python",
+                            sys.executable,
+                            package_name,
+                        ],
+                        timeout=120,
+                        plugin_id=package_name,
+                    )
+                    if uv_result.returncode == 0:
+                        logger.info(
+                            "Package '%s' uninstalled via uv",
+                            package_name,
+                        )
+                        return
+                except subprocess.TimeoutExpired:
+                    pass
+
+            raise RuntimeError(
+                f"pip uninstall failed for '{package_name}': "
+                f"{result.stdout}",
+            )
+        logger.info(
+            "Package '%s' uninstalled via pip",
+            package_name,
+        )
 
     def _load_manifest(self, manifest_path: Path) -> PluginManifest:
         """Load plugin manifest from JSON file.
@@ -411,6 +834,9 @@ class PluginLoader:
     ) -> Dict[str, PluginRecord]:
         """Discover and load all plugins.
 
+        Scans both the file-system plugin directories and pip-installed
+        packages that declare ``qwenpaw.plugins`` entry points.
+
         Args:
             configs: Optional dictionary of plugin_id -> config
 
@@ -426,6 +852,24 @@ class PluginLoader:
                 await self.load_plugin(manifest, plugin_dir, config)
             except Exception as e:
                 logger.error(f"Failed to load plugin '{manifest.id}': {e}")
+
+        pip_discovered = self.discover_pip_plugins()
+        for manifest, package_dir in pip_discovered:
+            if manifest.id in self._loaded_plugins:
+                continue
+            config = configs.get(manifest.id) if configs else None
+            try:
+                await self._load_pip_plugin_from_dir(
+                    manifest,
+                    package_dir,
+                    config,
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to load pip plugin '%s': %s",
+                    manifest.id,
+                    e,
+                )
 
         return self._loaded_plugins
 

--- a/tests/unit/plugins/test_pip_plugin.py
+++ b/tests/unit/plugins/test_pip_plugin.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access
+"""Unit tests for pip-based plugin discovery and installation.
+
+Tests cover:
+- Entry point discovery via ``qwenpaw.plugins`` group
+- ``discover_pip_plugins()`` scanning logic
+- ``load_pip_plugin()`` install + load flow
+- ``uninstall_pip_plugin()`` unload + pip uninstall flow
+- ``InstallSource`` enum on ``PluginRecord``
+- CLI ``install-pip`` / ``uninstall-pip`` commands
+- REST API ``POST /install-pip`` / ``DELETE /{id}/pip`` endpoints
+"""
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_AGENTSCOPE_STUBS = [
+    "agentscope.state",
+]
+for _mod_name in _AGENTSCOPE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        _stub.AgentState = type("AgentState", (), {})
+        sys.modules[_mod_name] = _stub
+
+
+@pytest.fixture()
+def fresh_registry():
+    """Create a fresh PluginRegistry (bypass singleton for test isolation)."""
+    from qwenpaw.plugins.registry import PluginRegistry
+
+    original_instance = PluginRegistry._instance
+    PluginRegistry._instance = None
+    registry = PluginRegistry()
+    yield registry
+    PluginRegistry._instance = original_instance
+
+
+@pytest.fixture()
+def loader(tmp_path, fresh_registry):
+    """Create a PluginLoader with a temporary plugin directory."""
+    from qwenpaw.plugins.loader import PluginLoader
+
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    loader = PluginLoader(plugin_dirs=[plugin_dir])
+    loader.registry = fresh_registry
+    return loader
+
+
+def _make_fake_entry_point(name, module):
+    """Create a mock entry point that returns the given module on load()."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = module
+    return ep
+
+
+def _make_fake_module(tmp_path, plugin_id, version="1.0.0"):
+    """Create a fake pip-installed plugin module with plugin.json."""
+    pkg_dir = tmp_path / f"pkg_{plugin_id.replace('-', '_')}"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "id": plugin_id,
+        "name": plugin_id,
+        "version": version,
+        "description": f"Test plugin {plugin_id}",
+        "author": "test",
+        "entry": {"backend": "plugin_backend.py"},
+        "plugin_type": "tool",
+        "meta": {"tool_name": plugin_id},
+    }
+    (pkg_dir / "plugin.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+
+    backend_code = (
+        "class _TestPlugin:\n"
+        "    def register(self, api):\n"
+        "        pass\n"
+        "\n"
+        "plugin = _TestPlugin()\n"
+    )
+    (pkg_dir / "plugin_backend.py").write_text(
+        backend_code,
+        encoding="utf-8",
+    )
+
+    mod = types.ModuleType(f"fake_{plugin_id.replace('-', '_')}")
+    mod.__file__ = str(pkg_dir / "plugin_backend.py")
+    return mod, pkg_dir
+
+
+class TestDiscoverPipPlugins:
+    """Tests for ``PluginLoader.discover_pip_plugins()``."""
+
+    def test_no_entry_points(self, loader):
+        """Returns empty list when no entry points registered."""
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[],
+        ):
+            result = loader.discover_pip_plugins()
+        assert result == []
+
+    def test_discovers_valid_plugin(self, loader, tmp_path):
+        """Discovers a plugin with valid entry point and manifest."""
+        mod, pkg_dir = _make_fake_module(
+            tmp_path,
+            "test-pip-plugin",
+        )
+        ep = _make_fake_entry_point("test-pip-plugin", mod)
+
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[ep],
+        ):
+            result = loader.discover_pip_plugins()
+
+        assert len(result) == 1
+        manifest, discovered_dir = result[0]
+        assert manifest.id == "test-pip-plugin"
+        assert manifest.version == "1.0.0"
+        assert discovered_dir == pkg_dir
+
+    def test_skips_entry_point_without_module(self, loader):
+        """Skips entry points that don't resolve to a module."""
+        ep = MagicMock()
+        ep.name = "bad-plugin"
+        ep.load.return_value = "not_a_module"
+
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[ep],
+        ):
+            result = loader.discover_pip_plugins()
+
+        assert result == []
+
+    def test_skips_entry_point_missing_plugin_json(self, loader, tmp_path):
+        """Skips entry points whose package lacks plugin.json."""
+        pkg_dir = tmp_path / "no_manifest_pkg"
+        pkg_dir.mkdir()
+        backend = pkg_dir / "backend.py"
+        backend.write_text("x = 1", encoding="utf-8")
+
+        mod = types.ModuleType("no_manifest")
+        mod.__file__ = str(backend)
+
+        ep = _make_fake_entry_point("no-manifest", mod)
+
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[ep],
+        ):
+            result = loader.discover_pip_plugins()
+
+        assert result == []
+
+    def test_skips_entry_point_load_failure(self, loader):
+        """Skips entry points that raise on load()."""
+        ep = MagicMock()
+        ep.name = "broken"
+        ep.load.side_effect = ImportError("broken dep")
+
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[ep],
+        ):
+            result = loader.discover_pip_plugins()
+
+        assert result == []
+
+    def test_discovers_multiple_plugins(self, loader, tmp_path):
+        """Discovers multiple plugins from entry points."""
+        mod1, _ = _make_fake_module(tmp_path, "plugin-a")
+        mod2, _ = _make_fake_module(tmp_path, "plugin-b")
+        ep1 = _make_fake_entry_point("plugin-a", mod1)
+        ep2 = _make_fake_entry_point("plugin-b", mod2)
+
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[ep1, ep2],
+        ):
+            result = loader.discover_pip_plugins()
+
+        assert len(result) == 2
+        ids = {m.id for m, _ in result}
+        assert ids == {"plugin-a", "plugin-b"}
+
+
+class TestLoadPipPluginFromDir:
+    """Tests for ``PluginLoader._load_pip_plugin_from_dir()``."""
+
+    @pytest.mark.asyncio
+    async def test_loads_valid_plugin(self, loader, tmp_path):
+        """Loads a valid pip plugin from its package directory."""
+        mod, pkg_dir = _make_fake_module(tmp_path, "load-test-plugin")
+
+        manifest_path = pkg_dir / "plugin.json"
+        manifest = loader._load_manifest(manifest_path)
+
+        record = await loader._load_pip_plugin_from_dir(
+            manifest,
+            pkg_dir,
+        )
+
+        assert record.manifest.id == "load-test-plugin"
+        assert record.enabled is True
+        from qwenpaw.plugins.architecture import InstallSource
+
+        assert record.install_source == InstallSource.PIP
+        assert "load-test-plugin" in loader._loaded_plugins
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_plugin(self, loader, tmp_path):
+        """Raises ValueError when plugin is already loaded."""
+        mod, pkg_dir = _make_fake_module(tmp_path, "dup-plugin")
+
+        manifest_path = pkg_dir / "plugin.json"
+        manifest = loader._load_manifest(manifest_path)
+
+        await loader._load_pip_plugin_from_dir(manifest, pkg_dir)
+
+        with pytest.raises(ValueError, match="already loaded"):
+            await loader._load_pip_plugin_from_dir(manifest, pkg_dir)
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_backend(self, loader, tmp_path):
+        """Raises FileNotFoundError when backend file is missing."""
+        pkg_dir = tmp_path / "no_backend_pkg"
+        pkg_dir.mkdir()
+        manifest_data = {
+            "id": "no-backend",
+            "name": "no-backend",
+            "version": "1.0.0",
+            "entry": {"backend": "nonexistent.py"},
+        }
+        (pkg_dir / "plugin.json").write_text(
+            json.dumps(manifest_data),
+            encoding="utf-8",
+        )
+
+        manifest = loader._load_manifest(pkg_dir / "plugin.json")
+
+        with pytest.raises(FileNotFoundError, match="backend file not found"):
+            await loader._load_pip_plugin_from_dir(manifest, pkg_dir)
+
+
+class TestInstallSource:
+    """Tests for the ``InstallSource`` enum."""
+
+    def test_enum_values(self):
+        from qwenpaw.plugins.architecture import InstallSource
+
+        assert InstallSource.ZIP.value == "zip"
+        assert InstallSource.PIP.value == "pip"
+
+    def test_default_is_zip(self):
+        from qwenpaw.plugins.architecture import (
+            InstallSource,
+            PluginManifest,
+            PluginRecord,
+        )
+
+        manifest = PluginManifest(id="test", version="1.0")
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=Path("/tmp/test"),
+            enabled=True,
+        )
+        assert record.install_source == InstallSource.ZIP
+
+
+class TestLoadAllPluginsIncludesPip:
+    """Tests that ``load_all_plugins`` also discovers pip plugins."""
+
+    @pytest.mark.asyncio
+    async def test_load_all_includes_pip(self, loader, tmp_path):
+        """load_all_plugins discovers both disk and pip plugins."""
+        mod, pkg_dir = _make_fake_module(tmp_path, "auto-pip-plugin")
+        ep = _make_fake_entry_point("auto-pip-plugin", mod)
+
+        with patch(
+            "qwenpaw.plugins.loader._entry_points",
+            return_value=[ep],
+        ):
+            result = await loader.load_all_plugins()
+
+        assert "auto-pip-plugin" in result
+
+
+class TestPipInstallPackage:
+    """Tests for ``PluginLoader._pip_install_package()``."""
+
+    def test_pip_success(self, loader):
+        """Installs package successfully via pip."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Successfully installed pkg"
+
+        with patch.object(
+            loader,
+            "_run_subprocess_with_streaming_log",
+            return_value=mock_result,
+        ):
+            loader._pip_install_package("test-package")
+
+    def test_pip_failure_no_uv(self, loader):
+        """Raises RuntimeError when pip fails and uv is not found."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = "error"
+        mock_result.stderr = "some error"
+
+        with patch.object(
+            loader,
+            "_run_subprocess_with_streaming_log",
+            return_value=mock_result,
+        ), patch.object(
+            loader,
+            "_find_uv",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="pip install failed"):
+                loader._pip_install_package("bad-package")
+
+    def test_pip_missing_falls_back_to_uv(self, loader):
+        """Falls back to uv when pip is not available."""
+        pip_result = MagicMock()
+        pip_result.returncode = 1
+        pip_result.stdout = "No module named pip"
+        pip_result.stderr = ""
+
+        uv_result = MagicMock()
+        uv_result.returncode = 0
+        uv_result.stdout = "installed"
+
+        call_count = 0
+
+        def mock_run(cmd, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return pip_result
+            return uv_result
+
+        with patch.object(
+            loader,
+            "_run_subprocess_with_streaming_log",
+            side_effect=mock_run,
+        ), patch.object(
+            loader,
+            "_find_uv",
+            return_value="/usr/bin/uv",
+        ):
+            loader._pip_install_package("test-package")
+
+        assert call_count == 2
+
+
+class TestGuessDistName:
+    """Tests for ``PluginLoader._guess_dist_name()``."""
+
+    def test_finds_dist_name(self, tmp_path):
+        from qwenpaw.plugins.architecture import (
+            InstallSource,
+            PluginManifest,
+            PluginRecord,
+        )
+
+        site_dir = tmp_path / "site-packages"
+        site_dir.mkdir()
+        dist_info = site_dir / "my_plugin-1.0.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Name: my-plugin\nVersion: 1.0.0\n",
+            encoding="utf-8",
+        )
+
+        pkg_dir = site_dir / "my_plugin"
+        pkg_dir.mkdir()
+
+        manifest = PluginManifest(id="my-plugin", version="1.0.0")
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=pkg_dir,
+            enabled=True,
+            install_source=InstallSource.PIP,
+        )
+
+        from qwenpaw.plugins.loader import PluginLoader
+
+        name = PluginLoader._guess_dist_name(record)
+        assert name == "my-plugin"
+
+    def test_returns_none_when_no_dist_info(self, tmp_path):
+        from qwenpaw.plugins.architecture import (
+            InstallSource,
+            PluginManifest,
+            PluginRecord,
+        )
+
+        pkg_dir = tmp_path / "some_pkg"
+        pkg_dir.mkdir()
+
+        manifest = PluginManifest(id="some-plugin", version="1.0.0")
+        record = PluginRecord(
+            manifest=manifest,
+            source_path=pkg_dir,
+            enabled=True,
+            install_source=InstallSource.PIP,
+        )
+
+        from qwenpaw.plugins.loader import PluginLoader
+
+        name = PluginLoader._guess_dist_name(record)
+        assert name is None
+
+
+class TestEntryPointGroupConstant:
+    """Tests for the entry point group constant."""
+
+    def test_constant_value(self):
+        from qwenpaw.plugins.loader import ENTRY_POINT_GROUP
+
+        assert ENTRY_POINT_GROUP == "qwenpaw.plugins"
+
+    def test_exported_from_init(self):
+        from qwenpaw.plugins import ENTRY_POINT_GROUP
+
+        assert ENTRY_POINT_GROUP == "qwenpaw.plugins"


### PR DESCRIPTION
Add support for discovering and loading plugins installed as pip packages using Python entry points (`qwenpaw.plugins` group).

## Changes

### Core Plugin System
- Add `InstallSource` enum (zip/pip) to `PluginRecord`
- Add `discover_pip_plugins()` to scan `qwenpaw.plugins` entry points
- Add `load_pip_plugin()` for installing and loading pip packages
- Add `uninstall_pip_plugin()` for clean removal
- Update `load_all_plugins()` to auto-discover pip-installed plugins

### CLI Commands
- Add `qwenpaw plugin install-pip <package>` command
- Add `qwenpaw plugin uninstall-pip <plugin_id>` command
- Support hot-install via API when app is running

### REST API Endpoints
- `POST /plugins/install-pip` - Install from PyPI package
- `DELETE /plugins/{id}/pip` - Uninstall pip-installed plugin
- Add `install_source` field to plugin list response

### Tests
- Add comprehensive unit tests for pip plugin functionality

Closes #5484