### PR TITLE
fix(token_usage): restore chat token/context usage ring & popover under agentscope 2.0

### DIFF
--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -444,7 +444,7 @@ class ConsoleChannel(BaseChannel):
                 elif obj == "response":
                     last_response = event
 
-            # AgentScope 2.0: session is on ``workspace.session``.
+            # Session is on ``workspace.session``.
             session = (
                 getattr(self._workspace, "session", None)
                 if self._workspace is not None

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -444,11 +444,7 @@ class ConsoleChannel(BaseChannel):
                 elif obj == "response":
                     last_response = event
 
-            # AgentScope 2.0: the workspace no longer exposes ``runner`` —
-            # the session lives on ``workspace.session`` (same instance the
-            # session load/save hooks use). The old ``runner.session`` access
-            # silently yielded None, so finalize was never called and the
-            # turn-usage ring/popover never rendered.
+            # AgentScope 2.0: session is on ``workspace.session``.
             session = (
                 getattr(self._workspace, "session", None)
                 if self._workspace is not None

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -444,8 +444,16 @@ class ConsoleChannel(BaseChannel):
                 elif obj == "response":
                     last_response = event
 
-            runner = getattr(self._workspace, "runner", None)
-            session = getattr(runner, "session", None) if runner else None
+            # AgentScope 2.0: the workspace no longer exposes ``runner`` —
+            # the session lives on ``workspace.session`` (same instance the
+            # session load/save hooks use). The old ``runner.session`` access
+            # silently yielded None, so finalize was never called and the
+            # turn-usage ring/popover never rendered.
+            session = (
+                getattr(self._workspace, "session", None)
+                if self._workspace is not None
+                else None
+            )
             agent_id = (
                 getattr(self._workspace, "agent_id", "default")
                 if self._workspace is not None

--- a/src/qwenpaw/token_usage/__init__.py
+++ b/src/qwenpaw/token_usage/__init__.py
@@ -12,7 +12,6 @@ from .manager import (
 from .model_wrapper import TokenRecordingModelWrapper
 from .turn_usage import (
     TURN_USAGE_META_KEY,
-    attach_turn_usage_metadata,
     finalize_console_turn_usage,
     fmt_tokens,
     get_pending_usage_for_stream,
@@ -29,7 +28,6 @@ __all__ = [
     "_UsageEvent",
     "fmt_tokens",
     "TURN_USAGE_META_KEY",
-    "attach_turn_usage_metadata",
     "finalize_console_turn_usage",
     "get_pending_usage_for_stream",
     "reset_pending_usage_for_stream",

--- a/src/qwenpaw/token_usage/turn_usage.py
+++ b/src/qwenpaw/token_usage/turn_usage.py
@@ -25,7 +25,7 @@ async def snapshot_context_usage_for_state(
     state: Any,
     agent_id: str,
 ) -> dict[str, Any] | None:
-    """Estimate token totals from an agentscope 2.0 ``AgentState``."""
+    """Estimate token totals from ``AgentState``."""
     try:
         from ..config.config import (
             load_agent_config,
@@ -190,7 +190,7 @@ async def finalize_console_turn_usage(
         state = None
 
     if state:
-        # AgentScope 2.0: agent context lives in ``agent.state``.
+        # Agent context lives in ``agent.state``.
         agent_raw = state.get("agent", {})
         state_raw = agent_raw.get("state")
         agent_state = None

--- a/src/qwenpaw/token_usage/turn_usage.py
+++ b/src/qwenpaw/token_usage/turn_usage.py
@@ -133,12 +133,7 @@ def reconcile_turn_with_context(
 
 
 def find_turn_closing_assistant_in_context(messages: Any) -> Any | None:
-    """Return the assistant message closing the latest turn.
-
-    ``AgentState.context`` (AgentScope 2.0) is a plain ``list[Msg]``; scan it
-    in reverse and return the assistant message that closes the most recent
-    turn (i.e. the one before the preceding user message).
-    """
+    """Return the last assistant message after the most recent user message."""
     if not messages:
         return None
     for msg in reversed(list(messages)):
@@ -195,8 +190,7 @@ async def finalize_console_turn_usage(
         state = None
 
     if state:
-        # AgentScope 2.0 persists the agent context under ``agent.state`` as
-        # an ``AgentState`` (see react_agent.state_dict and chats/api.py).
+        # AgentScope 2.0: agent context lives in ``agent.state``.
         agent_raw = state.get("agent", {})
         state_raw = agent_raw.get("state")
         agent_state = None

--- a/src/qwenpaw/token_usage/turn_usage.py
+++ b/src/qwenpaw/token_usage/turn_usage.py
@@ -21,15 +21,19 @@ _pending_usage_by_session: _PendingUsageMap = OrderedDict()
 _PENDING_USAGE_MAX_SESSIONS = 128
 
 
-async def snapshot_context_usage_for_memory(
-    memory: Any,
+async def snapshot_context_usage_for_state(
+    state: Any,
     agent_id: str,
 ) -> dict[str, Any] | None:
-    """Estimate token totals from a loaded memory object."""
+    """Estimate token totals from an agentscope 2.0 ``AgentState``."""
     try:
         from ..config.config import (
             load_agent_config,
             get_model_max_input_length,
+        )
+        from ..agents.utils.context_stats import estimate_context_tokens
+        from ..agents.utils.estimate_token_counter import (
+            EstimatedTokenCounter,
         )
 
         agent_config = load_agent_config(agent_id)
@@ -37,7 +41,11 @@ async def snapshot_context_usage_for_memory(
         if max_input_length <= 0:
             return None
 
-        stats = await memory.estimate_tokens(max_input_length)
+        stats = await estimate_context_tokens(
+            state,
+            EstimatedTokenCounter(),
+            max_input_length,
+        )
         details = stats.pop("messages_detail", None) or []
 
         last_user_idx = -1
@@ -124,12 +132,16 @@ def reconcile_turn_with_context(
     return turn
 
 
-def find_turn_closing_assistant(memory: Any) -> Any | None:
-    """Return the assistant message that closes the latest turn."""
-    content = getattr(memory, "content", None)
-    if not content:
+def find_turn_closing_assistant_in_context(messages: Any) -> Any | None:
+    """Return the assistant message closing the latest turn.
+
+    ``AgentState.context`` (AgentScope 2.0) is a plain ``list[Msg]``; scan it
+    in reverse and return the assistant message that closes the most recent
+    turn (i.e. the one before the preceding user message).
+    """
+    if not messages:
         return None
-    for msg, _marks in reversed(content):
+    for msg in reversed(list(messages)):
         role = getattr(msg, "role", None)
         if role == "user":
             break
@@ -138,16 +150,13 @@ def find_turn_closing_assistant(memory: Any) -> Any | None:
     return None
 
 
-def attach_turn_usage_metadata(
-    memory: Any,
+def _write_turn_usage_meta(
+    msg: Any,
     turn: dict[str, Any] | None,
     ctx: dict[str, Any] | None,
 ) -> bool:
-    """Write turn/context usage onto the closing assistant message."""
-    if turn is None and ctx is None:
-        return False
-    msg = find_turn_closing_assistant(memory)
-    if msg is None:
+    """Write turn/context usage onto a specific assistant message."""
+    if msg is None or (turn is None and ctx is None):
         return False
     meta = getattr(msg, "metadata", None)
     if not isinstance(meta, dict):
@@ -168,7 +177,9 @@ async def finalize_console_turn_usage(
     channel: str,
     agent_id: str,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    """After runner save, attach turn usage metadata and stage SSE pending."""
+    """After the session-save hook persists agent.state, attach per-turn usage
+    metadata to the closing assistant message and stage the SSE pending state.
+    """
     turn = TokenRecordingModelWrapper.pop_usage_for_session(session_id)
     ctx: dict[str, Any] | None = None
 
@@ -184,49 +195,46 @@ async def finalize_console_turn_usage(
         state = None
 
     if state:
-        memory_state = state.get("agent", {}).get("memory", {})
-        # AgentContext (legacy context module) was removed in AgentScope 2.0.
-        # Memory-based token tracking is not available in this architecture.
-        if memory_state:
+        # AgentScope 2.0 persists the agent context under ``agent.state`` as
+        # an ``AgentState`` (see react_agent.state_dict and chats/api.py).
+        agent_raw = state.get("agent", {})
+        state_raw = agent_raw.get("state")
+        agent_state = None
+        if isinstance(state_raw, dict):
             try:
-                from ..agents.context.agent_context import (  # noqa: F401
-                    AgentContext,
-                )
-                from ..agents.utils.estimate_token_counter import (
-                    EstimatedTokenCounter,
-                )
+                from agentscope.state import AgentState
 
-                memory = AgentContext(EstimatedTokenCounter())
-                memory.load_state_dict(memory_state, strict=False)
-                ctx = await snapshot_context_usage_for_memory(
-                    memory,
-                    agent_id,
+                agent_state = AgentState.model_validate(state_raw)
+            except Exception:
+                logger.debug("AgentState parse skipped", exc_info=True)
+                agent_state = None
+
+        if agent_state is not None:
+            ctx = await snapshot_context_usage_for_state(agent_state, agent_id)
+
+        turn = reconcile_turn_with_context(turn, ctx)
+
+        # Persist usage onto the closing assistant message so reopening the
+        # chat from history still renders the ring/popover.
+        if agent_state is not None:
+            try:
+                msg = find_turn_closing_assistant_in_context(
+                    getattr(agent_state, "context", None),
                 )
-                turn = reconcile_turn_with_context(turn, ctx)
-                if attach_turn_usage_metadata(memory, turn, ctx):
-                    try:
-                        await session.update_session_state(
-                            session_id=session_id,
-                            key="agent.memory",
-                            value=memory.state_dict(),
-                            user_id=user_id,
-                            channel=channel,
-                            create_if_not_exist=False,
-                        )
-                    except Exception:
-                        logger.debug(
-                            "update_session_state for turn usage skipped",
-                            exc_info=True,
-                        )
-            except ImportError:
-                # AgentContext not available in AgentScope 2.0.
+                if _write_turn_usage_meta(msg, turn, ctx):
+                    await session.update_session_state(
+                        session_id=session_id,
+                        key="agent.state",
+                        value=agent_state.model_dump(mode="json"),
+                        user_id=user_id,
+                        channel=channel,
+                        create_if_not_exist=False,
+                    )
+            except Exception:
                 logger.debug(
-                    "AgentContext not available; skipping memory-based "
-                    "turn usage tracking",
+                    "update_session_state for turn usage skipped",
+                    exc_info=True,
                 )
-                turn = reconcile_turn_with_context(turn, ctx)
-        else:
-            turn = reconcile_turn_with_context(turn, ctx)
     else:
         turn = reconcile_turn_with_context(turn, ctx)
 


### PR DESCRIPTION
## Description

After the agentscope 1.x → 2.0 migration, the per-turn **token / context usage ring + popover** stopped rendering entirely. This PR adapts the feature to the 2.0 runtime/state model and restores both the live display and history-reload display.


### Changes

    - **`app/channels/console/channel.py`** — resolve the session from `workspace.session` (the instance the session load/save hooks use) instead of the removed `workspace.runner.session`.
    - **`token_usage/turn_usage.py`**
    - Read the agent context from the 2.0 `agent.state` (`AgentState`) and compute context usage via the existing `agents/utils/context_stats.estimate_context_tokens` (the same helper `/history` uses) — yields `estimated_tokens` / `max_input_length` / `context_usage_ratio`.
    - Persist the usage metadata onto the closing assistant message and write back`agent.state` via `AgentState.model_dump(mode="json")` (identical to `react_agent.state_dict()`), so history reload still shows the ring/popover.
    - Remove the now-dead 1.x helpers `find_turn_closing_assistant` and `attach_turn_usage_metadata`; add the 2.0 list-based`find_turn_closing_assistant_in_context` and a shared `_write_turn_usage_meta`.
    - **`token_usage/__init__.py`** — drop the unused `attach_turn_usage_metadata` export.


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
