### PR TITLE
fix(cron): cron session visibility, memory isolation and hot-reload stability

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -326,7 +326,11 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                 SkillEnvHook,
                 SkillEnvCleanupHook,
             )
-            from ..hooks.cron.cron_hook import CronContextHook
+            from ..hooks.cron.cron_hook import (
+                CronContextHook,
+                CronMemoryIsolateHook,
+                CronMemoryRestoreHook,
+            )
             from ..hooks.request_setup.contextvars_hook import (
                 ContextVarsSetupHook,
             )
@@ -339,6 +343,8 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             # pylint: disable-next=protected-access
             workspace_registry._bootstrap_kwargs["builtin_hook_clses"] = [
                 CronContextHook,
+                CronMemoryIsolateHook,
+                CronMemoryRestoreHook,
                 SessionLoadHook,
                 SessionSaveHook,
                 BootstrapHook,

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -22,7 +22,7 @@ class CronExecutor:
         self._workspace = workspace
         self._channel_manager = channel_manager
 
-    # pylint: disable=too-many-statements
+    # pylint: disable=too-many-statements,too-many-branches
     async def execute(self, job: CronJobSpec) -> dict[str, Any]:
         """Execute one job once.
 
@@ -113,6 +113,25 @@ class CronExecutor:
                 else f"cron:{job.id}"
             )
             req["session_source"] = "cron"
+
+        # Register a ChatSpec so the session appears in the frontend list.
+        chat_manager = getattr(self._workspace, "chat_manager", None)
+        _chat_spec = None
+        if chat_manager is not None:
+            try:
+                _chat_spec = await chat_manager.get_or_create_chat(
+                    session_id=req["session_id"],
+                    user_id=req.get("user_id", "cron"),
+                    channel=target_channel,
+                    name=job.name or f"Cron: {job.id}",
+                    source="cron",
+                )
+            except Exception:
+                logger.debug(
+                    "cron: failed to register chat spec for job %s",
+                    job.id,
+                    exc_info=True,
+                )
 
         delivery_error: str | None = None
         baseline_messages = await read_session_messages(
@@ -229,3 +248,13 @@ class CronExecutor:
                 error=repr(e),
             )
             raise
+        finally:
+            if _chat_spec is not None and chat_manager is not None:
+                try:
+                    await chat_manager.touch_chat(_chat_spec.id)
+                except Exception:
+                    logger.debug(
+                        "cron: failed to touch chat for job %s",
+                        job.id,
+                        exc_info=True,
+                    )

--- a/src/qwenpaw/hooks/cron/cron_hook.py
+++ b/src/qwenpaw/hooks/cron/cron_hook.py
@@ -20,7 +20,7 @@ from ...runtime.phases import Phase
 logger = logging.getLogger(__name__)
 
 IS_CRON_KEY = "is_cron"
-_CRON_MEMORY_SNAPSHOT_KEY = "_cron_context_snapshot"
+_CRON_CONTEXT_SNAPSHOT_KEY = "_cron_context_snapshot"
 _CRON_SUMMARY_SNAPSHOT_KEY = "_cron_summary_snapshot"
 
 
@@ -62,7 +62,7 @@ class CronMemoryIsolateHook(LifecycleHook):
         state = getattr(agent, "state", None)
         if state is None or not hasattr(state, "context"):
             return HookResult()
-        ctx.extras[_CRON_MEMORY_SNAPSHOT_KEY] = list(state.context)
+        ctx.extras[_CRON_CONTEXT_SNAPSHOT_KEY] = list(state.context)
         ctx.extras[_CRON_SUMMARY_SNAPSHOT_KEY] = getattr(
             state,
             "summary",
@@ -71,10 +71,10 @@ class CronMemoryIsolateHook(LifecycleHook):
         state.context.clear()
         if hasattr(state, "summary"):
             state.summary = ""
-        logger.info(
+        logger.debug(
             "cron_memory_isolate: snapshotted %d msgs and cleared "
             "context for session_id=%s",
-            len(ctx.extras[_CRON_MEMORY_SNAPSHOT_KEY]),
+            len(ctx.extras[_CRON_CONTEXT_SNAPSHOT_KEY]),
             ctx.session_id,
         )
         return HookResult()
@@ -93,7 +93,7 @@ class CronMemoryRestoreHook(LifecycleHook):
     priority = 80
 
     async def run(self, ctx: HookContext) -> HookResult:
-        snapshot = ctx.extras.get(_CRON_MEMORY_SNAPSHOT_KEY)
+        snapshot = ctx.extras.get(_CRON_CONTEXT_SNAPSHOT_KEY)
         if snapshot is None:
             return HookResult()
         agent = ctx.agent
@@ -110,7 +110,7 @@ class CronMemoryRestoreHook(LifecycleHook):
             state.context.extend(new_messages)
             if hasattr(state, "summary") and old_summary:
                 state.summary = old_summary
-            logger.info(
+            logger.debug(
                 "cron_memory_restore: restored %d historical + %d new "
                 "messages for session_id=%s",
                 len(snapshot),

--- a/src/qwenpaw/hooks/cron/cron_hook.py
+++ b/src/qwenpaw/hooks/cron/cron_hook.py
@@ -1,17 +1,27 @@
 # -*- coding: utf-8 -*-
-"""Cron context hook.
+"""Cron lifecycle hooks.
 
-Marks cron-originated requests so downstream hooks can adjust behavior
-(e.g. BootstrapHook skips guidance injection for cron requests).
+- CronContextHook: marks cron-originated requests so downstream hooks
+  can adjust behavior (e.g. BootstrapHook skips guidance injection).
+- CronMemoryIsolateHook / CronMemoryRestoreHook: snapshot & clear
+  agent memory before execution, then restore the full history plus
+  new messages afterward so each cron run is context-free while the
+  persisted session still accumulates all runs' conversations.
 """
 
 from __future__ import annotations
+
+import logging
 
 from ..base import LifecycleHook
 from ...runtime.hooks import HookContext, HookResult
 from ...runtime.phases import Phase
 
+logger = logging.getLogger(__name__)
+
 IS_CRON_KEY = "is_cron"
+_CRON_MEMORY_SNAPSHOT_KEY = "_cron_context_snapshot"
+_CRON_SUMMARY_SNAPSHOT_KEY = "_cron_summary_snapshot"
 
 
 class CronContextHook(LifecycleHook):
@@ -28,4 +38,97 @@ class CronContextHook(LifecycleHook):
         return HookResult()
 
 
-__all__ = ["CronContextHook", "IS_CRON_KEY"]
+class CronMemoryIsolateHook(LifecycleHook):
+    """Snapshot and clear agent context so cron runs execute without
+    prior conversation history.
+
+    In 2.0, conversation context lives in ``agent.state.context``
+    (an ``AgentState`` pydantic model), not ``agent.memory``.
+
+    Runs at PRE_EXECUTE (after agent build + session load) so the
+    agent's state already contains the full history at this point.
+    """
+
+    phase = Phase.PRE_EXECUTE
+    name = "cron_memory_isolate"
+    priority = 10
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        if not ctx.extras.get(IS_CRON_KEY):
+            return HookResult()
+        agent = ctx.agent
+        if agent is None:
+            return HookResult()
+        state = getattr(agent, "state", None)
+        if state is None or not hasattr(state, "context"):
+            return HookResult()
+        ctx.extras[_CRON_MEMORY_SNAPSHOT_KEY] = list(state.context)
+        ctx.extras[_CRON_SUMMARY_SNAPSHOT_KEY] = getattr(
+            state,
+            "summary",
+            "",
+        )
+        state.context.clear()
+        if hasattr(state, "summary"):
+            state.summary = ""
+        logger.info(
+            "cron_memory_isolate: snapshotted %d msgs and cleared "
+            "context for session_id=%s",
+            len(ctx.extras[_CRON_MEMORY_SNAPSHOT_KEY]),
+            ctx.session_id,
+        )
+        return HookResult()
+
+
+class CronMemoryRestoreHook(LifecycleHook):
+    """Restore snapshotted context and append new messages produced by
+    the current cron run.
+
+    Must run at POST_RESPONSE *before* SessionSaveHook (priority 90)
+    so ``state_dict()`` captures the full history when persisted.
+    """
+
+    phase = Phase.POST_RESPONSE
+    name = "cron_memory_restore"
+    priority = 80
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        snapshot = ctx.extras.get(_CRON_MEMORY_SNAPSHOT_KEY)
+        if snapshot is None:
+            return HookResult()
+        agent = ctx.agent
+        if agent is None:
+            return HookResult()
+        state = getattr(agent, "state", None)
+        if state is None or not hasattr(state, "context"):
+            return HookResult()
+        try:
+            new_messages = list(state.context)
+            old_summary = ctx.extras.get(_CRON_SUMMARY_SNAPSHOT_KEY, "")
+            state.context.clear()
+            state.context.extend(snapshot)
+            state.context.extend(new_messages)
+            if hasattr(state, "summary") and old_summary:
+                state.summary = old_summary
+            logger.info(
+                "cron_memory_restore: restored %d historical + %d new "
+                "messages for session_id=%s",
+                len(snapshot),
+                len(new_messages),
+                ctx.session_id,
+            )
+        except Exception:
+            logger.warning(
+                "cron_memory_restore: failed for session_id=%s",
+                ctx.session_id,
+                exc_info=True,
+            )
+        return HookResult()
+
+
+__all__ = [
+    "CronContextHook",
+    "CronMemoryIsolateHook",
+    "CronMemoryRestoreHook",
+    "IS_CRON_KEY",
+]


### PR DESCRIPTION
## Description

Fix three cron-related regressions introduced during the 2.0 refactor:

1. **Session visibility**: Cron executions created session files on disk but
   did not register a `ChatSpec`, making them invisible in the frontend
   session list. Now `CronExecutor.execute()` calls `get_or_create_chat()`
   to ensure the session appears, and `touch_chat()` in a `finally` block
   to keep `updated_at` current.

2. **Memory isolation** (`share_session=False`): In 1.x, cron runs with
   isolated sessions executed with a clean slate while still accumulating
   full history in the session file. In 2.0 the agent carried all prior
   context, breaking the isolation contract. Two new lifecycle hooks
   restore the 1.x behavior:
   - `CronMemoryIsolateHook` (PRE_EXECUTE): snapshots
     `agent.state.context` and `summary`, then clears them so the agent
     runs context-free.
   - `CronMemoryRestoreHook` (POST_RESPONSE, priority 80): restores the
     historical snapshot and appends the new messages before
     `SessionSaveHook` (priority 90) persists the full state.

3. **No regression for `share_session=True`**: The isolation hooks only
   trigger when `session_source == "cron"`, which is only set in the
   `share_session=False` code path. Shared-session cron tasks and normal
   user interactions are completely unaffected.

**Related Issue:** N/A (internal regression from 2.0 refactor)

**Security Considerations:** None — no auth, env, or config changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

