### PR TITLE
fix(runtime): align envelope event translation with v1 streaming protocol

### DIFF
--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -11,12 +11,17 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 from typing import Any, AsyncGenerator, Dict
 
 from .message_convert import _media_type_to_block_type
 
 logger = logging.getLogger(__name__)
+
+
+def _gen_msg_id() -> str:
+    return "msg_" + uuid.uuid4().hex
 
 
 class Envelope:
@@ -39,9 +44,11 @@ class Envelope:
 
         self._response = AgentResponse(output=[], status=RunStatus.Created)
         self._response.object = "response"
+        self._response.id = "response_" + uuid.uuid4().hex
+        self._response.created_at = int(time.time())
         self._response.session_id = session_id
 
-        self._message_id = uuid.uuid4().hex
+        self._message_id = _gen_msg_id()
         self._completed_message = Message(
             id=self._message_id,
             type=MessageType.MESSAGE,
@@ -56,9 +63,24 @@ class Envelope:
         self._text_blocks: Dict[str, Dict[str, Any]] = {}
         self._reasoning_blocks: Dict[str, Dict[str, Any]] = {}
         self._tool_calls: Dict[str, Dict[str, Any]] = {}
+        self._data_blocks: Dict[str, Dict[str, Any]] = {}
+
+        self._seq_counter = 0
 
         self._error_text: str | None = None
         self._finalized = False
+
+    # ------------------------------------------------------------------
+    # Sequence number helper
+    # ------------------------------------------------------------------
+
+    def _next_seq(self) -> int:
+        self._seq_counter += 1
+        return self._seq_counter
+
+    def _tag_seq(self, obj: Any) -> Any:
+        obj.sequence_number = self._next_seq()
+        return obj
 
     # ------------------------------------------------------------------
     # Response lifecycle
@@ -68,16 +90,49 @@ class Envelope:
         from ..schemas import RunStatus
 
         self._response.status = RunStatus.Created
-        yield self._response
+        yield self._tag_seq(self._response)
         self._response.status = RunStatus.InProgress
-        yield self._response
+        yield self._tag_seq(self._response)
+
+    # ------------------------------------------------------------------
+    # Text message finalize helper
+    # ------------------------------------------------------------------
+
+    def _should_finalize_text_message(self) -> bool:
+        return (
+            self._message_started and len(self._completed_message.content) > 0
+        )
+
+    async def _finalize_text_message(self) -> AsyncGenerator[Any, None]:
+        """Finalize the current text message before a tool call starts."""
+        from ..schemas import RunStatus
+
+        self._completed_message.status = RunStatus.Completed
+        self._response.output.append(self._completed_message)
+        yield self._tag_seq(self._completed_message)
+
+        self._message_id = _gen_msg_id()
+        from ..schemas import Message, MessageType, Role
+
+        self._completed_message = Message(
+            id=self._message_id,
+            type=MessageType.MESSAGE,
+            role=Role.ASSISTANT,
+            content=[],
+            status=RunStatus.InProgress,
+        )
+        self._completed_message.name = "assistant"
+        self._completed_message.object = "message"
+        self._message_started = False
+        self._text_blocks = {}
 
     # ------------------------------------------------------------------
     # Event translation
     # ------------------------------------------------------------------
 
+    # pylint: disable=too-many-return-statements
     # pylint: disable=too-many-branches,too-many-statements
-    async def translate_event(  # noqa: C901, PLR0912
+    async def translate_event(  # noqa: C901, PLR0912, PLR0915
         self,
         event: Any,
     ) -> AsyncGenerator[Any, None]:
@@ -88,6 +143,11 @@ class Envelope:
         from ..schemas import (
             ContentType,
             DataContent,
+            FunctionCall,
+            FunctionCallOutput,
+            ImageContent,
+            AudioContent,
+            VideoContent,
             Message,
             MessageType,
             Role,
@@ -102,7 +162,7 @@ class Envelope:
         # === TEXT BLOCK ===
         if evt_type == EventType.TEXT_BLOCK_START.value:
             if not self._message_started:
-                yield self._completed_message
+                yield self._tag_seq(self._completed_message)
                 self._message_started = True
             block_id = event.block_id
             index = len(self._text_blocks)
@@ -110,7 +170,7 @@ class Envelope:
 
         elif evt_type == EventType.TEXT_BLOCK_DELTA.value:
             if not self._message_started:
-                yield self._completed_message
+                yield self._tag_seq(self._completed_message)
                 self._message_started = True
             block_id = event.block_id
             delta = event.delta or ""
@@ -126,8 +186,7 @@ class Envelope:
                 index=state["index"],
             )
             chunk.msg_id = self._message_id
-            chunk.object = "content"
-            yield chunk
+            yield self._tag_seq(chunk)
 
         elif evt_type == EventType.TEXT_BLOCK_END.value:
             block_id = event.block_id
@@ -141,8 +200,7 @@ class Envelope:
                 index=state["index"],
             )
             final_chunk.msg_id = self._message_id
-            final_chunk.object = "content"
-            yield final_chunk
+            yield self._tag_seq(final_chunk)
             self._completed_message.content.append(
                 TextContent(
                     type=ContentType.TEXT,
@@ -155,7 +213,7 @@ class Envelope:
         # === THINKING BLOCK ===
         elif evt_type == EventType.THINKING_BLOCK_START.value:
             block_id = event.block_id
-            r_msg_id = uuid.uuid4().hex
+            r_msg_id = _gen_msg_id()
             r_envelope = Message(
                 id=r_msg_id,
                 type=MessageType.REASONING,
@@ -170,14 +228,14 @@ class Envelope:
                 "envelope": r_envelope,
                 "text": "",
             }
-            yield r_envelope
+            yield self._tag_seq(r_envelope)
 
         elif evt_type == EventType.THINKING_BLOCK_DELTA.value:
             block_id = event.block_id
             delta = getattr(event, "delta", "") or ""
             state = self._reasoning_blocks.get(block_id)
             if state is None:
-                r_msg_id = uuid.uuid4().hex
+                r_msg_id = _gen_msg_id()
                 r_envelope = Message(
                     id=r_msg_id,
                     type=MessageType.REASONING,
@@ -193,7 +251,7 @@ class Envelope:
                     "text": "",
                 }
                 self._reasoning_blocks[block_id] = state
-                yield r_envelope
+                yield self._tag_seq(r_envelope)
             state["text"] += delta
             r_chunk = TextContent(
                 type=ContentType.TEXT,
@@ -202,8 +260,7 @@ class Envelope:
                 index=0,
             )
             r_chunk.msg_id = state["msg_id"]
-            r_chunk.object = "content"
-            yield r_chunk
+            yield self._tag_seq(r_chunk)
 
         elif evt_type == EventType.THINKING_BLOCK_END.value:
             block_id = event.block_id
@@ -217,8 +274,7 @@ class Envelope:
                 index=0,
             )
             r_final.msg_id = state["msg_id"]
-            r_final.object = "content"
-            yield r_final
+            yield self._tag_seq(r_final)
             state["envelope"].content.append(
                 TextContent(
                     type=ContentType.TEXT,
@@ -229,170 +285,402 @@ class Envelope:
             )
             state["envelope"].status = RunStatus.Completed
             self._response.output.append(state["envelope"])
-            yield state["envelope"]
+            yield self._tag_seq(state["envelope"])
 
         # === TOOL CALL ===
         elif evt_type == EventType.TOOL_CALL_START.value:
-            self._tool_calls[event.tool_call_id] = {
-                "input_msg_id": uuid.uuid4().hex,
+            # P0-5: finalize current text message if needed
+            if self._should_finalize_text_message():
+                async for obj in self._finalize_text_message():
+                    yield obj
+
+            call_id = event.tool_call_id
+            msg_id = _gen_msg_id()
+            plugin_call_message = Message(
+                id=msg_id,
+                type=MessageType.PLUGIN_CALL,
+                role=Role.ASSISTANT,
+                content=[],
+                status=RunStatus.InProgress,
+            )
+            plugin_call_message.name = "assistant"
+            plugin_call_message.object = "message"
+
+            stub_content = DataContent(
+                type=ContentType.DATA,
+                data=FunctionCall(
+                    call_id=call_id,
+                    name=event.tool_call_name,
+                    arguments="",
+                ).model_dump(),
+                delta=False,
+                index=0,
+            )
+            stub_content.msg_id = msg_id
+
+            yield self._tag_seq(plugin_call_message.in_progress())
+            yield self._tag_seq(stub_content.in_progress())
+
+            self._tool_calls[call_id] = {
                 "name": event.tool_call_name,
                 "args_json_acc": "",
+                "message": plugin_call_message,
                 "output_text_acc": "",
+                "output_data_blocks": {},
             }
 
         elif evt_type == EventType.TOOL_CALL_DELTA.value:
-            state = self._tool_calls.get(event.tool_call_id)
-            if state is None:
-                state = {
-                    "input_msg_id": uuid.uuid4().hex,
-                    "name": "",
-                    "args_json_acc": "",
-                    "output_text_acc": "",
-                }
-                self._tool_calls[event.tool_call_id] = state
-            state["args_json_acc"] += event.delta or ""
-
-        elif evt_type == EventType.TOOL_CALL_END.value:
-            state = self._tool_calls.get(event.tool_call_id)
+            call_id = event.tool_call_id
+            state = self._tool_calls.get(call_id)
             if state is None:
                 return
-            raw = state["args_json_acc"]
-            try:
-                parsed_args: Any = json.loads(raw) if raw else {}
-            except json.JSONDecodeError:
-                parsed_args = raw
-            in_data = DataContent(
+            state["args_json_acc"] += event.delta or ""
+
+            delta_content = DataContent(
                 type=ContentType.DATA,
-                data={
-                    "name": state["name"],
-                    "call_id": event.tool_call_id,
-                    "arguments": parsed_args,
-                },
+                data=FunctionCall(
+                    call_id=call_id,
+                    name=state["name"],
+                    arguments=state["args_json_acc"],
+                ).model_dump(),
+                delta=False,
+                index=0,
             )
-            in_envelope = Message(
-                id=state["input_msg_id"],
-                type=MessageType.PLUGIN_CALL,
-                role=Role.ASSISTANT,
-                content=[in_data],
-                status=RunStatus.Completed,
+            delta_content.msg_id = state["message"].id
+            yield self._tag_seq(delta_content.in_progress())
+
+        elif evt_type == EventType.TOOL_CALL_END.value:
+            call_id = event.tool_call_id
+            state = self._tool_calls.get(call_id)
+            if state is None:
+                return
+
+            final_content = DataContent(
+                type=ContentType.DATA,
+                data=FunctionCall(
+                    call_id=call_id,
+                    name=state["name"],
+                    arguments=state["args_json_acc"],
+                ).model_dump(),
+                delta=False,
             )
-            in_envelope.name = "assistant"
-            in_envelope.object = "message"
-            self._response.output.append(in_envelope)
-            yield in_envelope
+            state["message"].add_content(new_content=final_content)
+            yield self._tag_seq(final_content.completed())
+            self._response.output.append(state["message"])
+            yield self._tag_seq(state["message"].completed())
 
         # === TOOL RESULT ===
         elif evt_type == EventType.TOOL_RESULT_START.value:
-            state = self._tool_calls.get(event.tool_call_id)
+            call_id = event.tool_call_id
+            state = self._tool_calls.get(call_id)
             if state is None:
                 state = {
-                    "input_msg_id": uuid.uuid4().hex,
                     "name": event.tool_call_name,
                     "args_json_acc": "",
                     "output_text_acc": "",
+                    "output_data_blocks": {},
                 }
-                self._tool_calls[event.tool_call_id] = state
-            state["output_msg_id"] = uuid.uuid4().hex
-            stub_data = DataContent(
-                type=ContentType.DATA,
-                data={
-                    "name": state["name"],
-                    "call_id": event.tool_call_id,
-                    "output": "",
-                },
-            )
-            out_envelope = Message(
-                id=state["output_msg_id"],
+                self._tool_calls[call_id] = state
+
+            out_msg_id = _gen_msg_id()
+            out_message = Message(
+                id=out_msg_id,
                 type=MessageType.PLUGIN_CALL_OUTPUT,
-                role=Role.ASSISTANT,
-                content=[stub_data],
+                role=Role.TOOL,
+                content=[],
                 status=RunStatus.InProgress,
             )
-            out_envelope.name = "assistant"
-            out_envelope.object = "message"
-            state["output_envelope"] = out_envelope
-            yield out_envelope
+            out_message.name = "assistant"
+            out_message.object = "message"
+
+            stub_content = DataContent(
+                type=ContentType.DATA,
+                data=FunctionCallOutput(
+                    call_id=call_id,
+                    name=state["name"],
+                    output="",
+                ).model_dump(),
+                delta=False,
+                index=0,
+            )
+            stub_content.msg_id = out_msg_id
+
+            yield self._tag_seq(out_message.in_progress())
+            yield self._tag_seq(stub_content.in_progress())
+
+            state["output_message"] = out_message
+            state["output_text_acc"] = ""
+            state["output_data_blocks"] = {}
 
         elif evt_type == EventType.TOOL_RESULT_TEXT_DELTA.value:
-            state = self._tool_calls.get(event.tool_call_id)
-            if state is not None:
-                state["output_text_acc"] += event.delta or ""
+            call_id = event.tool_call_id
+            state = self._tool_calls.get(call_id)
+            if state is None:
+                return
+            state["output_text_acc"] += event.delta or ""
+
+            delta_content = self._build_tool_result_content(
+                call_id,
+                state,
+                ContentType,
+                FunctionCallOutput,
+            )
+            delta_content.msg_id = state["output_message"].id
+            yield self._tag_seq(delta_content.in_progress())
 
         elif evt_type == EventType.TOOL_RESULT_DATA_DELTA.value:
-            state = self._tool_calls.get(event.tool_call_id)
+            call_id = event.tool_call_id
+            state = self._tool_calls.get(call_id)
             if state is None:
                 return
-            data_blocks = state.setdefault("output_data_blocks", [])
+
+            block_id = event.block_id
             media_type = getattr(event, "media_type", None)
             block_type = _media_type_to_block_type(media_type)
-            block: dict[str, Any] = {"type": block_type, "source": {}}
+
+            blocks_dict: dict = state["output_data_blocks"]
             url = getattr(event, "url", None)
             b64 = getattr(event, "data", None)
-            if url:
-                block["source"] = {
-                    "type": "url",
-                    "url": url,
-                    "media_type": media_type or "",
+
+            if block_id in blocks_dict:
+                existing = blocks_dict[block_id]
+                if b64:
+                    existing["source"]["data"] = (
+                        existing["source"].get("data", "") + b64
+                    )
+            else:
+                source: dict[str, Any] = {}
+                if url:
+                    source = {
+                        "type": "url",
+                        "url": url,
+                        "media_type": media_type or "",
+                    }
+                elif b64:
+                    source = {
+                        "type": "base64",
+                        "data": b64,
+                        "media_type": media_type or "",
+                    }
+                blocks_dict[block_id] = {
+                    "type": block_type,
+                    "source": source,
                 }
-            elif b64:
-                block["source"] = {
-                    "type": "base64",
-                    "data": b64,
-                    "media_type": media_type or "",
-                }
-            data_blocks.append(block)
+
+            delta_content = self._build_tool_result_content(
+                call_id,
+                state,
+                ContentType,
+                FunctionCallOutput,
+            )
+            delta_content.msg_id = state["output_message"].id
+            yield self._tag_seq(delta_content.in_progress())
 
         elif evt_type == EventType.TOOL_RESULT_END.value:
-            state = self._tool_calls.get(event.tool_call_id)
+            call_id = event.tool_call_id
+            state = self._tool_calls.get(call_id)
             if state is None:
                 return
+
             tool_state = getattr(event, "state", None)
             if hasattr(tool_state, "value"):
                 tool_state = tool_state.value
-            data_blocks = state.get("output_data_blocks")
-            if data_blocks:
-                output_blocks: list[dict[str, Any]] = list(data_blocks)
-                text_acc = state["output_text_acc"]
-                if text_acc:
-                    output_blocks.append({"type": "text", "text": text_acc})
-                tool_output: Any = json.dumps(
-                    output_blocks,
-                    ensure_ascii=False,
-                )
-            else:
-                tool_output = state["output_text_acc"]
-            out_data = DataContent(
-                type=ContentType.DATA,
-                data={
-                    "name": state["name"],
-                    "call_id": event.tool_call_id,
-                    "output": tool_output,
-                    "state": tool_state,
-                },
+
+            final_content = self._build_tool_result_content(
+                call_id,
+                state,
+                ContentType,
+                FunctionCallOutput,
+                tool_state=tool_state,
             )
-            out_envelope = state.get("output_envelope")
-            if out_envelope is None:
-                out_envelope = Message(
-                    id=uuid.uuid4().hex,
+
+            out_message = state.get("output_message")
+            if out_message is None:
+                out_message = Message(
+                    id=_gen_msg_id(),
                     type=MessageType.PLUGIN_CALL_OUTPUT,
-                    role=Role.ASSISTANT,
-                    content=[out_data],
-                    status=RunStatus.Completed,
+                    role=Role.TOOL,
+                    content=[],
+                    status=RunStatus.InProgress,
                 )
-                out_envelope.name = "assistant"
-                out_envelope.object = "message"
+                out_message.name = "assistant"
+                out_message.object = "message"
+
+            out_message.add_content(new_content=final_content)
+            yield self._tag_seq(final_content.completed())
+            self._response.output.append(out_message)
+            yield self._tag_seq(out_message.completed())
+
+        # === DATA BLOCK ===
+        elif evt_type == EventType.DATA_BLOCK_START.value:
+            block_id = event.block_id
+            media_type = getattr(event, "media_type", "")
+
+            if not self._message_started:
+                yield self._tag_seq(self._completed_message)
+                self._message_started = True
+
+            self._data_blocks[block_id] = {
+                "media_type": media_type,
+                "data_acc": "",
+            }
+
+        elif evt_type == EventType.DATA_BLOCK_DELTA.value:
+            block_id = event.block_id
+            state = self._data_blocks.get(block_id)
+            if state is None:
+                return
+            state["data_acc"] += event.data or ""
+            # No intermediate yield: partial base64 cannot be decoded or
+            # rendered by the frontend.  Content is emitted once on
+            # DATA_BLOCK_END with the complete payload.
+
+        elif evt_type == EventType.DATA_BLOCK_END.value:
+            block_id = event.block_id
+            state = self._data_blocks.get(block_id)
+            if state is None:
+                return
+
+            media_type = state["media_type"]
+            b64_data = state["data_acc"]
+            major = (media_type.split("/", 1)[0]) if media_type else ""
+            index = len(self._completed_message.content)
+
+            if major == "audio":
+                fmt = media_type.split("/", 1)[1] if "/" in media_type else ""
+                content_block = AudioContent(
+                    type=ContentType.AUDIO,
+                    data=b64_data,
+                    format=fmt,
+                    delta=False,
+                    index=index,
+                )
+            elif major == "video":
+                video_uri = f"data:{media_type};base64,{b64_data}"
+                content_block = VideoContent(
+                    type=ContentType.VIDEO,
+                    video_url=video_uri,
+                    delta=False,
+                    index=index,
+                )
             else:
-                out_envelope.content = [out_data]
-                out_envelope.status = RunStatus.Completed
-            self._response.output.append(out_envelope)
-            yield out_envelope
+                data_uri = f"data:{media_type};base64,{b64_data}"
+                content_block = ImageContent(
+                    type=ContentType.IMAGE,
+                    image_url=data_uri,
+                    delta=False,
+                    index=index,
+                )
+
+            content_block.msg_id = self._message_id
+            self._completed_message.content.append(content_block)
+            yield self._tag_seq(content_block)
+
+        # === MODEL_CALL_END ===
+        elif evt_type == EventType.MODEL_CALL_END.value:
+            input_tokens = getattr(event, "input_tokens", 0)
+            output_tokens = getattr(event, "output_tokens", 0)
+            usage = {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            self._response.usage = usage
+            if self._message_started:
+                self._completed_message.usage = usage
+
+        # === EXCEED_MAX_ITERS ===
+        elif evt_type == EventType.EXCEED_MAX_ITERS.value:
+            agent_name = getattr(event, "name", "agent")
+            err_msg_id = _gen_msg_id()
+            err_message = Message(
+                id=err_msg_id,
+                type=MessageType.MESSAGE,
+                role=Role.ASSISTANT,
+                content=[],
+                status=RunStatus.InProgress,
+            )
+            err_message.name = "assistant"
+            err_message.object = "message"
+            yield self._tag_seq(err_message)
+
+            err_text = TextContent(
+                type=ContentType.TEXT,
+                text=(
+                    f"[Warning] Agent '{agent_name}' has reached "
+                    f"the maximum number of iterations."
+                ),
+                delta=False,
+                index=0,
+            )
+            err_text.msg_id = err_msg_id
+            yield self._tag_seq(err_text)
+
+            err_message.content.append(err_text)
+            err_message.status = RunStatus.Completed
+            self._response.output.append(err_message)
+            yield self._tag_seq(err_message)
+
+        # === HINT_BLOCK (P2-2: warn and drop) ===
+        elif evt_type == EventType.HINT_BLOCK.value:
+            source = getattr(event, "source", None) or ""
+            logger.warning(
+                "HintBlockEvent received but not rendered: "
+                "block_id=%s source=%s",
+                getattr(event, "block_id", "?"),
+                source,
+            )
+
+    # ------------------------------------------------------------------
+    # Tool result content builder
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_tool_result_content(
+        call_id: str,
+        state: Dict[str, Any],
+        ContentType: Any,
+        FunctionCallOutput: Any,
+        tool_state: Any = None,
+    ) -> Any:
+        from ..schemas import DataContent
+
+        blocks_dict: dict = state.get("output_data_blocks", {})
+        text_acc: str = state.get("output_text_acc", "")
+
+        if blocks_dict:
+            output_blocks: list[dict[str, Any]] = list(
+                blocks_dict.values(),
+            )
+            if text_acc:
+                output_blocks.append({"type": "text", "text": text_acc})
+            tool_output: Any = json.dumps(
+                output_blocks,
+                ensure_ascii=False,
+            )
+        else:
+            tool_output = text_acc
+
+        data_dict = FunctionCallOutput(
+            call_id=call_id,
+            name=state["name"],
+            output=tool_output,
+        ).model_dump()
+        if tool_state is not None:
+            data_dict["state"] = tool_state
+
+        return DataContent(
+            type=ContentType.DATA,
+            data=data_dict,
+            delta=False,
+            index=0,
+        )
 
     # ------------------------------------------------------------------
     # Heartbeat
     # ------------------------------------------------------------------
 
     async def heartbeat(self) -> AsyncGenerator[Any, None]:
-        yield self._response
+        yield self._tag_seq(self._response)
 
     # ------------------------------------------------------------------
     # Command short-circuit
@@ -407,7 +695,7 @@ class Envelope:
         cmd_text = cmd_msg.get_text_content() or ""
 
         if not self._message_started:
-            yield self._completed_message
+            yield self._tag_seq(self._completed_message)
             self._message_started = True
 
         tc = TextContent(
@@ -417,8 +705,7 @@ class Envelope:
             index=0,
         )
         tc.msg_id = self._message_id
-        tc.object = "content"
-        yield tc
+        yield self._tag_seq(tc)
 
         self._completed_message.content.append(tc)
         self._completed_message.status = RunStatus.Completed
@@ -426,10 +713,11 @@ class Envelope:
             getattr(cmd_msg, "metadata", None) or {}
         )
         self._response.output.append(self._completed_message)
-        yield self._completed_message
+        yield self._tag_seq(self._completed_message)
 
         self._response.status = RunStatus.Completed
-        yield self._response
+        self._response.completed_at = int(time.time())
+        yield self._tag_seq(self._response)
         self._finalized = True
 
     # ------------------------------------------------------------------
@@ -467,14 +755,15 @@ class Envelope:
         if self._message_started:
             self._completed_message.status = RunStatus.Completed
             self._response.output.append(self._completed_message)
-            yield self._completed_message
+            yield self._tag_seq(self._completed_message)
 
         if self._error_text:
             self._response.status = RunStatus.Failed
             self._response.error = self._error_text
         else:
             self._response.status = RunStatus.Completed
-        yield self._response
+        self._response.completed_at = int(time.time())
+        yield self._tag_seq(self._response)
         self._finalized = True
 
     @property

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 import uuid
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict
 
 from .message_convert import _media_type_to_block_type
@@ -45,7 +45,9 @@ class Envelope:
         self._response = AgentResponse(output=[], status=RunStatus.Created)
         self._response.object = "response"
         self._response.id = "response_" + uuid.uuid4().hex
-        self._response.created_at = int(time.time())
+        self._response.created_at = datetime.now(timezone.utc).isoformat(
+            timespec="seconds",
+        )
         self._response.session_id = session_id
 
         self._message_id = _gen_msg_id()
@@ -716,7 +718,9 @@ class Envelope:
         yield self._tag_seq(self._completed_message)
 
         self._response.status = RunStatus.Completed
-        self._response.completed_at = int(time.time())
+        self._response.completed_at = datetime.now(timezone.utc).isoformat(
+            timespec="seconds",
+        )
         yield self._tag_seq(self._response)
         self._finalized = True
 
@@ -762,7 +766,9 @@ class Envelope:
             self._response.error = self._error_text
         else:
             self._response.status = RunStatus.Completed
-        self._response.completed_at = int(time.time())
+        self._response.completed_at = datetime.now(timezone.utc).isoformat(
+            timespec="seconds",
+        )
         yield self._tag_seq(self._response)
         self._finalized = True
 

--- a/src/qwenpaw/schemas.py
+++ b/src/qwenpaw/schemas.py
@@ -70,6 +70,17 @@ class _ContentBase(BaseModel):
     type: ContentType
     delta: bool = False
     index: Optional[int] = None
+    status: Optional[RunStatus] = None
+    object: str = "content"
+    msg_id: Optional[str] = None
+
+    def in_progress(self) -> "_ContentBase":
+        self.status = RunStatus.InProgress
+        return self
+
+    def completed(self) -> "_ContentBase":
+        self.status = RunStatus.Completed
+        return self
 
 
 class TextContent(_ContentBase):
@@ -254,8 +265,11 @@ class AgentRequest(BaseModel):
 class AgentResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
+    id: Optional[str] = None
     output: List[Message] = Field(default_factory=list)
     status: RunStatus = RunStatus.Completed
+    created_at: Optional[int] = None
+    completed_at: Optional[int] = None
     metadata: Optional[Dict[str, Any]] = None
 
 

--- a/src/qwenpaw/schemas.py
+++ b/src/qwenpaw/schemas.py
@@ -268,8 +268,8 @@ class AgentResponse(BaseModel):
     id: Optional[str] = None
     output: List[Message] = Field(default_factory=list)
     status: RunStatus = RunStatus.Completed
-    created_at: Optional[int] = None
-    completed_at: Optional[int] = None
+    created_at: Optional[str] = None
+    completed_at: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
 
 


### PR DESCRIPTION
## Description

Align the 2.0 SSE envelope event translation logic (`Envelope.translate_event()`) with the 1.0 `adapt_agentscope_message_stream` behavior to fix broken tool call rendering in the frontend.

In 2.0, tool calls and results were rendered as stacked blocks (all calls grouped together, then all results grouped together) instead of appearing in the correct interleaved sequence. Root cause: the envelope was emitting tool call messages only at `TOOL_CALL_END` as a single completed message, skipping the `in_progress → delta → completed` lifecycle that `Builder.js` relies on to pair and render tool calls/results via `mergeToolMessages`.

This PR rewrites the tool call/result event translation to emit the full message + content lifecycle matching 1.0, and fixes several other gaps identified through systematic comparison.

### Key changes

**`schemas.py`**:
- Add `status`, `object`, `msg_id` fields and `in_progress()`/`completed()` lifecycle methods to `_ContentBase`, enabling `DataContent` to participate in the same content lifecycle as 1.0's `Content` (which inherited from `Event`)
- Add explicit `id`, `created_at`, `completed_at` fields to `AgentResponse`

**`envelope.py`**:
- **Tool call lifecycle**: Rewrite `TOOL_CALL_START/DELTA/END` to emit `message.in_progress()` → `content.in_progress()` → delta updates with full accumulated state → `content.completed()` → `message.completed()`. Remove `json.loads` on arguments to keep them as JSON strings (required by `Builder.js` string concatenation logic)
- **Tool result lifecycle**: Rewrite `TOOL_RESULT_START/TEXT_DELTA/DATA_DELTA/END` with `role=Role.TOOL` (was `ASSISTANT`), full content lifecycle, and `dict[block_id]` tracking for data blocks (was flat list append)
- **Text message finalization**: Finalize the current text message before the first `TOOL_CALL_START`, with guard conditions to prevent double-finalize or empty message emission
- **DATA_BLOCK events**: Handle `DATA_BLOCK_START/DELTA/END` for model-generated binary content (images, audio, video) that was previously silently dropped
- **Message ID prefix**: Add `msg_` prefix to all message IDs
- **Sequence numbers**: Add monotonic `sequence_number` to every yielded object
- **Response metadata**: Add `response_` prefixed ID and `created_at`/`completed_at` timestamps
- **MODEL_CALL_END**: Extract `input_tokens`/`output_tokens` into `usage` on response and message
- **EXCEED_MAX_ITERS**: Emit a warning message when the agent hits iteration limits
- **HINT_BLOCK**: Log a warning instead of silently dropping

**Security Considerations:** N/A — no auth, credential, or config changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start the QwenPaw server and open the console in a browser
2. Send a query that triggers tool calls (e.g., a web search query)
3. Open browser DevTools → Network → EventStream tab to inspect SSE events
4. **Verify interleaving**: tool call (`plugin_call`) and result (`plugin_call_output`) messages should alternate — not stack by type
5. **Verify lifecycle**: each tool message should follow `in_progress` → content deltas → `completed` sequence
6. **Verify role**: `plugin_call_output` messages should have `role: "tool"` (not `"assistant"`)
7. **Verify arguments format**: `plugin_call` content `data.arguments` should be a JSON string, not a parsed object
8. **Verify IDs**: all message IDs should start with `msg_`, response ID with `response_`
9. **Verify sequence_number**: every SSE event should carry an incrementing `sequence_number`

Verified via browser EventStream inspection — see screenshots in the linked issue discussion.

## Additional Notes

- The frontend (`Builder.js`, `v1Adapter.tsx`, `channels/base.py`) is **not modified** — all changes are in the backend envelope layer to produce the same event shape that 1.0 produced
- `extra="allow"` on pydantic models means the newly explicit fields on `AgentResponse` and `_ContentBase` are backward-compatible — previously they were set dynamically and still serialized correctly, but explicit fields are cleaner
- `DataBlock` events (model-generated images/audio) only emit content on `DATA_BLOCK_END` — partial base64 cannot be rendered, so no intermediate yield during `DATA_BLOCK_DELTA`
- `HintBlockEvent` is logged but not rendered; full rendering is deferred to a follow-up when multi-agent team scenarios are prioritized