### PR TITLE
fix: move Current date from env context to per-user-message dynamic prefix (#5455)

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -91,14 +91,6 @@ def build_env_context(
         Formatted environment context string
     """
     parts = []
-    user_tz = load_config().user_timezone or "UTC"
-    try:
-        now = datetime.now(ZoneInfo(user_tz))
-    except (ZoneInfoNotFoundError, KeyError):
-        logger.warning("Invalid timezone %r, falling back to UTC", user_tz)
-        now = datetime.now(timezone.utc)
-        user_tz = "UTC"
-
     if session_id is not None:
         parts.append(f"- Session ID: {session_id}")
     if user_id is not None:
@@ -128,11 +120,6 @@ def build_env_context(
             )
     elif working_dir is not None:
         parts.append(f"- Working directory: {working_dir}")
-    parts.append(
-        f"- Current date: {now.strftime('%Y-%m-%d')} "
-        f"{user_tz} ({now.strftime('%A')})",
-    )
-
     if add_hint:
         parts.append(
             "- Important:\n"

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .builder import AgentBuilder
 from .envelope import Envelope
@@ -25,6 +27,7 @@ from .executor import AgentExecutor
 from .hooks import HookAction, HookContext
 from .message_convert import _get_last_user_text, _request_input_to_msgs
 from .phases import Phase
+from ..config import load_config
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +122,7 @@ class Runtime:
                 # --- [fixed 3] execute agent ---
                 async for ev in envelope.emit_response_created():
                     yield ev
+                Runtime._inject_current_time(ctx.input_msgs)
                 executor = AgentExecutor(ctx.agent, envelope)
                 async for ev in executor.run(ctx.input_msgs):
                     yield ev
@@ -181,6 +185,43 @@ class Runtime:
         if not getattr(request, "user_id", None):
             request.user_id = request.session_id
         return request
+
+    @staticmethod
+    def _inject_current_time(msgs: list[Any]) -> None:
+        """Prepend current time to the last user message's first text block.
+
+        Operates in-place on *msgs* (a list of agentscope ``Msg`` objects)
+        so that only model-facing input receives the timestamp — slash
+        commands, lifecycle hooks, and short-circuit paths see raw text.
+
+        If the last user message has no text block (media-only input),
+        a text block with the timestamp alone is inserted.
+        """
+        try:
+            user_tz_name = load_config().user_timezone or "UTC"
+            now = datetime.now(ZoneInfo(user_tz_name))
+        except (ZoneInfoNotFoundError, KeyError, ValueError):
+            user_tz_name = "UTC"
+            now = datetime.now(timezone.utc)
+
+        prefix = (
+            f"Current time: {now.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"{user_tz_name} ({now.strftime('%A')})\n\n"
+        )
+
+        # Walk backwards to find the last user message
+        for msg in reversed(msgs):
+            if getattr(msg, "role", None) != "user":
+                continue
+            # Walk through content blocks (list of dicts)
+            content: list[dict] = getattr(msg, "content", None) or []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    block["text"] = prefix + block["text"]
+                    return
+            # No text block found — insert one (media-only edge case)
+            content.insert(0, {"type": "text", "text": prefix})
+            return
 
     def _build_context(self, request: Any) -> HookContext:
         workspace_dir = getattr(self.workspace, "workspace_dir", None)

--- a/tests/unit/app/chats/test_env_context.py
+++ b/tests/unit/app/chats/test_env_context.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-import pytest
-
 from qwenpaw.app.chats.utils import build_env_context
 from qwenpaw.runtime.runtime import Runtime
 
@@ -102,7 +100,7 @@ class TestInjectCurrentTime:
         ), f"Expected original text 'hello' to be preserved, got {text!r}"
 
     def test_inserts_text_block_for_media_only(self) -> None:
-        """When the user message has no text block, a text block is inserted."""
+        """Inserts text block when user msg has no text block."""
         msgs = [
             _make_assistant_msg(),
             _make_user_msg(
@@ -122,7 +120,7 @@ class TestInjectCurrentTime:
         assert any(b.get("type") == "image_url" for b in content)
 
     def test_ignores_non_user_messages(self) -> None:
-        """Only the *last* user message is modified; assistant msgs stay untouched."""
+        """Only last user message is modified; assistant keeps raw text."""
         msgs = [
             _make_assistant_msg(),
             _make_user_msg([{"type": "text", "text": "user says hi"}]),

--- a/tests/unit/app/chats/test_env_context.py
+++ b/tests/unit/app/chats/test_env_context.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for environment context and dynamic time injection.
+
+Covers:
+
+- ``build_env_context()`` no longer includes a static ``Current date``
+  so that prompt caching benefits from stable env context.
+- ``Runtime._inject_current_time()`` prepends a dynamic timestamp to
+  the last user message *after* slash-command dispatch, leaving the
+  raw text untouched for hooks and commands.
+"""
+# pylint: disable=protected-access,redefined-outer-name,unused-argument,wrong-import-position
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from qwenpaw.app.chats.utils import build_env_context
+from qwenpaw.runtime.runtime import Runtime
+
+
+# ---------------------------------------------------------------------------
+# _inject_current_time helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user_msg(content: list[dict[str, str]]) -> Any:
+    """Create a minimal Msg-like object that represents a user message."""
+    return SimpleNamespace(role="user", content=content)
+
+
+def _make_assistant_msg() -> Any:
+    """Create a minimal Msg-like object for a non-user message."""
+    return SimpleNamespace(role="assistant", content=[{"type": "text", "text": "ok"}])
+
+
+# ---------------------------------------------------------------------------
+# build_env_context — must NOT contain a static current date
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEnvContext:
+    """The env context string should be stable across requests."""
+
+    def test_no_current_date_field(self) -> None:
+        """``build_env_context()`` must not contain a ``Current date`` line."""
+        ctx = build_env_context(session_id="s1", user_id="u1", add_hint=True)
+        assert "Current date" not in ctx, (
+            "build_env_context() should no longer inject a static "
+            "current date.  Dynamic time is handled by "
+            "Runtime._inject_current_time()."
+        )
+
+    def test_stable_across_calls(self) -> None:
+        """Without time injection the env context should be identical."""
+        ctx1 = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            working_dir="/tmp",
+            add_hint=True,
+        )
+        ctx2 = build_env_context(
+            session_id="s1",
+            user_id="u1",
+            working_dir="/tmp",
+            add_hint=True,
+        )
+        assert ctx1 == ctx2, (
+            "build_env_context() returned different values for the "
+            "same arguments — it should be deterministic."
+        )
+
+
+# ---------------------------------------------------------------------------
+# _inject_current_time — dynamic time prefix on the last user message
+# ---------------------------------------------------------------------------
+
+
+class TestInjectCurrentTime:
+    """``Runtime._inject_current_time()`` prepends time to user text."""
+
+    def test_prepends_to_text_block(self) -> None:
+        """A normal text-only user message gets a ``Current time:`` prefix."""
+        msgs = [
+            _make_assistant_msg(),
+            _make_user_msg([{"type": "text", "text": "hello"}]),
+        ]
+        Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
+        text = msgs[-1].content[0]["text"]
+        assert text.startswith("Current time:"), (
+            f"Expected text to start with 'Current time:', got {text!r}"
+        )
+        # Original content should appear after the prefix
+        assert text.rstrip().endswith("hello"), (
+            f"Expected original text 'hello' to be preserved, got {text!r}"
+        )
+
+    def test_inserts_text_block_for_media_only(self) -> None:
+        """When the user message has no text block, a text block is inserted."""
+        msgs = [
+            _make_assistant_msg(),
+            _make_user_msg([{"type": "image_url", "image_url": "data:img/png;base64,abc"}]),
+        ]
+        Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
+        content = msgs[-1].content
+        assert content[0]["type"] == "text"
+        assert content[0]["text"].startswith("Current time:")
+        # The original image block should still be present
+        assert any(b.get("type") == "image_url" for b in content)
+
+    def test_ignores_non_user_messages(self) -> None:
+        """Only the *last* user message is modified; assistant msgs stay untouched."""
+        msgs = [
+            _make_assistant_msg(),
+            _make_user_msg([{"type": "text", "text": "user says hi"}]),
+        ]
+        Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
+        assert msgs[0].content[0]["text"] == "ok", (
+            "Assistant message should not be modified."
+        )
+        assert msgs[1].content[0]["text"].startswith("Current time:")
+
+    def test_timestamp_format_english(self) -> None:
+        """The weekday should be in English (``strftime('%A')``)."""
+        msgs = [_make_user_msg([{"type": "text", "text": "test"}])]
+        Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
+        text = msgs[0].content[0]["text"]
+        # Should contain something like "(Wednesday)" not "(星期三)"
+        assert "(" in text and ")" in text
+        weekday_part = text[text.rfind("(") + 1 : text.rfind(")")]
+        # Should not be Chinese
+        assert not any("\u4e00" <= c <= "\u9fff" for c in weekday_part), (
+            f"Weekday should be English, got {weekday_part!r}"
+        )
+
+    def test_empty_message_list(self) -> None:
+        """An empty message list should not raise."""
+        Runtime._inject_current_time([])  # type: ignore[arg-type]
+
+    def test_no_role_attribute(self) -> None:
+        """Messages without a ``role`` are skipped gracefully."""
+        msgs = [SimpleNamespace(content=[{"type": "text", "text": "no role"}])]
+        Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
+        # Should not crash and should not modify the non-role message
+        assert msgs[0].content[0]["text"] == "no role"

--- a/tests/unit/app/chats/test_env_context.py
+++ b/tests/unit/app/chats/test_env_context.py
@@ -9,7 +9,8 @@ Covers:
   the last user message *after* slash-command dispatch, leaving the
   raw text untouched for hooks and commands.
 """
-# pylint: disable=protected-access,redefined-outer-name,unused-argument,wrong-import-position
+# pylint: disable=protected-access,redefined-outer-name
+# pylint: disable=unused-argument,wrong-import-position
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -33,7 +34,10 @@ def _make_user_msg(content: list[dict[str, str]]) -> Any:
 
 def _make_assistant_msg() -> Any:
     """Create a minimal Msg-like object for a non-user message."""
-    return SimpleNamespace(role="assistant", content=[{"type": "text", "text": "ok"}])
+    return SimpleNamespace(
+        role="assistant",
+        content=[{"type": "text", "text": "ok"}],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -89,19 +93,26 @@ class TestInjectCurrentTime:
         ]
         Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
         text = msgs[-1].content[0]["text"]
-        assert text.startswith("Current time:"), (
-            f"Expected text to start with 'Current time:', got {text!r}"
-        )
+        assert text.startswith(
+            "Current time:",
+        ), f"Expected text to start with 'Current time:', got {text!r}"
         # Original content should appear after the prefix
-        assert text.rstrip().endswith("hello"), (
-            f"Expected original text 'hello' to be preserved, got {text!r}"
-        )
+        assert text.rstrip().endswith(
+            "hello",
+        ), f"Expected original text 'hello' to be preserved, got {text!r}"
 
     def test_inserts_text_block_for_media_only(self) -> None:
         """When the user message has no text block, a text block is inserted."""
         msgs = [
             _make_assistant_msg(),
-            _make_user_msg([{"type": "image_url", "image_url": "data:img/png;base64,abc"}]),
+            _make_user_msg(
+                [
+                    {
+                        "type": "image_url",
+                        "image_url": "data:img/png;base64,abc",
+                    },
+                ],
+            ),
         ]
         Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
         content = msgs[-1].content
@@ -117,9 +128,9 @@ class TestInjectCurrentTime:
             _make_user_msg([{"type": "text", "text": "user says hi"}]),
         ]
         Runtime._inject_current_time(msgs)  # type: ignore[arg-type]
-        assert msgs[0].content[0]["text"] == "ok", (
-            "Assistant message should not be modified."
-        )
+        assert (
+            msgs[0].content[0]["text"] == "ok"
+        ), "Assistant message should not be modified."
         assert msgs[1].content[0]["text"].startswith("Current time:")
 
     def test_timestamp_format_english(self) -> None:
@@ -131,9 +142,9 @@ class TestInjectCurrentTime:
         assert "(" in text and ")" in text
         weekday_part = text[text.rfind("(") + 1 : text.rfind(")")]
         # Should not be Chinese
-        assert not any("\u4e00" <= c <= "\u9fff" for c in weekday_part), (
-            f"Weekday should be English, got {weekday_part!r}"
-        )
+        assert not any(
+            "\u4e00" <= c <= "\u9fff" for c in weekday_part
+        ), f"Weekday should be English, got {weekday_part!r}"
 
     def test_empty_message_list(self) -> None:
         """An empty message list should not raise."""


### PR DESCRIPTION
## Description

Move `Current date` from the static `build_env_context()` (system/environment context) to a per-user-message dynamic timestamp prefix. This fixes stale time information in long sessions and improves prompt caching stability by avoiding per-request context changes.

Changes:
1. **`chats/utils.py`**: Remove `Current date` from `build_env_context()` — no more static timestamp in the system/environment context.
2. **`runtime/runtime.py`**: Add `_inject_current_time()` static method and call it in `_normalize()` — injects `Current date: YYYY-MM-DD Weekday TZ HH:MM:SS` as a prefix to the last user message's first text block.

## Related Issue

Closes #5455

## Checklist

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Implementation follows the established code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added unit tests that prove my fix is effective or that my feature works
