### PR TITLE
feat(tools): redesign Tools page with enabled/available split layout

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1970,7 +1970,13 @@
     "configured": "Configured",
     "requiresConfig": "Requires configuration",
     "configSaved": "Configuration saved",
-    "configSaveError": "Failed to save configuration"
+    "configSaveError": "Failed to save configuration",
+    "active": "active",
+    "available": "Available",
+    "noEnabled": "No tools enabled",
+    "goEnableBtn": "Go enable",
+    "configureAction": "Configure →",
+    "enableAction": "Enable →"
   },
   "modelConfig": {
     "promptTitle": "LLM Model Required — Select in Chat After Configuration",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -483,7 +483,13 @@
     "configured": "Terkonfigurasi",
     "requiresConfig": "Perlu konfigurasi",
     "configSaved": "Konfigurasi tersimpan",
-    "configSaveError": "Gagal menyimpan konfigurasi"
+    "configSaveError": "Gagal menyimpan konfigurasi",
+    "active": "aktif",
+    "available": "Tersedia",
+    "noEnabled": "Tidak ada alat yang diaktifkan",
+    "goEnableBtn": "Aktifkan sekarang",
+    "configureAction": "Konfigurasi →",
+    "enableAction": "Aktifkan →"
   },
   "modelConfig": {
     "promptTitle": "Model LLM Diperlukan - Pilih di Chat Setelah Konfigurasi",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1564,7 +1564,13 @@
     "configured": "設定済み",
     "requiresConfig": "設定が必要です",
     "configSaved": "設定を保存しました",
-    "configSaveError": "設定の保存に失敗しました"
+    "configSaveError": "設定の保存に失敗しました",
+    "active": "個が有効",
+    "available": "利用可能",
+    "noEnabled": "有効なツールはありません",
+    "goEnableBtn": "有効にする",
+    "configureAction": "設定 →",
+    "enableAction": "有効化 →"
   },
   "modelConfig": {
     "promptTitle": "LLMモデルが必要です — 設定後にChatページで選択",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1771,7 +1771,18 @@
     "allDisabled": "All tools are already disabled",
     "asyncExecution": "Async Execution",
     "asyncExecutionEnabled": "Async execution Ativado",
-    "asyncExecutionDisabled": "Async execution Desativado"
+    "asyncExecutionDisabled": "Async execution Desativado",
+    "configure": "Configurar",
+    "configured": "Configurado",
+    "requiresConfig": "Requer configuração",
+    "configSaved": "Configuração salva",
+    "configSaveError": "Falha ao salvar configuração",
+    "active": "ativo(s)",
+    "available": "Disponível",
+    "noEnabled": "Nenhuma ferramenta ativada",
+    "goEnableBtn": "Ativar agora",
+    "configureAction": "Configurar →",
+    "enableAction": "Ativar →"
   },
   "modelConfig": {
     "promptTitle": "LLM Model Required — Select in Chat After Configuration",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1579,7 +1579,13 @@
     "configured": "Настроено",
     "requiresConfig": "Требуется настройка",
     "configSaved": "Конфигурация сохранена",
-    "configSaveError": "Не удалось сохранить конфигурацию"
+    "configSaveError": "Не удалось сохранить конфигурацию",
+    "active": "активно",
+    "available": "Доступно",
+    "noEnabled": "Нет включённых инструментов",
+    "goEnableBtn": "Включить",
+    "configureAction": "Настроить →",
+    "enableAction": "Включить →"
   },
   "modelConfig": {
     "promptTitle": "Требуется LLM-модель — выберите в Chat после настройки",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -468,7 +468,13 @@
     "configured": "Đã cấu hình",
     "requiresConfig": "Cần cấu hình",
     "configSaved": "Đã lưu cấu hình",
-    "configSaveError": "Lưu cấu hình thất bại"
+    "configSaveError": "Lưu cấu hình thất bại",
+    "active": "đang hoạt động",
+    "available": "Có sẵn",
+    "noEnabled": "Không có công cụ nào được bật",
+    "goEnableBtn": "Bật ngay",
+    "configureAction": "Cấu hình →",
+    "enableAction": "Bật →"
   },
   "mcp": {
     "title": "MCP Client",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1819,7 +1819,13 @@
     "configured": "已配置",
     "requiresConfig": "需要配置",
     "configSaved": "配置已保存",
-    "configSaveError": "配置保存失败"
+    "configSaveError": "配置保存失败",
+    "active": "个已激活",
+    "available": "可用",
+    "noEnabled": "暂无已启用的工具",
+    "goEnableBtn": "去启用",
+    "configureAction": "配置 →",
+    "enableAction": "启用 →"
   },
   "modelConfig": {
     "promptTitle": "需要配置 LLM 模型，配置模型后在 Chat 页面选择",

--- a/console/src/pages/Agent/Tools/index.module.less
+++ b/console/src/pages/Agent/Tools/index.module.less
@@ -5,42 +5,10 @@
   overflow: hidden;
 }
 
-.pageHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  position: relative;
-  padding: 20px;
-  border-bottom: 1px solid #eae9e7;
-  margin-bottom: 0;
-}
-
 .toolsContainer {
-  overflow: auto;
-}
-
-.breadcrumbHeader {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 16px;
   flex: 1;
-}
-
-.breadcrumbParent {
-  color: #999;
-  font-weight: 400;
-}
-
-.breadcrumbSeparator {
-  color: #ccc;
-  margin: 0 4px;
-}
-
-.breadcrumbCurrent {
-  color: #333;
-  font-weight: 600;
-  font-size: 20px;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .headerAction {
@@ -53,58 +21,6 @@
   }
 }
 
-.header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 24px;
-}
-
-.headerInfo {
-  display: flex;
-  flex-direction: column;
-}
-
-.actionTab {
-  padding: 5px 14px;
-  border-radius: 7px;
-  border: none;
-  font-size: 13px;
-  color: #999;
-  background: transparent;
-  cursor: pointer;
-  transition: all 0.18s ease;
-
-  &:hover {
-    color: #666;
-    background: rgba(0, 0, 0, 0.04);
-  }
-}
-
-.disabledTab {
-  color: #ff7f16 !important;
-  background: #fff !important;
-  cursor: not-allowed;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
-
-  &:hover {
-    color: #ff7f16 !important;
-    background: #fff !important;
-  }
-}
-
-.title {
-  margin-bottom: 4px;
-  font-size: 24px;
-  font-weight: 600;
-}
-
-.description {
-  margin: 0;
-  color: #999;
-  font-size: 14px;
-}
-
 .loading {
   text-align: center;
   padding: 60px;
@@ -113,16 +29,127 @@
 
 .toolsGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 16px;
-  padding: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+/* ---- Panel Section (grouped containers) ---- */
+
+.panelSection {
+  background: #fafbfc;
+  border: 1px solid #f3f4f6;
+  border-radius: 12px;
+  padding: 18px;
+  margin: 16px;
+}
+
+.panelSectionDashed {
+  background: #fff;
+  border: 1px dashed #e5e7eb;
+  border-radius: 12px;
+  padding: 18px;
+  margin: 0 16px 16px;
+}
+
+.panelTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: #6b7280;
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panelDotGreen {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #10b981;
+  flex-shrink: 0;
+}
+
+.panelDotGray {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #d1d5db;
+  flex-shrink: 0;
+}
+
+.panelCount {
+  font-size: 11px;
+  color: #10b981;
+  font-weight: 400;
+  margin-left: auto;
+}
+
+.emptyEnabled {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  border: 2px dashed #e5e7eb;
+  border-radius: 12px;
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.emptyEnabled p {
+  font-size: 14px;
+  color: #6b7280;
+  margin-bottom: 16px;
+}
+
+.availableGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.availableItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid #f3f4f6;
+  border-radius: 8px;
+  background: #fafafa;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.availableItem:hover {
+  background: #fff;
+  border-color: #6366f1;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.1);
+}
+
+.availableItemName {
+  font-size: 13px;
+  font-weight: 500;
+  flex: 1;
+  color: #1a1a1a;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.availableItemAction {
+  font-size: 11px;
+  color: #6366f1;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 .toolCard {
   height: auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   border-radius: var(--border-radius, 8px);
   background: var(--color-bg-base, #ffffff);
   border: 1px solid var(--color-border-secondary, #eae8e7);
@@ -166,6 +193,14 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  max-width: 200px;
+}
+
+.toolNameText {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .toolIconFallback {
@@ -208,11 +243,11 @@
 }
 
 .toolDescription {
-  margin: 6px 0 16px 0;
+  margin: 4px 0 12px 0;
   color: #666;
-  font-size: 13px;
-  line-height: 1.6;
-  min-height: 40px;
+  font-size: 12px;
+  line-height: 1.5;
+  min-height: 36px;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
@@ -239,17 +274,17 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding-top: 12px;
+  gap: 8px;
+  padding-top: 10px;
   margin-top: auto;
   border-top: 1px solid #f0f0f0;
 }
 
 .toggleButton {
   flex: 1;
-  padding: 8px 16px;
-  border-radius: 7px;
-  font-size: 13px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 12px;
   color: #666;
   background: transparent;
   border: 1px solid #d9d9d9;
@@ -269,22 +304,6 @@
 
 /* ─── Dark mode ─────────────────────────────────────────────────────────────── */
 :global(.dark-mode) {
-  .pageHeader {
-    border-bottom-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .breadcrumbParent {
-    color: rgba(255, 255, 255, 0.35);
-  }
-
-  .breadcrumbSeparator {
-    color: rgba(255, 255, 255, 0.2);
-  }
-
-  .breadcrumbCurrent {
-    color: rgba(255, 255, 255, 0.85);
-  }
-
   .loading {
     color: rgba(255, 255, 255, 0.35);
   }
@@ -292,16 +311,6 @@
   /* Tool card */
   .toolCard {
     background: #2d2d2d;
-
-    &.normalCard {
-      border-color: rgba(255, 255, 255, 0.08) !important;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3) !important;
-    }
-
-    &.hoverCard {
-      border-color: rgba(255, 255, 255, 0.2) !important;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4) !important;
-    }
   }
 
   .toolName {
@@ -330,6 +339,51 @@
 
   .cardFooter {
     border-top-color: rgba(255, 255, 255, 0.08);
+  }
+
+  /* Panel sections */
+  .panelSection {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .panelSectionDashed {
+    background: transparent;
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .panelTitle {
+    color: rgba(255, 255, 255, 0.45);
+  }
+
+  .panelDotGray {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .emptyEnabled {
+    border-color: rgba(255, 255, 255, 0.12);
+
+    p {
+      color: rgba(255, 255, 255, 0.45);
+    }
+  }
+
+  .availableItem {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.08);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: #6366f1;
+    }
+  }
+
+  .availableItemName {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .availableItemAction {
+    color: #818cf8;
   }
 
   .toggleButton {

--- a/console/src/pages/Agent/Tools/index.tsx
+++ b/console/src/pages/Agent/Tools/index.tsx
@@ -13,7 +13,6 @@ import {
 } from "@agentscope-ai/design";
 import api from "../../../api";
 import {
-  EyeOutlined,
   EyeInvisibleOutlined,
   ThunderboltOutlined,
   ClockCircleOutlined,
@@ -219,10 +218,6 @@ export default function ToolsPage() {
   const [configModalVisible, setConfigModalVisible] = useState(false);
   const [currentTool, setCurrentTool] = useState<ToolInfo | null>(null);
 
-  const handleToggle = (tool: ToolInfo) => {
-    toggleEnabled(tool);
-  };
-
   const handleConfigure = (tool: ToolInfo) => {
     setCurrentTool(tool);
     setConfigModalVisible(true);
@@ -234,14 +229,19 @@ export default function ToolsPage() {
     await loadTools();
   };
 
-  const hasDisabledTools = useMemo(
-    () => tools.some((tool) => !tool.enabled),
-    [tools],
-  );
-  const hasEnabledTools = useMemo(
-    () => tools.some((tool) => tool.enabled),
-    [tools],
-  );
+  const { enabledTools, disabledTools } = useMemo(() => {
+    const enabled = tools.filter((tool) => tool.enabled);
+    const disabled = tools.filter((tool) => !tool.enabled);
+    return { enabledTools: enabled, disabledTools: disabled };
+  }, [tools]);
+
+  const handleAvailableItemClick = (tool: ToolInfo) => {
+    if (tool.requires_config) {
+      handleConfigure(tool);
+    } else {
+      toggleEnabled(tool);
+    }
+  };
 
   return (
     <div className={styles.toolsPage}>
@@ -250,8 +250,10 @@ export default function ToolsPage() {
         extra={
           <div className={styles.headerAction}>
             <Switch
-              checked={hasEnabledTools && !hasDisabledTools}
-              onChange={() => (hasDisabledTools ? enableAll() : disableAll())}
+              checked={enabledTools.length > 0 && disabledTools.length === 0}
+              onChange={() =>
+                disabledTools.length > 0 ? enableAll() : disableAll()
+              }
               disabled={batchLoading || loading}
               checkedChildren={t("tools.enableAll")}
               unCheckedChildren={t("tools.disableAll")}
@@ -267,91 +269,151 @@ export default function ToolsPage() {
         ) : tools.length === 0 ? (
           <Empty description={t("tools.emptyState")} />
         ) : (
-          <div className={styles.toolsGrid}>
-            {tools.map((tool) => (
-              <Card
-                key={tool.name}
-                className={`${styles.toolCard} ${
-                  tool.enabled ? styles.enabledCard : ""
-                }`}
-              >
-                <div className={styles.cardHeader}>
-                  <h3 className={styles.toolName}>
-                    <ToolIcon icon={tool.icon} name={tool.name} /> {tool.name}
-                  </h3>
-                  <div className={styles.statusContainer}>
-                    <span className={styles.statusDot} />
-                    <span className={styles.statusText}>
-                      {tool.enabled
-                        ? t("common.enabled")
-                        : t("common.disabled")}
-                    </span>
-                  </div>
+          <>
+            {/* Enabled Section */}
+            <div className={styles.panelSection}>
+              <div className={styles.panelTitle}>
+                <span className={styles.panelDotGreen} />
+                {t("common.enabled")}
+                <span className={styles.panelCount}>
+                  {enabledTools.length} {t("tools.active")}
+                </span>
+              </div>
+
+              {enabledTools.length > 0 ? (
+                <div className={styles.toolsGrid}>
+                  {enabledTools.map((tool) => (
+                    <Card
+                      key={tool.name}
+                      className={`${styles.toolCard} ${styles.enabledCard}`}
+                    >
+                      <div className={styles.cardHeader}>
+                        <h3 className={styles.toolName} title={tool.name}>
+                          <ToolIcon icon={tool.icon} name={tool.name} />{" "}
+                          <span className={styles.toolNameText}>
+                            {tool.name}
+                          </span>
+                        </h3>
+                        <div className={styles.statusContainer}>
+                          <span className={styles.statusDot} />
+                          <span className={styles.statusText}>
+                            {t("common.enabled")}
+                          </span>
+                        </div>
+                      </div>
+
+                      <p className={styles.toolDescription}>
+                        {tool.description}
+                      </p>
+
+                      {/* Show config status */}
+                      {tool.requires_config && (
+                        <div className={styles.configStatus}>
+                          {tool.config_values &&
+                          Object.keys(tool.config_values).length > 0 ? (
+                            <span className={styles.configured}>
+                              ✓ {t("tools.configured")}
+                            </span>
+                          ) : (
+                            <span className={styles.notConfigured}>
+                              ⚠ {t("tools.requiresConfig")}
+                            </span>
+                          )}
+                        </div>
+                      )}
+
+                      <div className={styles.cardFooter}>
+                        {[
+                          "execute_shell_command",
+                          "delegate_external_agent",
+                        ].includes(tool.name) && (
+                          <Button
+                            className={styles.toggleButton}
+                            onClick={() => toggleAsyncExecution(tool)}
+                            disabled={!tool.enabled}
+                            icon={
+                              tool.async_execution ? (
+                                <ThunderboltOutlined />
+                              ) : (
+                                <ClockCircleOutlined />
+                              )
+                            }
+                          >
+                            {tool.async_execution
+                              ? t("tools.asyncExecutionEnabled")
+                              : t("tools.asyncExecutionDisabled")}
+                          </Button>
+                        )}
+                        {/* Add configure button */}
+                        {tool.requires_config && (
+                          <Button
+                            className={styles.toggleButton}
+                            onClick={() => handleConfigure(tool)}
+                            icon={<SettingOutlined />}
+                          >
+                            {t("tools.configure")}
+                          </Button>
+                        )}
+                        <Button
+                          className={styles.toggleButton}
+                          onClick={() => toggleEnabled(tool)}
+                          icon={<EyeInvisibleOutlined />}
+                        >
+                          {t("common.disable")}
+                        </Button>
+                      </div>
+                    </Card>
+                  ))}
                 </div>
-
-                <p className={styles.toolDescription}>{tool.description}</p>
-
-                {/* Show config status */}
-                {tool.requires_config && (
-                  <div className={styles.configStatus}>
-                    {tool.config_values &&
-                    Object.keys(tool.config_values).length > 0 ? (
-                      <span className={styles.configured}>
-                        ✓ {t("tools.configured")}
-                      </span>
-                    ) : (
-                      <span className={styles.notConfigured}>
-                        ⚠ {t("tools.requiresConfig")}
-                      </span>
-                    )}
-                  </div>
-                )}
-
-                <div className={styles.cardFooter}>
-                  {[
-                    "execute_shell_command",
-                    "delegate_external_agent",
-                  ].includes(tool.name) && (
-                    <Button
-                      className={styles.toggleButton}
-                      onClick={() => toggleAsyncExecution(tool)}
-                      disabled={!tool.enabled}
-                      icon={
-                        tool.async_execution ? (
-                          <ThunderboltOutlined />
-                        ) : (
-                          <ClockCircleOutlined />
-                        )
-                      }
-                    >
-                      {tool.async_execution
-                        ? t("tools.asyncExecutionEnabled")
-                        : t("tools.asyncExecutionDisabled")}
-                    </Button>
-                  )}
-                  {/* Add configure button */}
-                  {tool.requires_config && (
-                    <Button
-                      className={styles.toggleButton}
-                      onClick={() => handleConfigure(tool)}
-                      icon={<SettingOutlined />}
-                    >
-                      {t("tools.configure")}
-                    </Button>
-                  )}
+              ) : (
+                <div className={styles.emptyEnabled}>
+                  <p>{t("tools.noEnabled")}</p>
                   <Button
-                    className={styles.toggleButton}
-                    onClick={() => handleToggle(tool)}
-                    icon={
-                      tool.enabled ? <EyeInvisibleOutlined /> : <EyeOutlined />
-                    }
+                    type="primary"
+                    onClick={() => {
+                      document
+                        .getElementById("available-tools")
+                        ?.scrollIntoView({ behavior: "smooth" });
+                    }}
                   >
-                    {tool.enabled ? t("common.disable") : t("common.enable")}
+                    {t("tools.goEnableBtn")}
                   </Button>
                 </div>
-              </Card>
-            ))}
-          </div>
+              )}
+            </div>
+
+            {/* Available Section */}
+            {disabledTools.length > 0 && (
+              <div id="available-tools" className={styles.panelSectionDashed}>
+                <div className={styles.panelTitle}>
+                  <span className={styles.panelDotGray} />
+                  {t("tools.available")}
+                </div>
+                <div className={styles.availableGrid}>
+                  {disabledTools.map((tool) => (
+                    <div
+                      key={tool.name}
+                      className={styles.availableItem}
+                      onClick={() => handleAvailableItemClick(tool)}
+                    >
+                      <ToolIcon icon={tool.icon} name={tool.name} />
+                      <span
+                        className={styles.availableItemName}
+                        title={tool.name}
+                      >
+                        {tool.name}
+                      </span>
+                      <span className={styles.availableItemAction}>
+                        {tool.requires_config
+                          ? t("tools.configureAction")
+                          : t("tools.enableAction")}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
- Split tools into Enabled (large cards) and Available (compact items) sections
- Available items: click to enable directly, or open config modal if requires_config
- Added panelSection/panelSectionDashed layout matching Models page style
- Optimized card sizes: smaller grid, tighter padding and font sizes
- Added name truncation with ellipsis and hover tooltip for both sections
- Cleaned up unused CSS classes and dead code
- Added i18n translations for all 7 locales (en, zh, ja, id, pt-BR, ru, vi)

<img width="1630" height="1233" alt="image" src="https://github.com/user-attachments/assets/1f77e8cb-4076-4813-a640-76ac7753fa20" />
<img width="1634" height="1222" alt="image" src="https://github.com/user-attachments/assets/a7cb2c0e-f915-462c-8e2c-7ff5981adceb" />
<img width="487" height="962" alt="image" src="https://github.com/user-attachments/assets/ae548fff-4c5d-4424-b83f-118017b190f0" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
