### PR TITLE
fix(tool-calls): cap tool responses before context insertion

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -771,6 +771,16 @@ class ToolResultPruningConfig(BaseModel):
         ),
     )
 
+    execution_layer_max_bytes: int = Field(
+        default=50000,
+        ge=1000,
+        description=(
+            "Hard byte cap applied at execution time before the tool "
+            "response is inserted into the agent context. Independent of "
+            "the tiered historical pruning thresholds."
+        ),
+    )
+
     offload_retention_days: int = Field(
         default=5,
         ge=1,

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -510,10 +510,44 @@ class AgentBuilder:
                 None,
             )
             if tool_coordinator is not None:
-                from ..tool_calls import ToolCoordinatorMiddleware
+                from ..tool_calls import (
+                    ToolCoordinatorMiddleware,
+                    ToolResultLimiter,
+                )
+
+                result_limiter = None
+                try:
+                    import os
+
+                    lcc = agent_config.running.light_context_config
+                    trc = lcc.tool_result_pruning_config
+                    workspace = getattr(ctx, "workspace", None)
+                    workspace_dir = (
+                        str(getattr(workspace, "workspace_dir", ""))
+                        if workspace is not None
+                        else ""
+                    )
+                    tool_results_dir = (
+                        os.path.join(workspace_dir, trc.tool_results_cache)
+                        if workspace_dir
+                        else None
+                    )
+                    result_limiter = ToolResultLimiter(
+                        enabled=trc.enabled,
+                        max_text_bytes=trc.pruning_recent_msg_max_bytes,
+                        cache_dir=tool_results_dir,
+                    )
+                except Exception:
+                    _logger.debug(
+                        "ToolResultLimiter not created",
+                        exc_info=True,
+                    )
 
                 mws.append(
-                    ToolCoordinatorMiddleware(coordinator=tool_coordinator),
+                    ToolCoordinatorMiddleware(
+                        coordinator=tool_coordinator,
+                        result_limiter=result_limiter,
+                    ),
                 )
 
         memory_manager = AgentBuilder._get_memory_manager(ctx)

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -534,7 +534,7 @@ class AgentBuilder:
                     )
                     result_limiter = ToolResultLimiter(
                         enabled=trc.enabled,
-                        max_text_bytes=trc.pruning_recent_msg_max_bytes,
+                        max_text_bytes=trc.execution_layer_max_bytes,
                         cache_dir=tool_results_dir,
                     )
                 except Exception:

--- a/src/qwenpaw/tool_calls/__init__.py
+++ b/src/qwenpaw/tool_calls/__init__.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tool call lifecycle management for QwenPaw."""
+
 from ._context import CancelReason, OffloadReason, ToolCallContext
 from ._coordinator import ToolCoordinator
 from ._ctxvars import get_call_context, reset_call_context, set_call_context
 from ._entry import ToolCallEntry, ToolCallStatus
 from ._hooks import ToolHookRegistry
 from ._middleware import ToolCoordinatorMiddleware
+from ._result_limiter import ToolResultLimiter
 from ._stream import ToolStream
 from ._timeout_helper import cancellable_wait, effective_timeout
 
@@ -17,6 +19,7 @@ __all__ = [
     "ToolCallStatus",
     "ToolCoordinator",
     "ToolCoordinatorMiddleware",
+    "ToolResultLimiter",
     "ToolHookRegistry",
     "ToolStream",
     "cancellable_wait",

--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """ToolCoordinator — single owner of all in-flight tool calls."""
+
 from __future__ import annotations
 
 import asyncio
@@ -12,7 +13,7 @@ from agentscope.tool import ToolChunk, ToolResponse
 
 from ._context import CancelReason, OffloadReason, ToolCallContext
 from ._ctxvars import reset_call_context, set_call_context
-from ._entry import ToolCallEntry, ToolCallStatus
+from ._entry import ResultFinalizer, ToolCallEntry, ToolCallStatus
 from ._hint import make_offload_hint_msg
 from ._hooks import ToolHookRegistry
 from ._stream import ToolStream, _SENTINEL as _STREAM_SENTINEL
@@ -72,6 +73,7 @@ class ToolCoordinator:
         agent_id: str,
         root_session_id: str,
         deadline_override: float | None = None,
+        result_finalizer: ResultFinalizer | None = None,
     ) -> AsyncGenerator[Any, None]:
         entry = self._create_entry(
             tool_call,
@@ -79,6 +81,7 @@ class ToolCoordinator:
             agent_id,
             root_session_id,
             deadline_override,
+            result_finalizer,
         )
         ctx = entry.ctx
 
@@ -112,6 +115,7 @@ class ToolCoordinator:
             entry.stream.remove_subscriber(chunk_queue)
 
         if terminal == "completed":
+            await self._await_background_task(entry)
             yield self._finalize_completed(entry)
             return
 
@@ -132,6 +136,7 @@ class ToolCoordinator:
         agent_id: str,
         root_session_id: str,
         deadline_override: float | None,
+        result_finalizer: ResultFinalizer | None,
     ) -> ToolCallEntry:
         loop = asyncio.get_running_loop()
         now = loop.time()
@@ -157,6 +162,7 @@ class ToolCoordinator:
                 session_id=session_id,
             ),
             final_response=ToolResponse(id=tool_call.id),
+            result_finalizer=result_finalizer,
         )
 
     async def _begin_offload(
@@ -600,13 +606,7 @@ class ToolCoordinator:
             if event.type == "stream_closed":
                 break
 
-        try:
-            await bg
-        except asyncio.CancelledError:
-            # Distinguish: bg task cancelled vs supervise task cancelled.
-            current = asyncio.current_task()
-            if current is not None and current.cancelled():
-                raise
+        await self._await_background_task(entry)
 
         self._finalize_completed(entry)
 
@@ -633,6 +633,19 @@ class ToolCoordinator:
         entry.force_cancelled = True
         entry.background_task.cancel()
 
+    @staticmethod
+    async def _await_background_task(entry: ToolCallEntry) -> None:
+        bg = entry.background_task
+        if bg is None:
+            return
+        try:
+            await bg
+        except asyncio.CancelledError:
+            # Distinguish: bg task cancelled vs caller task cancelled.
+            current = asyncio.current_task()
+            if current is not None and current.cancelled():
+                raise
+
     def _finalize_completed(self, entry: ToolCallEntry) -> ToolResponse:
         if entry.final_response is None:
             entry.final_response = ToolResponse(
@@ -645,6 +658,12 @@ class ToolCoordinator:
                 id=entry.ctx.tool_call_id,
                 state=ToolResultState.ERROR,
             )
+        if entry.result_finalizer is not None and not entry.result_finalized:
+            entry.final_response = entry.result_finalizer(
+                entry.final_response,
+                entry.ctx,
+            )
+            entry.result_finalized = True
         entry.status = ToolCallStatus.COMPLETED
         if entry.end_state is None:
             entry.end_state = (

--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Awaitable, Callable
@@ -116,7 +117,7 @@ class ToolCoordinator:
 
         if terminal == "completed":
             await self._await_background_task(entry)
-            yield self._finalize_completed(entry)
+            yield await self._finalize_completed(entry)
             return
 
         yield await self._begin_offload(entry)
@@ -608,7 +609,7 @@ class ToolCoordinator:
 
         await self._await_background_task(entry)
 
-        self._finalize_completed(entry)
+        await self._finalize_completed(entry)
 
         hint = make_offload_hint_msg(entry)
         async with self._hints_lock:
@@ -646,7 +647,7 @@ class ToolCoordinator:
             if current is not None and current.cancelled():
                 raise
 
-    def _finalize_completed(self, entry: ToolCallEntry) -> ToolResponse:
+    async def _finalize_completed(self, entry: ToolCallEntry) -> ToolResponse:
         if entry.final_response is None:
             entry.final_response = ToolResponse(
                 content=[
@@ -659,10 +660,13 @@ class ToolCoordinator:
                 state=ToolResultState.ERROR,
             )
         if entry.result_finalizer is not None and not entry.result_finalized:
-            entry.final_response = entry.result_finalizer(
+            finalized = entry.result_finalizer(
                 entry.final_response,
                 entry.ctx,
             )
+            if inspect.isawaitable(finalized):
+                finalized = await finalized
+            entry.final_response = finalized
             entry.result_finalized = True
         entry.status = ToolCallStatus.COMPLETED
         if entry.end_state is None:

--- a/src/qwenpaw/tool_calls/_coordinator.py
+++ b/src/qwenpaw/tool_calls/_coordinator.py
@@ -640,11 +640,11 @@ class ToolCoordinator:
         if bg is None:
             return
         try:
-            await bg
+            await asyncio.shield(bg)
         except asyncio.CancelledError:
             # Distinguish: bg task cancelled vs caller task cancelled.
             current = asyncio.current_task()
-            if current is not None and current.cancelled():
+            if current is not None and current.cancelling():
                 raise
 
     async def _finalize_completed(self, entry: ToolCallEntry) -> ToolResponse:

--- a/src/qwenpaw/tool_calls/_entry.py
+++ b/src/qwenpaw/tool_calls/_entry.py
@@ -1,14 +1,23 @@
 # -*- coding: utf-8 -*-
 """Single-owner state for one in-flight tool call."""
+
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from ._context import ToolCallContext
 from ._stream import ToolStream
+
+if TYPE_CHECKING:
+    from agentscope.tool import ToolResponse
+
+ResultFinalizer = Callable[
+    ["ToolResponse", ToolCallContext],
+    "ToolResponse",
+]
 
 
 class ToolCallStatus(StrEnum):
@@ -28,3 +37,5 @@ class ToolCallEntry:
     background_task: asyncio.Task[None] | None = None
     end_state: str | None = None
     force_cancelled: bool = False
+    result_finalizer: ResultFinalizer | None = None
+    result_finalized: bool = False

--- a/src/qwenpaw/tool_calls/_entry.py
+++ b/src/qwenpaw/tool_calls/_entry.py
@@ -12,11 +12,13 @@ from ._context import ToolCallContext
 from ._stream import ToolStream
 
 if TYPE_CHECKING:
+    from typing import Awaitable
+
     from agentscope.tool import ToolResponse
 
 ResultFinalizer = Callable[
     ["ToolResponse", ToolCallContext],
-    "ToolResponse",
+    "ToolResponse | Awaitable[ToolResponse]",
 ]
 
 

--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Construct hint messages for completed background tool calls."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -9,7 +10,7 @@ def make_offload_hint_msg(entry: Any) -> Any:
     """Construct a hint Msg for a completed offloaded tool call.
 
     The hint contains a system-notification TextBlock and a
-    ToolResultBlock with the full (untruncated) final_response content.
+    ToolResultBlock with the finalized response content.
     """
     from agentscope.message import Msg, TextBlock, ToolResultBlock
 
@@ -29,9 +30,10 @@ def make_offload_hint_msg(entry: Any) -> Any:
         id=entry.ctx.tool_call_id,
         name=entry.ctx.tool_name,
         output=list(entry.final_response.content or []),
+        state=entry.final_response.state,
     )
     return Msg(
         name="system",
-        role="system",
+        role="assistant",
         content=[notification, tool_result],
     )

--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -32,6 +32,9 @@ def make_offload_hint_msg(entry: Any) -> Any:
         output=list(entry.final_response.content or []),
         state=entry.final_response.state,
     )
+    # AgentScope 2.0 validates that system messages contain only text
+    # blocks.  This hint must carry a ToolResultBlock so provider formatters
+    # keep it on the tool-result path; use assistant role intentionally.
     return Msg(
         name="system",
         role="assistant",

--- a/src/qwenpaw/tool_calls/_middleware.py
+++ b/src/qwenpaw/tool_calls/_middleware.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """on_acting middleware delegating tool execution to ToolCoordinator."""
+
 from __future__ import annotations
 
 import logging
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
     from agentscope.agent import Agent
 
     from ._coordinator import ToolCoordinator
+    from ._result_limiter import ToolResultLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +25,13 @@ class ToolCoordinatorMiddleware(MiddlewareBase):
     ``_execute_tool_call`` side effects work automatically.
     """
 
-    def __init__(self, coordinator: "ToolCoordinator") -> None:
+    def __init__(
+        self,
+        coordinator: "ToolCoordinator",
+        result_limiter: "ToolResultLimiter | None" = None,
+    ) -> None:
         self._coordinator = coordinator
+        self._result_limiter = result_limiter
 
     async def on_acting(
         self,
@@ -45,5 +52,10 @@ class ToolCoordinatorMiddleware(MiddlewareBase):
             session_id=session_id,
             agent_id=agent_id,
             root_session_id=root_session_id,
+            result_finalizer=(
+                self._result_limiter.limit
+                if self._result_limiter is not None
+                else None
+            ),
         ):
             yield item

--- a/src/qwenpaw/tool_calls/_middleware.py
+++ b/src/qwenpaw/tool_calls/_middleware.py
@@ -53,7 +53,7 @@ class ToolCoordinatorMiddleware(MiddlewareBase):
             agent_id=agent_id,
             root_session_id=root_session_id,
             result_finalizer=(
-                self._result_limiter.limit
+                self._result_limiter.limit_async
                 if self._result_limiter is not None
                 else None
             ),

--- a/src/qwenpaw/tool_calls/_result_limiter.py
+++ b/src/qwenpaw/tool_calls/_result_limiter.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""Execution-layer hard cap for final tool responses."""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+from agentscope.message import TextBlock
+from agentscope.tool import ToolResponse
+
+from ..constant import TRUNCATION_NOTICE_MARKER
+from ._context import ToolCallContext
+
+logger = logging.getLogger(__name__)
+
+
+class ToolResultLimiter:
+    """Apply a strict aggregate text-byte cap to a final ToolResponse."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        max_text_bytes: int,
+        cache_dir: Path | str | None,
+    ) -> None:
+        self._enabled = enabled
+        self._max_text_bytes = max_text_bytes
+        self._cache_dir = Path(cache_dir) if cache_dir else None
+
+    def limit(
+        self,
+        response: ToolResponse,
+        context: ToolCallContext,
+    ) -> ToolResponse:
+        """Return a response whose aggregate text content is byte-bounded."""
+        if not self._enabled:
+            return response
+
+        try:
+            return self._limit(response, context)
+        except Exception:
+            logger.exception(
+                "Failed to limit tool result",
+                extra={
+                    "tool_name": context.tool_name,
+                    "tool_call_id": context.tool_call_id,
+                },
+            )
+            return self._fail_closed(response)
+
+    def _limit(
+        self,
+        response: ToolResponse,
+        context: ToolCallContext,
+    ) -> ToolResponse:
+        content = list(response.content or [])
+        original_bytes = _total_text_bytes(content)
+        if original_bytes == 0:
+            return response
+        if self._max_text_bytes <= 0:
+            return self._fail_closed(response)
+        if original_bytes <= self._max_text_bytes:
+            return response
+
+        saved_path = self._save_original_text(content, context)
+        limited_content, retained_bytes = self._limit_content(
+            content,
+            original_bytes=original_bytes,
+            saved_path=saved_path,
+        )
+        result = _copy_response_with_content(response, limited_content)
+
+        if _total_text_bytes(result.content or []) > self._max_text_bytes:
+            return self._fail_closed(response)
+
+        logger.info(
+            "Capped tool result",
+            extra={
+                "tool_name": context.tool_name,
+                "tool_call_id": context.tool_call_id,
+                "original_bytes": original_bytes,
+                "retained_bytes": retained_bytes,
+            },
+        )
+        return result
+
+    def _limit_content(
+        self,
+        content: list[Any],
+        *,
+        original_bytes: int,
+        saved_path: str | None,
+    ) -> tuple[list[Any], int]:
+        notice = _build_notice(
+            original_bytes=original_bytes,
+            retained_bytes=0,
+            saved_path=saved_path,
+        )
+        retained_content: list[Any] = []
+        retained_bytes = 0
+
+        for _ in range(8):
+            bounded_notice = _utf8_prefix(notice, self._max_text_bytes)
+            payload_budget = max(
+                0,
+                self._max_text_bytes - _byte_len(bounded_notice),
+            )
+            retained_content, retained_bytes = _retain_text_content(
+                content,
+                payload_budget,
+            )
+            next_notice = _build_notice(
+                original_bytes=original_bytes,
+                retained_bytes=retained_bytes,
+                saved_path=saved_path,
+            )
+            if next_notice == notice:
+                notice = next_notice
+                break
+            notice = next_notice
+
+        for _ in range(8):
+            bounded_notice = _utf8_prefix(notice, self._max_text_bytes)
+            payload_budget = max(
+                0,
+                self._max_text_bytes - _byte_len(bounded_notice),
+            )
+            retained_content, retained_bytes = _retain_text_content(
+                content,
+                payload_budget,
+            )
+            bounded_notice = _utf8_prefix(
+                _build_notice(
+                    original_bytes=original_bytes,
+                    retained_bytes=retained_bytes,
+                    saved_path=saved_path,
+                ),
+                self._max_text_bytes,
+            )
+            total_bytes = retained_bytes + _byte_len(bounded_notice)
+            if total_bytes <= self._max_text_bytes:
+                retained_content.append(
+                    TextBlock(type="text", text=bounded_notice),
+                )
+                return retained_content, retained_bytes
+            notice = bounded_notice
+
+        retained_content, _ = _retain_text_content(content, 0)
+        fallback_notice = _utf8_prefix(
+            _build_notice(
+                original_bytes=original_bytes,
+                retained_bytes=0,
+                saved_path=saved_path,
+            ),
+            self._max_text_bytes,
+        )
+        if fallback_notice:
+            retained_content.append(
+                TextBlock(type="text", text=fallback_notice),
+            )
+        return retained_content, 0
+
+    def _save_original_text(
+        self,
+        content: list[Any],
+        context: ToolCallContext,
+    ) -> str | None:
+        if self._cache_dir is None:
+            return None
+
+        try:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            safe_id = _safe_filename_part(context.tool_call_id)
+            path = self._cache_dir / f"{safe_id}-{uuid.uuid4().hex}.txt"
+            path.write_text(_join_text_blocks(content), encoding="utf-8")
+            return str(path)
+        except OSError as exc:
+            logger.warning(
+                "Failed to save full tool result",
+                extra={
+                    "tool_name": context.tool_name,
+                    "tool_call_id": context.tool_call_id,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+    def _fail_closed(self, response: ToolResponse) -> ToolResponse:
+        content = [
+            block
+            for block in list(response.content or [])
+            if not _is_text_block(block)
+        ]
+        notice = _utf8_prefix(
+            (
+                f"{TRUNCATION_NOTICE_MARKER}\n"
+                "Tool output omitted because it exceeded the safe size limit."
+            ),
+            max(0, self._max_text_bytes),
+        )
+        if notice:
+            content.append(TextBlock(type="text", text=notice))
+        return _copy_response_with_content(response, content)
+
+
+def _build_notice(
+    *,
+    original_bytes: int,
+    retained_bytes: int,
+    saved_path: str | None,
+) -> str:
+    lines = [
+        TRUNCATION_NOTICE_MARKER,
+        "Tool output truncated before entering agent context.",
+        f"Original size: {original_bytes} bytes.",
+        f"Retained size: {retained_bytes} bytes.",
+    ]
+    if saved_path:
+        lines.append(f"Full output saved to: {saved_path}.")
+    else:
+        lines.append("Full output could not be persisted.")
+    lines.append("Refine the query or read a smaller range.")
+    return "\n".join(lines)
+
+
+def _retain_text_content(
+    content: list[Any],
+    budget_bytes: int,
+) -> tuple[list[Any], int]:
+    remaining = max(0, budget_bytes)
+    retained_bytes = 0
+    retained_content: list[Any] = []
+
+    for block in content:
+        if not _is_text_block(block):
+            retained_content.append(block)
+            continue
+
+        if remaining <= 0:
+            continue
+
+        text = _get_text(block)
+        retained_text = _utf8_prefix(text, remaining)
+        if not retained_text:
+            continue
+
+        current_bytes = _byte_len(retained_text)
+        retained_content.append(_copy_text_block(block, retained_text))
+        retained_bytes += current_bytes
+        remaining -= current_bytes
+
+    return retained_content, retained_bytes
+
+
+def _join_text_blocks(content: list[Any]) -> str:
+    return "\n\n".join(
+        _get_text(block) for block in content if _is_text_block(block)
+    )
+
+
+def _total_text_bytes(content: list[Any]) -> int:
+    return sum(
+        _byte_len(_get_text(block))
+        for block in content
+        if _is_text_block(block)
+    )
+
+
+def _is_text_block(block: Any) -> bool:
+    if isinstance(block, dict):
+        return block.get("type") == "text" and isinstance(
+            block.get("text"),
+            str,
+        )
+    return getattr(block, "type", None) == "text" and isinstance(
+        getattr(block, "text", None),
+        str,
+    )
+
+
+def _get_text(block: Any) -> str:
+    if isinstance(block, dict):
+        return block.get("text", "")
+    return getattr(block, "text", "")
+
+
+def _copy_text_block(block: Any, text: str) -> Any:
+    if isinstance(block, dict):
+        copied = dict(block)
+        copied["text"] = text
+        return copied
+    if hasattr(block, "model_copy"):
+        return block.model_copy(update={"text": text})
+    copied = TextBlock(type="text", text=text)
+    block_id = getattr(block, "id", None)
+    if block_id is not None and hasattr(copied, "id"):
+        copied.id = block_id
+    return copied
+
+
+def _copy_response_with_content(
+    response: ToolResponse,
+    content: list[Any],
+) -> ToolResponse:
+    if hasattr(response, "model_copy"):
+        return response.model_copy(update={"content": content})
+    response.content = content
+    return response
+
+
+def _utf8_prefix(text: str, max_bytes: int) -> str:
+    if max_bytes <= 0:
+        return ""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _byte_len(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def _safe_filename_part(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", value)[:64].strip("._-")
+    return safe or "tool-result"

--- a/src/qwenpaw/tool_calls/_result_limiter.py
+++ b/src/qwenpaw/tool_calls/_result_limiter.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import copy
 import logging
 import re
 import uuid
@@ -12,10 +14,11 @@ from typing import Any
 from agentscope.message import TextBlock
 from agentscope.tool import ToolResponse
 
-from ..constant import TRUNCATION_NOTICE_MARKER
 from ._context import ToolCallContext
 
 logger = logging.getLogger(__name__)
+
+EXECUTION_TRUNCATION_NOTICE_MARKER = "<<<EXECUTION_TOOL_RESULT_TRUNCATED>>>"
 
 
 class ToolResultLimiter:
@@ -37,7 +40,11 @@ class ToolResultLimiter:
         response: ToolResponse,
         context: ToolCallContext,
     ) -> ToolResponse:
-        """Return a response whose aggregate text content is byte-bounded."""
+        """Return a byte-bounded response in synchronous callers.
+
+        Asyncio coordinator paths should use :meth:`limit_async` so cache
+        writes are offloaded from the event loop.
+        """
         if not self._enabled:
             return response
 
@@ -53,21 +60,87 @@ class ToolResultLimiter:
             )
             return self._fail_closed(response)
 
+    async def limit_async(
+        self,
+        response: ToolResponse,
+        context: ToolCallContext,
+    ) -> ToolResponse:
+        """Return a byte-bounded response without blocking the event loop."""
+        if not self._enabled:
+            return response
+
+        try:
+            return await self._limit_async(response, context)
+        except Exception:
+            logger.exception(
+                "Failed to limit tool result",
+                extra={
+                    "tool_name": context.tool_name,
+                    "tool_call_id": context.tool_call_id,
+                },
+            )
+            return self._fail_closed(response)
+
     def _limit(
         self,
         response: ToolResponse,
         context: ToolCallContext,
     ) -> ToolResponse:
+        content, original_bytes, early_result = self._prepare_limit(response)
+        if early_result is not None:
+            return early_result
+
+        saved_path = self._save_original_text(content, context)
+        return self._limit_prepared(
+            response,
+            context,
+            content=content,
+            original_bytes=original_bytes,
+            saved_path=saved_path,
+        )
+
+    async def _limit_async(
+        self,
+        response: ToolResponse,
+        context: ToolCallContext,
+    ) -> ToolResponse:
+        content, original_bytes, early_result = self._prepare_limit(response)
+        if early_result is not None:
+            return early_result
+
+        saved_path = await self._save_original_text_async(content, context)
+        return self._limit_prepared(
+            response,
+            context,
+            content=content,
+            original_bytes=original_bytes,
+            saved_path=saved_path,
+        )
+
+    def _prepare_limit(
+        self,
+        response: ToolResponse,
+    ) -> tuple[list[Any], int, ToolResponse | None]:
         content = list(response.content or [])
         original_bytes = _total_text_bytes(content)
         if original_bytes == 0:
-            return response
+            return content, original_bytes, response
         if self._max_text_bytes <= 0:
-            return self._fail_closed(response)
+            return content, original_bytes, self._fail_closed(response)
         if original_bytes <= self._max_text_bytes:
-            return response
+            return content, original_bytes, response
 
-        saved_path = self._save_original_text(content, context)
+        return content, original_bytes, None
+
+    def _limit_prepared(
+        self,
+        response: ToolResponse,
+        context: ToolCallContext,
+        *,
+        content: list[Any],
+        original_bytes: int,
+        saved_path: str | None,
+    ) -> ToolResponse:
         limited_content, retained_bytes = self._limit_content(
             content,
             original_bytes=original_bytes,
@@ -190,6 +263,19 @@ class ToolResultLimiter:
             )
             return None
 
+    async def _save_original_text_async(
+        self,
+        content: list[Any],
+        context: ToolCallContext,
+    ) -> str | None:
+        if self._cache_dir is None:
+            return None
+        return await asyncio.to_thread(
+            self._save_original_text,
+            content,
+            context,
+        )
+
     def _fail_closed(self, response: ToolResponse) -> ToolResponse:
         content = [
             block
@@ -198,7 +284,7 @@ class ToolResultLimiter:
         ]
         notice = _utf8_prefix(
             (
-                f"{TRUNCATION_NOTICE_MARKER}\n"
+                f"{EXECUTION_TRUNCATION_NOTICE_MARKER}\n"
                 "Tool output omitted because it exceeded the safe size limit."
             ),
             max(0, self._max_text_bytes),
@@ -215,7 +301,7 @@ def _build_notice(
     saved_path: str | None,
 ) -> str:
     lines = [
-        TRUNCATION_NOTICE_MARKER,
+        EXECUTION_TRUNCATION_NOTICE_MARKER,
         "Tool output truncated before entering agent context.",
         f"Original size: {original_bytes} bytes.",
         f"Retained size: {retained_bytes} bytes.",
@@ -309,8 +395,9 @@ def _copy_response_with_content(
 ) -> ToolResponse:
     if hasattr(response, "model_copy"):
         return response.model_copy(update={"content": content})
-    response.content = content
-    return response
+    copied = copy.copy(response)
+    copied.content = content
+    return copied
 
 
 def _utf8_prefix(text: str, max_bytes: int) -> str:

--- a/tests/unit/tool_calls/test_coordinator_result_finalizer.py
+++ b/tests/unit/tool_calls/test_coordinator_result_finalizer.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""Tests for ToolCoordinator final response limiting."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, AsyncGenerator
+
+import pytest
+from agentscope.message import TextBlock, ToolResultBlock
+from agentscope.tool import ToolResponse
+
+from qwenpaw.tool_calls import ToolCoordinator, ToolCoordinatorMiddleware
+from qwenpaw.tool_calls._context import ToolCallContext
+from qwenpaw.tool_calls._result_limiter import ToolResultLimiter
+
+
+@dataclass
+class _ToolCall:
+    id: str = "call-1"
+    name: str = "test_tool"
+    input: dict[str, Any] = field(default_factory=dict)
+
+
+def _text_response(tool_call_id: str, text: str) -> ToolResponse:
+    return ToolResponse(
+        content=[TextBlock(type="text", text=text)],
+        id=tool_call_id,
+    )
+
+
+def _tool_response_text_bytes(response: ToolResponse) -> int:
+    return sum(
+        len(block.text.encode("utf-8"))
+        for block in response.content
+        if getattr(block, "type", None) == "text"
+    )
+
+
+def _tool_result_output_text_bytes(block: ToolResultBlock) -> int:
+    if isinstance(block.output, str):
+        return len(block.output.encode("utf-8"))
+    return sum(
+        len(output.text.encode("utf-8"))
+        for output in block.output
+        if getattr(output, "type", None) == "text"
+    )
+
+
+async def _collect(
+    iterator: AsyncGenerator[Any, None],
+) -> list[Any]:
+    events: list[Any] = []
+    async for item in iterator:
+        events.append(item)
+    return events
+
+
+async def _wait_for_hint(
+    coordinator: ToolCoordinator,
+    session_id: str,
+) -> Any:
+    while True:
+        hints = await coordinator.pop_pending_hints(session_id)
+        if hints:
+            return hints[0]
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_foreground_finalizer_runs_after_after_hook(tmp_path):
+    coordinator = ToolCoordinator()
+    tool_call = _ToolCall(name="expanding_tool")
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+    finalizer_calls = 0
+    after_started = asyncio.Event()
+    release_after = asyncio.Event()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        yield _text_response(tool_call.id, "small")
+
+    async def after_hook(
+        response: ToolResponse,
+        ctx: ToolCallContext,
+    ) -> ToolResponse:
+        assert response.content[0].text == "small"
+        after_started.set()
+        await release_after.wait()
+        return _text_response(ctx.tool_call_id, "x" * 2000)
+
+    def finalizer(
+        response: ToolResponse,
+        ctx: ToolCallContext,
+    ) -> ToolResponse:
+        nonlocal finalizer_calls
+        finalizer_calls += 1
+        return limiter.limit(response, ctx)
+
+    coordinator.hooks.register("expanding_tool", after=after_hook)
+    task = asyncio.create_task(
+        _collect(
+            coordinator.execute(
+                tool_call=tool_call,
+                next_handler=next_handler,
+                session_id="session-1",
+                agent_id="agent-1",
+                root_session_id="root-1",
+                result_finalizer=finalizer,
+            ),
+        ),
+    )
+
+    await asyncio.wait_for(after_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    release_after.set()
+    events = await asyncio.wait_for(task, timeout=1)
+    final = events[-1]
+
+    assert isinstance(final, ToolResponse)
+    assert _tool_response_text_bytes(final) <= 512
+    assert finalizer_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_middleware_caller_observes_capped_response(tmp_path):
+    coordinator = ToolCoordinator()
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+    middleware = ToolCoordinatorMiddleware(
+        coordinator=coordinator,
+        result_limiter=limiter,
+    )
+    agent = type(
+        "AgentStub",
+        (),
+        {
+            "_request_context": {
+                "session_id": "session-1",
+                "agent_id": "agent-1",
+                "root_session_id": "root-1",
+            },
+        },
+    )()
+    tool_call = _ToolCall()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        yield _text_response(tool_call.id, "x" * 2000)
+
+    events = await _collect(
+        middleware.on_acting(
+            agent,
+            {"tool_call": tool_call},
+            next_handler,
+        ),
+    )
+
+    assert _tool_response_text_bytes(events[-1]) <= 512
+
+
+@pytest.mark.asyncio
+async def test_background_completion_hint_uses_finalized_response(tmp_path):
+    coordinator = ToolCoordinator(default_timeout_secs=0.001)
+    tool_call = _ToolCall(id="call-bg", name="slow_tool")
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+    finalizer_calls = 0
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        await asyncio.sleep(0.02)
+        yield _text_response(tool_call.id, "x" * 2000)
+
+    def finalizer(
+        response: ToolResponse,
+        ctx: ToolCallContext,
+    ) -> ToolResponse:
+        nonlocal finalizer_calls
+        finalizer_calls += 1
+        return limiter.limit(response, ctx)
+
+    events = await _collect(
+        coordinator.execute(
+            tool_call=tool_call,
+            next_handler=next_handler,
+            session_id="session-bg",
+            agent_id="agent-1",
+            root_session_id="root-1",
+            result_finalizer=finalizer,
+        ),
+    )
+    hint = await asyncio.wait_for(
+        _wait_for_hint(coordinator, "session-bg"),
+        timeout=1,
+    )
+    tool_result = next(
+        block
+        for block in hint.content
+        if getattr(block, "type", None) == "tool_result"
+    )
+
+    assert events[-1].metadata["offloaded"] is True
+    assert _tool_result_output_text_bytes(tool_result) <= 512
+    assert finalizer_calls == 1

--- a/tests/unit/tool_calls/test_coordinator_result_finalizer.py
+++ b/tests/unit/tool_calls/test_coordinator_result_finalizer.py
@@ -172,6 +172,37 @@ async def test_middleware_caller_observes_capped_response(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_async_finalizer_is_awaited():
+    coordinator = ToolCoordinator()
+    tool_call = _ToolCall()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[Any, None]:
+        yield _text_response(tool_call.id, "x" * 2000)
+
+    async def finalizer(
+        _response: ToolResponse,
+        ctx: ToolCallContext,
+    ) -> ToolResponse:
+        await asyncio.sleep(0)
+        return _text_response(ctx.tool_call_id, "finalized")
+
+    events = await _collect(
+        coordinator.execute(
+            tool_call=tool_call,
+            next_handler=next_handler,
+            session_id="session-1",
+            agent_id="agent-1",
+            root_session_id="root-1",
+            result_finalizer=finalizer,
+        ),
+    )
+
+    assert events[-1].content[0].text == "finalized"
+
+
+@pytest.mark.asyncio
 async def test_background_completion_hint_uses_finalized_response(tmp_path):
     coordinator = ToolCoordinator(default_timeout_secs=0.001)
     tool_call = _ToolCall(id="call-bg", name="slow_tool")
@@ -217,5 +248,6 @@ async def test_background_completion_hint_uses_finalized_response(tmp_path):
     )
 
     assert events[-1].metadata["offloaded"] is True
+    assert hint.role == "assistant"
     assert _tool_result_output_text_bytes(tool_result) <= 512
     assert finalizer_calls == 1

--- a/tests/unit/tool_calls/test_coordinator_result_finalizer.py
+++ b/tests/unit/tool_calls/test_coordinator_result_finalizer.py
@@ -13,7 +13,9 @@ from agentscope.tool import ToolResponse
 
 from qwenpaw.tool_calls import ToolCoordinator, ToolCoordinatorMiddleware
 from qwenpaw.tool_calls._context import ToolCallContext
+from qwenpaw.tool_calls._entry import ToolCallEntry
 from qwenpaw.tool_calls._result_limiter import ToolResultLimiter
+from qwenpaw.tool_calls._stream import ToolStream
 
 
 @dataclass
@@ -251,3 +253,51 @@ async def test_background_completion_hint_uses_finalized_response(tmp_path):
     assert hint.role == "assistant"
     assert _tool_result_output_text_bytes(tool_result) <= 512
     assert finalizer_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_does_not_cancel_background_task():
+    # pylint: disable=protected-access
+    bg_started = asyncio.Event()
+    bg_can_finish = asyncio.Event()
+    tool_call = _ToolCall(id="call-cancel", name="slow_tool")
+
+    async def background() -> None:
+        bg_started.set()
+        await bg_can_finish.wait()
+
+    bg_task = asyncio.create_task(background())
+    entry = ToolCallEntry(
+        ctx=ToolCallContext(
+            tool_call_id=tool_call.id,
+            tool_name=tool_call.name,
+            session_id="session-cancel",
+            agent_id="agent-1",
+            root_session_id="root-1",
+            started_at=0.0,
+            deadline=None,
+            cancel_event=asyncio.Event(),
+        ),
+        stream=ToolStream(
+            tool_call_id=tool_call.id,
+            session_id="session-cancel",
+        ),
+        final_response=ToolResponse(id=tool_call.id),
+        background_task=bg_task,
+    )
+
+    waiter = asyncio.create_task(
+        ToolCoordinator._await_background_task(entry),
+    )
+    await asyncio.wait_for(bg_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert not bg_task.cancelled()
+    assert not bg_task.done()
+
+    bg_can_finish.set()
+    await asyncio.wait_for(bg_task, timeout=1)

--- a/tests/unit/tool_calls/test_result_limiter.py
+++ b/tests/unit/tool_calls/test_result_limiter.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""Tests for execution-layer tool result limiting."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agentscope.message import DataBlock, TextBlock, ToolResultState, URLSource
+from agentscope.tool import ToolResponse
+
+from qwenpaw.constant import TRUNCATION_NOTICE_MARKER
+from qwenpaw.tool_calls._context import ToolCallContext
+from qwenpaw.tool_calls._result_limiter import ToolResultLimiter
+
+
+def _ctx() -> ToolCallContext:
+    return ToolCallContext(
+        tool_call_id="call-1",
+        tool_name="read_file",
+        session_id="session-1",
+        agent_id="agent-1",
+        root_session_id="root-1",
+        started_at=0.0,
+        deadline=None,
+        cancel_event=asyncio.Event(),
+    )
+
+
+def _response(
+    *blocks: object,
+    state: ToolResultState = ToolResultState.SUCCESS,
+) -> ToolResponse:
+    return ToolResponse(
+        content=list(blocks),
+        id="call-1",
+        state=state,
+        metadata={"source": "test"},
+    )
+
+
+def _text_response(text: str) -> ToolResponse:
+    return _response(TextBlock(type="text", text=text))
+
+
+def _text_blocks(response: ToolResponse) -> list[str]:
+    return [
+        block.text
+        for block in response.content
+        if getattr(block, "type", None) == "text"
+    ]
+
+
+def _all_text(response: ToolResponse) -> str:
+    return "".join(_text_blocks(response))
+
+
+def _total_text_bytes(response: ToolResponse) -> int:
+    return sum(len(text.encode("utf-8")) for text in _text_blocks(response))
+
+
+def test_small_result_is_returned_unchanged(tmp_path):
+    response = _text_response("hello")
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert result is response
+    assert _all_text(result) == "hello"
+    assert not list(tmp_path.iterdir())
+
+
+def test_ascii_result_is_capped_and_original_is_cached(tmp_path):
+    response = _text_response("a" * 2000)
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert _total_text_bytes(result) <= 512
+    assert TRUNCATION_NOTICE_MARKER in _all_text(result)
+    assert "Tool output truncated before entering agent context" in _all_text(
+        result,
+    )
+    saved = list(tmp_path.iterdir())
+    assert len(saved) == 1
+    assert saved[0].read_text(encoding="utf-8") == "a" * 2000
+
+
+def test_multibyte_result_is_capped_at_valid_utf8_boundary(tmp_path):
+    response = _text_response("你好🙂" * 1000)
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=700,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+    encoded = _all_text(result).encode("utf-8")
+
+    assert len(encoded) <= 700
+    assert encoded.decode("utf-8")
+
+
+def test_multiple_text_blocks_share_one_budget(tmp_path):
+    response = _response(
+        TextBlock(type="text", text="a" * 600),
+        TextBlock(type="text", text="b" * 600),
+        TextBlock(type="text", text="c" * 600),
+    )
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=640,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert _total_text_bytes(result) <= 640
+    assert TRUNCATION_NOTICE_MARKER in _all_text(result)
+
+
+def test_notice_counts_toward_total_limit(tmp_path):
+    response = _text_response("x" * 5000)
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=384,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert _total_text_bytes(result) <= 384
+
+
+def test_non_text_blocks_are_preserved(tmp_path):
+    data_block = DataBlock(
+        source=URLSource(
+            url="https://example.com/image.png",
+            media_type="image/png",
+        ),
+        name="image.png",
+    )
+    response = _response(
+        TextBlock(type="text", text="a" * 1000),
+        data_block,
+        TextBlock(type="text", text="b" * 1000),
+    )
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=800,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert data_block in result.content
+    assert _total_text_bytes(result) <= 800
+
+
+def test_response_identity_state_and_metadata_are_preserved(tmp_path):
+    response = _response(
+        TextBlock(type="text", text="error" * 1000),
+        state=ToolResultState.ERROR,
+    )
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert result.id == response.id
+    assert result.state == ToolResultState.ERROR
+    assert result.metadata == {"source": "test"}
+    assert _total_text_bytes(result) <= 512
+
+
+def test_cache_write_failure_still_caps_result(tmp_path):
+    cache_path = tmp_path / "not-a-directory"
+    cache_path.write_text("occupied", encoding="utf-8")
+    response = _text_response("x" * 2000)
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=cache_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert _total_text_bytes(result) <= 512
+    assert "full output could not be persisted" in _all_text(result).lower()
+
+
+def test_disabled_limiter_returns_original_response(tmp_path):
+    response = _text_response("x" * 2000)
+    limiter = ToolResultLimiter(
+        enabled=False,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert result is response

--- a/tests/unit/tool_calls/test_result_limiter.py
+++ b/tests/unit/tool_calls/test_result_limiter.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from agentscope.message import DataBlock, TextBlock, ToolResultState, URLSource
 from agentscope.tool import ToolResponse
 
 from qwenpaw.constant import TRUNCATION_NOTICE_MARKER
 from qwenpaw.tool_calls._context import ToolCallContext
-from qwenpaw.tool_calls._result_limiter import ToolResultLimiter
+from qwenpaw.tool_calls._result_limiter import (
+    EXECUTION_TRUNCATION_NOTICE_MARKER,
+    ToolResultLimiter,
+)
 
 
 def _ctx() -> ToolCallContext:
@@ -84,7 +88,8 @@ def test_ascii_result_is_capped_and_original_is_cached(tmp_path):
     result = limiter.limit(response, _ctx())
 
     assert _total_text_bytes(result) <= 512
-    assert TRUNCATION_NOTICE_MARKER in _all_text(result)
+    assert EXECUTION_TRUNCATION_NOTICE_MARKER in _all_text(result)
+    assert TRUNCATION_NOTICE_MARKER not in _all_text(result)
     assert "Tool output truncated before entering agent context" in _all_text(
         result,
     )
@@ -123,7 +128,7 @@ def test_multiple_text_blocks_share_one_budget(tmp_path):
     result = limiter.limit(response, _ctx())
 
     assert _total_text_bytes(result) <= 640
-    assert TRUNCATION_NOTICE_MARKER in _all_text(result)
+    assert EXECUTION_TRUNCATION_NOTICE_MARKER in _all_text(result)
 
 
 def test_notice_counts_toward_total_limit(tmp_path):
@@ -210,3 +215,49 @@ def test_disabled_limiter_returns_original_response(tmp_path):
     result = limiter.limit(response, _ctx())
 
     assert result is response
+
+
+@pytest.mark.asyncio
+async def test_async_limit_offloads_cache_write(monkeypatch, tmp_path):
+    response = _text_response("x" * 2000)
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+    calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    result = await limiter.limit_async(response, _ctx())
+
+    assert calls
+    assert _total_text_bytes(result) <= 512
+    assert list(tmp_path.iterdir())
+
+
+def test_legacy_response_fallback_copies_without_mutating_original(tmp_path):
+    class LegacyResponse:
+        def __init__(self):
+            self.content = [TextBlock(type="text", text="x" * 2000)]
+            self.id = "legacy-call"
+            self.state = ToolResultState.SUCCESS
+            self.metadata = {"source": "legacy"}
+
+    response = LegacyResponse()
+    original_content = list(response.content)
+    limiter = ToolResultLimiter(
+        enabled=True,
+        max_text_bytes=512,
+        cache_dir=tmp_path,
+    )
+
+    result = limiter.limit(response, _ctx())
+
+    assert result is not response
+    assert response.content == original_content
+    assert _total_text_bytes(result) <= 512

--- a/tests/unit/tool_calls/test_result_limiter_builder_config.py
+++ b/tests/unit/tool_calls/test_result_limiter_builder_config.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Tests for wiring execution-layer result limiting from config."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from qwenpaw.config.config import (
+    LightContextConfig,
+    ToolResultPruningConfig,
+)
+from qwenpaw.runtime.builder import AgentBuilder
+from qwenpaw.tool_calls import ToolCoordinator, ToolCoordinatorMiddleware
+
+
+def test_builder_uses_execution_layer_limit_independent_of_recent_limit(
+    tmp_path,
+):
+    pruning_config = ToolResultPruningConfig(
+        pruning_recent_msg_max_bytes=4096,
+        execution_layer_max_bytes=8192,
+    )
+    agent_config = SimpleNamespace(
+        id="agent-1",
+        running=SimpleNamespace(
+            light_context_config=LightContextConfig(
+                tool_result_pruning_config=pruning_config,
+            ),
+        ),
+    )
+    ctx = SimpleNamespace(
+        app_services=SimpleNamespace(tool_coordinator=ToolCoordinator()),
+        workspace=SimpleNamespace(workspace_dir=str(tmp_path)),
+    )
+
+    build_middlewares = getattr(AgentBuilder, "_build_middlewares")
+    middlewares = build_middlewares(ctx, agent_config)
+    coordinator_middleware = next(
+        mw for mw in middlewares if isinstance(mw, ToolCoordinatorMiddleware)
+    )
+
+    limiter = getattr(coordinator_middleware, "_result_limiter")
+    assert getattr(limiter, "_max_text_bytes") == 8192


### PR DESCRIPTION
## Description

This PR adds an execution-layer hard cap for final tool-response text before it
is inserted into the agent context.

The current historical pruning middleware runs after an acting step, so it can
be skipped when the next LLM call fails. This change adds a defense-in-depth
boundary inside the tool-call coordinator:

- cap final `ToolResponse` text after tool execution and after hooks complete;
- use one aggregate UTF-8 byte budget across all top-level text blocks,
  including the truncation notice;
- preserve response ID, state, metadata, and non-text blocks;
- save the full textual output to the existing tool-results cache on a
  best-effort basis;
- fail closed if limiting itself encounters an unexpected error;
- apply the same finalized response path to foreground and background tools.

Scope note: this limiter is intentionally a text-content cap, not a cap on the
full serialized `ToolResponse` payload. Non-text blocks such as media/data or
provider-specific structured blocks are preserved unchanged so their existing
formatting paths keep working.

`ToolResultPruningMiddleware` remains unchanged as the second-stage historical
pruning mechanism. The execution-layer cap reuses
`tool_result_pruning_config.enabled` and
`tool_result_pruning_config.execution_layer_max_bytes`.

Fixes #5342.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts

## Checklist

- [x] Run and pass `pre-commit run --all-files`
- [x] Run and pass relevant tests with `pytest`
- [x] Update documentation if needed: not needed; behavior reuses existing
      tool-result pruning configuration

## Testing

Relevant tests cover:

- small results remain unchanged;
- oversized ASCII and multibyte text are capped at valid UTF-8 boundaries;
- multiple text blocks share one aggregate budget;
- truncation notice counts toward the configured byte cap;
- non-text blocks, response ID, state, and metadata are preserved;
- cache-write failure still caps the text result;
- foreground finalization waits for after hooks before applying the cap;
- caller cancellation still propagates while waiting for tool completion;
- middleware callers only observe capped final text responses;
- background completion hints use the finalized capped text response.

## Local Verification Evidence

```text
uv pip install -e \".[dev,full]\"
Installed 24 packages
```

```text
uv run --python 3.11 --extra dev pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```

```text
uv run --python 3.11 --extra dev pytest tests/unit/tool_calls -q
............                                                             [100%]
12 passed in 0.24s
```

```text
uv run --python 3.11 --extra dev pytest tests/unit/agents/tools/test_file_io.py -q
....................................                                     [100%]
36 passed in 0.57s
```

Full pytest was also attempted locally:

```text
uv run --python 3.11 --extra dev pytest
8 failed, 582 passed, 11 skipped, 2 warnings in 777.83s (0:12:57)
```

This full run did not complete/pass in my local environment. It was stopped
after unrelated integration failures had already occurred at about 15% progress;
the first failures were existing `/api/agent/*` 404 integration assertions and
upload/provider-switching integration checks, not the tool-call limiter path.