### PR TITLE
fix(pack): repair desktop packaging builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -112,7 +112,7 @@ jobs:
         id: runner-python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install verify deps (Playwright + Chromium)
         shell: pwsh
@@ -321,7 +321,7 @@ jobs:
         id: runner-python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install verify deps (Playwright + Chromium)
         env:
@@ -355,25 +355,32 @@ jobs:
           # 2. Fix conda-pack paths (mandatory or python crashes on launch).
           (cd "$ENV_DIR" && ./bin/conda-unpack 2>/dev/null || true)
 
-          # 3. Force the bundled interpreter to ignore user site-packages.
-          export PYTHONHOME="$ENV_DIR"
+          # 3. Force only the bundled interpreter to ignore user site-packages.
+          # Keep PYTHONHOME scoped so the runner Python used by Playwright does
+          # not inherit the packaged stdlib path.
           export PYTHONNOUSERSITE=1
           export PATH="$ENV_DIR/bin:$PATH"
+          bundled_python() {
+            env PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1 \
+              PATH="$ENV_DIR/bin:$PATH" "$PYTHON" "$@"
+          }
 
           # 4. SSL certificates — required for DashScope HTTPS calls.
-          CERT_FILE="$("$PYTHON" -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
+          CERT_FILE="$(bundled_python -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
           if [ -n "${CERT_FILE:-}" ] && [ -f "$CERT_FILE" ]; then
             export SSL_CERT_FILE="$CERT_FILE"
             export REQUESTS_CA_BUNDLE="$CERT_FILE"
           fi
 
           # 5. Init workspace and start the desktop backend in the background.
-          "$PYTHON" -m qwenpaw init --defaults --accept-security
+          bundled_python -m qwenpaw init --defaults --accept-security
           # Skip the BootstrapHook onboarding script so the verifier
           # can drive the agent in normal QA mode (see
           # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
           rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
-          nohup "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
+          nohup env PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1 \
+            PATH="$ENV_DIR/bin:$PATH" \
+            "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
             > "$RUNNER_TEMP/qwenpaw-desktop-stdout.log" \
             2> "$RUNNER_TEMP/qwenpaw-desktop-stderr.log" &
           echo $! > "$RUNNER_TEMP/qwenpaw-desktop.pid"
@@ -393,7 +400,7 @@ jobs:
 
           # 7. Cross-version sanity: backend version must match source.
           expected="${{ steps.version.outputs.version }}"
-          actual="$(curl -sf http://127.0.0.1:8088/api/version | "$RUNNER_PYTHON" -c 'import sys,json; print(json.load(sys.stdin)["version"])')"
+          actual="$(curl -sf http://127.0.0.1:8088/api/version | env -u PYTHONHOME -u PYTHONPATH "$RUNNER_PYTHON" -c 'import sys,json; print(json.load(sys.stdin)["version"])')"
           if [ "$actual" != "$expected" ]; then
             echo "::error::Desktop version mismatch: expected=$expected actual=$actual"
             exit 1
@@ -403,7 +410,7 @@ jobs:
           #    Playwright + Chromium are installed). The bundled conda-pack
           #    python stays untouched so we don't pollute the actual env
           #    that ships to users.
-          "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
+          env -u PYTHONHOME -u PYTHONPATH "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
             --base-url http://127.0.0.1:8088 \
             --ui-mode legacy \
             --headed

--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -3,7 +3,9 @@
 PyInstaller spec file for QwenPaw Desktop (Tauri sidecar).
 
 Shared spec for both macOS and Windows. Builds an onedir backend bundle so the
-desktop startup can load Python directly without onefile extraction.
+desktop startup can load Python directly without onefile extraction. The same
+bundle also includes a qwenpaw CLI executable for the Windows installer PATH
+option.
 """
 
 import os
@@ -95,7 +97,10 @@ for _pkg in _metadata_pkgs:
         pass
 
 a = Analysis(
-    [str(SRC / "tauri" / "entry.py")],
+    [
+        str(SRC / "tauri" / "entry.py"),
+        str(SRC / "tauri" / "cli_entry.py"),
+    ],
     pathex=[str(REPO_ROOT), str(REPO_ROOT / "src")],
     binaries=[],
     datas=datas,
@@ -117,8 +122,6 @@ a = Analysis(
         *collect_submodules("qwenpaw.app.channels"),
         # ASGI app entry points
         "qwenpaw.app._app",
-        "qwenpaw.app.api",
-        "qwenpaw.app.middleware",
         "qwenpaw.app.multi_agent_manager",
         "qwenpaw.app.chats",
         "qwenpaw.app.task_tracker",
@@ -132,8 +135,6 @@ a = Analysis(
         # package root or when PyInstaller needs the top-level module anchor.
         *collect_submodules("dotenv"),
         "dotenv",
-        "a2a",
-        "a2a.types",
         *collect_submodules("acp"),
         "acp",
         "psutil",
@@ -154,9 +155,17 @@ a = Analysis(
 
 pyz = PYZ(a.pure)
 
-exe = EXE(
+
+def script_entry(file_name):
+    for item in a.scripts:
+        if Path(item[1]).name == file_name:
+            return [item]
+    raise SystemExit(f"script entry not found: {file_name}")
+
+
+backend_exe = EXE(
     pyz,
-    a.scripts,
+    script_entry("entry.py"),
     [],
     name="qwenpaw-backend",
     debug=False,
@@ -172,8 +181,26 @@ exe = EXE(
     exclude_binaries=True,
 )
 
+cli_exe = EXE(
+    pyz,
+    script_entry("cli_entry.py"),
+    [],
+    name="qwenpaw",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=codesign_identity,
+    exclude_binaries=True,
+)
+
 coll = COLLECT(
-    exe,
+    backend_exe,
+    cli_exe,
     a.binaries,
     a.datas,
     strip=False,

--- a/scripts/pack/build_common.py
+++ b/scripts/pack/build_common.py
@@ -91,8 +91,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--python",
-        default="3.10",
-        help="Python version for conda env (default: 3.10)",
+        default="3.11",
+        help="Python version for conda env (default: 3.11)",
     )
     parser.add_argument(
         "--wheel",


### PR DESCRIPTION
## Description

Fixes desktop packaging failures on `main` by keeping the packaging scripts, package metadata, and verification environment in sync:

- updates the legacy conda-pack environment default to Python 3.11 so it satisfies `requires-python = ">=3.11,<3.14"`
- restores the bundled Tauri `qwenpaw` CLI executable in the PyInstaller output, which is required by the existing Windows installer PATH option
- removes stale PyInstaller hidden imports for modules that no longer exist after the runtime refactor
- isolates legacy desktop verification runner Python from the packaged `PYTHONHOME` and aligns verifier setup with Python 3.11

**Related Issue:** N/A

**Security Considerations:** No auth, secret, or permission behavior changes. The existing Windows installer PATH option remains opt-in and continues to target the bundled Tauri backend directory.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `python -m py_compile scripts\pack\build_common.py`
- `python -c "import ast, pathlib; ast.parse(pathlib.Path('scripts/pack-tauri/qwenpaw.spec').read_text(encoding='utf-8')); print('qwenpaw.spec AST OK')"`
- `git diff --check`
- Origin desktop packaging workflow passed: https://github.com/jinglinpeng/CoPaw/actions/runs/28155561200

## Local Verification Evidence

```bash
python -m py_compile scripts\pack\build_common.py
# passed

python -c "import ast, pathlib; ast.parse(pathlib.Path('scripts/pack-tauri/qwenpaw.spec').read_text(encoding='utf-8')); print('qwenpaw.spec AST OK')"
# qwenpaw.spec AST OK

git diff --check
# passed

pre-commit run --all-files
# not run; focused packaging fix, draft PR

pytest
# not run; focused packaging fix, draft PR
```

## Additional Notes

The failing origin `main` run showed two independent packaging regressions: legacy desktop builds created Python 3.10 conda-pack environments despite the package requiring Python 3.11+, while Tauri PyInstaller builds still checked for `qwenpaw(.exe)` after the spec stopped producing the bundled CLI executable. A first verification run on this branch also exposed a legacy macOS verifier issue where runner Python inherited the packaged `PYTHONHOME`; this PR scopes `PYTHONHOME` to the bundled interpreter only.
