### PR TITLE
feat(inbox): add source type filter for push messages

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -171,7 +171,11 @@
     "detailPayload": "Payload",
     "detailExecutionTrace": "Execution Trace",
     "detailTraceEmpty": "No execution trace available",
-    "filterByAgent": "Filter by agent"
+    "filterByAgent": "Filter by agent",
+    "filterBySourceType": "Filter by source",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "acp": {
     "title": "ACP",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -987,7 +987,11 @@
     "detailPayload": "Payload",
     "detailExecutionTrace": "Jejak Eksekusi",
     "detailTraceEmpty": "Tidak ada jejak eksekusi",
-    "filterByAgent": "Filter berdasarkan agen"
+    "filterByAgent": "Filter berdasarkan agen",
+    "filterBySourceType": "Filter berdasarkan sumber",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "acp": {
     "title": "ACP",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2309,7 +2309,12 @@
     "detailContent": "出力",
     "detailPayload": "追加情報",
     "detailExecutionTrace": "実行トレース",
-    "detailTraceEmpty": "実行トレースはありません"
+    "detailTraceEmpty": "実行トレースはありません",
+    "filterByAgent": "エージェントで絞り込み",
+    "filterBySourceType": "ソースで絞り込み",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "codingMode": {
     "title": "コーディングモード",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2353,7 +2353,12 @@
     "detailContent": "Saída",
     "detailPayload": "Dados",
     "detailExecutionTrace": "Rastro de execução",
-    "detailTraceEmpty": "Nenhum rastro de execução disponível"
+    "detailTraceEmpty": "Nenhum rastro de execução disponível",
+    "filterByAgent": "Filtrar por agente",
+    "filterBySourceType": "Filtrar por origem",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "codingMode": {
     "title": "Modo de Codificação",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2324,7 +2324,12 @@
     "detailContent": "Вывод",
     "detailPayload": "Данные",
     "detailExecutionTrace": "Трассировка выполнения",
-    "detailTraceEmpty": "Трассировка выполнения недоступна"
+    "detailTraceEmpty": "Трассировка выполнения недоступна",
+    "filterByAgent": "Фильтр по агенту",
+    "filterBySourceType": "Фильтр по источнику",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "codingMode": {
     "title": "Режим кодирования",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -311,7 +311,11 @@
     "detailPayload": "Payload",
     "detailExecutionTrace": "Trace thực thi",
     "detailTraceEmpty": "Không có trace",
-    "filterByAgent": "Lọc theo agent"
+    "filterByAgent": "Lọc theo agent",
+    "filterBySourceType": "Lọc theo nguồn",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "acp": {
     "title": "ACP",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -171,7 +171,11 @@
     "detailPayload": "附加信息",
     "detailExecutionTrace": "执行轨迹",
     "detailTraceEmpty": "暂无执行轨迹",
-    "filterByAgent": "按 Agent 筛选"
+    "filterByAgent": "按 Agent 筛选",
+    "filterBySourceType": "按来源筛选",
+    "sourceTypeCron": "定时任务",
+    "sourceTypeHeartbeat": "心跳",
+    "sourceTypeMemory": "记忆"
   },
   "workspace": {
     "title": "文件",

--- a/console/src/pages/Inbox/index.tsx
+++ b/console/src/pages/Inbox/index.tsx
@@ -74,6 +74,9 @@ export default function InboxPage() {
   const [selectedAgentFilter, setSelectedAgentFilter] = useState<
     string | undefined
   >(undefined);
+  const [selectedSourceTypeFilter, setSelectedSourceTypeFilter] = useState<
+    string | undefined
+  >(undefined);
   const [messagesPage, setMessagesPage] = useState(1);
   const [selectedMessageIds, setSelectedMessageIds] = useState<string[]>([]);
   const [batchMode, setBatchMode] = useState(false);
@@ -93,14 +96,22 @@ export default function InboxPage() {
     [agents, t],
   );
   const filteredPushMessages = useMemo(() => {
-    if (!selectedAgentFilter) {
-      return pushMessages;
-    }
-    return pushMessages.filter(
-      (message) =>
-        (message.metadata?.agentId || DEFAULT_AGENT_ID) === selectedAgentFilter,
-    );
-  }, [pushMessages, selectedAgentFilter]);
+    return pushMessages.filter((message) => {
+      if (
+        selectedAgentFilter &&
+        (message.metadata?.agentId || DEFAULT_AGENT_ID) !== selectedAgentFilter
+      ) {
+        return false;
+      }
+      if (
+        selectedSourceTypeFilter &&
+        message.metadata?.sourceType !== selectedSourceTypeFilter
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [pushMessages, selectedAgentFilter, selectedSourceTypeFilter]);
   const pushMessageAgentOptions = useMemo(() => {
     const ids = new Set<string>(
       filteredPushMessages.map(
@@ -121,6 +132,24 @@ export default function InboxPage() {
       }));
     return options;
   }, [agentDisplayNameById, filteredPushMessages, pushMessages, t]);
+  const SOURCE_TYPE_LABEL_KEYS: Record<string, string> = {
+    cron: "inbox.sourceTypeCron",
+    heartbeat: "inbox.sourceTypeHeartbeat",
+    memory: "inbox.sourceTypeMemory",
+  };
+  const sourceTypeOptions = useMemo(() => {
+    const types = new Set<string>(
+      pushMessages
+        .map((m) => m.metadata?.sourceType)
+        .filter((v): v is string => Boolean(v)),
+    );
+    return Array.from(types)
+      .sort((a, b) => a.localeCompare(b))
+      .map((type) => ({
+        value: type,
+        label: t(SOURCE_TYPE_LABEL_KEYS[type] || type),
+      }));
+  }, [pushMessages, t]);
   const urgentApprovalCount = useMemo(
     () =>
       pendingApprovals.filter((item) =>
@@ -210,7 +239,7 @@ export default function InboxPage() {
 
   useEffect(() => {
     setMessagesPage(1);
-  }, [selectedAgentFilter]);
+  }, [selectedAgentFilter, selectedSourceTypeFilter]);
 
   const handleViewMessage = (messageId: string) => {
     const found = pushMessages.find((item) => item.id === messageId);
@@ -295,6 +324,15 @@ export default function InboxPage() {
                 options={pushMessageAgentOptions}
                 style={{ width: 180 }}
                 placeholder={t("inbox.filterByAgent")}
+              />
+              <Select
+                size="middle"
+                value={selectedSourceTypeFilter}
+                onChange={(value) => setSelectedSourceTypeFilter(value)}
+                allowClear
+                options={sourceTypeOptions}
+                style={{ width: 160 }}
+                placeholder={t("inbox.filterBySourceType")}
               />
             </div>
             <div className={styles.messagesSelectionTools}>

--- a/console/src/pages/Inbox/index.tsx
+++ b/console/src/pages/Inbox/index.tsx
@@ -50,6 +50,12 @@ type TabKey = "approvals" | "messages";
 const INBOX_TAB_STORAGE_KEY = "qwenpaw.inbox.activeTab";
 const PUSH_MESSAGES_PAGE_SIZE = 5;
 
+const SOURCE_TYPE_LABEL_KEYS: Record<string, string> = {
+  cron: "inbox.sourceTypeCron",
+  heartbeat: "inbox.sourceTypeHeartbeat",
+  memory: "inbox.sourceTypeMemory",
+};
+
 const resolveInitialTab = (): TabKey => {
   if (typeof window === "undefined") {
     return "messages";
@@ -132,11 +138,6 @@ export default function InboxPage() {
       }));
     return options;
   }, [agentDisplayNameById, filteredPushMessages, pushMessages, t]);
-  const SOURCE_TYPE_LABEL_KEYS: Record<string, string> = {
-    cron: "inbox.sourceTypeCron",
-    heartbeat: "inbox.sourceTypeHeartbeat",
-    memory: "inbox.sourceTypeMemory",
-  };
   const sourceTypeOptions = useMemo(() => {
     const types = new Set<string>(
       pushMessages


### PR DESCRIPTION
## Description

Add a source type filter to the Inbox push messages tab. Users can filter messages by Cron, Heartbeat, or Memory via a new dropdown selector. This filter works together with the existing agent filter using AND logic — both conditions must match for a message to appear. Switching either filter automatically resets pagination to page 1. Added i18n translations for zh, en, vi, and id locales.

Related Issue: N/A

Security Considerations: N/A — client-side UI filtering only, no backend API changes, no sensitive data handling.
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
