### PR TITLE
fix(tools): register spawn_subagent in runtime

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -291,8 +291,14 @@ def collect_final_agent_chat_response(
     to_agent: str,
     timeout: int,
 ) -> Optional[Dict[str, Any]]:
-    """Collect the last SSE payload from inter-agent chat."""
+    """Collect the final response envelope from inter-agent chat.
+
+    Console streams may append non-response events such as ``turn_usage``
+    after the completed response.  Keep the latest response-shaped payload
+    instead of blindly returning the final SSE event.
+    """
     response_data: Optional[Dict[str, Any]] = None
+    fallback_data: Optional[Dict[str, Any]] = None
     with create_agent_api_client(base_url) as client:
         with client.stream(
             "POST",
@@ -306,8 +312,13 @@ def collect_final_agent_chat_response(
                 if line:
                     parsed = parse_agent_sse_line(line)
                     if parsed:
-                        response_data = parsed
-    return response_data
+                        fallback_data = parsed
+                        if (
+                            parsed.get("object") == "response"
+                            or "output" in parsed
+                        ):
+                            response_data = parsed
+    return response_data or fallback_data
 
 
 def submit_agent_chat_task(

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -653,6 +653,7 @@ def _generate_subagent_session_id() -> str:
     return f"sub-{str(uuid4())[:8]}"
 
 
+@tool_descriptor(async_execution=True)
 async def spawn_subagent(
     task: str,
     fork: bool = False,

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncGenerator, Union
 
@@ -29,6 +30,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/console", tags=["console"])
 
+_CHAT_TASKS: dict[str, dict] = {}
+_CHAT_RUNTIME_TASKS: dict[str, asyncio.Task] = {}
+
 
 class MarkInboxReadRequest(BaseModel):
     event_ids: list[str] = []
@@ -36,6 +40,85 @@ class MarkInboxReadRequest(BaseModel):
 
 
 MAX_DEBUG_LOG_LINES = 1000
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_sse_payload(event_data: str) -> dict | None:
+    for line in event_data.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            parsed = json.loads(line[6:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+async def _run_console_chat_task(
+    *,
+    task_id: str,
+    workspace,
+    console_channel,
+    native_payload: dict,
+    session_id: str,
+    timeout: float | None,
+) -> None:
+    record = _CHAT_TASKS[task_id]
+    record["status"] = "running"
+    record["started_at"] = _now_iso()
+    run_key = f"console-task-{task_id}"
+    await workspace.task_tracker.register_external_task(run_key)
+
+    async def _collect() -> dict:
+        response_data: dict | None = None
+        fallback_data: dict | None = None
+        async for event_data in console_channel.stream_one(native_payload):
+            parsed = _parse_sse_payload(event_data)
+            if parsed is None:
+                continue
+            fallback_data = parsed
+            if parsed.get("object") == "response" or "output" in parsed:
+                response_data = parsed
+        return response_data or fallback_data or {}
+
+    result = {
+        "status": "failed",
+        "session_id": session_id,
+        "error": {"message": "Task did not complete"},
+    }
+    try:
+        if timeout is not None:
+            response_data = await asyncio.wait_for(_collect(), timeout=timeout)
+        else:
+            response_data = await _collect()
+        result = dict(response_data)
+        result["status"] = "completed"
+        result["session_id"] = session_id
+    except asyncio.CancelledError:
+        result = {
+            "status": "failed",
+            "session_id": session_id,
+            "error": {"message": "Task cancelled"},
+        }
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Background console chat task failed: %s", task_id)
+        result = {
+            "status": "failed",
+            "session_id": session_id,
+            "error": {"message": str(exc)},
+        }
+    finally:
+        record["status"] = "finished"
+        record["finished_at"] = _now_iso()
+        record["result"] = result
+        _CHAT_RUNTIME_TASKS.pop(task_id, None)
+        await workspace.task_tracker.unregister_external_task(run_key)
 
 
 def _safe_filename(name: str) -> str:
@@ -231,6 +314,99 @@ async def post_console_chat(
             "Connection": "keep-alive",
         },
     )
+
+
+@router.post(
+    "/chat/task",
+    status_code=200,
+    summary="Submit console chat as a background task",
+)
+async def post_console_chat_task(
+    request_data: Union[AgentRequest, dict],
+    request: Request,
+) -> dict:
+    """Submit a detached chat run and return a task id immediately."""
+    workspace = await get_agent_for_request(request)
+    console_channel = await workspace.channel_manager.get_channel("console")
+    if console_channel is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel Console not found",
+        )
+    try:
+        native_payload = _extract_session_and_payload(request_data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    session_id = console_channel.resolve_session_id(
+        sender_id=native_payload["sender_id"],
+        channel_meta=native_payload["meta"],
+    )
+    timeout = None
+    if (
+        isinstance(request_data, dict)
+        and request_data.get("timeout") is not None
+    ):
+        try:
+            timeout = float(request_data["timeout"])
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="timeout must be a number",
+            ) from exc
+        if timeout <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="timeout must be greater than zero",
+            )
+
+    task_id = str(uuid.uuid4())
+    record = {
+        "task_id": task_id,
+        "agent_id": workspace.agent_id,
+        "session_id": session_id,
+        "status": "submitted",
+        "submitted_at": _now_iso(),
+    }
+    _CHAT_TASKS[task_id] = record
+    runtime_task = asyncio.create_task(
+        _run_console_chat_task(
+            task_id=task_id,
+            workspace=workspace,
+            console_channel=console_channel,
+            native_payload=native_payload,
+            session_id=session_id,
+            timeout=timeout,
+        ),
+        name=f"console-chat-task-{task_id}",
+    )
+    _CHAT_RUNTIME_TASKS[task_id] = runtime_task
+    return {
+        "task_id": task_id,
+        "status": "submitted",
+        "session_id": session_id,
+    }
+
+
+@router.get(
+    "/chat/task/{task_id}",
+    status_code=200,
+    summary="Get background console chat task status",
+)
+async def get_console_chat_task_status(
+    task_id: str,
+    request: Request,
+) -> dict:
+    """Return task lifecycle state and the final response when available."""
+    workspace = await get_agent_for_request(request)
+    record = _CHAT_TASKS.get(task_id)
+    if record is None or record.get("agent_id") != workspace.agent_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return {
+        key: value
+        for key, value in record.items()
+        if key != "agent_id"
+    }
 
 
 @router.post(

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -32,6 +32,7 @@ router = APIRouter(prefix="/console", tags=["console"])
 
 _CHAT_TASKS: dict[str, dict] = {}
 _CHAT_RUNTIME_TASKS: dict[str, asyncio.Task] = {}
+_MAX_FINISHED_CHAT_TASKS = 100
 
 
 class MarkInboxReadRequest(BaseModel):
@@ -57,6 +58,36 @@ def _parse_sse_payload(event_data: str) -> dict | None:
         if isinstance(parsed, dict):
             return parsed
     return None
+
+
+def _public_chat_task_record(record: dict) -> dict:
+    return {
+        key: value
+        for key, value in record.items()
+        if key != "agent_id"
+    }
+
+
+def _prune_finished_chat_tasks() -> None:
+    finished_task_ids = [
+        task_id
+        for task_id, record in _CHAT_TASKS.items()
+        if record.get("status") == "finished"
+    ]
+    overflow = len(finished_task_ids) - _MAX_FINISHED_CHAT_TASKS
+    if overflow <= 0:
+        return
+
+    finished_task_ids.sort(
+        key=lambda task_id: (
+            _CHAT_TASKS[task_id].get("finished_at")
+            or _CHAT_TASKS[task_id].get("submitted_at")
+            or ""
+        ),
+    )
+    for task_id in finished_task_ids[:overflow]:
+        if task_id not in _CHAT_RUNTIME_TASKS:
+            _CHAT_TASKS.pop(task_id, None)
 
 
 async def _run_console_chat_task(
@@ -118,6 +149,7 @@ async def _run_console_chat_task(
         record["finished_at"] = _now_iso()
         record["result"] = result
         _CHAT_RUNTIME_TASKS.pop(task_id, None)
+        _prune_finished_chat_tasks()
         await workspace.task_tracker.unregister_external_task(run_key)
 
 
@@ -402,11 +434,10 @@ async def get_console_chat_task_status(
     record = _CHAT_TASKS.get(task_id)
     if record is None or record.get("agent_id") != workspace.agent_id:
         raise HTTPException(status_code=404, detail="Task not found")
-    return {
-        key: value
-        for key, value in record.items()
-        if key != "agent_id"
-    }
+    response = _public_chat_task_record(record)
+    if record.get("status") == "finished":
+        _CHAT_TASKS.pop(task_id, None)
+    return response
 
 
 @router.post(

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -153,6 +153,7 @@ def _create_default_registry() -> ToolRegistry:
     registry.register("ChatWithAgent", "internal", "agent_id")
     registry.register("SubmitToAgent", "internal", "agent_id")
     registry.register("CheckAgentTask", "internal", "task_id")
+    registry.register("SpawnSubagent", "internal", "task")
     registry.register("DelegateExternalAgent", "internal", "runner")
     registry.register("MemorySearch", "internal", "")
 
@@ -181,6 +182,7 @@ def _create_default_registry() -> ToolRegistry:
     registry.register_python_name("chat_with_agent", "ChatWithAgent")
     registry.register_python_name("submit_to_agent", "SubmitToAgent")
     registry.register_python_name("check_agent_task", "CheckAgentTask")
+    registry.register_python_name("spawn_subagent", "SpawnSubagent")
     registry.register_python_name("materialize_skill", "MaterializeSkill")
 
     return registry

--- a/tests/integration/test_spawn_subagent.py
+++ b/tests/integration/test_spawn_subagent.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""End-to-end coverage for foreground and background subagents."""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from http.server import HTTPServer
+
+import httpx
+import pytest
+
+from tests.integration.helpers import (
+    MOCK_LLM_PROVIDER_ID,
+    MockLLMHandler,
+    register_mock_provider,
+    scoped,
+    unregister_mock_provider,
+)
+
+_HTTP_TIMEOUT = 30.0
+_FOREGROUND_CHILD = "SUBAGENT_E2E_FOREGROUND_CHILD"
+_BACKGROUND_CHILD = "SUBAGENT_E2E_BACKGROUND_CHILD"
+
+
+class _SubagentMockLLMHandler(MockLLMHandler):
+    """Drive a parent tool call, then complete the spawned child turn."""
+
+    def _stream_completion(self):
+        body = self._read_body()
+        messages_text = json.dumps(
+            body.get("messages", []),
+            ensure_ascii=False,
+        )
+        tools = body.get("tools", [])
+        has_tool_result = any(
+            message.get("role") == "tool"
+            for message in body.get("messages", [])
+        )
+
+        if has_tool_result:
+            if "FOREGROUND_SUBAGENT_COMPLETED" in messages_text:
+                self.server.foreground_parent_result_seen.set()
+            if "[TASK_ID:" in messages_text:
+                self.server.background_submission_seen.set()
+                self.server.background_tool_result = messages_text
+            self._stream_text("PARENT_RECEIVED_SUBAGENT_RESULT")
+            return
+        if _FOREGROUND_CHILD in messages_text:
+            self.server.foreground_child_seen.set()
+            self._stream_text("FOREGROUND_SUBAGENT_COMPLETED")
+            return
+        if _BACKGROUND_CHILD in messages_text:
+            self.server.background_child_seen.set()
+            self._stream_text("BACKGROUND_SUBAGENT_COMPLETED")
+            return
+        if tools and "RUN_FOREGROUND_SUBAGENT" in messages_text:
+            self.server.tool_call_name = "spawn_subagent"
+            self.server.tool_call_arguments = json.dumps(
+                {
+                    "task": _FOREGROUND_CHILD,
+                    "background": False,
+                },
+            )
+            self._stream_tool_call()
+            return
+        if tools and "RUN_BACKGROUND_SUBAGENT" in messages_text:
+            self.server.tool_call_name = "spawn_subagent"
+            self.server.tool_call_arguments = json.dumps(
+                {
+                    "task": _BACKGROUND_CHILD,
+                    "background": True,
+                },
+            )
+            self._stream_tool_call()
+            return
+
+        self._stream_text("MOCK_AUXILIARY_RESPONSE")
+
+
+@pytest.fixture(scope="module")
+def subagent_mock_llm():
+    server = HTTPServer(("127.0.0.1", 0), _SubagentMockLLMHandler)
+    server.foreground_child_seen = threading.Event()
+    server.foreground_parent_result_seen = threading.Event()
+    server.background_child_seen = threading.Event()
+    server.background_submission_seen = threading.Event()
+    server.background_tool_result = ""
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _run_console_turn(app_server, prompt: str, session_id: str) -> str:
+    url = f"{app_server.base_url}{scoped('default', '/console/chat')}"
+    body = {
+        "input": [
+            {
+                "content": [{"type": "text", "text": prompt}],
+            },
+        ],
+        "user_id": f"user-{session_id}",
+        "session_id": session_id,
+    }
+    chunks: list[str] = []
+    with app_server.client.stream(
+        "POST",
+        url,
+        json=body,
+        timeout=httpx.Timeout(_HTTP_TIMEOUT, read=_HTTP_TIMEOUT),
+    ) as response:
+        assert response.status_code == 200, app_server.logs_tail()
+        for line in response.iter_lines():
+            chunks.append(line)
+    return "\n".join(chunks)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_spawn_subagent_foreground_and_background_end_to_end(
+    app_server,
+    subagent_mock_llm,
+) -> None:
+    """Run both modes through a real QwenPaw server and governance stack."""
+    server, mock_url = subagent_mock_llm
+    unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+    register_mock_provider(app_server, mock_url)
+
+    try:
+        foreground_stream = _run_console_turn(
+            app_server,
+            "RUN_FOREGROUND_SUBAGENT",
+            "spawn-e2e-foreground",
+        )
+        assert server.foreground_child_seen.wait(10), app_server.logs_tail()
+        assert server.foreground_parent_result_seen.wait(
+            10,
+        ), app_server.logs_tail()
+        assert "denied by policy" not in foreground_stream
+
+        background_stream = _run_console_turn(
+            app_server,
+            "RUN_BACKGROUND_SUBAGENT",
+            "spawn-e2e-background",
+        )
+        assert "denied by policy" not in background_stream
+        assert server.background_submission_seen.wait(
+            10,
+        ), app_server.logs_tail()
+        task_match = re.search(
+            r"\[TASK_ID:\s*([^\]]+)\]",
+            server.background_tool_result,
+        )
+        assert task_match, server.background_tool_result
+        task_id = task_match.group(1)
+
+        deadline = time.time() + 20
+        task_result = None
+        while time.time() < deadline:
+            response = app_server.api_request(
+                "GET",
+                scoped("default", f"/console/chat/task/{task_id}"),
+                timeout=_HTTP_TIMEOUT,
+            )
+            assert response.status_code == 200, app_server.logs_tail()
+            task_result = response.json()
+            if task_result.get("status") == "finished":
+                break
+            time.sleep(0.25)
+
+        assert server.background_child_seen.wait(10), app_server.logs_tail()
+        assert task_result is not None
+        assert task_result.get("status") == "finished", task_result
+        assert task_result.get("result", {}).get("status") == "completed"
+        assert (
+            "BACKGROUND_SUBAGENT_COMPLETED"
+            in json.dumps(task_result, ensure_ascii=False)
+        )
+    finally:
+        unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -220,6 +220,7 @@ async def test_agent_management_tools_can_be_registered_in_toolkit():
         tools=[
             FunctionTool(agent_management.list_agents),
             FunctionTool(agent_management.chat_with_agent),
+            FunctionTool(agent_management.spawn_subagent),
         ],
     )
 
@@ -228,6 +229,20 @@ async def test_agent_management_tools_can_be_registered_in_toolkit():
 
     assert "list_agents" in schema_names
     assert "chat_with_agent" in schema_names
+    assert "spawn_subagent" in schema_names
+
+
+def test_spawn_subagent_has_tool_descriptor():
+    from qwenpaw.agents.tools import discover_builtin_tool_funcs
+
+    descriptor = getattr(agent_management.spawn_subagent, "_tool_descriptor")
+    discovered_names = {
+        func._tool_descriptor.name for func in discover_builtin_tool_funcs()
+    }
+
+    assert descriptor.name == "spawn_subagent"
+    assert descriptor.async_execution is True
+    assert "spawn_subagent" in discovered_names
 
 
 async def test_list_agents_uses_to_thread(monkeypatch):

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -215,6 +215,35 @@ def test_collect_final_agent_chat_response_keeps_last_sse_payload(monkeypatch):
     assert agent_management.extract_agent_text_content(result) == "second"
 
 
+def test_collect_final_agent_chat_response_ignores_trailing_usage(monkeypatch):
+    fake_lines = [
+        (
+            'data: {"object": "response", "status": "completed", '
+            '"output": [{"content": '
+            '[{"type": "text", "text": "subagent result"}]}]}'
+        ),
+        'data: {"type": "turn_usage", "usage": {"total_tokens": 15}}',
+    ]
+    fake_client = _FakeClient(stream_response=_FakeResponse(lines=fake_lines))
+    monkeypatch.setattr(
+        agent_management,
+        "create_agent_api_client",
+        lambda _base_url: fake_client,
+    )
+
+    result = agent_management.collect_final_agent_chat_response(
+        "http://127.0.0.1:8088",
+        {"session_id": "sid", "input": []},
+        "bot_b",
+        30,
+    )
+
+    assert result is not None
+    assert agent_management.extract_agent_text_content(result) == (
+        "subagent result"
+    )
+
+
 async def test_agent_management_tools_can_be_registered_in_toolkit():
     toolkit = Toolkit(
         tools=[

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -310,6 +310,24 @@ class TestGovernancePolicyEvaluate:
         decision = policy.evaluate(tc)
         assert decision.action == GovernanceAction.DENY
 
+    def test_spawn_subagent_is_registered_internal_tool(self, policy):
+        """spawn_subagent should pass governance as an internal tool."""
+        policy_name = DEFAULT_REGISTRY.python_to_policy_name(
+            "spawn_subagent",
+        )
+        target = DEFAULT_REGISTRY.extract_target(
+            policy_name,
+            {"task": "Analyze the repository", "background": True},
+        )
+
+        assert policy_name == "SpawnSubagent"
+        assert target == "Analyze the repository"
+        assert DEFAULT_REGISTRY.get_type(policy_name) == "internal"
+        assert (
+            policy.evaluate(_tc(policy_name, target)).action
+            == GovernanceAction.ALLOW
+        )
+
     def test_ssh_dir_match_patterns(self, policy):
         """Various .ssh path patterns should match the builtin rule."""
         ssh_targets = [

--- a/tests/unit/routers/test_console_tasks.py
+++ b/tests/unit/routers/test_console_tasks.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for console background chat task bookkeeping."""
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.app.routers import console
+
+
+def setup_function() -> None:
+    console._CHAT_TASKS.clear()
+    console._CHAT_RUNTIME_TASKS.clear()
+
+
+def teardown_function() -> None:
+    console._CHAT_TASKS.clear()
+    console._CHAT_RUNTIME_TASKS.clear()
+
+
+def test_prune_finished_chat_tasks_keeps_recent_records(monkeypatch) -> None:
+    monkeypatch.setattr(console, "_MAX_FINISHED_CHAT_TASKS", 2)
+    console._CHAT_TASKS.update(
+        {
+            "old": {
+                "task_id": "old",
+                "agent_id": "default",
+                "status": "finished",
+                "finished_at": "2026-01-01T00:00:00+00:00",
+            },
+            "middle": {
+                "task_id": "middle",
+                "agent_id": "default",
+                "status": "finished",
+                "finished_at": "2026-01-02T00:00:00+00:00",
+            },
+            "new": {
+                "task_id": "new",
+                "agent_id": "default",
+                "status": "finished",
+                "finished_at": "2026-01-03T00:00:00+00:00",
+            },
+            "running": {
+                "task_id": "running",
+                "agent_id": "default",
+                "status": "running",
+            },
+        },
+    )
+
+    console._prune_finished_chat_tasks()
+
+    assert set(console._CHAT_TASKS) == {"middle", "new", "running"}
+
+
+@pytest.mark.asyncio
+async def test_finished_chat_task_status_is_dropped_after_read(
+    monkeypatch,
+) -> None:
+    class _Workspace:
+        agent_id = "default"
+
+    async def _fake_get_agent_for_request(_request):
+        return _Workspace()
+
+    monkeypatch.setattr(console, "get_agent_for_request", _fake_get_agent_for_request)
+    console._CHAT_TASKS["task-1"] = {
+        "task_id": "task-1",
+        "agent_id": "default",
+        "session_id": "session-1",
+        "status": "finished",
+        "result": {"status": "completed"},
+    }
+
+    result = await console.get_console_chat_task_status("task-1", object())
+
+    assert result == {
+        "task_id": "task-1",
+        "session_id": "session-1",
+        "status": "finished",
+        "result": {"status": "completed"},
+    }
+    assert "task-1" not in console._CHAT_TASKS
+
+
+@pytest.mark.asyncio
+async def test_running_chat_task_status_is_retained(monkeypatch) -> None:
+    class _Workspace:
+        agent_id = "default"
+
+    async def _fake_get_agent_for_request(_request):
+        return _Workspace()
+
+    monkeypatch.setattr(console, "get_agent_for_request", _fake_get_agent_for_request)
+    console._CHAT_TASKS["task-1"] = {
+        "task_id": "task-1",
+        "agent_id": "default",
+        "session_id": "session-1",
+        "status": "running",
+    }
+
+    result = await console.get_console_chat_task_status("task-1", object())
+
+    assert result["status"] == "running"
+    assert "task-1" in console._CHAT_TASKS


### PR DESCRIPTION
## Summary

- register spawn_subagent with Runtime 2.0 tool discovery
- register SpawnSubagent as an internal governance tool
- select the completed response envelope instead of trailing turn_usage SSE
- restore QwenPaw background chat submit/status endpoints
- add a real-process end-to-end test for foreground and background subagents

## Root causes found by end-to-end testing

The initial registration fix was insufficient. Running a real QwenPaw server exposed two additional Runtime 2.0 migration failures: foreground results were lost because turn_usage was treated as the final response, and background submission still targeted a removed endpoint that returned HTTP 405.

Closes #5523

## Tests

- Real QwenPaw subprocess E2E: 1 passed in 17.66s
  - parent invokes spawn_subagent through console HTTP/SSE
  - governance decision is allow
  - foreground child executes independently and returns output
  - background call returns task_id
  - status polling reaches finished/completed with child output
- Combined unit/integration verification: 44 passed
- Governance suite: 39 passed
- git diff --check
