### PR TITLE
fix(skillpool): restore SkillPool styles after PR #5521

### DIFF
--- a/console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillCard.tsx
@@ -8,7 +8,7 @@ import {
   getPoolBuiltinStatusTone,
   isSkillBuiltin,
 } from "@/utils/skill";
-import { getSkillVisual } from "../../../Agent/Skills/components";
+import { SkillVisual } from "@/components/SkillVisual";
 import styles from "../index.module.less";
 
 interface PoolSkillCardProps {
@@ -66,7 +66,11 @@ export function PoolSkillCard({
       {/* Top row: Icon (left) + Status badge + Checkbox (right) */}
       <div className={styles.cardTopRow}>
         <span className={styles.fileIcon}>
-          {getSkillVisual(skill.name, skill.emoji)}
+          <SkillVisual
+            name={skill.name}
+            emoji={skill.emoji}
+            emojiClassName={styles.skillEmoji}
+          />
         </span>
         <div className={styles.cardTopRight}>
           <span

--- a/console/src/pages/Settings/SkillPool/components/PoolSkillListItem.tsx
+++ b/console/src/pages/Settings/SkillPool/components/PoolSkillListItem.tsx
@@ -8,7 +8,7 @@ import {
   getPoolBuiltinStatusTone,
   isSkillBuiltin,
 } from "@/utils/skill";
-import { getSkillVisual } from "../../../Agent/Skills/components";
+import { SkillVisual } from "@/components/SkillVisual";
 import { SkillTagChips } from "./SkillMeta";
 import styles from "../index.module.less";
 dayjs.extend(relativeTime);
@@ -58,7 +58,11 @@ export function PoolSkillListItem({
       )}
       <div className={styles.listItemLeft}>
         <span className={styles.fileIcon}>
-          {getSkillVisual(skill.name, skill.emoji)}
+          <SkillVisual
+            name={skill.name}
+            emoji={skill.emoji}
+            emojiClassName={styles.skillEmoji}
+          />
         </span>
         <div className={styles.listItemInfo}>
           <div className={styles.listItemHeader}>

--- a/console/src/pages/Settings/SkillPool/components/SkillPoolListItem.tsx
+++ b/console/src/pages/Settings/SkillPool/components/SkillPoolListItem.tsx
@@ -6,7 +6,7 @@ import {
   getPoolBuiltinStatusLabel,
   getPoolBuiltinStatusTone,
 } from "@/utils/skill";
-import { getSkillVisual } from "../../../Agent/Skills/components";
+import { SkillVisual } from "@/components/SkillVisual";
 import styles from "../index.module.less";
 
 interface SkillPoolListItemProps {
@@ -55,7 +55,11 @@ export function SkillPoolListItem({
       )}
       <div className={styles.listItemLeft}>
         <span className={styles.fileIcon}>
-          {getSkillVisual(skill.name, skill.content)}
+          <SkillVisual
+            name={skill.name}
+            emoji={skill.content}
+            emojiClassName={styles.skillEmoji}
+          />
         </span>
         <div className={styles.listItemInfo}>
           <div className={styles.listItemHeader}>

--- a/console/src/pages/Settings/SkillPool/index.module.less
+++ b/console/src/pages/Settings/SkillPool/index.module.less
@@ -435,7 +435,9 @@
 
 /* ─── Skills Grid ─────────────────────────────────────────────────────────── */
 .skillsGrid {
-  /* Layout (grid + gap) is provided by the shared .responsive-grid utility. */
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
   padding: 16px;
 }
 
@@ -566,6 +568,18 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+}
+
+.skillEmoji {
+  width: 52px;
+  height: 52px;
+  border-radius: 10px;
+  background: #f7f5f3;
+  font-size: 28px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .titleRow {


### PR DESCRIPTION
- Add skillEmoji style (52px) to SkillPool/index.module.less
- Add grid layout to .skillsGrid (was missing responsive-grid utility)
- Use shared SkillVisual component with emojiClassName prop
- SkillPool now maintains independent styling from Agent/Skills changes

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
