### PR TITLE
Avoid treating content safety image errors as media capability failures

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -471,12 +471,13 @@ class QwenPawAgent(CodingModeMixin, Agent):
         """Return True for provider-side content safety rejections."""
         error_str = str(exc).lower()
         safety_markers = (
-            "sensitive",
             "new_sensitive",
+            "image is sensitive",
             "content policy",
             "content_policy",
             "moderation",
-            "safety",
+            "content_safety",
+            "safety_filter",
             "(1026)",
         )
         return any(marker in error_str for marker in safety_markers)

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -467,6 +467,21 @@ class QwenPawAgent(CodingModeMixin, Agent):
         return True
 
     @staticmethod
+    def _is_content_safety_error(exc: Exception) -> bool:
+        """Return True for provider-side content safety rejections."""
+        error_str = str(exc).lower()
+        safety_markers = (
+            "sensitive",
+            "new_sensitive",
+            "content policy",
+            "content_policy",
+            "moderation",
+            "safety",
+            "(1026)",
+        )
+        return any(marker in error_str for marker in safety_markers)
+
+    @staticmethod
     def _is_bad_request_or_media_error(exc: Exception) -> bool:
         """Return True only for errors that genuinely look media-related.
 
@@ -477,6 +492,11 @@ class QwenPawAgent(CodingModeMixin, Agent):
         subsequent requests to silently drop user-uploaded images.
         """
         error_str = str(exc).lower()
+
+        # Veto: content safety/moderation rejections are about a
+        # particular input, not about whether the model supports media.
+        if QwenPawAgent._is_content_safety_error(exc):
+            return False
 
         # Veto: errors clearly about request size / context length are
         # never about media support — stripping media may incidentally


### PR DESCRIPTION
## 概要

这个 PR 用于避免将 provider 侧的内容安全审核错误误判为模型媒体能力错误。

目前像 MiniMax `new_sensitive` / `(1026)` 这类错误信息里会包含 `image`，因此可能命中现有的媒体关键词判断，被误认为是模型拒绝媒体输入。这样 QwenPaw 可能会进入 media stripping fallback，并学习到 `rejects_media=True`，即使模型本身实际支持视觉能力。

## 修改内容

- 新增 `_is_content_safety_error()`
- 在媒体 fallback 判断前，先排除内容安全 / moderation 类错误
- 保留现有 request size / context length 的 veto 逻辑
- 保留现有针对真实媒体相关错误的 fallback 行为

## 示例

修改前，下面这类错误：

input new_sensitive, messages[10]'s content[0] image is sensitive, please check your input (1026)

可能会因为包含 `image` 而被当作媒体能力错误。

修改后，它会被识别为内容安全审核拒绝，不再进入 media fallback 路径。

## 验证

我在本地验证了：

image is sensitive ... (1026) -> 不再被当作 media rejection
model does not support image_url -> 仍然被当作媒体相关错误
request too large / context length -> 仍然会被 veto