### PR TITLE
fix(models): count only configured providers online

### DIFF
--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -21,7 +21,11 @@ import {
 import { PageHeader } from "@/components/PageHeader";
 import { useTranslation } from "react-i18next";
 import type { ProviderInfo } from "../../../api/types/provider";
-import { getIsConfigured, groupProviders } from "./utils";
+import {
+  countConfiguredProviders,
+  getIsConfigured,
+  groupProviders,
+} from "./utils";
 import { ProviderIcon } from "./components/ProviderIconComponent";
 import styles from "./index.module.less";
 
@@ -254,6 +258,15 @@ function ModelsPage() {
     };
   }, [providers, deferredSearchQuery]);
 
+  const configuredCloudProviderCount = useMemo(
+    () =>
+      countConfiguredProviders([
+        ...cloudConfiguredGrouped.flatMap((g) => g.providers),
+        ...cloudConfiguredUngrouped,
+      ]),
+    [cloudConfiguredGrouped, cloudConfiguredUngrouped],
+  );
+
   const renderProviderCards = (list: ProviderInfo[]) =>
     list.map((provider) => (
       <ProviderCard
@@ -388,10 +401,7 @@ function ModelsPage() {
                       <span className={styles.panelDotGreen} />
                       {t("models.configuredGroup")}
                       <span className={styles.panelCount}>
-                        {cloudConfiguredGrouped.reduce(
-                          (n, g) => n + g.providers.length,
-                          0,
-                        ) + cloudConfiguredUngrouped.length}{" "}
+                        {configuredCloudProviderCount}{" "}
                         {t("models.configuredOnline")}
                       </span>
                     </div>

--- a/console/src/pages/Settings/Models/utils.test.ts
+++ b/console/src/pages/Settings/Models/utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderInfo } from "../../../api/types/provider";
+import { countConfiguredProviders } from "./utils";
+
+function provider(overrides: Partial<ProviderInfo>): ProviderInfo {
+  return {
+    id: "provider",
+    name: "Provider",
+    api_key_prefix: "",
+    chat_model: "",
+    models: [],
+    extra_models: [],
+    is_custom: false,
+    is_local: false,
+    support_model_discovery: false,
+    support_connection_check: false,
+    freeze_url: false,
+    require_api_key: true,
+    api_key: "",
+    base_url: "",
+    generate_kwargs: {},
+    ...overrides,
+  };
+}
+
+describe("countConfiguredProviders", () => {
+  it("counts only configured providers inside grouped cloud provider cards", () => {
+    const providers = [
+      provider({
+        id: "provider-cn",
+        provider_group: "provider",
+        api_key: "configured-key",
+      }),
+      provider({
+        id: "provider-intl",
+        provider_group: "provider",
+        api_key: "",
+      }),
+    ];
+
+    expect(countConfiguredProviders(providers)).toBe(1);
+  });
+
+  it("counts custom providers with a base URL as configured", () => {
+    const providers = [
+      provider({
+        id: "custom-openai",
+        is_custom: true,
+        base_url: "https://example.test/v1",
+      }),
+    ];
+
+    expect(countConfiguredProviders(providers)).toBe(1);
+  });
+});

--- a/console/src/pages/Settings/Models/utils.ts
+++ b/console/src/pages/Settings/Models/utils.ts
@@ -9,6 +9,10 @@ export function getIsConfigured(provider: ProviderInfo): boolean {
   return false;
 }
 
+export function countConfiguredProviders(providers: ProviderInfo[]): number {
+  return providers.filter(getIsConfigured).length;
+}
+
 export interface ProviderGroup {
   groupKey: string;
   groupName: string;


### PR DESCRIPTION
## Description

Fixes #5512.

The Models settings page groups cloud provider variants together when any variant in the group is configured. That grouping is useful, but the configured/online counter was summing every provider in those grouped cards, including variants that are not configured yet.

This PR keeps the grouped display behavior unchanged and updates the configured/online count to include only providers that satisfy the existing `getIsConfigured()` logic. The group card Live badge already uses the same configured-provider logic, so the section counter now matches the visible card state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated if needed (not needed for this UI bug fix)
- [x] Ready for review

## Testing

- Added `countConfiguredProviders` unit coverage for grouped cloud providers where only one variant is configured.
- Verified the Models page counter now uses configured-provider count rather than grouped-card provider count.
- Ran frontend build successfully.

## Local Verification Evidence

```bash
uv run --python 3.11 --extra dev pre-commit run --all-files
# check python ast Passed
# check yaml Passed
# check json Passed
# detect private key Passed
# trim trailing whitespace Passed
# Add trailing commas Passed
# mypy Passed
# black Passed
# flake8 Passed
# pylint Passed
# prettier Passed
```

```bash
npm run test:run -- src/pages/Settings/Models/utils.test.ts
# Test Files  1 passed (1)
# Tests       2 passed (2)
```

```bash
npm run build
# tsc -b && vite build
# 15088 modules transformed
# built successfully
```

## Additional Notes

`npm run lint` currently fails on existing repository-wide lint issues unrelated to this PR, including pre-existing `no-explicit-any`, `prefer-const`, missing plugin rule, and unused variable errors in files outside this change. The touched files are covered by the targeted test and the successful build/pre-commit run above.
