### PR TITLE
fix(chat): preserve assistant markdown newlines

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -231,6 +231,21 @@
   }
 }
 
+/* Fix #5480: Assistant response markdown may temporarily fall back to the
+ * vendor Raw renderer while streaming. Raw renders newline-bearing text as
+ * normal div children, so keep whitespace and wrap long lines on the host side.
+ */
+.chatMessagesArea :global {
+  [class*="bubble-start"] [class*="markdown"],
+  [class*="bubble-assistant"] [class*="markdown"] {
+    min-width: 0;
+    max-width: 100%;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+}
+
 /* Dark mode scrollbar for disabled overlay */
 :global(.dark-mode) {
   .chatDisabledOverlay :global([class*="chat-anywhere-input"]),

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const stylesSource = readFileSync(
+  join(process.cwd(), "src/pages/Chat/index.module.less"),
+  "utf8",
+);
+
+describe("Chat message markdown layout styles", () => {
+  it("preserves newlines for assistant markdown fallback content", () => {
+    const marker = "Fix #5480";
+    const markerIndex = stylesSource.indexOf(marker);
+    const rule = stylesSource.slice(
+      markerIndex,
+      stylesSource.indexOf("}", markerIndex) + 1,
+    );
+
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(rule).toContain('[class*="bubble-start"] [class*="markdown"]');
+    expect(rule).toMatch(/white-space:\s*pre-wrap/);
+    expect(rule).toMatch(/overflow-wrap:\s*anywhere/);
+    expect(rule).toMatch(/word-break:\s*normal/);
+    expect(rule).toMatch(/min-width:\s*0/);
+    expect(rule).toMatch(/max-width:\s*100%/);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #5480.

Assistant responses can temporarily render through the vendor Raw markdown fallback while streaming. That fallback renders newline-bearing plain text as normal DOM children, so the browser collapses line breaks when only user/end bubbles have `white-space: pre-wrap`.

This PR adds a scoped host-side style for assistant markdown containers so fallback content preserves newlines and long lines wrap inside the bubble. It also adds a narrow CSS regression test for the #5480 selector/properties.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core
- [x] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts

## Checklist

- [x] Run and pass `pre-commit run --all-files`
- [x] Run and pass relevant tests
- [x] Update documentation if needed (not needed; scoped UI bug fix)

## Testing

- `uv run --python 3.11 --extra dev pre-commit run --all-files`
- `npm run test:run -- src/pages/Chat/index.module.test.ts`
- `npx eslint src/pages/Chat/index.module.test.ts`
- `npm run build`

## Local Verification Evidence

### pre-commit run --all-files

Command:

```bash
uv run --python 3.11 --extra dev pre-commit run --all-files
```

Summary:

```text
check python ast.........................................................Passed
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```

### pytest / relevant tests

This change is in the Console frontend, so I ran the targeted Vitest regression test instead of backend pytest.

Command:

```bash
npm run test:run -- src/pages/Chat/index.module.test.ts
```

Summary:

```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

### Additional Console checks

Command:

```bash
npx eslint src/pages/Chat/index.module.test.ts
```

Summary:

```text
Passed with no output.
```

Command:

```bash
npm run build
```

Summary:

```text
> qwenpaw-console@0.0.0 build
> tsc -b && vite build

✓ 15089 modules transformed.
✓ built in 45.23s
```

Note: Vite emitted existing dynamic-import/chunk-size warnings during build; the build completed successfully.
