### PR TITLE
feat(memory): refactor auto memory system with turn-based tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.4.0.3",
+    "reme-ai==0.4.0.4",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.4.0.2",
+    "reme-ai==0.4.0.3",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/src/qwenpaw/agents/memory/adbpg_memory_manager.py
+++ b/src/qwenpaw/agents/memory/adbpg_memory_manager.py
@@ -155,6 +155,10 @@ class ADBPGMemoryManager(BaseMemoryManager):
         """Return memory tools exposed to the agent."""
         return [self.memory_search]
 
+    def get_auto_memory_interval(self) -> int:
+        """Persist ADBPG user messages every turn."""
+        return 1
+
     # ------------------------------------------------------------------
     # Optional methods (override)
     # ------------------------------------------------------------------

--- a/src/qwenpaw/agents/memory/base_memory_manager.py
+++ b/src/qwenpaw/agents/memory/base_memory_manager.py
@@ -83,6 +83,15 @@ class BaseMemoryManager(ABC):
 
         return [MemoryMiddleware(memory_manager=self)]
 
+    def get_auto_memory_interval(self) -> int:
+        """Return the lifecycle auto-memory interval for this backend.
+
+        ``0`` disables middleware-driven periodic auto-memory. Backends that
+        support automatic persistence should override this with their own
+        configuration or fixed cadence.
+        """
+        return 0
+
     # pylint: disable=unused-argument
     async def summarize(self, messages: list[Msg], **kwargs) -> str:
         """Summarize conversation messages and persist to memory.

--- a/src/qwenpaw/agents/memory/reme_config.py
+++ b/src/qwenpaw/agents/memory/reme_config.py
@@ -135,7 +135,7 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
             "search": {
                 "backend": "base",
                 "description": (
-                    "Hybrid vault search (vector + BM25, RRF-fused)."
+                    "Hybrid workspace search (vector + BM25, RRF-fused)."
                 ),
                 "parameters": {
                     "type": "object",
@@ -169,7 +169,11 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
             },
             "node_search": {
                 "backend": "base",
-                "description": "Digest node recall.",
+                "description": (
+                    "Digest node recall — given a candidate abstraction's "
+                    "name+description, surface existing digest nodes similar "
+                    "enough to either dedup against or link to as related."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -193,35 +197,33 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
                     },
                 ],
             },
-            "daily_create": {
-                "backend": "base",
-                "description": (
-                    "Provision a session note under a daily folder."
-                ),
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "session_id": {"type": "string", "default": ""},
-                        "date": {"type": "string", "default": ""},
-                    },
-                },
-                "steps": [{"backend": "daily_create_step"}],
-            },
             "daily_list": {
                 "backend": "base",
                 "description": "List notes under a single day.",
                 "parameters": {
                     "type": "object",
-                    "properties": {"date": {"type": "string", "default": ""}},
+                    "properties": {
+                        "date": {
+                            "type": "string",
+                            "description": "YYYY-MM-DD; empty = today",
+                            "default": "",
+                        },
+                    },
                 },
                 "steps": [{"backend": "daily_list_step"}],
             },
             "daily_reindex": {
                 "backend": "base",
-                "description": "Rebuild the day-index page.",
+                "description": "Rebuild the day-index page daily/<date>.md.",
                 "parameters": {
                     "type": "object",
-                    "properties": {"date": {"type": "string", "default": ""}},
+                    "properties": {
+                        "date": {
+                            "type": "string",
+                            "description": "YYYY-MM-DD; empty = today",
+                            "default": "",
+                        },
+                    },
                 },
                 "steps": [{"backend": "daily_reindex_step"}],
             },
@@ -343,7 +345,10 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
             },
             "write": {
                 "backend": "base",
-                "description": "Write a markdown file.",
+                "description": (
+                    "Write a markdown file (create or overwrite) with "
+                    "name/description frontmatter."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -357,9 +362,54 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
                 },
                 "steps": [{"backend": "write_step"}],
             },
+            "daily_write": {
+                "backend": "base",
+                "description": (
+                    "Write a daily markdown note with conversation source "
+                    "frontmatter."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": (
+                                "daily note filename stem and frontmatter name"
+                            ),
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "frontmatter description",
+                        },
+                        "session_id": {
+                            "type": "string",
+                            "description": "source conversation session "
+                            "identifier",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "body",
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "description": "Optional extra frontmatter "
+                            "fields.",
+                        },
+                    },
+                    "required": [
+                        "name",
+                        "description",
+                        "session_id",
+                        "content",
+                    ],
+                },
+                "steps": [{"backend": "daily_write_step"}],
+            },
             "edit": {
                 "backend": "base",
-                "description": "Find-and-replace in a markdown file.",
+                "description": (
+                    "Find-and-replace in a markdown file (all occurrences)."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -373,13 +423,19 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
             },
             "auto_dream": {
                 "backend": "base",
-                "description": "Auto-dream memory consolidation.",
+                "description": (
+                    "Auto-dream: scan today's day-index and daily notes, "
+                    "globally extract merged units/topics, integrate digest "
+                    "units, write interests.yaml, and persist the dream "
+                    "catalog."
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "date": {"type": "string", "default": ""},
                         "hint": {"type": "string", "default": ""},
                         "scan_days": {"type": "integer", "default": 2},
+                        "max_units": {"type": "integer", "default": 5},
                         "topic_count": {"type": "integer", "default": 3},
                         "topic_diversity_days": {
                             "type": "integer",
@@ -393,6 +449,7 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
                         "file_catalog": "dream",
                         "topic_session_id": "interests",
                         "scan_days": 2,
+                        "max_units": 5,
                     },
                     {"backend": "dream_integrate_step"},
                     {
@@ -448,7 +505,22 @@ def _base_config(enable_search_raw_log: bool = False) -> dict[str, Any]:
                     "properties": {
                         "changes": {
                             "type": "array",
-                            "items": {"type": "object"},
+                            "description": (
+                                "resource change batch, each item has "
+                                "path/file_path and change"
+                            ),
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {"type": "string"},
+                                    "file_path": {"type": "string"},
+                                    "change": {
+                                        "type": "string",
+                                        "description": "added/"
+                                        "modified/deleted",
+                                    },
+                                },
+                            },
                         },
                     },
                     "required": ["changes"],

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -23,6 +23,11 @@ from .reme_config import get_reme_app_config
 from ..model_factory import create_model_and_formatter
 from ...app.inbox_store import append_event as append_inbox_event
 from ...config import load_config
+from ...constant import (
+    AUTO_MEMORY_SEARCH_MESSAGE_TAG,
+    AUTO_MEMORY_SEARCH_TEXT,
+    QWENPAW_MESSAGE_TAG_KEY,
+)
 from ...config.config import load_agent_config, AgentProfileConfig
 
 if TYPE_CHECKING:
@@ -37,8 +42,6 @@ INBOX_RESULT_JOB_NAMES = {"auto_memory", "auto_dream", "auto_resource"}
 INBOX_RESULT_HOOK_KEY = "qwenpaw_memory_result_hook"
 INBOX_EMITTED_METADATA_KEY = "_qwenpaw_inbox_emitted"
 MAX_INBOX_BODY_CHARS = 4000
-QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
-AUTO_MEMORY_SEARCH_MESSAGE_TAG = "auto_memory_search"
 
 
 def _tool_chunk(text: str, *, ok: bool = True) -> ToolChunk:
@@ -434,7 +437,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 QWENPAW_MESSAGE_TAG_KEY: AUTO_MEMORY_SEARCH_MESSAGE_TAG,
             },
             content=[
-                TextBlock(text="Searching memory for relevant context..."),
+                TextBlock(text=AUTO_MEMORY_SEARCH_TEXT),
                 ToolCallBlock(
                     id=tool_call_id,
                     name="memory_search",

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -148,6 +148,16 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         """Return memory tool functions to register with the agent toolkit."""
         return [self.memory_search]
 
+    def get_auto_memory_interval(self) -> int:
+        """Return ReMe light auto-memory cadence from agent config."""
+        agent_config = load_agent_config(self.agent_id)
+        interval = (
+            agent_config.running.reme_light_memory_config.auto_memory_interval
+        )
+        if interval is None:
+            return 0
+        return int(interval)
+
     async def _update_qwenpaw_model(self) -> None:
         """Reuse QwenPaw's active model in ReMe's default LLM component."""
         if self._reme is None:

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -225,6 +225,18 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             INBOX_EMITTED_METADATA_KEY,
         ):
             return False
+        if (
+            name in {"auto_memory", "auto_resource"}
+            and isinstance(response_metadata, dict)
+            and response_metadata.get("modified") is False
+        ):
+            logger.info(
+                "ReMe job result inbox push skipped; no memory change: "
+                "agent_id=%s job_name=%s modified=False",
+                self.agent_id,
+                name,
+            )
+            return False
 
         answer = str(getattr(response, "answer", "") or "").strip()
         if len(answer) > MAX_INBOX_BODY_CHARS:
@@ -263,11 +275,14 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 response_metadata[INBOX_EMITTED_METADATA_KEY] = True
             logger.info(
                 "ReMe job result pushed to inbox: "
-                "agent_id=%s job_name=%s event_id=%s status=%s",
+                "agent_id=%s job_name=%s event_id=%s status=%s modified=%s",
                 self.agent_id,
                 name,
                 event.get("id"),
                 event.get("status"),
+                response_metadata.get("modified")
+                if isinstance(response_metadata, dict)
+                else None,
             )
             return True
         except Exception:  # pylint: disable=broad-except
@@ -445,12 +460,21 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         **kwargs: Any,
     ) -> None:
         """Auto-extract memory for a prepared reply batch."""
-        if not kwargs.get("reply_ids") or not all_messages:
+        if not all_messages:
+            return
+        session_id = str(kwargs.get("session_id") or "")
+        if not session_id:
+            logger.warning(
+                "ReMe auto_memory skipped; session_id is empty: "
+                "agent_id=%s messages=%s",
+                self.agent_id,
+                len(all_messages),
+            )
             return
 
         self.add_summarize_task(
             messages=all_messages,
-            session_id=str(kwargs.get("session_id") or ""),
+            session_id=session_id,
         )
 
     async def dream(self, **kwargs: Any) -> None:

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -33,7 +33,10 @@ logger = logging.getLogger(__name__)
 MAX_AUTO_MEMORY_TURN_MARKERS = 1000
 QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
 AUTO_MEMORY_SEARCH_MESSAGE_TAG = "auto_memory_search"
-AUTO_MEMORY_SEARCH_TEXT = "Searching memory for relevant context..."
+AUTO_CONTINUE_MESSAGE_TAG = "auto_continue"
+AUTO_MEMORY_SEARCH_TEXT = (
+    "Find memory relevant to the latest user request and conversation context."
+)
 
 
 class MemoryMiddleware(MiddlewareBase):
@@ -233,11 +236,7 @@ class MemoryMiddleware(MiddlewareBase):
         ]
 
     def _auto_memory_interval(self) -> int:
-        interval = self._memory_config().auto_memory_interval
-
-        if interval is None:
-            return 0
-        return int(interval)
+        return int(self._memory_manager.get_auto_memory_interval())
 
     def _memory_config(self) -> Any:
         from ..config.config import load_agent_config
@@ -259,6 +258,12 @@ class MemoryMiddleware(MiddlewareBase):
     @classmethod
     def _is_auto_memory_search_msg(cls, msg: "Msg") -> bool:
         return cls._message_tag(msg) == AUTO_MEMORY_SEARCH_MESSAGE_TAG
+
+    @classmethod
+    def _is_memory_user_turn(cls, msg: "Msg") -> bool:
+        return msg.role == "user" and cls._message_tag(msg) not in {
+            AUTO_CONTINUE_MESSAGE_TAG
+        }
 
     @classmethod
     def _normal_memory_messages(cls, messages: list["Msg"]) -> list["Msg"]:
@@ -318,7 +323,7 @@ class MemoryMiddleware(MiddlewareBase):
     def _latest_user_turn_marker(messages: list["Msg"]) -> str:
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
-            if msg.role != "user":
+            if not MemoryMiddleware._is_memory_user_turn(msg):
                 continue
             return MemoryMiddleware._user_turn_marker(msg, idx)
         return ""
@@ -341,7 +346,7 @@ class MemoryMiddleware(MiddlewareBase):
         last_idx: int | None = None
         for idx, msg in enumerate(messages):
             if (
-                msg.role == "user"
+                MemoryMiddleware._is_memory_user_turn(msg)
                 and MemoryMiddleware._user_turn_marker(msg, idx) in targets
             ):
                 if first_idx is None:
@@ -353,11 +358,13 @@ class MemoryMiddleware(MiddlewareBase):
 
         end_idx = len(messages)
         for idx in range(last_idx + 1, len(messages)):
-            if messages[idx].role == "user":
+            if MemoryMiddleware._is_memory_user_turn(messages[idx]):
                 end_idx = idx
                 break
 
-        return messages[first_idx:end_idx]
+        return MemoryMiddleware._normal_memory_messages(
+            messages[first_idx:end_idx],
+        )
 
 
 class ToolResultPruningMiddleware(MiddlewareBase):

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -137,7 +137,11 @@ class MemoryMiddleware(MiddlewareBase):
         if len(self._pending_auto_memory_turn_markers) < interval:
             return
 
-        await self._flush_auto_memory(agent, count=interval)
+        await self._flush_auto_memory(
+            agent,
+            count=interval,
+            repair_context=False,
+        )
 
     async def on_compress_context(
         self,
@@ -160,6 +164,7 @@ class MemoryMiddleware(MiddlewareBase):
         agent: "Agent",
         *,
         count: int | None = None,
+        repair_context: bool = True,
     ) -> None:
         if not self._pending_auto_memory_turn_markers:
             return
@@ -171,7 +176,8 @@ class MemoryMiddleware(MiddlewareBase):
             turn_markers = self._pending_auto_memory_turn_markers[:count]
             del self._pending_auto_memory_turn_markers[:count]
 
-        self._repair_tagged_auto_memory_search_context(agent)
+        if repair_context:
+            self._repair_tagged_auto_memory_search_context(agent)
         normal_messages = self._normal_memory_messages(
             list(agent.state.context),
         )

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from agentscope.agent import Agent
 
 logger = logging.getLogger(__name__)
-MAX_AUTO_MEMORY_REPLY_IDS = 1000
+MAX_AUTO_MEMORY_TURN_MARKERS = 1000
 QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
 AUTO_MEMORY_SEARCH_MESSAGE_TAG = "auto_memory_search"
 AUTO_MEMORY_SEARCH_TEXT = "Searching memory for relevant context..."
@@ -50,9 +50,9 @@ class MemoryMiddleware(MiddlewareBase):
 
     def __init__(self, *, memory_manager: Any) -> None:
         self._memory_manager = memory_manager
-        self._searched_reply_id: str | None = None
-        self._pending_auto_memory_reply_ids: list[str] = []
-        self._seen_auto_memory_reply_ids: dict[str, None] = {}
+        self._searched_user_turn_marker: str | None = None
+        self._pending_auto_memory_turn_markers: list[str] = []
+        self._seen_auto_memory_turn_markers: dict[str, None] = {}
 
     async def on_system_prompt(
         self,
@@ -73,15 +73,15 @@ class MemoryMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., Any],
     ) -> Any:
-        reply_id = agent.state.reply_id
-        if reply_id != self._searched_reply_id:
-            self._searched_reply_id = reply_id
+        turn_marker = self._latest_user_turn_marker(agent.state.context)
+        if turn_marker and turn_marker != self._searched_user_turn_marker:
+            self._searched_user_turn_marker = turn_marker
             try:
                 result = await self._memory_manager.auto_memory_search(
                     list(agent.state.context),
                     agent_name=agent.name,
                     session_id=agent.state.session_id,
-                    reply_id=reply_id,
+                    user_turn_id=turn_marker,
                 )
             except Exception:
                 logger.exception(
@@ -110,24 +110,28 @@ class MemoryMiddleware(MiddlewareBase):
         async for item in next_handler(**input_kwargs):
             yield item
 
-        reply_id = agent.state.reply_id
-        if not reply_id or reply_id in self._seen_auto_memory_reply_ids:
+        self._repair_tagged_auto_memory_search_context(agent)
+        turn_marker = self._latest_user_turn_marker(agent.state.context)
+        if (
+            not turn_marker
+            or turn_marker in self._seen_auto_memory_turn_markers
+        ):
             return
-        self._repair_tagged_auto_memory_search_context(
-            agent,
-            reply_id=reply_id,
-        )
-        self._seen_auto_memory_reply_ids[reply_id] = None
-        if len(self._seen_auto_memory_reply_ids) > MAX_AUTO_MEMORY_REPLY_IDS:
-            oldest_key = next(iter(self._seen_auto_memory_reply_ids))
-            self._seen_auto_memory_reply_ids.pop(oldest_key)
-        self._pending_auto_memory_reply_ids.append(reply_id)
+
+        self._seen_auto_memory_turn_markers[turn_marker] = None
+        if (
+            len(self._seen_auto_memory_turn_markers)
+            > MAX_AUTO_MEMORY_TURN_MARKERS
+        ):
+            oldest_key = next(iter(self._seen_auto_memory_turn_markers))
+            self._seen_auto_memory_turn_markers.pop(oldest_key)
+        self._pending_auto_memory_turn_markers.append(turn_marker)
 
         interval = self._auto_memory_interval()
         if interval <= 0:
-            self._pending_auto_memory_reply_ids.clear()
+            self._pending_auto_memory_turn_markers.clear()
             return
-        if len(self._pending_auto_memory_reply_ids) < interval:
+        if len(self._pending_auto_memory_turn_markers) < interval:
             return
 
         await self._flush_auto_memory(agent, count=interval)
@@ -141,7 +145,7 @@ class MemoryMiddleware(MiddlewareBase):
         cfg = self._memory_config()
         if (
             cfg.summarize_when_compact
-            and self._pending_auto_memory_reply_ids
+            and self._pending_auto_memory_turn_markers
             and await self._will_compress_context(agent, input_kwargs)
         ):
             await self._flush_auto_memory(agent)
@@ -154,20 +158,23 @@ class MemoryMiddleware(MiddlewareBase):
         *,
         count: int | None = None,
     ) -> None:
-        if not self._pending_auto_memory_reply_ids:
+        if not self._pending_auto_memory_turn_markers:
             return
 
         if count is None:
-            reply_ids = list(self._pending_auto_memory_reply_ids)
-            self._pending_auto_memory_reply_ids.clear()
+            turn_markers = list(self._pending_auto_memory_turn_markers)
+            self._pending_auto_memory_turn_markers.clear()
         else:
-            reply_ids = self._pending_auto_memory_reply_ids[:count]
-            del self._pending_auto_memory_reply_ids[:count]
+            turn_markers = self._pending_auto_memory_turn_markers[:count]
+            del self._pending_auto_memory_turn_markers[:count]
 
-        messages = self._messages_for_reply_ids(
-            self._normal_memory_messages(list(agent.state.context)),
-            reply_ids=reply_ids,
-            agent_name=agent.name,
+        self._repair_tagged_auto_memory_search_context(agent)
+        normal_messages = self._normal_memory_messages(
+            list(agent.state.context),
+        )
+        messages = self._messages_for_user_turns(
+            normal_messages,
+            turn_markers=turn_markers,
         )
         if not messages:
             return
@@ -175,12 +182,20 @@ class MemoryMiddleware(MiddlewareBase):
         try:
             await self._memory_manager.auto_memory(
                 messages,
-                session_id=agent.state.session_id,
-                reply_id=reply_ids[-1],
-                reply_ids=reply_ids,
+                session_id=self._agent_session_id(agent),
             )
         except Exception:
             logger.exception("MemoryMiddleware auto_memory failed")
+
+    @staticmethod
+    def _agent_session_id(agent: "Agent") -> str:
+        session_id = str(getattr(agent.state, "session_id", "") or "")
+        if session_id:
+            return session_id
+        request_context = getattr(agent, "_request_context", None) or {}
+        if isinstance(request_context, dict):
+            return str(request_context.get("session_id") or "")
+        return ""
 
     @staticmethod
     async def _will_compress_context(
@@ -261,8 +276,6 @@ class MemoryMiddleware(MiddlewareBase):
     def _repair_tagged_auto_memory_search_context(
         cls,
         agent: "Agent",
-        *,
-        reply_id: str,
     ) -> None:
         """Split real reply blocks merged into tagged auto-search messages."""
         context = getattr(agent.state, "context", None) or []
@@ -293,7 +306,6 @@ class MemoryMiddleware(MiddlewareBase):
             context.insert(
                 idx + 1,
                 Msg(
-                    id=reply_id,
                     name=agent.name,
                     role="assistant",
                     content=deepcopy(reply_blocks),
@@ -303,13 +315,25 @@ class MemoryMiddleware(MiddlewareBase):
             return
 
     @staticmethod
-    def _messages_for_reply_ids(
+    def _latest_user_turn_marker(messages: list["Msg"]) -> str:
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
+            if msg.role != "user":
+                continue
+            return MemoryMiddleware._user_turn_marker(msg, idx)
+        return ""
+
+    @staticmethod
+    def _user_turn_marker(msg: "Msg", idx: int) -> str:
+        return msg.id or f"idx:{idx}"
+
+    @staticmethod
+    def _messages_for_user_turns(
         messages: list["Msg"],
         *,
-        reply_ids: list[str],
-        agent_name: str,
+        turn_markers: list[str],
     ) -> list["Msg"]:
-        targets = set(reply_ids)
+        targets = set(turn_markers)
         if not targets:
             return []
 
@@ -317,9 +341,8 @@ class MemoryMiddleware(MiddlewareBase):
         last_idx: int | None = None
         for idx, msg in enumerate(messages):
             if (
-                msg.role == "assistant"
-                and msg.name == agent_name
-                and msg.id in targets
+                msg.role == "user"
+                and MemoryMiddleware._user_turn_marker(msg, idx) in targets
             ):
                 if first_idx is None:
                     first_idx = idx
@@ -328,14 +351,13 @@ class MemoryMiddleware(MiddlewareBase):
         if first_idx is None or last_idx is None:
             return []
 
-        start_idx = 0
-        for idx in range(first_idx - 1, -1, -1):
-            msg = messages[idx]
-            if msg.role == "assistant" and msg.name == agent_name:
-                start_idx = idx + 1
+        end_idx = len(messages)
+        for idx in range(last_idx + 1, len(messages)):
+            if messages[idx].role == "user":
+                end_idx = idx
                 break
 
-        return messages[start_idx : last_idx + 1]
+        return messages[first_idx:end_idx]
 
 
 class ToolResultPruningMiddleware(MiddlewareBase):

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -311,6 +311,7 @@ class MemoryMiddleware(MiddlewareBase):
             context.insert(
                 idx + 1,
                 Msg(
+                    id=agent.state.reply_id,
                     name=agent.name,
                     role="assistant",
                     content=deepcopy(reply_blocks),

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -24,19 +24,19 @@ from agentscope.middleware import MiddlewareBase
 from agentscope.message import Msg, TextBlock, ToolCallBlock, ToolResultBlock
 
 from .tools.utils import truncate_text_output, DEFAULT_MAX_BYTES
-from ..constant import TRUNCATION_NOTICE_MARKER
+from ..constant import (
+    AUTO_CONTINUE_MESSAGE_TAG,
+    AUTO_MEMORY_SEARCH_MESSAGE_TAG,
+    AUTO_MEMORY_SEARCH_TEXT,
+    QWENPAW_MESSAGE_TAG_KEY,
+    TRUNCATION_NOTICE_MARKER,
+)
 
 if TYPE_CHECKING:
     from agentscope.agent import Agent
 
 logger = logging.getLogger(__name__)
 MAX_AUTO_MEMORY_TURN_MARKERS = 1000
-QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
-AUTO_MEMORY_SEARCH_MESSAGE_TAG = "auto_memory_search"
-AUTO_CONTINUE_MESSAGE_TAG = "auto_continue"
-AUTO_MEMORY_SEARCH_TEXT = (
-    "Find memory relevant to the latest user request and conversation context."
-)
 
 
 class MemoryMiddleware(MiddlewareBase):
@@ -262,7 +262,7 @@ class MemoryMiddleware(MiddlewareBase):
     @classmethod
     def _is_memory_user_turn(cls, msg: "Msg") -> bool:
         return msg.role == "user" and cls._message_tag(msg) not in {
-            AUTO_CONTINUE_MESSAGE_TAG
+            AUTO_CONTINUE_MESSAGE_TAG,
         }
 
     @classmethod

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -325,12 +325,8 @@ class MemoryMiddleware(MiddlewareBase):
             msg = messages[idx]
             if not MemoryMiddleware._is_memory_user_turn(msg):
                 continue
-            return MemoryMiddleware._user_turn_marker(msg, idx)
+            return msg.id
         return ""
-
-    @staticmethod
-    def _user_turn_marker(msg: "Msg", idx: int) -> str:
-        return msg.id or f"idx:{idx}"
 
     @staticmethod
     def _messages_for_user_turns(
@@ -347,7 +343,7 @@ class MemoryMiddleware(MiddlewareBase):
         for idx, msg in enumerate(messages):
             if (
                 MemoryMiddleware._is_memory_user_turn(msg)
-                and MemoryMiddleware._user_turn_marker(msg, idx) in targets
+                and msg.id in targets
             ):
                 if first_idx is None:
                     first_idx = idx

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -434,6 +434,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
                     name="user",
                     role="user",
                     content=[TextBlock(type="text", text=hint_body)],
+                    metadata={"qwenpaw_tag": "auto_continue"},
                 ),
             )
             return  # outer loop continues → _check_next_action → reasoning

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -23,7 +23,9 @@ from agentscope.tool import Toolkit
 from .skill_system import get_workspace_skills_dir
 from ..modes.coding import CodingModeMixin
 from ..constant import (
+    AUTO_CONTINUE_MESSAGE_TAG,
     MEDIA_UNSUPPORTED_PLACEHOLDER,
+    QWENPAW_MESSAGE_TAG_KEY,
     WORKING_DIR,
 )
 from ..providers.model_capability_cache import get_capability_cache
@@ -434,7 +436,9 @@ class QwenPawAgent(CodingModeMixin, Agent):
                     name="user",
                     role="user",
                     content=[TextBlock(type="text", text=hint_body)],
-                    metadata={"qwenpaw_tag": "auto_continue"},
+                    metadata={
+                        QWENPAW_MESSAGE_TAG_KEY: AUTO_CONTINUE_MESSAGE_TAG,
+                    },
                 ),
             )
             return  # outer loop continues → _check_next_action → reasoning

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -549,7 +549,7 @@ class AutoMemorySearchConfig(BaseModel):
     )
 
     persist_to_context: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Whether to persist auto memory search tool_call/tool_result "
             "messages into the conversation context"
@@ -672,7 +672,7 @@ class ReMeLightMemoryConfig(BaseModel):
     )
 
     auto_memory_interval: int | None = Field(
-        default=None,
+        default=5,
         description="Auto memory every N user queries. 1 means auto "
         "memory after every user query, 2 means every 2 queries, etc. "
         "None or <= 0 disables periodic auto memory. WARNING: Setting "

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -115,6 +115,14 @@ KEYRING_ACCOUNT_ENV = "QWENPAW_KEYRING_ACCOUNT"
 
 PROJECT_NAME = "QwenPaw"
 
+# Message metadata tags shared across agent middleware and memory managers.
+QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
+AUTO_MEMORY_SEARCH_MESSAGE_TAG = "auto_memory_search"
+AUTO_CONTINUE_MESSAGE_TAG = "auto_continue"
+AUTO_MEMORY_SEARCH_TEXT = (
+    "Find memory relevant to the latest user request and conversation context."
+)
+
 # Subdirectory name inside each agent's workspace that holds cloned / imported
 # coding projects.
 # Full path = <workspace_dir> / CODING_PROJECT_SUBDIR / <name>


### PR DESCRIPTION
- Refactor auto memory from reply-id tracking to user-turn marker tracking
- Replace `reply_id` tracking with user turn markers
- Rename `MAX_AUTO_MEMORY_REPLY_IDS` to `MAX_AUTO_MEMORY_TURN_MARKERS`
- Update `MemoryMiddleware` to use turn markers instead of reply IDs
- Add `_agent_session_id` helper for session ID retrieval
- Remove `reply_id` / `reply_ids` parameters from ReMe auto-memory flow
- Add `daily_write` operation to ReMe configuration
- Enhance `auto_dream` description and parameters
- Skip unchanged memory update inbox pushes when ReMe reports `modified=False`
- Improve logging with modified status information
- Add session_id validation in `auto_memory`
- Bump `reme-ai` from `0.4.0.2` to `0.4.0.4`

## Description

This PR refactors middleware-driven auto memory to group messages by user turns instead of assistant reply IDs. This makes periodic auto-memory extraction align with user queries, avoids auto-continue messages being treated as new user turns, and keeps auto memory search context separate from normal memory persistence.

It also updates the ReMe light defaults so memory search no longer pollutes conversation context by default, while periodic auto-memory is enabled at a conservative cadence.

**Related Issue:** N/A

**Security Considerations:** No new credentials, network endpoints, or authorization paths are introduced.

## Breaking Changes

1. `running.reme_light_memory_config.auto_memory_search_config.persist_to_context`
   default changed from `True` to `False`.

   Reason: auto memory search results should be injected into the model call without being persisted into the long-lived conversation context by default. This reduces context noise and prevents search tool call/result messages from later being treated as normal conversation history.

   Migration: if your workflow depends on auto memory search messages remaining in `agent.state.context`, explicitly set:

   ```yaml
   running:
     reme_light_memory_config:
       auto_memory_search_config:
         persist_to_context: true
   ```

2. `running.reme_light_memory_config.auto_memory_interval`
   default changed from `None` to `5`.

   Reason: ReMe light now enables middleware-driven periodic auto-memory by default, batching every five user queries to avoid writing memory on every turn while still preserving conversation progress.

   Migration: to keep the previous disabled behavior, explicitly set:

   ```yaml
   running:
     reme_light_memory_config:
       auto_memory_interval: null
   ```

   You can also set `auto_memory_interval: 0` or any negative value to disable periodic auto-memory.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

- `python -m py_compile src/qwenpaw/agents/middlewares.py`

## Local Verification Evidence

```bash
python -m py_compile src/qwenpaw/agents/middlewares.py
```

## Additional Notes

- Removed the redundant second `_repair_tagged_auto_memory_search_context` call on the `on_reply` auto-flush path. `_flush_auto_memory()` still repairs context by default for other callers such as context compression.
