### PR TITLE
fix(providers): sanitize nullable tool schemas

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Callable
 
 from agentscope.model import OpenAIChatModel
 from agentscope.model._model_response import ChatResponse
@@ -235,6 +235,61 @@ _MAP_SCHEMA_KEYWORDS = frozenset(
 )
 
 
+def _walk_schema(
+    schema: dict[str, Any],
+    transform: Callable[[Any], Any],
+    *,
+    dependency_schema_types: tuple[type, ...] = (dict,),
+) -> dict[str, Any]:
+    """Walk known JSON Schema child positions using *transform*."""
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key in _SINGLE_SCHEMA_KEYWORDS:
+            if key == "items" and isinstance(value, list):
+                result[key] = [transform(item) for item in value]
+            else:
+                result[key] = transform(value)
+        elif key in _ARRAY_SCHEMA_KEYWORDS:
+            if isinstance(value, list):
+                result[key] = [transform(item) for item in value]
+            else:
+                result[key] = value
+        elif key in _MAP_SCHEMA_KEYWORDS:
+            if isinstance(value, dict):
+                result[key] = {
+                    item_key: transform(item_value)
+                    for item_key, item_value in value.items()
+                }
+            else:
+                result[key] = value
+        elif key == "dependencies" and isinstance(value, dict):
+            # draft-07: value per key may be a schema or a string array.
+            result[key] = {
+                item_key: (
+                    transform(item_value)
+                    if isinstance(item_value, dependency_schema_types)
+                    else item_value
+                )
+                for item_key, item_value in value.items()
+            }
+        else:
+            result[key] = value
+    return result
+
+
+def _strip_boolean_schema_special_cases(schema: Any) -> Any:
+    if not isinstance(schema, dict):
+        return schema
+    return {
+        key: value
+        for key, value in schema.items()
+        if not (
+            (key == "additionalProperties" and value is True)
+            or (key == "required" and isinstance(value, bool))
+        )
+    }
+
+
 # pylint: disable=too-many-branches
 def _sanitize_boolean_schemas(schema: Any) -> Any:
     """Position-aware sanitizer for boolean JSON Schema values.
@@ -270,48 +325,112 @@ def _sanitize_boolean_schemas(schema: Any) -> Any:
         return {"not": {}}
     if not isinstance(schema, dict):
         return schema
+    return _walk_schema(
+        _strip_boolean_schema_special_cases(schema),
+        _sanitize_boolean_schemas,
+        dependency_schema_types=(dict, bool),
+    )
 
-    result: dict[str, Any] = {}
-    for key, value in schema.items():
-        # Strip special-cases intercepted before the keyword dispatch:
-        # `additionalProperties: False` / `: <object>` still fall through
-        # to the `_SINGLE_SCHEMA_KEYWORDS` branch below.
-        if key == "additionalProperties" and value is True:
-            continue
-        if key == "required" and isinstance(value, bool):
+
+def _is_null_schema(schema: Any) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    node_type = schema.get("type")
+    if node_type == "null":
+        return True
+    return isinstance(node_type, list) and set(node_type) == {"null"}
+
+
+def _ensure_object_type_for_untyped_schema(
+    schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Give a permissive nullable fallback an explicit provider type."""
+    if "type" not in schema and not any(
+        key in schema
+        for key in (
+            "$ref",
+            "allOf",
+            "anyOf",
+            "oneOf",
+            "not",
+            "enum",
+            "const",
+        )
+    ):
+        return {**schema, "type": "object"}
+    return schema
+
+
+def _normalize_nullable_type(schema: dict[str, Any]) -> dict[str, Any]:
+    node_type = schema.get("type")
+    if node_type == "null":
+        return {**schema, "type": "object"}
+    if not isinstance(node_type, list) or "null" not in node_type:
+        return schema
+
+    non_null_types = [value for value in node_type if value != "null"]
+    if not non_null_types:
+        return {**schema, "type": "object"}
+    if len(non_null_types) == 1:
+        return {**schema, "type": non_null_types[0]}
+    return {**schema, "type": non_null_types}
+
+
+# pylint: disable=too-many-branches
+def _sanitize_nullable_schemas(schema: Any) -> Any:
+    """Remove JSON Schema ``null`` types from provider tool schemas.
+
+    OpenAI-compatible relays that route to Gemini-style backends often reject
+    functionDeclaration schemas containing nullable branches such as
+    ``anyOf: [{"type": "string"}, {"type": "null"}]``.  Tool parameters are
+    still optional via ``required`` and ``default: null``, so the provider
+    schema can safely expose only the non-null branch.
+    """
+    if isinstance(schema, list):
+        return [_sanitize_nullable_schemas(item) for item in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    node = dict(schema)
+
+    for key in ("anyOf", "oneOf"):
+        variants = node.get(key)
+        if not isinstance(variants, list):
             continue
 
-        if key in _SINGLE_SCHEMA_KEYWORDS:
-            if key == "items" and isinstance(value, list):
-                # draft-07 tuple form
-                result[key] = [_sanitize_boolean_schemas(v) for v in value]
-            else:
-                result[key] = _sanitize_boolean_schemas(value)
-        elif key in _ARRAY_SCHEMA_KEYWORDS:
-            if isinstance(value, list):
-                result[key] = [_sanitize_boolean_schemas(v) for v in value]
-            else:
-                result[key] = value
-        elif key in _MAP_SCHEMA_KEYWORDS:
-            if isinstance(value, dict):
-                result[key] = {
-                    k: _sanitize_boolean_schemas(v) for k, v in value.items()
-                }
-            else:
-                result[key] = value
-        elif key == "dependencies" and isinstance(value, dict):
-            # draft-07: value per key may be a schema or a string array.
-            result[key] = {
-                k: (
-                    _sanitize_boolean_schemas(v)
-                    if isinstance(v, (dict, bool))
-                    else v
-                )
-                for k, v in value.items()
+        non_null_variants = [
+            variant for variant in variants if not _is_null_schema(variant)
+        ]
+        if len(non_null_variants) == len(variants):
+            continue
+
+        if len(non_null_variants) == 1:
+            branch = _sanitize_nullable_schemas(non_null_variants[0])
+            if not isinstance(branch, dict):
+                branch = {}
+            siblings = {
+                sibling_key: sibling_value
+                for sibling_key, sibling_value in node.items()
+                if sibling_key != key
             }
+            sanitized_siblings = _sanitize_nullable_schemas(siblings)
+            merged = dict(branch)
+            if isinstance(sanitized_siblings, dict):
+                for sibling_key, sibling_value in sanitized_siblings.items():
+                    merged.setdefault(sibling_key, sibling_value)
+            return _ensure_object_type_for_untyped_schema(
+                _normalize_nullable_type(merged),
+            )
+
+        if non_null_variants:
+            node[key] = non_null_variants
         else:
-            result[key] = value
-    return result
+            node.pop(key, None)
+            node = _ensure_object_type_for_untyped_schema(node)
+
+    return _normalize_nullable_type(
+        _walk_schema(node, _sanitize_nullable_schemas),
+    )
 
 
 def _collect_defs(schema: dict[str, Any]) -> dict[str, Any]:
@@ -415,13 +534,16 @@ def _sanitize_tool_schemas(
 ) -> list[dict[str, Any]]:
     """Sanitize tool function schemas to be compatible with strict providers.
 
-    Applies two passes over each tool's ``parameters`` schema:
+    Applies three passes over each tool's ``parameters`` schema:
 
     1. **$ref / $defs expansion** — inlines all local ``$ref`` references so
        that models which do not support ``$defs`` (e.g. GLM-5.x) receive a
        flat, self-contained schema.
     2. **Boolean schema sanitization** — replaces boolean JSON Schema values
        (``true`` / ``false``) that strict providers like DeepSeek V4 reject.
+    3. **Nullable schema sanitization** — removes JSON Schema ``null`` type
+       branches that OpenAI-compatible relays to Gemini-style providers reject
+       in function declarations.
     """
     sanitized = []
     for tool in tools:
@@ -436,8 +558,10 @@ def _sanitize_tool_schemas(
         if not isinstance(params, dict):
             sanitized.append(tool)
             continue
-        sanitized_params = _sanitize_boolean_schemas(
-            _expand_schema_refs(params),
+        sanitized_params = _sanitize_nullable_schemas(
+            _sanitize_boolean_schemas(
+                _expand_schema_refs(params),
+            ),
         )
         sanitized.append(
             {**tool, "function": {**func, "parameters": sanitized_params}},
@@ -535,9 +659,11 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                     in _tool_types
                     and (
                         not isinstance(
-                            b.get("id")
-                            if isinstance(b, dict)
-                            else getattr(b, "id", None),
+                            (
+                                b.get("id")
+                                if isinstance(b, dict)
+                                else getattr(b, "id", None)
+                            ),
                             str,
                         )
                         or not (

--- a/tests/unit/providers/test_openai_tool_schema_compat.py
+++ b/tests/unit/providers/test_openai_tool_schema_compat.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from agentscope.tool import Toolkit
+
+from qwenpaw.agents.tools.file_io import read_file
+from qwenpaw.agents.tools.shell import execute_shell_command
+from qwenpaw.governance import PolicyGuardedTool
+from qwenpaw.providers.openai_chat_model_compat import _sanitize_tool_schemas
+
+
+def _type_null_paths(node: Any, path: tuple[str, ...] = ()) -> list[str]:
+    paths: list[str] = []
+    if isinstance(node, dict):
+        node_type = node.get("type")
+        if node_type == "null" or (
+            isinstance(node_type, list) and "null" in node_type
+        ):
+            paths.append(".".join(path + ("type",)))
+        for key, value in node.items():
+            paths.extend(_type_null_paths(value, path + (str(key),)))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            paths.extend(_type_null_paths(value, path + (str(index),)))
+    return paths
+
+
+def _schema_by_name(
+    schemas: list[dict[str, Any]],
+    name: str,
+) -> dict[str, Any]:
+    for schema in schemas:
+        function = schema.get("function", {})
+        if function.get("name") == name:
+            return function["parameters"]
+    raise AssertionError(f"missing tool schema: {name}")
+
+
+def test_sanitize_tool_schemas_removes_nullable_inline_schema_branches() -> (
+    None
+):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo",
+                "description": "demo",
+                "parameters": {
+                    "type": "object",
+                    "required": ["path"],
+                    "properties": {
+                        "path": {
+                            "anyOf": [
+                                {"type": "string", "format": "path"},
+                                {"type": "null"},
+                            ],
+                            "default": None,
+                        },
+                        "config": {
+                            "anyOf": [
+                                {},
+                                {"type": "null"},
+                            ],
+                            "default": None,
+                            "description": "optional config",
+                        },
+                        "nested": {
+                            "type": "object",
+                            "properties": {
+                                "limit": {
+                                    "oneOf": [
+                                        {"type": "integer"},
+                                        {"type": "null"},
+                                    ],
+                                    "default": None,
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    ]
+
+    sanitized = _sanitize_tool_schemas(tools)
+    parameters = sanitized[0]["function"]["parameters"]
+
+    assert not _type_null_paths(sanitized)
+    assert parameters == {
+        "type": "object",
+        "required": ["path"],
+        "properties": {
+            "path": {
+                "type": "string",
+                "format": "path",
+                "default": None,
+            },
+            "config": {
+                "default": None,
+                "description": "optional config",
+                "type": "object",
+            },
+            "nested": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "default": None,
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_sanitize_tool_schemas_removes_nullable_builtin_tool_branches() -> (
+    None
+):
+    tools = [
+        PolicyGuardedTool(
+            read_file,
+            governor=None,
+            request_context={},
+        ),
+        PolicyGuardedTool(
+            execute_shell_command,
+            governor=None,
+            request_context={},
+        ),
+    ]
+    schemas = asyncio.run(Toolkit(tools=tools).get_tool_schemas())
+
+    sanitized = _sanitize_tool_schemas(schemas)
+
+    assert not _type_null_paths(sanitized)
+
+    read_file_params = _schema_by_name(sanitized, "read_file")
+    assert read_file_params["required"] == ["file_path"]
+    start_line = read_file_params["properties"]["start_line"]
+    assert start_line == {
+        "type": "integer",
+        "description": "First line to read (1-based, inclusive).",
+        "default": None,
+    }
+
+    shell_params = _schema_by_name(sanitized, "execute_shell_command")
+    assert shell_params["required"] == ["command"]
+    cwd = shell_params["properties"]["cwd"]
+    assert cwd == {
+        "type": "string",
+        "format": "path",
+        "description": (
+            "The working directory for the command execution.\n"
+            "If None, defaults to the agent workspace."
+        ),
+        "default": None,
+    }
+
+    sandbox_config = shell_params["properties"]["sandbox_config"]
+    assert sandbox_config == {
+        "default": None,
+        "description": (
+            "Sandbox execution configuration compiled from "
+            "governance policy.\n"
+            "When provided, the command executes within a sandboxed "
+            "environment\n"
+            "with the specified mount permissions and network restrictions."
+        ),
+        "type": "object",
+    }
+
+
+def test_sanitize_tool_schemas_removes_null_from_type_arrays() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo",
+                "description": "demo",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "single": {
+                            "type": ["string", "null"],
+                            "default": None,
+                        },
+                        "multiple": {
+                            "type": ["integer", "number", "null"],
+                        },
+                        "null_only": {
+                            "type": ["null"],
+                            "default": None,
+                        },
+                    },
+                },
+            },
+        },
+    ]
+
+    sanitized = _sanitize_tool_schemas(tools)
+    properties = sanitized[0]["function"]["parameters"]["properties"]
+
+    assert properties == {
+        "single": {"type": "string", "default": None},
+        "multiple": {"type": ["integer", "number"]},
+        "null_only": {"type": "object", "default": None},
+    }


### PR DESCRIPTION
## Description

Fixes #5543.

Some OpenAI-compatible relays route tool schemas into Gemini-style `functionDeclaration` validators. QwenPaw's built-in tools can emit nullable JSON Schema branches such as:

```json
{
  "anyOf": [
    { "format": "path", "type": "string" },
    { "type": "null" }
  ],
  "default": null
}
```

Those nullable branches are valid JSON Schema, but the relay rejects them with errors like `schema didn't specify the schema type field`.

This PR extends the OpenAI-compatible tool schema sanitizer so final tool payloads no longer include `type: "null"` branches:

- collapses `anyOf` / `oneOf` nullable branches to the non-null schema;
- removes `"null"` from JSON Schema `type` arrays;
- converts null-only or permissive nullable fallbacks to an explicit `type: "object"`;
- preserves useful metadata such as `description`, `default: null`, and `required`;
- keeps the existing `$ref` expansion and boolean-schema sanitization behavior intact;
- reuses one schema walker for boolean-schema and nullable-schema sanitization.

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts

## Checklist

- [x] Run and pass `pre-commit run --all-files`
- [x] Run and pass relevant tests
- [x] Update documentation if needed (not needed; provider compatibility bug fix)

## Testing

- `env BLACK_CACHE_DIR=/tmp/qwenpaw-black-cache .venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest tests/unit/providers`
- `.venv/bin/pytest tests/unit/providers/test_openai_tool_schema_compat.py tests/unit/providers/test_openai_stream_toolcall_compat.py`
- `uv run --python 3.11 --extra dev pytest` attempted earlier; one unrelated OneBot watchdog test fails locally and also fails when run alone.

## Local Verification Evidence

### pre-commit run --all-files

Command:

```bash
env BLACK_CACHE_DIR=/tmp/qwenpaw-black-cache .venv/bin/pre-commit run --all-files
```

Summary:

```text
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```

### Relevant pytest

Command:

```bash
.venv/bin/pytest tests/unit/providers
```

Summary:

```text
223 passed in 2.06s
```

Command:

```bash
.venv/bin/pytest tests/unit/providers/test_openai_tool_schema_compat.py tests/unit/providers/test_openai_stream_toolcall_compat.py
```

Summary:

```text
5 passed in 0.31s
```

### Full pytest attempt

Command:

```bash
uv run --python 3.11 --extra dev pytest
```

Summary from the earlier full-suite attempt:

```text
1 failed, 3759 passed, 11 skipped, 55 warnings in 971.12s
```

The failure is unrelated to this provider schema change:

```text
FAILED tests/unit/channels/test_onebot_channel.py::TestWatchdog::test_watchdog_restarts_when_port_unreachable
AssertionError: watchdog should have created a new site
```

After rebasing this branch, I also reran that single failing test and it still fails independently:

```bash
uv run --python 3.11 --extra dev pytest tests/unit/channels/test_onebot_channel.py::TestWatchdog::test_watchdog_restarts_when_port_unreachable
```

```text
1 failed in 0.91s
```
