### PR TITLE
fix(hooks): inject user_id and channel into ContextVarsSetupHook

### DIFF
--- a/src/qwenpaw/hooks/request_setup/contextvars_hook.py
+++ b/src/qwenpaw/hooks/request_setup/contextvars_hook.py
@@ -33,8 +33,10 @@ class ContextVarsSetupHook(LifecycleHook):
         )
         from ...app.agent_context import (
             set_current_agent_id,
+            set_current_channel,
             set_current_root_session_id,
             set_current_session_id as _set_app_session_id,
+            set_current_user_id,
         )
 
         if ctx.workspace_dir is not None:
@@ -46,6 +48,8 @@ class ContextVarsSetupHook(LifecycleHook):
         set_current_root_session_id(
             ctx.root_session_id or ctx.session_id or "",
         )
+        set_current_user_id(ctx.request.user_id)
+        set_current_channel(getattr(ctx.request, "channel", None))
 
         try:
             from ...config.config import load_agent_config


### PR DESCRIPTION
## Description

`ContextVarsSetupHook` was missing `set_current_user_id()` and `set_current_channel()` calls, causing `get_current_user_id()` / `get_current_channel()` to always return `None` during agent execution. This broke any downstream code relying on these ContextVar getters (e.g. forked subagent spawning in `_spawn_forked_subagent`).

This PR adds the two missing setter calls in the `PRE_EXECUTE` hook, reading values directly from `ctx.request` which already carries both fields from all upstream entry points (channel adapters, CLI, ACP server).

**Security Considerations:** No security impact. Values are read-only from the already-validated `AgentRequest`; `set_current_channel(None)` is safe for requests without a channel (e.g. headless API calls).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Additional Notes

- Single-file change: `src/qwenpaw/hooks/request_setup/contextvars_hook.py`
- `user_id` uses direct attribute access (`ctx.request.user_id`) consistent with existing `ctx.session_id` / `ctx.agent_id` patterns; `_normalize()` guarantees it is never `None`.
- `channel` uses `getattr(ctx.request, "channel", None)` because it is an `extra="allow"` dynamic field not declared in the Pydantic model.