### PR TITLE
fix(channel): use event content as primary text source in streaming end

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -831,7 +831,8 @@ class BaseChannel(ABC):
                 None,
             )
 
-            accumulated = streaming_buffers.pop(stream_type, "")
+            buf = streaming_buffers.pop(stream_type, "")
+            accumulated = self._extract_text_from_event(event) or buf
             await self.on_streaming_end(
                 request,
                 to_handle,
@@ -841,6 +842,19 @@ class BaseChannel(ABC):
                 accumulated_text=accumulated,
             )
         return True
+
+    @staticmethod
+    def _extract_text_from_event(event: Any) -> str:
+        """Extract concatenated text from event.content list."""
+        content = getattr(event, "content", None)
+        if not content or not isinstance(content, list):
+            return ""
+        parts = []
+        for item in content:
+            text = getattr(item, "text", None)
+            if text:
+                parts.append(text)
+        return "".join(parts)
 
     async def _stream_with_tracker(
         self,


### PR DESCRIPTION
## Description

In `_on_stream_msg_end`, prefer extracting text from the Message Completed
event's `content` list over the streaming buffer. The buffer serves as
fallback only.

This fixes non-streaming responses (e.g. `/clear`) producing empty
streaming cards — the end event always carries the full text, while
the buffer remains empty when no deltas were received.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
