### PR TITLE
fix(channels): process WeCom media-only messages

### DIFF
--- a/src/qwenpaw/app/channels/wecom/channel.py
+++ b/src/qwenpaw/app/channels/wecom/channel.py
@@ -1271,6 +1271,22 @@ class WecomChannel(BaseChannel):
     # Session processing state management
     # ------------------------------------------------------------------
 
+    def _apply_no_text_debounce(
+        self,
+        session_id: str,
+        content_parts: list[Any],
+    ) -> tuple[bool, list[Any]]:
+        """Process media-only WeCom messages without waiting for text."""
+        has_media = any(
+            getattr(part, "type", None)
+            not in (ContentType.TEXT, ContentType.REFUSAL)
+            for part in content_parts
+        )
+        if has_media:
+            pending = self._pending_content_by_session.pop(session_id, [])
+            return True, pending + list(content_parts)
+        return super()._apply_no_text_debounce(session_id, content_parts)
+
     async def _consume_with_tracker(
         self,
         request: "AgentRequest",

--- a/tests/unit/channels/test_wecom.py
+++ b/tests/unit/channels/test_wecom.py
@@ -714,6 +714,103 @@ class TestWecomChannelBuildAgentRequest:
 
 
 # =============================================================================
+# P0: Media-only Debounce Tests
+# =============================================================================
+
+
+class TestWecomChannelMediaOnlyDebounce:
+    """
+    P0: WeCom media-only messages should be processed without waiting for text.
+    """
+
+    def test_file_only_content_processes_immediately(self, wecom_channel):
+        """A pure file message should not be buffered until a text message."""
+        from qwenpaw.schemas import FileContent
+
+        file_part = FileContent(
+            type="file",
+            file_url="/tmp/document.pdf",
+            filename="document.pdf",
+        )
+
+        should_process, merged = wecom_channel._apply_no_text_debounce(
+            "wecom:user_123",
+            [file_part],
+        )
+
+        assert should_process is True
+        assert merged == [file_part]
+        assert (
+            "wecom:user_123" not in wecom_channel._pending_content_by_session
+        )
+
+    def test_native_file_payload_passes_debounce(self, wecom_channel):
+        """A native WeCom file payload should pass debounce."""
+        from qwenpaw.schemas import FileContent
+
+        file_part = FileContent(
+            type="file",
+            file_url="/tmp/document.pdf",
+            filename="document.pdf",
+        )
+        payload = {
+            "channel_id": "wecom",
+            "sender_id": "user_123",
+            "session_id": "wecom:user_123",
+            "content_parts": [file_part],
+            "meta": {"wecom_chat_type": "single"},
+        }
+
+        assert wecom_channel._debounce_payload(payload) is True
+        assert payload["content_parts"] == [file_part]
+        assert (
+            "wecom:user_123" not in wecom_channel._pending_content_by_session
+        )
+
+    def test_media_only_content_prepends_existing_pending_parts(
+        self,
+        wecom_channel,
+    ):
+        """Existing buffered media should be preserved before new media."""
+        from qwenpaw.schemas import FileContent, ImageContent
+
+        image_part = ImageContent(type="image", image_url="/tmp/image.jpg")
+        file_part = FileContent(
+            type="file",
+            file_url="/tmp/document.pdf",
+            filename="document.pdf",
+        )
+        wecom_channel._pending_content_by_session["wecom:user_123"] = [
+            image_part,
+        ]
+
+        should_process, merged = wecom_channel._apply_no_text_debounce(
+            "wecom:user_123",
+            [file_part],
+        )
+
+        assert should_process is True
+        assert merged == [image_part, file_part]
+        assert (
+            "wecom:user_123" not in wecom_channel._pending_content_by_session
+        )
+
+    def test_text_content_keeps_base_debounce_behavior(self, wecom_channel):
+        """Text messages should still process normally."""
+        from qwenpaw.schemas import TextContent
+
+        text_part = TextContent(type="text", text="hello")
+
+        should_process, merged = wecom_channel._apply_no_text_debounce(
+            "wecom:user_123",
+            [text_part],
+        )
+
+        assert should_process is True
+        assert merged == [text_part]
+
+
+# =============================================================================
 # P0: Merge Native Items Tests
 # =============================================================================
 


### PR DESCRIPTION
## Description

Refs #5554.

This PR fixes WeCom media-only messages getting buffered by the base no-text debounce path and never reaching the agent until a later text message arrives.

WeCom already downloads incoming `file`, `image`, and `video` messages and converts them into content blocks. The missing piece was matching the behavior already used by Telegram and OneBot: media-only payloads should be treated as complete user input instead of waiting for text.

The change adds a WeCom-specific `_apply_no_text_debounce()` override that:

- processes media-only content immediately;
- prepends any previously buffered content for the same session;
- keeps normal text-message debounce behavior unchanged.

I am keeping the broader reload/shutdown pending-work issue out of this PR. That affects all manager-queue channels and should be handled separately in a follow-up PR for `ChannelManager` / `UnifiedQueueManager` lifecycle handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend
- [ ] Console
- [x] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit checks locally through the commit hook
- [x] I ran relevant tests locally
- [ ] Documentation updated
- [x] Ready for review

## Testing

Added unit coverage for WeCom media-only debounce behavior:

- pure `FileContent` is processed immediately;
- native WeCom file payloads pass the debounce boundary instead of being buffered;
- pending media is prepended before new media;
- text-only content still follows the base behavior.

## Local Verification Evidence

```bash
git commit --amend --no-edit
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check xml............................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check docstring is first.................................................Passed
check json...........................................(no files to check)Skipped
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.............................................(no files to check)Skipped
```

```bash
.venv/bin/pytest tests/unit/channels/test_wecom.py tests/unit/channels/test_base_core.py -q
139 passed, 1 skipped in 1.48s
```
