### PR TITLE
fix: re-enqueue in-flight batch on CancelledError to prevent message loss during hot-reload

### DIFF
--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -453,6 +453,11 @@ class ChannelManager:
                     f"session={session_id[:30]} "
                     f"priority={priority_level}",
                 )
+                # Re-enqueue in-flight batch so messages are not lost
+                # during hot-reload (zero-downtime agent restart).
+                if batch:
+                    for item in reversed(batch):
+                        await queue.put(item)
                 break
             except Exception:
                 logger.exception(


### PR DESCRIPTION
## Bug

When `AgentConfigWatcher` triggers a zero-downtime reload while `_consume_queue` is processing a batch (e.g. file upload), the `CancelledError` causes the already-dequeued batch to be silently lost. The new Consumer starts with an empty queue and the message is gone forever.

## Root Cause

In `_consume_queue` (`manager.py`), when `CancelledError` is raised during `_process_batch()`, the batch has already been taken out of the queue via `queue.get()` but has not been processed. The current handler simply `break`s out of the loop, discarding the batch.

## Reproduce

1. User sends a file via WeChat Work to an agent
2. Consumer dequeues the batch and starts `_process_batch()`
3. During processing, `AgentConfigWatcher` detects an `agent.json` change (e.g. `last_dispatch` update) and triggers hot-reload
4. `stop_all()` → `CancelledError` thrown inside `_process_batch()`
5. Consumer catches the error and `break`s, batch is discarded
6. New Consumer starts with empty queue → file message is permanently lost

## Fix

Re-enqueue the in-flight batch items (in reverse order to preserve FIFO) before breaking out of the consumer loop so the new Consumer can pick them up.

```python
except asyncio.CancelledError:
    logger.debug(...)
+   # Re-enqueue in-flight batch so messages are not lost
+   # during hot-reload (zero-downtime agent restart).
+   if batch:
+       for item in reversed(batch):
+           await queue.put(item)
    break
```

## Component(s) Affected

- [x] Channels (UnifiedQueueManager / ChannelManager)
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
