### PR TITLE
fix(plugin): fix the qwenpaw pet plugin

### DIFF
--- a/plugins/bundle/qwenpaw-pet/emitter.py
+++ b/plugins/bundle/qwenpaw-pet/emitter.py
@@ -247,18 +247,19 @@ def _living_desktop_present(host: str, port: int) -> bool:
     health = desktop_health()
     if health and health.get("ok"):
         return True
+    has_claim = False
     try:
         from qwenpaw_pet_desktop import runtime as pet_rt
 
         if pet_rt.spawn_claim_active():
-            return True
+            has_claim = True
         pid = pet_rt.read_pid()
         if pid and pet_rt.is_pid_running(pid):
             return True
     except ImportError:
         pass
-    # Uvicorn may have bound the port before /health responds.
-    if not _tcp_bind_test(host, port):
+
+    if has_claim and not _tcp_bind_test(host, port):
         return True
     return False
 
@@ -365,9 +366,7 @@ def _spawn_desktop_background_impl() -> tuple[bool, str | None]:
                 "Could not pre-create pet bridge token",
                 exc_info=True,
             )
-        if not _tcp_bind_test(host, preferred_port):
-            return False, "Desktop pet is already running or starting."
-        port = preferred_port
+        port = _pick_listen_port(host, preferred_port)
         pet_rt.write_spawn_claim(host, port)
         display_host = (
             "127.0.0.1" if host in ("0.0.0.0", "::", "[::]") else host

--- a/plugins/bundle/qwenpaw-pet/emitter.py
+++ b/plugins/bundle/qwenpaw-pet/emitter.py
@@ -242,25 +242,29 @@ def desktop_health() -> dict[str, Any] | None:
     return None
 
 
-def _living_desktop_present(host: str, port: int) -> bool:
+def _living_desktop_present(
+    host: str,  # pylint: disable=unused-argument
+    port: int,  # pylint: disable=unused-argument
+) -> bool:
     """True when a pet desktop is up or still starting on the bridge port."""
     health = desktop_health()
     if health and health.get("ok"):
         return True
-    has_claim = False
     try:
         from qwenpaw_pet_desktop import runtime as pet_rt
 
+        # A recent spawn claim is authoritative: the child process may
+        # not have written its PID or bound the port yet (especially on
+        # Windows cold starts where PySide6 + uvicorn can take seconds).
+        # Treating the claim as "starting" prevents duplicate spawns
+        # from rapid UI clicks.
         if pet_rt.spawn_claim_active():
-            has_claim = True
+            return True
         pid = pet_rt.read_pid()
         if pid and pet_rt.is_pid_running(pid):
             return True
     except ImportError:
         pass
-
-    if has_claim and not _tcp_bind_test(host, port):
-        return True
     return False
 
 

--- a/plugins/bundle/qwenpaw-pet/plugin.py
+++ b/plugins/bundle/qwenpaw-pet/plugin.py
@@ -5,6 +5,7 @@
 
 import atexit
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -14,6 +15,25 @@ from pathlib import Path
 _plugin_dir = str(Path(__file__).resolve().parent)
 if _plugin_dir not in sys.path:
     sys.path.insert(0, _plugin_dir)
+
+# Evict stale cached sibling modules so hot-reload after plugin
+# reinstall picks up the new files instead of the previous version
+# lingering in ``sys.modules``.
+for _sib in (
+    "emitter",
+    "patch_runner",
+    "patch_approval",
+    "router",
+    "pet_paths",
+):
+    _cached = sys.modules.get(_sib)
+    if _cached is None:
+        continue
+    _cached_file = getattr(_cached, "__file__", None) or ""
+    if _cached_file and os.path.realpath(_cached_file).startswith(
+        os.path.realpath(_plugin_dir) + os.sep,
+    ):
+        del sys.modules[_sib]
 
 from qwenpaw.plugins.api import PluginApi  # noqa: E402
 

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -840,6 +840,29 @@ class PluginLoader:
         for k in stale:
             sys.modules.pop(k, None)
 
+        # Plugins that manipulate ``sys.path`` (e.g. inserting their own
+        # directory) and use bare ``from sibling import …`` load sibling
+        # modules as top-level entries in ``sys.modules`` — the prefix
+        # cleanup above misses them.  Sweep any module whose ``__file__``
+        # lives inside the plugin directory so a reinstall always gets
+        # fresh code.
+        source_resolved = str(record.source_path.resolve()) + os.sep
+        stale_by_file = [
+            k
+            for k, mod in list(sys.modules.items())
+            if (mod_file := getattr(mod, "__file__", None)) is not None
+            and os.path.realpath(mod_file).startswith(source_resolved)
+        ]
+        for k in stale_by_file:
+            sys.modules.pop(k, None)
+
+        # Remove the plugin directory from sys.path (plugins add it at
+        # import time for sibling imports; leaving it leaks into later
+        # imports and prevents clean hot-reload).
+        plugin_dir_str = str(record.source_path.resolve())
+        while plugin_dir_str in sys.path:
+            sys.path.remove(plugin_dir_str)
+
         # Clear all in-memory registry entries for this plugin
         self.registry.unregister_plugin(plugin_id)
 

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -858,10 +858,13 @@ class PluginLoader:
 
         # Remove the plugin directory from sys.path (plugins add it at
         # import time for sibling imports; leaving it leaks into later
-        # imports and prevents clean hot-reload).
-        plugin_dir_str = str(record.source_path.resolve())
-        while plugin_dir_str in sys.path:
-            sys.path.remove(plugin_dir_str)
+        # imports and prevents clean hot-reload).  Compare by realpath
+        # so symlinks or non-resolved spellings of the same directory
+        # are also caught.
+        plugin_dir_real = os.path.realpath(record.source_path)
+        sys.path[:] = [
+            p for p in sys.path if os.path.realpath(p) != plugin_dir_real
+        ]
 
         # Clear all in-memory registry entries for this plugin
         self.registry.unregister_plugin(plugin_id)

--- a/tests/integration/test_plugin_types.py
+++ b/tests/integration/test_plugin_types.py
@@ -20,6 +20,7 @@ uninstall → side-effect gone.
 Reuses _build_sample_plugin_zip pattern from test_plugins.py and the
 _upload_plugin_zip / _delete_plugin helpers.
 """
+
 from __future__ import annotations
 
 import io
@@ -727,12 +728,12 @@ def test_command_plugin_command_actually_registered(app_server) -> None:
         resp = _upload(app_server, pid, _command_plugin_zip(pid))
         assert resp.status_code == 200, app_server.logs_tail()
 
-        logs = app_server.logs_tail(8000)
+        logs = app_server.logs_tail(32000)
         # Look for either the registration log line or the
         # CommandRegistry confirmation. Both should be present.
-        assert expected_cmd in logs, (
-            f"command '{expected_cmd}' not in server logs:\n" f"{logs[-2000:]}"
-        )
+        assert (
+            expected_cmd in logs
+        ), f"command '{expected_cmd}' not in server logs:\n{logs[-2000:]}"
         # Stronger check: explicit registration confirmation.
         assert (
             "Registered plugin control command" in logs


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
