### PR TITLE
fix(plugins): fix official plugin installation failures on QwenPaw 2.0

### DIFF
--- a/plugins/bundle/cloudpaw/hooks.py
+++ b/plugins/bundle/cloudpaw/hooks.py
@@ -388,6 +388,18 @@ def setup_tool_and_prompt_hooks() -> (  # pylint: disable=too-many-statements
         )
         return
 
+    # In QwenPaw 2.0 (agentscope 2.x), the agent no longer builds its
+    # own toolkit or system prompt internally — these are constructed by
+    # AgentBuilder and injected via the constructor.  Skip monkey-patching
+    # when the legacy methods are absent.
+    if not hasattr(QwenPawAgent, "_create_toolkit"):
+        logger.info(
+            "QwenPawAgent._create_toolkit not found (QwenPaw 2.0); "
+            "tool/prompt monkey-patches skipped — use api.register_tool() "
+            "for plugin tools.",
+        )
+        return
+
     _original_create_toolkit = QwenPawAgent._create_toolkit
     _original_build_sys_prompt = QwenPawAgent._build_sys_prompt
 

--- a/plugins/bundle/cloudpaw/plugin.json
+++ b/plugins/bundle/cloudpaw/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "cloudpaw",
   "name": "CloudPaw",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "general",
   "description": "CloudPaw —— QwenPaw 云能力增强插件。用自然语言描述需求，自动完成从资源创建到应用部署的全流程。安装后请完成以下配置：1) 在「环境变量」中配置阿里云 AK-SK（ALIBABA_CLOUD_ACCESS_KEY_ID / ALIBABA_CLOUD_ACCESS_KEY_SECRET）；2) 安装完成后请刷新当前页面以加载插件。",
   "description_i18n": {

--- a/plugins/bundle/cloudpaw/plugin.json
+++ b/plugins/bundle/cloudpaw/plugin.json
@@ -14,7 +14,7 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "1.1.7",
+  "min_version": "2.0.0",
   "meta": {
     "category": "cloud-deployment",
     "features": [

--- a/plugins/tool/gpt-image2/README.md
+++ b/plugins/tool/gpt-image2/README.md
@@ -71,8 +71,8 @@ Generate an image using OpenAI GPT Image 2 model from text prompt only.
 
 **Returns:**
 
-- ImageBlock with the generated image
-- TextBlock with generation metadata
+- DataBlock with the generated image
+- TextContent with generation metadata
 
 ### edit_image_gpt
 
@@ -92,8 +92,8 @@ Edit or generate image using reference images with OpenAI GPT Image 2 model.
 
 **Returns:**
 
-- ImageBlock with the edited/generated image
-- TextBlock with editing metadata
+- DataBlock with the edited/generated image
+- TextContent with editing metadata
 
 **Supported Image Formats:**
 
@@ -103,7 +103,7 @@ Edit or generate image using reference images with OpenAI GPT Image 2 model.
 
 ## Requirements
 
-- QwenPaw >= 1.1.6
+- QwenPaw >= 2.0.0
 - httpx >= 0.24.0
 - Valid OpenAI API key with access to GPT Image 2
 

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -13,7 +13,7 @@
     "backend": "gpt_image2.py"
   },
   "dependencies": ["httpx>=0.24.0"],
-  "min_version": "1.1.7",
+  "min_version": "2.0.0",
   "meta": {
     "tools": [
       {

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "gpt-image2-tool",
   "name": "GPT Image 2 Tool",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "type": "tool",
   "description": "Generate and edit images using OpenAI GPT Image 2 model",
   "description_i18n": {

--- a/plugins/tool/qwen-image/plugin.json
+++ b/plugins/tool/qwen-image/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-image-tool",
   "name": "Qwen-Image Tool",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "tool",
   "description": "Generate and edit images using Alibaba Qwen-Image models",
   "description_i18n": {

--- a/plugins/tool/qwen-image/plugin.json
+++ b/plugins/tool/qwen-image/plugin.json
@@ -2,6 +2,7 @@
   "id": "qwen-image-tool",
   "name": "Qwen-Image Tool",
   "version": "1.0.0",
+  "type": "tool",
   "description": "Generate and edit images using Alibaba Qwen-Image models",
   "description_i18n": {
     "zh-CN": "使用阿里云 Qwen-Image 模型生成与编辑图像",
@@ -12,7 +13,7 @@
     "backend": "qwen_image.py"
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
-  "min_version": "1.1.6",
+  "min_version": "2.0.0",
   "meta": {
     "tools": [
       {

--- a/plugins/tool/wan27/plugin.json
+++ b/plugins/tool/wan27/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "wan27-tool",
   "name": "Wan 2.7 Video Generation Tool",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "tool",
   "description": "Generate videos using Alibaba Wan 2.7 models (text-to-video, image-to-video, reference-to-video)",
   "description_i18n": {

--- a/plugins/tool/wan27/plugin.json
+++ b/plugins/tool/wan27/plugin.json
@@ -2,6 +2,7 @@
   "id": "wan27-tool",
   "name": "Wan 2.7 Video Generation Tool",
   "version": "1.0.0",
+  "type": "tool",
   "description": "Generate videos using Alibaba Wan 2.7 models (text-to-video, image-to-video, reference-to-video)",
   "description_i18n": {
     "zh-CN": "使用阿里云 Wan 2.7 模型生成视频（文生视频、图生视频、参考生视频）",
@@ -12,7 +13,7 @@
     "backend": "wan27.py"
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
-  "min_version": "1.1.6",
+  "min_version": "2.0.0",
   "meta": {
     "tools": [
       {


### PR DESCRIPTION
## Summary

Fix all 5 official plugins failing to install from the CDN catalog on QwenPaw 2.0 due to agentscope 2.x breaking changes.

## Problem

After the agentscope 1.x → 2.0 migration (#4846), the 3 tool-type plugins and CloudPaw bundle fail when installed from the official plugin page:

- Tool plugins (GPT Image 2, Qwen-Image, Wan 2.7): `ImportError: cannot import name 'ImageBlock'/'VideoBlock' from 'agentscope.message'`
- CloudPaw: `AttributeError: type object 'QwenPawAgent' has no attribute '_create_toolkit'`

The plugin Python code was already migrated in #4846, but:

1. `plugin.json` manifests still declared old `min_version` (1.1.x)
2. Plugin version numbers were not bumped, so CDN edge nodes continue serving stale cached ZIPs (immutable 1-year cache keyed by `{plugin_id}-{version}.zip`)
3. CloudPaw's `hooks.py` unconditionally monkey-patches removed Agent methods

## Changes

### Tool plugins (gpt-image2, qwen-image, wan27)

- Bump version to `2.0.0` → new CDN ZIP filename, bypasses immutable cache
- Set `min_version` to `2.0.0` → signals QwenPaw 2.0+ requirement
- Add explicit `"type": "tool"` field (qwen-image, wan27)

### CloudPaw bundle

- Bump version to `0.0.4`
- Set `min_version` to `2.0.0`
- Add `hasattr` guard in `hooks.py` to skip legacy `_create_toolkit` / `_build_sys_prompt` monkey-patches on QwenPaw 2.0

### Documentation

- `plugins/tool/gpt-image2/README.md`
  - Update return-type descriptions from `ImageBlock` / `TextBlock` to `DataBlock` / `TextContent` to match the QwenPaw 2.0 / agentscope 2.x API.
  - Update requirement from `QwenPaw >= 1.1.6` to `QwenPaw >= 2.0.0`.

## How it works after merge

1. Merge PR → publish GitHub Release
2. `plugins-release.yml` triggers → scans `plugins/`, builds new ZIPs with bumped versions
3. CDN index updates (60s cache) → points to new ZIP URLs (e.g. `wan27-tool-2.0.0.zip`)
4. Users see updated versions in official plugin page → install succeeds

## Testing

- Verified all 3 tool plugin modules load without import errors via importlib simulation
- Verified CloudPaw `setup_tool_and_prompt_hooks()` gracefully skips on QwenPaw 2.0
- Updated `gpt-image2` README to reflect QwenPaw 2.0 return types