### PR TITLE
fix: refresh chat on channel session updates

### DIFF
--- a/console/src/components/ConsolePollService/index.tsx
+++ b/console/src/components/ConsolePollService/index.tsx
@@ -2,6 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { MessageCircle, X } from "lucide-react";
 import { consoleApi, type PushMessage } from "../../api/modules/console";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
+import {
+  dispatchSessionUpdated,
+  getSessionIdFromPushMessage,
+} from "../../events/sessionUpdate";
 import styles from "./index.module.less";
 
 const POLL_INTERVAL_MS = 2500;
@@ -57,6 +61,11 @@ export default function ConsolePollService() {
           for (const m of res.messages) {
             if (seen.has(m.id)) continue;
             seen.add(m.id);
+            const updatedSessionId = getSessionIdFromPushMessage(m.text);
+            if (updatedSessionId) {
+              dispatchSessionUpdated(updatedSessionId);
+              continue;
+            }
             newItems.push({ ...m, dismissAt: now + AUTO_DISMISS_MS });
           }
           if (newItems.length === 0) return;

--- a/console/src/events/sessionUpdate.ts
+++ b/console/src/events/sessionUpdate.ts
@@ -1,0 +1,20 @@
+export const SESSION_UPDATED_EVENT = "qwenpaw:session-updated";
+export const SESSION_UPDATED_PUSH_PREFIX = "session_updated:";
+
+export interface SessionUpdatedEventDetail {
+  sessionId: string;
+}
+
+export function getSessionIdFromPushMessage(text?: string): string | null {
+  if (!text?.startsWith(SESSION_UPDATED_PUSH_PREFIX)) return null;
+  const sessionId = text.substring(SESSION_UPDATED_PUSH_PREFIX.length);
+  return sessionId || null;
+}
+
+export function dispatchSessionUpdated(sessionId: string) {
+  window.dispatchEvent(
+    new CustomEvent<SessionUpdatedEventDetail>(SESSION_UPDATED_EVENT, {
+      detail: { sessionId },
+    }),
+  );
+}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -38,6 +38,7 @@ import {
   wrapChatResponseUsageStream,
 } from "./turnUsage";
 import ChatHeaderTitle from "./components/ChatHeaderTitle";
+import { useSessionUpdateRefresh } from "./useSessionUpdateRefresh";
 import ChatSessionInitializer from "./components/ChatSessionInitializer";
 import { ApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { commandsApi } from "../../api/modules/commands";
@@ -1566,6 +1567,8 @@ export default function ChatPage() {
     window.addEventListener("model-switched", handler);
     return () => window.removeEventListener("model-switched", handler);
   }, [fetchMultimodalCaps]);
+
+  useSessionUpdateRefresh(chatIdRef, setRefreshKey);
 
   const pendingClearHistoryRef = useRef(false);
   const whisperSpeechRef = useRef<WhisperSpeechButtonRef>(null);

--- a/console/src/pages/Chat/useSessionUpdateRefresh.test.tsx
+++ b/console/src/pages/Chat/useSessionUpdateRefresh.test.tsx
@@ -1,0 +1,44 @@
+import { act, render, screen } from "@testing-library/react";
+import { useRef, useState } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  dispatchSessionUpdated,
+  getSessionIdFromPushMessage,
+} from "../../events/sessionUpdate";
+import { useSessionUpdateRefresh } from "./useSessionUpdateRefresh";
+
+function Harness({ chatId }: { chatId: string | null }) {
+  const chatIdRef = useRef(chatId);
+  chatIdRef.current = chatId;
+  const [refreshKey, setRefreshKey] = useState(0);
+  useSessionUpdateRefresh(chatIdRef, setRefreshKey);
+  return <div data-testid="refresh-key">{refreshKey}</div>;
+}
+
+describe("useSessionUpdateRefresh", () => {
+  it("extracts session update push message ids", () => {
+    expect(getSessionIdFromPushMessage("session_updated:wecom:user1")).toBe(
+      "wecom:user1",
+    );
+    expect(getSessionIdFromPushMessage("cron message")).toBeNull();
+    expect(getSessionIdFromPushMessage("session_updated:")).toBeNull();
+  });
+
+  it("refreshes only when the updated session is currently open", () => {
+    render(<Harness chatId="wecom:user1" />);
+
+    expect(screen.getByTestId("refresh-key")).toHaveTextContent("0");
+
+    act(() => {
+      dispatchSessionUpdated("wecom:other");
+    });
+
+    expect(screen.getByTestId("refresh-key")).toHaveTextContent("0");
+
+    act(() => {
+      dispatchSessionUpdated("wecom:user1");
+    });
+
+    expect(screen.getByTestId("refresh-key")).toHaveTextContent("1");
+  });
+});

--- a/console/src/pages/Chat/useSessionUpdateRefresh.ts
+++ b/console/src/pages/Chat/useSessionUpdateRefresh.ts
@@ -1,0 +1,27 @@
+import {
+  useEffect,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from "react";
+import {
+  SESSION_UPDATED_EVENT,
+  type SessionUpdatedEventDetail,
+} from "../../events/sessionUpdate";
+
+export function useSessionUpdateRefresh(
+  chatIdRef: RefObject<string | null | undefined>,
+  setRefreshKey: Dispatch<SetStateAction<number>>,
+) {
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { sessionId } = (e as CustomEvent<SessionUpdatedEventDetail>)
+        .detail;
+      if (sessionId && sessionId === chatIdRef.current) {
+        setRefreshKey((k) => k + 1);
+      }
+    };
+    window.addEventListener(SESSION_UPDATED_EVENT, handler);
+    return () => window.removeEventListener(SESSION_UPDATED_EVENT, handler);
+  }, [chatIdRef, setRefreshKey]);
+}

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -39,6 +39,9 @@ from .renderer import MessageRenderer, RenderStyle
 from .schema import ChannelType
 from .access_control import get_access_control_store
 from ...config.utils import load_config
+from ..console_push_store import (
+    append_session_updated as push_store_append_session_updated,
+)
 
 # Optional callback to enqueue payload (set by manager)
 EnqueueCallback = Optional[Callable[[Any], None]]
@@ -948,6 +951,10 @@ class BaseChannel(ABC):
                     to_handle,
                     send_meta,
                 )
+                await self._notify_console_session_updated(
+                    request,
+                    send_meta,
+                )
 
             if self._on_reply_sent:
                 args = self.get_on_reply_sent_args(request, to_handle)
@@ -1383,6 +1390,10 @@ class BaseChannel(ABC):
                     to_handle,
                     send_meta,
                 )
+                await self._notify_console_session_updated(
+                    request,
+                    send_meta,
+                )
             if self._on_reply_sent:
                 args = self.get_on_reply_sent_args(request, to_handle)
                 self._on_reply_sent(self.channel, *args)
@@ -1392,6 +1403,33 @@ class BaseChannel(ABC):
                 request,
                 to_handle,
                 "An error occurred while processing your request.",
+            )
+
+    def _should_notify_console_session_updated(
+        self,
+        send_meta: Optional[Dict[str, Any]],
+    ) -> bool:
+        if self.channel == "console":
+            return False
+        if (send_meta or {}).get("suppress_console_push"):
+            return False
+        return True
+
+    async def _notify_console_session_updated(
+        self,
+        request: "AgentRequest",
+        send_meta: Optional[Dict[str, Any]],
+    ) -> None:
+        if not self._should_notify_console_session_updated(send_meta):
+            return
+        session_id = str(getattr(request, "session_id", "") or "")
+        if not session_id:
+            return
+        try:
+            await push_store_append_session_updated(session_id)
+        except Exception:
+            logger.exception(
+                "failed to push console session update notification",
             )
 
     def _get_response_error_message(self, last_response: Any) -> Optional[str]:

--- a/src/qwenpaw/app/console_push_store.py
+++ b/src/qwenpaw/app/console_push_store.py
@@ -17,6 +17,7 @@ _list: List[Dict[str, Any]] = []
 _lock = asyncio.Lock()
 _MAX_AGE_SECONDS = 60
 _MAX_MESSAGES = 500
+SESSION_UPDATED_PUSH_PREFIX = "session_updated:"
 
 
 async def append(session_id: str, text: str, *, sticky: bool = False) -> None:
@@ -36,6 +37,15 @@ async def append(session_id: str, text: str, *, sticky: bool = False) -> None:
         if len(_list) > _MAX_MESSAGES:
             _list.sort(key=lambda m: m["ts"])
             del _list[: len(_list) - _MAX_MESSAGES]
+
+
+async def append_session_updated(session_id: str) -> None:
+    """Notify the console UI that a session received channel-side updates."""
+    await append(
+        session_id,
+        f"{SESSION_UPDATED_PUSH_PREFIX}{session_id}",
+        sticky=False,
+    )
 
 
 async def take(session_id: str) -> List[Dict[str, Any]]:

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -1356,6 +1356,76 @@ class TestRunProcessLoopIntegration:
         # Verify send_message_content was called
         base_channel.send_message_content.assert_called_once()
 
+    async def test_channel_completion_pushes_console_session_update(
+        self,
+        base_channel,
+    ):
+        """Non-console channel completion should refresh the web chat."""
+        from qwenpaw.schemas import (
+            RunStatus,
+            Event,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        base_channel.channel = "wecom"
+        base_channel.send_message_content = AsyncMock()
+
+        mock_request = MagicMock()
+        mock_request.user_id = "user1"
+        mock_request.session_id = "wecom:user1"
+        mock_request.channel_meta = {}
+
+        async def mock_process(_request):
+            yield Event(
+                object="message",
+                status=RunStatus.Completed,
+                type="message.completed",
+                id="msg-1",
+                created_at=1234567890,
+                message=Message(
+                    type=MessageType.MESSAGE,
+                    role=Role.ASSISTANT,
+                    content=[TextContent(type=ContentType.TEXT, text="Hello")],
+                ),
+            )
+
+        base_channel._process = mock_process
+
+        with patch(
+            "qwenpaw.app.channels.base.push_store_append_session_updated",
+            new_callable=AsyncMock,
+        ) as mock_push:
+            await base_channel._run_process_loop(
+                mock_request,
+                to_handle="user1",
+                send_meta={},
+            )
+
+        mock_push.assert_awaited_once_with("wecom:user1")
+
+    async def test_console_channel_completion_does_not_push_session_update(
+        self,
+        base_channel,
+    ):
+        """Console chat already streams locally and should not remount itself."""
+        mock_request = MagicMock()
+        mock_request.session_id = "console:user1"
+
+        with patch(
+            "qwenpaw.app.channels.base.push_store_append_session_updated",
+            new_callable=AsyncMock,
+        ) as mock_push:
+            await base_channel._notify_console_session_updated(
+                mock_request,
+                send_meta={},
+            )
+
+        mock_push.assert_not_awaited()
+
     @pytest.mark.skip(
         reason="Response/AgentResponse classes removed from schema",
     )


### PR DESCRIPTION
## Summary
- notify the console UI when non-console channel processing completes
- convert session update pushes into browser events and refresh the currently open chat
- add backend and frontend coverage for the refresh path

## Testing
- `npx vitest run src/pages/Chat/useSessionUpdateRefresh.test.tsx`
- `npx tsc -b --noEmit`
- `python -m compileall src/qwenpaw/app/channels/base.py src/qwenpaw/app/console_push_store.py`
- manual backend `_run_process_loop` check with the installed QwenPaw venv

Note: full `pytest` was not run locally because the available Python environments do not include pytest and the attempted temporary install was blocked by PyPI SSL connectivity.