### PR TITLE
feat(channels): make no-text debounce configurable

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -4,6 +4,7 @@
 """
 Base Channel: bound to AgentRequest/AgentResponse, unified by process.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -133,6 +134,7 @@ class BaseChannel(ABC):
         streaming_enabled: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
+        no_text_debounce_enabled: bool = True,
     ):
         self._process = process
         self._on_reply_sent = on_reply_sent
@@ -149,6 +151,7 @@ class BaseChannel(ABC):
         self.require_mention = require_mention
         self.access_control_dm = access_control_dm
         self.access_control_group = access_control_group
+        self._no_text_debounce_enabled = bool(no_text_debounce_enabled)
         self._language = "zh"
         self._enqueue: EnqueueCallback = None
         self._workspace = None
@@ -297,6 +300,10 @@ class BaseChannel(ABC):
             for c in (contents or [])
         )
 
+    def set_no_text_debounce_enabled(self, enabled: bool) -> None:
+        """Configure whether media-only content waits for follow-up text."""
+        self._no_text_debounce_enabled = bool(enabled)
+
     def _apply_no_text_debounce(
         self,
         session_id: str,
@@ -309,6 +316,13 @@ class BaseChannel(ABC):
         (voice messages are standalone user input, not partial uploads).
         """
         if not self._content_has_text(content_parts):
+            if not self._no_text_debounce_enabled:
+                pending = self._pending_content_by_session.pop(
+                    session_id,
+                    [],
+                )
+                merged = pending + list(content_parts)
+                return (True, merged)
             if self._content_has_audio(content_parts):
                 # Audio-only messages (e.g. voice messages) should be
                 # processed immediately — they are complete user input.

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -167,6 +167,10 @@ class ChannelManager:
                     False,
                 )
                 filter_thinking = ch_cfg.get("filter_thinking", False)
+                no_text_debounce_enabled = ch_cfg.get(
+                    "no_text_debounce_enabled",
+                    None,
+                )
             else:
                 filter_tool_messages = getattr(
                     ch_cfg,
@@ -177,6 +181,11 @@ class ChannelManager:
                     ch_cfg,
                     "filter_thinking",
                     False,
+                )
+                no_text_debounce_enabled = getattr(
+                    ch_cfg,
+                    "no_text_debounce_enabled",
+                    None,
                 )
 
             from_config_kwargs = {
@@ -206,7 +215,7 @@ class ChannelManager:
                 }
 
             try:
-                channels.append(ch_cls.from_config(**filtered_kwargs))
+                channel = ch_cls.from_config(**filtered_kwargs)
             except Exception as e:
                 logger.warning(
                     "Failed to initialize channel '%s', skipping: %s",
@@ -214,6 +223,14 @@ class ChannelManager:
                     e,
                 )
                 continue
+            if no_text_debounce_enabled is not None and hasattr(
+                channel,
+                "set_no_text_debounce_enabled",
+            ):
+                channel.set_no_text_debounce_enabled(
+                    bool(no_text_debounce_enabled),
+                )
+            channels.append(channel)
 
         return cls(channels)
 

--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -74,6 +74,7 @@ class OneBotChannel(BaseChannel):
         share_session_in_group: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
+        no_text_debounce_enabled: bool = False,
     ):
         super().__init__(
             process,
@@ -88,6 +89,7 @@ class OneBotChannel(BaseChannel):
             require_mention=require_mention,
             access_control_dm=access_control_dm,
             access_control_group=access_control_group,
+            no_text_debounce_enabled=no_text_debounce_enabled,
         )
         self.enabled = enabled
         self.bot_prefix = bot_prefix
@@ -181,6 +183,12 @@ class OneBotChannel(BaseChannel):
             ),
             access_control_group=bool(
                 getattr(config, "access_control_group", False),
+            ),
+            no_text_debounce_enabled=(
+                bool(getattr(config, "no_text_debounce_enabled"))
+                if getattr(config, "no_text_debounce_enabled", None)
+                is not None
+                else False
             ),
         )
 
@@ -688,6 +696,8 @@ class OneBotChannel(BaseChannel):
         media (image, audio, video, file), process it immediately
         instead of buffering until a text message arrives.
         """
+        if self._no_text_debounce_enabled:
+            return super()._apply_no_text_debounce(session_id, content_parts)
         has_media = any(
             getattr(part, "type", None)
             not in (ContentType.TEXT, ContentType.REFUSAL)

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -309,6 +309,7 @@ class TelegramChannel(BaseChannel):
         streaming_enabled: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
+        no_text_debounce_enabled: bool = False,
     ):
         super().__init__(
             process,
@@ -324,6 +325,7 @@ class TelegramChannel(BaseChannel):
             streaming_enabled=streaming_enabled,
             access_control_dm=access_control_dm,
             access_control_group=access_control_group,
+            no_text_debounce_enabled=no_text_debounce_enabled,
         )
         self.enabled = enabled
         self._bot_token = bot_token
@@ -477,6 +479,8 @@ class TelegramChannel(BaseChannel):
         content_parts: list[Any],
     ) -> tuple[bool, list[Any]]:
         """Process media-only Telegram messages without waiting for text."""
+        if self._no_text_debounce_enabled:
+            return super()._apply_no_text_debounce(session_id, content_parts)
         has_media = any(
             getattr(part, "type", None)
             not in (ContentType.TEXT, ContentType.REFUSAL)
@@ -616,6 +620,7 @@ class TelegramChannel(BaseChannel):
         show_typing = c.get("show_typing")
         if show_typing is None:
             show_typing = True
+        no_text_debounce_enabled = c.get("no_text_debounce_enabled")
 
         return cls(
             process=process,
@@ -641,6 +646,11 @@ class TelegramChannel(BaseChannel):
             ),
             access_control_group=bool(
                 c.get("access_control_group", False),
+            ),
+            no_text_debounce_enabled=(
+                bool(no_text_debounce_enabled)
+                if no_text_debounce_enabled is not None
+                else False
             ),
         )
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -198,6 +198,7 @@ class BaseChannelConfig(BaseModel):
     bot_prefix: str = ""
     filter_tool_messages: bool = False
     filter_thinking: bool = False
+    no_text_debounce_enabled: Optional[bool] = None
     dm_policy: Literal["open", "allowlist"] = "open"
     group_policy: Literal["open", "allowlist"] = "open"
     allow_from: List[str] = Field(default_factory=list)

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -14,6 +14,7 @@ Corresponding Tier Strategy:
 - This file: As B-tier supplement, covers complex internal logic
   (debounce, merge, permissions)
 """
+
 # pylint: disable=redefined-outer-name,protected-access,unused-argument
 # pylint: disable=reimported,broad-exception-raised,using-constant-test
 from __future__ import annotations
@@ -26,7 +27,6 @@ import pytest
 # Import BaseChannel directly for internal logic testing
 from qwenpaw.app.channels.base import BaseChannel, ProcessHandler
 from qwenpaw.app.channels.console.channel import ConsoleChannel
-
 
 # =============================================================================
 # Test Fixtures (Shared Infrastructure)
@@ -287,6 +287,44 @@ class TestNoTextDebounceBuffering:
         # Verify content is buffered
         assert "session_1" in base_channel._pending_content_by_session
         assert len(base_channel._pending_content_by_session["session_1"]) == 1
+
+    def test_no_text_content_processed_when_debounce_disabled(
+        self,
+        base_channel,
+        content_builder,
+    ):
+        """Disabling no-text debounce should process media-only content."""
+        parts = [content_builder.image("http://a.jpg")]
+
+        base_channel.set_no_text_debounce_enabled(False)
+        should_process, merged = base_channel._apply_no_text_debounce(
+            "session_1",
+            parts,
+        )
+
+        assert should_process is True
+        assert merged == parts
+        assert "session_1" not in base_channel._pending_content_by_session
+
+    def test_no_text_debounce_disabled_releases_existing_buffer(
+        self,
+        base_channel,
+        content_builder,
+    ):
+        """A disabled debounce pass should not strand previous media."""
+        first = content_builder.image("http://1.jpg")
+        second = content_builder.image("http://2.jpg")
+        base_channel._pending_content_by_session["session_1"] = [first]
+
+        base_channel.set_no_text_debounce_enabled(False)
+        should_process, merged = base_channel._apply_no_text_debounce(
+            "session_1",
+            [second],
+        )
+
+        assert should_process is True
+        assert merged == [first, second]
+        assert "session_1" not in base_channel._pending_content_by_session
 
     def test_text_content_releases_buffer(self, base_channel, content_builder):
         """Text content should trigger buffer release"""

--- a/tests/unit/channels/test_manager.py
+++ b/tests/unit/channels/test_manager.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,redefined-outer-name
+"""Unit tests for ChannelManager channel construction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from qwenpaw.app.channels import manager as manager_module
+from qwenpaw.app.channels.base import BaseChannel
+from qwenpaw.app.channels.manager import ChannelManager
+from qwenpaw.schemas import ContentType, ImageContent
+
+
+class _ConfigurableChannel(BaseChannel):
+    """Minimal channel used to verify manager-level config wiring."""
+
+    channel = "configurable"
+
+    @classmethod
+    def from_config(
+        cls,
+        process,
+        config,
+        on_reply_sent=None,
+        show_tool_details=True,
+        filter_tool_messages=False,
+        filter_thinking=False,
+    ):
+        channel = cls(
+            process=process,
+            on_reply_sent=on_reply_sent,
+            show_tool_details=show_tool_details,
+            filter_tool_messages=filter_tool_messages,
+            filter_thinking=filter_thinking,
+        )
+        channel.enabled = getattr(config, "enabled", False)
+        return channel
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def send(self, to_handle: str, text: str, meta=None) -> None:
+        del to_handle, text, meta
+
+
+@pytest.fixture
+def mock_process():
+    async def _process(_request: Any):
+        yield None
+
+    return _process
+
+
+def test_from_config_applies_no_text_debounce_toggle(
+    monkeypatch,
+    mock_process,
+):
+    """Manager should apply the common no-text debounce toggle."""
+    monkeypatch.setattr(
+        manager_module,
+        "get_available_channels",
+        lambda: ["configurable"],
+    )
+    monkeypatch.setattr(
+        manager_module,
+        "get_channel_registry",
+        lambda: {"configurable": _ConfigurableChannel},
+    )
+    config = SimpleNamespace(
+        show_tool_details=True,
+        channels=SimpleNamespace(
+            configurable={
+                "enabled": True,
+                "no_text_debounce_enabled": False,
+            },
+        ),
+    )
+
+    manager = ChannelManager.from_config(mock_process, config)
+
+    assert len(manager.channels) == 1
+    channel = manager.channels[0]
+    parts = [
+        ImageContent(
+            type=ContentType.IMAGE,
+            image_url="https://example.com/image.png",
+        ),
+    ]
+    should_process, merged = channel._apply_no_text_debounce(
+        "session_1",
+        parts,
+    )
+
+    assert should_process is True
+    assert merged == parts

--- a/tests/unit/channels/test_onebot_channel.py
+++ b/tests/unit/channels/test_onebot_channel.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
 """Unit tests for OneBot v11 channel."""
+
 from __future__ import annotations
 
 import asyncio
@@ -12,7 +13,6 @@ from qwenpaw.schemas import (
 )
 
 from qwenpaw.app.channels.onebot.channel import OneBotChannel
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -197,6 +197,59 @@ class TestParseMessageSegments:
             [{"type": "unknown_type", "data": {}}],
         )
         assert len(parts) == 0
+
+
+# ===================================================================
+# No-text debounce
+# ===================================================================
+
+
+class TestOneBotNoTextDebounce:
+    def test_media_only_triggers_immediate_processing_by_default(self):
+        """OneBot should preserve its current media-only default behavior."""
+        from qwenpaw.schemas import (
+            ImageContent,
+        )
+
+        ch = _make_channel()
+        parts = [
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url="https://img.example.com/1.jpg",
+            ),
+        ]
+
+        should_process, merged = ch._apply_no_text_debounce(
+            "session_1",
+            parts,
+        )
+
+        assert should_process is True
+        assert merged == parts
+
+    def test_media_only_uses_base_behavior_when_no_text_debounce_enabled(self):
+        """Enabling no-text debounce should buffer media-only content."""
+        from qwenpaw.schemas import (
+            ImageContent,
+        )
+
+        ch = _make_channel()
+        ch.set_no_text_debounce_enabled(True)
+        parts = [
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url="https://img.example.com/1.jpg",
+            ),
+        ]
+
+        should_process, merged = ch._apply_no_text_debounce(
+            "session_1",
+            parts,
+        )
+
+        assert should_process is False
+        assert merged == []
+        assert ch._pending_content_by_session["session_1"] == parts
 
 
 # ===================================================================

--- a/tests/unit/channels/test_telegram.py
+++ b/tests/unit/channels/test_telegram.py
@@ -21,6 +21,7 @@ Run:
     pytest tests/unit/channels/test_telegram.py -v
     pytest tests/unit/channels/test_telegram.py::TestTelegramChannelInit -v
 """
+
 # pylint: disable=redefined-outer-name,protected-access,unused-argument
 # pylint: disable=broad-exception-raised,using-constant-test
 from __future__ import annotations
@@ -40,7 +41,6 @@ from qwenpaw.schemas import (
     FileContent,
     ContentType,
 )
-
 
 # =============================================================================
 # Fixtures
@@ -1175,6 +1175,30 @@ class TestTelegramNoTextDebounce:
 
         assert should_process is True
         assert len(merged) == 1
+
+    def test_media_only_uses_base_behavior_when_no_text_debounce_enabled(
+        self,
+        telegram_channel,
+    ):
+        """Enabling no-text debounce should buffer media-only content."""
+        telegram_channel.set_no_text_debounce_enabled(True)
+        parts = [
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url="http://example.com/img.jpg",
+            ),
+        ]
+
+        should_process, merged = telegram_channel._apply_no_text_debounce(
+            "session_1",
+            parts,
+        )
+
+        assert should_process is False
+        assert merged == []
+        assert (
+            telegram_channel._pending_content_by_session["session_1"] == parts
+        )
 
     def test_text_content_uses_base_behavior(
         self,

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -1340,17 +1340,18 @@ Field details and structure are in the tables above and [Config & working dir](.
 
 All channels support the following common fields:
 
-| Field                  | Type     | Default  | Description                                                               |
-| ---------------------- | -------- | -------- | ------------------------------------------------------------------------- |
-| `enabled`              | bool     | `false`  | Whether to enable this channel                                            |
-| `bot_prefix`           | string   | `""`     | Bot reply prefix (e.g., `[BOT]`)                                          |
-| `filter_tool_messages` | bool     | `false`  | Whether to filter tool call/output messages                               |
-| `filter_thinking`      | bool     | `false`  | Whether to filter thinking/reasoning content                              |
-| `dm_policy`            | string   | `"open"` | Direct message access policy: `"open"` (open) / `"allowlist"` (whitelist) |
-| `group_policy`         | string   | `"open"` | Group chat access policy: `"open"` (open) / `"allowlist"` (whitelist)     |
-| `allow_from`           | string[] | `[]`     | Whitelist (effective when policy is `"allowlist"`)                        |
-| `deny_message`         | string   | `""`     | Denial message when access is denied                                      |
-| `require_mention`      | bool     | `false`  | Whether @mention is required to respond                                   |
+| Field                      | Type      | Default  | Description                                                                           |
+| -------------------------- | --------- | -------- | ------------------------------------------------------------------------------------- |
+| `enabled`                  | bool      | `false`  | Whether to enable this channel                                                        |
+| `bot_prefix`               | string    | `""`     | Bot reply prefix (e.g., `[BOT]`)                                                      |
+| `filter_tool_messages`     | bool      | `false`  | Whether to filter tool call/output messages                                           |
+| `filter_thinking`          | bool      | `false`  | Whether to filter thinking/reasoning content                                          |
+| `no_text_debounce_enabled` | bool/null | `null`   | Whether media-only messages wait for follow-up text; `null` keeps the channel default |
+| `dm_policy`                | string    | `"open"` | Direct message access policy: `"open"` (open) / `"allowlist"` (whitelist)             |
+| `group_policy`             | string    | `"open"` | Group chat access policy: `"open"` (open) / `"allowlist"` (whitelist)                 |
+| `allow_from`               | string[]  | `[]`     | Whitelist (effective when policy is `"allowlist"`)                                    |
+| `deny_message`             | string    | `""`     | Denial message when access is denied                                                  |
+| `require_mention`          | bool      | `false`  | Whether @mention is required to respond                                               |
 
 ### Multi-modal message support
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -1373,17 +1373,18 @@ pip install "qwenpaw[sip,sip-livekit]"
 
 所有频道都支持以下通用字段：
 
-| 字段                   | 类型     | 默认值   | 说明                                                    |
-| ---------------------- | -------- | -------- | ------------------------------------------------------- |
-| `enabled`              | bool     | `false`  | 是否启用该频道                                          |
-| `bot_prefix`           | string   | `""`     | 机器人回复前缀（如 `[BOT]`）                            |
-| `filter_tool_messages` | bool     | `false`  | 是否过滤工具调用/输出消息                               |
-| `filter_thinking`      | bool     | `false`  | 是否过滤思考/推理内容                                   |
-| `dm_policy`            | string   | `"open"` | 私聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单） |
-| `group_policy`         | string   | `"open"` | 群聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单） |
-| `allow_from`           | string[] | `[]`     | 白名单列表（当 policy 为 `"allowlist"` 时生效）         |
-| `deny_message`         | string   | `""`     | 拒绝访问时的提示消息                                    |
-| `require_mention`      | bool     | `false`  | 是否需要 @机器人 才响应                                 |
+| 字段                       | 类型      | 默认值   | 说明                                                      |
+| -------------------------- | --------- | -------- | --------------------------------------------------------- |
+| `enabled`                  | bool      | `false`  | 是否启用该频道                                            |
+| `bot_prefix`               | string    | `""`     | 机器人回复前缀（如 `[BOT]`）                              |
+| `filter_tool_messages`     | bool      | `false`  | 是否过滤工具调用/输出消息                                 |
+| `filter_thinking`          | bool      | `false`  | 是否过滤思考/推理内容                                     |
+| `no_text_debounce_enabled` | bool/null | `null`   | 是否让无文本媒体消息等待后续文本；`null` 保持频道默认行为 |
+| `dm_policy`                | string    | `"open"` | 私聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单）   |
+| `group_policy`             | string    | `"open"` | 群聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单）   |
+| `allow_from`               | string[]  | `[]`     | 白名单列表（当 policy 为 `"allowlist"` 时生效）           |
+| `deny_message`             | string    | `""`     | 拒绝访问时的提示消息                                      |
+| `require_mention`          | bool      | `false`  | 是否需要 @机器人 才响应                                   |
 
 ### 多模态消息支持
 


### PR DESCRIPTION
## Description

Refs #5554.

This PR adds a common `no_text_debounce_enabled` channel config toggle so users can decide whether media-only messages should wait for follow-up text or be processed immediately.

The implementation keeps existing channel defaults when the field is unset (`null`): base channels continue to debounce media-only content, while Telegram and OneBot keep their existing media-only immediate processing defaults. When the field is explicitly set, `ChannelManager.from_config()` applies it to every channel instance through the shared BaseChannel setter.

For WeCom or any other base-channel path, setting `no_text_debounce_enabled: false` processes media/file-only messages immediately without hardcoding a WeCom-specific bypass. Setting it to `true` makes Telegram/OneBot use the shared base debounce path.

Docs for the common channel fields were updated in both English and Chinese.

## Type of Change

- Feature

## Component(s) Affected

- Channels
- Config
- Documentation
- Tests

## Checklist

- [x] Run and pass `pre-commit run --all-files`
- [x] Run and pass relevant tests (`pytest`)
- [x] Update documentation if needed

## Testing

- Verified the shared BaseChannel behavior when no-text debounce is disabled.
- Verified ChannelManager applies the config toggle to constructed channels.
- Verified WeCom channel tests still pass.
- Verified Telegram and OneBot preserve their current default media-only behavior, and use the base debounce behavior when the toggle is explicitly enabled.
- Verified updated docs with Prettier 3.0.0.

## Local Verification Evidence

```text
env BLACK_CACHE_DIR=/tmp/qwenpaw-black-cache .venv/bin/pre-commit run --all-files
# Passed
```

```text
.venv/bin/pytest tests/unit/channels/test_base_core.py::TestNoTextDebounceBuffering tests/unit/channels/test_manager.py tests/unit/channels/test_wecom.py tests/unit/channels/test_telegram.py::TestTelegramNoTextDebounce tests/unit/channels/test_onebot_channel.py::TestOneBotNoTextDebounce
# 81 passed
```

```text
npx --yes prettier@3.0.0 --check public/docs/channels.en.md public/docs/channels.zh.md
# All matched files use Prettier code style
```