### PR TITLE
feat(channels): add opt-in reply aggregation

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -3,6 +3,7 @@ export interface BaseChannelConfig {
   bot_prefix: string;
   filter_tool_messages?: boolean;
   filter_thinking?: boolean;
+  aggregate_message_replies?: boolean;
   dm_policy?: "open" | "allowlist";
   group_policy?: "open" | "allowlist";
   allow_from?: string[];

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -1065,6 +1065,8 @@
     "filterToolMessagesTooltip": "Show tool call and output messages to users (turn off to hide)",
     "filterThinking": "Show Thinking",
     "filterThinkingTooltip": "Show model thinking/reasoning content to users (turn off to hide)",
+    "aggregateMessageReplies": "Aggregate Replies",
+    "aggregateMessageRepliesTooltip": "Batch normal assistant reply messages from one run into a single channel message",
     "streamingEnabled": "Streaming Output",
     "streamingEnabledDingtalkHint": "Only effective when message type is Card",
     "streamingEnabledFeishuHint": "Requires enabling cardkit:card:write permission in the Feishu Open Platform permission management page",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -710,6 +710,8 @@
     "filterToolMessagesTooltip": "ツール呼び出しと出力メッセージをユーザーに表示します（オフにすると非表示）",
     "filterThinking": "思考過程を表示",
     "filterThinkingTooltip": "モデルの思考・推論内容をユーザーに表示します（オフにすると非表示）",
+    "aggregateMessageReplies": "Aggregate Replies",
+    "aggregateMessageRepliesTooltip": "Batch normal assistant reply messages from one run into a single channel message",
     "streamingEnabled": "ストリーミング出力",
     "streamingEnabledDingtalkHint": "メッセージタイプがCardの場合のみ有効",
     "streamingEnabledFeishuHint": "Feishuオープンプラットフォームの権限管理ページでcardkit:card:write権限を有効にする必要があります",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -913,6 +913,8 @@
     "filterToolMessagesTooltip": "Show tool call and output messages to users (turn off to hide)",
     "filterThinking": "Mostrar Thinking",
     "filterThinkingTooltip": "Show model thinking/reasoning content to users (turn off to hide)",
+    "aggregateMessageReplies": "Aggregate Replies",
+    "aggregateMessageRepliesTooltip": "Batch normal assistant reply messages from one run into a single channel message",
     "streamingEnabled": "Saída em Streaming",
     "streamingEnabledDingtalkHint": "Apenas efetivo quando o tipo de mensagem é Card",
     "streamingEnabledFeishuHint": "Requer habilitar a permissão cardkit:card:write na página de gerenciamento de permissões da Plataforma Aberta Feishu",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -710,6 +710,8 @@
     "filterToolMessagesTooltip": "Показывать пользователям вызовы инструментов и их вывод (выключите, чтобы скрыть)",
     "filterThinking": "Показывать рассуждения",
     "filterThinkingTooltip": "Показывать пользователям рассуждения модели (выключите, чтобы скрыть)",
+    "aggregateMessageReplies": "Aggregate Replies",
+    "aggregateMessageRepliesTooltip": "Batch normal assistant reply messages from one run into a single channel message",
     "streamingEnabled": "Потоковый вывод",
     "streamingEnabledDingtalkHint": "Действует только при типе сообщения Card",
     "streamingEnabledFeishuHint": "Необходимо включить разрешение cardkit:card:write на странице управления разрешениями открытой платформы Feishu",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -935,6 +935,8 @@
     "filterToolMessagesTooltip": "Hiển thị lời gọi công cụ và kết quả cho người dùng (tắt để ẩn)",
     "filterThinking": "Hiển thị suy luận",
     "filterThinkingTooltip": "Hiển thị nội dung suy luận của mô hình (tắt để ẩn)",
+    "aggregateMessageReplies": "Aggregate Replies",
+    "aggregateMessageRepliesTooltip": "Batch normal assistant reply messages from one run into a single channel message",
     "streamingEnabled": "Xuất streaming",
     "ackMessage": "Tin nhắn xác nhận",
     "ackMessageTooltip": "Gửi phản hồi tức thì khi nhận được tin nhắn, trước khi xử lý",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -904,6 +904,8 @@
     "filterToolMessagesTooltip": "向用户显示工具调用和输出消息（关闭则隐藏）",
     "filterThinking": "显示思考过程",
     "filterThinkingTooltip": "向用户显示模型的思考/推理内容（关闭则隐藏）",
+    "aggregateMessageReplies": "聚合回复消息",
+    "aggregateMessageRepliesTooltip": "将一次运行中的普通助手回复合并为一条频道消息",
     "streamingEnabled": "流式输出",
     "streamingEnabledDingtalkHint": "仅在消息类型为 Card 时生效",
     "streamingEnabledFeishuHint": "需要在飞书开放平台权限管理界面开通 cardkit:card:write 权限",

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -91,6 +91,7 @@ const BASE_FIELDS = [
   "bot_prefix",
   "filter_tool_messages",
   "filter_thinking",
+  "aggregate_message_replies",
   "isBuiltin",
 ];
 
@@ -1427,6 +1428,14 @@ export function ChannelDrawer({
                 label={t("channels.filterThinking")}
                 valuePropName="checked"
                 tooltip={t("channels.filterThinkingTooltip")}
+              >
+                <Switch />
+              </Form.Item>
+              <Form.Item
+                name="aggregate_message_replies"
+                label={t("channels.aggregateMessageReplies")}
+                valuePropName="checked"
+                tooltip={t("channels.aggregateMessageRepliesTooltip")}
               >
                 <Switch />
               </Form.Item>

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -54,6 +54,7 @@ _TOOL_OUTPUT_MESSAGE_TYPES = {
     MessageType.PLUGIN_CALL_OUTPUT,
     MessageType.MCP_TOOL_CALL_OUTPUT,
 }
+_AGGREGATED_REPLY_META_KEY = "_aggregated_message_reply_parts"
 
 if TYPE_CHECKING:
     from qwenpaw.schemas import (
@@ -131,6 +132,7 @@ class BaseChannel(ABC):
         deny_message: str = "",
         require_mention: bool = False,
         streaming_enabled: bool = False,
+        aggregate_message_replies: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
     ):
@@ -139,6 +141,7 @@ class BaseChannel(ABC):
         self._show_tool_details = show_tool_details
         self._filter_tool_messages = filter_tool_messages
         self._filter_thinking = filter_thinking
+        self._aggregate_message_replies = aggregate_message_replies
         self.streaming_enabled = streaming_enabled
         # Legacy fields — stored for backward compat but not used for
         # filtering (new ACL gate handles access control).
@@ -174,6 +177,10 @@ class BaseChannel(ABC):
         self._debounce_seconds: float = 0.0
         self._debounce_pending: Dict[str, List[Any]] = {}
         self._debounce_timers: Dict[str, asyncio.Task[None]] = {}
+
+    def set_message_reply_aggregation(self, enabled: bool) -> None:
+        """Enable or disable reply aggregation for this channel instance."""
+        self._aggregate_message_replies = bool(enabled)
 
     def _is_native_payload(self, payload: Any) -> bool:
         """True if payload is a native dict that can be time-debounced."""
@@ -871,12 +878,20 @@ class BaseChannel(ABC):
 
             err_msg = self._get_response_error_message(last_response)
             if err_msg:
+                await self._flush_aggregated_message_replies(
+                    to_handle,
+                    send_meta,
+                )
                 await self._on_consume_error(
                     request,
                     to_handle,
                     f"Error: {err_msg}",
                 )
             else:
+                await self._flush_aggregated_message_replies(
+                    to_handle,
+                    send_meta,
+                )
                 await self._on_process_completed(
                     request,
                     to_handle,
@@ -901,6 +916,10 @@ class BaseChannel(ABC):
                 f"channel _stream_with_tracker failed: {e}, "
                 f"session={getattr(request, 'session_id', 'N/A')[:30]}, "
                 f"agent={to_handle}",
+            )
+            await self._flush_aggregated_message_replies(
+                to_handle,
+                send_meta,
             )
             await self._on_consume_error(
                 request,
@@ -1306,12 +1325,20 @@ class BaseChannel(ABC):
                     await self.on_event_response(request, event)
             err_msg = self._get_response_error_message(last_response)
             if err_msg:
+                await self._flush_aggregated_message_replies(
+                    to_handle,
+                    send_meta,
+                )
                 await self._on_consume_error(
                     request,
                     to_handle,
                     f"Error: {err_msg}",
                 )
             else:
+                await self._flush_aggregated_message_replies(
+                    to_handle,
+                    send_meta,
+                )
                 await self._on_process_completed(
                     request,
                     to_handle,
@@ -1322,6 +1349,10 @@ class BaseChannel(ABC):
                 self._on_reply_sent(self.channel, *args)
         except Exception:
             logger.exception("channel consume_one failed")
+            await self._flush_aggregated_message_replies(
+                to_handle,
+                send_meta,
+            )
             await self._on_consume_error(
                 request,
                 to_handle,
@@ -1489,7 +1520,94 @@ class BaseChannel(ABC):
         Hook: one message event completed. Default: send_message_content.
         Override for batch/debounce (e.g. DingTalk merge then send).
         """
+        if self._aggregate_message_replies:
+            parts = self._message_to_content_parts(event)
+            reply_text = self._get_aggregateable_reply_text(event, parts)
+            if reply_text is not None:
+                self._append_aggregated_message_reply(send_meta, reply_text)
+                return
+
+            await self._flush_aggregated_message_replies(
+                to_handle,
+                send_meta,
+            )
+            await self._send_message_parts(to_handle, event, parts, send_meta)
+            return
+
         await self.send_message_content(to_handle, event, send_meta)
+
+    def _get_aggregateable_reply_text(
+        self,
+        message: Any,
+        parts: List[OutgoingContentPart],
+    ) -> Optional[str]:
+        """Return text for plain assistant replies safe to batch."""
+        if getattr(message, "type", None) != MessageType.MESSAGE:
+            return None
+        if not parts:
+            return None
+
+        text_parts: List[str] = []
+        for part in parts:
+            part_type = getattr(part, "type", None)
+            if part_type == ContentType.TEXT:
+                text = getattr(part, "text", "") or ""
+            elif part_type == ContentType.REFUSAL:
+                text = getattr(part, "refusal", "") or ""
+            else:
+                return None
+            if text:
+                text_parts.append(text)
+
+        if not text_parts:
+            return None
+        reply_text = "\n".join(text_parts).strip()
+        return reply_text or None
+
+    def _append_aggregated_message_reply(
+        self,
+        send_meta: Dict[str, Any],
+        text: str,
+    ) -> None:
+        """Buffer one plain reply in the current run's send metadata."""
+        if not text:
+            return
+        parts = send_meta.setdefault(_AGGREGATED_REPLY_META_KEY, [])
+        if parts:
+            text = "\n" + text
+        parts.append(TextContent(type=ContentType.TEXT, text=text))
+
+    async def _flush_aggregated_message_replies(
+        self,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Send and clear any buffered plain reply messages for this run."""
+        parts = send_meta.pop(_AGGREGATED_REPLY_META_KEY, [])
+        if not parts:
+            return
+        await self.send_content_parts(to_handle, parts, send_meta)
+
+    async def _send_message_parts(
+        self,
+        to_handle: str,
+        message: Any,
+        parts: List[OutgoingContentPart],
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Send pre-rendered message parts without rendering twice."""
+        if not parts:
+            logger.debug(
+                f"channel send_message_content: no parts for to_handle="
+                f"{to_handle}, skip send",
+            )
+            return
+        logger.debug(
+            f"channel send_message_content: to_handle={to_handle} "
+            f"parts_count={len(parts)} "
+            f"part_types={[getattr(p, 'type', None) for p in parts]}",
+        )
+        await self.send_content_parts(to_handle, parts, meta)
 
     async def on_event_response(
         self,
@@ -1565,18 +1683,7 @@ class BaseChannel(ABC):
         multi-part sending.
         """
         parts = self._message_to_content_parts(message)
-        if not parts:
-            logger.debug(
-                f"channel send_message_content: no parts for to_handle="
-                f"{to_handle}, skip send",
-            )
-            return
-        logger.debug(
-            f"channel send_message_content: to_handle={to_handle} "
-            f"parts_count={len(parts)} "
-            f"part_types={[getattr(p, 'type', None) for p in parts]}",
-        )
-        await self.send_content_parts(to_handle, parts, meta)
+        await self._send_message_parts(to_handle, message, parts, meta)
 
     def _truncate_stream_tool_chunk(
         self,
@@ -1735,10 +1842,10 @@ class BaseChannel(ABC):
         Subclasses must implement from_config(process, config, on_reply_sent).
 
         show_tool_details is global config (not in channel config), so we
-        preserve from self. filter_tool_messages and filter_thinking are
-        per-channel config, so we read from new config.
+        preserve from self. Channel-level delivery/filter options are read
+        from the new config.
         """
-        return self.__class__.from_config(
+        channel = self.__class__.from_config(
             process=self._process,
             config=config,
             on_reply_sent=self._on_reply_sent,
@@ -1754,6 +1861,11 @@ class BaseChannel(ABC):
                 False,
             ),
         )
+        if hasattr(channel, "set_message_reply_aggregation"):
+            channel.set_message_reply_aggregation(
+                getattr(config, "aggregate_message_replies", False),
+            )
+        return channel
 
     async def health_check(self) -> Dict[str, Any]:
         """Return health status for this channel.

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -167,6 +167,10 @@ class ChannelManager:
                     False,
                 )
                 filter_thinking = ch_cfg.get("filter_thinking", False)
+                aggregate_message_replies = ch_cfg.get(
+                    "aggregate_message_replies",
+                    False,
+                )
             else:
                 filter_tool_messages = getattr(
                     ch_cfg,
@@ -178,6 +182,11 @@ class ChannelManager:
                     "filter_thinking",
                     False,
                 )
+                aggregate_message_replies = getattr(
+                    ch_cfg,
+                    "aggregate_message_replies",
+                    False,
+                )
 
             from_config_kwargs = {
                 "process": process,
@@ -186,6 +195,7 @@ class ChannelManager:
                 "show_tool_details": show_tool_details,
                 "filter_tool_messages": filter_tool_messages,
                 "filter_thinking": filter_thinking,
+                "aggregate_message_replies": aggregate_message_replies,
                 "workspace_dir": workspace_dir,
             }
 
@@ -206,7 +216,12 @@ class ChannelManager:
                 }
 
             try:
-                channels.append(ch_cls.from_config(**filtered_kwargs))
+                channel = ch_cls.from_config(**filtered_kwargs)
+                if hasattr(channel, "set_message_reply_aggregation"):
+                    channel.set_message_reply_aggregation(
+                        aggregate_message_replies,
+                    )
+                channels.append(channel)
             except Exception as e:
                 logger.warning(
                     "Failed to initialize channel '%s', skipping: %s",

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -198,6 +198,7 @@ class BaseChannelConfig(BaseModel):
     bot_prefix: str = ""
     filter_tool_messages: bool = False
     filter_thinking: bool = False
+    aggregate_message_replies: bool = False
     dm_policy: Literal["open", "allowlist"] = "open"
     group_policy: Literal["open", "allowlist"] = "open"
     allow_from: List[str] = Field(default_factory=list)

--- a/tests/unit/channels/test_base_core.py
+++ b/tests/unit/channels/test_base_core.py
@@ -14,6 +14,7 @@ Corresponding Tier Strategy:
 - This file: As B-tier supplement, covers complex internal logic
   (debounce, merge, permissions)
 """
+
 # pylint: disable=redefined-outer-name,protected-access,unused-argument
 # pylint: disable=reimported,broad-exception-raised,using-constant-test
 from __future__ import annotations
@@ -26,7 +27,6 @@ import pytest
 # Import BaseChannel directly for internal logic testing
 from qwenpaw.app.channels.base import BaseChannel, ProcessHandler
 from qwenpaw.app.channels.console.channel import ConsoleChannel
-
 
 # =============================================================================
 # Test Fixtures (Shared Infrastructure)
@@ -1355,6 +1355,169 @@ class TestRunProcessLoopIntegration:
 
         # Verify send_message_content was called
         base_channel.send_message_content.assert_called_once()
+
+    async def test_aggregate_message_replies_sends_once_on_completion(
+        self,
+        base_channel,
+    ):
+        """Plain assistant messages can be batched into one reply."""
+        from qwenpaw.schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        def completed_text(text: str) -> Message:
+            return Message(
+                object="message",
+                type=MessageType.MESSAGE,
+                role=Role.ASSISTANT,
+                status=RunStatus.Completed,
+                content=[TextContent(type=ContentType.TEXT, text=text)],
+            )
+
+        async def mock_process(_request):
+            yield completed_text("First step")
+            yield completed_text("Second step")
+
+        base_channel._process = mock_process
+        base_channel.set_message_reply_aggregation(True)
+        base_channel.send_content_parts = AsyncMock()
+
+        mock_request = MagicMock()
+        mock_request.user_id = "user1"
+        mock_request.session_id = "test:user1"
+        mock_request.channel_meta = {}
+
+        await base_channel._run_process_loop(
+            mock_request,
+            to_handle="user1",
+            send_meta={},
+        )
+
+        base_channel.send_content_parts.assert_awaited_once()
+        sent_parts = base_channel.send_content_parts.await_args.args[1]
+        assert [part.text for part in sent_parts] == [
+            "First step",
+            "\nSecond step",
+        ]
+
+    async def test_aggregate_message_replies_default_remains_immediate(
+        self,
+        base_channel,
+    ):
+        """Disabled aggregation preserves one send per completed message."""
+        from qwenpaw.schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ContentType,
+        )
+
+        def completed_text(text: str) -> Message:
+            return Message(
+                object="message",
+                type=MessageType.MESSAGE,
+                role=Role.ASSISTANT,
+                status=RunStatus.Completed,
+                content=[TextContent(type=ContentType.TEXT, text=text)],
+            )
+
+        async def mock_process(_request):
+            yield completed_text("First step")
+            yield completed_text("Second step")
+
+        base_channel._process = mock_process
+        base_channel.send_content_parts = AsyncMock()
+
+        mock_request = MagicMock()
+        mock_request.user_id = "user1"
+        mock_request.session_id = "test:user1"
+        mock_request.channel_meta = {}
+
+        await base_channel._run_process_loop(
+            mock_request,
+            to_handle="user1",
+            send_meta={},
+        )
+
+        assert base_channel.send_content_parts.await_count == 2
+        assert [
+            call.args[1][0].text
+            for call in base_channel.send_content_parts.await_args_list
+        ] == [
+            "First step",
+            "Second step",
+        ]
+
+    async def test_aggregate_message_replies_flushes_before_media(
+        self,
+        base_channel,
+    ):
+        """Media messages are not folded into the text aggregation buffer."""
+        from qwenpaw.schemas import (
+            RunStatus,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+            ImageContent,
+            ContentType,
+        )
+
+        text_message = Message(
+            object="message",
+            type=MessageType.MESSAGE,
+            role=Role.ASSISTANT,
+            status=RunStatus.Completed,
+            content=[TextContent(type=ContentType.TEXT, text="Text first")],
+        )
+        image_message = Message(
+            object="message",
+            type=MessageType.MESSAGE,
+            role=Role.ASSISTANT,
+            status=RunStatus.Completed,
+            content=[
+                ImageContent(
+                    type=ContentType.IMAGE,
+                    image_url="https://example.com/a.png",
+                ),
+            ],
+        )
+
+        async def mock_process(_request):
+            yield text_message
+            yield image_message
+
+        base_channel._process = mock_process
+        base_channel.set_message_reply_aggregation(True)
+        base_channel.send_content_parts = AsyncMock()
+
+        mock_request = MagicMock()
+        mock_request.user_id = "user1"
+        mock_request.session_id = "test:user1"
+        mock_request.channel_meta = {}
+
+        await base_channel._run_process_loop(
+            mock_request,
+            to_handle="user1",
+            send_meta={},
+        )
+
+        assert base_channel.send_content_parts.await_count == 2
+        first_parts = base_channel.send_content_parts.await_args_list[0].args[
+            1
+        ]
+        second_parts = base_channel.send_content_parts.await_args_list[1].args[
+            1
+        ]
+        assert first_parts[0].text == "Text first"
+        assert second_parts[0].image_url == "https://example.com/a.png"
 
     @pytest.mark.skip(
         reason="Response/AgentResponse classes removed from schema",

--- a/tests/unit/channels/test_manager_config.py
+++ b/tests/unit/channels/test_manager_config.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""ChannelManager config propagation tests."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from typing import Any
+
+from qwenpaw.app.channels.manager import ChannelManager
+from qwenpaw.config.config import ChannelConfig, Config, ConsoleConfig
+
+
+async def _noop_process(_request: Any):
+    if False:  # pylint: disable=using-constant-test
+        yield None
+
+
+def test_from_config_applies_aggregate_message_replies_to_channel():
+    """Common channel config should reach the channel instance."""
+    config = Config(
+        channels=ChannelConfig(
+            console=ConsoleConfig(
+                enabled=True,
+                aggregate_message_replies=True,
+            ),
+        ),
+    )
+
+    manager = ChannelManager.from_config(_noop_process, config)
+
+    console = next(ch for ch in manager.channels if ch.channel == "console")
+    assert console._aggregate_message_replies is True

--- a/website/public/docs/channels.en.md
+++ b/website/public/docs/channels.en.md
@@ -1340,17 +1340,18 @@ Field details and structure are in the tables above and [Config & working dir](.
 
 All channels support the following common fields:
 
-| Field                  | Type     | Default  | Description                                                               |
-| ---------------------- | -------- | -------- | ------------------------------------------------------------------------- |
-| `enabled`              | bool     | `false`  | Whether to enable this channel                                            |
-| `bot_prefix`           | string   | `""`     | Bot reply prefix (e.g., `[BOT]`)                                          |
-| `filter_tool_messages` | bool     | `false`  | Whether to filter tool call/output messages                               |
-| `filter_thinking`      | bool     | `false`  | Whether to filter thinking/reasoning content                              |
-| `dm_policy`            | string   | `"open"` | Direct message access policy: `"open"` (open) / `"allowlist"` (whitelist) |
-| `group_policy`         | string   | `"open"` | Group chat access policy: `"open"` (open) / `"allowlist"` (whitelist)     |
-| `allow_from`           | string[] | `[]`     | Whitelist (effective when policy is `"allowlist"`)                        |
-| `deny_message`         | string   | `""`     | Denial message when access is denied                                      |
-| `require_mention`      | bool     | `false`  | Whether @mention is required to respond                                   |
+| Field                       | Type     | Default  | Description                                                               |
+| --------------------------- | -------- | -------- | ------------------------------------------------------------------------- |
+| `enabled`                   | bool     | `false`  | Whether to enable this channel                                            |
+| `bot_prefix`                | string   | `""`     | Bot reply prefix (e.g., `[BOT]`)                                          |
+| `filter_tool_messages`      | bool     | `false`  | Whether to filter tool call/output messages                               |
+| `filter_thinking`           | bool     | `false`  | Whether to filter thinking/reasoning content                              |
+| `aggregate_message_replies` | bool     | `false`  | Whether to batch normal assistant replies from one run into one message   |
+| `dm_policy`                 | string   | `"open"` | Direct message access policy: `"open"` (open) / `"allowlist"` (whitelist) |
+| `group_policy`              | string   | `"open"` | Group chat access policy: `"open"` (open) / `"allowlist"` (whitelist)     |
+| `allow_from`                | string[] | `[]`     | Whitelist (effective when policy is `"allowlist"`)                        |
+| `deny_message`              | string   | `""`     | Denial message when access is denied                                      |
+| `require_mention`           | bool     | `false`  | Whether @mention is required to respond                                   |
 
 ### Multi-modal message support
 

--- a/website/public/docs/channels.zh.md
+++ b/website/public/docs/channels.zh.md
@@ -1373,17 +1373,18 @@ pip install "qwenpaw[sip,sip-livekit]"
 
 所有频道都支持以下通用字段：
 
-| 字段                   | 类型     | 默认值   | 说明                                                    |
-| ---------------------- | -------- | -------- | ------------------------------------------------------- |
-| `enabled`              | bool     | `false`  | 是否启用该频道                                          |
-| `bot_prefix`           | string   | `""`     | 机器人回复前缀（如 `[BOT]`）                            |
-| `filter_tool_messages` | bool     | `false`  | 是否过滤工具调用/输出消息                               |
-| `filter_thinking`      | bool     | `false`  | 是否过滤思考/推理内容                                   |
-| `dm_policy`            | string   | `"open"` | 私聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单） |
-| `group_policy`         | string   | `"open"` | 群聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单） |
-| `allow_from`           | string[] | `[]`     | 白名单列表（当 policy 为 `"allowlist"` 时生效）         |
-| `deny_message`         | string   | `""`     | 拒绝访问时的提示消息                                    |
-| `require_mention`      | bool     | `false`  | 是否需要 @机器人 才响应                                 |
+| 字段                        | 类型     | 默认值   | 说明                                                    |
+| --------------------------- | -------- | -------- | ------------------------------------------------------- |
+| `enabled`                   | bool     | `false`  | 是否启用该频道                                          |
+| `bot_prefix`                | string   | `""`     | 机器人回复前缀（如 `[BOT]`）                            |
+| `filter_tool_messages`      | bool     | `false`  | 是否过滤工具调用/输出消息                               |
+| `filter_thinking`           | bool     | `false`  | 是否过滤思考/推理内容                                   |
+| `aggregate_message_replies` | bool     | `false`  | 是否将一次运行中的普通助手回复聚合为一条消息            |
+| `dm_policy`                 | string   | `"open"` | 私聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单） |
+| `group_policy`              | string   | `"open"` | 群聊访问策略：`"open"`（开放）/ `"allowlist"`（白名单） |
+| `allow_from`                | string[] | `[]`     | 白名单列表（当 policy 为 `"allowlist"` 时生效）         |
+| `deny_message`              | string   | `""`     | 拒绝访问时的提示消息                                    |
+| `require_mention`           | bool     | `false`  | 是否需要 @机器人 才响应                                 |
 
 ### 多模态消息支持
 


### PR DESCRIPTION
## Description

Relates to #5563.

Adds an opt-in channel setting, `aggregate_message_replies`, that batches normal assistant reply messages from one agent run in the shared `BaseChannel` path. The default remains `false`, so existing per-step delivery is unchanged unless a channel enables the setting.

The aggregation is intentionally scoped to normal text/refusal assistant messages. Tool, card, and media messages stay on the existing immediate path; if one appears after buffered text, the buffer is flushed first.

**Related Issue:** Relates to #5563

**Security Considerations:** No credential, auth, or access-control changes. This only changes delivery timing for opt-in normal assistant replies.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [x] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pre-commit` commit hook: passed (`check json`, `mypy`, `black`, `flake8`, `pylint`, etc.).
- `.venv/bin/pytest tests/unit/channels/test_base_core.py::TestRunProcessLoopIntegration tests/unit/channels/test_manager_config.py`: 5 passed, 1 skipped.
- `.venv/bin/pytest tests/contract/channels -q --tb=short`: 243 passed, 2 skipped.
- `cd console && npm run build`: passed. Vite emitted existing chunk warnings only.
- `.venv/bin/pytest tests/unit/channels -v --tb=short`: 1523 passed, 1 skipped, 1 unrelated failure in `tests/unit/channels/test_onebot_channel.py::TestWatchdog::test_watchdog_restarts_when_port_unreachable`.

## Local Verification Evidence

```bash
# commit hook
check python ast: Passed
check json: Passed
mypy: Passed
black: Passed
flake8: Passed
pylint: Passed

.venv/bin/pytest tests/unit/channels/test_base_core.py::TestRunProcessLoopIntegration tests/unit/channels/test_manager_config.py
# 5 passed, 1 skipped

.venv/bin/pytest tests/contract/channels -q --tb=short
# 243 passed, 2 skipped

cd console && npm run build
# built successfully
```

`./scripts/check-channels.sh --changed` did not reach the test phase in this local environment. In the sandbox it failed on dependency download; after network access it failed because the script checks `import copaw` and falls back to system `pip`, which tries to install into `/usr/local/lib/python3.10/dist-packages`. I ran the script-equivalent channel contract command directly with the project venv, and it passed.

## Additional Notes

Verification matrix:

- Shared BaseChannel fallback path: covered.
- Existing default behavior: unchanged and covered.
- Opt-in text/refusal aggregation: covered.
- Tool/card/media behavior: intentionally not aggregated; media flush ordering covered.
- Streaming/edit-card paths: unchanged because handled streaming events do not enter the completed-message fallback.