### PR TITLE
fix(ci): remove bootstrap after Tauri initialization

### DIFF
--- a/scripts/verify/launch_tauri_macos.sh
+++ b/scripts/verify/launch_tauri_macos.sh
@@ -17,11 +17,7 @@ echo "[launch_tauri_macos] Found app: $APP"
 # 2. Remove macOS quarantine (CI download marks it).
 xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
 
-# 3. Pre-delete BOOTSTRAP.md so the agent answers in plain QA mode.
-mkdir -p "$HOME/.qwenpaw/workspaces/default"
-rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
-
-# 4. Launch the full Tauri shell (matches real user double-click).
+# 3. Launch the full Tauri shell (matches real user double-click).
 echo "[launch_tauri_macos] Launching Tauri shell..."
 open "$APP"
 echo "[launch_tauri_macos] open exit=$?"
@@ -29,7 +25,7 @@ sleep 3
 echo "[launch_tauri_macos] Process snapshot after launch:"
 ps -ef | grep -iE "qwenpaw|tauri" | grep -v grep || echo "  (no matching processes)"
 
-# 5. Wait for the sidecar to write the port file and respond.
+# 4. Wait for the sidecar to write the port file and respond.
 #    The sidecar writes desktop_port at WORKING_DIR root (~/.qwenpaw),
 #    not inside the workspace dir.
 PORT_FILE="$HOME/.qwenpaw/desktop_port"
@@ -57,6 +53,10 @@ for i in $(seq 1 60); do
   fi
   sleep 2
 done
+
+# 5. Auto-init creates BOOTSTRAP.md during startup. Remove it afterwards so
+#    the verifier can drive the agent in normal QA mode.
+rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
 
 export BASE_URL="http://127.0.0.1:$PORT"
 echo "BASE_URL=$BASE_URL" >> "$GITHUB_ENV"

--- a/scripts/verify/launch_tauri_windows.ps1
+++ b/scripts/verify/launch_tauri_windows.ps1
@@ -81,20 +81,14 @@ if ($wv2Files) {
   Write-Host "::warning::WebView2 bootstrapper not found in install dir"
 }
 
-# 3. Pre-delete BOOTSTRAP.md so the agent answers in plain QA mode.
-$wsDir = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default"
-New-Item -ItemType Directory -Force -Path $wsDir | Out-Null
-$bootstrapMd = Join-Path $wsDir "BOOTSTRAP.md"
-if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
-
-# 4. Launch the full Tauri shell with CDP debugging enabled.
+# 3. Launch the full Tauri shell with CDP debugging enabled.
 #    This makes WebView2 expose a Chrome DevTools Protocol port so
 #    Playwright can connect_over_cdp() to the real embedded webview.
 $cdpPort = 9222
 $env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--remote-debugging-port=$cdpPort"
 Start-Process -FilePath $tauriExe
 
-# 5. Wait for the sidecar to write the port file and respond.
+# 4. Wait for the sidecar to write the port file and respond.
 #    The sidecar writes desktop_port at WORKING_DIR root (~/.qwenpaw),
 #    not inside the workspace dir.
 $portFile = Join-Path $env:USERPROFILE ".qwenpaw\desktop_port"
@@ -120,6 +114,11 @@ if (-not $port) {
   Write-Host "::error::Tauri app did not start within 120s"
   exit 1
 }
+
+# 5. Auto-init creates BOOTSTRAP.md during startup. Remove it afterwards so
+#    the verifier can drive the agent in normal QA mode.
+$bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
+if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
 
 # 6. Wait for CDP endpoint to become available.
 $cdpUrl = "http://127.0.0.1:$cdpPort"


### PR DESCRIPTION
## Description

Fix the packaged Tauri desktop verification flow on Windows and macOS by
removing `BOOTSTRAP.md` after the sidecar has completed automatic
initialization.

The Tauri launch scripts previously removed the file before starting the app.
On a clean runner, the sidecar then ran `qwenpaw init` and recreated it. The UI
verifier's simple chat prompt could consequently trigger the BootstrapHook,
request a file-read approval, and time out. The legacy desktop verification
already removes the file after initialization.

This change waits for `/api/version` to confirm that the sidecar is ready, then
removes `BOOTSTRAP.md` before the shared UI verifier starts.

**Related Issue:** N/A (follow-up to the failure in
https://github.com/agentscope-ai/QwenPaw/actions/runs/28231605314)

**Security Considerations:** CI-only change. Product permissions, runtime
security policy, and shipped application behavior are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; CI-only change)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Build and install the packaged Tauri desktop application on a clean runner.
2. Wait for the sidecar `/api/version` endpoint to become ready.
3. Confirm the launch helper removes the newly generated `BOOTSTRAP.md`.
4. Run `desktop_verify.py` and confirm the chat test completes without a
   BootstrapHook security approval prompt.

## Local Verification Evidence

```text
git diff --check
# passed

bash -n scripts/verify/launch_tauri_macos.sh
# passed

PowerShell AST parse: scripts/verify/launch_tauri_windows.ps1
# passed

pre-commit run trailing-whitespace --files \
  scripts/verify/launch_tauri_macos.sh \
  scripts/verify/launch_tauri_windows.ps1
# passed
```

Full packaged desktop build and verification:
https://github.com/jinglinpeng/CoPaw/actions/runs/28275946273

- Legacy Windows: passed
- Legacy macOS: passed
- Tauri Windows: build, updater staging, UI verification, and artifact upload passed
- Tauri macOS: build, UI verification, and artifact upload passed

## Additional Notes

The full local pre-commit run could not initialize the unrelated Node/Prettier
hook on Windows (`expected environment for node to be healthy immediately
after install`). The affected shell scripts passed their relevant syntax,
whitespace, and diff checks. The full desktop release workflow passed on the
fork for all four packaged desktop jobs.
