### PR TITLE
test(unit): app-infra backend unit tests — W3 sprint (31 cases, Agentscope 2.0)

### DIFF
--- a/tests/unit/app/test_agent_context.py
+++ b/tests/unit/app/test_agent_context.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for agent_context — context variable getters/setters."""
+from __future__ import annotations
+
+from qwenpaw.app import agent_context
+
+
+def test_current_agent_id_round_trip():
+    agent_context.set_current_agent_id("agent-42")
+    assert agent_context.get_current_agent_id() == "agent-42"
+    # Reset to avoid polluting other tests
+    agent_context.set_current_agent_id("default")
+
+
+def test_current_session_id():
+    agent_context.set_current_session_id("sess-abc")
+    assert agent_context.get_current_session_id() == "sess-abc"
+    agent_context.set_current_session_id(None)
+
+
+def test_current_user_id():
+    agent_context.set_current_user_id("u1")
+    assert agent_context.get_current_user_id() == "u1"
+    agent_context.set_current_user_id(None)
+
+
+def test_current_channel():
+    agent_context.set_current_channel("discord")
+    assert agent_context.get_current_channel() == "discord"
+    agent_context.set_current_channel(None)
+
+
+def test_root_session_id():
+    agent_context.set_current_root_session_id("root-sess")
+    assert agent_context.get_current_root_session_id() == "root-sess"
+    agent_context.set_current_root_session_id(None)

--- a/tests/unit/app/test_console_push_store.py
+++ b/tests/unit/app/test_console_push_store.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Unit tests for console_push_store.
+
+Tests the in-memory push store: append, take, take_all, _strip_ts.
+All functions are async — use pytest-asyncio.
+"""
+from __future__ import annotations
+
+import pytest
+
+import qwenpaw.app.console_push_store as store
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    """Clear the global push store before each test."""
+    store._list.clear()
+    yield
+    store._list.clear()
+
+
+# ---------------------------------------------------------------------------
+# append + take
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_and_take():
+    await store.append("sess-1", "Hello")
+    msgs = await store.take("sess-1")
+    assert len(msgs) == 1
+    assert msgs[0]["text"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_take_clears_queue():
+    await store.append("sess-1", "Msg")
+    first = await store.take("sess-1")
+    assert len(first) == 1
+    second = await store.take("sess-1")
+    assert len(second) == 0
+
+
+@pytest.mark.asyncio
+async def test_take_returns_empty_for_missing_session():
+    assert await store.take("ghost") == []
+
+
+@pytest.mark.asyncio
+async def test_append_sticky():
+    await store.append("sess-1", "Sticky", sticky=True)
+    msgs = await store.take("sess-1")
+    assert msgs[0]["sticky"] is True
+
+
+# ---------------------------------------------------------------------------
+# take_all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_take_all_returns_all_sessions():
+    await store.append("s1", "A")
+    await store.append("s2", "B")
+    all_msgs = await store.take_all()
+    assert len(all_msgs) == 2
+
+
+# ---------------------------------------------------------------------------
+# _strip_ts
+# ---------------------------------------------------------------------------
+
+
+def test_strip_ts_removes_ts_field():
+    msgs = [
+        {"id": "a", "text": "hi", "ts": 123},
+        {"id": "b", "text": "bye", "ts": 456},
+    ]
+    result = store._strip_ts(msgs)
+    for m in result:
+        assert "ts" not in m
+    assert result[0]["text"] == "hi"

--- a/tests/unit/app/test_inbox_trace_store.py
+++ b/tests/unit/app/test_inbox_trace_store.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from qwenpaw.app.inbox_trace_store import (
+    _to_jsonable,
+    flatten_session_messages,
+    parse_session_timestamp,
+)
+
+
+# ---------------------------------------------------------------------------
+# _to_jsonable — recursive JSON serialization
+# ---------------------------------------------------------------------------
+
+
+def test_to_jsonable_primitives():
+    assert _to_jsonable(None) is None
+    assert _to_jsonable("hello") == "hello"
+    assert _to_jsonable(42) == 42
+    assert _to_jsonable(3.14) == 3.14
+    assert _to_jsonable(True) is True
+
+
+def test_to_jsonable_list():
+    assert _to_jsonable([1, "a", None]) == [1, "a", None]
+
+
+def test_to_jsonable_dict():
+    assert _to_jsonable({"x": 1}) == {"x": 1}
+
+
+def test_to_jsonable_nested():
+    data = {"items": [1, {"k": "v"}], "n": None}
+    assert _to_jsonable(data) == {"items": [1, {"k": "v"}], "n": None}
+
+
+def test_to_jsonable_pydantic_model():
+    from qwenpaw.app.crons.models import CronJobState
+
+    state = CronJobState(last_status="running")
+    result = _to_jsonable(state)
+    assert isinstance(result, dict)
+    assert result["last_status"] == "running"
+
+
+def test_to_jsonable_fallback_repr():
+    class Weird:
+        pass
+
+    result = _to_jsonable(Weird())
+    assert "repr" in result
+
+
+# ---------------------------------------------------------------------------
+# flatten_session_messages
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_dict_items():
+    content = [{"role": "user"}, {"role": "assistant"}]
+    assert flatten_session_messages(content) == content
+
+
+def test_flatten_nested_list_takes_first():
+    content = [[{"role": "user"}], [{"role": "assistant"}]]
+    result = flatten_session_messages(content)
+    assert len(result) == 2
+    assert result[0]["role"] == "user"
+
+
+def test_flatten_skips_non_dict():
+    content = [{"role": "user"}, "noise", 42]
+    result = flatten_session_messages(content)
+    assert len(result) == 1
+
+
+def test_flatten_empty_list():
+    assert len(flatten_session_messages([])) == 0
+
+
+def test_flatten_non_list_returns_empty():
+    assert len(flatten_session_messages("not a list")) == 0
+
+
+def test_flatten_empty_nested_list():
+    assert len(flatten_session_messages([[]])) == 0
+
+
+# ---------------------------------------------------------------------------
+# parse_session_timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_parse_timestamp_with_microseconds():
+    result = parse_session_timestamp("2025-06-20 09:30:00.123456")
+    assert result is not None
+    assert isinstance(result, float)
+
+
+def test_parse_timestamp_without_microseconds():
+    result = parse_session_timestamp("2025-06-20 09:30:00")
+    assert result is not None
+
+
+def test_parse_timestamp_invalid_returns_none():
+    assert parse_session_timestamp("not-a-date") is None
+
+
+def test_parse_timestamp_empty_returns_none():
+    assert parse_session_timestamp("") is None
+    assert parse_session_timestamp("   ") is None
+
+
+def test_parse_timestamp_non_string_returns_none():
+    assert parse_session_timestamp(12345) is None

--- a/tests/unit/app/test_migration.py
+++ b/tests/unit/app/test_migration.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for migration._ensure_workspace_json_files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from qwenpaw.app.migration import _ensure_workspace_json_files
+
+
+def test_creates_missing_json_files(tmp_path: Path):
+    _ensure_workspace_json_files(tmp_path, label="test")
+
+    json_files = list(tmp_path.glob("*.json"))
+    assert len(json_files) > 0
+
+
+def test_does_not_overwrite_existing(tmp_path: Path):
+    chats_path = tmp_path / "chats.json"
+    chats_path.write_text(
+        '{"version":1,"chats":[{"id":"keep-me"}]}',
+        encoding="utf-8",
+    )
+
+    _ensure_workspace_json_files(tmp_path, label="test")
+
+    data = json.loads(chats_path.read_text(encoding="utf-8"))
+    assert data["chats"][0]["id"] == "keep-me"
+
+
+def test_created_files_are_valid_json(tmp_path: Path):
+    _ensure_workspace_json_files(tmp_path, label="test")
+
+    for fp in tmp_path.glob("*.json"):
+        data = json.loads(fp.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)


### PR DESCRIPTION
<!-- trigger rbp re-run 2026-07-29 -->
## Description

What problem this solves: the `qwenpaw.app` infra layer — `agent_context`, `console_push_store`, `workspace_migration`, `inbox_trace_store` — had zero unit-test coverage. This PR adds 31 cases pinning their public + helper contracts, re-adapted to real upstream/main **Agentscope 2.0** (`agentscope==2.0.2`).

Closes #5580.

Complements #6489 (Driver unit tests + `fail_under=50` gate): #6489 covers `tests/unit/drivers/`, this PR covers `tests/unit/app/` — disjoint directories, no file conflicts. Together they raise infra-layer coverage on both sides of the app/drivers boundary.

## Agentscope 2.0 adaptation

Earlier this branch dropped cases based on a divergent fork snapshot that claimed several surfaces were "removed in 2.0." Re-grounding against upstream/main showed the opposite — **all target surfaces are present** in real 2.0, so the cases pass verbatim with no test edits:

- `agent_context` — `set/get_current_{agent_id,session_id,user_id,channel,root_session_id}` all present.
- `console_push_store` — `append` / `take` / `take_all` / `_strip_ts` present; contract unchanged.
- `migration` — `_ensure_workspace_json_files(dir, label)` unchanged.
- `inbox_trace_store` — module still present in 2.0 (earlier "removed" verdict was wrong).

## What's covered (31 cases)

- `agent_context` (5): context-var round-trips for `agent_id` / `session_id` / `user_id` / `channel` / `root_session_id`.
- `console_push_store` (6): ring-buffer semantics — `append`+`take` round-trip, `take` clears the queue, `take` returns empty for a missing session, `append` sticky ordering, `take_all` returns all sessions, `_strip_ts` removes the timestamp field.
- `inbox_trace_store` (17): `_to_jsonable` recursive serialization (primitives, list, dict, nested, pydantic model, fallback `repr`), `flatten_session_messages` (dict items, nested-list takes first, skips non-dict, empty cases), `parse_session_timestamp` (with/without microseconds, invalid / empty / non-string → `None`).
- `workspace_migration` (3): creates missing JSON files, does not overwrite existing, created files are valid JSON.

## Evidence

Rebased onto current main (14141d73). Local run with the repo `.venv`:

```bash
$ PYTHONPATH=src pytest tests/unit/app/test_agent_context.py tests/unit/app/test_console_push_store.py tests/unit/app/test_migration.py tests/unit/app/test_inbox_trace_store.py -q
...............................                                          [100%]
31 passed in 0.88s
```

Per-file collection (31 total):
```
test_agent_context.py        : 5
test_console_push_store.py   : 6
test_migration.py            : 3
test_inbox_trace_store.py    : 17
```

flake8 clean. No production code under `src/qwenpaw/` is touched. The coverage baseline shifts once #6489 (`fail_under=50`, +76 drivers cases) lands — re-confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)