### PR TITLE
fix(providers): recover streaming reasoning_content errors

### DIFF
--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -537,110 +537,90 @@ class RetryChatModel(ChatModelBase):
                 ``on_success()`` so stale pauses are cleared but fresh ones
                 (set by a concurrent 429 after this call acquired) are kept.
         """
-        try:
-            async for chunk in self._consume_stream_with_slot(
-                stream,
-                limiter,
-                acquired_at,
-            ):
-                yield chunk
-            return  # stream completed without error
-        except Exception as failed_exc:
-            if _is_retryable(failed_exc) and _is_rate_limit(failed_exc):
-                await limiter.report_rate_limit(
-                    _extract_retry_after(failed_exc),
-                )
+        attempt = current_attempt
+        pending_stream: AsyncGenerator[ChatResponse, None] | None = stream
+        pending_acquired_at = acquired_at
+        reasoning_injected = False
 
-            if (
-                not _is_retryable(failed_exc)
-                or current_attempt >= max_attempts
-            ):
-                raise failed_exc
-
-            delay = _compute_backoff(current_attempt, self._retry_config)
-            logger.warning(
-                "LLM stream failed (attempt %d/%d): %s. Retrying in %.1fs ...",
-                current_attempt,
-                max_attempts,
-                failed_exc,
-                delay,
-            )
-            await asyncio.sleep(delay)
-
-        # Retry loop for stream failures
-        for attempt in range(current_attempt + 1, max_attempts + 1):
-            acquired = False
-            owns_semaphore = True
-            retry_acquired_at: float = 0.0
+        while True:
             try:
+                if pending_stream is not None:
+                    async for chunk in self._consume_stream_with_slot(
+                        pending_stream,
+                        limiter,
+                        pending_acquired_at,
+                    ):
+                        yield chunk
+                    return  # stream completed without error
+
+                acquired = False
+                owns_semaphore = True
+                retry_acquired_at: float = 0.0
                 try:
-                    retry_acquired_at = await asyncio.wait_for(
-                        limiter.acquire(),
-                        timeout=self._rate_limit_config.acquire_timeout,
-                    )
-                    acquired = True
-                except asyncio.TimeoutError as exc:
-                    raise _AcquireTimeoutError(
-                        operation="LLM execution (stream retry)",
-                        retry_after=int(
-                            self._rate_limit_config.acquire_timeout,
-                        ),
-                        details={
-                            "reason": "Timed out waiting for execution slot",
-                        },
-                    ) from exc
-
-                result = await self._inner(*call_args, **call_kwargs)
-
-                if isinstance(result, AsyncGenerator):
-                    owns_semaphore = False
                     try:
-                        async for chunk in self._consume_stream_with_slot(
-                            result,
-                            limiter,
-                            retry_acquired_at,
-                        ):
-                            yield chunk
-                        return  # stream completed without error
-                    except Exception as retry_failed:
-                        if _is_retryable(retry_failed) and _is_rate_limit(
-                            retry_failed,
-                        ):
-                            await limiter.report_rate_limit(
-                                _extract_retry_after(retry_failed),
-                            )
-                        if (
-                            not _is_retryable(retry_failed)
-                            or attempt >= max_attempts
-                        ):
-                            raise retry_failed
-                        retry_delay = _compute_backoff(
-                            attempt,
-                            self._retry_config,
+                        retry_acquired_at = await asyncio.wait_for(
+                            limiter.acquire(),
+                            timeout=self._rate_limit_config.acquire_timeout,
                         )
-                        logger.warning(
-                            "LLM stream retry failed (attempt %d/%d): %s. "
-                            "Retrying in %.1fs ...",
-                            attempt,
-                            max_attempts,
-                            retry_failed,
-                            retry_delay,
-                        )
-                        await asyncio.sleep(retry_delay)
-                else:
+                        acquired = True
+                    except asyncio.TimeoutError as exc:
+                        raise _AcquireTimeoutError(
+                            operation="LLM execution (stream retry)",
+                            retry_after=int(
+                                self._rate_limit_config.acquire_timeout,
+                            ),
+                            details={
+                                "reason": (
+                                    "Timed out waiting for execution slot"
+                                ),
+                            },
+                        ) from exc
+
+                    result = await self._inner(*call_args, **call_kwargs)
+
+                    if isinstance(result, AsyncGenerator):
+                        owns_semaphore = False
+                        pending_stream = result
+                        pending_acquired_at = retry_acquired_at
+                        continue
+
                     yield result
                     return
+                finally:
+                    if owns_semaphore and acquired:
+                        limiter.release()
 
             except Exception as retry_exc:
+                pending_stream = None
+                if (
+                    not reasoning_injected
+                    and _is_missing_reasoning_content_error(retry_exc)
+                    and _inject_reasoning_content(call_args, call_kwargs)
+                ):
+                    reasoning_injected = True
+                    get_capability_cache().learn(
+                        self.model_key,
+                        "needs_reasoning_content",
+                        True,
+                    )
+                    logger.warning(
+                        "Thinking-mode stream requires reasoning_content "
+                        "on every assistant message. Injecting empty "
+                        "values and retrying (learned for future calls).",
+                    )
+                    continue
+
                 if _is_retryable(retry_exc) and _is_rate_limit(retry_exc):
                     await limiter.report_rate_limit(
                         _extract_retry_after(retry_exc),
                     )
+
                 if not _is_retryable(retry_exc) or attempt >= max_attempts:
                     raise
+
                 retry_delay = _compute_backoff(attempt, self._retry_config)
                 logger.warning(
-                    "LLM stream retry failed (attempt %d/%d): %s. "
+                    "LLM stream failed (attempt %d/%d): %s. "
                     "Retrying in %.1fs ...",
                     attempt,
                     max_attempts,
@@ -648,7 +628,4 @@ class RetryChatModel(ChatModelBase):
                     retry_delay,
                 )
                 await asyncio.sleep(retry_delay)
-
-            finally:
-                if owns_semaphore and acquired:
-                    limiter.release()
+                attempt += 1

--- a/tests/unit/providers/test_retry_chat_model.py
+++ b/tests/unit/providers/test_retry_chat_model.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=protected-access
+# pylint: disable=protected-access,too-few-public-methods
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any, AsyncGenerator, cast
 
 import pytest
 
+from qwenpaw.providers.model_capability_cache import get_capability_cache
 from qwenpaw.providers.retry_chat_model import (
     RETRYABLE_STATUS_CODES,
+    RetryChatModel,
     RetryConfig,
     RateLimitConfig,
     _compute_backoff,
@@ -19,6 +22,40 @@ from qwenpaw.providers.retry_chat_model import (
     _normalize_rate_limit_config,
     _normalize_retry_config,
 )
+
+
+async def _failing_reasoning_stream() -> AsyncGenerator[Any, None]:
+    for chunk in ():
+        yield chunk
+    exc = Exception("The `reasoning_content` in thinking mode is required")
+    exc.status_code = 400  # type: ignore[attr-defined]
+    raise exc
+
+
+async def _successful_stream() -> AsyncGenerator[Any, None]:
+    yield SimpleNamespace(content="ok")
+
+
+class _ReasoningRetryStreamModel:
+    model = "reasoning-stream-test"
+    stream = True
+    context_size = 32768
+    parameters = None
+    _provider_id = "unit"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        self.calls += 1
+        if self.calls == 1:
+            return _failing_reasoning_stream()
+        return _successful_stream()
+
 
 # ---------------------------------------------------------------------------
 # _is_retryable
@@ -251,3 +288,41 @@ def test_normalize_rate_limit_config_clamps() -> None:
     assert result.pause_seconds >= 1.0
     assert result.jitter_range >= 0.0
     assert result.acquire_timeout >= 10.0
+
+
+# ---------------------------------------------------------------------------
+# RetryChatModel streaming reasoning_content recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_recovers_missing_reasoning_content_error() -> None:
+    cache = get_capability_cache()
+    model_key = "unit:reasoning-stream-test"
+    cache.clear(model_key)
+
+    try:
+        inner = _ReasoningRetryStreamModel()
+        model = RetryChatModel(
+            inner,  # type: ignore[arg-type]
+            retry_config=RetryConfig(enabled=False),
+            rate_limit_config=RateLimitConfig(
+                max_concurrent=1,
+                max_qpm=0,
+                pause_seconds=1.0,
+                jitter_range=0.0,
+                acquire_timeout=10.0,
+            ),
+        )
+        messages = [{"role": "assistant", "content": "previous reply"}]
+
+        result = await model(messages=messages)
+        stream = cast(AsyncGenerator[Any, None], result)
+        chunks = [chunk async for chunk in stream]
+
+        assert [chunk.content for chunk in chunks] == ["ok"]
+        assert inner.calls == 2
+        assert messages[0]["reasoning_content"] == " "
+        assert cache.get(model_key, "needs_reasoning_content") is True
+    finally:
+        cache.clear(model_key)


### PR DESCRIPTION
## Description

Relates to #5573.

The non-streaming `RetryChatModel.__call__` path already handles a 400 that mentions `reasoning_content` by injecting empty values into assistant messages, learning `needs_reasoning_content`, and retrying. The streaming `_wrap_stream` path only treated transient status codes as retryable, so the same thinking-mode 400 could still pass through during stream consumption.

This PR moves the stream retry path into one loop and adds the same missing-`reasoning_content` recovery there. The recovery stays in the shared retry wrapper instead of adding DeepSeek-specific provider logic.

**Related Issue:** Relates to #5573

**Security Considerations:** No auth, secret, or user-permission behavior changes. The request payload is only patched after the upstream model rejects the stream for missing `reasoning_content`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; provider retry compatibility bug fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Added a unit test for a stream that raises the missing-`reasoning_content` 400 during consumption and then succeeds after retry.
- Verified the recovery still works when transient retry is disabled, matching the existing non-streaming capability fallback behavior.

## Local Verification Evidence

```bash
env BLACK_CACHE_DIR=/tmp/qwenpaw-black-cache .venv/bin/pre-commit run --all-files
# all hooks passed, including mypy, black, flake8, pylint, and prettier

.venv/bin/pytest tests/unit/providers/test_retry_chat_model.py::test_stream_recovers_missing_reasoning_content_error -q
# 1 passed

.venv/bin/pytest tests/unit/providers -q
# 226 passed
```

## Additional Notes

Root cause: `_wrap_stream` retried only transient failures, while the non-streaming path had a dedicated thinking-mode capability fallback for `reasoning_content` 400s.

Scope:
- OpenAI-compatible thinking models/proxies using `RetryChatModel` streams: covered.
- Non-streaming retry path: unchanged.
- Nullable tool schema cleanup: intentionally not changed here; it overlaps with #5549.
- Channels, console, docs, and provider schema sanitizers: unchanged.

Verification matrix:
- Shared stream retry wrapper: covered by unit test.
- Non-streaming path: unchanged existing behavior.
- Schema sanitizer issue from #5573: out of scope, tracked by #5549.
