### PR TITLE
feat(channels): matrix Add Streaming Mode Like Discord in Matrix

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -91,6 +91,7 @@ export interface MatrixConfig extends BaseChannelConfig {
   homeserver: string;
   user_id: string;
   access_token: string;
+  streaming_enabled?: boolean;
 }
 
 export interface MattermostConfig extends BaseChannelConfig {

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -1483,7 +1483,8 @@ export function ChannelDrawer({
             activeKey === "dingtalk" ||
             activeKey === "feishu" ||
             activeKey === "discord" ||
-            activeKey === "slack") && (
+            activeKey === "slack" ||
+            activeKey === "matrix") && (
             <Form.Item
               name="streaming_enabled"
               label={t("channels.streamingEnabled")}

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -234,6 +234,7 @@ class MatrixChannel(BaseChannel):
         filter_tool_messages: bool = False,
         no_text_debounce: bool = True,
         filter_thinking: bool = False,
+        streaming_enabled: bool = False,
         workspace_dir: Path | None = None,
         access_control_dm: bool = False,
         access_control_group: bool = False,
@@ -247,6 +248,7 @@ class MatrixChannel(BaseChannel):
             filter_tool_messages=filter_tool_messages,
             no_text_debounce=no_text_debounce,
             filter_thinking=filter_thinking,
+            streaming_enabled=streaming_enabled,
             access_control_dm=access_control_dm,
             access_control_group=access_control_group,
         )
@@ -345,6 +347,7 @@ class MatrixChannel(BaseChannel):
                 filter_thinking or raw.get("filter_thinking", False)
             ),
             no_text_debounce=no_text_debounce,
+            streaming_enabled=raw.get("streaming_enabled", False),
             workspace_dir=workspace_dir,
             access_control_dm=bool(raw.get("access_control_dm", False)),
             access_control_group=bool(raw.get("access_control_group", False)),

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -209,6 +209,10 @@ class MatrixChannel(BaseChannel):
     channel = CHANNEL_KEY  # type: ignore[assignment]
     uses_manager_queue: bool = True
 
+    # Streaming constants — placeholder message + in-place edit
+    _STREAM_PLACEHOLDER = "..."
+    _STREAM_DELTA_MIN_INTERVAL_S: float = 1.0
+
     def __init__(
         self,
         process: Callable,
@@ -3002,8 +3006,130 @@ class MatrixChannel(BaseChannel):
             )
 
     # ------------------------------------------------------------------
+    # Streaming — placeholder message + in-place edit (MSC2676 m.replace)
+    # ------------------------------------------------------------------
+
+    def _get_stream_state(
+        self,
+        send_meta: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Per-request streaming state stored in *send_meta*."""
+        state = send_meta.get("_matrix_stream")
+        if state is None:
+            state = {"event_ids": {}}
+            send_meta["_matrix_stream"] = state
+        return state
+
+    async def _edit_stream_message(
+        self,
+        room_id: str,
+        event_id: str,
+        text: str,
+    ) -> bool:
+        """Edit a previously sent message using MSC2676 ``m.replace``."""
+        if not self._client:
+            return False
+        html_body = _md_to_html(text)
+        content: dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": f"* {text}",
+            "format": "org.matrix.custom.html",
+            "formatted_body": f"* {html_body}",
+            "m.new_content": {
+                "msgtype": "m.text",
+                "body": text,
+                "format": "org.matrix.custom.html",
+                "formatted_body": html_body,
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": event_id,
+            },
+        }
+        try:
+            await self._prepare_room_send(room_id)
+            await self._client.room_send(
+                room_id,
+                "m.room.message",
+                content,
+                ignore_unverified_devices=True,
+            )
+            return True
+        except Exception:
+            logger.debug(
+                "MatrixChannel: stream edit failed for %s in %s",
+                event_id,
+                room_id,
+                exc_info=True,
+            )
+            return False
+
+    async def on_streaming_start(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        state = self._get_stream_state(send_meta)
+        event_id = await self.send(
+            to_handle,
+            self._STREAM_PLACEHOLDER,
+            send_meta,
+        )
+        if event_id:
+            state["event_ids"][stream_type] = event_id
+
+    async def on_streaming_delta(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        state = send_meta.get("_matrix_stream")
+        if not state:
+            return
+        event_id = state["event_ids"].get(stream_type)
+        if not event_id:
+            return
+        room_id = send_meta.get("room_id") or to_handle
+        await self._edit_stream_message(room_id, event_id, accumulated_text)
+
+    async def on_streaming_end(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        state = send_meta.get("_matrix_stream")
+        event_id = state["event_ids"].pop(stream_type, None) if state else None
+        room_id = send_meta.get("room_id") or to_handle
+
+        if not event_id or not accumulated_text:
+            if accumulated_text:
+                await self.send(to_handle, accumulated_text, send_meta)
+            return
+
+        success = await self._edit_stream_message(
+            room_id,
+            event_id,
+            accumulated_text,
+        )
+        if not success:
+            await self.send(to_handle, accumulated_text, send_meta)
+
+    # ------------------------------------------------------------------
     # Outgoing send — text
     # Markdown→HTML (formatted_body); m.mentions when meta has sender_id.
+    # Returns the event_id of the sent message, or None on failure.
     # ------------------------------------------------------------------
 
     async def send(
@@ -3011,10 +3137,10 @@ class MatrixChannel(BaseChannel):
         to_handle: str,
         text: str,
         meta: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    ) -> Optional[str]:
         if not self._client:
             logger.error("MatrixChannel: send called but client not ready")
-            return
+            return None
 
         room_id = (meta or {}).get("room_id") or to_handle
 
@@ -3027,7 +3153,7 @@ class MatrixChannel(BaseChannel):
                 room_id,
             )
             await self._send_typing(room_id, False)
-            return
+            return None
 
         html_body = _md_to_html(text)
         content: dict[str, Any] = {
@@ -3051,18 +3177,20 @@ class MatrixChannel(BaseChannel):
 
         try:
             await self._prepare_room_send(room_id)
-            await self._client.room_send(
+            resp = await self._client.room_send(
                 room_id,
                 "m.room.message",
                 content,
                 ignore_unverified_devices=True,
             )
+            return getattr(resp, "event_id", None)
         except Exception as exc:
             logger.exception(
                 "MatrixChannel: send failed to %s: %s",
                 room_id,
                 exc,
             )
+            return None
         finally:
             await self._send_typing(room_id, False)
 

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -3077,7 +3077,7 @@ class MatrixChannel(BaseChannel):
         accumulated_text: str = "",
     ) -> None:
         state = self._get_stream_state(send_meta)
-        event_id = await self.send(
+        event_id = await self._send_message(
             to_handle,
             self._STREAM_PLACEHOLDER,
             send_meta,
@@ -3135,12 +3135,13 @@ class MatrixChannel(BaseChannel):
     # Returns the event_id of the sent message, or None on failure.
     # ------------------------------------------------------------------
 
-    async def send(
+    async def _send_message(
         self,
         to_handle: str,
         text: str,
         meta: Optional[Dict[str, Any]] = None,
     ) -> Optional[str]:
+        """Internal send that returns the Matrix event_id (or None)."""
         if not self._client:
             logger.error("MatrixChannel: send called but client not ready")
             return None
@@ -3196,6 +3197,14 @@ class MatrixChannel(BaseChannel):
             return None
         finally:
             await self._send_typing(room_id, False)
+
+    async def send(
+        self,
+        to_handle: str,
+        text: str,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        await self._send_message(to_handle, text, meta)
 
     # ------------------------------------------------------------------
     # Outgoing send — media

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -370,6 +370,7 @@ class MatrixConfig(BaseChannelConfig):
     mention_pill_in_body: bool = False
     # When True, apply m.mentions + optional pill on outbound messages.
     outbound_structured_mentions: bool = True
+    streaming_enabled: bool = False
 
 
 class VoiceChannelConfig(BaseChannelConfig):


### PR DESCRIPTION
## Description

Add Stream Mode Like Discord in Matrix
Now just wait TTFT then the reply will show soon

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [X] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [X] I ran `pre-commit run --all-files` locally and it passes
- [X] If pre-commit auto-fixed files, I committed those changes and reran checks
- [X] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
