### PR TITLE
fix(context): prioritize runtime model over static config for compaction threshold

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2354,14 +2354,16 @@ def get_model_max_input_length(
     """
     from ..providers import ProviderManager
 
-    model_slot = agent_config.active_model
+    # First try the runtime active model (set by zorrofox)
+    try:
+        manager = ProviderManager.get_instance()
+        model_slot = manager.get_active_model()
+    except Exception:
+        model_slot = None
+        
     # Fallback: if agent.json doesn't have active_model, try ProviderManager
     if not model_slot or not model_slot.provider_id:
-        try:
-            manager = ProviderManager.get_instance()
-            model_slot = manager.get_active_model()
-        except Exception:
-            pass
+        model_slot = agent_config.active_model
 
     if model_slot and model_slot.provider_id and model_slot.model:
         try:

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2354,7 +2354,7 @@ def get_model_max_input_length(
     """
     from ..providers import ProviderManager
 
-    # First try the runtime active model (set by zorrofox)
+    # First try the runtime active model (set by zorrofox1121)
     try:
         manager = ProviderManager.get_instance()
         model_slot = manager.get_active_model()


### PR DESCRIPTION
## Context compaction threshold ignores conversation-level model override

### Description

When a user switches the model **inside a conversation session** (via the UI dropdown, not via Settings → Set as Default), the `light_context_config` compaction logic still reads `max_input_length` from the default model defined in `agent.json`. This causes the compact threshold to be calculated against the wrong model's context length, potentially leading to `MODEL_CONTEXT_LENGTH_EXCEEDED` errors or premature/overdue compaction.

### Root Cause

QwenPaw has two model-switching mechanisms, but the compaction code only reads from one:

| Mechanism | Scope | Persistence |
|-----------|-------|-------------|
| Settings → Models → Set as Default | Global / Agent-wide | `agent.json.active_model` + `active_model.json` |
| In-session dropdown selection | Current conversation only | Agent model instance only — **no** config file is updated |

The compaction threshold (`compact_threshold = max_input_length × compact_threshold_ratio`) is calculated via `get_model_max_input_length(agent_config)`, which queries `agent.json` / `active_model.json` — both of which always point to the **default** model, not the session-level override.

### Model Object Chain (for reference when fixing)

The session-level model information is available in the agent's runtime model chain:

```
agent.model
  └─ RetryChatModel
       └─ ._inner → TokenRecordingModelWrapper
            ├─ ._provider_id      → actual provider in use
            ├─ .model_name        → actual model in use
            └─ .model             → OpenAIChatModelCompat
```

`TokenRecordingModelWrapper` is created in `model_factory.py::create_model_and_formatter()` and always carries the correct `_provider_id` and `model_name`, regardless of how the model was selected.

### Expected Behavior

When a user switches models in-session, the compaction threshold should be calculated against the **currently active model**'s `max_input_length`, not the default model's.

### Actual Behavior

The compaction threshold is always calculated against the default model, ignoring in-session overrides.

### Steps to Reproduce

1. Set the default model to one with a large `max_input_length` (e.g., 131072)
2. Configure another provider/model with a smaller `max_input_length` (e.g., 65536) and set `compact_threshold_ratio = 0.5`
3. In the conversation UI, switch to the smaller model (via dropdown — **do not** set it as default)
4. Accumulate context by sending messages
5. **Expected**: compaction triggers at ~32K (`65536 × 0.5`)
6. **Actual**: compaction triggers at ~65K (`131072 × 0.5`), which may already exceed the backend's context window limit

### Environment

- QwenPaw version: main branch (as of 2026-06-28)
- Backend: llama.cpp / any OpenAI-compatible API
- Custom provider with `ModelInfo.max_input_length` set via `update_model_config()` API

### Additional Context

This issue was discovered and fixed locally against a later build that includes a `light_context_manager.py` module not yet present in the public `main` branch. The fix involves two parts:

#### Part 1: Fix `config.py` (can be applied now)

**File:** `src/qwenpaw/config/config.py`

**Function:** `get_model_max_input_length(agent_config)` (~line 2354)

Change the priority from `agent_config.active_model → runtime` to `runtime → agent_config.active_model`:

```diff
 # Before: try agent.json first, fall back to runtime
-model_slot = agent_config.active_model
+model_slot = ProviderManager.get_active_model()
 if not model_slot or not model_slot.provider_id:
-    model_slot = ProviderManager.get_active_model()
+    model_slot = agent_config.active_model
```

This fixes the path for `/model` command switches (which write to `agent.json`).

#### Part 2: Fix the session-level model path (needs the new code)

In the upcoming version that includes `agents/context/light_context_manager.py`, the `pre_reasoning()` method should read `max_input_length` from `agent.model` instead of `agent_config`. The approach is:

1. Add a new function `get_model_max_input_length_from_agent()` that traverses `agent.model → _inner → TokenRecordingModelWrapper` to extract `_provider_id` and `model_name`, then looks up the provider's `ModelInfo.max_input_length`, falling back to `get_model_max_input_length(agent_config)` on failure
2. In `pre_reasoning()`, replace `get_model_max_input_length(agent_config)` with this new function call

This ensures the compaction threshold always follows the conversation-level model, no matter which selection mechanism was used.
