### PR TITLE
feat(channels): support dingtalk mentions in proactive sends

### DIFF
--- a/src/qwenpaw/agents/skills/channel_message-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/channel_message-en/SKILL.md
@@ -88,6 +88,11 @@ qwenpaw channels send \
 - `--target-session`
 - `--text`
 
+For DingTalk group sends, you may add `--at-user-ids`,
+`--at-dingtalk-ids`, or `--at-all` when the user explicitly asks to mention
+someone. `--at-user-ids` and `--at-dingtalk-ids` may be repeated or
+comma-separated.
+
 ### Must Query First
 
 Before sending, run:

--- a/src/qwenpaw/agents/skills/channel_message-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/channel_message-zh/SKILL.md
@@ -88,6 +88,10 @@ qwenpaw channels send \
 - `--target-session`
 - `--text`
 
+DingTalk 群发送时，如果用户明确要求 @ 某人，可以追加
+`--at-user-ids`、`--at-dingtalk-ids` 或 `--at-all`。
+`--at-user-ids` 和 `--at-dingtalk-ids` 支持重复传入或逗号分隔。
+
 ### 必须先查询
 
 发送前先执行：

--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -921,20 +921,21 @@ class DingTalkChannel(BaseChannel):
         bot_prefix: str = "",
         at_user_ids: Optional[List[str]] = None,
         at_dingtalk_ids: Optional[List[str]] = None,
+        is_at_all: bool = False,
     ) -> bool:
         """Send one text message via DingTalk sessionWebhook. Returns True
         on success.
 
-        When ``at_user_ids`` or ``at_dingtalk_ids`` is provided, the
-        ``at`` field is added to the webhook payload so that the
-        mentioned users receive a push notification.  The @mention text
-        is also prepended to the message body (DingTalk requires both).
+        When mention options are provided, the ``at`` field is added to
+        the webhook payload so that mentioned users receive a push
+        notification.  The @mention text is also prepended to the
+        message body for specific user mentions.
         """
         text = (bot_prefix + "  " + body) if body else bot_prefix
 
         # Build at payload and prepend @mention text
         at_payload: Optional[Dict[str, Any]] = None
-        if at_user_ids or at_dingtalk_ids:
+        if at_user_ids or at_dingtalk_ids or is_at_all:
             at_payload = {}
             mentions = []
             if at_user_ids:
@@ -943,7 +944,11 @@ class DingTalkChannel(BaseChannel):
             if at_dingtalk_ids:
                 at_payload["atDingtalkIds"] = at_dingtalk_ids
                 mentions.extend(f"@{did}" for did in at_dingtalk_ids)
-            text = " ".join(mentions) + "\n" + text
+            if is_at_all:
+                at_payload["isAtAll"] = True
+                mentions.append("@all")
+            if mentions:
+                text = " ".join(mentions) + "\n" + text
 
         if len(text) > 3500:
             payload: Dict[str, Any] = {
@@ -967,6 +972,38 @@ class DingTalkChannel(BaseChannel):
             session_webhook,
             payload,
         )
+
+    @staticmethod
+    def _normalize_mention_ids(value: Any) -> Optional[List[str]]:
+        """Return non-empty mention IDs from metadata values."""
+        if value is None:
+            return None
+        raw_values = (
+            value if isinstance(value, (list, tuple, set)) else [value]
+        )
+        normalized: List[str] = []
+        for raw in raw_values:
+            if raw is None:
+                continue
+            for part in str(raw).split(","):
+                item = part.strip()
+                if item:
+                    normalized.append(item)
+        return normalized or None
+
+    @classmethod
+    def _mentions_from_meta(
+        cls,
+        meta: Optional[Dict[str, Any]],
+    ) -> tuple[Optional[List[str]], Optional[List[str]], bool]:
+        """Extract DingTalk mention options from send metadata."""
+        meta = meta or {}
+        at_user_ids = cls._normalize_mention_ids(meta.get("at_user_ids"))
+        at_dingtalk_ids = cls._normalize_mention_ids(
+            meta.get("at_dingtalk_ids"),
+        )
+        is_at_all = bool(meta.get("is_at_all") or meta.get("at_all"))
+        return at_user_ids, at_dingtalk_ids, is_at_all
 
     async def _send_via_open_api(
         self,
@@ -1889,6 +1926,9 @@ class DingTalkChannel(BaseChannel):
             body = prefix + "  " + body
         elif prefix and not body and not media_parts:
             body = prefix
+        at_user_ids, at_dingtalk_ids, is_at_all = self._mentions_from_meta(
+            meta,
+        )
         session_webhook = await self._get_session_webhook_for_send(
             to_handle,
             meta,
@@ -1903,7 +1943,12 @@ class DingTalkChannel(BaseChannel):
         )
 
         # ---------- AI Card path (cron / proactive sends) ----------
-        if self._cron_ai_card_enabled() and body.strip():
+        has_webhook_only_mentions = bool(at_dingtalk_ids or is_at_all)
+        if (
+            self._cron_ai_card_enabled()
+            and body.strip()
+            and not has_webhook_only_mentions
+        ):
             params = await self._resolve_open_api_params_from_handle(
                 to_handle,
                 meta,
@@ -1915,6 +1960,7 @@ class DingTalkChannel(BaseChannel):
                     "conversation_type": params["conversation_type"],
                     "sender_staff_id": params["sender_staff_id"],
                     "is_group": params["conversation_type"] == "group",
+                    "at_user_ids": at_user_ids,
                 }
                 try:
                     card = await self._create_ai_card(
@@ -1965,6 +2011,9 @@ class DingTalkChannel(BaseChannel):
                     session_webhook,
                     body.strip(),
                     bot_prefix="",
+                    at_user_ids=at_user_ids,
+                    at_dingtalk_ids=at_dingtalk_ids,
+                    is_at_all=is_at_all,
                 )
             if not text_ok:
                 await self._invalidate_session_webhook(to_handle)
@@ -2974,8 +3023,14 @@ class DingTalkChannel(BaseChannel):
         # enterprise userId (senderStaffId).  Only set when available.
         card_at_user_ids: Optional[List[str]] = None
         card_user_id_type: Optional[int] = None
-        if self.at_sender_on_reply and is_group and sender_staff_id:
+        explicit_at_user_ids = self._normalize_mention_ids(
+            meta.get("at_user_ids"),
+        )
+        if explicit_at_user_ids:
+            card_at_user_ids = explicit_at_user_ids
+        elif self.at_sender_on_reply and is_group and sender_staff_id:
             card_at_user_ids = [sender_staff_id]
+        if card_at_user_ids:
             card_user_id_type = 1
 
         create_request = dingtalk_card_models.CreateCardRequest(

--- a/src/qwenpaw/app/routers/messages.py
+++ b/src/qwenpaw/app/routers/messages.py
@@ -61,6 +61,18 @@ class SendMessageRequest(BaseModel):
         ...,
         description="Text message to send",
     )
+    at_user_ids: Optional[list[str]] = Field(
+        default=None,
+        description="Optional DingTalk user IDs to @mention",
+    )
+    at_dingtalk_ids: Optional[list[str]] = Field(
+        default=None,
+        description="Optional DingTalk IDs to @mention",
+    )
+    is_at_all: bool = Field(
+        default=False,
+        description="Whether to @all in DingTalk group messages",
+    )
 
 
 class SendMessageResponse(BaseModel):
@@ -157,6 +169,12 @@ async def send_message(
         meta: dict = {"_api_send": True}
         if x_agent_id:
             meta["agent_id"] = x_agent_id
+        if request.at_user_ids:
+            meta["at_user_ids"] = request.at_user_ids
+        if request.at_dingtalk_ids:
+            meta["at_dingtalk_ids"] = request.at_dingtalk_ids
+        if request.is_at_all:
+            meta["is_at_all"] = True
         await channel_manager.send_text(
             channel=request.channel,
             user_id=request.target_user,

--- a/src/qwenpaw/cli/channels_cmd.py
+++ b/src/qwenpaw/cli/channels_cmd.py
@@ -64,6 +64,17 @@ _ALL_CHANNEL_NAMES = {
 # Public alias for tests and external use.
 CHANNEL_NAMES = _ALL_CHANNEL_NAMES
 
+
+def _split_csv_options(values: tuple[str, ...]) -> list[str]:
+    """Normalize repeatable comma-separated CLI option values."""
+    result: list[str] = []
+    for value in values:
+        result.extend(
+            part.strip() for part in value.split(",") if part.strip()
+        )
+    return result
+
+
 # Template for `qwenpaw channels install <key>` stub (channel key substituted).
 CHANNEL_TEMPLATE = '''# -*- coding: utf-8 -*-
 """Custom channel: {key}. Edit and implement required methods."""
@@ -1234,6 +1245,23 @@ def configure_cmd(agent_id: str) -> None:
     default=None,
     help="Override the API base URL. Defaults to global --host/--port.",
 )
+@click.option(
+    "--at-user-ids",
+    multiple=True,
+    help=(
+        "DingTalk user IDs to @mention. May be repeated or comma-separated."
+    ),
+)
+@click.option(
+    "--at-dingtalk-ids",
+    multiple=True,
+    help=("DingTalk IDs to @mention. May be repeated or comma-separated."),
+)
+@click.option(
+    "--at-all",
+    is_flag=True,
+    help="Mention all members for DingTalk group messages.",
+)
 @click.pass_context
 def send_cmd(
     ctx: click.Context,
@@ -1243,6 +1271,9 @@ def send_cmd(
     target_session: str,
     text: str,
     base_url: Optional[str],
+    at_user_ids: tuple[str, ...],
+    at_dingtalk_ids: tuple[str, ...],
+    at_all: bool,
 ) -> None:
     """Send a text message to a channel.
 
@@ -1297,6 +1328,14 @@ def send_cmd(
         "target_session": target_session,
         "text": text,
     }
+    parsed_at_user_ids = _split_csv_options(at_user_ids)
+    parsed_at_dingtalk_ids = _split_csv_options(at_dingtalk_ids)
+    if parsed_at_user_ids:
+        payload["at_user_ids"] = parsed_at_user_ids
+    if parsed_at_dingtalk_ids:
+        payload["at_dingtalk_ids"] = parsed_at_dingtalk_ids
+    if at_all:
+        payload["is_at_all"] = True
 
     with client(base_url) as c:
         headers = {"X-Agent-Id": agent_id}

--- a/tests/unit/app/routers/test_messages_router.py
+++ b/tests/unit/app/routers/test_messages_router.py
@@ -89,6 +89,31 @@ def test_send_message_passes_x_agent_id_into_meta(
     assert meta == {"_api_send": True, "agent_id": "my_bot"}
 
 
+def test_send_message_passes_dingtalk_mentions_into_meta(
+    client,
+    workspace_mock,
+):
+    payload = {
+        **_DEFAULT_PAYLOAD,
+        "channel": "dingtalk",
+        "at_user_ids": ["staff-1", "staff-2"],
+        "at_dingtalk_ids": ["dt-1"],
+        "is_at_all": True,
+    }
+
+    response = client.post("/api/messages/send", json=payload)
+
+    assert response.status_code == 200
+    call_kwargs = workspace_mock.channel_manager.send_text.await_args.kwargs
+    assert call_kwargs["channel"] == "dingtalk"
+    assert call_kwargs["meta"] == {
+        "_api_send": True,
+        "at_user_ids": ["staff-1", "staff-2"],
+        "at_dingtalk_ids": ["dt-1"],
+        "is_at_all": True,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -732,6 +732,42 @@ class TestDingTalkSendMethods:
         assert result is True
         assert mock_http_session.call_count == 1
 
+    async def test_send_via_session_webhook_includes_mentions(
+        self,
+        dingtalk_channel,
+        mock_http_session,
+    ):
+        """Mention options should be emitted in DingTalk webhook payload."""
+        dingtalk_channel._http = mock_http_session
+        mock_http_session.expect_post(
+            url="https://oapi.dingtalk.com/robot/send",
+            response_status=200,
+            response_json={"errcode": 0, "errmsg": "ok"},
+        )
+
+        result = await dingtalk_channel._send_via_session_webhook(
+            session_webhook="https://oapi.dingtalk.com/robot/send?session=abc",
+            body="Hello from test",
+            at_user_ids=["staff-1"],
+            at_dingtalk_ids=["dt-1"],
+            is_at_all=True,
+        )
+
+        assert result is True
+        payload = mock_http_session._requests[0]["kwargs"]["json"]
+        assert payload["at"] == {
+            "atUserIds": ["staff-1"],
+            "atDingtalkIds": ["dt-1"],
+            "isAtAll": True,
+        }
+        text = (
+            payload.get("markdown", {}).get("text")
+            or payload["text"]["content"]
+        )
+        assert "@staff-1" in text
+        assert "@dt-1" in text
+        assert "@all" in text
+
     async def test_send_via_session_webhook_api_error(
         self,
         dingtalk_channel,
@@ -1924,6 +1960,31 @@ class TestDingTalkAICardMethods:
         )
 
         assert card is not None
+
+    async def test_create_ai_card_uses_explicit_at_user_ids(
+        self,
+        dingtalk_channel,
+    ):
+        """Explicit proactive mentions should be passed to AI card create."""
+        dingtalk_channel.message_type = "card"
+        dingtalk_channel.card_template_id = "template_123"
+        dingtalk_channel.card_template_key = "content"
+        dingtalk_channel.robot_code = "robot_123"
+        dingtalk_channel._oauth_sdk = _make_oauth_sdk("token_123")
+        card_sdk = _make_card_sdk()
+        dingtalk_channel._card_sdk = card_sdk
+
+        card = await dingtalk_channel._create_ai_card(
+            conversation_id="cid_group_123",
+            meta={"is_group": True, "at_user_ids": ["staff-1"]},
+        )
+
+        assert card is not None
+        create_request = (
+            card_sdk.create_card_with_options_async.await_args.args[0]
+        )
+        assert create_request.card_at_user_ids == ["staff-1"]
+        assert create_request.user_id_type == 1
 
     async def test_create_ai_card_dm_requires_staff_id(
         self,
@@ -3126,6 +3187,91 @@ class TestDingTalkLoadSessionWebhookEntry:
         )
 
         assert result is None
+
+
+# =============================================================================
+# P2: DingTalk proactive mention tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+class TestDingTalkProactiveMentions:
+    """Tests for proactive send mention metadata."""
+
+    async def test_send_content_parts_forwards_mention_meta(
+        self,
+        dingtalk_channel,
+    ):
+        from qwenpaw.app.channels.base import ContentType, TextContent
+
+        parts = [TextContent(type=ContentType.TEXT, text="Hello world")]
+
+        with patch.object(
+            dingtalk_channel,
+            "_send_via_session_webhook",
+            new=AsyncMock(return_value=True),
+        ) as mock_send:
+            await dingtalk_channel.send_content_parts(
+                to_handle="dingtalk:sw:test",
+                parts=parts,
+                meta={
+                    "session_webhook": "http://webhook.url",
+                    "at_user_ids": ["staff-1"],
+                    "at_dingtalk_ids": ["dt-1"],
+                    "is_at_all": True,
+                },
+            )
+
+        mock_send.assert_awaited_once_with(
+            "http://webhook.url",
+            "Hello world",
+            bot_prefix="",
+            at_user_ids=["staff-1"],
+            at_dingtalk_ids=["dt-1"],
+            is_at_all=True,
+        )
+
+    async def test_send_content_parts_skips_card_for_webhook_only_mentions(
+        self,
+        dingtalk_channel,
+    ):
+        from qwenpaw.app.channels.base import ContentType, TextContent
+
+        dingtalk_channel.cron_message_type = "card"
+        dingtalk_channel.card_template_id = "template_123"
+        dingtalk_channel.robot_code = "robot_123"
+        parts = [TextContent(type=ContentType.TEXT, text="Hello world")]
+
+        with (
+            patch.object(
+                dingtalk_channel,
+                "_create_ai_card",
+                new=AsyncMock(),
+            ) as mock_create,
+            patch.object(
+                dingtalk_channel,
+                "_send_via_session_webhook",
+                new=AsyncMock(return_value=True),
+            ) as mock_send,
+        ):
+            await dingtalk_channel.send_content_parts(
+                to_handle="dingtalk:sw:test",
+                parts=parts,
+                meta={
+                    "session_webhook": "http://webhook.url",
+                    "at_dingtalk_ids": ["dt-1"],
+                },
+            )
+
+        mock_create.assert_not_awaited()
+        mock_send.assert_awaited_once_with(
+            "http://webhook.url",
+            "Hello world",
+            bot_prefix="",
+            at_user_ids=None,
+            at_dingtalk_ids=["dt-1"],
+            is_at_all=False,
+        )
 
 
 # =============================================================================

--- a/tests/unit/cli/test_channels_send.py
+++ b/tests/unit/cli/test_channels_send.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from qwenpaw.cli.main import cli
+
+
+class _Response:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, bool]:
+        return {"success": True}
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.posts: list[dict] = []
+
+    def __enter__(self) -> "_Client":
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+    def post(self, path: str, *, json: dict, headers: dict) -> _Response:
+        self.posts.append({"path": path, "json": json, "headers": headers})
+        return _Response()
+
+
+def test_channels_send_passes_dingtalk_mentions(monkeypatch) -> None:
+    http_client = _Client()
+    monkeypatch.setattr(
+        "qwenpaw.cli.channels_cmd.client",
+        lambda _base_url: http_client,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "channels",
+            "send",
+            "--agent-id",
+            "bot",
+            "--channel",
+            "dingtalk",
+            "--target-user",
+            "user",
+            "--target-session",
+            "session",
+            "--text",
+            "hello",
+            "--at-user-ids",
+            "staff-1,staff-2",
+            "--at-user-ids",
+            "staff-3",
+            "--at-dingtalk-ids",
+            "dt-1",
+            "--at-all",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert http_client.posts == [
+        {
+            "path": "/messages/send",
+            "headers": {"X-Agent-Id": "bot"},
+            "json": {
+                "channel": "dingtalk",
+                "target_user": "user",
+                "target_session": "session",
+                "text": "hello",
+                "at_user_ids": ["staff-1", "staff-2", "staff-3"],
+                "at_dingtalk_ids": ["dt-1"],
+                "is_at_all": True,
+            },
+        },
+    ]

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -379,6 +379,12 @@ qwenpaw channels send \
 - `--target-session`: Session ID (get from `qwenpaw chats list`)
 - `--text`: Message content
 
+**DingTalk `@mention` options:**
+
+- `--at-user-ids`: DingTalk user IDs to mention. Repeat the option or pass a comma-separated list.
+- `--at-dingtalk-ids`: DingTalk IDs to mention. Repeat the option or pass a comma-separated list.
+- `--at-all`: Mention all members in a DingTalk group.
+
 **Important:**
 
 - Always query sessions with `qwenpaw chats list` first — do NOT guess `target-user` or `target-session`

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -364,6 +364,12 @@ qwenpaw channels send \
 - `--target-session`：会话 ID（从 `qwenpaw chats list` 获取）
 - `--text`：消息内容
 
+**DingTalk `@mention` 可选参数：**
+
+- `--at-user-ids`：要 @ 的 DingTalk userId，可重复传入，也可用逗号分隔。
+- `--at-dingtalk-ids`：要 @ 的 DingTalk ID，可重复传入，也可用逗号分隔。
+- `--at-all`：在 DingTalk 群聊中 @所有人。
+
 **重要提示：**
 
 - 发送前必须先用 `qwenpaw chats list` 查询 —— 不要猜测 `target-user` 或 `target-session`


### PR DESCRIPTION
## Description

Adds DingTalk `@mention` support to the proactive send path used by
`/messages/send`, `qwenpaw channels send`, and cron text delivery.

The shared API/CLI path now accepts optional DingTalk mention parameters and
passes them through existing send metadata. DingTalk consumes those fields in
its webhook send path and preserves `at_user_ids` for proactive AI Card
creation when supported. `at_dingtalk_ids` and `is_at_all` stay on the webhook
path because the current AI Card request path only has an enterprise userId
mention field.

This keeps the change scoped to DingTalk mention behavior without introducing
a broad cross-channel mention abstraction.

**Related Issue:** Fixes #5564

**Security Considerations:** No credentials or auth changes. The API/CLI only
forwards explicit mention IDs supplied by the caller to the configured DingTalk
send path.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [x] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

Note: I attempted `./scripts/check-channels.sh --changed`. In this environment
it first hit sandboxed pip network restrictions; after rerunning with network
access, the script attempted a system install via Python 3.10 and failed with
permission denied under `/usr/local/lib/python3.10/dist-packages`. I ran the
equivalent DingTalk contract and unit tests directly in the project `.venv`
instead.

## Testing

```bash
env PRE_COMMIT_HOME=/tmp/pre-commit-cache .venv/bin/pre-commit run --all-files
# Passed

.venv/bin/pytest tests/unit/app/routers/test_messages_router.py tests/unit/cli/test_channels_send.py tests/unit/channels/test_dingtalk.py
# 166 passed, 28 warnings

.venv/bin/pytest tests/contract/channels/test_dingtalk_contract.py tests/unit/channels/test_dingtalk.py
# 181 passed, 27 warnings
```

Warnings are existing asyncio marker/resource warnings in
`tests/unit/channels/test_dingtalk.py`.

## Local Verification Evidence

```bash
env PRE_COMMIT_HOME=/tmp/pre-commit-cache .venv/bin/pre-commit run --all-files
# check python ast.........................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed
# prettier.................................................................Passed

.venv/bin/pytest tests/unit/app/routers/test_messages_router.py tests/unit/cli/test_channels_send.py tests/unit/channels/test_dingtalk.py
# 166 passed, 28 warnings

.venv/bin/pytest tests/contract/channels/test_dingtalk_contract.py tests/unit/channels/test_dingtalk.py
# 181 passed, 27 warnings
```

## Additional Notes

Verification matrix:

- `/messages/send` API: covered
- `qwenpaw channels send` CLI: covered
- `ChannelManager.send_text` metadata path: covered through API and cron-shared send path
- DingTalk webhook `atUserIds` / `atDingtalkIds` / `isAtAll`: covered
- DingTalk AI Card `at_user_ids`: covered
- Other channels: unchanged and ignore the optional metadata
