### PR TITLE
fix(memory): skip auto-memory and search for heartbeat/cron requests

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 MAX_AUTO_MEMORY_TURN_MARKERS = 1000
+_AUTOMATION_MEMORY_SKIP_SOURCES = frozenset({"cron", "heartbeat"})
 
 
 class MemoryMiddleware(MiddlewareBase):
@@ -76,6 +77,9 @@ class MemoryMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., Any],
     ) -> Any:
+        if self._is_automation_request(agent):
+            return await next_handler(**input_kwargs)
+
         turn_marker = self._latest_user_turn_marker(agent.state.context)
         if turn_marker and turn_marker != self._searched_user_turn_marker:
             self._searched_user_turn_marker = turn_marker
@@ -113,6 +117,9 @@ class MemoryMiddleware(MiddlewareBase):
         async for item in next_handler(**input_kwargs):
             yield item
 
+        if self._is_automation_request(agent):
+            return
+
         self._repair_tagged_auto_memory_search_context(agent)
         turn_marker = self._latest_user_turn_marker(agent.state.context)
         if (
@@ -149,6 +156,10 @@ class MemoryMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., Any],
     ) -> None:
+        if self._is_automation_request(agent):
+            await next_handler(**input_kwargs)
+            return
+
         cfg = self._memory_config()
         if (
             cfg.summarize_when_compact
@@ -166,6 +177,16 @@ class MemoryMiddleware(MiddlewareBase):
         count: int | None = None,
         repair_context: bool = True,
     ) -> None:
+        if self._is_automation_request(agent):
+            logger.debug(
+                "MemoryMiddleware auto_memory skipped for automation source: "
+                "agent=%s",
+                agent.name,
+            )
+            # Defensive: clear in case on_reply guard was bypassed
+            self._pending_auto_memory_turn_markers.clear()
+            return
+
         if not self._pending_auto_memory_turn_markers:
             return
 
@@ -205,6 +226,15 @@ class MemoryMiddleware(MiddlewareBase):
         if isinstance(request_context, dict):
             return str(request_context.get("session_id") or "")
         return ""
+
+    @staticmethod
+    def _is_automation_request(agent: "Agent") -> bool:
+        """Return True when the request originates from non-user automation."""
+        request_context = getattr(agent, "_request_context", None) or {}
+        if not isinstance(request_context, dict):
+            return False
+        source = str(request_context.get("source") or "").strip().lower()
+        return source in _AUTOMATION_MEMORY_SKIP_SOURCES
 
     @staticmethod
     async def _will_compress_context(

--- a/tests/unit/agents/test_memory_middleware.py
+++ b/tests/unit/agents/test_memory_middleware.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+"""Tests for MemoryMiddleware automation-source skip logic."""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agentscope.message import Msg, TextBlock
+
+from qwenpaw.agents.middlewares import MemoryMiddleware
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(*, source: str | None = None):
+    """Build a minimal fake agent with optional request_context source."""
+    agent = MagicMock()
+    agent.name = "TestAgent"
+    agent.state = SimpleNamespace(
+        context=[],
+        session_id="session-1",
+        reply_id="reply-1",
+    )
+    if source is not None:
+        agent._request_context = {"source": source, "session_id": "session-1"}
+    else:
+        agent._request_context = {"session_id": "session-1"}
+    return agent
+
+
+def _user_msg(text: str = "hello", *, msg_id: str = "turn-1") -> Msg:
+    msg = Msg(
+        name="user",
+        role="user",
+        content=[TextBlock(type="text", text=text)],
+    )
+    msg.id = msg_id
+    return msg
+
+
+def _make_memory_manager(*, interval: int = 1):
+    mm = MagicMock()
+    mm.agent_id = "test-agent"
+    mm.get_auto_memory_interval.return_value = interval
+    mm.auto_memory = AsyncMock()
+    mm.auto_memory_search = AsyncMock(return_value=None)
+    mm.get_memory_prompt.return_value = ""
+    return mm
+
+
+# ---------------------------------------------------------------------------
+# _is_automation_request unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsAutomationRequest:
+    def test_cron_source(self):
+        agent = _make_agent(source="cron")
+        assert MemoryMiddleware._is_automation_request(agent) is True
+
+    def test_heartbeat_source(self):
+        agent = _make_agent(source="heartbeat")
+        assert MemoryMiddleware._is_automation_request(agent) is True
+
+    def test_cron_uppercase(self):
+        agent = _make_agent(source="CRON")
+        assert MemoryMiddleware._is_automation_request(agent) is True
+
+    def test_heartbeat_mixed_case(self):
+        agent = _make_agent(source="HeartBeat")
+        assert MemoryMiddleware._is_automation_request(agent) is True
+
+    def test_user_source(self):
+        agent = _make_agent(source="user")
+        assert MemoryMiddleware._is_automation_request(agent) is False
+
+    def test_empty_source(self):
+        agent = _make_agent(source="")
+        assert MemoryMiddleware._is_automation_request(agent) is False
+
+    def test_no_source_key(self):
+        agent = _make_agent(source=None)
+        assert MemoryMiddleware._is_automation_request(agent) is False
+
+    def test_no_request_context_attr(self):
+        agent = MagicMock(spec=[])
+        assert MemoryMiddleware._is_automation_request(agent) is False
+
+    def test_request_context_not_dict(self):
+        agent = MagicMock()
+        agent._request_context = "not-a-dict"
+        assert MemoryMiddleware._is_automation_request(agent) is False
+
+
+# ---------------------------------------------------------------------------
+# on_model_call integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnModelCallAutomationSkip:
+    @pytest.mark.asyncio
+    async def test_cron_skips_auto_memory_search(self):
+        """Automation requests must skip auto_memory_search entirely."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="cron")
+        agent.state.context = [_user_msg()]
+
+        next_handler = AsyncMock(return_value="model_result")
+        result = await mw.on_model_call(agent, {"messages": []}, next_handler)
+
+        mm.auto_memory_search.assert_not_awaited()
+        next_handler.assert_awaited_once()
+        assert result == "model_result"
+
+    @pytest.mark.asyncio
+    async def test_user_calls_auto_memory_search(self):
+        """Normal user requests should trigger auto_memory_search."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        agent.state.context = [_user_msg()]
+
+        next_handler = AsyncMock(return_value="model_result")
+        await mw.on_model_call(agent, {"messages": []}, next_handler)
+
+        mm.auto_memory_search.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# on_reply integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnReplyAutomationSkip:
+    @pytest.mark.asyncio
+    async def test_cron_skips_marker_tracking(self):
+        """Automation requests must not append to pending markers."""
+        mm = _make_memory_manager(interval=1)
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="cron")
+        agent.state.context = [_user_msg()]
+
+        async def _next(**_kwargs):
+            yield "done"
+
+        gen = mw.on_reply(agent, {}, _next)
+        async for _ in gen:
+            pass
+
+        assert not mw._pending_auto_memory_turn_markers
+        assert not mw._seen_auto_memory_turn_markers
+        mm.auto_memory.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_user_triggers_auto_memory(self):
+        """Normal user requests should trigger auto_memory as usual."""
+        mm = _make_memory_manager(interval=1)
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        agent.state.context = [_user_msg()]
+
+        async def _next(**_kwargs):
+            yield "done"
+
+        gen = mw.on_reply(agent, {}, _next)
+        async for _ in gen:
+            pass
+
+        mm.auto_memory.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# on_compress_context integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOnCompressContextAutomationSkip:
+    @pytest.mark.asyncio
+    async def test_heartbeat_skips_memory_flush_but_compresses(self):
+        """Automation skips memory flush; compression still runs."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="heartbeat")
+        next_handler = AsyncMock()
+
+        await mw.on_compress_context(agent, {}, next_handler)
+
+        next_handler.assert_awaited_once_with()
+        mm.auto_memory.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_does_not_call_will_compress(self):
+        """_will_compress_context must NOT be called for automation."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="heartbeat")
+        next_handler = AsyncMock()
+
+        with patch.object(
+            MemoryMiddleware,
+            "_will_compress_context",
+        ) as mock_wc:
+            await mw.on_compress_context(agent, {}, next_handler)
+            mock_wc.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_normal_request_may_flush_on_compress(self):
+        """Non-automation requests follow the normal compress path."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        mw._pending_auto_memory_turn_markers = ["m1"]
+        agent = _make_agent(source="user")
+        next_handler = AsyncMock()
+
+        with patch.object(
+            MemoryMiddleware,
+            "_memory_config",
+        ) as mock_cfg, patch.object(
+            MemoryMiddleware,
+            "_will_compress_context",
+            return_value=True,
+        ) as mock_wc:
+            cfg = MagicMock()
+            cfg.summarize_when_compact = True
+            mock_cfg.return_value = cfg
+
+            agent.state.context = [_user_msg()]
+
+            await mw.on_compress_context(agent, {}, next_handler)
+
+            mock_wc.assert_awaited_once()
+            next_handler.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _flush_auto_memory defensive guard
+# ---------------------------------------------------------------------------
+
+
+class TestFlushAutoMemoryDefensiveGuard:
+    @pytest.mark.asyncio
+    async def test_automation_clears_pending_and_skips(self):
+        """Defensive guard in _flush_auto_memory clears markers."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        mw._pending_auto_memory_turn_markers = ["m1", "m2"]
+        agent = _make_agent(source="cron")
+
+        await mw._flush_auto_memory(agent)
+
+        assert not mw._pending_auto_memory_turn_markers
+        mm.auto_memory.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_normal_request_flushes(self):
+        """Non-automation requests proceed with auto_memory."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        mw._pending_auto_memory_turn_markers = ["turn-1"]
+        agent = _make_agent(source="user")
+        agent.state.context = [_user_msg()]
+
+        await mw._flush_auto_memory(agent)
+
+        mm.auto_memory.assert_awaited_once()


### PR DESCRIPTION
## Description

Restore the lost `a0741c0b` commit functionality that was dropped during the 2.0 branch merge. Heartbeat and cron requests were triggering unnecessary auto-memory writes, auto-memory-search calls, and summarization on every execution, wasting tokens and polluting the memory store.

This PR adds automation-source skip logic to `MemoryMiddleware` across four guard points:
- **`on_model_call`**: Skips `auto_memory_search` for automation requests
- **`on_reply`**: Skips marker tracking entirely (primary defense), preventing marker accumulation that could accidentally clear legitimate user memory
- **`on_compress_context`**: Skips memory flush but preserves context compression
- **`_flush_auto_memory`**: Defensive secondary guard with debug logging

The `request_context.source` field is already correctly set by cron executor and heartbeat runner; this PR adds the missing consumer-side check in the new middleware architecture.

**Related Issue:** Relates to #4348

**Security Considerations:** None. This change only reads `request_context.source` (already set internally by trusted cron/heartbeat code) to skip memory operations. No external input is trusted or exposed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. **Unit tests**: Run `pytest tests/unit/agents/test_memory_middleware.py -v` — all 18 tests pass, covering:
   - `_is_automation_request` boundary cases (cron, heartbeat, case-insensitive, user, empty, missing, non-dict)
   - `on_model_call` skips `auto_memory_search` for automation, triggers for user
   - `on_reply` skips marker tracking for automation, triggers `auto_memory` for user
   - `on_compress_context` skips flush + `_will_compress_context` for automation, preserves compression
   - `_flush_auto_memory` defensive guard clears markers and skips write
2. **Manual verification**: Trigger a cron job and confirm no memory write appears in inbox/memory logs; trigger a normal user message and confirm memory write proceeds normally.

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/agents/middlewares.py tests/unit/agents/test_memory_middleware.py
# check python ast............................Passed
# check docstring is first....................Passed
# fix python encoding pragma..................Passed
# detect private key..........................Passed
# trim trailing whitespace....................Passed
# Add trailing commas.........................Passed
# mypy........................................Passed
# black.......................................Passed
# flake8......................................Passed
# pylint......................................Passed

pytest tests/unit/agents/test_memory_middleware.py -v
# 18 passed in 0.09s
```

## Additional Notes

- The original `a0741c0b` commit placed skip logic in `LightContextManager` (old architecture). After the 2.0 merge, memory behavior moved to `MemoryMiddleware`, but the skip condition was not migrated. The `request_context.source` producer-side code survived the merge intact.
- The four-layer guard design ensures correctness even if future refactoring changes call paths: `on_reply` prevents marker pollution (primary), `_flush_auto_memory` provides defensive fallback with observability.
- `_AUTOMATION_MEMORY_SKIP_SOURCES` uses `frozenset` for immutability and can be extended with new automation sources (e.g., webhook, scheduled report) without code changes beyond adding to the set.