### PR TITLE
fix(chat): remove white-space pre-wrap causing extra blank lines

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -233,14 +233,13 @@
 
 /* Fix #5480: Assistant response markdown may temporarily fall back to the
  * vendor Raw renderer while streaming. Raw renders newline-bearing text as
- * normal div children, so keep whitespace and wrap long lines on the host side.
+ * normal div children, so wrap long lines on the host side.
  */
 .chatMessagesArea :global {
   [class*="bubble-start"] [class*="markdown"],
   [class*="bubble-assistant"] [class*="markdown"] {
     min-width: 0;
     max-width: 100%;
-    white-space: pre-wrap;
     overflow-wrap: anywhere;
     word-break: normal;
   }

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -8,7 +8,7 @@ const stylesSource = readFileSync(
 );
 
 describe("Chat message markdown layout styles", () => {
-  it("preserves newlines for assistant markdown fallback content", () => {
+  it("wraps long lines for assistant markdown fallback content", () => {
     const marker = "Fix #5480";
     const markerIndex = stylesSource.indexOf(marker);
     const rule = stylesSource.slice(
@@ -18,7 +18,7 @@ describe("Chat message markdown layout styles", () => {
 
     expect(markerIndex).toBeGreaterThanOrEqual(0);
     expect(rule).toContain('[class*="bubble-start"] [class*="markdown"]');
-    expect(rule).toMatch(/white-space:\s*pre-wrap/);
+    expect(rule).not.toMatch(/white-space:\s*pre-wrap/);
     expect(rule).toMatch(/overflow-wrap:\s*anywhere/);
     expect(rule).toMatch(/word-break:\s*normal/);
     expect(rule).toMatch(/min-width:\s*0/);


### PR DESCRIPTION
Problem: After PR #5538 merged, console output shows extra blank lines after each line.

Root cause: white-space: pre-wrap preserves \n characters in text, but markdown renderer already outputs HTML tags (<p>, <br>) that create line breaks. This causes double line breaks.

Solution: Remove white-space: pre-wrap from assistant message markdown container while keeping overflow-wrap and word-break for proper text wrapping.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
