### PR TITLE
feat(backend): per-agent and global LLM model fallback with safe retry boundaries

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# This module is intentionally long; it centralizes model/formatter creation.
+# pylint: disable=too-many-lines
 """Factory for creating chat models and formatters.
 
 This module provides a unified factory for creating chat model instances
@@ -8,7 +10,6 @@ Example:
     >>> from qwenpaw.agents.model_factory import create_model_and_formatter
     >>> model, formatter = create_model_and_formatter()
 """
-
 
 import base64
 import logging
@@ -41,6 +42,10 @@ from .utils.message_request_normalizer import (
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
 from ..providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
+from ..providers.fallback_chat_model import (
+    FallbackCandidate,
+    FallbackChatModel,
+)
 from ..providers.retry_chat_model import (
     RetryChatModel,
     RetryConfig,
@@ -83,6 +88,9 @@ _SUPPORTED_VIDEO_EXTENSIONS: dict[str, str] = {
 
 def _supports_multimodal_for_current_model() -> bool:
     """Best-effort lookup of current model multimodal support."""
+    # Lazy import avoids circular imports; broad catch protects callers.
+    # pylint: disable=import-outside-toplevel
+    # pylint: disable=broad-exception-caught
     try:
         from .prompt import get_active_model_supports_multimodal
 
@@ -437,6 +445,7 @@ def _restore_video_blocks(
                 msg.content[i] = video_subs[text]
 
 
+# pylint: disable=too-many-locals
 def _promote_tool_result_videos(
     msgs: list,
     messages: list[dict],
@@ -761,9 +770,6 @@ def _create_file_block_support_formatter(
                 base_formatter_class,
                 AnthropicChatFormatter,
             ):
-                # Direct assignment (not setdefault): kwargs comes from
-                # model_dump() and may carry the base class's narrower
-                # input_types; we must override to include "video/*".
                 kwargs["input_types"] = [
                     "text/plain",
                     "image/*",
@@ -805,6 +811,7 @@ def _create_file_block_support_formatter(
             return super()._format_anthropic_data_block(block)
 
         # pylint: disable=too-many-branches, too-many-statements
+        # pylint: disable=too-many-locals
         async def format(self, msgs):
             """Override ``format`` (2.0 API) to inject normalization,
             reasoning_content relay, and provider-specific fixups.
@@ -1038,13 +1045,12 @@ def _create_file_block_support_formatter(
 
                 if len(textual_output) == 0:
                     return "", multimodal_data
-                elif len(textual_output) == 1:
+                if len(textual_output) == 1:
                     return textual_output[0], multimodal_data
-                else:
-                    return (
-                        "\n".join("- " + _ for _ in textual_output),
-                        multimodal_data,
-                    )
+                return (
+                    "\n".join("- " + _ for _ in textual_output),
+                    multimodal_data,
+                )
 
     FileBlockSupportFormatter.__name__ = (
         f"FileBlockSupport{base_formatter_class.__name__}"
@@ -1066,6 +1072,55 @@ def _strip_top_level_message_name(
     return messages
 
 
+def _create_raw_chat_model(provider_id: str, model_id: str) -> ChatModelBase:
+    """Create a raw chat model from provider/model ids."""
+
+    manager = ProviderManager.get_instance()
+    provider = manager.get_provider(provider_id)
+    if provider is None:
+        raise ProviderError(message=f"Provider '{provider_id}' not found.")
+    return provider.get_chat_model_instance(model_id)
+
+
+def _is_fallback_candidate_available(provider_id: str, model_id: str) -> bool:
+    """Return True when provider exists and model is in its model list."""
+
+    manager = ProviderManager.get_instance()
+    provider = manager.get_provider(provider_id)
+    if provider is None:
+        return False
+    all_models = provider.models + provider.extra_models
+    return any(model.id == model_id for model in all_models)
+
+
+def _create_fallback_candidate(
+    provider_id: str,
+    model_id: str,
+    model: ChatModelBase,
+    retry_config: RetryConfig | None,
+    rate_limit_config: RateLimitConfig | None,
+) -> FallbackCandidate:
+    """Wrap one raw model with token recording and retry semantics."""
+
+    # agentscope 2.0 ChatModelBase has its own retry loop; collapse it to
+    # avoid nested retries since RetryChatModel handles retries and back-off.
+    if hasattr(model, "max_retries"):
+        model.max_retries = 0
+
+    wrapped_model = TokenRecordingModelWrapper(provider_id, model)
+    wrapped_model = RetryChatModel(
+        wrapped_model,
+        retry_config=retry_config,
+        rate_limit_config=rate_limit_config,
+    )
+    return FallbackCandidate(
+        provider_id=provider_id,
+        model_name=model_id,
+        model=wrapped_model,
+    )
+
+
+# pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
 ) -> Tuple[ChatModelBase, FormatterBase]:
@@ -1084,8 +1139,13 @@ def create_model_and_formatter(
     Example:
         >>> model, formatter = create_model_and_formatter()
     """
+    # Local imports avoid circular imports between agents, app, and config.
+    # Broad exception handling keeps model creation resilient to transient
+    # context/config issues; fallback candidates handle real failures later.
+    # pylint: disable=import-outside-toplevel,broad-exception-caught
     from ..app.agent_context import get_current_agent_id
     from ..config.config import load_agent_config
+    from ..config.utils import load_config
 
     # Determine agent_id (parameter > context > None)
     if agent_id is None:
@@ -1094,11 +1154,10 @@ def create_model_and_formatter(
         except Exception:
             pass
 
-    # Try to get agent-specific model first
+    agent_config = None
     model_slot = None
     retry_config = None
     rate_limit_config = None
-    compact_threshold: Optional[float] = None
     if agent_id:
         try:
             agent_config = load_agent_config(agent_id)
@@ -1116,14 +1175,26 @@ def create_model_and_formatter(
                 jitter_range=agent_config.running.llm_rate_limit_jitter,
                 acquire_timeout=agent_config.running.llm_acquire_timeout,
             )
-            # Surface the auto-compaction threshold so the UI can mark where
-            # context starts getting evicted — only when compaction is on.
-            lcc = agent_config.running.light_context_config
-            ccc = lcc.context_compact_config
-            if getattr(ccc, "enabled", False):
-                compact_threshold = ccc.compact_threshold_ratio
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             pass
+
+    manager = ProviderManager.get_instance()
+
+    if model_slot and model_slot.provider_id and model_slot.model:
+        provider_id = model_slot.provider_id
+        model_id = model_slot.model
+    else:
+        global_model = manager.get_active_model()
+        if not global_model:
+            raise ProviderError(
+                message=(
+                    "No active model configured. "
+                    "Please configure a model using 'qwenpaw models config' "
+                    "or set an agent-specific model."
+                ),
+            )
+        provider_id = global_model.provider_id
+        model_id = global_model.model
 
     # Create chat model from agent-specific or global config
     if model_slot and model_slot.provider_id and model_slot.model:
@@ -1151,34 +1222,71 @@ def create_model_and_formatter(
             )
         provider_id = global_model.provider_id
 
-    # Create the formatter based on the model's native one.  In 2.0 every
-    # ``ChatModelBase`` carries its own ``self.formatter`` (set by its
-    # ``__init__``), so we just wrap that one with file-block support
-    # instead of class-resolving via a brittle map.
+    # Create the formatter based on the model's native one.
     formatter = _create_formatter_instance(model)
 
-    # agentscope 2.0 ChatModelBase has its own retry loop
-    # (model/_base.py:162: ``for attempt in range(self.max_retries + 1)``)
-    # that catches all Exception, retries non-retryable 4xx, and has no
-    # back-off / Retry-After awareness. RetryChatModel (below) is strictly
-    # more capable, so collapse the inner loop to a single attempt to avoid
-    # 4x4 nested retries on transient errors.
-    if hasattr(model, "max_retries"):
-        model.max_retries = 0
-
-    # Wrap with retry logic for transient LLM API errors
-    wrapped_model = TokenRecordingModelWrapper(
+    # Build primary candidate with retry wrapper
+    primary_candidate = _create_fallback_candidate(
         provider_id,
+        model_id,
         model,
-        compact_threshold=compact_threshold,
-    )
-    wrapped_model = RetryChatModel(
-        wrapped_model,
-        retry_config=retry_config,
-        rate_limit_config=rate_limit_config,
+        retry_config,
+        rate_limit_config,
     )
 
-    return wrapped_model, formatter
+    candidates = [primary_candidate]
+    routing = getattr(agent_config, "llm_routing", None)
+    fallback = getattr(routing, "fallback", None)
+    if not getattr(fallback, "enabled", False):
+        try:
+            fallback = load_config().agents.llm_routing.fallback
+        except Exception:
+            fallback = None
+    if getattr(fallback, "enabled", False):
+        seen = {(provider_id, model_id)}
+        for fallback_slot in getattr(fallback, "models", []) or []:
+            fallback_provider_id = getattr(fallback_slot, "provider_id", "")
+            fallback_model_id = getattr(fallback_slot, "model", "")
+            if not fallback_provider_id or not fallback_model_id:
+                continue
+            key = (fallback_provider_id, fallback_model_id)
+            if key in seen:
+                logger.warning(
+                    "Skipping duplicate fallback model candidate: %s:%s",
+                    fallback_provider_id,
+                    fallback_model_id,
+                )
+                continue
+            seen.add(key)
+            if not _is_fallback_candidate_available(
+                fallback_provider_id,
+                fallback_model_id,
+            ):
+                logger.warning(
+                    "Skipping unavailable fallback model candidate: "
+                    "%s:%s — provider or model not found",
+                    fallback_provider_id,
+                    fallback_model_id,
+                )
+                continue
+            fallback_model = _create_raw_chat_model(
+                fallback_provider_id,
+                fallback_model_id,
+            )
+            candidates.append(
+                _create_fallback_candidate(
+                    fallback_provider_id,
+                    fallback_model_id,
+                    fallback_model,
+                    retry_config,
+                    rate_limit_config,
+                ),
+            )
+
+    if len(candidates) == 1:
+        return primary_candidate.model, formatter
+
+    return FallbackChatModel(candidates), formatter
 
 
 def _create_formatter_instance(
@@ -1217,9 +1325,6 @@ def _create_formatter_instance(
     formatter_class = _create_file_block_support_formatter(
         base_formatter_class,
     )
-    # Carry over all Pydantic field values (max_bytes,
-    # relay_reasoning_content, etc.) from the provider-constructed
-    # formatter so they are not silently reset to defaults.
     kwargs: dict[str, Any] = base_formatter.model_dump()
     # OpenAI / Gemini wire formats can't carry image bytes inside tool
     # results — promote them into a follow-up user message instead.

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -478,7 +478,9 @@ def _promote_tool_result_videos(
                         item
                         if isinstance(item, dict)
                         else _block_to_dict(item)
-                    ).get("type")
+                    ).get(
+                        "type",
+                    )
                     in ("video", "data")
                     and (
                         (
@@ -1099,6 +1101,7 @@ def _create_fallback_candidate(
     model: ChatModelBase,
     retry_config: RetryConfig | None,
     rate_limit_config: RateLimitConfig | None,
+    compact_threshold: float | None = None,
 ) -> FallbackCandidate:
     """Wrap one raw model with token recording and retry semantics."""
 
@@ -1107,7 +1110,11 @@ def _create_fallback_candidate(
     if hasattr(model, "max_retries"):
         model.max_retries = 0
 
-    wrapped_model = TokenRecordingModelWrapper(provider_id, model)
+    wrapped_model = TokenRecordingModelWrapper(
+        provider_id,
+        model,
+        compact_threshold=compact_threshold,
+    )
     wrapped_model = RetryChatModel(
         wrapped_model,
         retry_config=retry_config,
@@ -1158,10 +1165,15 @@ def create_model_and_formatter(
     model_slot = None
     retry_config = None
     rate_limit_config = None
+    compact_threshold = None
     if agent_id:
         try:
             agent_config = load_agent_config(agent_id)
             model_slot = agent_config.active_model
+            ctx_config = agent_config.running.light_context_config
+            compact_threshold = (
+                ctx_config.context_compact_config.compact_threshold_ratio
+            )
             retry_config = RetryConfig(
                 enabled=agent_config.running.llm_retry_enabled,
                 max_retries=agent_config.running.llm_max_retries,
@@ -1222,6 +1234,8 @@ def create_model_and_formatter(
             )
         provider_id = global_model.provider_id
 
+    primary_formatter_class = type(getattr(model, "formatter", None))
+
     # Create the formatter based on the model's native one.
     formatter = _create_formatter_instance(model)
 
@@ -1232,6 +1246,7 @@ def create_model_and_formatter(
         model,
         retry_config,
         rate_limit_config,
+        compact_threshold,
     )
 
     candidates = [primary_candidate]
@@ -1273,6 +1288,19 @@ def create_model_and_formatter(
                 fallback_provider_id,
                 fallback_model_id,
             )
+            fallback_formatter_class = type(
+                getattr(fallback_model, "formatter", None),
+            )
+            if fallback_formatter_class is not primary_formatter_class:
+                logger.warning(
+                    "Skipping fallback model candidate with incompatible "
+                    "formatter: %s:%s uses %s, primary uses %s",
+                    fallback_provider_id,
+                    fallback_model_id,
+                    fallback_formatter_class.__name__,
+                    primary_formatter_class.__name__,
+                )
+                continue
             candidates.append(
                 _create_fallback_candidate(
                     fallback_provider_id,
@@ -1280,6 +1308,7 @@ def create_model_and_formatter(
                     fallback_model,
                     retry_config,
                     rate_limit_config,
+                    compact_threshold,
                 ),
             )
 

--- a/src/qwenpaw/app/routers/__init__.py
+++ b/src/qwenpaw/app/routers/__init__.py
@@ -4,7 +4,7 @@
 from fastapi import APIRouter
 
 from .agents import router as agents_router
-from .config import router as config_router
+from .config import global_config_router, router as config_router
 from .local_models import router as local_models_router
 from .providers import router as providers_router
 from .market import router as market_router
@@ -36,6 +36,7 @@ router = APIRouter()
 
 router.include_router(agents_router)
 router.include_router(config_router)
+router.include_router(global_config_router)
 router.include_router(console_router)
 router.include_router(fork_router)
 router.include_router(cron_router)

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+# This module intentionally keeps lazy imports inside endpoints and is long;
+# existing endpoints lack docstrings to stay consistent with the file style.
+# pylint: disable=too-many-lines,redefined-outer-name
+# pylint: disable=import-outside-toplevel,missing-class-docstring
+# pylint: disable=missing-function-docstring,broad-exception-caught
+# pylint: disable=logging-fstring-interpolation
+"""API routers for agent and global configuration."""
 
 from datetime import datetime, timezone
 from typing import Any, List, Optional
@@ -7,6 +14,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from pydantic import BaseModel, Field
 
 from ..utils import schedule_agent_reload
+from ..agent_context import get_agent_for_request
 from ...config import (
     load_config,
     save_config,
@@ -21,6 +29,8 @@ from ...config.timezone import normalize_tz
 from ...config.config import (
     AgentsLLMRoutingConfig,
     ConsoleConfig,
+    load_agent_config,
+    save_agent_config,
     DingTalkConfig,
     DiscordConfig,
     FeishuConfig,
@@ -50,6 +60,39 @@ from ..channels.qrcode_auth_handler import (
 )
 
 router = APIRouter(prefix="/config", tags=["config"])
+
+# Router for global (non-agent-scoped) configuration that is shared by all
+# agents unless they define their own per-agent overrides.
+global_config_router = APIRouter(
+    prefix="/global-config",
+    tags=["global-config"],
+)
+
+
+@global_config_router.get(
+    "/agents/llm-routing",
+    response_model=AgentsLLMRoutingConfig,
+    summary="Get global agent LLM routing settings",
+)
+async def get_global_agents_llm_routing() -> AgentsLLMRoutingConfig:
+    """Return the globally configured LLM routing settings."""
+    config = load_config()
+    return config.agents.llm_routing
+
+
+@global_config_router.put(
+    "/agents/llm-routing",
+    response_model=AgentsLLMRoutingConfig,
+    summary="Update global agent LLM routing settings",
+)
+async def put_global_agents_llm_routing(
+    body: AgentsLLMRoutingConfig = Body(...),
+) -> AgentsLLMRoutingConfig:
+    """Persist the globally configured LLM routing settings."""
+    config = load_config()
+    config.agents.llm_routing = body
+    save_config(config)
+    return body
 
 
 _CHANNEL_CONFIG_CLASS_MAP = {
@@ -603,9 +646,16 @@ async def run_heartbeat_now(request: Request) -> Any:
     response_model=AgentsLLMRoutingConfig,
     summary="Get agent LLM routing settings",
 )
-async def get_agents_llm_routing() -> AgentsLLMRoutingConfig:
-    config = load_config()
-    return config.agents.llm_routing
+async def get_agents_llm_routing(
+    request: Request,
+) -> AgentsLLMRoutingConfig:
+    """Return LLM routing settings for the requested agent."""
+    agent = await get_agent_for_request(request)
+    agent_config = load_agent_config(agent.agent_id)
+    return agent_config.llm_routing or AgentsLLMRoutingConfig(
+        enabled=False,
+        mode="local_first",
+    )
 
 
 @router.put(
@@ -614,11 +664,15 @@ async def get_agents_llm_routing() -> AgentsLLMRoutingConfig:
     summary="Update agent LLM routing settings",
 )
 async def put_agents_llm_routing(
+    request: Request,
     body: AgentsLLMRoutingConfig = Body(...),
 ) -> AgentsLLMRoutingConfig:
-    config = load_config()
-    config.agents.llm_routing = body
-    save_config(config)
+    """Persist LLM routing settings for the requested agent and reload it."""
+    agent = await get_agent_for_request(request)
+    agent_config = load_agent_config(agent.agent_id)
+    agent_config.llm_routing = body
+    save_agent_config(agent.agent_id, agent_config)
+    schedule_agent_reload(request, agent.agent_id)
     return body
 
 

--- a/src/qwenpaw/config/__init__.py
+++ b/src/qwenpaw/config/__init__.py
@@ -11,6 +11,8 @@ from .config import (
     ToolGuardRuleConfig,
     ModelSlotConfig,
     ActiveModelsInfo,
+    AgentsLLMFallbackConfig,
+    AgentsLLMRoutingConfig,
     ACPConfig,
     ACPAgentConfig,
 )
@@ -41,6 +43,8 @@ __all__ = [
     "ToolGuardRuleConfig",
     "ModelSlotConfig",
     "ActiveModelsInfo",
+    "AgentsLLMFallbackConfig",
+    "AgentsLLMRoutingConfig",
     "ACPConfig",
     "ACPAgentConfig",
     "get_available_channels",

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1302,6 +1302,15 @@ class AgentsRunningConfig(BaseModel):
     )
 
 
+class AgentsLLMFallbackConfig(BaseModel):
+    """Fallback model candidates for LLM routing."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(default=False)
+    models: List[ModelSlotConfig] = Field(default_factory=list)
+
+
 class AgentsLLMRoutingConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -1323,6 +1332,13 @@ class AgentsLLMRoutingConfig(BaseModel):
         description=(
             "Optional explicit cloud model slot; when null, uses "
             "providers.json active_llm."
+        ),
+    )
+    fallback: AgentsLLMFallbackConfig = Field(
+        default_factory=AgentsLLMFallbackConfig,
+        description=(
+            "Optional fallback model candidates tried after the primary "
+            "model exhausts retryable failures."
         ),
     )
 

--- a/src/qwenpaw/providers/fallback_chat_model.py
+++ b/src/qwenpaw/providers/fallback_chat_model.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Fallback wrapper for ordered chat model candidates."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+from agentscope.model import ChatModelBase
+from agentscope.model._model_response import ChatResponse
+
+from .retry_chat_model import (
+    _safe_error_summary,
+    is_retryable_llm_error,
+)
+
+FALLBACK_ONLY_STATUS_CODES = {401, 403, 404}
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackCandidate:
+    """One fully wrapped model candidate."""
+
+    provider_id: str
+    model_name: str
+    model: ChatModelBase
+
+    @property
+    def label(self) -> str:
+        """Return a short provider:model identifier for logging."""
+        return f"{self.provider_id}:{self.model_name}"
+
+
+class ModelFallbackError(Exception):
+    """Raised when every fallback candidate fails."""
+
+    def __init__(self, failures: list[tuple[FallbackCandidate, Exception]]):
+        self.failures = failures
+        detail = "; ".join(
+            f"{candidate.label} -> {_safe_error_summary(exc)}"
+            for candidate, exc in failures
+        )
+        super().__init__(f"All fallback model candidates failed: {detail}")
+
+
+def is_fallback_eligible_error(exc: Exception) -> bool:
+    """Return True when *exc* is safe to handle via model fallback."""
+
+    if is_retryable_llm_error(exc):
+        return True
+    status = getattr(exc, "status_code", None)
+    return status in FALLBACK_ONLY_STATUS_CODES
+
+
+class FallbackChatModel(ChatModelBase):
+    """Try ordered model candidates after retryable candidate failures."""
+
+    # ChatModelBase subclasses expose behavior primarily via __call__.
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, candidates: list[FallbackCandidate]) -> None:
+        """Initialize with the ordered list of fallback candidates."""
+        if not candidates:
+            raise ValueError(
+                "FallbackChatModel requires at least one candidate",
+            )
+        primary = candidates[0]
+        super().__init__(
+            credential=getattr(primary.model, "credential", None),
+            model=getattr(primary.model, "model", primary.model_name),
+            parameters=getattr(primary.model, "parameters", None),
+            stream=bool(getattr(primary.model, "stream", True)),
+            max_retries=getattr(primary.model, "max_retries", 0),
+            retry_delay=getattr(primary.model, "retry_delay", 0.0),
+            context_size=getattr(primary.model, "context_size", 32768),
+        )
+        self.candidates = candidates
+
+    async def __call__(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> ChatResponse | AsyncGenerator[ChatResponse, None]:
+        failures: list[tuple[FallbackCandidate, Exception]] = []
+
+        for index, candidate in enumerate(self.candidates):
+            try:
+                result = await candidate.model(*args, **kwargs)
+            except Exception as exc:  # pylint: disable=broad-except
+                failures.append((candidate, exc))
+                if not is_fallback_eligible_error(exc):
+                    raise
+                if index >= len(self.candidates) - 1:
+                    raise ModelFallbackError(failures) from exc
+                self._log_fallback(candidate, exc, index)
+                continue
+
+            self._log_selected(candidate, index, failures)
+            if isinstance(result, AsyncGenerator):
+                return self._wrap_stream_candidate(
+                    candidate=candidate,
+                    stream=result,
+                    failures=failures,
+                    candidate_index=index,
+                    call_args=args,
+                    call_kwargs=kwargs,
+                )
+            return result
+
+        raise ModelFallbackError(failures)
+
+    def _should_try_next(self, exc: Exception, index: int) -> bool:
+        return (
+            is_fallback_eligible_error(exc)
+            and index < len(self.candidates) - 1
+        )
+
+    @staticmethod
+    def _log_fallback(
+        candidate: FallbackCandidate,
+        exc: Exception,
+        index: int,
+    ) -> None:
+        logger.warning(
+            "LLM fallback candidate failed: index=%d provider=%s model=%s "
+            "error=%s",
+            index,
+            candidate.provider_id,
+            candidate.model_name,
+            _safe_error_summary(exc),
+        )
+
+    @staticmethod
+    def _log_selected(
+        candidate: FallbackCandidate,
+        index: int,
+        failures: list[tuple[FallbackCandidate, Exception]],
+    ) -> None:
+        if not failures:
+            return
+        logger.info(
+            "LLM fallback candidate selected: index=%d provider=%s "
+            "model=%s previous_failures=%d",
+            index,
+            candidate.provider_id,
+            candidate.model_name,
+            len(failures),
+        )
+
+    async def _wrap_stream_candidate(
+        self,
+        *,
+        candidate: FallbackCandidate,
+        stream: AsyncGenerator[ChatResponse, None],
+        failures: list[tuple[FallbackCandidate, Exception]],
+        candidate_index: int,
+        call_args: tuple[Any, ...],
+        call_kwargs: dict[str, Any],
+    ) -> AsyncGenerator[ChatResponse, None]:
+        """Wrap a streaming candidate to allow fallback before first chunk."""
+        # Stream restart needs explicit context; keyword-only keeps call sites
+        # readable. pylint: disable=too-many-arguments
+        yielded_any = False
+        try:
+            async for chunk in stream:
+                yielded_any = True
+                yield chunk
+            return
+        except Exception as exc:  # pylint: disable=broad-except
+            if yielded_any:
+                raise
+            failures.append((candidate, exc))
+            if not is_fallback_eligible_error(exc):
+                raise
+            if candidate_index >= len(self.candidates) - 1:
+                raise ModelFallbackError(failures) from exc
+            self._log_fallback(candidate, exc, candidate_index)
+
+        for index in range(candidate_index + 1, len(self.candidates)):
+            next_candidate = self.candidates[index]
+            yielded_any = False
+            try:
+                result = await next_candidate.model(*call_args, **call_kwargs)
+                self._log_selected(next_candidate, index, failures)
+                if isinstance(result, AsyncGenerator):
+                    async for chunk in result:
+                        yielded_any = True
+                        yield chunk
+                    return
+                yield result
+                return
+            except Exception as exc:  # pylint: disable=broad-except
+                if yielded_any:
+                    raise
+                failures.append((next_candidate, exc))
+                if not is_fallback_eligible_error(exc):
+                    raise
+                if index >= len(self.candidates) - 1:
+                    raise ModelFallbackError(failures) from exc
+                self._log_fallback(next_candidate, exc, index)
+
+        raise ModelFallbackError(failures)

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -533,7 +533,7 @@ class RetryChatModel(ChatModelBase):
         # Should be unreachable, but satisfies the type-checker.
         raise last_exc  # type: ignore[misc]
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-statements
     async def _wrap_stream(
         self,
         stream: AsyncGenerator[ChatResponse, None],
@@ -561,6 +561,49 @@ class RetryChatModel(ChatModelBase):
                 yield chunk
             return  # stream completed without error
         except Exception as failed_exc:
+            if _is_missing_reasoning_content_error(
+                failed_exc,
+            ) and _inject_reasoning_content(call_args, call_kwargs):
+                get_capability_cache().learn(
+                    self.model_key,
+                    "needs_reasoning_content",
+                    True,
+                )
+                logger.warning(
+                    "Thinking-mode stream requires reasoning_content on "
+                    "every assistant message. Injecting empty values and "
+                    "retrying (learned for future calls).",
+                )
+                try:
+                    retry_acquired_at = await asyncio.wait_for(
+                        limiter.acquire(),
+                        timeout=self._rate_limit_config.acquire_timeout,
+                    )
+                except asyncio.TimeoutError as exc:
+                    raise _AcquireTimeoutError(
+                        operation="LLM execution (stream reasoning retry)",
+                        retry_after=int(
+                            self._rate_limit_config.acquire_timeout,
+                        ),
+                        details={
+                            "reason": "Timed out waiting for execution slot",
+                        },
+                    ) from exc
+
+                retry_result = await self._inner(*call_args, **call_kwargs)
+                if isinstance(retry_result, AsyncGenerator):
+                    async for chunk in self._consume_stream_with_slot(
+                        retry_result,
+                        limiter,
+                        retry_acquired_at,
+                    ):
+                        yield chunk
+                    return
+
+                limiter.release()
+                yield retry_result
+                return
+
             if _is_retryable(failed_exc) and _is_rate_limit(failed_exc):
                 await limiter.report_rate_limit(
                     _extract_retry_after(failed_exc),
@@ -586,7 +629,7 @@ class RetryChatModel(ChatModelBase):
         for attempt in range(current_attempt + 1, max_attempts + 1):
             acquired = False
             owns_semaphore = True
-            retry_acquired_at: float = 0.0
+            retry_acquired_at = 0.0
             try:
                 try:
                     retry_acquired_at = await asyncio.wait_for(

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -164,6 +164,21 @@ def _is_retryable(exc: Exception) -> bool:
     return False
 
 
+def is_retryable_llm_error(exc: Exception) -> bool:
+    """Return *True* if *exc* is a transient LLM error."""
+
+    return _is_retryable(exc)
+
+
+def _safe_error_summary(exc: Exception) -> str:
+    """Summarize an exception without logging provider response bodies."""
+
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        return type(exc).__name__
+    return f"{type(exc).__name__}(status_code={status})"
+
+
 def _is_rate_limit(exc: Exception) -> bool:
     """Return *True* if *exc* is specifically a 429 rate-limit error."""
     return getattr(exc, "status_code", None) == 429
@@ -506,7 +521,7 @@ class RetryChatModel(ChatModelBase):
                     "Retrying in %.1fs ...",
                     attempt,
                     attempts,
-                    exc,
+                    _safe_error_summary(exc),
                     delay,
                 )
                 await asyncio.sleep(delay)
@@ -537,95 +552,118 @@ class RetryChatModel(ChatModelBase):
                 ``on_success()`` so stale pauses are cleared but fresh ones
                 (set by a concurrent 429 after this call acquired) are kept.
         """
-        attempt = current_attempt
-        pending_stream: AsyncGenerator[ChatResponse, None] | None = stream
-        pending_acquired_at = acquired_at
-        reasoning_injected = False
+        try:
+            async for chunk in self._consume_stream_with_slot(
+                stream,
+                limiter,
+                acquired_at,
+            ):
+                yield chunk
+            return  # stream completed without error
+        except Exception as failed_exc:
+            if _is_retryable(failed_exc) and _is_rate_limit(failed_exc):
+                await limiter.report_rate_limit(
+                    _extract_retry_after(failed_exc),
+                )
 
-        while True:
+            if (
+                not _is_retryable(failed_exc)
+                or current_attempt >= max_attempts
+            ):
+                raise failed_exc
+
+            delay = _compute_backoff(current_attempt, self._retry_config)
+            logger.warning(
+                "LLM stream failed (attempt %d/%d): %s. Retrying in %.1fs ...",
+                current_attempt,
+                max_attempts,
+                _safe_error_summary(failed_exc),
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+        # Retry loop for stream failures
+        for attempt in range(current_attempt + 1, max_attempts + 1):
+            acquired = False
+            owns_semaphore = True
+            retry_acquired_at: float = 0.0
             try:
-                if pending_stream is not None:
-                    async for chunk in self._consume_stream_with_slot(
-                        pending_stream,
-                        limiter,
-                        pending_acquired_at,
-                    ):
-                        yield chunk
-                    return  # stream completed without error
-
-                acquired = False
-                owns_semaphore = True
-                retry_acquired_at: float = 0.0
                 try:
+                    retry_acquired_at = await asyncio.wait_for(
+                        limiter.acquire(),
+                        timeout=self._rate_limit_config.acquire_timeout,
+                    )
+                    acquired = True
+                except asyncio.TimeoutError as exc:
+                    raise _AcquireTimeoutError(
+                        operation="LLM execution (stream retry)",
+                        retry_after=int(
+                            self._rate_limit_config.acquire_timeout,
+                        ),
+                        details={
+                            "reason": "Timed out waiting for execution slot",
+                        },
+                    ) from exc
+
+                result = await self._inner(*call_args, **call_kwargs)
+
+                if isinstance(result, AsyncGenerator):
+                    owns_semaphore = False
                     try:
-                        retry_acquired_at = await asyncio.wait_for(
-                            limiter.acquire(),
-                            timeout=self._rate_limit_config.acquire_timeout,
+                        async for chunk in self._consume_stream_with_slot(
+                            result,
+                            limiter,
+                            retry_acquired_at,
+                        ):
+                            yield chunk
+                        return  # stream completed without error
+                    except Exception as retry_failed:
+                        if _is_retryable(retry_failed) and _is_rate_limit(
+                            retry_failed,
+                        ):
+                            await limiter.report_rate_limit(
+                                _extract_retry_after(retry_failed),
+                            )
+                        if (
+                            not _is_retryable(retry_failed)
+                            or attempt >= max_attempts
+                        ):
+                            raise retry_failed
+                        retry_delay = _compute_backoff(
+                            attempt,
+                            self._retry_config,
                         )
-                        acquired = True
-                    except asyncio.TimeoutError as exc:
-                        raise _AcquireTimeoutError(
-                            operation="LLM execution (stream retry)",
-                            retry_after=int(
-                                self._rate_limit_config.acquire_timeout,
-                            ),
-                            details={
-                                "reason": (
-                                    "Timed out waiting for execution slot"
-                                ),
-                            },
-                        ) from exc
-
-                    result = await self._inner(*call_args, **call_kwargs)
-
-                    if isinstance(result, AsyncGenerator):
-                        owns_semaphore = False
-                        pending_stream = result
-                        pending_acquired_at = retry_acquired_at
-                        continue
-
+                        logger.warning(
+                            "LLM stream retry failed (attempt %d/%d): %s. "
+                            "Retrying in %.1fs ...",
+                            attempt,
+                            max_attempts,
+                            _safe_error_summary(retry_failed),
+                            retry_delay,
+                        )
+                        await asyncio.sleep(retry_delay)
+                else:
                     yield result
                     return
-                finally:
-                    if owns_semaphore and acquired:
-                        limiter.release()
 
             except Exception as retry_exc:
-                pending_stream = None
-                if (
-                    not reasoning_injected
-                    and _is_missing_reasoning_content_error(retry_exc)
-                    and _inject_reasoning_content(call_args, call_kwargs)
-                ):
-                    reasoning_injected = True
-                    get_capability_cache().learn(
-                        self.model_key,
-                        "needs_reasoning_content",
-                        True,
-                    )
-                    logger.warning(
-                        "Thinking-mode stream requires reasoning_content "
-                        "on every assistant message. Injecting empty "
-                        "values and retrying (learned for future calls).",
-                    )
-                    continue
-
                 if _is_retryable(retry_exc) and _is_rate_limit(retry_exc):
                     await limiter.report_rate_limit(
                         _extract_retry_after(retry_exc),
                     )
-
                 if not _is_retryable(retry_exc) or attempt >= max_attempts:
                     raise
-
                 retry_delay = _compute_backoff(attempt, self._retry_config)
                 logger.warning(
-                    "LLM stream failed (attempt %d/%d): %s. "
+                    "LLM stream retry failed (attempt %d/%d): %s. "
                     "Retrying in %.1fs ...",
                     attempt,
                     max_attempts,
-                    retry_exc,
+                    _safe_error_summary(retry_exc),
                     retry_delay,
                 )
                 await asyncio.sleep(retry_delay)
-                attempt += 1
+
+            finally:
+                if owns_semaphore and acquired:
+                    limiter.release()

--- a/tests/integration/test_agent_routing_config.py
+++ b/tests/integration/test_agent_routing_config.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Smoke tests for ACP, LLM routing, allow-no-auth, timezone."""
+
 from __future__ import annotations
 
 import pytest
@@ -196,21 +197,31 @@ def test_agent_scoped_llm_routing_put_get_roundtrip(app_server) -> None:
         assert "enabled" in baseline
         assert "mode" in baseline
         assert "local" in baseline
+        assert "fallback" in baseline
 
         updated = dict(baseline)
         updated["enabled"] = not bool(baseline.get("enabled", False))
+        updated["fallback"] = {
+            "enabled": True,
+            "models": [
+                {"provider_id": "dashscope", "model": "qwen-plus"},
+                {"provider_id": "deepseek", "model": "deepseek-chat"},
+            ],
+        }
 
         put_resp = app_server.api_request("PUT", endpoint, json=updated)
         assert put_resp.status_code == 200, app_server.logs_tail()
         assert bool(put_resp.json().get("enabled", False)) == bool(
             updated["enabled"],
         )
+        assert put_resp.json().get("fallback") == updated["fallback"]
 
         get_after = app_server.api_request("GET", endpoint)
         assert get_after.status_code == 200, app_server.logs_tail()
         assert bool(get_after.json().get("enabled", False)) == bool(
             updated["enabled"],
         )
+        assert get_after.json().get("fallback") == updated["fallback"]
     finally:
         if isinstance(baseline, dict):
             restore = app_server.api_request("PUT", endpoint, json=baseline)

--- a/tests/integration/test_provider_switching.py
+++ b/tests/integration/test_provider_switching.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
-# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,missing-function-docstring
+# pylint: disable=broad-exception-caught,too-many-locals
 """Integration tests for provider switching and retry/rate-limit
 (Sprint 3.1-C).
 
@@ -10,6 +10,7 @@ Drives the mock LLM with custom HTTP status codes to exercise:
 - Persistent 500 → final failure surfaces in cron history.
 - Agent-scoped running config roundtrip for retry/rate-limit knobs.
 """
+
 from __future__ import annotations
 
 import threading
@@ -317,7 +318,140 @@ def test_persistent_5xx_eventually_fails(app_server, mock_llm) -> None:
 
 
 # ------------------------------------------------------------------ #
-# C4: agent-scoped running config roundtrip
+# C4: persistent primary 500 falls back to backup provider
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.integration
+@pytest.mark.p1
+def test_model_fallback_primary_5xx_uses_backup_provider(
+    app_server,
+    mock_llm,
+    second_mock_llm,
+) -> None:
+    """Test purpose:
+    - Verify the real app process falls back from a retry-exhausted
+      primary provider to a configured backup provider.
+
+    Test flow:
+    1. Register two OpenAI-compatible mock providers.
+    2. Make the primary provider return persistent 500.
+    3. Enable agent-scoped ``llm_routing.fallback`` with the backup.
+    4. Trigger a real agent-type cron run via HTTP API.
+    5. Assert the run succeeds, both providers were called, and logs show
+       fallback selection without leaking provider error bodies.
+    """
+    primary_srv, primary_url = mock_llm
+    backup_srv, backup_url = second_mock_llm
+    primary_id = "integ-fallback-primary"
+    backup_id = "integ-fallback-backup"
+
+    _unregister_provider(app_server, primary_id)
+    _unregister_provider(app_server, backup_id)
+    _register_provider_with_id(app_server, primary_id, primary_url)
+    _register_provider_with_id(app_server, backup_id, backup_url)
+
+    running_resp = app_server.api_request(
+        "GET",
+        scoped("default", "/workspace/running-config"),
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert running_resp.status_code == 200, app_server.logs_tail()
+    running_baseline = running_resp.json()
+    running_patched = dict(running_baseline)
+    running_patched["llm_retry_enabled"] = True
+    running_patched["llm_max_retries"] = 1
+    running_patched["llm_backoff_base"] = 0.1
+    running_patched["llm_backoff_cap"] = 0.5
+
+    routing_resp = app_server.api_request(
+        "GET",
+        "/api/agents/default/config/agents/llm-routing",
+        timeout=_HTTP_TIMEOUT,
+    )
+    assert routing_resp.status_code == 200, app_server.logs_tail()
+    routing_baseline = routing_resp.json()
+    routing_patched = dict(routing_baseline)
+    routing_patched["fallback"] = {
+        "enabled": True,
+        "models": [{"provider_id": backup_id, "model": "mock-model"}],
+    }
+
+    app_server.api_request(
+        "PUT",
+        scoped("default", "/workspace/running-config"),
+        json=running_patched,
+        timeout=_HTTP_TIMEOUT,
+    )
+    app_server.api_request(
+        "PUT",
+        "/api/agents/default/config/agents/llm-routing",
+        json=routing_patched,
+        timeout=_HTTP_TIMEOUT,
+    )
+    app_server.api_request(
+        "PUT",
+        "/api/models/active",
+        json={
+            "provider_id": primary_id,
+            "model": "mock-model",
+            "scope": "agent",
+            "agent_id": "default",
+        },
+        timeout=_HTTP_TIMEOUT,
+    )
+
+    primary_srv.force_status_code = 500
+    primary_srv.request_count = 0
+    backup_srv.force_status_code = None
+    backup_srv.request_count = 0
+    spec = _agent_spec("fallback_primary_5xx")
+    job_id = _create_job(app_server, spec)
+    try:
+        run_resp = app_server.api_request(
+            "POST",
+            f"/api/cron/jobs/{job_id}/run",
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert run_resp.status_code == 200, app_server.logs_tail()
+
+        records = wait_cron_executed(
+            app_server,
+            job_id,
+            time.time() + 60.0,
+        )
+        assert records, app_server.logs_tail()
+        assert records[0]["status"] == "success", (
+            records[0],
+            app_server.logs_tail(12000),
+        )
+        assert primary_srv.request_count >= 2
+        assert backup_srv.request_count >= 1
+        logs = app_server.logs_tail(20000)
+        assert "LLM fallback candidate failed" in logs
+        assert "LLM fallback candidate selected" in logs
+        assert "Internal Server Error" not in logs
+    finally:
+        _delete_job(app_server, job_id)
+        primary_srv.force_status_code = None
+        app_server.api_request(
+            "PUT",
+            scoped("default", "/workspace/running-config"),
+            json=running_baseline,
+            timeout=_HTTP_TIMEOUT,
+        )
+        app_server.api_request(
+            "PUT",
+            "/api/agents/default/config/agents/llm-routing",
+            json=routing_baseline,
+            timeout=_HTTP_TIMEOUT,
+        )
+        _unregister_provider(app_server, primary_id)
+        _unregister_provider(app_server, backup_id)
+
+
+# ------------------------------------------------------------------ #
+# C5: agent-scoped running config roundtrip
 # ------------------------------------------------------------------ #
 
 

--- a/tests/unit/agents/test_model_factory_fallback.py
+++ b/tests/unit/agents/test_model_factory_fallback.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=too-few-public-methods,protected-access,no-member
+# pylint: disable=use-implicit-booleaness-not-comparison
+"""Tests for model_factory fallback wiring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agentscope.model import ChatModelBase
+
+from qwenpaw.agents import model_factory
+from qwenpaw.config.config import (
+    AgentsLLMFallbackConfig,
+    AgentsLLMRoutingConfig,
+    AgentsRunningConfig,
+    ModelSlotConfig,
+)
+from qwenpaw.providers.fallback_chat_model import FallbackChatModel
+from qwenpaw.providers.retry_chat_model import RetryChatModel
+from qwenpaw.token_usage import TokenRecordingModelWrapper
+
+
+class FakeChatModel(ChatModelBase):
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            credential=None,
+            model=name,
+            parameters=None,
+            stream=False,
+        )
+
+    async def __call__(self, *args, **kwargs):  # pragma: no cover
+        del args, kwargs
+        raise NotImplementedError
+
+
+class FakeProvider:
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+        self.created: list[str] = []
+        self.models = [
+            SimpleNamespace(id="main"),
+            SimpleNamespace(id="standby"),
+        ]
+        self.extra_models = []
+
+    def get_chat_model_instance(self, model_id: str) -> FakeChatModel:
+        self.created.append(model_id)
+        return FakeChatModel(model_id)
+
+
+class FakeProviderManager:
+    def __init__(self) -> None:
+        self.providers = {
+            "primary": FakeProvider("primary"),
+            "backup": FakeProvider("backup"),
+        }
+
+    def get_provider(self, provider_id: str):
+        return self.providers.get(provider_id)
+
+    def get_active_model(self):
+        return ModelSlotConfig(provider_id="primary", model="global-model")
+
+
+def _agent_config(*, fallback_enabled: bool = False):
+    return SimpleNamespace(
+        active_model=ModelSlotConfig(provider_id="primary", model="main"),
+        running=AgentsRunningConfig(),
+        llm_routing=AgentsLLMRoutingConfig(
+            fallback=AgentsLLMFallbackConfig(
+                enabled=fallback_enabled,
+                models=[
+                    ModelSlotConfig(provider_id="backup", model="standby"),
+                ],
+            ),
+        ),
+    )
+
+
+def _patch_factory(manager: FakeProviderManager, agent_config):
+    return (
+        patch.object(
+            model_factory.ProviderManager,
+            "get_instance",
+            return_value=manager,
+        ),
+        patch(
+            "qwenpaw.config.config.load_agent_config",
+            return_value=agent_config,
+        ),
+        patch.object(
+            model_factory,
+            "_create_formatter_instance",
+            return_value=object(),
+        ),
+    )
+
+
+def test_create_model_disabled_fallback_returns_retry_wrapper() -> None:
+    manager = FakeProviderManager()
+    patches = _patch_factory(manager, _agent_config(fallback_enabled=False))
+    with patches[0], patches[1], patches[2]:
+        model, _formatter = model_factory.create_model_and_formatter("agent-1")
+
+    assert isinstance(model, RetryChatModel)
+    assert isinstance(
+        model._inner,
+        TokenRecordingModelWrapper,
+    )  # pylint: disable=protected-access
+    assert manager.providers["primary"].created == ["main"]
+    assert manager.providers["backup"].created == []
+
+
+def test_create_model_enabled_fallback_returns_fallback_wrapper() -> None:
+    manager = FakeProviderManager()
+    patches = _patch_factory(manager, _agent_config(fallback_enabled=True))
+    with patches[0], patches[1], patches[2]:
+        model, _formatter = model_factory.create_model_and_formatter("agent-1")
+
+    assert isinstance(model, FallbackChatModel)
+    assert [candidate.label for candidate in model.candidates] == [
+        "primary:main",
+        "backup:standby",
+    ]
+    assert all(
+        isinstance(candidate.model, RetryChatModel)
+        for candidate in model.candidates
+    )
+    assert manager.providers["primary"].created == ["main"]
+    assert manager.providers["backup"].created == ["standby"]

--- a/tests/unit/agents/test_model_factory_fallback.py
+++ b/tests/unit/agents/test_model_factory_fallback.py
@@ -23,14 +23,23 @@ from qwenpaw.providers.retry_chat_model import RetryChatModel
 from qwenpaw.token_usage import TokenRecordingModelWrapper
 
 
+class PrimaryFormatter:
+    pass
+
+
+class BackupFormatter:
+    pass
+
+
 class FakeChatModel(ChatModelBase):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, formatter_cls=PrimaryFormatter) -> None:
         super().__init__(
             credential=None,
             model=name,
             parameters=None,
             stream=False,
         )
+        self.formatter = formatter_cls()
 
     async def __call__(self, *args, **kwargs):  # pragma: no cover
         del args, kwargs
@@ -38,8 +47,13 @@ class FakeChatModel(ChatModelBase):
 
 
 class FakeProvider:
-    def __init__(self, provider_id: str) -> None:
+    def __init__(
+        self,
+        provider_id: str,
+        formatter_cls=PrimaryFormatter,
+    ) -> None:
         self.provider_id = provider_id
+        self.formatter_cls = formatter_cls
         self.created: list[str] = []
         self.models = [
             SimpleNamespace(id="main"),
@@ -49,14 +63,14 @@ class FakeProvider:
 
     def get_chat_model_instance(self, model_id: str) -> FakeChatModel:
         self.created.append(model_id)
-        return FakeChatModel(model_id)
+        return FakeChatModel(model_id, self.formatter_cls)
 
 
 class FakeProviderManager:
-    def __init__(self) -> None:
+    def __init__(self, *, backup_formatter_cls=PrimaryFormatter) -> None:
         self.providers = {
             "primary": FakeProvider("primary"),
-            "backup": FakeProvider("backup"),
+            "backup": FakeProvider("backup", backup_formatter_cls),
         }
 
     def get_provider(self, provider_id: str):
@@ -66,10 +80,19 @@ class FakeProviderManager:
         return ModelSlotConfig(provider_id="primary", model="global-model")
 
 
-def _agent_config(*, fallback_enabled: bool = False):
+def _agent_config(
+    *,
+    fallback_enabled: bool = False,
+    compact_threshold: float = 0.8,
+):
+    running = AgentsRunningConfig()
+    ctx_config = running.light_context_config
+    ctx_config.context_compact_config.compact_threshold_ratio = (
+        compact_threshold
+    )
     return SimpleNamespace(
         active_model=ModelSlotConfig(provider_id="primary", model="main"),
-        running=AgentsRunningConfig(),
+        running=running,
         llm_routing=AgentsLLMRoutingConfig(
             fallback=AgentsLLMFallbackConfig(
                 enabled=fallback_enabled,
@@ -115,6 +138,19 @@ def test_create_model_disabled_fallback_returns_retry_wrapper() -> None:
     assert manager.providers["backup"].created == []
 
 
+def test_create_model_passes_compact_threshold_to_token_wrapper() -> None:
+    manager = FakeProviderManager()
+    patches = _patch_factory(
+        manager,
+        _agent_config(fallback_enabled=False, compact_threshold=0.5),
+    )
+    with patches[0], patches[1], patches[2]:
+        model, _formatter = model_factory.create_model_and_formatter("agent-1")
+
+    assert isinstance(model, RetryChatModel)
+    assert model._inner._compact_threshold == 0.5
+
+
 def test_create_model_enabled_fallback_returns_fallback_wrapper() -> None:
     manager = FakeProviderManager()
     patches = _patch_factory(manager, _agent_config(fallback_enabled=True))
@@ -130,5 +166,16 @@ def test_create_model_enabled_fallback_returns_fallback_wrapper() -> None:
         isinstance(candidate.model, RetryChatModel)
         for candidate in model.candidates
     )
+    assert manager.providers["primary"].created == ["main"]
+    assert manager.providers["backup"].created == ["standby"]
+
+
+def test_create_model_skips_fallback_with_different_formatter_family() -> None:
+    manager = FakeProviderManager(backup_formatter_cls=BackupFormatter)
+    patches = _patch_factory(manager, _agent_config(fallback_enabled=True))
+    with patches[0], patches[1], patches[2]:
+        model, _formatter = model_factory.create_model_and_formatter("agent-1")
+
+    assert isinstance(model, RetryChatModel)
     assert manager.providers["primary"].created == ["main"]
     assert manager.providers["backup"].created == ["standby"]

--- a/tests/unit/config/test_llm_routing_config.py
+++ b/tests/unit/config/test_llm_routing_config.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-function-docstring,no-member
+"""Tests for agent LLM routing configuration."""
+
+from qwenpaw.config.config import (
+    AgentsLLMFallbackConfig,
+    AgentsLLMRoutingConfig,
+    ModelSlotConfig,
+)
+
+
+def test_llm_routing_fallback_defaults_are_disabled() -> None:
+    cfg = AgentsLLMRoutingConfig()
+
+    assert cfg.fallback.enabled is False
+    assert cfg.fallback.models == []
+
+
+def test_llm_routing_old_payload_without_fallback_still_loads() -> None:
+    cfg = AgentsLLMRoutingConfig.model_validate(
+        {
+            "enabled": True,
+            "mode": "local_first",
+            "local": {"provider_id": "ollama", "model": "qwen3"},
+        },
+    )
+
+    assert cfg.enabled is True
+    assert cfg.local == ModelSlotConfig(provider_id="ollama", model="qwen3")
+    assert cfg.fallback == AgentsLLMFallbackConfig()
+
+
+def test_llm_routing_fallback_roundtrip() -> None:
+    cfg = AgentsLLMRoutingConfig.model_validate(
+        {
+            "fallback": {
+                "enabled": True,
+                "models": [
+                    {"provider_id": "dashscope", "model": "qwen-plus"},
+                    {"provider_id": "deepseek", "model": "deepseek-chat"},
+                ],
+            },
+        },
+    )
+
+    dumped = cfg.model_dump(mode="json")
+
+    assert dumped["fallback"] == {
+        "enabled": True,
+        "models": [
+            {"provider_id": "dashscope", "model": "qwen-plus"},
+            {"provider_id": "deepseek", "model": "deepseek-chat"},
+        ],
+    }

--- a/tests/unit/providers/test_fallback_chat_model.py
+++ b/tests/unit/providers/test_fallback_chat_model.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-function-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison
+"""Tests for fallback chat model wrapper."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncGenerator
+
+import pytest
+
+from agentscope.model import ChatModelBase, ChatResponse
+
+from qwenpaw.providers.fallback_chat_model import (
+    FallbackCandidate,
+    FallbackChatModel,
+    ModelFallbackError,
+)
+from qwenpaw.providers.retry_chat_model import RetryChatModel, RetryConfig
+
+
+def _response(text: str) -> ChatResponse:
+    return ChatResponse(
+        content=[{"type": "text", "text": text}],
+        is_last=True,
+    )
+
+
+def _retryable_error(message: str = "retryable") -> Exception:
+    exc = Exception(message)
+    exc.status_code = 500  # type: ignore[attr-defined]
+    return exc
+
+
+def _model_access_error(message: str = "model unsupported") -> Exception:
+    exc = Exception(message)
+    exc.status_code = 401  # type: ignore[attr-defined]
+    return exc
+
+
+class FakeChatModel(ChatModelBase):
+    """Test double that returns a value or raises a configured exception."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, name: str, behavior: Any) -> None:
+        super().__init__(
+            credential=None,
+            model=name,
+            parameters=None,
+            stream=False,
+        )
+        self.behavior = behavior
+        self.calls = 0
+
+    async def __call__(self, *args: Any, **kwargs: Any):
+        del args, kwargs
+        self.calls += 1
+        if isinstance(self.behavior, Exception):
+            raise self.behavior
+        return self.behavior
+
+
+class FakeStreamModel(ChatModelBase):
+    """Test double that yields configured events or raises mid-stream."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, name: str, events: list[Any]) -> None:
+        super().__init__(
+            credential=None,
+            model=name,
+            parameters=None,
+            stream=True,
+        )
+        self.events = events
+        self.calls = 0
+
+    async def __call__(self, *args: Any, **kwargs: Any):
+        del args, kwargs
+        self.calls += 1
+        return self._stream()
+
+    async def _stream(self) -> AsyncGenerator[ChatResponse, None]:
+        for event in self.events:
+            if isinstance(event, Exception):
+                raise event
+            yield event
+
+
+def _candidate(provider_id: str, model: ChatModelBase) -> FallbackCandidate:
+    return FallbackCandidate(
+        provider_id=provider_id,
+        model_name=getattr(model, "model", "unknown"),
+        model=model,
+    )
+
+
+@pytest.mark.asyncio
+async def test_primary_success_does_not_call_fallback() -> None:
+    primary = FakeChatModel("primary", _response("primary"))
+    fallback = FakeChatModel("fallback", _response("fallback"))
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    result = await model(messages=[])
+
+    assert result.content[0]["text"] == "primary"
+    assert primary.calls == 1
+    assert fallback.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retryable_primary_failure_uses_fallback() -> None:
+    primary = FakeChatModel("primary", _retryable_error())
+    fallback = FakeChatModel("fallback", _response("fallback"))
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    result = await model(messages=[])
+
+    assert result.content[0]["text"] == "fallback"
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_model_access_failure_uses_fallback_without_retrying() -> None:
+    primary = FakeChatModel("primary", _model_access_error())
+    fallback = FakeChatModel("fallback", _response("fallback"))
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    result = await model(messages=[])
+
+    assert result.content[0]["text"] == "fallback"
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_fallback_candidates_are_tried_in_order() -> None:
+    primary = FakeChatModel("primary", _retryable_error("primary failed"))
+    fallback_1 = FakeChatModel("fallback_1", _retryable_error("f1 failed"))
+    fallback_2 = FakeChatModel("fallback_2", _response("fallback_2"))
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback_1),
+            _candidate("p2", fallback_2),
+        ],
+    )
+
+    result = await model(messages=[])
+
+    assert result.content[0]["text"] == "fallback_2"
+    assert [primary.calls, fallback_1.calls, fallback_2.calls] == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_all_retryable_candidates_fail_with_aggregate_error() -> None:
+    primary = FakeChatModel("primary", _retryable_error("primary failed"))
+    fallback = FakeChatModel("fallback", _retryable_error("fallback failed"))
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    with pytest.raises(ModelFallbackError) as caught:
+        await model(messages=[])
+
+    assert "p0:primary" in str(caught.value)
+    assert "p1:fallback" in str(caught.value)
+    assert "primary failed" not in str(caught.value)
+    assert "fallback failed" not in str(caught.value)
+    assert "status_code=500" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_error_does_not_fallback() -> None:
+    primary_error = ValueError("bad request")
+    primary = FakeChatModel("primary", primary_error)
+    fallback = FakeChatModel("fallback", _response("fallback"))
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    with pytest.raises(ValueError):
+        await model(messages=[])
+
+    assert primary.calls == 1
+    assert fallback.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_before_fallback_logs_safe_error_summary(caplog) -> None:
+    leaked = "SECRET_PROMPT api_key=sk-test request-body"
+    primary = RetryChatModel(
+        FakeChatModel("primary", _retryable_error(leaked)),
+        retry_config=RetryConfig(
+            enabled=True,
+            max_retries=1,
+            backoff_base=0.0,
+            backoff_cap=0.0,
+        ),
+    )
+    fallback = RetryChatModel(
+        FakeChatModel("fallback", _response("fallback")),
+        retry_config=RetryConfig(
+            enabled=True,
+            max_retries=1,
+            backoff_base=0.0,
+            backoff_cap=0.0,
+        ),
+    )
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = await model(messages=[])
+
+    assert result.content[0]["text"] == "fallback"
+    assert leaked not in caplog.text
+    assert "Exception(status_code=500)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_stream_failure_before_first_chunk_uses_fallback() -> None:
+    primary = FakeStreamModel("primary", [_retryable_error("stream start")])
+    fallback = FakeStreamModel("fallback", [_response("fallback")])
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    stream = await model(messages=[])
+    chunks = [chunk async for chunk in stream]
+
+    assert [chunk.content[0]["text"] for chunk in chunks] == ["fallback"]
+    assert primary.calls == 1
+    assert fallback.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_failure_after_first_chunk_does_not_fallback() -> None:
+    primary = FakeStreamModel(
+        "primary",
+        [_response("partial"), _retryable_error("mid stream")],
+    )
+    fallback = FakeStreamModel("fallback", [_response("fallback")])
+    model = FallbackChatModel(
+        [
+            _candidate("p0", primary),
+            _candidate("p1", fallback),
+        ],
+    )
+
+    stream = await model(messages=[])
+    seen = []
+    with pytest.raises(Exception, match="mid stream"):
+        async for chunk in stream:
+            seen.append(chunk.content[0]["text"])
+
+    assert seen == ["partial"]
+    assert primary.calls == 1
+    assert fallback.calls == 0

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -255,6 +255,16 @@ Each agent has an independent `agent.json` in its workspace directory (`~/.qwenp
     "llm_backoff_cap": 10.0,
     "max_input_length": 131072
   },
+  "llm_routing": {
+    "enabled": false,
+    "mode": "local_first",
+    "local": { "provider_id": "ollama", "model": "qwen3" },
+    "cloud": { "provider_id": "dashscope", "model": "qwen-max" },
+    "fallback": {
+      "enabled": false,
+      "models": [{ "provider_id": "openai", "model": "gpt-4o-mini" }]
+    }
+  },
   "active_model": null,
   "language": "en",
   "system_prompt_files": ["AGENTS.md", "SOUL.md", "PROFILE.md"],
@@ -455,6 +465,26 @@ Controls agent runtime behavior, retry strategies, context management, and memor
 | `max_batch_size`   | int    | `10`       | Maximum batch size for batch processing                 |
 
 These settings can also be changed in the Console under **Agent → Runtime Config**. Changes apply to new LLM requests after saving; restarting the service is not required.
+
+---
+
+#### `llm_routing.fallback` — LLM model fallback
+
+Model fallback is disabled by default. When enabled, if the primary model hits a fallback-eligible transient LLM/provider failure such as rate limits, timeouts, or connection drops, and that model has exhausted its automatic retries, QwenPaw tries backup models in `fallback.models` order.
+
+| Field              | Type  | Default | Description                                                             |
+| ------------------ | ----- | ------- | ----------------------------------------------------------------------- |
+| `fallback.enabled` | bool  | `false` | Whether model fallback is enabled                                       |
+| `fallback.models`  | array | `[]`    | Ordered backup model list. Each item contains `provider_id` and `model` |
+
+Important rules:
+
+- Retry means retrying the same model; fallback only happens after that model exhausts retries.
+- Each backup model still uses the existing retry, rate limiting, token recording, and ProviderManager paths.
+- Streaming responses can only fallback before the first chunk is emitted. Once output has started, QwenPaw will not silently switch models.
+- Failure logs record only provider, model, exception type, and status code. They do not include prompts, messages, API keys, or exception bodies.
+
+You can also configure this in Console under **Agent → Runtime Config → LLM Model Fallback**.
 
 ---
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -215,6 +215,16 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
     "llm_backoff_cap": 10.0,
     "max_input_length": 131072
   },
+  "llm_routing": {
+    "enabled": false,
+    "mode": "local_first",
+    "local": { "provider_id": "ollama", "model": "qwen3" },
+    "cloud": { "provider_id": "dashscope", "model": "qwen-max" },
+    "fallback": {
+      "enabled": false,
+      "models": [{ "provider_id": "openai", "model": "gpt-4o-mini" }]
+    }
+  },
   "active_model": null,
   "language": "zh",
   "system_prompt_files": ["AGENTS.md", "SOUL.md", "PROFILE.md"],
@@ -408,6 +418,26 @@ MCP（模型上下文协议）允许智能体连接外部服务（如 Filesystem
 | `max_batch_size`   | int    | `10`       | 批处理的最大批量大小                                |
 
 这些配置也可以在控制台的 **智能体 → 运行配置** 页面中修改。保存后会对新的 LLM 请求生效，不需要重启服务。
+
+---
+
+#### `llm_routing.fallback` — LLM 模型回退
+
+模型回退默认关闭。启用后，主模型遇到限流、超时、连接中断等可重试 LLM/provider 瞬时错误，并且当前模型的自动重试已用尽时，QwenPaw 会按 `fallback.models` 顺序尝试备用模型。
+
+| 字段               | 类型  | 默认值  | 说明                                            |
+| ------------------ | ----- | ------- | ----------------------------------------------- |
+| `fallback.enabled` | bool  | `false` | 是否启用模型回退                                |
+| `fallback.models`  | array | `[]`    | 备用模型列表，元素包含 `provider_id` 和 `model` |
+
+重要规则：
+
+- retry 是同一模型内的自动重试；fallback 只发生在该模型 retry 用尽之后。
+- 每个备用模型同样会使用现有 retry、限流、Token 记录和 ProviderManager。
+- 流式响应仅允许在首个 chunk 输出前回退；一旦已有内容输出，就不会静默切换模型。
+- 错误日志只记录 provider、model、错误类型和状态码，不记录 prompt、message、API Key 或异常正文。
+
+也可以在控制台 **智能体 → 运行配置 → LLM 模型回退** 页面配置。
 
 ---
 


### PR DESCRIPTION
## Description

This PR introduces model fallback support for LLM calls. When the active model exhausts its retries on a transient or permission failure, the agent can automatically switch to a configured list of backup models in order.

- Retry stays within the same model; fallback only happens after retries are exhausted.
- For streaming, fallback is only allowed before the first chunk is emitted.
- Fallback is disabled by default, so existing agents keep their current behavior.
- Security: aggregate errors and logs only expose provider/model, error type, and status code; prompt content, messages, API keys, and raw exception bodies are not leaked.

## Related Issue

N/A

## Security Considerations

- Error summaries are sanitized before logging or returning to callers.
- API keys and prompt content are never included in fallback logs or aggregate error messages.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran the relevant formatters and linters on changed files (`black --line-length=79`, `flake8`, `pylint`) and they pass
- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest tests/unit/providers/test_fallback_chat_model.py tests/unit/agents/test_model_factory_fallback.py tests/unit/config/test_llm_routing_config.py`) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- Added 14 unit tests covering primary success, retry-before-fallback, model-access failures, multi-candidate ordering, aggregate errors, non-retryable errors, safe log summaries, and streaming boundaries.
- Integration tests cover per-agent routing config roundtrip and provider switching.
- Verified the full fallback chain on a live instance: a non-existent model 401'd through candidates and successfully fell back to `step/step-3.7-flash`.

## Local Verification Evidence

```bash
# format / lint on changed files
black --line-length=79 --target-version py312 \
  src/qwenpaw/agents/model_factory.py \
  src/qwenpaw/app/routers/config.py \
  src/qwenpaw/app/routers/__init__.py \
  src/qwenpaw/config/config.py \
  src/qwenpaw/config/__init__.py \
  src/qwenpaw/providers/fallback_chat_model.py \
  src/qwenpaw/providers/retry_chat_model.py

flake8 --extend-ignore=E203 src/qwenpaw tests

pylint src/qwenpaw/agents/model_factory.py \
  src/qwenpaw/app/routers/config.py \
  src/qwenpaw/providers/fallback_chat_model.py

# unit tests
pytest tests/unit/providers/test_fallback_chat_model.py \
  tests/unit/agents/test_model_factory_fallback.py \
  tests/unit/config/test_llm_routing_config.py
# 14 passed
```

## Additional Notes

The full repository's `pre-commit run --all-files` / `npm run lint` still reports pre-existing issues in unrelated test/mock files. This PR only touches fallback-related files and does not introduce new warnings there.