### PR TITLE
[codex] Send uploaded DingTalk images as previewable image messages

### DIFF
--- a/src/qwenpaw/app/channels/dingtalk/channel.py
+++ b/src/qwenpaw/app/channels/dingtalk/channel.py
@@ -1177,9 +1177,27 @@ class DingTalkChannel(BaseChannel):
             )
             return False
 
-        # Send via Open API with appropriate msgKey
-        # Note: sampleImageMsg does not support mediaId, so we send as
-        # sampleFile for all media types including images.
+        # Send via Open API with appropriate msgKey.
+        # DingTalk sampleImageMsg photoURL accepts uploaded image mediaId,
+        # so local/base64 images can still render as previewable images.
+        if upload_type == "image":
+            ok = await self._send_open_api_message(
+                msg_key="sampleImageMsg",
+                msg_param={
+                    "photoURL": media_id,
+                },
+                conversation_id=conversation_id,
+                conversation_type=conversation_type,
+                sender_staff_id=sender_staff_id,
+            )
+            if ok:
+                return True
+            logger.info(
+                "dingtalk _send_media_part_via_open_api: "
+                "sampleImageMsg with mediaId failed, falling back to "
+                "sampleFile",
+            )
+
         return await self._send_open_api_message(
             msg_key="sampleFile",
             msg_param={
@@ -1577,12 +1595,10 @@ class DingTalkChannel(BaseChannel):
                 return False
 
             if upload_type == "image":
-                # Use markdown with media_id for inline image preview
                 payload = {
-                    "msgtype": "markdown",
-                    "markdown": {
-                        "title": filename or "image",
-                        "text": f"![{filename or 'image'}]({media_id})",
+                    "msgtype": "image",
+                    "image": {
+                        "picURL": media_id,
                     },
                 }
                 ok = await self._send_payload_via_session_webhook(
@@ -1591,7 +1607,7 @@ class DingTalkChannel(BaseChannel):
                 )
                 if ok:
                     return True
-                # Fallback to file card if markdown fails
+                # Fallback to file card if mediaId image send fails.
                 payload = {
                     "msgtype": "file",
                     "file": {
@@ -1746,12 +1762,10 @@ class DingTalkChannel(BaseChannel):
 
         # ---------- send ----------
         if upload_type == "image":
-            # Use markdown with media_id for inline image preview
             payload = {
-                "msgtype": "markdown",
-                "markdown": {
-                    "title": filename or "image",
-                    "text": f"![{filename or 'image'}]({media_id})",
+                "msgtype": "image",
+                "image": {
+                    "picURL": media_id,
                 },
             }
             ok = await self._send_payload_via_session_webhook(
@@ -1760,19 +1774,12 @@ class DingTalkChannel(BaseChannel):
             )
             if ok:
                 return True
-            # Fallback to file card if markdown fails
-            payload = {
-                "msgtype": "file",
-                "file": {
-                    "mediaId": media_id,
-                    "fileType": ext,
-                    "fileName": filename,
-                },
-            }
-            return await self._send_payload_via_session_webhook(
-                session_webhook,
-                payload,
+            logger.info(
+                "dingtalk _send_media_part_via_webhook: "
+                "msgtype=image with mediaId failed, trying Open API "
+                "fallback",
             )
+            return False
 
         if upload_type == "voice":
             # sendBySession returns 400105 for voice; send as file.
@@ -2417,10 +2424,33 @@ class DingTalkChannel(BaseChannel):
             )
             for part in parts:
                 if getattr(part, "type", None) in media_types:
-                    await self._send_media_part_via_webhook(
+                    ok = await self._send_media_part_via_webhook(
                         session_webhook,
                         part,
                     )
+                    if not ok:
+                        logger.info(
+                            "dingtalk on_event_message_completed: webhook "
+                            "media send failed, trying Open API fallback",
+                        )
+                        params = await self._resolve_open_api_params_from_handle(
+                            to_handle,
+                            send_meta,
+                        )
+                        cid = params.get("conversation_id", "")
+                        if cid:
+                            await self._send_media_part_via_open_api(
+                                part,
+                                conversation_id=cid,
+                                conversation_type=params.get(
+                                    "conversation_type",
+                                    "",
+                                ),
+                                sender_staff_id=params.get(
+                                    "sender_staff_id",
+                                    "",
+                                ),
+                            )
         elif body.strip() or parts:
             await self.send_content_parts(to_handle, parts, send_meta)
 

--- a/tests/unit/channels/test_dingtalk.py
+++ b/tests/unit/channels/test_dingtalk.py
@@ -2717,6 +2717,11 @@ class TestDingTalkMediaPartSending:
         )
 
         assert result is True
+        payload = mock_http_session._requests[-1]["kwargs"]["json"]
+        assert payload == {
+            "msgtype": "image",
+            "image": {"picURL": "existing_media_123"},
+        }
 
     async def test_send_media_part_via_webhook_fetch_and_upload(
         self,
@@ -2727,13 +2732,6 @@ class TestDingTalkMediaPartSending:
         """Fetch and upload when no media_id."""
         dingtalk_channel._http = mock_http_session
         dingtalk_channel._media_dir = tmp_path
-
-        # Mock file download
-        mock_http_session.expect_get(
-            url="http://example.com/img.jpg",
-            response_status=200,
-            response_data=b"\xff\xd8\xff\xe0image data",
-        )
 
         # Mock token and upload
         mock_http_session.expect_post(
@@ -2758,7 +2756,9 @@ class TestDingTalkMediaPartSending:
 
         part = ImageContent(
             type=ContentType.IMAGE,
-            image_url="http://example.com/img.jpg",
+            image_url=(
+                "data:image/jpeg;base64,/9j/4GltYWdlIGRhdGE="
+            ),
             # No media_id, should fetch and upload
         )
 
@@ -2768,6 +2768,45 @@ class TestDingTalkMediaPartSending:
         )
 
         assert result is True
+        payload = mock_http_session._requests[-1]["kwargs"]["json"]
+        assert payload == {
+            "msgtype": "image",
+            "image": {"picURL": "uploaded_media_123"},
+        }
+
+    async def test_send_media_part_via_open_api_uploaded_image_media_id(
+        self,
+        dingtalk_channel,
+    ):
+        """Send uploaded image media_id as Open API image message."""
+        from qwenpaw.app.channels.base import ImageContent, ContentType
+
+        part = ImageContent(
+            type=ContentType.IMAGE,
+            image_url="data:image/png;base64,aW1hZ2UgZGF0YQ==",
+        )
+        dingtalk_channel._upload_media = AsyncMock(
+            return_value="uploaded_image_media_123",
+        )
+        dingtalk_channel._send_open_api_message = AsyncMock(
+            return_value=True,
+        )
+
+        result = await dingtalk_channel._send_media_part_via_open_api(
+            part,
+            conversation_id="cid_123",
+            conversation_type="group",
+            sender_staff_id="staff_123",
+        )
+
+        assert result is True
+        dingtalk_channel._send_open_api_message.assert_awaited_once_with(
+            msg_key="sampleImageMsg",
+            msg_param={"photoURL": "uploaded_image_media_123"},
+            conversation_id="cid_123",
+            conversation_type="group",
+            sender_staff_id="staff_123",
+        )
 
     async def test_send_media_part_empty_media_id_skipped(
         self,


### PR DESCRIPTION
## Summary

Fix DingTalk image delivery so uploaded local/base64 images are sent as previewable image messages when possible instead of degrading to file/markdown messages.

## Changes

- Send uploaded image `media_id` through Open API `sampleImageMsg` using `photoURL=<media_id>` before falling back to `sampleFile`.
- Send DingTalk session webhook image media IDs with `msgtype=image` / `image.picURL=<media_id>` instead of Markdown image syntax.
- Return `False` from the uploaded-image webhook path when `msgtype=image` is rejected so existing callers can try the Open API fallback.
- Add unit coverage for webhook image payloads and Open API uploaded-image delivery.

## Why

DingTalk clients currently show non-public generated images as file attachments. DingTalk media upload returns a `media_id`, and current DingTalk docs indicate image message fields can reference uploaded media IDs, which allows local/base64 image outputs to render as images without requiring public object storage URLs.

Closes #5593.

## Validation

- `python -m py_compile src/qwenpaw/app/channels/dingtalk/channel.py tests/unit/channels/test_dingtalk.py`

Full pytest was not run locally because this PR was prepared from a clean API-sourced snapshot due local checkout/network constraints; CI should run the full test suite.