### PR TITLE
chore(deps): update reme-ai dependency to version 0.4.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.4.0.4",
+    "reme-ai==0.4.0.5",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",


### PR DESCRIPTION
Remove ingest step: superseded by auto_resource (drop files under resource/ → watcher interprets them); its meta.json/.md outputs had no consumers and tripped the auto_resource watcher.
Replace lsof/pgrep shell-outs in service_utils with psutil (per-process enumeration, no root needed on macOS) for Windows/macOS/Linux support.
Add cross-platform test coverage for _pid_on_port / _scan_reme_procs.
Deps: +psutil, -filelock (only used by the removed ingest lock).