### PR TITLE
fix(providers): restore non-standard kwargs routing into extra_body

### DIFF
--- a/src/qwenpaw/providers/_openai_params.py
+++ b/src/qwenpaw/providers/_openai_params.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""OpenAI SDK parameter whitelists and non-standard kwargs routing utility."""
+from __future__ import annotations
+
+from typing import Any
+
+# OpenAI SDK chat.completions.create() accepted parameters.
+# Parameters NOT in this set are routed into extra_body.
+# Reference: openai-python SDK v2.33 (last verified)
+# API: https://platform.openai.com/docs/api-reference/chat/create
+# SDK: https://github.com/openai/openai-python
+OPENAI_CHAT_CREATE_PARAMS: frozenset[str] = frozenset(
+    {
+        "messages",
+        "model",
+        "audio",
+        "frequency_penalty",
+        "function_call",
+        "functions",
+        "logit_bias",
+        "logprobs",
+        "max_completion_tokens",
+        "max_tokens",
+        "metadata",
+        "modalities",
+        "n",
+        "parallel_tool_calls",
+        "prediction",
+        "presence_penalty",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "reasoning_effort",
+        "response_format",
+        "safety_identifier",
+        "seed",
+        "service_tier",
+        "stop",
+        "store",
+        "stream",
+        "stream_options",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p",
+        "user",
+        "verbosity",
+        "web_search_options",
+        # SDK-level params (not sent in body, handled by SDK transport)
+        "extra_headers",
+        "extra_query",
+        "extra_body",
+        "timeout",
+    },
+)
+
+# OpenAI SDK responses.create() accepted parameters.
+# Reference: openai-python SDK v2.33 (last verified)
+# API: https://platform.openai.com/docs/api-reference/responses/create
+OPENAI_RESPONSE_CREATE_PARAMS: frozenset[str] = frozenset(
+    {
+        "model",
+        "input",
+        "stream",
+        "include",
+        "instructions",
+        "max_output_tokens",
+        "metadata",
+        "parallel_tool_calls",
+        "previous_response_id",
+        "reasoning",
+        "store",
+        "temperature",
+        "text",
+        "tool_choice",
+        "tools",
+        "top_p",
+        "truncation",
+        "user",
+        # SDK-level params
+        "extra_headers",
+        "extra_query",
+        "extra_body",
+        "timeout",
+    },
+)
+
+
+def _deep_merge(
+    base: dict[str, Any],
+    override: dict[str, Any],
+) -> dict[str, Any]:
+    """Recursively merge *override* into *base* (returns a new dict).
+
+    Intentional copy of Provider._deep_merge to avoid circular import
+    between this utility module and provider.py.  Keep in sync.
+    """
+    result = dict(base)
+    for key, val in override.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(val, dict)
+        ):
+            result[key] = _deep_merge(result[key], val)
+        else:
+            result[key] = val
+    return result
+
+
+def route_non_standard_to_extra_body(
+    gen_kwargs: dict[str, Any],
+    known_params: frozenset[str] = OPENAI_CHAT_CREATE_PARAMS,
+) -> None:
+    """Route non-standard kwargs in *gen_kwargs* into ``extra_body``.
+
+    **Mutates** *gen_kwargs* in place.  Callers must pass a mutable copy
+    (``get_effective_generate_kwargs()`` always returns a fresh dict).
+
+    Routing rules:
+
+    - Keys not in *known_params* are considered non-standard and moved
+      into ``gen_kwargs["extra_body"]``.
+    - User-explicit ``extra_body`` takes precedence over auto-routed keys
+      of the same name (deep merge with explicit values winning).
+    - If ``extra_body`` is configured as a non-dict, it is treated as
+      empty to avoid deferred TypeErrors.
+    """
+    if not gen_kwargs:
+        return
+    extra_body = gen_kwargs.pop("extra_body", None)
+    if not isinstance(extra_body, dict):
+        extra_body = {}
+    non_standard = {
+        k: v for k, v in list(gen_kwargs.items()) if k not in known_params
+    }
+    for k in non_standard:
+        del gen_kwargs[k]
+    if non_standard or extra_body:
+        merged = _deep_merge(non_standard, extra_body)
+        if merged:
+            gen_kwargs["extra_body"] = merged

--- a/src/qwenpaw/providers/ollama_provider.py
+++ b/src/qwenpaw/providers/ollama_provider.py
@@ -81,6 +81,11 @@ class OllamaProvider(OpenAIProvider):
             temperature=gen_kwargs.pop("temperature", None),
             top_p=gen_kwargs.pop("top_p", None),
         )
+
+        from ._openai_params import route_non_standard_to_extra_body
+
+        route_non_standard_to_extra_body(gen_kwargs)
+
         return OpenAIChatModelCompat(
             credential=credential,
             model=model_id,

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -199,6 +199,10 @@ class OpenAIProvider(Provider):
             top_p=gen_kwargs.pop("top_p", None),
         )
 
+        from ._openai_params import route_non_standard_to_extra_body
+
+        route_non_standard_to_extra_body(gen_kwargs)
+
         return OpenAIChatModelCompat(
             credential=credential,
             model=model_id,

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -123,6 +123,16 @@ class OpenAIResponseProvider(OpenAIProvider):
             temperature=gen_kwargs.pop("temperature", None),
         )
 
+        from ._openai_params import (
+            OPENAI_RESPONSE_CREATE_PARAMS,
+            route_non_standard_to_extra_body,
+        )
+
+        route_non_standard_to_extra_body(
+            gen_kwargs,
+            OPENAI_RESPONSE_CREATE_PARAMS,
+        )
+
         client_kwargs: dict[str, Any] = {}
         if merged_headers:
             client_kwargs["default_headers"] = merged_headers

--- a/src/qwenpaw/providers/openrouter_provider.py
+++ b/src/qwenpaw/providers/openrouter_provider.py
@@ -359,7 +359,9 @@ class OpenRouterProvider(Provider):
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
         from agentscope.credential._openai import OpenAICredential
+        from agentscope.model import OpenAIChatModel
 
+        from ._openai_params import route_non_standard_to_extra_body
         from .openai_chat_model_compat import OpenAIChatModelCompat
 
         credential = OpenAICredential(
@@ -367,11 +369,22 @@ class OpenRouterProvider(Provider):
             api_key=self.api_key,
             base_url=self.base_url,
         )
+
+        gen_kwargs = self.get_effective_generate_kwargs(model_id)
+        parameters = OpenAIChatModel.Parameters(
+            max_tokens=gen_kwargs.pop("max_tokens", None),
+            temperature=gen_kwargs.pop("temperature", None),
+            top_p=gen_kwargs.pop("top_p", None),
+        )
+        route_non_standard_to_extra_body(gen_kwargs)
+
         return OpenAIChatModelCompat(
             credential=credential,
             model=model_id,
+            parameters=parameters,
             stream=True,
             default_headers=self._build_default_headers() or None,
+            extra_generate_kwargs=gen_kwargs or None,
             context_size=self._get_context_size(model_id),
             formatter=_CappingOpenAIFormatter(
                 max_bytes=self.max_inline_media_bytes,

--- a/tests/unit/providers/test_openai_params.py
+++ b/tests/unit/providers/test_openai_params.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Tests for _openai_params module: whitelist routing and deep merge."""
+from __future__ import annotations
+
+from qwenpaw.providers._openai_params import (
+    OPENAI_CHAT_CREATE_PARAMS,
+    OPENAI_RESPONSE_CREATE_PARAMS,
+    _deep_merge,
+    route_non_standard_to_extra_body,
+)
+
+
+class TestDeepMerge:
+    def test_flat_override(self) -> None:
+        base = {"a": 1, "b": 2}
+        override = {"b": 3, "c": 4}
+        assert _deep_merge(base, override) == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_dict_recursive(self) -> None:
+        base = {"opts": {"x": 1, "y": 2}}
+        override = {"opts": {"y": 3, "z": 4}}
+        assert _deep_merge(base, override) == {
+            "opts": {"x": 1, "y": 3, "z": 4},
+        }
+
+    def test_override_replaces_non_dict(self) -> None:
+        base = {"a": {"nested": True}}
+        override = {"a": "scalar"}
+        assert _deep_merge(base, override) == {"a": "scalar"}
+
+    def test_does_not_mutate_base(self) -> None:
+        base = {"a": {"b": 1}}
+        override = {"a": {"c": 2}}
+        _deep_merge(base, override)
+        assert base == {"a": {"b": 1}}
+
+
+class TestRouteNonStandardToExtraBody:
+    def test_empty_dict_is_noop(self) -> None:
+        kwargs: dict = {}
+        route_non_standard_to_extra_body(kwargs)
+        assert not kwargs
+
+    def test_standard_params_preserved(self) -> None:
+        kwargs = {"seed": 42, "stop": ["\n"], "temperature": 0.7}
+        route_non_standard_to_extra_body(kwargs)
+        assert kwargs == {"seed": 42, "stop": ["\n"], "temperature": 0.7}
+
+    def test_non_standard_routed_to_extra_body(self) -> None:
+        kwargs = {"seed": 42, "enable_search": True, "custom_flag": "yes"}
+        route_non_standard_to_extra_body(kwargs)
+        assert kwargs == {
+            "seed": 42,
+            "extra_body": {"enable_search": True, "custom_flag": "yes"},
+        }
+
+    def test_explicit_extra_body_wins_over_auto_routed(self) -> None:
+        kwargs = {
+            "enable_search": False,
+            "extra_body": {"enable_search": True, "other": 1},
+        }
+        route_non_standard_to_extra_body(kwargs)
+        assert kwargs == {
+            "extra_body": {"enable_search": True, "other": 1},
+        }
+
+    def test_deep_merge_nested_dict_conflict(self) -> None:
+        kwargs = {
+            "search_options": {"enable_citation": True},
+            "extra_body": {"search_options": {"source": "web"}},
+        }
+        route_non_standard_to_extra_body(kwargs)
+        assert kwargs == {
+            "extra_body": {
+                "search_options": {"enable_citation": True, "source": "web"},
+            },
+        }
+
+    def test_extra_body_non_dict_degrades_to_empty(self) -> None:
+        kwargs = {"enable_search": True, "extra_body": "invalid"}
+        route_non_standard_to_extra_body(kwargs)
+        assert kwargs == {"extra_body": {"enable_search": True}}
+
+    def test_extra_body_none_treated_as_empty(self) -> None:
+        kwargs = {"enable_search": True, "extra_body": None}
+        route_non_standard_to_extra_body(kwargs)
+        assert kwargs == {"extra_body": {"enable_search": True}}
+
+    def test_response_api_whitelist(self) -> None:
+        kwargs = {
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "enable_thinking": True,
+        }
+        route_non_standard_to_extra_body(kwargs, OPENAI_RESPONSE_CREATE_PARAMS)
+        assert kwargs == {
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "extra_body": {"enable_thinking": True},
+        }
+
+    def test_no_extra_body_when_nothing_to_route(self) -> None:
+        kwargs = {"temperature": 0.5, "seed": 123}
+        route_non_standard_to_extra_body(kwargs)
+        assert "extra_body" not in kwargs
+
+
+class TestWhitelistCompleteness:
+    """Sanity checks on the whitelists themselves."""
+
+    def test_chat_params_contains_sdk_transport(self) -> None:
+        for param in ("extra_headers", "extra_query", "extra_body", "timeout"):
+            assert param in OPENAI_CHAT_CREATE_PARAMS
+
+    def test_response_params_contains_sdk_transport(self) -> None:
+        for param in ("extra_headers", "extra_query", "extra_body", "timeout"):
+            assert param in OPENAI_RESPONSE_CREATE_PARAMS
+
+    def test_chat_params_contains_common_params(self) -> None:
+        for param in (
+            "temperature",
+            "max_tokens",
+            "top_p",
+            "seed",
+            "stop",
+            "stream",
+            "tools",
+        ):
+            assert param in OPENAI_CHAT_CREATE_PARAMS
+
+    def test_original_commit_params_present(self) -> None:
+        """Params from original commit 881b9dbd must all be present."""
+        for param in (
+            "prompt_cache_key",
+            "prompt_cache_retention",
+            "safety_identifier",
+            "verbosity",
+        ):
+            assert param in OPENAI_CHAT_CREATE_PARAMS


### PR DESCRIPTION
## Description

During the 2.0 development branch merge into main, commit `881b9dbd` (route non-standard kwargs into extra_body #4689) was lost due to code divergence. This commit originally defined an `_OPENAI_CREATE_PARAMS` whitelist and routing logic that automatically moved non-standard parameters (e.g. `enable_search`, `enable_thinking`) into `extra_body` before calling the OpenAI SDK. Without this mechanism, any provider-specific parameters passed through `generate_kwargs` are forwarded directly to the SDK's `create()` method, causing `TypeError: unexpected keyword argument`.

This PR restores the non-standard kwargs routing mechanism, adapted to the 2.0 architecture where parameter flow was refactored from `generate_kwargs` to `extra_generate_kwargs` + `Parameters`. The routing is now performed at the **Provider layer** (in `get_chat_model_instance()`) rather than the Compat layer, consistent with `DashScopeProvider`'s existing `extra_body` handling pattern. A shared utility module `_openai_params.py` provides whitelists and the routing function for all OpenAI-compatible providers.

Additionally, this PR fixes a pre-existing issue where `OpenRouterProvider.get_chat_model_instance()` silently discarded all `generate_kwargs` (including standard parameters like `temperature`).

**Related Issue:** Fixes #4689

**Security Considerations:** None. This change only affects how generation parameters are routed to the OpenAI SDK; no authentication, credential handling, or user input validation is modified.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Configure a provider with non-standard parameters in `generate_kwargs`:
   ```json
   {"generate_kwargs": {"enable_search": true, "temperature": 0.7}}
   ```
2. Verify that API calls succeed without `TypeError: unexpected keyword argument`
3. Verify that `enable_search` appears in the request body via `extra_body`
4. Verify that standard parameters (`temperature`, `seed`, `stop`, etc.) continue to work normally
5. Test with explicit `extra_body` in config to confirm user values take precedence over auto-routed params
6. Test OpenRouter provider to confirm `generate_kwargs` are now correctly passed through

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/providers/_openai_params.py src/qwenpaw/providers/openai_provider.py src/qwenpaw/providers/openai_response_provider.py src/qwenpaw/providers/ollama_provider.py src/qwenpaw/providers/openrouter_provider.py tests/unit/providers/test_openai_params.py
# check python ast......................Passed
# check docstring is first..............Passed
# fix python encoding pragma............Passed
# detect private key....................Passed
# trim trailing whitespace..............Passed
# Add trailing commas...................Passed
# mypy..................................Passed
# black.................................Passed
# flake8................................Passed
# pylint................................Passed

pytest tests/unit/providers/test_openai_params.py -v
# 17 passed in 0.02s
```

## Additional Notes

- **Architecture decision**: Routing is placed at the Provider layer (`get_chat_model_instance()`) rather than the Compat layer (`__init__`), keeping the Compat layer focused on safe parameter passing and consistent with `DashScopeProvider`'s existing pattern.
- **Known limitation**: `OpenAIResponseProvider` does not pop `top_p` into `Parameters` because `OpenAIResponseModel.Parameters` has no `top_p` field. The parameter remains in `extra_generate_kwargs` and is passed directly to the SDK, which accepts it as a valid Responses API parameter. This is a pre-existing inconsistency unrelated to this fix.
- **Whitelist maintenance**: Whitelists are annotated with SDK version and API reference links. Missing a standard parameter causes it to be routed into `extra_body` — functionally harmless but semantically imprecise.