### PR TITLE
Fix/plugin market version routing

### DIFF
--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -109,6 +109,19 @@ jobs:
             --acl public-read \
             --force \
             --meta "Cache-Control:public, max-age=60, must-revalidate"
+          for major in 1 2; do
+            label_path="dist/plugins/v${major}/index.json"
+            if [ -f "$label_path" ]; then
+              echo "Uploading versioned index: v${major}/index.json"
+              ossutil cp "$label_path" \
+                "oss://qwenpaw-download/metadata/plugins/v${major}/index.json" \
+                --acl public-read \
+                --force \
+                --meta "Cache-Control:public, max-age=60, must-revalidate"
+            else
+              echo "No versioned index for v${major}; skipping"
+            fi
+          done
 
       - name: Patch main metadata index to advertise plugins product
         run: |

--- a/console/src/api/modules/pluginMarket.ts
+++ b/console/src/api/modules/pluginMarket.ts
@@ -17,6 +17,8 @@ export interface MarketPluginEntry {
   view_count: number;
   details_url: string | null;
   locales: Record<string, MarketPluginLocale>;
+  /** QwenPaw major-version compatibility labels, e.g. ["1.x"] or ["2.x"]. */
+  qwenpaw_compat_labels?: string[];
 }
 
 interface MarketPluginListResponse {
@@ -67,8 +69,27 @@ export async function fetchMarketPlugins(
   return json.data;
 }
 
-export function buildMarketDownloadUrl(entry: MarketPluginEntry): string {
+/** Derive the major-version compatibility label from a QwenPaw version string. */
+export function getQwenPawCompatLabel(version: string): string {
+  const major = version.split(".", 1)[0];
+  return `${major}.x`;
+}
+
+export function buildMarketDownloadUrl(
+  entry: MarketPluginEntry,
+  qwenpawVersion?: string,
+): string {
   const id = entry.id.startsWith("@") ? entry.id.slice(1) : entry.id;
   const [owner, name] = id.split("/");
-  return `https://platform.agentscope.io/plugins/${owner}/${name}/archive/zip/master`;
+  // Route the download by QwenPaw major version when the entry declares
+  // compatibility labels and the caller provides a version.  Fall back to
+  // the legacy master branch when no specific branch can be determined.
+  let branch = "master";
+  if (qwenpawVersion && entry.qwenpaw_compat_labels?.length) {
+    const label = getQwenPawCompatLabel(qwenpawVersion);
+    if (entry.qwenpaw_compat_labels.includes(label)) {
+      branch = `v${label.replace(".x", "")}`;
+    }
+  }
+  return `https://platform.agentscope.io/plugins/${owner}/${name}/archive/zip/${branch}`;
 }

--- a/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
@@ -4,9 +4,11 @@ import { useAppMessage } from "@/hooks/useAppMessage";
 import {
   fetchMarketPlugins,
   buildMarketDownloadUrl,
+  getQwenPawCompatLabel,
   type MarketPluginEntry,
 } from "@/api/modules/pluginMarket";
 import { installPlugin } from "@/api/modules/plugin";
+import { rootApi } from "@/api/modules/root";
 
 interface UseMarketPluginsOptions {
   onInstalled: () => void;
@@ -22,6 +24,7 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   const [error, setError] = useState<string | null>(null);
   const [plugins, setPlugins] = useState<MarketPluginEntry[]>([]);
   const [total, setTotal] = useState(0);
+  const [qwenpawVersion, setQwenpawVersion] = useState<string>("");
   const [page, setPage] = useState(1);
   const [pageSize] = useState(20);
   const [search, setSearch] = useState("");
@@ -39,7 +42,18 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
           search: keyword || undefined,
           category: cat || undefined,
         });
-        setPlugins(data.plugins ?? []);
+        const compatLabel = qwenpawVersion
+          ? getQwenPawCompatLabel(qwenpawVersion)
+          : null;
+        const compatiblePlugins = (data.plugins ?? []).filter((entry) => {
+          // Entries without compatibility labels are treated as
+          // compatible with all versions for backward compatibility.
+          if (!compatLabel || !entry.qwenpaw_compat_labels?.length) {
+            return true;
+          }
+          return entry.qwenpaw_compat_labels.includes(compatLabel);
+        });
+        setPlugins(compatiblePlugins);
         setTotal(data.total);
       } catch {
         setError(tRef.current("pluginManager.marketUnavailable"));
@@ -49,12 +63,19 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
         setLoading(false);
       }
     },
-    [pageSize],
+    [pageSize, qwenpawVersion],
   );
 
   useEffect(() => {
     void loadPlugins(page, search, category);
   }, [page, search, category, loadPlugins]);
+
+  useEffect(() => {
+    rootApi
+      .getVersion()
+      .then((res) => setQwenpawVersion(res?.version ?? ""))
+      .catch(() => {});
+  }, []);
 
   const handleSearch = useCallback((keyword: string) => {
     setSearch(keyword);
@@ -78,7 +99,7 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
     async (entry: MarketPluginEntry) => {
       setInstallingId(entry.id);
       try {
-        const downloadUrl = buildMarketDownloadUrl(entry);
+        const downloadUrl = buildMarketDownloadUrl(entry, qwenpawVersion);
         const result = await installPlugin(downloadUrl, { force: true });
         message.success(
           `${tRef.current("pluginManager.installSuccess")}: ${result.name}`,
@@ -95,7 +116,7 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
         setInstallingId(null);
       }
     },
-    [message, onInstalled],
+    [message, onInstalled, qwenpawVersion],
   );
 
   return {

--- a/plugins/bundle/cloudpaw/hooks.py
+++ b/plugins/bundle/cloudpaw/hooks.py
@@ -388,6 +388,18 @@ def setup_tool_and_prompt_hooks() -> (  # pylint: disable=too-many-statements
         )
         return
 
+    # In QwenPaw 2.0 (agentscope 2.x), the agent no longer builds its
+    # own toolkit or system prompt internally — these are constructed by
+    # AgentBuilder and injected via the constructor.  Skip monkey-patching
+    # when the legacy methods are absent.
+    if not hasattr(QwenPawAgent, "_create_toolkit"):
+        logger.info(
+            "QwenPawAgent._create_toolkit not found (QwenPaw 2.0); "
+            "tool/prompt monkey-patches skipped — use api.register_tool() "
+            "for plugin tools.",
+        )
+        return
+
     _original_create_toolkit = QwenPawAgent._create_toolkit
     _original_build_sys_prompt = QwenPawAgent._build_sys_prompt
 

--- a/plugins/bundle/cloudpaw/plugin.json
+++ b/plugins/bundle/cloudpaw/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "cloudpaw",
   "name": "CloudPaw",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "general",
   "description": "CloudPaw —— QwenPaw 云能力增强插件。用自然语言描述需求，自动完成从资源创建到应用部署的全流程。安装后请完成以下配置：1) 在「环境变量」中配置阿里云 AK-SK（ALIBABA_CLOUD_ACCESS_KEY_ID / ALIBABA_CLOUD_ACCESS_KEY_SECRET）；2) 安装完成后请刷新当前页面以加载插件。",
   "description_i18n": {

--- a/plugins/bundle/cloudpaw/plugin.json
+++ b/plugins/bundle/cloudpaw/plugin.json
@@ -15,6 +15,7 @@
   },
   "dependencies": [],
   "min_version": "2.0.0",
+  "qwenpaw_compat_labels": ["2.x"],
   "meta": {
     "category": "cloud-deployment",
     "features": [

--- a/plugins/bundle/cloudpaw/plugin.json
+++ b/plugins/bundle/cloudpaw/plugin.json
@@ -14,7 +14,7 @@
     "backend": "plugin.py"
   },
   "dependencies": [],
-  "min_version": "1.1.7",
+  "min_version": "2.0.0",
   "meta": {
     "category": "cloud-deployment",
     "features": [

--- a/plugins/bundle/qwenpaw-pet/plugin.json
+++ b/plugins/bundle/qwenpaw-pet/plugin.json
@@ -21,6 +21,7 @@
     "pyside6-essentials>=6.6"
   ],
   "min_version": "1.1.5",
+  "qwenpaw_compat_labels": ["1.x"],
   "meta": {
     "desktop_url": "http://127.0.0.1:8765"
   }

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -13,7 +13,7 @@
     "backend": "gpt_image2.py"
   },
   "dependencies": ["httpx>=0.24.0"],
-  "min_version": "1.1.7",
+  "min_version": "2.0.0",
   "meta": {
     "tools": [
       {

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "gpt-image2-tool",
   "name": "GPT Image 2 Tool",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "type": "tool",
   "description": "Generate and edit images using OpenAI GPT Image 2 model",
   "description_i18n": {

--- a/plugins/tool/gpt-image2/plugin.json
+++ b/plugins/tool/gpt-image2/plugin.json
@@ -14,6 +14,7 @@
   },
   "dependencies": ["httpx>=0.24.0"],
   "min_version": "2.0.0",
+  "qwenpaw_compat_labels": ["2.x"],
   "meta": {
     "tools": [
       {

--- a/plugins/tool/qwen-image/plugin.json
+++ b/plugins/tool/qwen-image/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "qwen-image-tool",
   "name": "Qwen-Image Tool",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "tool",
   "description": "Generate and edit images using Alibaba Qwen-Image models",
   "description_i18n": {

--- a/plugins/tool/qwen-image/plugin.json
+++ b/plugins/tool/qwen-image/plugin.json
@@ -14,6 +14,7 @@
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
   "min_version": "2.0.0",
+  "qwenpaw_compat_labels": ["2.x"],
   "meta": {
     "tools": [
       {

--- a/plugins/tool/qwen-image/plugin.json
+++ b/plugins/tool/qwen-image/plugin.json
@@ -2,6 +2,7 @@
   "id": "qwen-image-tool",
   "name": "Qwen-Image Tool",
   "version": "1.0.0",
+  "type": "tool",
   "description": "Generate and edit images using Alibaba Qwen-Image models",
   "description_i18n": {
     "zh-CN": "使用阿里云 Qwen-Image 模型生成与编辑图像",
@@ -12,7 +13,7 @@
     "backend": "qwen_image.py"
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
-  "min_version": "1.1.6",
+  "min_version": "2.0.0",
   "meta": {
     "tools": [
       {

--- a/plugins/tool/wan27/plugin.json
+++ b/plugins/tool/wan27/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "wan27-tool",
   "name": "Wan 2.7 Video Generation Tool",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "tool",
   "description": "Generate videos using Alibaba Wan 2.7 models (text-to-video, image-to-video, reference-to-video)",
   "description_i18n": {

--- a/plugins/tool/wan27/plugin.json
+++ b/plugins/tool/wan27/plugin.json
@@ -14,6 +14,7 @@
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
   "min_version": "2.0.0",
+  "qwenpaw_compat_labels": ["2.x"],
   "meta": {
     "tools": [
       {

--- a/plugins/tool/wan27/plugin.json
+++ b/plugins/tool/wan27/plugin.json
@@ -2,6 +2,7 @@
   "id": "wan27-tool",
   "name": "Wan 2.7 Video Generation Tool",
   "version": "1.0.0",
+  "type": "tool",
   "description": "Generate videos using Alibaba Wan 2.7 models (text-to-video, image-to-video, reference-to-video)",
   "description_i18n": {
     "zh-CN": "使用阿里云 Wan 2.7 模型生成视频（文生视频、图生视频、参考生视频）",
@@ -12,7 +13,7 @@
     "backend": "wan27.py"
   },
   "dependencies": ["dashscope>=1.25.16", "httpx>=0.24.0"],
-  "min_version": "1.1.6",
+  "min_version": "2.0.0",
   "meta": {
     "tools": [
       {

--- a/scripts/pack/generate_plugin_metadata.py
+++ b/scripts/pack/generate_plugin_metadata.py
@@ -140,6 +140,21 @@ def _localized_description(manifest: dict[str, Any]) -> dict[str, str]:
     return _localized_field(manifest.get("description") or "")
 
 
+def _derive_compat_labels(manifest: dict[str, Any]) -> list[str]:
+    """Return QwenPaw compatibility labels for a plugin.
+
+    If ``qwenpaw_compat_labels`` is explicitly declared in ``plugin.json``,
+    use it. Otherwise derive from ``min_version`` by taking the major
+    version number and appending ``.x``.
+    """
+    labels = manifest.get("qwenpaw_compat_labels")
+    if isinstance(labels, list) and labels:
+        return [str(label) for label in labels]
+    min_version = str(manifest.get("min_version") or "")
+    major = min_version.split(".", 1)[0] if min_version else "1"
+    return [f"{major}.x"]
+
+
 def _build_metadata(
     manifest: dict[str, Any],
     *,
@@ -167,28 +182,51 @@ def _build_metadata(
         "sha256": _sha256_of_file(zip_path),
         "updated_at": datetime.now(timezone.utc).isoformat(),
         "type": "zip",
+        "qwenpaw_compat_labels": _derive_compat_labels(manifest),
     }
+
+
+def _empty_index(updated_at: str) -> dict[str, Any]:
+    return {
+        "product": "plugins",
+        "updated_at": updated_at,
+        "platforms": {},
+        "files": {},
+    }
+
+
+def _add_to_index(
+    index: dict[str, Any],
+    metadata: dict[str, Any],
+    kind: str,
+    file_id: str,
+) -> None:
+    index["files"][file_id] = metadata
+    kind_entry = index["platforms"].setdefault(kind, {"versions": []})
+    if file_id not in kind_entry["versions"]:
+        kind_entry["versions"].insert(0, file_id)
 
 
 def discover_and_pack(
     plugins_root: Path,
     dist_root: Path,
     cdn_prefix: str,
-) -> dict[str, Any]:
-    """Scan, zip, and assemble the plugins index. Always full-rebuild."""
-    index: dict[str, Any] = {
-        "product": "plugins",
-        "updated_at": datetime.now(timezone.utc).isoformat(),
-        "platforms": {},
-        "files": {},
-    }
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    """Scan, zip, and assemble the plugins index. Always full-rebuild.
+
+    Returns the legacy all-plugins index plus a mapping of compatibility
+    label -> per-version index (e.g. ``"1.x" -> index``).
+    """
+    updated_at = datetime.now(timezone.utc).isoformat()
+    index = _empty_index(updated_at)
+    per_label_indexes: dict[str, dict[str, Any]] = {}
 
     if not plugins_root.is_dir():
         print(
             f"WARNING: plugins root does not exist: {plugins_root}",
             file=sys.stderr,
         )
-        return index
+        return index, per_label_indexes
 
     for kind in KIND_DIRS:
         kind_dir = plugins_root / kind
@@ -226,12 +264,17 @@ def discover_and_pack(
                 zip_path=zip_path,
                 cdn_path=cdn_path,
             )
-            index["files"][file_id] = metadata
-            kind_entry = index["platforms"].setdefault(kind, {"versions": []})
-            if file_id not in kind_entry["versions"]:
-                kind_entry["versions"].insert(0, file_id)
+            labels = _derive_compat_labels(manifest)
 
-    return index
+            _add_to_index(index, metadata, kind, file_id)
+            for label in labels:
+                label_index = per_label_indexes.setdefault(
+                    label,
+                    _empty_index(updated_at),
+                )
+                _add_to_index(label_index, metadata, kind, file_id)
+
+    return index, per_label_indexes
 
 
 def main() -> int:
@@ -311,11 +354,21 @@ def main() -> int:
                     shutil.rmtree(child)
     dist_root.mkdir(parents=True, exist_ok=True)
 
-    index = discover_and_pack(plugins_root, dist_root, args.cdn_prefix)
+    index, per_label_indexes = discover_and_pack(
+        plugins_root, dist_root, args.cdn_prefix,
+    )
 
     metadata_out.parent.mkdir(parents=True, exist_ok=True)
     with metadata_out.open("w", encoding="utf-8") as f:
         json.dump(index, f, indent=2, ensure_ascii=False)
+
+    for label, label_index in per_label_indexes.items():
+        major = label.replace(".x", "")
+        label_out = metadata_out.parent / f"v{major}" / metadata_out.name
+        label_out.parent.mkdir(parents=True, exist_ok=True)
+        with label_out.open("w", encoding="utf-8") as f:
+            json.dump(label_index, f, indent=2, ensure_ascii=False)
+        print(f"Wrote index: {label_out}")
 
     print()
     print(f"Wrote index: {metadata_out}")

--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,3 +1,17 @@
 # -*- coding: utf-8 -*-
 
 __version__ = "2.0.0b2"
+
+
+def get_qwenpaw_compat_label(version: str | None = None) -> str:
+    """Return the major-version compatibility label used by the plugin market.
+
+    Examples:
+        >>> get_qwenpaw_compat_label("1.1.12")
+        '1.x'
+        >>> get_qwenpaw_compat_label("2.0.0b1")
+        '2.x'
+    """
+    version = (version or __version__).strip()
+    major = version.split(".", 1)[0] if version else "0"
+    return f"{major}.x"

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -19,6 +19,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from ..utils import schedule_agent_reload
+from ..__version__ import get_qwenpaw_compat_label
 
 logger = logging.getLogger(__name__)
 
@@ -898,9 +899,19 @@ async def search_market_plugins(
     page_size: int = 20,
     search: Optional[str] = None,
     category: Optional[str] = None,
+    qwenpaw_version: Optional[str] = None,
 ):
-    """Proxy plugin search to AgentScope Platform to avoid CORS."""
+    """Proxy plugin search to AgentScope Platform to avoid CORS.
+
+    The optional ``qwenpaw_version`` parameter lets callers request plugins
+    compatible with a specific QwenPaw release.  When omitted, the current
+    running version is used.  The upstream platform may use this to filter
+    results; the field is always forwarded verbatim so the console can do
+    client-side filtering as a fallback.
+    """
     import httpx
+
+    compat_label = get_qwenpaw_compat_label(qwenpaw_version or "")
 
     params: dict = {
         "page_number": page_number,
@@ -910,6 +921,9 @@ async def search_market_plugins(
         params["search"] = search
     if category:
         params["category"] = category
+    # Forward the compatibility label so the platform can filter results
+    # once it supports version-aware search.
+    params["qwenpaw_compat_label"] = compat_label
 
     try:
         async with httpx.AsyncClient(

--- a/src/qwenpaw/plugins/download_catalog.py
+++ b/src/qwenpaw/plugins/download_catalog.py
@@ -12,10 +12,23 @@ from typing import Any
 
 from packaging.version import InvalidVersion, Version
 
+from ..__version__ import get_qwenpaw_compat_label
+
 logger = logging.getLogger(__name__)
 
 PLUGIN_DOWNLOAD_CDN = "https://download.qwenpaw.agentscope.io"
 _FETCH_TIMEOUT = 30
+
+
+def _plugins_index_path() -> str:
+    """Return the CDN plugins index path for the current QwenPaw major version.
+
+    Falls back to the un-versioned path when the versioned index is not yet
+    available on the CDN.
+    """
+    label = get_qwenpaw_compat_label()
+    major = label.replace(".x", "")
+    return f"/metadata/plugins/v{major}/index.json"
 
 
 def _fetch_json(url: str) -> Any:
@@ -129,17 +142,36 @@ def build_plugin_catalog() -> dict[str, Any]:
     if not plugins_product:
         return result
 
-    index_path = str(plugins_product.get("index_url") or "")
-    if not index_path.startswith("/"):
-        result["error"] = "Invalid plugins index_url in main metadata"
-        return result
-
+    # Prefer the versioned index for the current QwenPaw major release so
+    # that v1.x and v2.x users receive compatible plugin catalogs.  Fall back
+    # to the legacy un-versioned index when the versioned one is missing.
+    index_path = _plugins_index_path()
     try:
         plugins_index = _fetch_json(f"{base}{index_path}")
     except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as exc:
-        logger.warning("Plugin catalog: plugins index fetch failed: %s", exc)
-        result["error"] = "Failed to fetch plugins metadata"
-        return result
+        logger.debug(
+            "Plugin catalog: versioned index %s unavailable (%s), "
+            "falling back to legacy index",
+            index_path,
+            exc,
+        )
+        legacy_path = str(plugins_product.get("index_url") or "")
+        if not legacy_path.startswith("/"):
+            result["error"] = "Invalid plugins index_url in main metadata"
+            return result
+        try:
+            plugins_index = _fetch_json(f"{base}{legacy_path}")
+        except (
+            urllib.error.URLError,
+            json.JSONDecodeError,
+            TimeoutError,
+        ) as exc2:
+            logger.warning(
+                "Plugin catalog: plugins index fetch failed: %s",
+                exc2,
+            )
+            result["error"] = "Failed to fetch plugins metadata"
+            return result
 
     result["updated_at"] = plugins_index.get("updated_at")
     files = plugins_index.get("files") or {}

--- a/tests/unit/cli/test_cli_version.py
+++ b/tests/unit/cli/test_cli_version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from click.testing import CliRunner
 
-from qwenpaw.__version__ import __version__
+from qwenpaw.__version__ import __version__, get_qwenpaw_compat_label
 from qwenpaw.cli.main import cli
 
 
@@ -10,3 +10,21 @@ def test_cli_version_option_outputs_current_version() -> None:
 
     assert result.exit_code == 0
     assert __version__ in result.output
+
+
+def test_get_qwenpaw_compat_label_maps_to_major_x() -> None:
+    assert get_qwenpaw_compat_label("1.1.12") == "1.x"
+    assert get_qwenpaw_compat_label("2.0.0b1") == "2.x"
+    assert get_qwenpaw_compat_label("2.1.0.post2") == "2.x"
+
+
+def test_get_qwenpaw_compat_label_defaults_to_current_version() -> None:
+    label = get_qwenpaw_compat_label()
+    assert label.endswith(".x")
+    assert label == f"{__version__.split('.', 1)[0]}.x"
+
+
+def test_get_qwenpaw_compat_label_handles_empty_and_none() -> None:
+    # Empty/None inputs fall back to the current version.
+    assert get_qwenpaw_compat_label("") == get_qwenpaw_compat_label()
+    assert get_qwenpaw_compat_label(None) == get_qwenpaw_compat_label()

--- a/tests/unit/scripts/test_generate_plugin_metadata.py
+++ b/tests/unit/scripts/test_generate_plugin_metadata.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=import-outside-toplevel
+"""Unit tests for scripts/pack/generate_plugin_metadata.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pack" / "generate_plugin_metadata.py"
+
+
+def _load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "generate_plugin_metadata",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["generate_plugin_metadata"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script() -> Any:
+    return _load_script_module()
+
+
+def test_derive_compat_labels_uses_explicit_value(script: Any) -> None:
+    assert script._derive_compat_labels(
+        {"qwenpaw_compat_labels": ["2.x"]}
+    ) == ["2.x"]
+    assert script._derive_compat_labels(
+        {"qwenpaw_compat_labels": ["1.x", "2.x"]}
+    ) == ["1.x", "2.x"]
+
+
+def test_derive_compat_labels_derives_from_min_version(script: Any) -> None:
+    assert script._derive_compat_labels({"min_version": "1.1.5"}) == ["1.x"]
+    assert script._derive_compat_labels({"min_version": "2.0.0"}) == ["2.x"]
+
+
+def test_derive_compat_labels_defaults_to_1x(script: Any) -> None:
+    assert script._derive_compat_labels({}) == ["1.x"]
+
+
+def test_discover_and_pack_groups_by_compat_label(
+    script: Any,
+    tmp_path: Path,
+) -> None:
+    plugins_root = tmp_path / "plugins"
+
+    v1_dir = plugins_root / "tool" / "v1-tool"
+    v1_dir.mkdir(parents=True)
+    (v1_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "id": "v1-tool",
+                "version": "1.0.0",
+                "min_version": "1.1.0",
+            }
+        )
+    )
+    (v1_dir / "main.py").write_text("print('v1')")
+
+    v2_dir = plugins_root / "bundle" / "v2-bundle"
+    v2_dir.mkdir(parents=True)
+    (v2_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "id": "v2-bundle",
+                "version": "2.0.0",
+                "qwenpaw_compat_labels": ["2.x"],
+            }
+        )
+    )
+    (v2_dir / "plugin.py").write_text("print('v2')")
+
+    dist_root = tmp_path / "dist"
+    index, per_label = script.discover_and_pack(
+        plugins_root, dist_root, "/files/plugins"
+    )
+
+    assert "v1-tool-1.0.0" in index["files"]
+    assert "v2-bundle-2.0.0" in index["files"]
+    v1_labels = index["files"]["v1-tool-1.0.0"]["qwenpaw_compat_labels"]
+    v2_labels = index["files"]["v2-bundle-2.0.0"]["qwenpaw_compat_labels"]
+    assert v1_labels == ["1.x"]
+    assert v2_labels == ["2.x"]
+
+    assert "1.x" in per_label
+    assert "2.x" in per_label
+    assert "v1-tool-1.0.0" in per_label["1.x"]["files"]
+    assert "v2-bundle-2.0.0" in per_label["2.x"]["files"]
+    assert "v2-bundle-2.0.0" not in per_label["1.x"]["files"]
+    assert "v1-tool-1.0.0" not in per_label["2.x"]["files"]
+
+
+def test_discover_and_pack_skips_publish_false(
+    script: Any,
+    tmp_path: Path,
+) -> None:
+    plugins_root = tmp_path / "plugins"
+    plugin_dir = plugins_root / "tool" / "unpublished"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "id": "unpublished",
+                "version": "1.0.0",
+                "publish": False,
+            }
+        )
+    )
+
+    dist_root = tmp_path / "dist"
+    index, per_label = script.discover_and_pack(
+        plugins_root, dist_root, "/files/plugins"
+    )
+
+    assert "unpublished-1.0.0" not in index["files"]
+    assert not per_label
+
+
+def test_build_metadata_includes_compat_labels(
+    script: Any,
+    tmp_path: Path,
+) -> None:
+    manifest = {
+        "id": "demo",
+        "name": "Demo",
+        "version": "1.0.0",
+        "min_version": "2.0.0",
+    }
+    zip_path = tmp_path / "demo-1.0.0.zip"
+    zip_path.write_bytes(b"fake")
+
+    metadata = script._build_metadata(
+        manifest,
+        file_id="demo-1.0.0",
+        plugin_id="demo",
+        version="1.0.0",
+        kind="tool",
+        zip_path=zip_path,
+        cdn_path="/files/plugins/tool/demo/demo-1.0.0.zip",
+    )
+
+    assert metadata["qwenpaw_compat_labels"] == ["2.x"]


### PR DESCRIPTION
## Description

After QwenPaw 2.0.0b1 was released, plugin market download routes were not isolated by QwenPaw major version, so v1.x and v2.x users could download incompatible plugins. This PR fixes the issue across the frontend, backend, and CDN release pipeline:
Frontend: MarketPluginEntry now includes qwenpaw_compat_labels; the market list is filtered by the current QwenPaw version; download URLs pick the v{major} branch based on compatibility labels.
Backend: /api/plugins/market/search forwards qwenpaw_compat_label to the platform and returns compatibility labels in the response.
CDN release pipeline: generate_plugin_metadata.py generates per-version indexes at /metadata/plugins/v1/index.json and /metadata/plugins/v2/index.json; plugins-release.yml uploads both versioned indexes.
Plugin manifests: existing plugins now explicitly declare qwenpaw_compat_labels (1.x or 2.x).
Related Issue: Relates to the v2.0.0b1 plugin compatibility routing issue.Security Considerations: No new authentication or sensitive configuration handling. CDN index paths remain public resources; access control is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
