### PR TITLE
fix: deepen chat session selected bg & cleanup unused CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Reme local data
+.reme/
+
 # Local issue tracking (not committed)
 .scratch/
 

--- a/console/src/pages/Chat/ModelSelector/index.module.less
+++ b/console/src/pages/Chat/ModelSelector/index.module.less
@@ -69,20 +69,6 @@
   }
 }
 
-.triggerArrow {
-  flex-shrink: 0;
-  font-size: 18px;
-  color: #999;
-  transition:
-    transform 0.2s,
-    color 0.15s;
-
-  &.triggerArrowOpen {
-    transform: rotate(180deg);
-    color: #ff7f16;
-  }
-}
-
 .providerIcon {
   width: 16px;
   height: 16px;
@@ -468,14 +454,6 @@
     &.triggerActive {
       color: #ff7f16;
       box-shadow: 0 2px 8px rgba(97, 92, 237, 0.2);
-    }
-  }
-
-  .triggerArrow {
-    color: rgba(255, 255, 255, 0.3);
-
-    &.triggerArrowOpen {
-      color: #ff7f16;
     }
   }
 

--- a/console/src/pages/Chat/components/ChatSessionItem/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionItem/index.module.less
@@ -58,7 +58,7 @@
 
   &.active {
     border-radius: 6px;
-    background: var(--color-fill-tertiary, rgba(43, 18, 0, 0.03));
+    background: var(--color-fill-secondary, rgba(43, 18, 0, 0.08));
   }
 
   &.disabled {
@@ -265,7 +265,7 @@
     }
 
     &.active {
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.15);
     }
   }
 

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -15,30 +15,6 @@
   height: 100%;
 }
 
-/* Disabled input overlay */
-.chatDisabledOverlay {
-  position: relative;
-  height: 100%;
-  width: 100%;
-}
-
-.chatDisabledOverlay :global([class*="chat-anywhere-input"]),
-.chatDisabledOverlay :global([class*="chat-input"]),
-.chatDisabledOverlay :global(textarea),
-.chatDisabledOverlay :global(input[type="text"]) {
-  pointer-events: none !important;
-  opacity: 0.5 !important;
-  background-color: #f5f5f5 !important;
-  cursor: not-allowed !important;
-}
-
-.chatDisabledOverlay :global(button[class*="send"]),
-.chatDisabledOverlay :global(button[class*="submit"]) {
-  pointer-events: none !important;
-  opacity: 0.3 !important;
-  cursor: not-allowed !important;
-}
-
 /* Chat messages scrollable area */
 .chatMessagesArea {
   flex: 1;
@@ -242,16 +218,6 @@
     max-width: 100%;
     overflow-wrap: anywhere;
     word-break: normal;
-  }
-}
-
-/* Dark mode scrollbar for disabled overlay */
-:global(.dark-mode) {
-  .chatDisabledOverlay :global([class*="chat-anywhere-input"]),
-  .chatDisabledOverlay :global([class*="chat-input"]),
-  .chatDisabledOverlay :global(textarea),
-  .chatDisabledOverlay :global(input[type="text"]) {
-    background-color: #2a2a2a !important;
   }
 }
 


### PR DESCRIPTION
- Deepen selected session background color in ChatSessionItem (Fixes #5583)
  - Light mode: 0.03 -> 0.08 opacity, use color-fill-secondary
  - Dark mode: 0.08 -> 0.15 opacity
- Remove unused .chatDisabledOverlay styles from Chat/index.module.less
- Remove unused .triggerArrow/.triggerArrowOpen styles from ModelSelector/index.module.less

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
