### PR TITLE
fix(governance): OFF mode still triggers tool approval

### DIFF
--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -59,6 +59,29 @@ def _is_execution_level_off() -> bool:
         return False
 
 
+def _resolve_agent_approval_level(request_context: dict[str, str] | None) -> str:
+    """Resolve the per-agent approval_level from agent.json.
+
+    This is what the Web UI 'Tool Execution Security' card saves to.
+    Returns the canonical level string ('off'/'auto'/'smart'/'strict'),
+    or empty string if unresolvable.
+    """
+    if not request_context:
+        return ""
+    agent_id = request_context.get("agent_id", "")
+    if not agent_id:
+        return ""
+    try:
+        from ..config.config import load_agent_config
+        from ..security.tool_guard.execution_level import ToolExecutionLevel
+
+        profile = load_agent_config(agent_id)
+        raw = getattr(profile, "approval_level", None)
+        return ToolExecutionLevel.from_config(raw).value
+    except Exception:
+        return ""
+
+
 # ---------------------------------------------------------------------------
 # PolicyGuardedTool
 # ---------------------------------------------------------------------------
@@ -159,6 +182,24 @@ async def _policy_tool_check_permissions(
     del context
 
     governor = getattr(self, "_qp_governor", None)
+
+    # ── Agent-level approval_level check ──
+    # Web UI saves approval_level to agent.json; governance
+    # policy.yaml has its own execution_level.  We must honour
+    # the agent-level setting so the UI toggle works.
+    request_ctx = getattr(self, "_qp_request_context", None) or {}
+    agent_level = _resolve_agent_approval_level(request_ctx)
+    if agent_level == "off":
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message="governance: approval_level=off, all tools allowed.",
+        )
+
+    # Sync agent-level approval_level to the governor's policy
+    # so the three-phase evaluation uses the correct threshold.
+    if governor is not None and agent_level:
+        governor.policy.execution_level = agent_level
+
     if governor is None:
         # Check if execution_level is "off" (dev mode) — allow pass-through
         if _is_execution_level_off():
@@ -257,10 +298,7 @@ async def _policy_tool_call(
     result = await FunctionTool.__call__(self, *args, **kwargs)
 
     # Check if sandbox violation was returned (state=DENIED)
-    if not (
-        isinstance(result, ToolChunk)
-        and result.state == ToolResultState.DENIED
-    ):
+    if not (isinstance(result, ToolChunk) and result.state == ToolResultState.DENIED):
         return result
 
     # Extract violation message from metadata or content
@@ -272,9 +310,7 @@ async def _policy_tool_call(
         for block in result.content or []:
             if hasattr(block, "text") and "Sandbox violation:" in block.text:
                 violation_msg = (
-                    block.text.split("Sandbox violation:", 1)[1]
-                    .split("\n")[0]
-                    .strip()
+                    block.text.split("Sandbox violation:", 1)[1].split("\n")[0].strip()
                 )
                 break
 
@@ -324,9 +360,11 @@ async def _policy_tool_call(
         tc_spec,
         GovernanceDecision(
             action=GovernanceAction.ASK,
-            reason=f"sandbox violation: {violation_msg}"
-            if violation_msg
-            else "sandbox violation, ask user",
+            reason=(
+                f"sandbox violation: {violation_msg}"
+                if violation_msg
+                else "sandbox violation, ask user"
+            ),
         ),
     )
 
@@ -455,9 +493,7 @@ async def _ask_user_approval(
                     rule_id="policy_ask",
                     category=GuardThreatCategory.RESOURCE_ABUSE,
                     severity=(
-                        GuardSeverity.HIGH
-                        if violation_msg
-                        else GuardSeverity.INFO
+                        GuardSeverity.HIGH if violation_msg else GuardSeverity.INFO
                     ),
                     title=(
                         "Sandbox Violation — Approve Unsandboxed Execution?"

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -59,7 +59,9 @@ def _is_execution_level_off() -> bool:
         return False
 
 
-def _resolve_agent_approval_level(request_context: dict[str, str] | None) -> str:
+def _resolve_agent_approval_level(
+    request_context: dict[str, str] | None,
+) -> str:
     """Resolve the per-agent approval_level from agent.json.
 
     This is what the Web UI 'Tool Execution Security' card saves to.
@@ -298,7 +300,10 @@ async def _policy_tool_call(
     result = await FunctionTool.__call__(self, *args, **kwargs)
 
     # Check if sandbox violation was returned (state=DENIED)
-    if not (isinstance(result, ToolChunk) and result.state == ToolResultState.DENIED):
+    if not (
+        isinstance(result, ToolChunk)
+        and result.state == ToolResultState.DENIED
+    ):
         return result
 
     # Extract violation message from metadata or content
@@ -310,7 +315,9 @@ async def _policy_tool_call(
         for block in result.content or []:
             if hasattr(block, "text") and "Sandbox violation:" in block.text:
                 violation_msg = (
-                    block.text.split("Sandbox violation:", 1)[1].split("\n")[0].strip()
+                    block.text.split("Sandbox violation:", 1)[1]
+                    .split("\n")[0]
+                    .strip()
                 )
                 break
 
@@ -493,7 +500,9 @@ async def _ask_user_approval(
                     rule_id="policy_ask",
                     category=GuardThreatCategory.RESOURCE_ABUSE,
                     severity=(
-                        GuardSeverity.HIGH if violation_msg else GuardSeverity.INFO
+                        GuardSeverity.HIGH
+                        if violation_msg
+                        else GuardSeverity.INFO
                     ),
                     title=(
                         "Sandbox Violation — Approve Unsandboxed Execution?"

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -61,27 +61,26 @@ def _is_execution_level_off() -> bool:
 
 def _resolve_agent_approval_level(
     request_context: dict[str, str] | None,
-) -> str:
+) -> Optional[Any]:
     """Resolve the per-agent approval_level from agent.json.
 
     This is what the Web UI 'Tool Execution Security' card saves to.
-    Returns the canonical level string ('off'/'auto'/'smart'/'strict'),
-    or empty string if unresolvable.
+    Returns the ToolExecutionLevel enum, or None if unresolvable.
     """
     if not request_context:
-        return ""
+        return None
     agent_id = request_context.get("agent_id", "")
     if not agent_id:
-        return ""
+        return None
     try:
         from ..config.config import load_agent_config
         from ..security.tool_guard.execution_level import ToolExecutionLevel
 
         profile = load_agent_config(agent_id)
         raw = getattr(profile, "approval_level", None)
-        return ToolExecutionLevel.from_config(raw).value
+        return ToolExecutionLevel.from_config(raw)
     except Exception:
-        return ""
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +190,7 @@ async def _policy_tool_check_permissions(
     # the agent-level setting so the UI toggle works.
     request_ctx = getattr(self, "_qp_request_context", None) or {}
     agent_level = _resolve_agent_approval_level(request_ctx)
-    if agent_level == "off":
+    if agent_level is not None and agent_level.is_disabled():
         return PermissionDecision(
             behavior=PermissionBehavior.ALLOW,
             message="governance: approval_level=off, all tools allowed.",
@@ -199,8 +198,8 @@ async def _policy_tool_check_permissions(
 
     # Sync agent-level approval_level to the governor's policy
     # so the three-phase evaluation uses the correct threshold.
-    if governor is not None and agent_level:
-        governor.policy.execution_level = agent_level
+    if governor is not None and agent_level is not None:
+        governor.policy.execution_level = agent_level.value
 
     if governor is None:
         # Check if execution_level is "off" (dev mode) — allow pass-through


### PR DESCRIPTION
## Description

**Bug:** When the user sets "Tool Execution Security" to OFF mode (关闭模式) via the Web UI, tool calls still trigger approval prompts instead of executing immediately.

**Root cause:** Web UI saves `approval_level` to `agent.json`, but `PolicyGuardedTool` reads `execution_level` from `policy.yaml` (defaults to `"smart"`). The two configs were never synced.

**Fix (tool_adapter.py only):**
- Add `_resolve_agent_approval_level()` to read the agent-level `approval_level` from `agent.json`
- In `_policy_tool_check_permissions()`: when agent's `approval_level` is `"off"`, return ALLOW immediately before reaching `governor.assert_policy()`
- For other levels (auto/smart/strict): sync agent-level setting to `governor.policy.execution_level` so the policy evaluation uses the correct threshold

No changes to `policy.py` — the fix addresses the root cause (config source mismatch) at the adapter layer, making strategy-layer modifications unnecessary.

**Related Issue:** N/A

**Security Considerations:** OFF mode intentionally disables all tool approval checks. This is the documented behavior for development/testing environments. The `ToolExecutionLevel.OFF` enum already states: "All tools execute immediately without any checks."

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start QwenPaw service
2. Navigate to Agent Config → Tool Execution Security
3. Select "OFF" mode (关闭模式) and save
4. Send a message that triggers a tool call (e.g., ask the agent to run `ls ~/.ssh`)
5. **Expected:** Tool executes immediately without approval prompt
6. **Before fix:** Approval popup appeared despite OFF mode being selected

## Local Verification Evidence

```bash
# pre-commit passed during commit (git hook)
INFO[2026-06-29 21:48:21] Running git hook  hook=pre-commit

# Syntax verification
python -c "import ast; ast.parse(open('src/qwenpaw/governance/tool_adapter.py').read()); print('OK')"
# OK

# Manual E2E: set OFF mode via Web UI → tool executed without approval ✓
# Server log confirmed: stream done, event_count=626, has_response=True, no errors