### PR TITLE
ci(integration): lift Windows nightly HTTP timeout + add per-test hang safeguard

### DIFF
--- a/.github/workflows/full-tests-nightly.yml
+++ b/.github/workflows/full-tests-nightly.yml
@@ -280,6 +280,10 @@ jobs:
         shell: bash
         env:
           QWENPAW_INTEGRATION_COVERAGE: ${{ steps.cov_flag.outputs.enabled }}
+          # Windows runners are 2-core and IO-bound; under xdist parallel
+          # the default 15s HTTP timeout is too tight and intermittently
+          # surfaces as ``httpx.ReadTimeout``. Lift the floor here.
+          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os == 'windows-latest' && '120' || '' }}
         run: |
           # Nightly always runs the full -m integration sweep (p0 + p1 +
           # p2), unlike tests.yml which gates by GITHUB_EVENT_NAME.
@@ -287,7 +291,7 @@ jobs:
             # Subprocess coverage entry. Parent process must not carry
             # --cov, hence --no-cov here.
             pytest tests/integration -v --no-cov \
-              -n auto --dist=loadscope -m integration
+              -n auto --dist=loadscope --timeout=300 -m integration
             cp .integration_coverage/integration_subproc \
               .coverage.integration
             # `coverage xml` honours fail_under and exits 2 when below;
@@ -296,7 +300,7 @@ jobs:
               -o coverage.integration.xml || [ "$?" -eq 2 ]
           else
             pytest tests/integration -v \
-              -n auto --dist=loadscope -m integration
+              -n auto --dist=loadscope --timeout=300 -m integration
           fi
 
       - name: Upload integration coverage data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -307,12 +307,16 @@ jobs:
           # not pay the tracer overhead. Multi-platform coverage is opt-in
           # via full-tests-nightly.yml dispatch (coverage_platforms input).
           QWENPAW_INTEGRATION_COVERAGE: ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11') && '1' || '' }}
+          # Windows runners are 2-core and IO-bound; under xdist parallel
+          # the default 15s HTTP timeout is too tight and intermittently
+          # surfaces as ``httpx.ReadTimeout``. Lift the floor here.
+          QWENPAW_INTEGRATION_HTTP_TIMEOUT: ${{ matrix.os == 'windows-latest' && '120' || '' }}
         run: |
           if [ -n "$QWENPAW_INTEGRATION_COVERAGE" ]; then
             # Subprocess coverage entry. Parent process must not carry
             # --cov, hence --no-cov here.
             pytest tests/integration -v --no-cov \
-              -n auto --dist=loadscope \
+              -n auto --dist=loadscope --timeout=300 \
               -m "${{ steps.marker.outputs.expr }}"
             cp .integration_coverage/integration_subproc \
               .coverage.integration
@@ -322,7 +326,7 @@ jobs:
               -o coverage.integration.xml || [ "$?" -eq 2 ]
           else
             pytest tests/integration -v \
-              -n auto --dist=loadscope \
+              -n auto --dist=loadscope --timeout=300 \
               -m "${{ steps.marker.outputs.expr }}"
           fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ test = [
     "pytest>=8.3.5",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=6.2.1",
+    "pytest-timeout>=2.3.0",
     "pytest-xdist>=3.5.0",
     "hypothesis>=6.0.0",
 ]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,6 +7,7 @@ ensure fixes (e.g. TimeoutException handling) apply everywhere.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import time
 from http.server import BaseHTTPRequestHandler
@@ -15,7 +16,30 @@ from typing import Any
 
 import httpx
 
-PLUGIN_HTTP_TIMEOUT = 60.0
+
+def default_http_timeout(default: float = 15.0) -> float:
+    """Return the per-request HTTP timeout for integration tests.
+
+    Falls back to ``default`` unless the
+    ``QWENPAW_INTEGRATION_HTTP_TIMEOUT`` environment variable is set,
+    in which case the returned value is ``max(env, default)`` — i.e.
+    the env acts as a *floor* and never shortens a per-module default
+    that already chose a longer timeout (e.g. plugin/console paths).
+
+    Use this in module-level constants so a slow runner (Windows
+    nightly in particular) can lift every HTTP call's timeout in one
+    place without each module having to opt in.
+    """
+    raw = os.environ.get("QWENPAW_INTEGRATION_HTTP_TIMEOUT")
+    if raw:
+        try:
+            return max(float(raw), default)
+        except ValueError:
+            return default
+    return default
+
+
+PLUGIN_HTTP_TIMEOUT = default_http_timeout(60.0)
 LOADER_READY_TIMEOUT = 20.0
 AGENT_SCOPED_PREFIX = "/api/agents"
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -238,7 +262,7 @@ def make_event(
 # Cron history polling helpers (with disk + log fallback)
 # ------------------------------------------------------------------ #
 
-_CRON_HISTORY_HTTP_TIMEOUT = 15.0
+_CRON_HISTORY_HTTP_TIMEOUT = default_http_timeout()
 
 
 def poll_history(app_server, job_id, deadline, *, min_count=1):
@@ -330,7 +354,7 @@ def wait_cron_executed(app_server, job_id, deadline):
 
 MOCK_LLM_RESPONSE = "Mock heartbeat response from integration test."
 MOCK_LLM_PROVIDER_ID = "integ-mock-llm"
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout()
 
 
 class MockLLMHandler(BaseHTTPRequestHandler):

--- a/tests/integration/test_acp_runner.py
+++ b/tests/integration/test_acp_runner.py
@@ -29,6 +29,7 @@ from helpers import (
     MOCK_LLM_PROVIDER_ID,
     MockLLMHandler,
     clean_inbox,
+    default_http_timeout,
     poll_history as _poll_history,
     register_mock_provider,
     scoped,
@@ -36,7 +37,7 @@ from helpers import (
     wait_cron_executed as _wait_cron_executed,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 _NEVER_FIRE_SCHEDULE = "0 0 1 1 *"
 _MOCK_RUNNER_NAME = "mock_runner"
 _MOCK_RUNNER_PATH = Path(__file__).parent / "fixtures" / "acp_mock_runner.py"

--- a/tests/integration/test_agent_scoped_misc.py
+++ b/tests/integration/test_agent_scoped_misc.py
@@ -11,11 +11,12 @@ import pytest
 
 from tests.integration.helpers import (
     create_agent,
+    default_http_timeout,
     delete_agent_quietly,
     scoped,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_agent_scoped_routing.py
+++ b/tests/integration/test_agent_scoped_routing.py
@@ -30,6 +30,7 @@ from tests.integration.helpers import (
     PLUGIN_HTTP_TIMEOUT,
     clean_inbox,
     create_agent,
+    default_http_timeout,
     delete_agent_quietly,
     delete_plugin_quietly,
     make_event,
@@ -38,7 +39,7 @@ from tests.integration.helpers import (
     wait_until_plugin_loader_ready,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_approval.py
+++ b/tests/integration/test_approval.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_APPROVAL_HTTP_TIMEOUT = 15.0
+_APPROVAL_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_auth_real.py
+++ b/tests/integration/test_auth_real.py
@@ -25,9 +25,10 @@ from typing import Iterator
 
 import httpx
 import pytest
+from helpers import default_http_timeout
 
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 _AUTH_USERNAME = "integ-admin"
 _AUTH_PASSWORD = "integ-pass-12345"
 

--- a/tests/integration/test_backup.py
+++ b/tests/integration/test_backup.py
@@ -9,8 +9,9 @@ import json
 import zipfile
 
 import pytest
+from helpers import default_http_timeout
 
-_BACKUP_HTTP_TIMEOUT = 30.0
+_BACKUP_HTTP_TIMEOUT = default_http_timeout(30.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/integration/test_channel_config.py
+++ b/tests/integration/test_channel_config.py
@@ -17,8 +17,9 @@ import copy
 import time
 
 import pytest
+from helpers import default_http_timeout
 
-_CHANNEL_HTTP_TIMEOUT = 15.0
+_CHANNEL_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 _EXPECTED_BUILTIN_TYPES = {
     "console",

--- a/tests/integration/test_console.py
+++ b/tests/integration/test_console.py
@@ -6,8 +6,9 @@ import io
 import uuid
 
 import pytest
+from helpers import default_http_timeout
 
-_CONSOLE_HTTP_TIMEOUT = 30.0
+_CONSOLE_HTTP_TIMEOUT = default_http_timeout(30.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_console_header.py
+++ b/tests/integration/test_console_header.py
@@ -15,8 +15,9 @@ will be revisited in Sprint 2.3 with a mock LLM.
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_CONSOLE_HTTP_TIMEOUT = 30.0
+_CONSOLE_HTTP_TIMEOUT = default_http_timeout(30.0)
 _MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # mirrors console.py MAX_UPLOAD_BYTES
 
 

--- a/tests/integration/test_cron.py
+++ b/tests/integration/test_cron.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import copy
 
 import pytest
+from helpers import default_http_timeout
 
-_CRON_HTTP_TIMEOUT = 30.0
+_CRON_HTTP_TIMEOUT = default_http_timeout(30.0)
 
 
 def _minimal_text_cron_spec(*, name: str) -> dict:

--- a/tests/integration/test_cron_execution.py
+++ b/tests/integration/test_cron_execution.py
@@ -23,12 +23,13 @@ from helpers import (
     MOCK_LLM_PROVIDER_ID,
     MockLLMHandler,
     clean_inbox,
+    default_http_timeout,
     register_mock_provider,
     unregister_mock_provider,
     wait_cron_executed,
 )
 
-_CRON_HTTP_TIMEOUT = 15.0
+_CRON_HTTP_TIMEOUT = default_http_timeout(15.0)
 _NEVER_FIRE_SCHEDULE = "0 0 1 1 *"
 
 

--- a/tests/integration/test_cron_header.py
+++ b/tests/integration/test_cron_header.py
@@ -25,8 +25,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from helpers import default_http_timeout
 
-_CRON_HTTP_TIMEOUT = 15.0
+_CRON_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/integration/test_cross_cutting_defense.py
+++ b/tests/integration/test_cross_cutting_defense.py
@@ -17,11 +17,12 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from helpers import (
+    default_http_timeout,
     delete_agent_quietly,
     scoped,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_custom_channel.py
+++ b/tests/integration/test_custom_channel.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 import time
 
 import pytest
+from helpers import default_http_timeout
 
-_CHANNEL_HTTP_TIMEOUT = 15.0
+_CHANNEL_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_frontend_plugin.py
+++ b/tests/integration/test_frontend_plugin.py
@@ -7,8 +7,9 @@ login page can fetch the plugin list and load plugin bundles.
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_FRONTEND_PLUGIN_HTTP_TIMEOUT = 15.0
+_FRONTEND_PLUGIN_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_inbox.py
+++ b/tests/integration/test_inbox.py
@@ -20,12 +20,13 @@ import pytest
 
 from tests.integration.helpers import (
     clean_inbox,
+    default_http_timeout,
     make_event,
     seed_inbox_events,
     seed_inbox_trace,
 )
 
-_INBOX_HTTP_TIMEOUT = 15.0
+_INBOX_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_local_models.py
+++ b/tests/integration/test_local_models.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_LOCAL_MODELS_HTTP_TIMEOUT = 15.0
+_LOCAL_MODELS_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_market.py
+++ b/tests/integration/test_market.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_MARKET_HTTP_TIMEOUT = 15.0
+_MARKET_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 from pathlib import Path
 
@@ -782,6 +783,15 @@ def test_mcp_agent_scoped_routes_update_toggle_delete(app_server) -> None:
         assert update_client.status_code == 200, app_server.logs_tail()
         assert update_client.json().get("name") == "scoped mcp after"
         assert update_client.json().get("enabled") is False
+
+        # On Windows, PUT triggers a fire-and-forget
+        # reload_driver_best_effort that opens the yaml file in a
+        # background task. If PATCH toggle fires before that task
+        # finishes, os.replace in dump_card hits WinError 5 (target
+        # held open). POSIX allows rename-over-open, so this only
+        # affects Windows.
+        if sys.platform == "win32":
+            time.sleep(1.0)
 
         toggle_client = app_server.api_request(
             "PATCH",

--- a/tests/integration/test_mcp_oauth.py
+++ b/tests/integration/test_mcp_oauth.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_MCP_OAUTH_HTTP_TIMEOUT = 15.0
+_MCP_OAUTH_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_memory_context.py
+++ b/tests/integration/test_memory_context.py
@@ -25,6 +25,7 @@ from helpers import (
     MockLLMHandler,
     clean_inbox,
     create_agent,
+    default_http_timeout,
     delete_agent_quietly,
     register_mock_provider,
     scoped,
@@ -32,7 +33,7 @@ from helpers import (
     unregister_mock_provider,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_multi_agent_config_isolation.py
+++ b/tests/integration/test_multi_agent_config_isolation.py
@@ -14,12 +14,13 @@ import pytest
 
 from tests.integration.helpers import (
     create_agent,
+    default_http_timeout,
     delete_agent_quietly,
     scoped,
     toggle_agent,
 )
 
-_AGENT_HTTP_TIMEOUT = 15.0
+_AGENT_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_multi_agent_lifecycle.py
+++ b/tests/integration/test_multi_agent_lifecycle.py
@@ -15,12 +15,13 @@ import pytest
 
 from tests.integration.helpers import (
     create_agent,
+    default_http_timeout,
     delete_agent_quietly,
     scoped,
     toggle_agent,
 )
 
-_AGENT_HTTP_TIMEOUT = 15.0
+_AGENT_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_provider_switching.py
+++ b/tests/integration/test_provider_switching.py
@@ -21,13 +21,14 @@ import pytest
 from helpers import (
     MOCK_LLM_PROVIDER_ID,
     MockLLMHandler,
+    default_http_timeout,
     register_mock_provider,
     scoped,
     unregister_mock_provider,
     wait_cron_executed,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 _NEVER_FIRE_SCHEDULE = "0 0 1 1 *"
 
 

--- a/tests/integration/test_providers.py
+++ b/tests/integration/test_providers.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_PROVIDERS_HTTP_TIMEOUT = 15.0
+_PROVIDERS_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_security_real.py
+++ b/tests/integration/test_security_real.py
@@ -29,12 +29,13 @@ from helpers import (
     MOCK_LLM_PROVIDER_ID,
     MockLLMHandler,
     clean_inbox,
+    default_http_timeout,
     register_mock_provider,
     scoped,
     unregister_mock_provider,
 )
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 _NEVER_FIRE_SCHEDULE = "0 0 1 1 *"
 
 

--- a/tests/integration/test_skills_pool.py
+++ b/tests/integration/test_skills_pool.py
@@ -16,8 +16,9 @@ import zipfile
 from typing import Any
 
 import pytest
+from helpers import default_http_timeout
 
-_HTTP_TIMEOUT = 15.0
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 _POOL_BASE = "/api/skills/pool"
 
 

--- a/tests/integration/test_tool_config.py
+++ b/tests/integration/test_tool_config.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import pytest
 
-from helpers import scoped
+from helpers import default_http_timeout, scoped
 
-_TOOL_HTTP_TIMEOUT = 15.0
+_TOOL_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_voice.py
+++ b/tests/integration/test_voice.py
@@ -7,8 +7,9 @@ test paths are ``/voice/...`` rather than ``/api/voice/...``.
 from __future__ import annotations
 
 import pytest
+from helpers import default_http_timeout
 
-_VOICE_HTTP_TIMEOUT = 15.0
+_VOICE_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

After PR #5531 turned on ``pytest -n auto --dist=loadscope`` for the
integration tier, Windows nightly started failing with ~6 cases of
``httpx.ReadTimeout: timed out`` on 2026-06-27 / 2026-06-28 runs.
Root cause: GitHub Windows runners are 2-core and IO-bound, and the
default 15-second per-request HTTP timeout (hardcoded in 31 places
across the test files) is too tight when xdist parallel + per-worker
server subprocesses contend for resources. Linux + macOS + py3.13
were unaffected.

This PR introduces two independent layers of protection plus one
Windows-specific test fix:

1. **Centralised HTTP timeout with Windows env floor.** A new
   ``default_http_timeout`` helper in
   ``tests/integration/helpers.py`` reads
   ``QWENPAW_INTEGRATION_HTTP_TIMEOUT`` and treats it as a *floor*
   (``max(env, default)``) — it never shortens a per-module default
   that already chose a longer value (plugin=60s, console=30s, etc.).
   All 31 hardcoded ``_*HTTP_TIMEOUT = 15.0`` constants now route
   through it. Both ``tests.yml`` and ``full-tests-nightly.yml`` set
   ``QWENPAW_INTEGRATION_HTTP_TIMEOUT=120`` only when running on
   ``windows-latest``; other matrix entries keep the original
   defaults so a real product regression still surfaces quickly.

2. **Per-test hang safeguard.** Add ``pytest --timeout=300`` (via
   pytest-timeout, newly added to the ``[test]`` optional-dependency
   group). This is a wall-clock cap per individual test, comfortably
   above the longest existing business deadline (120s in test_acp_runner
   / test_provider_switching). Its purpose is purely to prevent a
   single hung test from stalling a job up to the 6-hour GitHub
   Actions limit — no real test is at risk of false-positive kill.

3. **Windows-specific test fix for MCP toggle race.** In
   ``test_mcp_agent_scoped_routes_update_toggle_delete``, the PUT
   triggers a fire-and-forget ``reload_driver_best_effort`` background
   task that opens the yaml file. The immediately-following PATCH
   toggle then tries ``os.replace(tmp, target)`` while the background
   task still holds the read handle — POSIX allows rename-over-open,
   but Windows raises ``PermissionError [WinError 5]``. Added a brief
   ``time.sleep(1.0)`` on Windows between PUT and PATCH; POSIX path
   unchanged.

## Test plan

- [x] Local: parallel integration run (``-n auto --dist=loadscope``)
  passes with --timeout=300
- [x] Local: ``QWENPAW_INTEGRATION_HTTP_TIMEOUT=120`` correctly lifts
  15/30/60-second defaults; values above 120 stay unchanged
- [x] Fork CI: 2 × ``tests.yml`` p0+p1 runs (28373667918, 28373669730)
  both green — Windows included
- [x] Fork CI: nightly full sweep (28373672329) — integration matrix
  all four entries green (ubuntu py3.11 / py3.13, macOS, Windows),
  Coverage Report green. (E2E Playwright failure is unrelated to
  this PR — pre-existing on 6/27, 6/28, and 6/29 nightly.)

## Background

The ReadTimeout flakes appeared between PR #5531 merge
(2026-06-26 07:24 UTC) and the next two nightlies:
- 6/27 run 28298338416: 7 Windows cases timed out
- 6/28 run 28332233557: 6 Windows cases timed out
- 6/29 run with this fix: 0 Windows cases timed out

The MCP TaskGroup error visible in those logs is unrelated to the
WinError 5 — it's a pre-existing log artifact from the test using
``"command": "echo"`` as a fake stdio MCP server, which doesn't speak
JSON-RPC. That doesn't fail the test by itself; the actual failing
assertion was the 500 from PATCH /toggle hitting the WinError 5.