### PR TITLE
fix(console): count normalized tool card results

### DIFF
--- a/console/src/components/Chat/ToolCards/cards/GlobSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GlobSearchCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { FolderOpenOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
 import { ToolCardShell, DefaultBlock } from "../shared";
-import { countLines, stringifyResult } from "../shared/utils";
+import { countResultLines, stringifyResult } from "../shared/utils";
 import styles from "../shared/toolCards.module.less";
 
 export interface GlobSearchCardProps {
@@ -23,7 +23,7 @@ const GlobSearchCard: React.FC<GlobSearchCardProps> = ({
     : t("tool.globSearchDefault");
 
   const resultText = stringifyResult(content.result);
-  const lineCount = countLines(content.result);
+  const lineCount = countResultLines(content.result);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (

--- a/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { SearchOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
 import { ToolCardShell, DefaultBlock } from "../shared";
-import { countLines, stringifyResult } from "../shared/utils";
+import { countResultLines, stringifyResult } from "../shared/utils";
 import styles from "../shared/toolCards.module.less";
 
 export interface GrepSearchCardProps {
@@ -23,7 +23,7 @@ const GrepSearchCard: React.FC<GrepSearchCardProps> = ({
     : t("tool.grepSearchDefault");
 
   const resultText = stringifyResult(content.result);
-  const lineCount = countLines(content.result);
+  const lineCount = countResultLines(content.result);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (

--- a/console/src/components/Chat/ToolCards/cards/ReadFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/ReadFileCard.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from "react-i18next";
 import { FileTextOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
 import { ToolCardShell, DefaultBlock } from "../shared";
-import { shortFileName, countLines } from "../shared/utils";
+import {
+  shortFileName,
+  countResultLines,
+  stringifyResult,
+} from "../shared/utils";
 import styles from "../shared/toolCards.module.less";
 
 export interface ReadFileCardProps {
@@ -20,8 +24,8 @@ const ReadFileCard: React.FC<ReadFileCardProps> = ({
   const file = shortFileName((params.file_path || params.path || "") as string);
   const title = file ? t("tool.readFile", { file }) : t("tool.readFileDefault");
 
-  const resultText = typeof content.result === "string" ? content.result : "";
-  const lineCount = countLines(content.result);
+  const resultText = stringifyResult(content.result);
+  const lineCount = countResultLines(content.result);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (

--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { TFunction } from "i18next";
-import { formatAgentList, formatMemorySearch } from "./utils";
+import { countResultLines, formatAgentList, formatMemorySearch } from "./utils";
 
 const translate = ((key: string) => {
   const translations: Record<string, string> = {
@@ -82,6 +82,36 @@ describe("formatMemorySearch", () => {
     expect(formattedResult).toContain("# 记忆与反思 - 2026-05-18");
     expect(formattedResult).not.toContain('[ { "path"');
     expect(formattedResult).not.toContain('"snippet":');
+  });
+});
+
+describe("countResultLines", () => {
+  it("counts lines from plain string results", () => {
+    const rawToolResult = "src/a.py\nsrc/b.py\nsrc/c.py";
+
+    expect(countResultLines(rawToolResult)).toBe(3);
+  });
+
+  it("counts lines from MCP text block array results", () => {
+    const rawToolResult = [
+      {
+        type: "text",
+        text: "src/a.py\nsrc/b.py\nsrc/c.py",
+      },
+    ];
+
+    expect(countResultLines(rawToolResult)).toBe(3);
+  });
+
+  it("counts lines from JSON-serialized MCP text block results", () => {
+    const rawToolResult = JSON.stringify([
+      {
+        type: "text",
+        text: "1| # Title\n2| content\n3| more content",
+      },
+    ]);
+
+    expect(countResultLines(rawToolResult)).toBe(3);
   });
 });
 

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -36,6 +36,11 @@ export function countLines(text: unknown): number {
   return text.split("\n").length;
 }
 
+/** Count lines in normalized tool result display text */
+export function countResultLines(result: unknown): number {
+  return countLines(stringifyResult(result));
+}
+
 /** Get language identifier from file extension for syntax highlighting */
 export function getFileLanguage(tc: ToolCallContent): string {
   const params = tc.params || {};


### PR DESCRIPTION
## Description

Fixes #5624.

Tool result badges in the Console built-in cards now count lines from the same normalized display text used by the Output panel. This fixes AgentScope 2.0-style MCP text block results that previously made `read_file`, `glob_search`, and `grep_search` badge counts show `1` even when the rendered output had many lines/files.

Root cause: these cards rendered normalized output through `stringifyResult(...)`, but counted raw `content.result` with `countLines(...)`. The fix adds a shared `countResultLines(...)` helper and routes the affected cards through it.

**Related Issue:** Fixes #5624

**Security Considerations:** N/A. This is Console display-only logic and does not change tool execution or backend data.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `cd console && npm run test:run -- src/components/Chat/ToolCards/shared/utils.test.ts`
- `cd console && npm run format:check`
- `cd console && npm run test:run`
- `git diff --check`
- `env PRE_COMMIT_HOME=/tmp/pre-commit-cache .venv/bin/pre-commit run --all-files`

## Local Verification Evidence

```bash
cd console && npm run test:run -- src/components/Chat/ToolCards/shared/utils.test.ts
# Test Files 1 passed (1), Tests 7 passed (7)

cd console && npm run format:check
# tsc -b --noEmit && prettier --check .
# All matched files use Prettier code style!

cd console && npm run test:run
# Test Files 51 passed (51), Tests 502 passed (502)

git diff --check
# passed

env PRE_COMMIT_HOME=/tmp/pre-commit-cache .venv/bin/pre-commit run --all-files
# Passed, including prettier
```

## Additional Notes

This is not a backend tool-output change. The chosen layer is the shared Console tool-card utility because multiple cards shared the same raw-result counting bug while already using normalized display text for output.

Verification matrix:
- `read_file`: covered by shared MCP text block line-count tests and card helper usage
- `glob_search`: covered by shared MCP text block line-count tests and card helper usage
- `grep_search`: covered by shared MCP text block line-count tests and card helper usage
- Backend tools: unchanged
- Channels: not applicable