### PR TITLE
fix(toolCards): use stringifyResult before counting lines in search a…

### DIFF
--- a/console/src/components/Chat/ToolCards/cards/GlobSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GlobSearchCard.tsx
@@ -23,7 +23,7 @@ const GlobSearchCard: React.FC<GlobSearchCardProps> = ({
     : t("tool.globSearchDefault");
 
   const resultText = stringifyResult(content.result);
-  const lineCount = countLines(content.result);
+  const lineCount = countLines(resultText);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (

--- a/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
@@ -23,7 +23,7 @@ const GrepSearchCard: React.FC<GrepSearchCardProps> = ({
     : t("tool.grepSearchDefault");
 
   const resultText = stringifyResult(content.result);
-  const lineCount = countLines(content.result);
+  const lineCount = countLines(resultText);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (

--- a/console/src/components/Chat/ToolCards/cards/ReadFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/ReadFileCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { FileTextOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
 import { ToolCardShell, DefaultBlock } from "../shared";
-import { shortFileName, countLines } from "../shared/utils";
+import { shortFileName, countLines, stringifyResult } from "../shared/utils";
 import styles from "../shared/toolCards.module.less";
 
 export interface ReadFileCardProps {
@@ -20,8 +20,8 @@ const ReadFileCard: React.FC<ReadFileCardProps> = ({
   const file = shortFileName((params.file_path || params.path || "") as string);
   const title = file ? t("tool.readFile", { file }) : t("tool.readFileDefault");
 
-  const resultText = typeof content.result === "string" ? content.result : "";
-  const lineCount = countLines(content.result);
+  const resultText = stringifyResult(content.result);
+  const lineCount = countLines(resultText);
 
   const badge =
     content.status === "done" && lineCount > 0 ? (


### PR DESCRIPTION
…nd read file cards

## Description

[Describe what this PR does and why]
<img width="1326" height="714" alt="image" src="https://github.com/user-attachments/assets/1de2348b-4610-4ddc-b8e9-4404c5be5f8e" />

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

 Fixes #5624
 
 
**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
