### PR TITLE
feat(subagent): add event-driven background lifecycle and parent wakeup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ sessions_mount_dir/
 # testing
 /coverage
 .coverage
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
 coverage.xml
 htmlcov/
 htmlcov.zip

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -17,6 +17,7 @@ register them. The literal names still appear in
 ``security/tool_guard`` guardians for backward compatibility with
 pre-existing allowlists.
 """
+
 from __future__ import annotations
 
 from typing import Callable
@@ -38,6 +39,7 @@ from .agent_management import (
     submit_to_agent,
     check_agent_task,
     spawn_subagent,
+    cancel_subagent,
 )
 from .delegate_external_agent import delegate_external_agent
 from .make_skill_tools import materialize_skill
@@ -80,6 +82,7 @@ __all__ = [
     "submit_to_agent",
     "check_agent_task",
     "spawn_subagent",
+    "cancel_subagent",
     "materialize_skill",
     "ast_search",
 ]

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -291,8 +291,14 @@ def collect_final_agent_chat_response(
     to_agent: str,
     timeout: int,
 ) -> Optional[Dict[str, Any]]:
-    """Collect the last SSE payload from inter-agent chat."""
+    """Collect the final response envelope from inter-agent chat.
+
+    Console streams may append non-response events such as ``turn_usage``
+    after the completed response. Keep the latest response-shaped payload
+    instead of blindly returning the final SSE event.
+    """
     response_data: Optional[Dict[str, Any]] = None
+    fallback_data: Optional[Dict[str, Any]] = None
     with create_agent_api_client(base_url) as client:
         with client.stream(
             "POST",
@@ -306,8 +312,13 @@ def collect_final_agent_chat_response(
                 if line:
                     parsed = parse_agent_sse_line(line)
                     if parsed:
-                        response_data = parsed
-    return response_data
+                        fallback_data = parsed
+                        if (
+                            parsed.get("object") == "response"
+                            or "output" in parsed
+                        ):
+                            response_data = parsed
+    return response_data or fallback_data
 
 
 def submit_agent_chat_task(
@@ -636,6 +647,32 @@ async def check_agent_task(
             "ERROR: 'task_id' is required to check task status",
         )
 
+    # ``spawn_subagent(background=True)`` is managed in-process and wakes the
+    # parent automatically.  Keep this branch only as a human/manual fallback;
+    # the spawn tool explicitly tells the model not to poll it.
+    from ...app.subagents.context import get_subagent_spawn_context
+
+    spawn_context = get_subagent_spawn_context()
+    if spawn_context is not None:
+        record = await spawn_context.manager.get(normalized_task_id)
+        if (
+            record is not None
+            and record.parent_session_id == spawn_context.session_id
+        ):
+            return _tool_text_response(
+                "\n".join(
+                    [
+                        f"[TASK_ID: {record.task_id}]",
+                        f"[STATUS: {record.status.value}]",
+                        f"[SESSION: {record.child_session_id}]",
+                        "",
+                        record.result
+                        or record.error
+                        or "No terminal result yet.",
+                    ],
+                ),
+            )
+
     result = await asyncio.to_thread(
         get_agent_chat_task_status,
         None,
@@ -653,6 +690,22 @@ def _generate_subagent_session_id() -> str:
     return f"sub-{str(uuid4())[:8]}"
 
 
+def _format_subagent_submission(task_id: str, session_id: str) -> str:
+    return "\n".join(
+        [
+            f"[TASK_ID: {task_id}]",
+            f"[SESSION: {session_id}]",
+            "",
+            "Background subagent started. You will be notified automatically ",
+            "when it completes, fails, or is cancelled.",
+            "Do not call check_agent_task, sleep, wait, or any polling tool ",
+            "for this task. Continue independent work, or end this turn.",
+        ],
+    )
+
+
+# pylint: disable=too-many-return-statements
+@tool_descriptor(async_execution=True)
 async def spawn_subagent(
     task: str,
     fork: bool = False,
@@ -676,9 +729,11 @@ async def spawn_subagent(
             back to workspace; no worktree if not a git repo).
             If False (default), starts with a fresh empty session.
         background: If True, submit as background task and return
-            immediately with a task_id. Use check_agent_task(task_id)
-            to poll status and retrieve the result.
-        timeout: Foreground wait timeout in seconds (default 600).
+            immediately with a task_id. Completion automatically wakes this
+            parent session and injects the result; do not poll.
+        timeout: Foreground wait timeout in seconds (default 600). Background
+            subagents have no total runtime limit; this value is ignored when
+            ``background=True``.
 
     Returns:
         Foreground: subagent result text with [SESSION: <id>].
@@ -688,6 +743,15 @@ async def spawn_subagent(
     if not task or not task.strip():
         return _tool_text_response(
             "ERROR: 'task' is required for spawn_subagent",
+        )
+
+    from ...app.subagents.context import get_subagent_spawn_context
+
+    spawn_context = get_subagent_spawn_context()
+    if spawn_context is not None and spawn_context.is_subagent:
+        return _tool_text_response(
+            "ERROR: nested subagents are not supported; only a top-level "
+            "agent may call spawn_subagent",
         )
 
     from ...app.agent_context import get_current_agent_id
@@ -721,18 +785,28 @@ async def spawn_subagent(
     }
 
     if background:
-        result = await asyncio.to_thread(
-            submit_agent_chat_task,
-            None,
-            request_payload,
-            current_agent_id,
-            int(DEFAULT_AGENT_API_TIMEOUT),
-        )
+        if spawn_context is None:
+            return _tool_text_response(
+                "ERROR: background subagent manager is unavailable outside "
+                "a QwenPaw Runtime request",
+            )
+        try:
+            record = await spawn_context.manager.spawn(
+                prompt=task,
+                parent_agent_id=spawn_context.agent_id,
+                parent_session_id=spawn_context.session_id,
+                root_session_id=spawn_context.root_session_id,
+                child_agent_id=current_agent_id,
+                child_session_id=subagent_session_id,
+                user_id=spawn_context.user_id,
+                channel=spawn_context.channel,
+                channel_meta=spawn_context.channel_meta,
+                parent_is_subagent=spawn_context.is_subagent,
+            )
+        except (RuntimeError, ValueError) as exc:
+            return _tool_text_response(f"ERROR: {exc}")
         return _tool_text_response(
-            format_background_submission_text(
-                result,
-                subagent_session_id,
-            ),
+            _format_subagent_submission(record.task_id, subagent_session_id),
         )
 
     response_data = await asyncio.to_thread(
@@ -752,6 +826,41 @@ async def spawn_subagent(
             response_data,
             session_id=subagent_session_id,
         ),
+    )
+
+
+@tool_descriptor(async_execution=True)
+async def cancel_subagent(task_id: str) -> ToolChunk:
+    """Cancel a background subagent created by this parent session.
+
+    This is an explicit control operation, not a status/polling tool.  A task
+    can only be cancelled from the parent session that created it.
+    """
+    normalized_task_id = normalize_id(task_id)
+    if not normalized_task_id:
+        return _tool_text_response("ERROR: 'task_id' is required")
+
+    from ...app.subagents.context import get_subagent_spawn_context
+
+    spawn_context = get_subagent_spawn_context()
+    if spawn_context is None:
+        return _tool_text_response("ERROR: subagent manager unavailable")
+    record = await spawn_context.manager.get(normalized_task_id)
+    if record is None or record.parent_session_id != spawn_context.session_id:
+        return _tool_text_response(
+            f"ERROR: subagent task '{normalized_task_id}' not found for "
+            "the current parent session",
+        )
+    cancelled = await spawn_context.manager.cancel_task(
+        normalized_task_id,
+        reason="cancelled explicitly by parent agent",
+    )
+    if not cancelled:
+        return _tool_text_response(
+            f"Task {normalized_task_id} is already terminal.",
+        )
+    return _tool_text_response(
+        f"Cancellation requested for subagent task {normalized_task_id}.",
     )
 
 
@@ -827,6 +936,7 @@ async def _maybe_cleanup_worktree(
     return await asyncio.to_thread(_cleanup)
 
 
+# pylint: disable=too-many-branches
 async def _spawn_forked_subagent(
     task: str,
     current_agent_id: str,
@@ -882,15 +992,33 @@ async def _spawn_forked_subagent(
     }
 
     if background:
-        result = await asyncio.to_thread(
-            submit_agent_chat_task,
-            None,
-            request_payload,
-            current_agent_id,
-            int(DEFAULT_AGENT_API_TIMEOUT),
-        )
-        submission_text = format_background_submission_text(
-            result,
+        from ...app.subagents.context import get_subagent_spawn_context
+
+        spawn_context = get_subagent_spawn_context()
+        if spawn_context is None:
+            return _tool_text_response(
+                "ERROR: background subagent manager is unavailable outside "
+                "a QwenPaw Runtime request",
+            )
+        try:
+            record = await spawn_context.manager.spawn(
+                prompt=task,
+                parent_agent_id=spawn_context.agent_id,
+                parent_session_id=spawn_context.session_id,
+                root_session_id=spawn_context.root_session_id,
+                child_agent_id=current_agent_id,
+                child_session_id=fork_session_id,
+                user_id=user_id,
+                channel=channel,
+                channel_meta=spawn_context.channel_meta,
+                parent_is_subagent=spawn_context.is_subagent,
+                request_context=request_context,
+                worktree_branch=worktree_branch,
+            )
+        except (RuntimeError, ValueError) as exc:
+            return _tool_text_response(f"ERROR: {exc}")
+        submission_text = _format_subagent_submission(
+            record.task_id,
             fork_session_id,
         )
         if worktree_path:

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -353,6 +353,12 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                 ErrorNormalizeHook,
                 CancelCleanupHook,
             )
+            from .subagents.hooks import (
+                SubagentContextCleanupHook,
+                SubagentContextSetupHook,
+                SubagentEventAckHook,
+                SubagentWakeGuardHook,
+            )
 
             # pylint: disable-next=protected-access
             workspace_registry._bootstrap_kwargs["builtin_hook_clses"] = [
@@ -368,6 +374,10 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                 MediaProcessHook,
                 ErrorNormalizeHook,
                 CancelCleanupHook,
+                SubagentWakeGuardHook,
+                SubagentContextSetupHook,
+                SubagentEventAckHook,
+                SubagentContextCleanupHook,
             ]
 
             try:

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -503,7 +503,18 @@ class ConsoleChannel(BaseChannel):
             self._print_error(err_msg)
 
     async def consume_one(self, payload: Any) -> None:
-        """Process one payload; drain stream_one (queue/terminal)."""
+        """Process one queue payload.
+
+        Ordinary console requests own an HTTP SSE subscriber and keep the
+        historical ``stream_one`` drain behavior.  A subagent wakeup has no
+        browser request to receive that stream, so route it through the base
+        channel send path; completed messages are then written to the
+        console push store and picked up by the frontend poll service.
+        """
+        request_context = getattr(payload, "request_context", None) or {}
+        if request_context.get("subagent_wakeup"):
+            await super().consume_one(payload)
+            return
         async for _ in self.stream_one(payload):
             pass
 

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Console APIs: push messages, chat, and file upload for chat."""
+
 from __future__ import annotations
 
 import asyncio
@@ -7,6 +8,7 @@ import json
 import logging
 import re
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncGenerator, Union
 
@@ -24,10 +26,13 @@ from ..approvals.display import approval_display_fields
 from ..chats.title_generator import generate_and_update_title
 from ..utils import check_upload_size
 
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/console", tags=["console"])
+
+_CHAT_TASKS: dict[str, dict] = {}
+_CHAT_RUNTIME_TASKS: dict[str, asyncio.Task] = {}
+_MAX_FINISHED_CHAT_TASKS = 100
 
 
 class MarkInboxReadRequest(BaseModel):
@@ -36,6 +41,112 @@ class MarkInboxReadRequest(BaseModel):
 
 
 MAX_DEBUG_LOG_LINES = 1000
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_sse_payload(event_data: str) -> dict | None:
+    for line in event_data.splitlines():
+        if not line.startswith("data: "):
+            continue
+        try:
+            parsed = json.loads(line[6:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _public_chat_task_record(record: dict) -> dict:
+    return {key: value for key, value in record.items() if key != "agent_id"}
+
+
+def _prune_finished_chat_tasks() -> None:
+    finished_task_ids = [
+        task_id
+        for task_id, record in _CHAT_TASKS.items()
+        if record.get("status") == "finished"
+    ]
+    overflow = len(finished_task_ids) - _MAX_FINISHED_CHAT_TASKS
+    if overflow <= 0:
+        return
+
+    finished_task_ids.sort(
+        key=lambda task_id: (
+            _CHAT_TASKS[task_id].get("finished_at")
+            or _CHAT_TASKS[task_id].get("submitted_at")
+            or ""
+        ),
+    )
+    for task_id in finished_task_ids[:overflow]:
+        if task_id not in _CHAT_RUNTIME_TASKS:
+            _CHAT_TASKS.pop(task_id, None)
+
+
+async def _run_console_chat_task(
+    *,
+    task_id: str,
+    workspace,
+    console_channel,
+    native_payload: dict,
+    session_id: str,
+    timeout: float | None,
+) -> None:
+    record = _CHAT_TASKS[task_id]
+    record["status"] = "running"
+    record["started_at"] = _now_iso()
+    run_key = f"console-task-{task_id}"
+    await workspace.task_tracker.register_external_task(run_key)
+
+    async def _collect() -> dict:
+        response_data: dict | None = None
+        fallback_data: dict | None = None
+        async for event_data in console_channel.stream_one(native_payload):
+            parsed = _parse_sse_payload(event_data)
+            if parsed is None:
+                continue
+            fallback_data = parsed
+            if parsed.get("object") == "response" or "output" in parsed:
+                response_data = parsed
+        return response_data or fallback_data or {}
+
+    result = {
+        "status": "failed",
+        "session_id": session_id,
+        "error": {"message": "Task did not complete"},
+    }
+    try:
+        if timeout is not None:
+            response_data = await asyncio.wait_for(_collect(), timeout=timeout)
+        else:
+            response_data = await _collect()
+        result = dict(response_data)
+        result["status"] = "completed"
+        result["session_id"] = session_id
+    except asyncio.CancelledError:
+        result = {
+            "status": "failed",
+            "session_id": session_id,
+            "error": {"message": "Task cancelled"},
+        }
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Background console chat task failed: %s", task_id)
+        result = {
+            "status": "failed",
+            "session_id": session_id,
+            "error": {"message": str(exc)},
+        }
+    finally:
+        record["status"] = "finished"
+        record["finished_at"] = _now_iso()
+        record["result"] = result
+        _CHAT_RUNTIME_TASKS.pop(task_id, None)
+        _prune_finished_chat_tasks()
+        await workspace.task_tracker.unregister_external_task(run_key)
 
 
 def _safe_filename(name: str) -> str:
@@ -156,6 +267,7 @@ async def post_console_chat(
     Stop via POST /console/chat/stop. Reconnect with body.reconnect=true.
     """
     workspace = await get_agent_for_request(request)
+
     console_channel = await workspace.channel_manager.get_channel("console")
     if console_channel is None:
         raise HTTPException(
@@ -234,6 +346,98 @@ async def post_console_chat(
 
 
 @router.post(
+    "/chat/task",
+    status_code=200,
+    summary="Submit console chat as a background task",
+)
+async def post_console_chat_task(
+    request_data: Union[AgentRequest, dict],
+    request: Request,
+) -> dict:
+    """Submit a detached chat run and return a task id immediately."""
+    workspace = await get_agent_for_request(request)
+    console_channel = await workspace.channel_manager.get_channel("console")
+    if console_channel is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel Console not found",
+        )
+    try:
+        native_payload = _extract_session_and_payload(request_data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    session_id = console_channel.resolve_session_id(
+        sender_id=native_payload["sender_id"],
+        channel_meta=native_payload["meta"],
+    )
+    timeout = None
+    if (
+        isinstance(request_data, dict)
+        and request_data.get("timeout") is not None
+    ):
+        try:
+            timeout = float(request_data["timeout"])
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="timeout must be a number",
+            ) from exc
+        if timeout <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="timeout must be greater than zero",
+            )
+
+    task_id = str(uuid.uuid4())
+    record = {
+        "task_id": task_id,
+        "agent_id": workspace.agent_id,
+        "session_id": session_id,
+        "status": "submitted",
+        "submitted_at": _now_iso(),
+    }
+    _CHAT_TASKS[task_id] = record
+    runtime_task = asyncio.create_task(
+        _run_console_chat_task(
+            task_id=task_id,
+            workspace=workspace,
+            console_channel=console_channel,
+            native_payload=native_payload,
+            session_id=session_id,
+            timeout=timeout,
+        ),
+        name=f"console-chat-task-{task_id}",
+    )
+    _CHAT_RUNTIME_TASKS[task_id] = runtime_task
+    return {
+        "task_id": task_id,
+        "status": "submitted",
+        "session_id": session_id,
+    }
+
+
+@router.get(
+    "/chat/task/{task_id}",
+    status_code=200,
+    summary="Get background console chat task status",
+)
+async def get_console_chat_task_status(
+    task_id: str,
+    request: Request,
+) -> dict:
+    """Return task lifecycle state and final response when available."""
+    workspace = await get_agent_for_request(request)
+    record = _CHAT_TASKS.get(task_id)
+    if record is None or record.get("agent_id") != workspace.agent_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    response = _public_chat_task_record(record)
+    if record.get("status") == "finished":
+        _CHAT_TASKS.pop(task_id, None)
+    return response
+
+
+@router.post(
     "/chat/stop",
     status_code=200,
     summary="Stop running console chat",
@@ -245,6 +449,13 @@ async def post_console_chat_stop(
     """Stop the running chat. Only stops when called."""
     logger.debug("[STOP API] Received stop request for chat_id=%s", chat_id)
     workspace = await get_agent_for_request(request)
+
+    # Resolve the parent session independently of the stream task lookup so
+    # already-idle parents can still cancel their background children.
+    parent_session_id = chat_id
+    chat_spec = await workspace.chat_manager.get_chat(chat_id)
+    if chat_spec is not None:
+        parent_session_id = chat_spec.session_id
 
     # Try to stop with the provided chat_id first
     logger.debug(
@@ -279,7 +490,17 @@ async def post_console_chat_stop(
         "[STOP API] task_tracker.request_stop returned: stopped=%s",
         stopped,
     )
-    return {"stopped": stopped}
+    subagents_cancelled = 0
+    subagent_manager = getattr(workspace, "subagent_task_manager", None)
+    if subagent_manager is not None:
+        subagents_cancelled = await subagent_manager.cancel_by_parent(
+            parent_session_id,
+            reason="parent session stopped from console",
+        )
+    return {
+        "stopped": stopped or subagents_cancelled > 0,
+        "subagents_cancelled": subagents_cancelled,
+    }
 
 
 @router.post("/upload", response_model=dict, summary="Upload file for chat")

--- a/src/qwenpaw/app/subagents/__init__.py
+++ b/src/qwenpaw/app/subagents/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Background subagent lifecycle management."""
+
+from .context import SubagentSpawnContext, get_subagent_spawn_context
+from .manager import (
+    SubagentLifecycleEvent,
+    SubagentStatus,
+    SubagentTaskManager,
+    SubagentTaskRecord,
+)
+
+__all__ = [
+    "SubagentLifecycleEvent",
+    "SubagentSpawnContext",
+    "SubagentStatus",
+    "SubagentTaskManager",
+    "SubagentTaskRecord",
+    "get_subagent_spawn_context",
+]

--- a/src/qwenpaw/app/subagents/context.py
+++ b/src/qwenpaw/app/subagents/context.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Request-local context used by ``spawn_subagent``.
+
+Tools are registered as plain functions, so they cannot receive a Workspace
+dependency through their signature.  A ContextVar keeps that dependency
+request-scoped and follows AgentScope's async tool execution tasks naturally.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SubagentSpawnContext:
+    """Identity and routing information inherited by a child task."""
+
+    manager: Any
+    agent_id: str
+    session_id: str
+    root_session_id: str
+    user_id: str
+    channel: str
+    channel_meta: dict[str, Any] = field(default_factory=dict)
+    is_subagent: bool = False
+
+
+_CURRENT: ContextVar[SubagentSpawnContext | None] = ContextVar(
+    "qwenpaw_subagent_spawn_context",
+    default=None,
+)
+
+
+def set_subagent_spawn_context(
+    value: SubagentSpawnContext,
+) -> Token[SubagentSpawnContext | None]:
+    """Bind *value* and return a token for deterministic cleanup."""
+    return _CURRENT.set(value)
+
+
+def reset_subagent_spawn_context(
+    token: Token[SubagentSpawnContext | None],
+) -> None:
+    """Restore the ContextVar value that preceded *token*."""
+    _CURRENT.reset(token)
+
+
+def get_subagent_spawn_context() -> SubagentSpawnContext | None:
+    """Return the request-local spawn context, if execution is in Runtime."""
+    return _CURRENT.get()
+
+
+__all__ = [
+    "SubagentSpawnContext",
+    "get_subagent_spawn_context",
+    "reset_subagent_spawn_context",
+    "set_subagent_spawn_context",
+]

--- a/src/qwenpaw/app/subagents/hooks.py
+++ b/src/qwenpaw/app/subagents/hooks.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""QwenPaw Runtime hooks for background-subagent integration."""
+
+from __future__ import annotations
+
+from ...hooks.base import LifecycleHook
+from ...runtime.hooks import HookAction, HookContext, HookResult
+from ...runtime.phases import Phase
+from .context import (
+    SubagentSpawnContext,
+    reset_subagent_spawn_context,
+    set_subagent_spawn_context,
+)
+
+
+class SubagentWakeGuardHook(LifecycleHook):
+    """Skip a queued wakeup if another run already consumed its events."""
+
+    phase = Phase.PRE_EXECUTE
+    name = "subagent_wake_guard"
+    priority = 5
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        request_context = getattr(ctx.request, "request_context", None) or {}
+        if not request_context.get("subagent_wakeup"):
+            return HookResult()
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        if manager is None:
+            return HookResult(action=HookAction.SKIP_AGENT)
+        if not await manager.has_pending_events(ctx.session_id):
+            return HookResult(action=HookAction.SKIP_AGENT)
+
+        # AgentScope rejects ``inputs=None`` while a tool call is parked on
+        # user confirmation or external execution.  Keep the inbox pending;
+        # the real continuation request will drain it before reasoning.
+        agent = getattr(ctx, "agent", None)
+        state = getattr(agent, "state", None)
+        context = getattr(state, "context", None) or []
+        if context:
+            from agentscope.message import ToolCallState
+
+            last = context[-1]
+            tool_calls = last.get_content_blocks("tool_call")
+            if any(
+                call.state in (ToolCallState.ASKING, ToolCallState.SUBMITTED)
+                for call in tool_calls
+            ):
+                return HookResult(action=HookAction.SKIP_AGENT)
+        return HookResult()
+
+
+class SubagentContextSetupHook(LifecycleHook):
+    """Expose the current Workspace manager to plain function tools."""
+
+    phase = Phase.PRE_EXECUTE
+    name = "subagent_context_setup"
+    priority = 15
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        if manager is None:
+            return HookResult()
+        request_context = getattr(ctx.request, "request_context", None) or {}
+        token = set_subagent_spawn_context(
+            SubagentSpawnContext(
+                manager=manager,
+                agent_id=ctx.agent_id,
+                session_id=ctx.session_id,
+                root_session_id=ctx.root_session_id or ctx.session_id,
+                user_id=getattr(ctx.request, "user_id", "") or "",
+                channel=getattr(ctx.request, "channel", "") or "console",
+                channel_meta=dict(
+                    getattr(ctx.request, "channel_meta", None) or {},
+                ),
+                is_subagent=bool(request_context.get("is_subagent")),
+            ),
+        )
+        ctx.extras["subagent_context_token"] = token
+        return HookResult()
+
+
+class SubagentContextCleanupHook(LifecycleHook):
+    """Reset the request-local spawn context on every exit path."""
+
+    phase = Phase.FINALLY
+    name = "subagent_context_cleanup"
+    priority = 90
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        claim_id = getattr(
+            ctx.agent,
+            "_qwenpaw_subagent_event_claim_id",
+            None,
+        )
+        if manager is not None and claim_id:
+            await manager.release_events(claim_id)
+        token = ctx.extras.pop("subagent_context_token", None)
+        if token is not None:
+            reset_subagent_spawn_context(token)
+        return HookResult()
+
+
+class SubagentEventAckHook(LifecycleHook):
+    """Ack claimed inbox events only after session persistence succeeds."""
+
+    phase = Phase.POST_RESPONSE
+    name = "subagent_event_ack"
+    priority = 95
+    after = ("session_save",)
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        if not ctx.extras.get("session_save_succeeded"):
+            return HookResult()
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        claim_id = getattr(
+            ctx.agent,
+            "_qwenpaw_subagent_event_claim_id",
+            None,
+        )
+        if manager is not None and claim_id:
+            await manager.ack_events(claim_id)
+            delattr(ctx.agent, "_qwenpaw_subagent_event_claim_id")
+        return HookResult()
+
+
+__all__ = [
+    "SubagentContextCleanupHook",
+    "SubagentContextSetupHook",
+    "SubagentEventAckHook",
+    "SubagentWakeGuardHook",
+]

--- a/src/qwenpaw/app/subagents/manager.py
+++ b/src/qwenpaw/app/subagents/manager.py
@@ -1,0 +1,779 @@
+# -*- coding: utf-8 -*-
+"""Workspace-scoped background subagent task manager.
+
+The design follows AgentScope 2.0's background-tool lifecycle: keep the
+asyncio task handle locally, publish lifecycle events into a parent-session
+inbox, then enqueue an idle-session wakeup.  QwenPaw supplies its own inbox and
+wakeup bridge because it does not run the ``agentscope.app`` service stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+from ...runtime.heartbeat import HEARTBEAT_INTERVAL_SECONDS
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 4
+DEFAULT_WATCHDOG_INTERVAL_SECONDS = HEARTBEAT_INTERVAL_SECONDS
+DEFAULT_CANCEL_GRACE_SECONDS = 10.0
+
+
+class SubagentStatus(str, Enum):
+    """Stable lifecycle states exposed to tools, logs, and tests."""
+
+    SUBMITTED = "submitted"
+    RUNNING = "running"
+    CANCELLING = "cancelling"
+    STALE = "stale"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+TERMINAL_STATUSES = frozenset(
+    {
+        SubagentStatus.COMPLETED,
+        SubagentStatus.FAILED,
+        SubagentStatus.CANCELLED,
+    },
+)
+
+
+@dataclass
+class SubagentTaskRecord:
+    """Runtime metadata plus the local task handle."""
+
+    task_id: str
+    parent_agent_id: str
+    parent_session_id: str
+    root_session_id: str
+    child_agent_id: str
+    child_session_id: str
+    prompt: str
+    user_id: str
+    channel: str
+    channel_meta: dict[str, Any] = field(default_factory=dict)
+    status: SubagentStatus = SubagentStatus.SUBMITTED
+    created_at: float = field(default_factory=time.time)
+    started_at: float | None = None
+    finished_at: float | None = None
+    last_heartbeat_at: float = 0.0
+    cancel_requested_at: float | None = None
+    stale_notified: bool = False
+    result: str | None = None
+    error: str | None = None
+    cancel_reason: str | None = None
+    notify_on_cancel: bool = True
+    worktree_branch: str = ""
+    asyncio_task: asyncio.Task | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+
+@dataclass
+class SubagentLifecycleEvent:
+    """A child lifecycle event waiting to be injected into its parent."""
+
+    event_id: str
+    task_id: str
+    parent_session_id: str
+    child_session_id: str
+    status: SubagentStatus
+    prompt: str
+    created_at: float = field(default_factory=time.time)
+    result: str | None = None
+    error: str | None = None
+    elapsed_seconds: float | None = None
+    worktree_branch: str = ""
+    claim_id: str | None = None
+
+
+class SubagentTaskManager:
+    """AS2-style lifecycle adapter for leaf subagents in one Workspace.
+
+    This is intentionally not a generic background-task framework.  It only
+    adds parent/child identity and child Runtime execution around the same
+    inbox, HintBlock, wakeup, and cancellation semantics used by AS2.
+    """
+
+    def __init__(
+        self,
+        workspace: Any,
+        *,
+        max_running_per_parent: int = 8,
+        heartbeat_timeout_seconds: float = DEFAULT_HEARTBEAT_TIMEOUT_SECONDS,
+        watchdog_interval_seconds: float = DEFAULT_WATCHDOG_INTERVAL_SECONDS,
+        cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS,
+    ) -> None:
+        self.workspace = workspace
+        self.max_running_per_parent = max_running_per_parent
+        self.heartbeat_timeout_seconds = max(
+            float(heartbeat_timeout_seconds),
+            0.01,
+        )
+        self.watchdog_interval_seconds = max(
+            float(watchdog_interval_seconds),
+            0.01,
+        )
+        self.cancel_grace_seconds = max(float(cancel_grace_seconds), 0.0)
+        self._records: dict[str, SubagentTaskRecord] = {}
+        self._events: list[SubagentLifecycleEvent] = []
+        self._lock = asyncio.Lock()
+        self._watchdog_task: asyncio.Task | None = None
+        self._notification_tasks: set[asyncio.Task] = set()
+        self._stopping = False
+
+    async def start(self) -> None:
+        """Start one workspace-wide heartbeat watchdog."""
+        if self._watchdog_task is not None and not self._watchdog_task.done():
+            return
+        self._stopping = False
+        self._watchdog_task = asyncio.create_task(
+            self._watchdog_loop(),
+            name="qwenpaw-subagent-watchdog",
+        )
+
+    async def stop(self) -> None:
+        """Cancel live children without waking parents during shutdown."""
+        self._stopping = True
+        watchdog = self._watchdog_task
+        self._watchdog_task = None
+        if watchdog is not None and not watchdog.done():
+            watchdog.cancel()
+            await asyncio.gather(watchdog, return_exceptions=True)
+
+        async with self._lock:
+            tasks = []
+            for record in self._records.values():
+                task = record.asyncio_task
+                if task is not None and not task.done():
+                    record.cancel_reason = "workspace shutdown"
+                    record.notify_on_cancel = False
+                    tasks.append(task)
+                    task.cancel()
+            notifications = list(self._notification_tasks)
+            for task in notifications:
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if notifications:
+            await asyncio.gather(*notifications, return_exceptions=True)
+
+    async def spawn(
+        self,
+        *,
+        prompt: str,
+        parent_agent_id: str,
+        parent_session_id: str,
+        root_session_id: str,
+        child_agent_id: str,
+        child_session_id: str,
+        user_id: str,
+        channel: str,
+        channel_meta: dict[str, Any] | None,
+        parent_is_subagent: bool,
+        request_context: dict[str, Any] | None = None,
+        worktree_branch: str = "",
+    ) -> SubagentTaskRecord:
+        """Create, register, and start one child Runtime task."""
+        if parent_is_subagent:
+            raise ValueError(
+                "nested subagents are not supported; only a top-level "
+                "agent may call spawn_subagent",
+            )
+
+        async with self._lock:
+            running = sum(
+                1
+                for item in self._records.values()
+                if item.parent_session_id == parent_session_id
+                and item.status not in TERMINAL_STATUSES
+            )
+            if running >= self.max_running_per_parent:
+                raise RuntimeError(
+                    "background subagent limit reached for this parent "
+                    f"({running}/{self.max_running_per_parent})",
+                )
+
+            task_id = f"subtask-{uuid4().hex[:12]}"
+            record = SubagentTaskRecord(
+                task_id=task_id,
+                parent_agent_id=parent_agent_id,
+                parent_session_id=parent_session_id,
+                root_session_id=root_session_id or parent_session_id,
+                child_agent_id=child_agent_id,
+                child_session_id=child_session_id,
+                prompt=prompt,
+                user_id=user_id,
+                channel=channel or "console",
+                channel_meta=self._routing_meta(channel_meta or {}),
+                last_heartbeat_at=time.monotonic(),
+                worktree_branch=worktree_branch,
+            )
+            self._records[task_id] = record
+
+            child_context = dict(request_context or {})
+            child_context.update(
+                {
+                    "is_subagent": True,
+                    "subagent_task_id": task_id,
+                    "subagent_parent_session_id": parent_session_id,
+                },
+            )
+            record.asyncio_task = asyncio.create_task(
+                self._run_child(record, child_context),
+                name=f"qwenpaw-subagent:{task_id}",
+            )
+
+            def _done_callback(done: asyncio.Task) -> None:
+                self._on_task_done(record, done)
+
+            record.asyncio_task.add_done_callback(_done_callback)
+            return record
+
+    def _on_task_done(
+        self,
+        record: SubagentTaskRecord,
+        task: asyncio.Task,
+    ) -> None:
+        """Close the pre-start cancellation gap in asyncio task execution."""
+        if record.status in TERMINAL_STATUSES:
+            return
+        try:
+            asyncio.create_task(self._ensure_done_state(record, task))
+        except RuntimeError:
+            # Event loop is already closed during interpreter shutdown.
+            return
+
+    async def _ensure_done_state(
+        self,
+        record: SubagentTaskRecord,
+        task: asyncio.Task,
+    ) -> None:
+        if record.status in TERMINAL_STATUSES:
+            return
+        if task.cancelled():
+            await self._finish(
+                record,
+                SubagentStatus.CANCELLED,
+                error=record.cancel_reason or "subagent task was cancelled",
+                notify_parent=record.notify_on_cancel,
+            )
+            return
+        exc = task.exception()
+        if exc is not None:
+            await self._finish(
+                record,
+                SubagentStatus.FAILED,
+                error=str(exc) or type(exc).__name__,
+            )
+            return
+        await self._finish(
+            record,
+            SubagentStatus.FAILED,
+            error="subagent task exited without a terminal lifecycle state",
+        )
+
+    async def _run_child(
+        self,
+        record: SubagentTaskRecord,
+        request_context: dict[str, Any],
+    ) -> None:
+        try:
+            async with self._lock:
+                record.status = SubagentStatus.RUNNING
+                record.started_at = time.time()
+                record.last_heartbeat_at = time.monotonic()
+
+            request = self._build_child_request(record, request_context)
+            final_text = ""
+            async for item in self.workspace.stream_query(request):
+                # AgentExecutor already emits heartbeat envelopes while
+                # the AS2 event stream is idle. Reuse that established
+                # mechanism instead of creating another timer task.
+                await self.touch(record.task_id)
+                text = self._completed_assistant_text(item)
+                if text:
+                    final_text = text
+
+            await self._finish(
+                record,
+                SubagentStatus.COMPLETED,
+                result=final_text
+                or "(Subagent completed with no text output)",
+            )
+        except asyncio.CancelledError:
+            reason = record.cancel_reason or "subagent task was cancelled"
+            await self._finish(
+                record,
+                SubagentStatus.CANCELLED,
+                error=reason,
+                notify_parent=record.notify_on_cancel,
+            )
+            raise
+        except BaseException as exc:  # noqa: BLE001
+            logger.exception("Background subagent %s failed", record.task_id)
+            await self._finish(
+                record,
+                SubagentStatus.FAILED,
+                error=str(exc) or type(exc).__name__,
+            )
+
+    async def _finish(
+        self,
+        record: SubagentTaskRecord,
+        status: SubagentStatus,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+        notify_parent: bool = True,
+    ) -> None:
+        async with self._lock:
+            if record.status in TERMINAL_STATUSES:
+                return
+            should_notify = notify_parent and record.notify_on_cancel
+            record.status = status
+            record.finished_at = time.time()
+            record.result = result
+            record.error = error
+            if should_notify:
+                self._append_lifecycle_event_locked(record)
+            else:
+                self._records.pop(record.task_id, None)
+        if should_notify:
+            await self._enqueue_parent_wakeup(record)
+
+    async def touch(
+        self,
+        task_id: str,
+    ) -> None:
+        """Record one liveness pulse from the child Runtime stream."""
+        async with self._lock:
+            record = self._records.get(task_id)
+            if record is None or record.status not in {
+                SubagentStatus.SUBMITTED,
+                SubagentStatus.RUNNING,
+            }:
+                return
+            record.last_heartbeat_at = time.monotonic()
+
+    async def cancel_task(
+        self,
+        task_id: str,
+        *,
+        reason: str = "cancelled by parent",
+        notify_parent: bool = True,
+    ) -> bool:
+        """Cancel one task by id.  Idempotent for terminal/unknown tasks."""
+        async with self._lock:
+            record = self._records.get(task_id)
+            if record is None or record.status in TERMINAL_STATUSES:
+                return False
+            record.cancel_reason = reason
+            record.notify_on_cancel = notify_parent
+            task = record.asyncio_task
+            if task is None or task.done():
+                return False
+            if record.status == SubagentStatus.CANCELLING:
+                return False
+            if record.status == SubagentStatus.STALE:
+                task.cancel()
+                return True
+            record.status = SubagentStatus.CANCELLING
+            record.cancel_requested_at = time.monotonic()
+            task.cancel()
+            return True
+
+    async def cancel_by_parent(
+        self,
+        parent_session_id: str,
+        *,
+        reason: str = "parent session cancelled",
+    ) -> int:
+        """Silently cancel all children and discard pending callbacks."""
+        async with self._lock:
+            discarded_task_ids = {
+                event.task_id
+                for event in self._events
+                if event.parent_session_id == parent_session_id
+            }
+            self._events = [
+                event
+                for event in self._events
+                if event.parent_session_id != parent_session_id
+            ]
+            for task_id in discarded_task_ids:
+                record = self._records.get(task_id)
+                if record is not None and record.status in TERMINAL_STATUSES:
+                    self._records.pop(task_id, None)
+
+            tasks = [
+                record
+                for record in self._records.values()
+                if record.parent_session_id == parent_session_id
+                and record.status not in TERMINAL_STATUSES
+            ]
+            cancelled = 0
+            for record in tasks:
+                task = record.asyncio_task
+                if task is None or task.done():
+                    continue
+                record.cancel_reason = reason
+                record.notify_on_cancel = False
+                if record.status == SubagentStatus.CANCELLING:
+                    continue
+                if record.status != SubagentStatus.STALE:
+                    record.status = SubagentStatus.CANCELLING
+                    record.cancel_requested_at = time.monotonic()
+                task.cancel()
+                cancelled += 1
+            return cancelled
+
+    async def _watchdog_loop(self) -> None:
+        """Cancel children whose Runtime heartbeat stream has stopped."""
+        previous_tick = time.monotonic()
+        try:
+            while True:
+                await asyncio.sleep(self.watchdog_interval_seconds)
+                now = time.monotonic()
+                tick_delay = now - previous_tick
+                previous_tick = now
+
+                # If this watchdog was delayed too, the whole event loop was
+                # paused. Give every child a fresh lease instead of killing
+                # healthy work after suspend, debugger pause, or starvation.
+                if tick_delay > self.watchdog_interval_seconds * 2:
+                    await self._reset_leases_after_loop_pause(now)
+                    continue
+
+                stale_records = await self._watchdog_tick(now)
+                for record in stale_records:
+                    self._schedule_parent_wakeup(record)
+        except Exception:  # pragma: no cover - defensive service boundary
+            logger.exception(
+                "Subagent heartbeat watchdog stopped unexpectedly",
+            )
+
+    async def _reset_leases_after_loop_pause(self, now: float) -> None:
+        async with self._lock:
+            for record in self._records.values():
+                if record.status in {
+                    SubagentStatus.SUBMITTED,
+                    SubagentStatus.RUNNING,
+                }:
+                    record.last_heartbeat_at = now
+                elif record.status == SubagentStatus.CANCELLING:
+                    record.cancel_requested_at = now
+
+    async def _watchdog_tick(
+        self,
+        now: float,
+    ) -> list[SubagentTaskRecord]:
+        """Apply heartbeat leases and return newly stale records."""
+        newly_stale: list[SubagentTaskRecord] = []
+        async with self._lock:
+            for record in self._records.values():
+                task = record.asyncio_task
+                if task is None or task.done():
+                    continue
+
+                if record.status in {
+                    SubagentStatus.SUBMITTED,
+                    SubagentStatus.RUNNING,
+                }:
+                    heartbeat_age = now - record.last_heartbeat_at
+                    if heartbeat_age < self.heartbeat_timeout_seconds:
+                        continue
+                    record.status = SubagentStatus.CANCELLING
+                    record.cancel_reason = (
+                        f"subagent heartbeat lost for {heartbeat_age:.1f}s"
+                    )
+                    record.notify_on_cancel = True
+                    record.cancel_requested_at = now
+                    task.cancel()
+                    continue
+
+                if record.status != SubagentStatus.CANCELLING:
+                    continue
+                requested_at = record.cancel_requested_at
+                if requested_at is None:
+                    record.cancel_requested_at = now
+                    continue
+                if now - requested_at < self.cancel_grace_seconds:
+                    continue
+                if record.stale_notified:
+                    continue
+
+                record.status = SubagentStatus.STALE
+                record.stale_notified = True
+                record.error = (
+                    f"{record.cancel_reason or 'subagent cancellation'}; "
+                    "cancellation did not complete within "
+                    f"{self.cancel_grace_seconds:g}s"
+                )
+                if record.notify_on_cancel:
+                    self._append_lifecycle_event_locked(record)
+                    newly_stale.append(record)
+        return newly_stale
+
+    def _schedule_parent_wakeup(self, record: SubagentTaskRecord) -> None:
+        """Schedule a non-blocking wakeup without stalling the watchdog."""
+        if self._stopping:
+            return
+        task = asyncio.create_task(
+            self._enqueue_parent_wakeup(record),
+            name=f"qwenpaw-subagent-wakeup:{record.task_id}",
+        )
+        self._notification_tasks.add(task)
+        task.add_done_callback(self._notification_tasks.discard)
+
+    async def get(self, task_id: str) -> SubagentTaskRecord | None:
+        async with self._lock:
+            return self._records.get(task_id)
+
+    async def has_pending_events(self, parent_session_id: str) -> bool:
+        async with self._lock:
+            return any(
+                event.parent_session_id == parent_session_id
+                for event in self._events
+            )
+
+    async def claim_events(
+        self,
+        parent_session_id: str,
+        claim_id: str,
+    ) -> list[SubagentLifecycleEvent]:
+        """Lease all currently available events to one parent run."""
+        async with self._lock:
+            events = [
+                event
+                for event in self._events
+                if event.parent_session_id == parent_session_id
+                and event.claim_id is None
+            ]
+            for event in events:
+                event.claim_id = claim_id
+            return events
+
+    async def ack_events(self, claim_id: str) -> int:
+        """Commit a delivery after the parent session state was saved."""
+        async with self._lock:
+            acknowledged = [
+                event for event in self._events if event.claim_id == claim_id
+            ]
+            if not acknowledged:
+                return 0
+            acknowledged_ids = {event.event_id for event in acknowledged}
+            self._events = [
+                event
+                for event in self._events
+                if event.event_id not in acknowledged_ids
+            ]
+            for event in acknowledged:
+                record = self._records.get(event.task_id)
+                if (
+                    event.status in TERMINAL_STATUSES
+                    and record is not None
+                    and record.status in TERMINAL_STATUSES
+                ):
+                    self._records.pop(event.task_id, None)
+            return len(acknowledged)
+
+    async def release_events(self, claim_id: str) -> int:
+        """Release an uncommitted delivery for a later user/wakeup run."""
+        count = 0
+        async with self._lock:
+            for event in self._events:
+                if event.claim_id != claim_id:
+                    continue
+                event.claim_id = None
+                count += 1
+        return count
+
+    async def drain_events(
+        self,
+        parent_session_id: str,
+    ) -> list[SubagentLifecycleEvent]:
+        """Compatibility helper for non-runtime consumers and tests."""
+        claim_id = f"drain-{uuid4().hex}"
+        events = await self.claim_events(parent_session_id, claim_id)
+        await self.ack_events(claim_id)
+        return events
+
+    def _append_lifecycle_event_locked(
+        self,
+        record: SubagentTaskRecord,
+    ) -> None:
+        elapsed = None
+        if record.started_at is not None and record.finished_at is not None:
+            elapsed = max(0.0, record.finished_at - record.started_at)
+        self._events.append(
+            SubagentLifecycleEvent(
+                event_id=f"subevent-{uuid4().hex[:12]}",
+                task_id=record.task_id,
+                parent_session_id=record.parent_session_id,
+                child_session_id=record.child_session_id,
+                status=record.status,
+                prompt=record.prompt,
+                result=record.result,
+                error=record.error,
+                elapsed_seconds=elapsed,
+                worktree_branch=record.worktree_branch,
+            ),
+        )
+
+    async def _enqueue_parent_wakeup(
+        self,
+        record: SubagentTaskRecord,
+    ) -> None:
+        """Wake the parent only after its current run becomes idle.
+
+        Channel queues serialize ordinary chat traffic, but Console HTTP can
+        drive TaskTracker directly.  Waiting here prevents two Runtime
+        instances from loading and saving the same parent session at once.
+        """
+        manager = getattr(self.workspace, "channel_manager", None)
+        if manager is None or not record.channel:
+            logger.warning(
+                "Cannot wake parent for subagent %s: channel unavailable",
+                record.task_id,
+            )
+            return
+        try:
+            chat_manager = getattr(self.workspace, "chat_manager", None)
+            tracker = getattr(self.workspace, "task_tracker", None)
+            chat_id = None
+            if chat_manager is not None:
+                chat_id = await chat_manager.get_chat_id_by_session(
+                    record.parent_session_id,
+                    record.channel,
+                )
+            while chat_id and tracker is not None:
+                if await tracker.get_status(chat_id) != "running":
+                    break
+                # The active parent may consume the HintBlock on its next
+                # reasoning step.  If so, no follow-up wake is necessary.
+                if not await self.has_pending_events(
+                    record.parent_session_id,
+                ):
+                    return
+                await asyncio.sleep(0.1)
+
+            if not await self.has_pending_events(record.parent_session_id):
+                return
+
+            from ...schemas import AgentRequest
+
+            request = AgentRequest(
+                input=[],
+                session_id=record.parent_session_id,
+                user_id=record.user_id or record.parent_session_id,
+                channel=record.channel,
+                root_session_id=record.root_session_id,
+                root_agent_id=record.parent_agent_id,
+                request_context={
+                    "subagent_wakeup": True,
+                    "subagent_event_task_id": record.task_id,
+                },
+            )
+            request.channel_meta = dict(record.channel_meta)
+            manager.enqueue(record.channel, request)
+        except Exception:
+            logger.exception(
+                "Failed to enqueue parent wakeup for %s",
+                record.task_id,
+            )
+
+    @staticmethod
+    def _build_child_request(
+        record: SubagentTaskRecord,
+        request_context: dict[str, Any],
+    ) -> Any:
+        from ...schemas import (
+            AgentRequest,
+            ContentType,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+        )
+
+        message = Message(
+            type=MessageType.MESSAGE,
+            role=Role.USER,
+            content=[TextContent(type=ContentType.TEXT, text=record.prompt)],
+        )
+        return AgentRequest(
+            input=[message],
+            session_id=record.child_session_id,
+            user_id=record.user_id or record.parent_agent_id,
+            channel=record.channel,
+            agent_id=record.child_agent_id,
+            root_session_id=record.root_session_id,
+            root_agent_id=record.parent_agent_id,
+            request_context=request_context,
+        )
+
+    @staticmethod
+    def _completed_assistant_text(item: Any) -> str:
+        role = getattr(item, "role", None)
+        status = getattr(item, "status", None)
+        if hasattr(role, "value"):
+            role = role.value
+        if hasattr(status, "value"):
+            status = status.value
+        if role != "assistant" or status != "completed":
+            return ""
+        parts = []
+        for block in getattr(item, "content", None) or []:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and text:
+                parts.append(text)
+        return "\n".join(parts).strip()
+
+    @staticmethod
+    def _routing_meta(value: dict[str, Any]) -> dict[str, Any]:
+        """Keep reusable routing values, dropping callbacks and secrets."""
+        safe: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key).lower()
+            if any(
+                sensitive in normalized_key
+                for sensitive in (
+                    "token",
+                    "secret",
+                    "password",
+                    "webhook",
+                    "api_key",
+                    "reply_future",
+                    "reply_loop",
+                    "incoming_message",
+                )
+            ):
+                continue
+            if not isinstance(
+                item,
+                (str, int, float, bool, type(None), list, dict),
+            ):
+                continue
+            safe[str(key)] = item
+        return safe
+
+
+__all__ = [
+    "SubagentLifecycleEvent",
+    "SubagentStatus",
+    "SubagentTaskManager",
+    "SubagentTaskRecord",
+    "TERMINAL_STATUSES",
+]

--- a/src/qwenpaw/app/subagents/middleware.py
+++ b/src/qwenpaw/app/subagents/middleware.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""AgentScope 2.0 middleware for parent subagent-result inboxes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.agent import Agent
+from agentscope.event import HintBlockEvent
+from agentscope.message import AssistantMsg, HintBlock
+from agentscope.middleware import MiddlewareBase
+
+from .manager import SubagentLifecycleEvent, SubagentTaskManager
+
+
+class SubagentInboxMiddleware(MiddlewareBase):
+    """Inject child lifecycle events before parent reasoning."""
+
+    def __init__(
+        self,
+        manager: SubagentTaskManager,
+        parent_session_id: str,
+    ) -> None:
+        self._manager = manager
+        self._parent_session_id = parent_session_id
+
+    async def on_reasoning(
+        self,
+        agent: Agent,
+        input_kwargs: dict,
+        next_handler: Callable[..., AsyncGenerator],
+    ) -> AsyncGenerator[Any, None]:
+        claim_id = (
+            f"{self._parent_session_id}:"
+            f"{agent.state.reply_id}:subagent-events"
+        )
+        events = await self._manager.claim_events(
+            self._parent_session_id,
+            claim_id,
+        )
+        if events:
+            setattr(agent, "_qwenpaw_subagent_event_claim_id", claim_id)
+            hints = [self._to_hint(event) for event in events]
+            if agent.state.context:
+                last = agent.state.context[-1]
+                if last.role == "assistant" and last.name == agent.name:
+                    last.content.extend(hints)
+                else:
+                    agent.state.context.append(
+                        AssistantMsg(
+                            id=agent.state.reply_id,
+                            name=agent.name,
+                            content=hints,
+                        ),
+                    )
+            else:
+                agent.state.context.append(
+                    AssistantMsg(
+                        id=agent.state.reply_id,
+                        name=agent.name,
+                        content=hints,
+                    ),
+                )
+
+            for hint in hints:
+                yield HintBlockEvent(
+                    reply_id=agent.state.reply_id,
+                    block_id=hint.id,
+                    source=hint.source,
+                    hint=hint.hint,
+                )
+
+        async for event in next_handler(**input_kwargs):
+            yield event
+
+    @staticmethod
+    def _to_hint(event: SubagentLifecycleEvent) -> HintBlock:
+        source = json.dumps(
+            {
+                "label": "subagent",
+                "sublabel": f"{event.task_id} · {event.status.value}",
+            },
+            ensure_ascii=False,
+        )
+        elapsed = (
+            f" after {event.elapsed_seconds:.1f}s"
+            if event.elapsed_seconds is not None
+            else ""
+        )
+        lines = [
+            "<system-notification>",
+            "Background subagent "
+            f"{event.task_id} {event.status.value}{elapsed}.",
+            f"Original task: {event.prompt}",
+        ]
+        if event.result:
+            lines.extend(["", "Result:", event.result])
+        if event.error:
+            lines.extend(["", "Error:", event.error])
+        if event.worktree_branch:
+            lines.extend(["", f"Fork branch: {event.worktree_branch}"])
+        if event.status.value == "stale":
+            lines.extend(
+                [
+                    "",
+                    "The child stopped sending heartbeats and did not exit ",
+                    "within the cancellation grace period. Do not poll it. ",
+                    "You may report the stalled task or explicitly request ",
+                    "cancellation again.",
+                ],
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    "Use this result now. Do not call a polling or waiting ",
+                    "tool for this completed task.",
+                ],
+            )
+        lines.append("</system-notification>")
+        return HintBlock(hint="\n".join(lines), source=source)
+
+
+__all__ = ["SubagentInboxMiddleware"]

--- a/src/qwenpaw/app/workspace/local_workspace.py
+++ b/src/qwenpaw/app/workspace/local_workspace.py
@@ -47,7 +47,7 @@ class QwenPawLocalWorkspace(AgentScopeLocalWorkspace):
         *,
         agent_config: Any = None,
         agent_id: str | None = None,  # pylint: disable=unused-argument
-        request_context: dict[str, str] | None = None,
+        request_context: dict[str, Any] | None = None,
         active_modes: tuple[str, ...] | set[str] = (),
         active_skills: tuple[str, ...] | set[str] = (),
         enabled_features: tuple[str, ...] | set[str] = (),
@@ -66,6 +66,12 @@ class QwenPawLocalWorkspace(AgentScopeLocalWorkspace):
             allowed, denied = self._resolve_config_gates(agent_config)
         else:
             allowed, denied = None, set()
+
+        # Background subagents are deliberately leaves.  Hiding delegation
+        # tools from their schema prevents the model from attempting a nested
+        # call; SubagentTaskManager repeats the check defensively at runtime.
+        if request_context and request_context.get("is_subagent"):
+            denied.update({"spawn_subagent", "cancel_subagent"})
 
         descs = self._tool_registry.filter(
             active_modes=set(active_modes),

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -10,6 +10,7 @@ Each Workspace represents a standalone agent workspace with its own:
 
 Request processing is handled by ``Runtime`` (see ``stream_query``).
 """
+
 import logging
 from pathlib import Path
 from typing import Any, AsyncGenerator, Iterable, Optional
@@ -118,6 +119,11 @@ class Workspace:
     def cron_manager(self):
         """Get cron manager instance from ServiceManager."""
         return self._service_manager.services.get("cron_manager")
+
+    @property
+    def subagent_task_manager(self):
+        """Get the workspace-scoped background subagent manager."""
+        return self._service_manager.services.get("subagent_task_manager")
 
     # Non-service state
     @property
@@ -368,6 +374,22 @@ class Workspace:
                 start_method="start_all",
                 stop_method="stop_all",
                 priority=30,
+                concurrent_init=False,
+            ),
+        )
+
+        # Priority 35: background subagent lifecycle.  Start after channels so
+        # terminal events can be routed through the wakeup bridge.
+        from ..subagents import SubagentTaskManager
+
+        sm.register(
+            ServiceDescriptor(
+                name="subagent_task_manager",
+                service_class=SubagentTaskManager,
+                init_args=lambda ws: {"workspace": ws},
+                start_method="start",
+                stop_method="stop",
+                priority=35,
                 concurrent_init=False,
             ),
         )

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1687,6 +1687,12 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
             ),
             icon="🔀",
         ),
+        "cancel_subagent": BuiltinToolConfig(
+            name="cancel_subagent",
+            enabled=True,
+            description="Cancel a background subagent owned by this session",
+            icon="🛑",
+        ),
     }
 
     # Merge dynamically registered tools from plugins

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -118,11 +118,13 @@ class ToolRegistry:
 
 
 # ---------------------------------------------------------------------------
-# Default registry instance (21 tools)
+# Default registry instance
 # ---------------------------------------------------------------------------
 
 
-def _create_default_registry() -> ToolRegistry:
+def _create_default_registry() -> (
+    ToolRegistry
+):  # pylint: disable=too-many-statements
     """Create and populate the default ToolRegistry."""
     registry = ToolRegistry()
 
@@ -153,8 +155,11 @@ def _create_default_registry() -> ToolRegistry:
     registry.register("ChatWithAgent", "internal", "agent_id")
     registry.register("SubmitToAgent", "internal", "agent_id")
     registry.register("CheckAgentTask", "internal", "task_id")
+    # Keep the upstream registration semantics from PR #5524: governance
+    # evaluates a spawn request against its primary ``task`` argument.
+    registry.register("SpawnSubagent", "internal", "task")
+    registry.register("CancelSubagent", "internal", "task_id")
     registry.register("DelegateExternalAgent", "internal", "runner")
-    registry.register("RecallHistoryPython", "shell", "source")
     registry.register("MemorySearch", "internal", "")
 
     # ── Python function name mappings ──
@@ -182,6 +187,8 @@ def _create_default_registry() -> ToolRegistry:
     registry.register_python_name("chat_with_agent", "ChatWithAgent")
     registry.register_python_name("submit_to_agent", "SubmitToAgent")
     registry.register_python_name("check_agent_task", "CheckAgentTask")
+    registry.register_python_name("spawn_subagent", "SpawnSubagent")
+    registry.register_python_name("cancel_subagent", "CancelSubagent")
     registry.register_python_name("materialize_skill", "MaterializeSkill")
 
     return registry

--- a/src/qwenpaw/hooks/error/error_hook.py
+++ b/src/qwenpaw/hooks/error/error_hook.py
@@ -110,6 +110,21 @@ class CancelCleanupHook(LifecycleHook):
                 except Exception:
                     pass
 
+        # A parent request owns the lifetime of its direct background child.
+        # Subagents are leaves, so cancellation never recurses further.
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        if manager is not None:
+            try:
+                await manager.cancel_by_parent(
+                    ctx.session_id,
+                    reason="parent request cancelled",
+                )
+            except Exception:
+                logger.debug(
+                    "cancel_cleanup: subagent cancellation failed",
+                    exc_info=True,
+                )
+
         return HookResult()
 
 

--- a/src/qwenpaw/hooks/session/session_hook.py
+++ b/src/qwenpaw/hooks/session/session_hook.py
@@ -81,7 +81,9 @@ class SessionSaveHook(LifecycleHook):
                 channel=channel,
                 agent=proxy,
             )
+            ctx.extras["session_save_succeeded"] = True
         except Exception:
+            ctx.extras["session_save_succeeded"] = False
             logger.debug("session_save: failed", exc_info=True)
         return HookResult()
 

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -713,6 +713,26 @@ class AgentBuilder:
             except Exception:
                 _logger.debug("Memory middlewares not created", exc_info=True)
 
+        # AgentScope 2.0-native subagent lifecycle integration.  The inbox
+        # middleware is always present so an idle parent can be woken with an
+        # empty request and receive child terminal results as HintBlocks.
+        workspace = getattr(ctx, "workspace", None)
+        subagent_manager = (
+            getattr(workspace, "subagent_task_manager", None)
+            if workspace is not None
+            else None
+        )
+        if subagent_manager is not None:
+            from ..app.subagents.middleware import (
+                SubagentInboxMiddleware,
+            )
+
+            mws.append(
+                SubagentInboxMiddleware(
+                    subagent_manager,
+                    ctx.session_id,
+                ),
+            )
         # Tiered tool-result pruning (ported from LightContextManager)
         try:
             import os

--- a/src/qwenpaw/runtime/commands/control/stop_handler.py
+++ b/src/qwenpaw/runtime/commands/control/stop_handler.py
@@ -56,7 +56,19 @@ class StopCommandHandler(BaseControlCommandHandler):
             channel_id,
         )
 
-        if chat_id is None:
+        subagents_cancelled = 0
+        subagent_manager = getattr(
+            workspace,
+            "subagent_task_manager",
+            None,
+        )
+        if subagent_manager is not None:
+            subagents_cancelled = await subagent_manager.cancel_by_parent(
+                target_session_id,
+                reason="parent session stopped with /stop",
+            )
+
+        if chat_id is None and subagents_cancelled == 0:
             logger.warning(
                 f"/stop: No active chat found for "
                 f"session={target_session_id[:30]} channel={channel_id}",
@@ -67,7 +79,11 @@ class StopCommandHandler(BaseControlCommandHandler):
                 f"`{target_session_id[:40]}`."
             )
 
-        stopped = await workspace.task_tracker.request_stop(chat_id)
+        stopped = (
+            await workspace.task_tracker.request_stop(chat_id)
+            if chat_id is not None
+            else False
+        )
 
         cleared = await workspace.channel_manager.clear_queue(
             channel_id,
@@ -75,7 +91,7 @@ class StopCommandHandler(BaseControlCommandHandler):
             20,
         )
 
-        if stopped or cleared > 0:
+        if stopped or cleared > 0 or subagents_cancelled > 0:
             logger.info(
                 f"/stop: stopped={stopped} cleared={cleared} "
                 f"chat_id={chat_id} session={target_session_id[:30]}",
@@ -85,6 +101,10 @@ class StopCommandHandler(BaseControlCommandHandler):
                 status_parts.append("running task stopped")
             if cleared > 0:
                 status_parts.append(f"{cleared} queued message(s) cleared")
+            if subagents_cancelled > 0:
+                status_parts.append(
+                    f"{subagents_cancelled} background subagent(s) cancelled",
+                )
             status_text = " and ".join(status_parts)
             return (
                 f"**Task Stopped**\n\n"

--- a/tests/integration/test_spawn_subagent.py
+++ b/tests/integration/test_spawn_subagent.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""End-to-end coverage for foreground and background subagents."""
+
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import HTTPServer
+
+import httpx
+import pytest
+
+from tests.integration.helpers import (
+    MOCK_LLM_PROVIDER_ID,
+    MockLLMHandler,
+    register_mock_provider,
+    scoped,
+    unregister_mock_provider,
+)
+
+_HTTP_TIMEOUT = 30.0
+_FOREGROUND_CHILD = "SUBAGENT_E2E_FOREGROUND_CHILD"
+_BACKGROUND_CHILD = "SUBAGENT_E2E_BACKGROUND_CHILD"
+
+
+class _SubagentMockLLMHandler(MockLLMHandler):
+    """Drive parent tool calls and observe child completion delivery."""
+
+    def _stream_completion(self):
+        body = self._read_body()
+        messages_text = json.dumps(
+            body.get("messages", []),
+            ensure_ascii=False,
+        )
+        tools = body.get("tools", [])
+        has_tool_result = any(
+            message.get("role") == "tool"
+            for message in body.get("messages", [])
+        )
+
+        if has_tool_result:
+            if "FOREGROUND_SUBAGENT_COMPLETED" in messages_text:
+                self.server.foreground_parent_result_seen.set()
+            if "[TASK_ID:" in messages_text:
+                self.server.background_submission_seen.set()
+            if "BACKGROUND_SUBAGENT_COMPLETED" in messages_text:
+                self.server.background_parent_result_seen.set()
+            self._stream_text("PARENT_RECEIVED_SUBAGENT_RESULT")
+            return
+        if _FOREGROUND_CHILD in messages_text:
+            self.server.foreground_child_seen.set()
+            self._stream_text("FOREGROUND_SUBAGENT_COMPLETED")
+            return
+        if _BACKGROUND_CHILD in messages_text:
+            self.server.background_child_seen.set()
+            self._stream_text("BACKGROUND_SUBAGENT_COMPLETED")
+            return
+        if tools and "RUN_FOREGROUND_SUBAGENT" in messages_text:
+            self.server.tool_call_name = "spawn_subagent"
+            self.server.tool_call_arguments = json.dumps(
+                {
+                    "task": _FOREGROUND_CHILD,
+                    "background": False,
+                },
+            )
+            self._stream_tool_call()
+            return
+        if tools and "RUN_BACKGROUND_SUBAGENT" in messages_text:
+            self.server.tool_call_name = "spawn_subagent"
+            self.server.tool_call_arguments = json.dumps(
+                {
+                    "task": _BACKGROUND_CHILD,
+                    "background": True,
+                },
+            )
+            self._stream_tool_call()
+            return
+
+        self._stream_text("MOCK_AUXILIARY_RESPONSE")
+
+
+@pytest.fixture(scope="module")
+def subagent_mock_llm():
+    server = HTTPServer(("127.0.0.1", 0), _SubagentMockLLMHandler)
+    server.foreground_child_seen = threading.Event()
+    server.foreground_parent_result_seen = threading.Event()
+    server.background_child_seen = threading.Event()
+    server.background_submission_seen = threading.Event()
+    server.background_parent_result_seen = threading.Event()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _run_console_turn(app_server, prompt: str, session_id: str) -> str:
+    url = f"{app_server.base_url}{scoped('default', '/console/chat')}"
+    body = {
+        "input": [
+            {
+                "content": [{"type": "text", "text": prompt}],
+            },
+        ],
+        "user_id": f"user-{session_id}",
+        "session_id": session_id,
+    }
+    chunks: list[str] = []
+    with app_server.client.stream(
+        "POST",
+        url,
+        json=body,
+        timeout=httpx.Timeout(_HTTP_TIMEOUT, read=_HTTP_TIMEOUT),
+    ) as response:
+        assert response.status_code == 200, app_server.logs_tail()
+        chunks.extend(response.iter_lines())
+    return "\n".join(chunks)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_spawn_subagent_foreground_and_background_end_to_end(
+    app_server,
+    subagent_mock_llm,
+) -> None:
+    """Run both modes through Runtime, governance, and callback wakeup."""
+    server, mock_url = subagent_mock_llm
+    unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+    register_mock_provider(app_server, mock_url)
+
+    try:
+        foreground_stream = _run_console_turn(
+            app_server,
+            "RUN_FOREGROUND_SUBAGENT",
+            "spawn-e2e-foreground",
+        )
+        assert server.foreground_child_seen.wait(10), app_server.logs_tail()
+        assert server.foreground_parent_result_seen.wait(
+            10,
+        ), app_server.logs_tail()
+        assert "denied by policy" not in foreground_stream
+
+        background_stream = _run_console_turn(
+            app_server,
+            "RUN_BACKGROUND_SUBAGENT",
+            "spawn-e2e-background",
+        )
+        assert "denied by policy" not in background_stream
+        assert server.background_submission_seen.wait(
+            10,
+        ), app_server.logs_tail()
+        assert server.background_child_seen.wait(10), app_server.logs_tail()
+        assert server.background_parent_result_seen.wait(
+            20,
+        ), app_server.logs_tail()
+    finally:
+        unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -8,6 +8,11 @@ from agentscope.tool import Toolkit
 
 from agentscope.tool import FunctionTool
 from qwenpaw.agents.tools import agent_management
+from qwenpaw.app.subagents.context import (
+    SubagentSpawnContext,
+    reset_subagent_spawn_context,
+    set_subagent_spawn_context,
+)
 
 
 class _FakeResponse:
@@ -215,11 +220,41 @@ def test_collect_final_agent_chat_response_keeps_last_sse_payload(monkeypatch):
     assert agent_management.extract_agent_text_content(result) == "second"
 
 
+def test_collect_final_agent_chat_response_ignores_trailing_usage(monkeypatch):
+    fake_lines = [
+        (
+            'data: {"object": "response", "status": "completed", '
+            '"output": [{"content": '
+            '[{"type": "text", "text": "subagent result"}]}]}'
+        ),
+        'data: {"type": "turn_usage", "usage": {"total_tokens": 15}}',
+    ]
+    fake_client = _FakeClient(stream_response=_FakeResponse(lines=fake_lines))
+    monkeypatch.setattr(
+        agent_management,
+        "create_agent_api_client",
+        lambda _base_url: fake_client,
+    )
+
+    result = agent_management.collect_final_agent_chat_response(
+        "http://127.0.0.1:8088",
+        {"session_id": "sid", "input": []},
+        "bot_b",
+        30,
+    )
+
+    assert result is not None
+    assert agent_management.extract_agent_text_content(result) == (
+        "subagent result"
+    )
+
+
 async def test_agent_management_tools_can_be_registered_in_toolkit():
     toolkit = Toolkit(
         tools=[
             FunctionTool(agent_management.list_agents),
             FunctionTool(agent_management.chat_with_agent),
+            FunctionTool(agent_management.spawn_subagent),
         ],
     )
 
@@ -228,6 +263,21 @@ async def test_agent_management_tools_can_be_registered_in_toolkit():
 
     assert "list_agents" in schema_names
     assert "chat_with_agent" in schema_names
+    assert "spawn_subagent" in schema_names
+
+
+def test_spawn_subagent_has_tool_descriptor():
+    from qwenpaw.agents.tools import discover_builtin_tool_funcs
+
+    descriptor = getattr(agent_management.spawn_subagent, "_tool_descriptor")
+    discovered_names = {
+        getattr(func, "_tool_descriptor").name
+        for func in discover_builtin_tool_funcs()
+    }
+
+    assert descriptor.name == "spawn_subagent"
+    assert descriptor.async_execution is True
+    assert "spawn_subagent" in discovered_names
 
 
 async def test_list_agents_uses_to_thread(monkeypatch):
@@ -391,3 +441,97 @@ async def test_chat_with_agent_returns_clear_error_when_agent_missing(
     )
 
     assert response.content[0].text == "Agent [missing_bot] not exists"
+
+
+async def test_background_spawn_uses_manager_and_forbids_polling():
+    captured = {}
+
+    class _Manager:
+        async def spawn(self, **kwargs):
+            captured.update(kwargs)
+            return type(
+                "Record",
+                (),
+                {"task_id": "subtask-1"},
+            )()
+
+    from qwenpaw.app import agent_context
+
+    agent_context.set_current_agent_id("default")
+    token = set_subagent_spawn_context(
+        SubagentSpawnContext(
+            manager=_Manager(),
+            agent_id="default",
+            session_id="console:parent",
+            root_session_id="console:parent",
+            user_id="parent",
+            channel="console",
+            is_subagent=False,
+        ),
+    )
+    try:
+        response = await agent_management.spawn_subagent(
+            "inspect the repository",
+            background=True,
+        )
+    finally:
+        reset_subagent_spawn_context(token)
+
+    text = response.content[0].text
+    assert captured["parent_session_id"] == "console:parent"
+    assert captured["parent_is_subagent"] is False
+    assert "[TASK_ID: subtask-1]" in text
+    assert "notified automatically" in text
+    assert "Do not call check_agent_task" in text
+
+
+async def test_subagent_cannot_spawn_another_subagent():
+    token = set_subagent_spawn_context(
+        SubagentSpawnContext(
+            manager=object(),
+            agent_id="default",
+            session_id="sub-child",
+            root_session_id="console:parent",
+            user_id="parent",
+            channel="console",
+            is_subagent=True,
+        ),
+    )
+    try:
+        response = await agent_management.spawn_subagent(
+            "try nested delegation",
+            background=False,
+            fork=True,
+        )
+    finally:
+        reset_subagent_spawn_context(token)
+
+    assert "nested subagents are not supported" in response.content[0].text
+
+
+async def test_cancel_subagent_is_scoped_to_parent_session():
+    class _Record:
+        parent_session_id = "console:other"
+
+    class _Manager:
+        async def get(self, _task_id):
+            return _Record()
+
+    token = set_subagent_spawn_context(
+        SubagentSpawnContext(
+            manager=_Manager(),
+            agent_id="default",
+            session_id="console:parent",
+            root_session_id="console:parent",
+            user_id="parent",
+            channel="console",
+        ),
+    )
+    try:
+        response = await agent_management.cancel_subagent("subtask-other")
+    finally:
+        reset_subagent_spawn_context(token)
+
+    assert (
+        "not found for the current parent session" in response.content[0].text
+    )

--- a/tests/unit/app/test_subagent_lifecycle.py
+++ b/tests/unit/app/test_subagent_lifecycle.py
@@ -1,0 +1,593 @@
+# -*- coding: utf-8 -*-
+"""Behavioral tests for the AS2-native background subagent lifecycle."""
+
+# pylint: disable=using-constant-test,protected-access
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from agentscope.message import AssistantMsg
+
+from qwenpaw.app.subagents.manager import (
+    SubagentStatus,
+    SubagentTaskManager,
+)
+from qwenpaw.app.subagents.hooks import SubagentWakeGuardHook
+from qwenpaw.app.subagents.middleware import SubagentInboxMiddleware
+from qwenpaw.app.workspace.local_workspace import QwenPawLocalWorkspace
+from qwenpaw.runtime.hooks import HookAction
+from qwenpaw.runtime.tool_registry import ToolDescriptor, ToolRegistry
+
+
+class _ChannelManager:
+    def __init__(self) -> None:
+        self.enqueued = []
+
+    def enqueue(self, channel, request) -> None:
+        self.enqueued.append((channel, request))
+
+
+class _Workspace:
+    def __init__(self, path, stream_factory) -> None:
+        self.workspace_dir = path
+        self.channel_manager = _ChannelManager()
+        self._stream_factory = stream_factory
+
+    async def stream_query(self, request):
+        async for item in self._stream_factory(request):
+            yield item
+
+
+def _completed_message(text: str):
+    return SimpleNamespace(
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(text=text)],
+    )
+
+
+async def _wait_terminal(manager, task_id, timeout=1.0):
+    async with asyncio.timeout(timeout):
+        while True:
+            record = await manager.get(task_id)
+            if record is not None and record.status in {
+                SubagentStatus.COMPLETED,
+                SubagentStatus.FAILED,
+                SubagentStatus.CANCELLED,
+            }:
+                return record
+            await asyncio.sleep(0.005)
+
+
+async def _spawn(manager, **overrides):
+    params = {
+        "prompt": "research the issue",
+        "parent_agent_id": "default",
+        "parent_session_id": "console:parent",
+        "root_session_id": "console:parent",
+        "child_agent_id": "default",
+        "child_session_id": "sub-child",
+        "user_id": "parent",
+        "channel": "console",
+        "channel_meta": {"session_id": "console:parent"},
+        "parent_is_subagent": False,
+    }
+    params.update(overrides)
+    return await manager.spawn(**params)
+
+
+@pytest.mark.asyncio
+async def test_completion_publishes_event_and_wakes_parent(tmp_path):
+    async def stream(_request):
+        yield _completed_message("child summary")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+
+    record = await _spawn(manager)
+    terminal = await _wait_terminal(manager, record.task_id)
+
+    assert terminal.status == SubagentStatus.COMPLETED
+    assert terminal.result == "child summary"
+    assert len(workspace.channel_manager.enqueued) == 1
+    channel, request = workspace.channel_manager.enqueued[0]
+    assert channel == "console"
+    assert request.session_id == "console:parent"
+    assert request.input == []
+    assert request.request_context["subagent_wakeup"] is True
+
+    events = await manager.drain_events("console:parent")
+    assert [event.status for event in events] == [SubagentStatus.COMPLETED]
+    assert events[0].result == "child summary"
+    assert not await manager.has_pending_events("console:parent")
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_parent_agents_with_same_session_are_workspace_isolated(
+    tmp_path,
+):
+    async def stream_a(_request):
+        yield _completed_message("result-a")
+
+    async def stream_b(_request):
+        yield _completed_message("result-b")
+
+    manager_a = SubagentTaskManager(_Workspace(tmp_path / "a", stream_a))
+    manager_b = SubagentTaskManager(_Workspace(tmp_path / "b", stream_b))
+    assert manager_a.max_running_per_parent == 8
+
+    record_a = await _spawn(manager_a, parent_agent_id="agent-a")
+    record_b = await _spawn(manager_b, parent_agent_id="agent-b")
+    await _wait_terminal(manager_a, record_a.task_id)
+    await _wait_terminal(manager_b, record_b.task_id)
+
+    events_a = await manager_a.drain_events("console:parent")
+    events_b = await manager_b.drain_events("console:parent")
+    assert [event.result for event in events_a] == ["result-a"]
+    assert [event.result for event in events_b] == ["result-b"]
+
+
+@pytest.mark.asyncio
+async def test_wakeup_waits_for_active_parent_and_avoids_session_race(
+    tmp_path,
+):
+    async def stream(_request):
+        yield _completed_message("child summary")
+
+    class _Chats:
+        async def get_chat_id_by_session(self, _session_id, _channel):
+            return "chat-1"
+
+    class _Tracker:
+        running = True
+
+        async def get_status(self, _chat_id):
+            return "running" if self.running else "idle"
+
+    workspace = _Workspace(tmp_path, stream)
+    workspace.chat_manager = _Chats()
+    workspace.task_tracker = _Tracker()
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+
+    record = await _spawn(manager)
+    await _wait_terminal(manager, record.task_id)
+    await asyncio.sleep(0.02)
+    assert not workspace.channel_manager.enqueued
+
+    workspace.task_tracker.running = False
+    await asyncio.wait_for(record.asyncio_task, timeout=1)
+    assert len(workspace.channel_manager.enqueued) == 1
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_long_running_child_is_not_cancelled_by_elapsed_time(tmp_path):
+    release = asyncio.Event()
+
+    async def stream(_request):
+        await release.wait()
+        yield {"output": "done"}
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+    record = await _spawn(manager)
+
+    # Elapsed wall time alone must never terminate a healthy background
+    # subagent. It runs until completion or an explicit lifecycle cancel.
+    await asyncio.sleep(0.05)
+    running = await manager.get(record.task_id)
+    assert running is not None
+    assert running.status == SubagentStatus.RUNNING
+    assert not record.asyncio_task.done()
+
+    release.set()
+    terminal = await _wait_terminal(manager, record.task_id)
+    assert terminal.status == SubagentStatus.COMPLETED
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_runtime_heartbeat_renews_child_lease(tmp_path):
+    gate = asyncio.Event()
+
+    async def stream(_request):
+        await gate.wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        heartbeat_timeout_seconds=10,
+    )
+    record = await _spawn(manager)
+    await asyncio.sleep(0)
+
+    before = record.last_heartbeat_at
+    await manager.touch(record.task_id)
+    assert record.last_heartbeat_at >= before
+    assert (
+        await manager._watchdog_tick(
+            record.last_heartbeat_at + 9,
+        )
+        == []
+    )
+    assert record.status == SubagentStatus.RUNNING
+    assert not record.asyncio_task.done()
+
+    await manager.cancel_task(record.task_id, notify_parent=False)
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loss_cancels_child_and_notifies_parent(tmp_path):
+    started = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        await asyncio.Event().wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        heartbeat_timeout_seconds=10,
+    )
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert (
+        await manager._watchdog_tick(
+            record.last_heartbeat_at + 10,
+        )
+        == []
+    )
+    assert record.status == SubagentStatus.CANCELLING
+
+    terminal = await _wait_terminal(manager, record.task_id)
+    assert terminal.status == SubagentStatus.CANCELLED
+    assert "heartbeat lost" in (terminal.error or "")
+    events = await manager.drain_events("console:parent")
+    assert [event.status for event in events] == [
+        SubagentStatus.CANCELLED,
+    ]
+    assert len(workspace.channel_manager.enqueued) == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_resistant_child_becomes_stale_once_then_completes(
+    tmp_path,
+):
+    started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+        await release.wait()
+        yield _completed_message("recovered result")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        heartbeat_timeout_seconds=10,
+        cancel_grace_seconds=5,
+    )
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await manager._watchdog_tick(record.last_heartbeat_at + 10)
+    await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+    requested_at = record.cancel_requested_at
+    assert requested_at is not None
+
+    newly_stale = await manager._watchdog_tick(requested_at + 5)
+    assert newly_stale == [record]
+    for stale_record in newly_stale:
+        manager._schedule_parent_wakeup(stale_record)
+    await asyncio.sleep(0)
+    assert record.status == SubagentStatus.STALE
+    assert await manager._watchdog_tick(requested_at + 10) == []
+    assert len(workspace.channel_manager.enqueued) == 1
+
+    stale_events = await manager.drain_events("console:parent")
+    assert [event.status for event in stale_events] == [SubagentStatus.STALE]
+    # STALE is non-terminal: the handle and concurrency ownership remain.
+    assert await manager.get(record.task_id) is record
+
+    release.set()
+    terminal = await _wait_terminal(manager, record.task_id)
+    assert terminal.status == SubagentStatus.COMPLETED
+    completed_events = await manager.drain_events("console:parent")
+    assert [event.status for event in completed_events] == [
+        SubagentStatus.COMPLETED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_loop_pause_renews_leases_instead_of_killing(tmp_path):
+    gate = asyncio.Event()
+
+    async def stream(_request):
+        await gate.wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    record = await _spawn(manager)
+    await asyncio.sleep(0)
+
+    resumed_at = record.last_heartbeat_at + 1000
+    await manager._reset_leases_after_loop_pause(resumed_at)
+    assert record.last_heartbeat_at == resumed_at
+    assert record.status == SubagentStatus.RUNNING
+    assert not record.asyncio_task.done()
+
+    await manager.cancel_task(record.task_id, notify_parent=False)
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_parent_cancel_propagates_to_running_child(tmp_path):
+    started = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        await asyncio.sleep(60)
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert await manager.cancel_by_parent("console:parent") == 1
+    await asyncio.wait_for(
+        asyncio.gather(record.asyncio_task, return_exceptions=True),
+        timeout=1,
+    )
+    assert record.status == SubagentStatus.CANCELLED
+    assert record.error == "parent session cancelled"
+    assert await manager.get(record.task_id) is None
+    assert not await manager.has_pending_events("console:parent")
+    assert not workspace.channel_manager.enqueued
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_parent_kill_suppresses_stale_and_late_completion(tmp_path):
+    started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+        await release.wait()
+        yield _completed_message("too late")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace, cancel_grace_seconds=5)
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert await manager.cancel_by_parent("console:parent") == 1
+    await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+    requested_at = record.cancel_requested_at
+    assert requested_at is not None
+    assert await manager.cancel_by_parent("console:parent") == 0
+    assert record.cancel_requested_at == requested_at
+    assert await manager._watchdog_tick(requested_at + 5) == []
+    assert record.status == SubagentStatus.STALE
+    assert not await manager.has_pending_events("console:parent")
+
+    release.set()
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+    assert not await manager.has_pending_events("console:parent")
+    assert not workspace.channel_manager.enqueued
+
+
+@pytest.mark.asyncio
+async def test_parent_stop_discards_completed_but_unread_callback(tmp_path):
+    async def stream(_request):
+        yield _completed_message("finished just before stop")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    record = await _spawn(manager)
+    await _wait_terminal(manager, record.task_id)
+    assert await manager.has_pending_events("console:parent")
+
+    assert await manager.cancel_by_parent("console:parent") == 0
+    assert not await manager.has_pending_events("console:parent")
+    assert await manager.get(record.task_id) is None
+
+
+@pytest.mark.asyncio
+async def test_concurrency_guard_and_nested_subagent_rejection(tmp_path):
+    gate = asyncio.Event()
+
+    async def stream(_request):
+        await gate.wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        max_running_per_parent=1,
+    )
+    await manager.start()
+    first = await _spawn(manager)
+
+    with pytest.raises(RuntimeError, match="limit reached"):
+        await _spawn(manager, child_session_id="sub-second")
+    with pytest.raises(ValueError, match="nested subagents are not supported"):
+        await _spawn(
+            manager,
+            parent_session_id="different-parent",
+            child_session_id="sub-nested",
+            parent_is_subagent=True,
+        )
+
+    await manager.cancel_task(first.task_id)
+    await _wait_terminal(manager, first.task_id)
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_inbox_middleware_injects_hint_once(tmp_path):
+    async def stream(_request):
+        yield _completed_message("useful result")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+    record = await _spawn(manager)
+    await _wait_terminal(manager, record.task_id)
+
+    agent = SimpleNamespace(
+        name="QwenPaw",
+        state=SimpleNamespace(
+            # AS2 owns an internal session id that is intentionally distinct
+            # from QwenPaw's routing/session id.
+            session_id="as2-internal-session",
+            reply_id="reply-1",
+            context=[AssistantMsg("QwenPaw", "parent context")],
+        ),
+    )
+
+    async def downstream(**_kwargs):
+        yield "model-event"
+
+    middleware = SubagentInboxMiddleware(manager, "console:parent")
+    output = [
+        item
+        async for item in middleware.on_reasoning(
+            agent,
+            {"tool_choice": None},
+            downstream,
+        )
+    ]
+
+    assert output[-1] == "model-event"
+    hint = agent.state.context[-1].content[-1]
+    assert "useful result" in hint.hint
+    assert "Do not call a polling" in hint.hint
+    claim_id = agent._qwenpaw_subagent_event_claim_id
+    assert await manager.has_pending_events("console:parent")
+    assert await manager.ack_events(claim_id) == 1
+    assert not await manager.has_pending_events("console:parent")
+    assert await manager.get(record.task_id) is None
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_failed_parent_delivery_releases_claim_for_retry(tmp_path):
+    async def stream(_request):
+        yield _completed_message("retry me")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+    record = await _spawn(manager)
+    await _wait_terminal(manager, record.task_id)
+
+    events = await manager.claim_events("console:parent", "attempt-1")
+    assert len(events) == 1
+    assert await manager.release_events("attempt-1") == 1
+
+    retried = await manager.claim_events("console:parent", "attempt-2")
+    assert [event.task_id for event in retried] == [record.task_id]
+    assert await manager.ack_events("attempt-2") == 1
+    await manager.stop()
+
+
+def test_channel_metadata_filters_secrets_and_runtime_objects():
+    safe = SubagentTaskManager._routing_meta(
+        {
+            "channel_id": "123",
+            "session_webhook": "https://secret.example",
+            "access_token": "secret",
+            "reply_future": object(),
+        },
+    )
+    assert safe == {"channel_id": "123"}
+
+
+@pytest.mark.asyncio
+async def test_wakeup_guard_keeps_event_while_parent_waits_for_approval():
+    class _Manager:
+        async def has_pending_events(self, _session_id):
+            return True
+
+    from agentscope.message import ToolCallState
+
+    last = SimpleNamespace(
+        get_content_blocks=lambda _kind: [
+            SimpleNamespace(state=ToolCallState.ASKING),
+        ],
+    )
+    ctx = SimpleNamespace(
+        request=SimpleNamespace(
+            request_context={"subagent_wakeup": True},
+        ),
+        workspace=SimpleNamespace(subagent_task_manager=_Manager()),
+        session_id="console:parent",
+        agent=SimpleNamespace(
+            state=SimpleNamespace(context=[last]),
+        ),
+    )
+
+    result = await SubagentWakeGuardHook().run(ctx)
+
+    assert result.action == HookAction.SKIP_AGENT
+
+
+@pytest.mark.asyncio
+async def test_subagent_toolkit_hides_delegation_tools(tmp_path):
+    registry = ToolRegistry()
+
+    async def spawn_subagent():
+        return None
+
+    async def cancel_subagent():
+        return None
+
+    async def read_file():
+        return None
+
+    for tool in (spawn_subagent, cancel_subagent, read_file):
+        registry.register(ToolDescriptor(name=tool.__name__, func=tool))
+    workspace = QwenPawLocalWorkspace(
+        tool_registry=registry,
+        workdir=str(tmp_path),
+        workspace_id="default",
+        default_mcps=[],
+        skill_paths=[],
+    )
+
+    tools = await workspace.list_tools(
+        request_context={"is_subagent": True},
+    )
+    names = {tool.name for tool in tools}
+
+    assert names == {"read_file"}

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -596,6 +596,30 @@ class TestConsoleStreaming:
         ):
             await stream_channel.consume_one({"test": "payload"})
 
+    async def test_subagent_wakeup_uses_console_push_path(
+        self,
+        stream_channel,
+    ):
+        """A detached wake has no SSE client, so use BaseChannel send."""
+        from types import SimpleNamespace
+        from unittest.mock import patch, AsyncMock
+
+        payload = SimpleNamespace(
+            request_context={"subagent_wakeup": True},
+        )
+        with (
+            patch.object(
+                stream_channel,
+                "_consume_one_request",
+                new_callable=AsyncMock,
+            ) as consume_request,
+            patch.object(stream_channel, "stream_one") as stream_one,
+        ):
+            await stream_channel.consume_one(payload)
+
+        consume_request.assert_awaited_once_with(payload)
+        stream_one.assert_not_called()
+
 
 # =============================================================================
 # P2: Console Media Handling

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -206,7 +206,7 @@ class TestAssertPolicySSHCommands:
 # ---------------------------------------------------------------------------
 
 
-class TestGovernancePolicyEvaluate:
+class TestGovernancePolicyEvaluate:  # pylint: disable=too-many-public-methods
     """Direct evaluate() tests on GovernancePolicy."""
 
     @pytest.fixture()
@@ -250,6 +250,26 @@ class TestGovernancePolicyEvaluate:
         """Internal tools should be ALLOW from user_rules."""
         tc = _tc("GetCurrentTime", "")
         decision = policy.evaluate(tc)
+        assert decision.action == GovernanceAction.ALLOW
+
+    @pytest.mark.parametrize(
+        ("python_name", "policy_name"),
+        [
+            ("spawn_subagent", "SpawnSubagent"),
+            ("cancel_subagent", "CancelSubagent"),
+        ],
+    )
+    def test_subagent_tools_are_registered_internal_tools(
+        self,
+        policy,
+        python_name,
+        policy_name,
+    ):
+        assert (
+            DEFAULT_REGISTRY.python_to_policy_name(python_name) == policy_name
+        )
+        assert DEFAULT_REGISTRY.get_type(policy_name) == "internal"
+        decision = policy.evaluate(_tc(policy_name, ""))
         assert decision.action == GovernanceAction.ALLOW
 
     def test_workspace_read_allow(self, policy):
@@ -309,6 +329,24 @@ class TestGovernancePolicyEvaluate:
         tc = _tc("SomeRandomTool", "/etc/passwd")
         decision = policy.evaluate(tc)
         assert decision.action == GovernanceAction.DENY
+
+    def test_spawn_subagent_is_registered_internal_tool(self, policy):
+        """spawn_subagent should pass governance as an internal tool."""
+        policy_name = DEFAULT_REGISTRY.python_to_policy_name(
+            "spawn_subagent",
+        )
+        target = DEFAULT_REGISTRY.extract_target(
+            policy_name,
+            {"task": "Analyze the repository", "background": True},
+        )
+
+        assert policy_name == "SpawnSubagent"
+        assert target == "Analyze the repository"
+        assert DEFAULT_REGISTRY.get_type(policy_name) == "internal"
+        assert (
+            policy.evaluate(_tc(policy_name, target)).action
+            == GovernanceAction.ALLOW
+        )
 
     def test_ssh_dir_match_patterns(self, policy):
         """Various .ssh path patterns should match the builtin rule."""

--- a/tests/unit/routers/test_console_tasks.py
+++ b/tests/unit/routers/test_console_tasks.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for console background chat task bookkeeping."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import pytest
+
+from qwenpaw.app.routers import console
+
+
+def setup_function() -> None:
+    console._CHAT_TASKS.clear()
+    console._CHAT_RUNTIME_TASKS.clear()
+
+
+def teardown_function() -> None:
+    console._CHAT_TASKS.clear()
+    console._CHAT_RUNTIME_TASKS.clear()
+
+
+def test_prune_finished_chat_tasks_keeps_recent_records(monkeypatch) -> None:
+    monkeypatch.setattr(console, "_MAX_FINISHED_CHAT_TASKS", 2)
+    console._CHAT_TASKS.update(
+        {
+            "old": {
+                "task_id": "old",
+                "agent_id": "default",
+                "status": "finished",
+                "finished_at": "2026-01-01T00:00:00+00:00",
+            },
+            "middle": {
+                "task_id": "middle",
+                "agent_id": "default",
+                "status": "finished",
+                "finished_at": "2026-01-02T00:00:00+00:00",
+            },
+            "new": {
+                "task_id": "new",
+                "agent_id": "default",
+                "status": "finished",
+                "finished_at": "2026-01-03T00:00:00+00:00",
+            },
+            "running": {
+                "task_id": "running",
+                "agent_id": "default",
+                "status": "running",
+            },
+        },
+    )
+
+    console._prune_finished_chat_tasks()
+
+    assert set(console._CHAT_TASKS) == {"middle", "new", "running"}
+
+
+@pytest.mark.asyncio
+async def test_finished_chat_task_status_is_dropped_after_read(
+    monkeypatch,
+) -> None:
+    class _Workspace:
+        agent_id = "default"
+
+    async def _fake_get_agent_for_request(_request):
+        return _Workspace()
+
+    monkeypatch.setattr(
+        console,
+        "get_agent_for_request",
+        _fake_get_agent_for_request,
+    )
+    console._CHAT_TASKS["task-1"] = {
+        "task_id": "task-1",
+        "agent_id": "default",
+        "session_id": "session-1",
+        "status": "finished",
+        "result": {"status": "completed"},
+    }
+
+    result = await console.get_console_chat_task_status("task-1", object())
+
+    assert result == {
+        "task_id": "task-1",
+        "session_id": "session-1",
+        "status": "finished",
+        "result": {"status": "completed"},
+    }
+    assert "task-1" not in console._CHAT_TASKS
+
+
+@pytest.mark.asyncio
+async def test_running_chat_task_status_is_retained(monkeypatch) -> None:
+    class _Workspace:
+        agent_id = "default"
+
+    async def _fake_get_agent_for_request(_request):
+        return _Workspace()
+
+    monkeypatch.setattr(
+        console,
+        "get_agent_for_request",
+        _fake_get_agent_for_request,
+    )
+    console._CHAT_TASKS["task-1"] = {
+        "task_id": "task-1",
+        "agent_id": "default",
+        "session_id": "session-1",
+        "status": "running",
+    }
+
+    result = await console.get_console_chat_task_status("task-1", object())
+
+    assert result["status"] == "running"
+    assert "task-1" in console._CHAT_TASKS


### PR DESCRIPTION
## Summary

This PR changes `spawn_subagent(background=True)` from a polling-based task
into an event-driven child lifecycle. A background child returns immediately,
runs independently, and wakes its parent with the result when it finishes.

It also adds heartbeat detection, parent-to-child cancellation, per-parent
concurrency limits, and reliable event delivery. Healthy long-running children
have no total runtime timeout, and nested subagents are intentionally disabled.

Fixes https://github.com/agentscope-ai/QwenPaw/issues/4873.

## Relation to #5524

This PR includes the Runtime 2.0 registration and background-route fixes from
https://github.com/agentscope-ai/QwenPaw/pull/5524 because it has not merged
yet, then adds the lifecycle behavior above. If #5524 lands first, the
overlapping fixes can be dropped during rebase.

## Summary of changes

### 1. Restore the Runtime 2.0 subagent entry points

- Register `spawn_subagent` with `@tool_descriptor(async_execution=True)`.
- Register `SpawnSubagent(task)` in governance using the same semantics as
  PR #5524.
- Select the last response-shaped SSE envelope instead of a trailing
  `turn_usage` event for foreground agent calls.
- Restore `POST /console/chat/task` and `GET /console/chat/task/{task_id}` for
  generic background agent chat (`submit_to_agent`).
- Bound completed generic task records and remove a finished record after it
  is read.

### 2. Add a workspace-scoped background subagent manager

`SubagentTaskManager` owns only background subagents; it is not a new generic
task framework. Each Workspace has one manager and one watchdog.

It tracks:

- parent/root/child agent and session identities;
- the real `asyncio.Task` handle;
- lifecycle state, result/error, heartbeat lease, cancellation reason, and
  optional fork branch;
- terminal/stale events waiting for the parent session.

Lifecycle states:

```text
SUBMITTED -> RUNNING -> COMPLETED
                     -> FAILED
                     -> CANCELLING -> CANCELLED
                                   -> STALE -> eventual real terminal state
```

`STALE` is deliberately non-terminal. It means cooperative cancellation did
not finish within the grace period; the task handle and concurrency slot are
retained instead of pretending the child was killed.

### 3. Replace polling with callback wakeup

For `spawn_subagent(background=True)`:

- run the child through the existing `workspace.stream_query` Runtime path;
- return `[TASK_ID]` and `[SESSION]` immediately;
- tell the model not to poll or sleep;
- publish a terminal/stale event into the parent-session inbox;
- wait for an active parent run to become idle, then wake an idle parent via
  `ChannelManager.enqueue`;
- inject child results before parent reasoning as AgentScope 2.0
  `HintBlock`/`HintBlockEvent` values;
- acknowledge events only after parent session persistence succeeds;
- release a claim on failure so a later run can retry delivery.

`check_agent_task` remains available as a manual/debug fallback. It is no
longer the normal coordination mechanism for background subagents.

### 4. Add heartbeat and watchdog semantics

- Reuse QwenPaw's existing Runtime heartbeat envelope; do not create a
  per-child heartbeat task.
- Runtime heartbeat interval: 25 seconds.
- Missing-heartbeat threshold: four intervals (about 100 seconds).
- Cancellation grace period: 10 seconds.
- No total runtime limit for background subagents. The `timeout` argument is
  ignored in background mode; model/tool/network operations retain their own
  timeouts.
- If the watchdog itself is delayed by event-loop suspension, refresh leases
  instead of mass-cancelling healthy children.

### 5. Add ownership, cancellation, and isolation

- Add `cancel_subagent(task_id)`; only the creating parent session can cancel
  its child.
- Console stop, `/stop`, Runtime cancellation, and Workspace shutdown cancel
  linked children.
- Parent termination discards pending child callbacks and suppresses late
  wakeups.
- Limit each parent session to eight non-terminal background children.
- Managers are Workspace-scoped, so different agents cannot mix records or
  events even if session IDs happen to match.
- Background subagents are leaf nodes: nested `spawn_subagent` calls are
  rejected and delegation tools are hidden from the child toolkit.
- Channel metadata is filtered before reuse so tokens, secrets, callbacks,
  and runtime-only objects are not copied into child routing metadata.

### 6. Keep foreground and generic background behavior compatible

- `spawn_subagent(background=False)` keeps the existing synchronous path and
  foreground timeout semantics, with the SSE response-selection fix from
  #5524.
- Forked foreground behavior remains unchanged.
- Forked background children use the same lifecycle manager and report the
  worktree branch in the parent notification.
- `submit_to_agent` continues to use the generic Console background task plus
  `check_agent_task`; this PR changes only background subagent coordination.

## AgentScope 2.0 integration

The implementation reuses AgentScope/QwenPaw extension points rather than
patching AgentScope internals:

- `MiddlewareBase.on_reasoning` for inbox delivery;
- `HintBlock` and `HintBlockEvent` for lifecycle notifications;
- existing Runtime `stream_query` and heartbeat envelopes;
- QwenPaw lifecycle hooks for request-local context and post-save ack;
- Workspace `ServiceManager` for manager startup/shutdown;
- existing `ChannelManager` for parent wakeup.

QwenPaw's normal Runtime does not run the full `agentscope.app` service stack,
so AgentScope's distributed `BackgroundTaskManager`/wakeup dispatcher cannot
be used directly here. The new manager is a small in-process adapter for
subagent-specific parent/child semantics, not a replacement for that stack.

## Expected behavior

| Scenario | Expected result |
| --- | --- |
| Foreground child | Parent blocks and receives the final child result as before. |
| Healthy long background task | Continues indefinitely while Runtime heartbeats arrive. |
| Background completion/failure | Parent receives a HintBlock and is automatically woken if idle. |
| Parent is already running | Wakeup waits; the active run may consume the event on its next reasoning step. |
| Delivery/session save fails | Event claim is released and remains available for retry. |
| Parent stop/cancel | Direct children are cancelled and no late callback re-wakes the parent. |
| Heartbeat disappears | Child is cancelled; parent receives CANCELLED or one STALE event if cancellation does not finish. |
| Event loop pauses | Leases are refreshed; children are not falsely killed in bulk. |
| Ninth child from one parent | Spawn is rejected until one of the eight non-terminal children exits. |
| Different parent/Workspace | Tasks and notifications remain isolated. |
| Child attempts nested spawn | Tool is hidden and runtime validation rejects the call. |

## Files

### New runtime package

- `src/qwenpaw/app/subagents/__init__.py`
- `src/qwenpaw/app/subagents/context.py`
- `src/qwenpaw/app/subagents/hooks.py`
- `src/qwenpaw/app/subagents/manager.py`
- `src/qwenpaw/app/subagents/middleware.py`

### Modified production files

- `src/qwenpaw/agents/tools/agent_management.py`
- `src/qwenpaw/agents/tools/__init__.py`
- `src/qwenpaw/app/_app.py`
- `src/qwenpaw/app/workspace/workspace.py`
- `src/qwenpaw/app/workspace/local_workspace.py`
- `src/qwenpaw/runtime/builder.py`
- `src/qwenpaw/runtime/commands/control/stop_handler.py`
- `src/qwenpaw/app/routers/console.py`
- `src/qwenpaw/app/channels/console/channel.py`
- `src/qwenpaw/hooks/error/error_hook.py`
- `src/qwenpaw/hooks/session/session_hook.py`
- `src/qwenpaw/config/config.py`
- `src/qwenpaw/governance/tool_registry.py`

### Tests

- `tests/unit/app/test_subagent_lifecycle.py`
- `tests/integration/test_spawn_subagent.py`
- `tests/unit/routers/test_console_tasks.py`
- `tests/unit/agents/tools/test_agent_management.py`
- `tests/unit/channels/test_console.py`
- `tests/unit/governance/test_policy.py`

## Verification

Against official `origin/main` commit
`d3a418a21790e178a550015a478685f539df9234`:

```text
Focused unit suites:
108 passed

Real-process foreground/background subagent E2E:
1 passed in 16.96s

Console channel contract + unit suites:
48 passed, 1 skipped

pre-commit on all changed Python source/test files:
passed (AST, encoding, trailing comma, mypy, black, flake8, pylint)

git diff --check:
passed
```

The full repository test suite and `pre-commit run --all-files` have not been
run in this verification pass.

### Manual runtime verification
**1. Background subagents start without a `check_agent_task` polling loop**
<img width="856" height="470" alt="WDjMvcgAQ3" src="https://github.com/user-attachments/assets/f5a2345e-8b34-4c98-b194-2c0571e1a744" />

**2. Child completion wakes the parent and delivers the result automatically**
<img width="822" height="636" alt="XDGghYqM3l" src="https://github.com/user-attachments/assets/990fdf65-efba-41d1-9393-1daf05d09347" />

## Scope and known limitations

- Lifecycle records and inbox events are in memory. Process restart does not
  resume children or recover undelivered callbacks.
- This targets QwenPaw's current single-process Workspace model; it is not a
  distributed queue or persistent task scheduler.
- `asyncio.Task.cancel()` is cooperative. A child stuck in non-interruptible
  synchronous code may remain `STALE`; process/tool-level cleanup remains the
  tool runner's responsibility.
- Only one subagent level is supported intentionally.
- Heartbeats are liveness signals, not semantic progress reports.
- **Terminal records are retained until delivery is acknowledged (or the parent
  is stopped/Workspace shuts down), prioritizing reliable delivery over TTL
  eviction. A future persistent/distributed implementation should add durable
  retention and cleanup policy.**

## Reviewer note about #5524

The following parts overlap with #5524 and should use the upstream version if
that PR lands first:

- `spawn_subagent` tool descriptor;
- `SpawnSubagent(task)` governance registration;
- foreground SSE response-envelope selection;
- generic `/console/chat/task` submit/status routes and bounded records;
- the corresponding registration, governance, Console task, and foreground
  E2E assertions.

The parent/child manager, heartbeat watchdog, HintBlock delivery, callback
wakeup, cancellation propagation, one-level restriction, and no-polling
behavior are the additional lifecycle functionality introduced by this PR.
