### PR TITLE
chore(e2e): drop SLASH-006 plan command case

### DIFF
--- a/e2e/tests/test_slash_commands.py
+++ b/e2e/tests/test_slash_commands.py
@@ -229,17 +229,6 @@ def test_slash_proactive_status(clean_chat_page: ChatPage):
 
 
 @pytest.mark.slash_commands
-@pytest.mark.p1
-@pytest.mark.test_id("SLASH-006")
-@pytest.mark.xfail(strict=False, reason=_XFAIL_FIRST_MSG_RERENDER)
-def test_slash_plan_status(clean_chat_page: ChatPage):
-    """Bare ``/plan`` shows plan-mode status (enabled or disabled hint)."""
-    chat = clean_chat_page.open()
-    text = _send_slash(chat, "/plan")
-    _assert_any(text, "Plan", "plan", "Settings")
-
-
-@pytest.mark.slash_commands
 @pytest.mark.p2
 @pytest.mark.test_id("SLASH-007")
 @pytest.mark.xfail(strict=False, reason=_XFAIL_FIRST_MSG_RERENDER)


### PR DESCRIPTION
## Summary

- After agentscope 2.0 (#5542), the product removed the `/plan` command and the Plan-Mode panel route. The corresponding `e2e/tests/test_plan.py` and `e2e/pages/plan_page.py` were also deleted in #5542.
- `SLASH-006 test_slash_plan_status` still exercises the removed `/plan` command and only keeps passing through `xfail(strict=False)`, providing no real value.
- This PR removes `SLASH-006`. The remaining eight slash-command cases (`SLASH-001..005, 007..009`) are untouched.

## Test plan

- [x] `pytest e2e/tests/test_slash_commands.py --collect-only` reports 8 cases (was 9).
- [x] Fork PR (yutai78786/QwenPaw#23) — **Playwright UI Smoke** PASS in 1m39s.
- [x] Fork manual **E2E Integration Tests** run (`-m slash_commands`) — 1 passed / 1 xfailed / 6 xpassed / 0 failed in 10m17s. Run: https://github.com/yutai78786/QwenPaw/actions/runs/28373626285
