### PR TITLE
fix(runtime, agents): convert Windows paths to file:// URLs and fix reverse parsing

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -671,9 +671,7 @@ def _fixup_media_list(items: list) -> None:
             source = getattr(block, "source", None)
             url_str = str(getattr(source, "url", "")) if source else ""
             if url_str.startswith("file://"):
-                local_path = unquote(
-                    url_str.removeprefix("file://"),
-                )
+                local_path = _file_url_to_path(url_str)
                 if not os.path.exists(local_path):
                     mt = getattr(source, "media_type", "") or ""
                     media_name = mt.split("/")[0] or "media"
@@ -690,7 +688,7 @@ def _fixup_media_list(items: list) -> None:
                         ),
                     )
                 elif unquote(url_str) != url_str:
-                    source.url = "file://" + local_path
+                    source.url = unquote(url_str)
         elif btype == "file":
             if isinstance(block, dict):
                 source = block.get("source") or {}

--- a/src/qwenpaw/runtime/message_convert.py
+++ b/src/qwenpaw/runtime/message_convert.py
@@ -38,6 +38,9 @@ def _get_last_user_text(msgs: List[Any]) -> str | None:
 def _ensure_url_scheme(url: str) -> str:
     """Prepend ``file://`` when *url* is an absolute local path.
 
+    Handles both Unix paths (``/``, ``~``) and Windows paths
+    (e.g. ``C:\\`` or ``C:/``).
+
     Always ``unquote()`` first so percent-encoded non-ASCII characters
     (e.g. ``%E6%B5%8B%E8%AF%95`` → ``测试``) resolve to the real
     filename on disk.  Then uses ``file://`` + raw path (not
@@ -45,8 +48,15 @@ def _ensure_url_scheme(url: str) -> str:
     """
     if url.startswith(("/", "~")):
         resolved = str(Path(unquote(url)).expanduser().resolve())
-        return "file://" + resolved
-    return url
+    elif len(url) >= 3 and url[1] == ":" and url[2] in ("/", "\\"):
+        resolved = str(Path(unquote(url)).resolve())
+    else:
+        return url
+
+    resolved = resolved.replace("\\", "/")
+    if not resolved.startswith("/"):
+        resolved = "/" + resolved
+    return "file://" + resolved
 
 
 # pylint: disable=too-many-branches


### PR DESCRIPTION
## Description

[On Windows, when a user uploads an image/file through the Console, the /upload API returns a local Windows path such as C:\Users\...\file.png. The _ensure_url_scheme() helper in src/qwenpaw/runtime/message_convert.py only recognized Unix-style absolute paths (/, ~), so Windows paths were passed through unchanged to the DashScope API. DashScope rejected them with:
<400> InternalError.Algo.InvalidParameter: The provided URL does not appear to be valid
This PR:
Extends _ensure_url_scheme() to detect Windows absolute paths (C:\..., C:/...) and convert them to standard file:///C:/... URLs.
Fixes the reverse conversion in src/qwenpaw/agents/model_factory.py: the existing code stripped file:// and unquoted directly, producing an invalid /C:/... path on Windows, which caused _fixup_media_list() to falsely report Media file no longer exists and replace media blocks with placeholders.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Start QwenPaw on Windows:
qwenpaw app
Open Console at http://127.0.0.1:8088.
Configure a DashScope model (e.g., qwen3.7-plus or qwen-vl-plus).
Upload a local image and ask QwenPaw to describe it.
Expected: the model call succeeds and returns image description; no Media file no longer exists warning in logs.

## Local Verification Evidence
<img width="710" height="297" alt="test_url" src="https://github.com/user-attachments/assets/0bba3faf-251e-4563-9b2e-d92aee85e043" />

