### PR TITLE
feat(subagent): add event-driven background lifecycle and parent wakeup

### DIFF
--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -17,6 +17,7 @@ register them. The literal names still appear in
 ``security/tool_guard`` guardians for backward compatibility with
 pre-existing allowlists.
 """
+
 from __future__ import annotations
 
 from typing import Callable
@@ -39,6 +40,7 @@ from .agent_management import (
     submit_to_agent,
     check_agent_task,
     spawn_subagent,
+    cancel_subagent,
 )
 from .delegate_external_agent import delegate_external_agent
 from .make_skill_tools import materialize_skill
@@ -83,6 +85,7 @@ __all__ = [
     "submit_to_agent",
     "check_agent_task",
     "spawn_subagent",
+    "cancel_subagent",
     "materialize_skill",
     "ast_search",
 ]

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -640,6 +640,32 @@ async def check_agent_task(
             "ERROR: 'task_id' is required to check task status",
         )
 
+    # ``spawn_subagent(background=True)`` is managed in-process and wakes the
+    # parent automatically.  Keep this branch only as a human/manual fallback;
+    # the spawn tool explicitly tells the model not to poll it.
+    from ...app.subagents.context import get_subagent_spawn_context
+
+    spawn_context = get_subagent_spawn_context()
+    if spawn_context is not None:
+        record = await spawn_context.manager.get(normalized_task_id)
+        if (
+            record is not None
+            and record.parent_session_id == spawn_context.session_id
+        ):
+            return _tool_text_response(
+                "\n".join(
+                    [
+                        f"[TASK_ID: {record.task_id}]",
+                        f"[STATUS: {record.status.value}]",
+                        f"[SESSION: {record.child_session_id}]",
+                        "",
+                        record.result
+                        or record.error
+                        or "No terminal result yet.",
+                    ],
+                ),
+            )
+
     result = await asyncio.to_thread(
         get_agent_chat_task_status,
         None,
@@ -657,6 +683,21 @@ def _generate_subagent_session_id() -> str:
     return f"sub-{str(uuid4())[:8]}"
 
 
+def _format_subagent_submission(task_id: str, session_id: str) -> str:
+    return "\n".join(
+        [
+            f"[TASK_ID: {task_id}]",
+            f"[SESSION: {session_id}]",
+            "",
+            "Background subagent started. You will be notified automatically ",
+            "when it completes, fails, or is cancelled.",
+            "Do not call check_agent_task, sleep, wait, or any polling tool ",
+            "for this task. Continue independent work, or end this turn.",
+        ],
+    )
+
+
+# pylint: disable=too-many-return-statements
 @tool_descriptor(async_execution=True)
 async def spawn_subagent(
     task: str,
@@ -681,9 +722,11 @@ async def spawn_subagent(
             back to workspace; no worktree if not a git repo).
             If False (default), starts with a fresh empty session.
         background: If True, submit as background task and return
-            immediately with a task_id. Use check_agent_task(task_id)
-            to poll status and retrieve the result.
-        timeout: Foreground wait timeout in seconds (default 600).
+            immediately with a task_id. Completion automatically wakes this
+            parent session and injects the result; do not poll.
+        timeout: Foreground wait timeout in seconds (default 600). Background
+            subagents have no total runtime limit; this value is ignored when
+            ``background=True``.
 
     Returns:
         Foreground: subagent result text with [SESSION: <id>].
@@ -693,6 +736,15 @@ async def spawn_subagent(
     if not task or not task.strip():
         return _tool_text_response(
             "ERROR: 'task' is required for spawn_subagent",
+        )
+
+    from ...app.subagents.context import get_subagent_spawn_context
+
+    spawn_context = get_subagent_spawn_context()
+    if spawn_context is not None and spawn_context.is_subagent:
+        return _tool_text_response(
+            "ERROR: nested subagents are not supported; only a top-level "
+            "agent may call spawn_subagent",
         )
 
     from ...app.agent_context import get_current_agent_id
@@ -726,18 +778,28 @@ async def spawn_subagent(
     }
 
     if background:
-        result = await asyncio.to_thread(
-            submit_agent_chat_task,
-            None,
-            request_payload,
-            current_agent_id,
-            int(DEFAULT_AGENT_API_TIMEOUT),
-        )
+        if spawn_context is None:
+            return _tool_text_response(
+                "ERROR: background subagent manager is unavailable outside "
+                "a QwenPaw Runtime request",
+            )
+        try:
+            record = await spawn_context.manager.spawn(
+                prompt=task,
+                parent_agent_id=spawn_context.agent_id,
+                parent_session_id=spawn_context.session_id,
+                root_session_id=spawn_context.root_session_id,
+                child_agent_id=current_agent_id,
+                child_session_id=subagent_session_id,
+                user_id=spawn_context.user_id,
+                channel=spawn_context.channel,
+                channel_meta=spawn_context.channel_meta,
+                parent_is_subagent=spawn_context.is_subagent,
+            )
+        except (RuntimeError, ValueError) as exc:
+            return _tool_text_response(f"ERROR: {exc}")
         return _tool_text_response(
-            format_background_submission_text(
-                result,
-                subagent_session_id,
-            ),
+            _format_subagent_submission(record.task_id, subagent_session_id),
         )
 
     response_data = await asyncio.to_thread(
@@ -757,6 +819,41 @@ async def spawn_subagent(
             response_data,
             session_id=subagent_session_id,
         ),
+    )
+
+
+@tool_descriptor(async_execution=True)
+async def cancel_subagent(task_id: str) -> ToolChunk:
+    """Cancel a background subagent created by this parent session.
+
+    This is an explicit control operation, not a status/polling tool.  A task
+    can only be cancelled from the parent session that created it.
+    """
+    normalized_task_id = normalize_id(task_id)
+    if not normalized_task_id:
+        return _tool_text_response("ERROR: 'task_id' is required")
+
+    from ...app.subagents.context import get_subagent_spawn_context
+
+    spawn_context = get_subagent_spawn_context()
+    if spawn_context is None:
+        return _tool_text_response("ERROR: subagent manager unavailable")
+    record = await spawn_context.manager.get(normalized_task_id)
+    if record is None or record.parent_session_id != spawn_context.session_id:
+        return _tool_text_response(
+            f"ERROR: subagent task '{normalized_task_id}' not found for "
+            "the current parent session",
+        )
+    cancelled = await spawn_context.manager.cancel_task(
+        normalized_task_id,
+        reason="cancelled explicitly by parent agent",
+    )
+    if not cancelled:
+        return _tool_text_response(
+            f"Task {normalized_task_id} is already terminal.",
+        )
+    return _tool_text_response(
+        f"Cancellation requested for subagent task {normalized_task_id}.",
     )
 
 
@@ -832,6 +929,7 @@ async def _maybe_cleanup_worktree(
     return await asyncio.to_thread(_cleanup)
 
 
+# pylint: disable=too-many-branches
 async def _spawn_forked_subagent(
     task: str,
     current_agent_id: str,
@@ -887,15 +985,33 @@ async def _spawn_forked_subagent(
     }
 
     if background:
-        result = await asyncio.to_thread(
-            submit_agent_chat_task,
-            None,
-            request_payload,
-            current_agent_id,
-            int(DEFAULT_AGENT_API_TIMEOUT),
-        )
-        submission_text = format_background_submission_text(
-            result,
+        from ...app.subagents.context import get_subagent_spawn_context
+
+        spawn_context = get_subagent_spawn_context()
+        if spawn_context is None:
+            return _tool_text_response(
+                "ERROR: background subagent manager is unavailable outside "
+                "a QwenPaw Runtime request",
+            )
+        try:
+            record = await spawn_context.manager.spawn(
+                prompt=task,
+                parent_agent_id=spawn_context.agent_id,
+                parent_session_id=spawn_context.session_id,
+                root_session_id=spawn_context.root_session_id,
+                child_agent_id=current_agent_id,
+                child_session_id=fork_session_id,
+                user_id=user_id,
+                channel=channel,
+                channel_meta=spawn_context.channel_meta,
+                parent_is_subagent=spawn_context.is_subagent,
+                request_context=request_context,
+                worktree_branch=worktree_branch,
+            )
+        except (RuntimeError, ValueError) as exc:
+            return _tool_text_response(f"ERROR: {exc}")
+        submission_text = _format_subagent_submission(
+            record.task_id,
             fork_session_id,
         )
         if worktree_path:

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -360,6 +360,12 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                 SkillEnvCleanupHook,
                 SkillEnvHook,
             )
+            from .subagents.hooks import (
+                SubagentContextCleanupHook,
+                SubagentContextSetupHook,
+                SubagentEventAckHook,
+                SubagentWakeGuardHook,
+            )
 
             # pylint: disable-next=protected-access
             workspace_registry._bootstrap_kwargs["builtin_hook_clses"] = [
@@ -375,6 +381,10 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
                 MediaProcessHook,
                 ErrorNormalizeHook,
                 CancelCleanupHook,
+                SubagentWakeGuardHook,
+                SubagentContextSetupHook,
+                SubagentEventAckHook,
+                SubagentContextCleanupHook,
             ]
 
             try:

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -507,7 +507,18 @@ class ConsoleChannel(BaseChannel):
             self._print_error(err_msg)
 
     async def consume_one(self, payload: Any) -> None:
-        """Process one payload; drain stream_one (queue/terminal)."""
+        """Process one queue payload.
+
+        Ordinary console requests own an HTTP SSE subscriber and keep the
+        historical ``stream_one`` drain behavior.  A subagent wakeup has no
+        browser request to receive that stream, so route it through the base
+        channel send path; completed messages are then written to the
+        console push store and picked up by the frontend poll service.
+        """
+        request_context = getattr(payload, "request_context", None) or {}
+        if request_context.get("subagent_wakeup"):
+            await super().consume_one(payload)
+            return
         async for _ in self.stream_one(payload):
             pass
 

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Console APIs: push messages, chat, and file upload for chat."""
+
 from __future__ import annotations
 
 import asyncio
@@ -32,7 +33,6 @@ from ..agent_context import get_agent_for_request
 from ..approvals.display import approval_display_fields
 from ..chats.title_generator import generate_and_update_title
 from ..utils import check_upload_size
-
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +193,7 @@ async def post_console_chat(
     Stop via POST /console/chat/stop. Reconnect with body.reconnect=true.
     """
     workspace = await get_agent_for_request(request)
+
     console_channel = await workspace.channel_manager.get_channel("console")
     if console_channel is None:
         raise HTTPException(
@@ -283,6 +284,13 @@ async def post_console_chat_stop(
     logger.debug("[STOP API] Received stop request for chat_id=%s", chat_id)
     workspace = await get_agent_for_request(request)
 
+    # Resolve the parent session independently of the stream task lookup so
+    # already-idle parents can still cancel their background children.
+    parent_session_id = chat_id
+    chat_spec = await workspace.chat_manager.get_chat(chat_id)
+    if chat_spec is not None:
+        parent_session_id = chat_spec.session_id
+
     # Try to stop with the provided chat_id first
     logger.debug(
         "[STOP API] Got workspace, calling task_tracker.request_stop...",
@@ -316,7 +324,17 @@ async def post_console_chat_stop(
         "[STOP API] task_tracker.request_stop returned: stopped=%s",
         stopped,
     )
-    return {"stopped": stopped}
+    subagents_cancelled = 0
+    subagent_manager = getattr(workspace, "subagent_task_manager", None)
+    if subagent_manager is not None:
+        subagents_cancelled = await subagent_manager.cancel_by_parent(
+            parent_session_id,
+            reason="parent session stopped from console",
+        )
+    return {
+        "stopped": stopped or subagents_cancelled > 0,
+        "subagents_cancelled": subagents_cancelled,
+    }
 
 
 @router.post("/upload", response_model=dict, summary="Upload file for chat")

--- a/src/qwenpaw/app/subagents/__init__.py
+++ b/src/qwenpaw/app/subagents/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""Background subagent lifecycle management."""
+
+from .context import SubagentSpawnContext, get_subagent_spawn_context
+from .manager import (
+    SubagentLifecycleEvent,
+    SubagentStatus,
+    SubagentTaskManager,
+    SubagentTaskRecord,
+)
+
+__all__ = [
+    "SubagentLifecycleEvent",
+    "SubagentSpawnContext",
+    "SubagentStatus",
+    "SubagentTaskManager",
+    "SubagentTaskRecord",
+    "get_subagent_spawn_context",
+]

--- a/src/qwenpaw/app/subagents/context.py
+++ b/src/qwenpaw/app/subagents/context.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Request-local context used by ``spawn_subagent``.
+
+Tools are registered as plain functions, so they cannot receive a Workspace
+dependency through their signature.  A ContextVar keeps that dependency
+request-scoped and follows AgentScope's async tool execution tasks naturally.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SubagentSpawnContext:
+    """Identity and routing information inherited by a child task."""
+
+    manager: Any
+    agent_id: str
+    session_id: str
+    root_session_id: str
+    user_id: str
+    channel: str
+    channel_meta: dict[str, Any] = field(default_factory=dict)
+    is_subagent: bool = False
+
+
+_CURRENT: ContextVar[SubagentSpawnContext | None] = ContextVar(
+    "qwenpaw_subagent_spawn_context",
+    default=None,
+)
+
+
+def set_subagent_spawn_context(
+    value: SubagentSpawnContext,
+) -> Token[SubagentSpawnContext | None]:
+    """Bind *value* and return a token for deterministic cleanup."""
+    return _CURRENT.set(value)
+
+
+def reset_subagent_spawn_context(
+    token: Token[SubagentSpawnContext | None],
+) -> None:
+    """Restore the ContextVar value that preceded *token*."""
+    _CURRENT.reset(token)
+
+
+def get_subagent_spawn_context() -> SubagentSpawnContext | None:
+    """Return the request-local spawn context, if execution is in Runtime."""
+    return _CURRENT.get()
+
+
+__all__ = [
+    "SubagentSpawnContext",
+    "get_subagent_spawn_context",
+    "reset_subagent_spawn_context",
+    "set_subagent_spawn_context",
+]

--- a/src/qwenpaw/app/subagents/hooks.py
+++ b/src/qwenpaw/app/subagents/hooks.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""QwenPaw Runtime hooks for background-subagent integration."""
+
+from __future__ import annotations
+
+from ...hooks.base import LifecycleHook
+from ...runtime.hooks import HookAction, HookContext, HookResult
+from ...runtime.phases import Phase
+from .context import (
+    SubagentSpawnContext,
+    reset_subagent_spawn_context,
+    set_subagent_spawn_context,
+)
+
+
+class SubagentWakeGuardHook(LifecycleHook):
+    """Skip a queued wakeup if another run already consumed its events."""
+
+    phase = Phase.PRE_EXECUTE
+    name = "subagent_wake_guard"
+    priority = 5
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        request_context = getattr(ctx.request, "request_context", None) or {}
+        if not request_context.get("subagent_wakeup"):
+            return HookResult()
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        if manager is None:
+            return HookResult(action=HookAction.SKIP_AGENT)
+        if not await manager.has_pending_events(ctx.session_id):
+            return HookResult(action=HookAction.SKIP_AGENT)
+
+        # AgentScope rejects ``inputs=None`` while a tool call is parked on
+        # user confirmation or external execution.  Keep the inbox pending;
+        # the real continuation request will drain it before reasoning.
+        agent = getattr(ctx, "agent", None)
+        state = getattr(agent, "state", None)
+        context = getattr(state, "context", None) or []
+        if context:
+            from agentscope.message import ToolCallState
+
+            last = context[-1]
+            tool_calls = last.get_content_blocks("tool_call")
+            if any(
+                call.state in (ToolCallState.ASKING, ToolCallState.SUBMITTED)
+                for call in tool_calls
+            ):
+                return HookResult(action=HookAction.SKIP_AGENT)
+        return HookResult()
+
+
+class SubagentContextSetupHook(LifecycleHook):
+    """Expose the current Workspace manager to plain function tools."""
+
+    phase = Phase.PRE_EXECUTE
+    name = "subagent_context_setup"
+    priority = 15
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        if manager is None:
+            return HookResult()
+        request_context = getattr(ctx.request, "request_context", None) or {}
+        token = set_subagent_spawn_context(
+            SubagentSpawnContext(
+                manager=manager,
+                agent_id=ctx.agent_id,
+                session_id=ctx.session_id,
+                root_session_id=ctx.root_session_id or ctx.session_id,
+                user_id=getattr(ctx.request, "user_id", "") or "",
+                channel=getattr(ctx.request, "channel", "") or "console",
+                channel_meta=dict(
+                    getattr(ctx.request, "channel_meta", None) or {},
+                ),
+                is_subagent=bool(request_context.get("is_subagent")),
+            ),
+        )
+        ctx.extras["subagent_context_token"] = token
+        return HookResult()
+
+
+class SubagentContextCleanupHook(LifecycleHook):
+    """Reset the request-local spawn context on every exit path."""
+
+    phase = Phase.FINALLY
+    name = "subagent_context_cleanup"
+    priority = 90
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        claim_id = getattr(
+            ctx.agent,
+            "_qwenpaw_subagent_event_claim_id",
+            None,
+        )
+        if manager is not None and claim_id:
+            await manager.release_events(claim_id)
+        token = ctx.extras.pop("subagent_context_token", None)
+        if token is not None:
+            reset_subagent_spawn_context(token)
+        return HookResult()
+
+
+class SubagentEventAckHook(LifecycleHook):
+    """Ack claimed inbox events only after session persistence succeeds."""
+
+    phase = Phase.POST_RESPONSE
+    name = "subagent_event_ack"
+    priority = 95
+    after = ("session_save",)
+
+    async def run(self, ctx: HookContext) -> HookResult:
+        if not ctx.extras.get("session_save_succeeded"):
+            return HookResult()
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        claim_id = getattr(
+            ctx.agent,
+            "_qwenpaw_subagent_event_claim_id",
+            None,
+        )
+        if manager is not None and claim_id:
+            await manager.ack_events(claim_id)
+            delattr(ctx.agent, "_qwenpaw_subagent_event_claim_id")
+        return HookResult()
+
+
+__all__ = [
+    "SubagentContextCleanupHook",
+    "SubagentContextSetupHook",
+    "SubagentEventAckHook",
+    "SubagentWakeGuardHook",
+]

--- a/src/qwenpaw/app/subagents/hooks.py
+++ b/src/qwenpaw/app/subagents/hooks.py
@@ -12,6 +12,24 @@ from .context import (
     set_subagent_spawn_context,
 )
 
+_CLAIM_ID_ATTR = "_qwenpaw_subagent_event_claim_id"
+_CLAIM_IDS_ATTR = "_qwenpaw_subagent_event_claim_ids"
+
+
+def _claimed_event_ids(agent: object) -> list[str]:
+    claim_ids = list(getattr(agent, _CLAIM_IDS_ATTR, []))
+    legacy_claim_id = getattr(agent, _CLAIM_ID_ATTR, None)
+    if legacy_claim_id and legacy_claim_id not in claim_ids:
+        claim_ids.append(legacy_claim_id)
+    return claim_ids
+
+
+def _clear_claimed_event_ids(agent: object) -> None:
+    if hasattr(agent, _CLAIM_IDS_ATTR):
+        delattr(agent, _CLAIM_IDS_ATTR)
+    if hasattr(agent, _CLAIM_ID_ATTR):
+        delattr(agent, _CLAIM_ID_ATTR)
+
 
 class SubagentWakeGuardHook(LifecycleHook):
     """Skip a queued wakeup if another run already consumed its events."""
@@ -88,13 +106,11 @@ class SubagentContextCleanupHook(LifecycleHook):
 
     async def run(self, ctx: HookContext) -> HookResult:
         manager = getattr(ctx.workspace, "subagent_task_manager", None)
-        claim_id = getattr(
-            ctx.agent,
-            "_qwenpaw_subagent_event_claim_id",
-            None,
-        )
-        if manager is not None and claim_id:
-            await manager.release_events(claim_id)
+        claim_ids = _claimed_event_ids(ctx.agent)
+        if manager is not None:
+            for claim_id in claim_ids:
+                await manager.release_events(claim_id)
+        _clear_claimed_event_ids(ctx.agent)
         token = ctx.extras.pop("subagent_context_token", None)
         if token is not None:
             reset_subagent_spawn_context(token)
@@ -113,14 +129,11 @@ class SubagentEventAckHook(LifecycleHook):
         if not ctx.extras.get("session_save_succeeded"):
             return HookResult()
         manager = getattr(ctx.workspace, "subagent_task_manager", None)
-        claim_id = getattr(
-            ctx.agent,
-            "_qwenpaw_subagent_event_claim_id",
-            None,
-        )
-        if manager is not None and claim_id:
-            await manager.ack_events(claim_id)
-            delattr(ctx.agent, "_qwenpaw_subagent_event_claim_id")
+        claim_ids = _claimed_event_ids(ctx.agent)
+        if manager is not None:
+            for claim_id in claim_ids:
+                await manager.ack_events(claim_id)
+        _clear_claimed_event_ids(ctx.agent)
         return HookResult()
 
 

--- a/src/qwenpaw/app/subagents/manager.py
+++ b/src/qwenpaw/app/subagents/manager.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 4
 DEFAULT_WATCHDOG_INTERVAL_SECONDS = HEARTBEAT_INTERVAL_SECONDS
 DEFAULT_CANCEL_GRACE_SECONDS = 10.0
+DEFAULT_PARENT_WAKEUP_WAIT_TIMEOUT_SECONDS = 300.0
+DEFAULT_PARENT_WAKEUP_RETRY_INTERVAL_SECONDS = 5.0
 
 
 class SubagentStatus(str, Enum):
@@ -114,6 +116,12 @@ class SubagentTaskManager:
         heartbeat_timeout_seconds: float = DEFAULT_HEARTBEAT_TIMEOUT_SECONDS,
         watchdog_interval_seconds: float = DEFAULT_WATCHDOG_INTERVAL_SECONDS,
         cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS,
+        parent_wakeup_wait_timeout_seconds: float = (
+            DEFAULT_PARENT_WAKEUP_WAIT_TIMEOUT_SECONDS
+        ),
+        parent_wakeup_retry_interval_seconds: float = (
+            DEFAULT_PARENT_WAKEUP_RETRY_INTERVAL_SECONDS
+        ),
     ) -> None:
         self.workspace = workspace
         self.max_running_per_parent = max_running_per_parent
@@ -126,11 +134,20 @@ class SubagentTaskManager:
             0.01,
         )
         self.cancel_grace_seconds = max(float(cancel_grace_seconds), 0.0)
+        self.parent_wakeup_wait_timeout_seconds = max(
+            float(parent_wakeup_wait_timeout_seconds),
+            0.0,
+        )
+        self.parent_wakeup_retry_interval_seconds = max(
+            float(parent_wakeup_retry_interval_seconds),
+            0.01,
+        )
         self._records: dict[str, SubagentTaskRecord] = {}
         self._events: list[SubagentLifecycleEvent] = []
         self._lock = asyncio.Lock()
         self._watchdog_task: asyncio.Task | None = None
         self._notification_tasks: set[asyncio.Task] = set()
+        self._wakeup_retry_parents: set[str] = set()
         self._stopping = False
 
     async def start(self) -> None:
@@ -442,8 +459,8 @@ class SubagentTaskManager:
     async def _watchdog_loop(self) -> None:
         """Cancel children whose Runtime heartbeat stream has stopped."""
         previous_tick = time.monotonic()
-        try:
-            while True:
+        while True:
+            try:
                 await asyncio.sleep(self.watchdog_interval_seconds)
                 now = time.monotonic()
                 tick_delay = now - previous_tick
@@ -459,10 +476,10 @@ class SubagentTaskManager:
                 stale_records = await self._watchdog_tick(now)
                 for record in stale_records:
                     self._schedule_parent_wakeup(record)
-        except Exception:  # pragma: no cover - defensive service boundary
-            logger.exception(
-                "Subagent heartbeat watchdog stopped unexpectedly",
-            )
+            except Exception:  # pragma: no cover - defensive service boundary
+                logger.exception(
+                    "Subagent watchdog tick failed; will retry next interval",
+                )
 
     async def _reset_leases_after_loop_pause(self, now: float) -> None:
         async with self._lock:
@@ -536,6 +553,51 @@ class SubagentTaskManager:
         )
         self._notification_tasks.add(task)
         task.add_done_callback(self._notification_tasks.discard)
+
+    def _schedule_parent_wakeup_retry(
+        self,
+        record: SubagentTaskRecord,
+    ) -> None:
+        """Retry an automatic parent wakeup without a tight idle poll loop."""
+        if self._stopping:
+            return
+        parent_session_id = record.parent_session_id
+        if parent_session_id in self._wakeup_retry_parents:
+            return
+        self._wakeup_retry_parents.add(parent_session_id)
+        task = asyncio.create_task(
+            self._retry_parent_wakeup_when_idle(record),
+            name=f"qwenpaw-subagent-wakeup-retry:{parent_session_id}",
+        )
+        self._notification_tasks.add(task)
+
+        def _done(done: asyncio.Task) -> None:
+            self._notification_tasks.discard(done)
+            self._wakeup_retry_parents.discard(parent_session_id)
+
+        task.add_done_callback(_done)
+
+    async def _retry_parent_wakeup_when_idle(
+        self,
+        record: SubagentTaskRecord,
+    ) -> None:
+        """Retry wakeup delivery at low frequency until the parent is idle."""
+        while not self._stopping:
+            await asyncio.sleep(self.parent_wakeup_retry_interval_seconds)
+            if not await self.has_pending_events(record.parent_session_id):
+                return
+            if await self._parent_session_is_running(record):
+                continue
+            manager = getattr(self.workspace, "channel_manager", None)
+            if manager is None or not record.channel:
+                logger.warning(
+                    "Cannot wake parent for subagent %s: channel unavailable",
+                    record.task_id,
+                )
+                return
+            if await self.has_pending_events(record.parent_session_id):
+                self._enqueue_parent_request(record, manager)
+            return
 
     async def get(self, task_id: str) -> SubagentTaskRecord | None:
         async with self._lock:
@@ -658,7 +720,18 @@ class SubagentTaskManager:
                     record.parent_session_id,
                     record.channel,
                 )
+            deadline = (
+                time.monotonic() + self.parent_wakeup_wait_timeout_seconds
+            )
             while chat_id and tracker is not None:
+                if time.monotonic() > deadline:
+                    logger.warning(
+                        "Timed out waiting for parent session %s to become "
+                        "idle; retrying wakeup when the parent becomes idle",
+                        record.parent_session_id,
+                    )
+                    self._schedule_parent_wakeup_retry(record)
+                    return
                 if await tracker.get_status(chat_id) != "running":
                     break
                 # The active parent may consume the HintBlock on its next
@@ -671,28 +744,50 @@ class SubagentTaskManager:
 
             if not await self.has_pending_events(record.parent_session_id):
                 return
-
-            from ...schemas import AgentRequest
-
-            request = AgentRequest(
-                input=[],
-                session_id=record.parent_session_id,
-                user_id=record.user_id or record.parent_session_id,
-                channel=record.channel,
-                root_session_id=record.root_session_id,
-                root_agent_id=record.parent_agent_id,
-                request_context={
-                    "subagent_wakeup": True,
-                    "subagent_event_task_id": record.task_id,
-                },
-            )
-            request.channel_meta = dict(record.channel_meta)
-            manager.enqueue(record.channel, request)
+            self._enqueue_parent_request(record, manager)
         except Exception:
             logger.exception(
                 "Failed to enqueue parent wakeup for %s",
                 record.task_id,
             )
+
+    @staticmethod
+    def _enqueue_parent_request(
+        record: SubagentTaskRecord,
+        manager: Any,
+    ) -> None:
+        from ...schemas import AgentRequest
+
+        request = AgentRequest(
+            input=[],
+            session_id=record.parent_session_id,
+            user_id=record.user_id or record.parent_session_id,
+            channel=record.channel,
+            root_session_id=record.root_session_id,
+            root_agent_id=record.parent_agent_id,
+            request_context={
+                "subagent_wakeup": True,
+                "subagent_event_task_id": record.task_id,
+            },
+        )
+        request.channel_meta = dict(record.channel_meta)
+        manager.enqueue(record.channel, request)
+
+    async def _parent_session_is_running(
+        self,
+        record: SubagentTaskRecord,
+    ) -> bool:
+        chat_manager = getattr(self.workspace, "chat_manager", None)
+        tracker = getattr(self.workspace, "task_tracker", None)
+        if chat_manager is None or tracker is None:
+            return False
+        chat_id = await chat_manager.get_chat_id_by_session(
+            record.parent_session_id,
+            record.channel,
+        )
+        if not chat_id:
+            return False
+        return await tracker.get_status(chat_id) == "running"
 
     @staticmethod
     def _build_child_request(

--- a/src/qwenpaw/app/subagents/manager.py
+++ b/src/qwenpaw/app/subagents/manager.py
@@ -1,0 +1,779 @@
+# -*- coding: utf-8 -*-
+"""Workspace-scoped background subagent task manager.
+
+The design follows AgentScope 2.0's background-tool lifecycle: keep the
+asyncio task handle locally, publish lifecycle events into a parent-session
+inbox, then enqueue an idle-session wakeup.  QwenPaw supplies its own inbox and
+wakeup bridge because it does not run the ``agentscope.app`` service stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+from ...runtime.heartbeat import HEARTBEAT_INTERVAL_SECONDS
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEARTBEAT_TIMEOUT_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 4
+DEFAULT_WATCHDOG_INTERVAL_SECONDS = HEARTBEAT_INTERVAL_SECONDS
+DEFAULT_CANCEL_GRACE_SECONDS = 10.0
+
+
+class SubagentStatus(str, Enum):
+    """Stable lifecycle states exposed to tools, logs, and tests."""
+
+    SUBMITTED = "submitted"
+    RUNNING = "running"
+    CANCELLING = "cancelling"
+    STALE = "stale"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+TERMINAL_STATUSES = frozenset(
+    {
+        SubagentStatus.COMPLETED,
+        SubagentStatus.FAILED,
+        SubagentStatus.CANCELLED,
+    },
+)
+
+
+@dataclass
+class SubagentTaskRecord:
+    """Runtime metadata plus the local task handle."""
+
+    task_id: str
+    parent_agent_id: str
+    parent_session_id: str
+    root_session_id: str
+    child_agent_id: str
+    child_session_id: str
+    prompt: str
+    user_id: str
+    channel: str
+    channel_meta: dict[str, Any] = field(default_factory=dict)
+    status: SubagentStatus = SubagentStatus.SUBMITTED
+    created_at: float = field(default_factory=time.time)
+    started_at: float | None = None
+    finished_at: float | None = None
+    last_heartbeat_at: float = 0.0
+    cancel_requested_at: float | None = None
+    stale_notified: bool = False
+    result: str | None = None
+    error: str | None = None
+    cancel_reason: str | None = None
+    notify_on_cancel: bool = True
+    worktree_branch: str = ""
+    asyncio_task: asyncio.Task | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+
+@dataclass
+class SubagentLifecycleEvent:
+    """A child lifecycle event waiting to be injected into its parent."""
+
+    event_id: str
+    task_id: str
+    parent_session_id: str
+    child_session_id: str
+    status: SubagentStatus
+    prompt: str
+    created_at: float = field(default_factory=time.time)
+    result: str | None = None
+    error: str | None = None
+    elapsed_seconds: float | None = None
+    worktree_branch: str = ""
+    claim_id: str | None = None
+
+
+class SubagentTaskManager:
+    """AS2-style lifecycle adapter for leaf subagents in one Workspace.
+
+    This is intentionally not a generic background-task framework.  It only
+    adds parent/child identity and child Runtime execution around the same
+    inbox, HintBlock, wakeup, and cancellation semantics used by AS2.
+    """
+
+    def __init__(
+        self,
+        workspace: Any,
+        *,
+        max_running_per_parent: int = 8,
+        heartbeat_timeout_seconds: float = DEFAULT_HEARTBEAT_TIMEOUT_SECONDS,
+        watchdog_interval_seconds: float = DEFAULT_WATCHDOG_INTERVAL_SECONDS,
+        cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS,
+    ) -> None:
+        self.workspace = workspace
+        self.max_running_per_parent = max_running_per_parent
+        self.heartbeat_timeout_seconds = max(
+            float(heartbeat_timeout_seconds),
+            0.01,
+        )
+        self.watchdog_interval_seconds = max(
+            float(watchdog_interval_seconds),
+            0.01,
+        )
+        self.cancel_grace_seconds = max(float(cancel_grace_seconds), 0.0)
+        self._records: dict[str, SubagentTaskRecord] = {}
+        self._events: list[SubagentLifecycleEvent] = []
+        self._lock = asyncio.Lock()
+        self._watchdog_task: asyncio.Task | None = None
+        self._notification_tasks: set[asyncio.Task] = set()
+        self._stopping = False
+
+    async def start(self) -> None:
+        """Start one workspace-wide heartbeat watchdog."""
+        if self._watchdog_task is not None and not self._watchdog_task.done():
+            return
+        self._stopping = False
+        self._watchdog_task = asyncio.create_task(
+            self._watchdog_loop(),
+            name="qwenpaw-subagent-watchdog",
+        )
+
+    async def stop(self) -> None:
+        """Cancel live children without waking parents during shutdown."""
+        self._stopping = True
+        watchdog = self._watchdog_task
+        self._watchdog_task = None
+        if watchdog is not None and not watchdog.done():
+            watchdog.cancel()
+            await asyncio.gather(watchdog, return_exceptions=True)
+
+        async with self._lock:
+            tasks = []
+            for record in self._records.values():
+                task = record.asyncio_task
+                if task is not None and not task.done():
+                    record.cancel_reason = "workspace shutdown"
+                    record.notify_on_cancel = False
+                    tasks.append(task)
+                    task.cancel()
+            notifications = list(self._notification_tasks)
+            for task in notifications:
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if notifications:
+            await asyncio.gather(*notifications, return_exceptions=True)
+
+    async def spawn(
+        self,
+        *,
+        prompt: str,
+        parent_agent_id: str,
+        parent_session_id: str,
+        root_session_id: str,
+        child_agent_id: str,
+        child_session_id: str,
+        user_id: str,
+        channel: str,
+        channel_meta: dict[str, Any] | None,
+        parent_is_subagent: bool,
+        request_context: dict[str, Any] | None = None,
+        worktree_branch: str = "",
+    ) -> SubagentTaskRecord:
+        """Create, register, and start one child Runtime task."""
+        if parent_is_subagent:
+            raise ValueError(
+                "nested subagents are not supported; only a top-level "
+                "agent may call spawn_subagent",
+            )
+
+        async with self._lock:
+            running = sum(
+                1
+                for item in self._records.values()
+                if item.parent_session_id == parent_session_id
+                and item.status not in TERMINAL_STATUSES
+            )
+            if running >= self.max_running_per_parent:
+                raise RuntimeError(
+                    "background subagent limit reached for this parent "
+                    f"({running}/{self.max_running_per_parent})",
+                )
+
+            task_id = f"subtask-{uuid4().hex[:12]}"
+            record = SubagentTaskRecord(
+                task_id=task_id,
+                parent_agent_id=parent_agent_id,
+                parent_session_id=parent_session_id,
+                root_session_id=root_session_id or parent_session_id,
+                child_agent_id=child_agent_id,
+                child_session_id=child_session_id,
+                prompt=prompt,
+                user_id=user_id,
+                channel=channel or "console",
+                channel_meta=self._routing_meta(channel_meta or {}),
+                last_heartbeat_at=time.monotonic(),
+                worktree_branch=worktree_branch,
+            )
+            self._records[task_id] = record
+
+            child_context = dict(request_context or {})
+            child_context.update(
+                {
+                    "is_subagent": True,
+                    "subagent_task_id": task_id,
+                    "subagent_parent_session_id": parent_session_id,
+                },
+            )
+            record.asyncio_task = asyncio.create_task(
+                self._run_child(record, child_context),
+                name=f"qwenpaw-subagent:{task_id}",
+            )
+
+            def _done_callback(done: asyncio.Task) -> None:
+                self._on_task_done(record, done)
+
+            record.asyncio_task.add_done_callback(_done_callback)
+            return record
+
+    def _on_task_done(
+        self,
+        record: SubagentTaskRecord,
+        task: asyncio.Task,
+    ) -> None:
+        """Close the pre-start cancellation gap in asyncio task execution."""
+        if record.status in TERMINAL_STATUSES:
+            return
+        try:
+            asyncio.create_task(self._ensure_done_state(record, task))
+        except RuntimeError:
+            # Event loop is already closed during interpreter shutdown.
+            return
+
+    async def _ensure_done_state(
+        self,
+        record: SubagentTaskRecord,
+        task: asyncio.Task,
+    ) -> None:
+        if record.status in TERMINAL_STATUSES:
+            return
+        if task.cancelled():
+            await self._finish(
+                record,
+                SubagentStatus.CANCELLED,
+                error=record.cancel_reason or "subagent task was cancelled",
+                notify_parent=record.notify_on_cancel,
+            )
+            return
+        exc = task.exception()
+        if exc is not None:
+            await self._finish(
+                record,
+                SubagentStatus.FAILED,
+                error=str(exc) or type(exc).__name__,
+            )
+            return
+        await self._finish(
+            record,
+            SubagentStatus.FAILED,
+            error="subagent task exited without a terminal lifecycle state",
+        )
+
+    async def _run_child(
+        self,
+        record: SubagentTaskRecord,
+        request_context: dict[str, Any],
+    ) -> None:
+        try:
+            async with self._lock:
+                record.status = SubagentStatus.RUNNING
+                record.started_at = time.time()
+                record.last_heartbeat_at = time.monotonic()
+
+            request = self._build_child_request(record, request_context)
+            final_text = ""
+            async for item in self.workspace.stream_query(request):
+                # AgentExecutor already emits heartbeat envelopes while
+                # the AS2 event stream is idle. Reuse that established
+                # mechanism instead of creating another timer task.
+                await self.touch(record.task_id)
+                text = self._completed_assistant_text(item)
+                if text:
+                    final_text = text
+
+            await self._finish(
+                record,
+                SubagentStatus.COMPLETED,
+                result=final_text
+                or "(Subagent completed with no text output)",
+            )
+        except asyncio.CancelledError:
+            reason = record.cancel_reason or "subagent task was cancelled"
+            await self._finish(
+                record,
+                SubagentStatus.CANCELLED,
+                error=reason,
+                notify_parent=record.notify_on_cancel,
+            )
+            raise
+        except BaseException as exc:  # noqa: BLE001
+            logger.exception("Background subagent %s failed", record.task_id)
+            await self._finish(
+                record,
+                SubagentStatus.FAILED,
+                error=str(exc) or type(exc).__name__,
+            )
+
+    async def _finish(
+        self,
+        record: SubagentTaskRecord,
+        status: SubagentStatus,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+        notify_parent: bool = True,
+    ) -> None:
+        async with self._lock:
+            if record.status in TERMINAL_STATUSES:
+                return
+            should_notify = notify_parent and record.notify_on_cancel
+            record.status = status
+            record.finished_at = time.time()
+            record.result = result
+            record.error = error
+            if should_notify:
+                self._append_lifecycle_event_locked(record)
+            else:
+                self._records.pop(record.task_id, None)
+        if should_notify:
+            await self._enqueue_parent_wakeup(record)
+
+    async def touch(
+        self,
+        task_id: str,
+    ) -> None:
+        """Record one liveness pulse from the child Runtime stream."""
+        async with self._lock:
+            record = self._records.get(task_id)
+            if record is None or record.status not in {
+                SubagentStatus.SUBMITTED,
+                SubagentStatus.RUNNING,
+            }:
+                return
+            record.last_heartbeat_at = time.monotonic()
+
+    async def cancel_task(
+        self,
+        task_id: str,
+        *,
+        reason: str = "cancelled by parent",
+        notify_parent: bool = True,
+    ) -> bool:
+        """Cancel one task by id.  Idempotent for terminal/unknown tasks."""
+        async with self._lock:
+            record = self._records.get(task_id)
+            if record is None or record.status in TERMINAL_STATUSES:
+                return False
+            record.cancel_reason = reason
+            record.notify_on_cancel = notify_parent
+            task = record.asyncio_task
+            if task is None or task.done():
+                return False
+            if record.status == SubagentStatus.CANCELLING:
+                return False
+            if record.status == SubagentStatus.STALE:
+                task.cancel()
+                return True
+            record.status = SubagentStatus.CANCELLING
+            record.cancel_requested_at = time.monotonic()
+            task.cancel()
+            return True
+
+    async def cancel_by_parent(
+        self,
+        parent_session_id: str,
+        *,
+        reason: str = "parent session cancelled",
+    ) -> int:
+        """Silently cancel all children and discard pending callbacks."""
+        async with self._lock:
+            discarded_task_ids = {
+                event.task_id
+                for event in self._events
+                if event.parent_session_id == parent_session_id
+            }
+            self._events = [
+                event
+                for event in self._events
+                if event.parent_session_id != parent_session_id
+            ]
+            for task_id in discarded_task_ids:
+                record = self._records.get(task_id)
+                if record is not None and record.status in TERMINAL_STATUSES:
+                    self._records.pop(task_id, None)
+
+            tasks = [
+                record
+                for record in self._records.values()
+                if record.parent_session_id == parent_session_id
+                and record.status not in TERMINAL_STATUSES
+            ]
+            cancelled = 0
+            for record in tasks:
+                task = record.asyncio_task
+                if task is None or task.done():
+                    continue
+                record.cancel_reason = reason
+                record.notify_on_cancel = False
+                if record.status == SubagentStatus.CANCELLING:
+                    continue
+                if record.status != SubagentStatus.STALE:
+                    record.status = SubagentStatus.CANCELLING
+                    record.cancel_requested_at = time.monotonic()
+                task.cancel()
+                cancelled += 1
+            return cancelled
+
+    async def _watchdog_loop(self) -> None:
+        """Cancel children whose Runtime heartbeat stream has stopped."""
+        previous_tick = time.monotonic()
+        try:
+            while True:
+                await asyncio.sleep(self.watchdog_interval_seconds)
+                now = time.monotonic()
+                tick_delay = now - previous_tick
+                previous_tick = now
+
+                # If this watchdog was delayed too, the whole event loop was
+                # paused. Give every child a fresh lease instead of killing
+                # healthy work after suspend, debugger pause, or starvation.
+                if tick_delay > self.watchdog_interval_seconds * 2:
+                    await self._reset_leases_after_loop_pause(now)
+                    continue
+
+                stale_records = await self._watchdog_tick(now)
+                for record in stale_records:
+                    self._schedule_parent_wakeup(record)
+        except Exception:  # pragma: no cover - defensive service boundary
+            logger.exception(
+                "Subagent heartbeat watchdog stopped unexpectedly",
+            )
+
+    async def _reset_leases_after_loop_pause(self, now: float) -> None:
+        async with self._lock:
+            for record in self._records.values():
+                if record.status in {
+                    SubagentStatus.SUBMITTED,
+                    SubagentStatus.RUNNING,
+                }:
+                    record.last_heartbeat_at = now
+                elif record.status == SubagentStatus.CANCELLING:
+                    record.cancel_requested_at = now
+
+    async def _watchdog_tick(
+        self,
+        now: float,
+    ) -> list[SubagentTaskRecord]:
+        """Apply heartbeat leases and return newly stale records."""
+        newly_stale: list[SubagentTaskRecord] = []
+        async with self._lock:
+            for record in self._records.values():
+                task = record.asyncio_task
+                if task is None or task.done():
+                    continue
+
+                if record.status in {
+                    SubagentStatus.SUBMITTED,
+                    SubagentStatus.RUNNING,
+                }:
+                    heartbeat_age = now - record.last_heartbeat_at
+                    if heartbeat_age < self.heartbeat_timeout_seconds:
+                        continue
+                    record.status = SubagentStatus.CANCELLING
+                    record.cancel_reason = (
+                        f"subagent heartbeat lost for {heartbeat_age:.1f}s"
+                    )
+                    record.notify_on_cancel = True
+                    record.cancel_requested_at = now
+                    task.cancel()
+                    continue
+
+                if record.status != SubagentStatus.CANCELLING:
+                    continue
+                requested_at = record.cancel_requested_at
+                if requested_at is None:
+                    record.cancel_requested_at = now
+                    continue
+                if now - requested_at < self.cancel_grace_seconds:
+                    continue
+                if record.stale_notified:
+                    continue
+
+                record.status = SubagentStatus.STALE
+                record.stale_notified = True
+                record.error = (
+                    f"{record.cancel_reason or 'subagent cancellation'}; "
+                    "cancellation did not complete within "
+                    f"{self.cancel_grace_seconds:g}s"
+                )
+                if record.notify_on_cancel:
+                    self._append_lifecycle_event_locked(record)
+                    newly_stale.append(record)
+        return newly_stale
+
+    def _schedule_parent_wakeup(self, record: SubagentTaskRecord) -> None:
+        """Schedule a non-blocking wakeup without stalling the watchdog."""
+        if self._stopping:
+            return
+        task = asyncio.create_task(
+            self._enqueue_parent_wakeup(record),
+            name=f"qwenpaw-subagent-wakeup:{record.task_id}",
+        )
+        self._notification_tasks.add(task)
+        task.add_done_callback(self._notification_tasks.discard)
+
+    async def get(self, task_id: str) -> SubagentTaskRecord | None:
+        async with self._lock:
+            return self._records.get(task_id)
+
+    async def has_pending_events(self, parent_session_id: str) -> bool:
+        async with self._lock:
+            return any(
+                event.parent_session_id == parent_session_id
+                for event in self._events
+            )
+
+    async def claim_events(
+        self,
+        parent_session_id: str,
+        claim_id: str,
+    ) -> list[SubagentLifecycleEvent]:
+        """Lease all currently available events to one parent run."""
+        async with self._lock:
+            events = [
+                event
+                for event in self._events
+                if event.parent_session_id == parent_session_id
+                and event.claim_id is None
+            ]
+            for event in events:
+                event.claim_id = claim_id
+            return events
+
+    async def ack_events(self, claim_id: str) -> int:
+        """Commit a delivery after the parent session state was saved."""
+        async with self._lock:
+            acknowledged = [
+                event for event in self._events if event.claim_id == claim_id
+            ]
+            if not acknowledged:
+                return 0
+            acknowledged_ids = {event.event_id for event in acknowledged}
+            self._events = [
+                event
+                for event in self._events
+                if event.event_id not in acknowledged_ids
+            ]
+            for event in acknowledged:
+                record = self._records.get(event.task_id)
+                if (
+                    event.status in TERMINAL_STATUSES
+                    and record is not None
+                    and record.status in TERMINAL_STATUSES
+                ):
+                    self._records.pop(event.task_id, None)
+            return len(acknowledged)
+
+    async def release_events(self, claim_id: str) -> int:
+        """Release an uncommitted delivery for a later user/wakeup run."""
+        count = 0
+        async with self._lock:
+            for event in self._events:
+                if event.claim_id != claim_id:
+                    continue
+                event.claim_id = None
+                count += 1
+        return count
+
+    async def drain_events(
+        self,
+        parent_session_id: str,
+    ) -> list[SubagentLifecycleEvent]:
+        """Compatibility helper for non-runtime consumers and tests."""
+        claim_id = f"drain-{uuid4().hex}"
+        events = await self.claim_events(parent_session_id, claim_id)
+        await self.ack_events(claim_id)
+        return events
+
+    def _append_lifecycle_event_locked(
+        self,
+        record: SubagentTaskRecord,
+    ) -> None:
+        elapsed = None
+        if record.started_at is not None and record.finished_at is not None:
+            elapsed = max(0.0, record.finished_at - record.started_at)
+        self._events.append(
+            SubagentLifecycleEvent(
+                event_id=f"subevent-{uuid4().hex[:12]}",
+                task_id=record.task_id,
+                parent_session_id=record.parent_session_id,
+                child_session_id=record.child_session_id,
+                status=record.status,
+                prompt=record.prompt,
+                result=record.result,
+                error=record.error,
+                elapsed_seconds=elapsed,
+                worktree_branch=record.worktree_branch,
+            ),
+        )
+
+    async def _enqueue_parent_wakeup(
+        self,
+        record: SubagentTaskRecord,
+    ) -> None:
+        """Wake the parent only after its current run becomes idle.
+
+        Channel queues serialize ordinary chat traffic, but Console HTTP can
+        drive TaskTracker directly.  Waiting here prevents two Runtime
+        instances from loading and saving the same parent session at once.
+        """
+        manager = getattr(self.workspace, "channel_manager", None)
+        if manager is None or not record.channel:
+            logger.warning(
+                "Cannot wake parent for subagent %s: channel unavailable",
+                record.task_id,
+            )
+            return
+        try:
+            chat_manager = getattr(self.workspace, "chat_manager", None)
+            tracker = getattr(self.workspace, "task_tracker", None)
+            chat_id = None
+            if chat_manager is not None:
+                chat_id = await chat_manager.get_chat_id_by_session(
+                    record.parent_session_id,
+                    record.channel,
+                )
+            while chat_id and tracker is not None:
+                if await tracker.get_status(chat_id) != "running":
+                    break
+                # The active parent may consume the HintBlock on its next
+                # reasoning step.  If so, no follow-up wake is necessary.
+                if not await self.has_pending_events(
+                    record.parent_session_id,
+                ):
+                    return
+                await asyncio.sleep(0.1)
+
+            if not await self.has_pending_events(record.parent_session_id):
+                return
+
+            from ...schemas import AgentRequest
+
+            request = AgentRequest(
+                input=[],
+                session_id=record.parent_session_id,
+                user_id=record.user_id or record.parent_session_id,
+                channel=record.channel,
+                root_session_id=record.root_session_id,
+                root_agent_id=record.parent_agent_id,
+                request_context={
+                    "subagent_wakeup": True,
+                    "subagent_event_task_id": record.task_id,
+                },
+            )
+            request.channel_meta = dict(record.channel_meta)
+            manager.enqueue(record.channel, request)
+        except Exception:
+            logger.exception(
+                "Failed to enqueue parent wakeup for %s",
+                record.task_id,
+            )
+
+    @staticmethod
+    def _build_child_request(
+        record: SubagentTaskRecord,
+        request_context: dict[str, Any],
+    ) -> Any:
+        from ...schemas import (
+            AgentRequest,
+            ContentType,
+            Message,
+            MessageType,
+            Role,
+            TextContent,
+        )
+
+        message = Message(
+            type=MessageType.MESSAGE,
+            role=Role.USER,
+            content=[TextContent(type=ContentType.TEXT, text=record.prompt)],
+        )
+        return AgentRequest(
+            input=[message],
+            session_id=record.child_session_id,
+            user_id=record.user_id or record.parent_agent_id,
+            channel=record.channel,
+            agent_id=record.child_agent_id,
+            root_session_id=record.root_session_id,
+            root_agent_id=record.parent_agent_id,
+            request_context=request_context,
+        )
+
+    @staticmethod
+    def _completed_assistant_text(item: Any) -> str:
+        role = getattr(item, "role", None)
+        status = getattr(item, "status", None)
+        if hasattr(role, "value"):
+            role = role.value
+        if hasattr(status, "value"):
+            status = status.value
+        if role != "assistant" or status != "completed":
+            return ""
+        parts = []
+        for block in getattr(item, "content", None) or []:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and text:
+                parts.append(text)
+        return "\n".join(parts).strip()
+
+    @staticmethod
+    def _routing_meta(value: dict[str, Any]) -> dict[str, Any]:
+        """Keep reusable routing values, dropping callbacks and secrets."""
+        safe: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = str(key).lower()
+            if any(
+                sensitive in normalized_key
+                for sensitive in (
+                    "token",
+                    "secret",
+                    "password",
+                    "webhook",
+                    "api_key",
+                    "reply_future",
+                    "reply_loop",
+                    "incoming_message",
+                )
+            ):
+                continue
+            if not isinstance(
+                item,
+                (str, int, float, bool, type(None), list, dict),
+            ):
+                continue
+            safe[str(key)] = item
+        return safe
+
+
+__all__ = [
+    "SubagentLifecycleEvent",
+    "SubagentStatus",
+    "SubagentTaskManager",
+    "SubagentTaskRecord",
+    "TERMINAL_STATUSES",
+]

--- a/src/qwenpaw/app/subagents/middleware.py
+++ b/src/qwenpaw/app/subagents/middleware.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""AgentScope 2.0 middleware for parent subagent-result inboxes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncGenerator, Callable
+
+from agentscope.agent import Agent
+from agentscope.event import HintBlockEvent
+from agentscope.message import AssistantMsg, HintBlock
+from agentscope.middleware import MiddlewareBase
+
+from .manager import SubagentLifecycleEvent, SubagentTaskManager
+
+
+class SubagentInboxMiddleware(MiddlewareBase):
+    """Inject child lifecycle events before parent reasoning."""
+
+    def __init__(
+        self,
+        manager: SubagentTaskManager,
+        parent_session_id: str,
+    ) -> None:
+        self._manager = manager
+        self._parent_session_id = parent_session_id
+
+    async def on_reasoning(
+        self,
+        agent: Agent,
+        input_kwargs: dict,
+        next_handler: Callable[..., AsyncGenerator],
+    ) -> AsyncGenerator[Any, None]:
+        claim_id = (
+            f"{self._parent_session_id}:"
+            f"{agent.state.reply_id}:subagent-events"
+        )
+        events = await self._manager.claim_events(
+            self._parent_session_id,
+            claim_id,
+        )
+        if events:
+            setattr(agent, "_qwenpaw_subagent_event_claim_id", claim_id)
+            hints = [self._to_hint(event) for event in events]
+            if agent.state.context:
+                last = agent.state.context[-1]
+                if last.role == "assistant" and last.name == agent.name:
+                    last.content.extend(hints)
+                else:
+                    agent.state.context.append(
+                        AssistantMsg(
+                            id=agent.state.reply_id,
+                            name=agent.name,
+                            content=hints,
+                        ),
+                    )
+            else:
+                agent.state.context.append(
+                    AssistantMsg(
+                        id=agent.state.reply_id,
+                        name=agent.name,
+                        content=hints,
+                    ),
+                )
+
+            for hint in hints:
+                yield HintBlockEvent(
+                    reply_id=agent.state.reply_id,
+                    block_id=hint.id,
+                    source=hint.source,
+                    hint=hint.hint,
+                )
+
+        async for event in next_handler(**input_kwargs):
+            yield event
+
+    @staticmethod
+    def _to_hint(event: SubagentLifecycleEvent) -> HintBlock:
+        source = json.dumps(
+            {
+                "label": "subagent",
+                "sublabel": f"{event.task_id} · {event.status.value}",
+            },
+            ensure_ascii=False,
+        )
+        elapsed = (
+            f" after {event.elapsed_seconds:.1f}s"
+            if event.elapsed_seconds is not None
+            else ""
+        )
+        lines = [
+            "<system-notification>",
+            "Background subagent "
+            f"{event.task_id} {event.status.value}{elapsed}.",
+            f"Original task: {event.prompt}",
+        ]
+        if event.result:
+            lines.extend(["", "Result:", event.result])
+        if event.error:
+            lines.extend(["", "Error:", event.error])
+        if event.worktree_branch:
+            lines.extend(["", f"Fork branch: {event.worktree_branch}"])
+        if event.status.value == "stale":
+            lines.extend(
+                [
+                    "",
+                    "The child stopped sending heartbeats and did not exit ",
+                    "within the cancellation grace period. Do not poll it. ",
+                    "You may report the stalled task or explicitly request ",
+                    "cancellation again.",
+                ],
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    "Use this result now. Do not call a polling or waiting ",
+                    "tool for this completed task.",
+                ],
+            )
+        lines.append("</system-notification>")
+        return HintBlock(hint="\n".join(lines), source=source)
+
+
+__all__ = ["SubagentInboxMiddleware"]

--- a/src/qwenpaw/app/subagents/middleware.py
+++ b/src/qwenpaw/app/subagents/middleware.py
@@ -40,6 +40,11 @@ class SubagentInboxMiddleware(MiddlewareBase):
             claim_id,
         )
         if events:
+            claim_ids = list(
+                getattr(agent, "_qwenpaw_subagent_event_claim_ids", []),
+            )
+            claim_ids.append(claim_id)
+            setattr(agent, "_qwenpaw_subagent_event_claim_ids", claim_ids)
             setattr(agent, "_qwenpaw_subagent_event_claim_id", claim_id)
             hints = [self._to_hint(event) for event in events]
             if agent.state.context:

--- a/src/qwenpaw/app/workspace/local_workspace.py
+++ b/src/qwenpaw/app/workspace/local_workspace.py
@@ -47,7 +47,7 @@ class QwenPawLocalWorkspace(AgentScopeLocalWorkspace):
         *,
         agent_config: Any = None,
         agent_id: str | None = None,  # pylint: disable=unused-argument
-        request_context: dict[str, str] | None = None,
+        request_context: dict[str, Any] | None = None,
         active_modes: tuple[str, ...] | set[str] = (),
         active_skills: tuple[str, ...] | set[str] = (),
         enabled_features: tuple[str, ...] | set[str] = (),
@@ -66,6 +66,12 @@ class QwenPawLocalWorkspace(AgentScopeLocalWorkspace):
             allowed, denied = self._resolve_config_gates(agent_config)
         else:
             allowed, denied = None, set()
+
+        # Background subagents are deliberately leaves.  Hiding delegation
+        # tools from their schema prevents the model from attempting a nested
+        # call; SubagentTaskManager repeats the check defensively at runtime.
+        if request_context and request_context.get("is_subagent"):
+            denied.update({"spawn_subagent", "cancel_subagent"})
 
         descs = self._tool_registry.filter(
             active_modes=set(active_modes),

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -10,6 +10,7 @@ Each Workspace represents a standalone agent workspace with its own:
 
 Request processing is handled by ``Runtime`` (see ``stream_query``).
 """
+
 import logging
 from pathlib import Path
 from typing import Any, AsyncGenerator, Iterable, Optional
@@ -118,6 +119,11 @@ class Workspace:
     def cron_manager(self):
         """Get cron manager instance from ServiceManager."""
         return self._service_manager.services.get("cron_manager")
+
+    @property
+    def subagent_task_manager(self):
+        """Get the workspace-scoped background subagent manager."""
+        return self._service_manager.services.get("subagent_task_manager")
 
     # Non-service state
     @property
@@ -368,6 +374,22 @@ class Workspace:
                 start_method="start_all",
                 stop_method="stop_all",
                 priority=30,
+                concurrent_init=False,
+            ),
+        )
+
+        # Priority 35: background subagent lifecycle.  Start after channels so
+        # terminal events can be routed through the wakeup bridge.
+        from ..subagents import SubagentTaskManager
+
+        sm.register(
+            ServiceDescriptor(
+                name="subagent_task_manager",
+                service_class=SubagentTaskManager,
+                init_args=lambda ws: {"workspace": ws},
+                start_method="start",
+                stop_method="stop",
+                priority=35,
                 concurrent_init=False,
             ),
         )

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1872,6 +1872,12 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
             ),
             icon="🔀",
         ),
+        "cancel_subagent": BuiltinToolConfig(
+            name="cancel_subagent",
+            enabled=True,
+            description="Cancel a background subagent owned by this session",
+            icon="🛑",
+        ),
     }
 
     # Merge dynamically registered tools from plugins

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -146,7 +146,7 @@ class ToolRegistry:
 
 
 # ---------------------------------------------------------------------------
-# Default registry instance (21 tools)
+# Default registry instance
 # ---------------------------------------------------------------------------
 
 
@@ -198,6 +198,7 @@ def _register_builtin_tools(r: ToolRegistry) -> None:
         ("SubmitToAgent", "agent_id"),
         ("CheckAgentTask", "task_id"),
         ("SpawnSubagent", ""),
+        ("CancelSubagent", "task_id"),
         ("DelegateExternalAgent", "runner"),
         ("MemorySearch", ""),
     ]:
@@ -233,6 +234,7 @@ def _register_python_name_mappings(
         "submit_to_agent": "SubmitToAgent",
         "check_agent_task": "CheckAgentTask",
         "spawn_subagent": "SpawnSubagent",
+        "cancel_subagent": "CancelSubagent",
         "materialize_skill": "MaterializeSkill",
     }
     for py_name, policy_name in mappings.items():

--- a/src/qwenpaw/hooks/error/error_hook.py
+++ b/src/qwenpaw/hooks/error/error_hook.py
@@ -114,6 +114,21 @@ class CancelCleanupHook(LifecycleHook):
                 except Exception:
                     pass
 
+        # A parent request owns the lifetime of its direct background child.
+        # Subagents are leaves, so cancellation never recurses further.
+        manager = getattr(ctx.workspace, "subagent_task_manager", None)
+        if manager is not None:
+            try:
+                await manager.cancel_by_parent(
+                    ctx.session_id,
+                    reason="parent request cancelled",
+                )
+            except Exception:
+                logger.debug(
+                    "cancel_cleanup: subagent cancellation failed",
+                    exc_info=True,
+                )
+
         return HookResult()
 
 

--- a/src/qwenpaw/hooks/session/session_hook.py
+++ b/src/qwenpaw/hooks/session/session_hook.py
@@ -98,7 +98,9 @@ class SessionSaveHook(LifecycleHook):
                 channel=channel,
                 agent=proxy,
             )
+            ctx.extras["session_save_succeeded"] = True
         except Exception:
+            ctx.extras["session_save_succeeded"] = False
             logger.debug("session_save: failed", exc_info=True)
         return HookResult()
 

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -970,6 +970,27 @@ class AgentBuilder:
         if tool_coordinator is None and pruning_middleware is not None:
             mws.append(pruning_middleware)
 
+        # AgentScope 2.0-native subagent lifecycle integration.  The inbox
+        # middleware is always present so an idle parent can be woken with an
+        # empty request and receive child terminal results as HintBlocks.
+        workspace = getattr(ctx, "workspace", None)
+        subagent_manager = (
+            getattr(workspace, "subagent_task_manager", None)
+            if workspace is not None
+            else None
+        )
+        if subagent_manager is not None:
+            from ..app.subagents.middleware import (
+                SubagentInboxMiddleware,
+            )
+
+            mws.append(
+                SubagentInboxMiddleware(
+                    subagent_manager,
+                    ctx.session_id,
+                ),
+            )
+
         # Langfuse tool observability
         try:
             from ..observability.langfuse import is_langfuse_enabled

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -901,7 +901,7 @@ class AgentBuilder:
             agent_id=getattr(agent_config, "id", "default"),
         )
 
-    # pylint: disable=too-many-statements,too-many-branches
+    # pylint: disable-next=too-many-statements,too-many-branches
     @staticmethod
     def _build_middlewares(
         ctx: Any,

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -901,8 +901,8 @@ class AgentBuilder:
             agent_id=getattr(agent_config, "id", "default"),
         )
 
-    # pylint: disable-next=too-many-statements,too-many-branches
     @staticmethod
+    # pylint: disable-next=too-many-statements,too-many-branches
     def _build_middlewares(
         ctx: Any,
         agent_config: Any,

--- a/src/qwenpaw/runtime/commands/control/stop_handler.py
+++ b/src/qwenpaw/runtime/commands/control/stop_handler.py
@@ -61,7 +61,19 @@ class StopCommandHandler(BaseControlCommandHandler):
             user_id=context.user_id,
         )
 
-        if chat_id is None:
+        subagents_cancelled = 0
+        subagent_manager = getattr(
+            workspace,
+            "subagent_task_manager",
+            None,
+        )
+        if subagent_manager is not None:
+            subagents_cancelled = await subagent_manager.cancel_by_parent(
+                target_session_id,
+                reason="parent session stopped with /stop",
+            )
+
+        if chat_id is None and subagents_cancelled == 0:
             logger.warning(
                 f"/stop: No active chat found for "
                 f"session={target_session_id[:30]} channel={channel_id}",
@@ -72,7 +84,11 @@ class StopCommandHandler(BaseControlCommandHandler):
                 f"`{target_session_id[:40]}`."
             )
 
-        stopped = await workspace.task_tracker.request_stop(chat_id)
+        stopped = (
+            await workspace.task_tracker.request_stop(chat_id)
+            if chat_id is not None
+            else False
+        )
 
         cleared = await workspace.channel_manager.clear_queue(
             channel_id,
@@ -80,7 +96,7 @@ class StopCommandHandler(BaseControlCommandHandler):
             20,
         )
 
-        if stopped or cleared > 0:
+        if stopped or cleared > 0 or subagents_cancelled > 0:
             logger.info(
                 f"/stop: stopped={stopped} cleared={cleared} "
                 f"chat_id={chat_id} session={target_session_id[:30]}",
@@ -90,6 +106,10 @@ class StopCommandHandler(BaseControlCommandHandler):
                 status_parts.append("running task stopped")
             if cleared > 0:
                 status_parts.append(f"{cleared} queued message(s) cleared")
+            if subagents_cancelled > 0:
+                status_parts.append(
+                    f"{subagents_cancelled} background subagent(s) cancelled",
+                )
             status_text = " and ".join(status_parts)
             return (
                 f"**Task Stopped**\n\n"

--- a/tests/integration/test_spawn_subagent.py
+++ b/tests/integration/test_spawn_subagent.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+"""End-to-end coverage for background subagent callback wakeup."""
+
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import HTTPServer
+
+import httpx
+import pytest
+
+from tests.integration.helpers import (
+    MOCK_LLM_PROVIDER_ID,
+    MockLLMHandler,
+    register_mock_provider,
+    scoped,
+    unregister_mock_provider,
+)
+
+_HTTP_TIMEOUT = 30.0
+_BACKGROUND_CHILD = "SUBAGENT_E2E_BACKGROUND_CHILD"
+
+
+class _SubagentMockLLMHandler(MockLLMHandler):
+    """Drive parent tool calls and observe child completion delivery."""
+
+    def _stream_completion(self):
+        body = self._read_body()
+        messages_text = json.dumps(
+            body.get("messages", []),
+            ensure_ascii=False,
+        )
+        tools = body.get("tools", [])
+        has_tool_result = any(
+            message.get("role") == "tool"
+            for message in body.get("messages", [])
+        )
+
+        if has_tool_result:
+            if "[TASK_ID:" in messages_text:
+                self.server.background_submission_seen.set()
+            if "BACKGROUND_SUBAGENT_COMPLETED" in messages_text:
+                self.server.background_parent_result_seen.set()
+            self._stream_text("PARENT_RECEIVED_SUBAGENT_RESULT")
+            return
+        if _BACKGROUND_CHILD in messages_text:
+            self.server.background_child_seen.set()
+            self._stream_text("BACKGROUND_SUBAGENT_COMPLETED")
+            return
+        if tools and "RUN_BACKGROUND_SUBAGENT" in messages_text:
+            self.server.tool_call_name = "spawn_subagent"
+            self.server.tool_call_arguments = json.dumps(
+                {
+                    "task": _BACKGROUND_CHILD,
+                    "background": True,
+                },
+            )
+            self._stream_tool_call()
+            return
+
+        self._stream_text("MOCK_AUXILIARY_RESPONSE")
+
+
+@pytest.fixture(scope="module")
+def subagent_mock_llm():
+    server = HTTPServer(("127.0.0.1", 0), _SubagentMockLLMHandler)
+    server.background_child_seen = threading.Event()
+    server.background_submission_seen = threading.Event()
+    server.background_parent_result_seen = threading.Event()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def _run_console_turn(app_server, prompt: str, session_id: str) -> str:
+    url = f"{app_server.base_url}{scoped('default', '/console/chat')}"
+    body = {
+        "input": [
+            {
+                "content": [{"type": "text", "text": prompt}],
+            },
+        ],
+        "user_id": f"user-{session_id}",
+        "session_id": session_id,
+    }
+    chunks: list[str] = []
+    with app_server.client.stream(
+        "POST",
+        url,
+        json=body,
+        timeout=httpx.Timeout(_HTTP_TIMEOUT, read=_HTTP_TIMEOUT),
+    ) as response:
+        assert response.status_code == 200, app_server.logs_tail()
+        chunks.extend(response.iter_lines())
+    return "\n".join(chunks)
+
+
+@pytest.mark.integration
+@pytest.mark.p0
+def test_background_subagent_callback_wakeup_end_to_end(
+    app_server,
+    subagent_mock_llm,
+) -> None:
+    """Run the added background lifecycle through the real Runtime."""
+    server, mock_url = subagent_mock_llm
+    unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
+    register_mock_provider(app_server, mock_url)
+
+    try:
+        background_stream = _run_console_turn(
+            app_server,
+            "RUN_BACKGROUND_SUBAGENT",
+            "spawn-e2e-background",
+        )
+        assert "denied by policy" not in background_stream
+        assert server.background_submission_seen.wait(
+            10,
+        ), app_server.logs_tail()
+        assert server.background_child_seen.wait(10), app_server.logs_tail()
+        assert server.background_parent_result_seen.wait(
+            20,
+        ), app_server.logs_tail()
+    finally:
+        unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -8,6 +8,11 @@ from agentscope.tool import Toolkit
 
 from agentscope.tool import FunctionTool
 from qwenpaw.agents.tools import agent_management
+from qwenpaw.app.subagents.context import (
+    SubagentSpawnContext,
+    reset_subagent_spawn_context,
+    set_subagent_spawn_context,
+)
 
 
 class _FakeResponse:
@@ -391,3 +396,97 @@ async def test_chat_with_agent_returns_clear_error_when_agent_missing(
     )
 
     assert response.content[0].text == "Agent [missing_bot] not exists"
+
+
+async def test_background_spawn_uses_manager_and_forbids_polling():
+    captured = {}
+
+    class _Manager:
+        async def spawn(self, **kwargs):
+            captured.update(kwargs)
+            return type(
+                "Record",
+                (),
+                {"task_id": "subtask-1"},
+            )()
+
+    from qwenpaw.app import agent_context
+
+    agent_context.set_current_agent_id("default")
+    token = set_subagent_spawn_context(
+        SubagentSpawnContext(
+            manager=_Manager(),
+            agent_id="default",
+            session_id="console:parent",
+            root_session_id="console:parent",
+            user_id="parent",
+            channel="console",
+            is_subagent=False,
+        ),
+    )
+    try:
+        response = await agent_management.spawn_subagent(
+            "inspect the repository",
+            background=True,
+        )
+    finally:
+        reset_subagent_spawn_context(token)
+
+    text = response.content[0].text
+    assert captured["parent_session_id"] == "console:parent"
+    assert captured["parent_is_subagent"] is False
+    assert "[TASK_ID: subtask-1]" in text
+    assert "notified automatically" in text
+    assert "Do not call check_agent_task" in text
+
+
+async def test_subagent_cannot_spawn_another_subagent():
+    token = set_subagent_spawn_context(
+        SubagentSpawnContext(
+            manager=object(),
+            agent_id="default",
+            session_id="sub-child",
+            root_session_id="console:parent",
+            user_id="parent",
+            channel="console",
+            is_subagent=True,
+        ),
+    )
+    try:
+        response = await agent_management.spawn_subagent(
+            "try nested delegation",
+            background=False,
+            fork=True,
+        )
+    finally:
+        reset_subagent_spawn_context(token)
+
+    assert "nested subagents are not supported" in response.content[0].text
+
+
+async def test_cancel_subagent_is_scoped_to_parent_session():
+    class _Record:
+        parent_session_id = "console:other"
+
+    class _Manager:
+        async def get(self, _task_id):
+            return _Record()
+
+    token = set_subagent_spawn_context(
+        SubagentSpawnContext(
+            manager=_Manager(),
+            agent_id="default",
+            session_id="console:parent",
+            root_session_id="console:parent",
+            user_id="parent",
+            channel="console",
+        ),
+    )
+    try:
+        response = await agent_management.cancel_subagent("subtask-other")
+    finally:
+        reset_subagent_spawn_context(token)
+
+    assert (
+        "not found for the current parent session" in response.content[0].text
+    )

--- a/tests/unit/app/test_subagent_lifecycle.py
+++ b/tests/unit/app/test_subagent_lifecycle.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+"""Behavioral tests for the AS2-native background subagent lifecycle."""
+
+# pylint: disable=using-constant-test,protected-access
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from agentscope.message import AssistantMsg
+
+from qwenpaw.app.subagents.manager import (
+    SubagentStatus,
+    SubagentTaskManager,
+)
+from qwenpaw.app.subagents.hooks import SubagentWakeGuardHook
+from qwenpaw.app.subagents.middleware import SubagentInboxMiddleware
+from qwenpaw.app.workspace.local_workspace import QwenPawLocalWorkspace
+from qwenpaw.runtime.hooks import HookAction
+from qwenpaw.runtime.tool_registry import ToolDescriptor, ToolRegistry
+
+
+class _ChannelManager:
+    def __init__(self) -> None:
+        self.enqueued = []
+
+    def enqueue(self, channel, request) -> None:
+        self.enqueued.append((channel, request))
+
+
+class _Workspace:
+    def __init__(self, path, stream_factory) -> None:
+        self.workspace_dir = path
+        self.channel_manager = _ChannelManager()
+        self._stream_factory = stream_factory
+
+    async def stream_query(self, request):
+        async for item in self._stream_factory(request):
+            yield item
+
+
+def _completed_message(text: str):
+    return SimpleNamespace(
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(text=text)],
+    )
+
+
+async def _wait_terminal(manager, task_id, timeout=1.0):
+    async with asyncio.timeout(timeout):
+        while True:
+            record = await manager.get(task_id)
+            if record is not None and record.status in {
+                SubagentStatus.COMPLETED,
+                SubagentStatus.FAILED,
+                SubagentStatus.CANCELLED,
+            }:
+                return record
+            await asyncio.sleep(0.005)
+
+
+async def _spawn(manager, **overrides):
+    params = {
+        "prompt": "research the issue",
+        "parent_agent_id": "default",
+        "parent_session_id": "console:parent",
+        "root_session_id": "console:parent",
+        "child_agent_id": "default",
+        "child_session_id": "sub-child",
+        "user_id": "parent",
+        "channel": "console",
+        "channel_meta": {"session_id": "console:parent"},
+        "parent_is_subagent": False,
+    }
+    params.update(overrides)
+    return await manager.spawn(**params)
+
+
+@pytest.mark.asyncio
+async def test_completion_publishes_event_and_wakes_parent(tmp_path):
+    async def stream(_request):
+        yield _completed_message("child summary")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+
+    record = await _spawn(manager)
+    terminal = await _wait_terminal(manager, record.task_id)
+
+    assert terminal.status == SubagentStatus.COMPLETED
+    assert terminal.result == "child summary"
+    assert len(workspace.channel_manager.enqueued) == 1
+    channel, request = workspace.channel_manager.enqueued[0]
+    assert channel == "console"
+    assert request.session_id == "console:parent"
+    assert request.input == []
+    assert request.request_context["subagent_wakeup"] is True
+
+    events = await manager.drain_events("console:parent")
+    assert [event.status for event in events] == [SubagentStatus.COMPLETED]
+    assert events[0].result == "child summary"
+    assert not await manager.has_pending_events("console:parent")
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_parent_agents_with_same_session_are_workspace_isolated(
+    tmp_path,
+):
+    async def stream_a(_request):
+        yield _completed_message("result-a")
+
+    async def stream_b(_request):
+        yield _completed_message("result-b")
+
+    manager_a = SubagentTaskManager(_Workspace(tmp_path / "a", stream_a))
+    manager_b = SubagentTaskManager(_Workspace(tmp_path / "b", stream_b))
+    assert manager_a.max_running_per_parent == 8
+
+    record_a = await _spawn(manager_a, parent_agent_id="agent-a")
+    record_b = await _spawn(manager_b, parent_agent_id="agent-b")
+    await _wait_terminal(manager_a, record_a.task_id)
+    await _wait_terminal(manager_b, record_b.task_id)
+
+    events_a = await manager_a.drain_events("console:parent")
+    events_b = await manager_b.drain_events("console:parent")
+    assert [event.result for event in events_a] == ["result-a"]
+    assert [event.result for event in events_b] == ["result-b"]
+
+
+@pytest.mark.asyncio
+async def test_wakeup_waits_for_active_parent_and_avoids_session_race(
+    tmp_path,
+):
+    async def stream(_request):
+        yield _completed_message("child summary")
+
+    class _Chats:
+        async def get_chat_id_by_session(self, _session_id, _channel):
+            return "chat-1"
+
+    class _Tracker:
+        running = True
+
+        async def get_status(self, _chat_id):
+            return "running" if self.running else "idle"
+
+    workspace = _Workspace(tmp_path, stream)
+    workspace.chat_manager = _Chats()
+    workspace.task_tracker = _Tracker()
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+
+    record = await _spawn(manager)
+    await _wait_terminal(manager, record.task_id)
+    await asyncio.sleep(0.02)
+    assert not workspace.channel_manager.enqueued
+
+    workspace.task_tracker.running = False
+    await asyncio.wait_for(record.asyncio_task, timeout=1)
+    assert len(workspace.channel_manager.enqueued) == 1
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_long_running_child_is_not_cancelled_by_elapsed_time(tmp_path):
+    release = asyncio.Event()
+
+    async def stream(_request):
+        await release.wait()
+        yield {"output": "done"}
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+    record = await _spawn(manager)
+
+    # Elapsed wall time alone must never terminate a healthy background
+    # subagent. It runs until completion or an explicit lifecycle cancel.
+    await asyncio.sleep(0.05)
+    running = await manager.get(record.task_id)
+    assert running is not None
+    assert running.status == SubagentStatus.RUNNING
+    assert not record.asyncio_task.done()
+
+    release.set()
+    terminal = await _wait_terminal(manager, record.task_id)
+    assert terminal.status == SubagentStatus.COMPLETED
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loss_cancels_child_and_notifies_parent(tmp_path):
+    started = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        await asyncio.Event().wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        heartbeat_timeout_seconds=10,
+    )
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert (
+        await manager._watchdog_tick(
+            record.last_heartbeat_at + 10,
+        )
+        == []
+    )
+    assert record.status == SubagentStatus.CANCELLING
+
+    terminal = await _wait_terminal(manager, record.task_id)
+    assert terminal.status == SubagentStatus.CANCELLED
+    assert "heartbeat lost" in (terminal.error or "")
+    events = await manager.drain_events("console:parent")
+    assert [event.status for event in events] == [
+        SubagentStatus.CANCELLED,
+    ]
+    assert len(workspace.channel_manager.enqueued) == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_resistant_child_becomes_stale_once_then_completes(
+    tmp_path,
+):
+    started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+        await release.wait()
+        yield _completed_message("recovered result")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        heartbeat_timeout_seconds=10,
+        cancel_grace_seconds=5,
+    )
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    await manager._watchdog_tick(record.last_heartbeat_at + 10)
+    await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+    requested_at = record.cancel_requested_at
+    assert requested_at is not None
+
+    newly_stale = await manager._watchdog_tick(requested_at + 5)
+    assert newly_stale == [record]
+    for stale_record in newly_stale:
+        manager._schedule_parent_wakeup(stale_record)
+    await asyncio.sleep(0)
+    assert record.status == SubagentStatus.STALE
+    assert await manager._watchdog_tick(requested_at + 10) == []
+    assert len(workspace.channel_manager.enqueued) == 1
+
+    stale_events = await manager.drain_events("console:parent")
+    assert [event.status for event in stale_events] == [SubagentStatus.STALE]
+    # STALE is non-terminal: the handle and concurrency ownership remain.
+    assert await manager.get(record.task_id) is record
+
+    release.set()
+    terminal = await _wait_terminal(manager, record.task_id)
+    assert terminal.status == SubagentStatus.COMPLETED
+    completed_events = await manager.drain_events("console:parent")
+    assert [event.status for event in completed_events] == [
+        SubagentStatus.COMPLETED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_loop_pause_renews_leases_instead_of_killing(tmp_path):
+    gate = asyncio.Event()
+
+    async def stream(_request):
+        await gate.wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    record = await _spawn(manager)
+    await asyncio.sleep(0)
+
+    resumed_at = record.last_heartbeat_at + 1000
+    await manager._reset_leases_after_loop_pause(resumed_at)
+    assert record.last_heartbeat_at == resumed_at
+    assert record.status == SubagentStatus.RUNNING
+    assert not record.asyncio_task.done()
+
+    await manager.cancel_task(record.task_id, notify_parent=False)
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_parent_kill_suppresses_stale_and_late_completion(tmp_path):
+    started = asyncio.Event()
+    cancellation_seen = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stream(_request):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+        await release.wait()
+        yield _completed_message("too late")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace, cancel_grace_seconds=5)
+    record = await _spawn(manager)
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    assert await manager.cancel_by_parent("console:parent") == 1
+    await asyncio.wait_for(cancellation_seen.wait(), timeout=1)
+    requested_at = record.cancel_requested_at
+    assert requested_at is not None
+    assert await manager.cancel_by_parent("console:parent") == 0
+    assert record.cancel_requested_at == requested_at
+    assert await manager._watchdog_tick(requested_at + 5) == []
+    assert record.status == SubagentStatus.STALE
+    assert not await manager.has_pending_events("console:parent")
+
+    release.set()
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+    assert not await manager.has_pending_events("console:parent")
+    assert not workspace.channel_manager.enqueued
+
+
+@pytest.mark.asyncio
+async def test_concurrency_guard_and_nested_subagent_rejection(tmp_path):
+    gate = asyncio.Event()
+
+    async def stream(_request):
+        await gate.wait()
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(
+        workspace,
+        max_running_per_parent=1,
+    )
+    await manager.start()
+    first = await _spawn(manager)
+
+    with pytest.raises(RuntimeError, match="limit reached"):
+        await _spawn(manager, child_session_id="sub-second")
+    with pytest.raises(ValueError, match="nested subagents are not supported"):
+        await _spawn(
+            manager,
+            parent_session_id="different-parent",
+            child_session_id="sub-nested",
+            parent_is_subagent=True,
+        )
+
+    await manager.cancel_task(first.task_id)
+    await _wait_terminal(manager, first.task_id)
+    await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_inbox_middleware_injects_hint_once(tmp_path):
+    async def stream(_request):
+        yield _completed_message("useful result")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    await manager.start()
+    record = await _spawn(manager)
+    await _wait_terminal(manager, record.task_id)
+
+    agent = SimpleNamespace(
+        name="QwenPaw",
+        state=SimpleNamespace(
+            # AS2 owns an internal session id that is intentionally distinct
+            # from QwenPaw's routing/session id.
+            session_id="as2-internal-session",
+            reply_id="reply-1",
+            context=[AssistantMsg("QwenPaw", "parent context")],
+        ),
+    )
+
+    async def downstream(**_kwargs):
+        yield "model-event"
+
+    middleware = SubagentInboxMiddleware(manager, "console:parent")
+    output = [
+        item
+        async for item in middleware.on_reasoning(
+            agent,
+            {"tool_choice": None},
+            downstream,
+        )
+    ]
+
+    assert output[-1] == "model-event"
+    hint = agent.state.context[-1].content[-1]
+    assert "useful result" in hint.hint
+    assert "Do not call a polling" in hint.hint
+    claim_id = agent._qwenpaw_subagent_event_claim_id
+    assert await manager.has_pending_events("console:parent")
+    assert await manager.ack_events(claim_id) == 1
+    assert not await manager.has_pending_events("console:parent")
+    assert await manager.get(record.task_id) is None
+    await manager.stop()
+
+
+def test_channel_metadata_filters_secrets_and_runtime_objects():
+    safe = SubagentTaskManager._routing_meta(
+        {
+            "channel_id": "123",
+            "session_webhook": "https://secret.example",
+            "access_token": "secret",
+            "reply_future": object(),
+        },
+    )
+    assert safe == {"channel_id": "123"}
+
+
+@pytest.mark.asyncio
+async def test_wakeup_guard_keeps_event_while_parent_waits_for_approval():
+    class _Manager:
+        async def has_pending_events(self, _session_id):
+            return True
+
+    from agentscope.message import ToolCallState
+
+    last = SimpleNamespace(
+        get_content_blocks=lambda _kind: [
+            SimpleNamespace(state=ToolCallState.ASKING),
+        ],
+    )
+    ctx = SimpleNamespace(
+        request=SimpleNamespace(
+            request_context={"subagent_wakeup": True},
+        ),
+        workspace=SimpleNamespace(subagent_task_manager=_Manager()),
+        session_id="console:parent",
+        agent=SimpleNamespace(
+            state=SimpleNamespace(context=[last]),
+        ),
+    )
+
+    result = await SubagentWakeGuardHook().run(ctx)
+
+    assert result.action == HookAction.SKIP_AGENT
+
+
+@pytest.mark.asyncio
+async def test_subagent_toolkit_hides_delegation_tools(tmp_path):
+    registry = ToolRegistry()
+
+    async def spawn_subagent():
+        return None
+
+    async def cancel_subagent():
+        return None
+
+    async def read_file():
+        return None
+
+    for tool in (spawn_subagent, cancel_subagent, read_file):
+        registry.register(ToolDescriptor(name=tool.__name__, func=tool))
+    workspace = QwenPawLocalWorkspace(
+        tool_registry=registry,
+        workdir=str(tmp_path),
+        workspace_id="default",
+        default_mcps=[],
+        skill_paths=[],
+    )
+
+    tools = await workspace.list_tools(
+        request_context={"is_subagent": True},
+    )
+    names = {tool.name for tool in tools}
+
+    assert names == {"read_file"}

--- a/tests/unit/app/test_subagent_lifecycle.py
+++ b/tests/unit/app/test_subagent_lifecycle.py
@@ -15,7 +15,10 @@ from qwenpaw.app.subagents.manager import (
     SubagentStatus,
     SubagentTaskManager,
 )
-from qwenpaw.app.subagents.hooks import SubagentWakeGuardHook
+from qwenpaw.app.subagents.hooks import (
+    SubagentEventAckHook,
+    SubagentWakeGuardHook,
+)
 from qwenpaw.app.subagents.middleware import SubagentInboxMiddleware
 from qwenpaw.app.workspace.local_workspace import QwenPawLocalWorkspace
 from qwenpaw.runtime.hooks import HookAction
@@ -308,6 +311,118 @@ async def test_watchdog_loop_pause_renews_leases_instead_of_killing(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_watchdog_loop_survives_one_tick_failure(tmp_path):
+    async def stream(_request):
+        if False:
+            yield None
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace, watchdog_interval_seconds=0.01)
+    ticked_after_failure = asyncio.Event()
+    calls = 0
+
+    async def failing_once(_now):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("transient tick failure")
+        ticked_after_failure.set()
+        return []
+
+    manager._watchdog_tick = failing_once
+    task = asyncio.create_task(manager._watchdog_loop())
+    await asyncio.wait_for(ticked_after_failure.wait(), timeout=1)
+
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    assert calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_parent_wakeup_timeout_leaves_event_in_inbox(tmp_path):
+    async def stream(_request):
+        await asyncio.Event().wait()
+        if False:
+            yield None
+
+    class _ChatManager:
+        async def get_chat_id_by_session(self, _session_id, _channel):
+            return "chat-1"
+
+    class _TaskTracker:
+        async def get_status(self, _chat_id):
+            return "running"
+
+    workspace = _Workspace(tmp_path, stream)
+    workspace.chat_manager = _ChatManager()
+    workspace.task_tracker = _TaskTracker()
+    manager = SubagentTaskManager(
+        workspace,
+        parent_wakeup_wait_timeout_seconds=0,
+        parent_wakeup_retry_interval_seconds=60,
+    )
+    record = await _spawn(manager)
+    async with manager._lock:
+        manager._append_lifecycle_event_locked(record)
+
+    await manager._enqueue_parent_wakeup(record)
+
+    assert await manager.has_pending_events("console:parent")
+    assert not workspace.channel_manager.enqueued
+    assert manager._wakeup_retry_parents == {"console:parent"}
+    await manager.stop()
+    await manager.cancel_task(record.task_id, notify_parent=False)
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_parent_wakeup_retry_enqueues_after_parent_becomes_idle(
+    tmp_path,
+):
+    async def stream(_request):
+        await asyncio.Event().wait()
+        if False:
+            yield None
+
+    class _ChatManager:
+        async def get_chat_id_by_session(self, _session_id, _channel):
+            return "chat-1"
+
+    class _TaskTracker:
+        def __init__(self) -> None:
+            self.statuses = ["running", "idle"]
+
+        async def get_status(self, _chat_id):
+            if self.statuses:
+                return self.statuses.pop(0)
+            return "idle"
+
+    workspace = _Workspace(tmp_path, stream)
+    workspace.chat_manager = _ChatManager()
+    workspace.task_tracker = _TaskTracker()
+    manager = SubagentTaskManager(
+        workspace,
+        parent_wakeup_wait_timeout_seconds=0,
+        parent_wakeup_retry_interval_seconds=0.01,
+    )
+    record = await _spawn(manager)
+    async with manager._lock:
+        manager._append_lifecycle_event_locked(record)
+
+    await manager._enqueue_parent_wakeup(record)
+    async with asyncio.timeout(1):
+        while not workspace.channel_manager.enqueued:
+            await asyncio.sleep(0.005)
+
+    assert workspace.channel_manager.enqueued[0][1].session_id == (
+        "console:parent"
+    )
+    await manager.stop()
+    await manager.cancel_task(record.task_id, notify_parent=False)
+    await asyncio.gather(record.asyncio_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_parent_kill_suppresses_stale_and_late_completion(tmp_path):
     started = asyncio.Event()
     cancellation_seen = asyncio.Event()
@@ -420,6 +535,54 @@ async def test_inbox_middleware_injects_hint_once(tmp_path):
     assert not await manager.has_pending_events("console:parent")
     assert await manager.get(record.task_id) is None
     await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_inbox_middleware_acks_multiple_claims_from_one_run(tmp_path):
+    async def stream(_request):
+        yield _completed_message("first result")
+
+    workspace = _Workspace(tmp_path, stream)
+    manager = SubagentTaskManager(workspace)
+    first = await _spawn(manager)
+    await _wait_terminal(manager, first.task_id)
+
+    agent = SimpleNamespace(
+        name="QwenPaw",
+        state=SimpleNamespace(
+            reply_id="reply-1",
+            context=[],
+        ),
+    )
+
+    async def downstream(**_kwargs):
+        yield "model-event"
+
+    middleware = SubagentInboxMiddleware(manager, "console:parent")
+    _ = [item async for item in middleware.on_reasoning(agent, {}, downstream)]
+
+    async def stream_second(_request):
+        yield _completed_message("second result")
+
+    workspace._stream_factory = stream_second
+    second = await _spawn(manager, child_session_id="sub-second")
+    await _wait_terminal(manager, second.task_id)
+    agent.state.reply_id = "reply-2"
+    _ = [item async for item in middleware.on_reasoning(agent, {}, downstream)]
+
+    assert len(agent._qwenpaw_subagent_event_claim_ids) == 2
+    ctx = SimpleNamespace(
+        extras={"session_save_succeeded": True},
+        workspace=SimpleNamespace(subagent_task_manager=manager),
+        agent=agent,
+    )
+    await SubagentEventAckHook().run(ctx)
+
+    assert not await manager.has_pending_events("console:parent")
+    assert await manager.get(first.task_id) is None
+    assert await manager.get(second.task_id) is None
+    assert not hasattr(agent, "_qwenpaw_subagent_event_claim_id")
+    assert not hasattr(agent, "_qwenpaw_subagent_event_claim_ids")
 
 
 def test_channel_metadata_filters_secrets_and_runtime_objects():

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -634,6 +634,30 @@ class TestConsoleStreaming:
         ):
             await stream_channel.consume_one({"test": "payload"})
 
+    async def test_subagent_wakeup_uses_console_push_path(
+        self,
+        stream_channel,
+    ):
+        """A detached wake has no SSE client, so use BaseChannel send."""
+        from types import SimpleNamespace
+        from unittest.mock import patch, AsyncMock
+
+        payload = SimpleNamespace(
+            request_context={"subagent_wakeup": True},
+        )
+        with (
+            patch.object(
+                stream_channel,
+                "_consume_one_request",
+                new_callable=AsyncMock,
+            ) as consume_request,
+            patch.object(stream_channel, "stream_one") as stream_one,
+        ):
+            await stream_channel.consume_one(payload)
+
+        consume_request.assert_awaited_once_with(payload)
+        stream_one.assert_not_called()
+
 
 # =============================================================================
 # P2: Console Media Handling


### PR DESCRIPTION
## Summary

This PR changes `spawn_subagent(background=True)` from a polling-based task
into an event-driven child lifecycle. A background child returns immediately,
runs independently, and wakes its parent with the result when it finishes.

It also adds heartbeat detection, parent-to-child cancellation, per-parent
concurrency limits, and reliable event delivery. Healthy long-running children
have no total runtime timeout, and nested subagents are intentionally disabled.

Fixes https://github.com/agentscope-ai/QwenPaw/issues/4873.

## What Problem This Solves

Background subagents currently rely on parent-side polling to discover completion. That wastes turns, cannot reliably wake an idle parent, and leaves cancellation, heartbeat loss, ownership, and callback delivery spread across unrelated runtime paths. This change adds a workspace-scoped lifecycle manager so a background child returns immediately, runs independently, and delivers a terminal result back to its owning parent session without a polling loop.

## Evidence

- Post-rebase focused lifecycle, agent-management, Console, and integration suites pass: 64 passed in 21.19s.
- `git diff --check` passes against official `origin/main` at `af13614c`.
- The manual runtime captures below show that background children start without `check_agent_task` polling and that completion wakes the parent and delivers the result automatically.
- The lifecycle tests cover callback claiming/acknowledgement, retry after save failure, heartbeat expiry, cancellation propagation, parent isolation, concurrency limits, stale-task handling, and nested-subagent rejection.

## Upstream basis

This PR is rebased on the latest official `main`, including the official
Runtime 2.0 `spawn_subagent` and generic background-chat implementation merged
in https://github.com/agentscope-ai/QwenPaw/pull/5660. It does not replace or
duplicate those routes; it adds subagent-specific parent/child lifecycle
behavior on top.

## Summary of changes

### 1. Build on the official Runtime 2.0 background-task path

- Reuse the official `spawn_subagent` tool descriptor and governance target.
- Reuse the official `/console/chat/task` routes and `_bg_tasks` store for
  generic background agent chat (`submit_to_agent`).
- Keep foreground response selection and generic background behavior from the
  upstream implementation.
- Add only the `CancelSubagent` governance entry and subagent-specific
  lifecycle integration required by the sections below.

### 2. Add a workspace-scoped background subagent manager

`SubagentTaskManager` owns only background subagents; it is not a new generic
task framework. Each Workspace has one manager and one watchdog.

It tracks:

- parent/root/child agent and session identities;
- the real `asyncio.Task` handle;
- lifecycle state, result/error, heartbeat lease, cancellation reason, and
  optional fork branch;
- terminal/stale events waiting for the parent session.

Lifecycle states:

```text
SUBMITTED -> RUNNING -> COMPLETED
                     -> FAILED
                     -> CANCELLING -> CANCELLED
                                   -> STALE -> eventual real terminal state
```

`STALE` is deliberately non-terminal. It means cooperative cancellation did
not finish within the grace period; the task handle and concurrency slot are
retained instead of pretending the child was killed.

### 3. Replace polling with callback wakeup

For `spawn_subagent(background=True)`:

- run the child through the existing `workspace.stream_query` Runtime path;
- return `[TASK_ID]` and `[SESSION]` immediately;
- tell the model not to poll or sleep;
- publish a terminal/stale event into the parent-session inbox;
- wait for an active parent run to become idle, then wake an idle parent via
  `ChannelManager.enqueue`;
- inject child results before parent reasoning as AgentScope 2.0
  `HintBlock`/`HintBlockEvent` values;
- acknowledge events only after parent session persistence succeeds;
- release a claim on failure so a later run can retry delivery.

`check_agent_task` remains available as a manual/debug fallback. It is no
longer the normal coordination mechanism for background subagents.

### 4. Add heartbeat and watchdog semantics

- Reuse QwenPaw's existing Runtime heartbeat envelope; do not create a
  per-child heartbeat task.
- Runtime heartbeat interval: 25 seconds.
- Missing-heartbeat threshold: four intervals (about 100 seconds).
- Cancellation grace period: 10 seconds.
- No total runtime limit for background subagents. The `timeout` argument is
  ignored in background mode; model/tool/network operations retain their own
  timeouts.
- If the watchdog itself is delayed by event-loop suspension, refresh leases
  instead of mass-cancelling healthy children.

### 5. Add ownership, cancellation, and isolation

- Add `cancel_subagent(task_id)`; only the creating parent session can cancel
  its child.
- Console stop, `/stop`, Runtime cancellation, and Workspace shutdown cancel
  linked children.
- Parent termination discards pending child callbacks and suppresses late
  wakeups.
- Limit each parent session to eight non-terminal background children.
- Managers are Workspace-scoped, so different agents cannot mix records or
  events even if session IDs happen to match.
- Background subagents are leaf nodes: nested `spawn_subagent` calls are
  rejected and delegation tools are hidden from the child toolkit.
- Channel metadata is filtered before reuse so tokens, secrets, callbacks,
  and runtime-only objects are not copied into child routing metadata.

### 6. Keep foreground and generic background behavior compatible

- `spawn_subagent(background=False)` keeps the existing synchronous path and
  foreground timeout semantics from the official implementation.
- Forked foreground behavior remains unchanged.
- Forked background children use the same lifecycle manager and report the
  worktree branch in the parent notification.
- `submit_to_agent` continues to use the generic Console background task plus
  `check_agent_task`; this PR changes only background subagent coordination.

## AgentScope 2.0 integration

The implementation reuses AgentScope/QwenPaw extension points rather than
patching AgentScope internals:

- `MiddlewareBase.on_reasoning` for inbox delivery;
- `HintBlock` and `HintBlockEvent` for lifecycle notifications;
- existing Runtime `stream_query` and heartbeat envelopes;
- QwenPaw lifecycle hooks for request-local context and post-save ack;
- Workspace `ServiceManager` for manager startup/shutdown;
- existing `ChannelManager` for parent wakeup.

QwenPaw's normal Runtime does not run the full `agentscope.app` service stack,
so AgentScope's distributed `BackgroundTaskManager`/wakeup dispatcher cannot
be used directly here. The new manager is a small in-process adapter for
subagent-specific parent/child semantics, not a replacement for that stack.

## Expected behavior

| Scenario | Expected result |
| --- | --- |
| Foreground child | Parent blocks and receives the final child result as before. |
| Healthy long background task | Continues indefinitely while Runtime heartbeats arrive. |
| Background completion/failure | Parent receives a HintBlock and is automatically woken if idle. |
| Parent is already running | Wakeup waits; the active run may consume the event on its next reasoning step. |
| Delivery/session save fails | Event claim is released and remains available for retry. |
| Parent stop/cancel | Direct children are cancelled and no late callback re-wakes the parent. |
| Heartbeat disappears | Child is cancelled; parent receives CANCELLED or one STALE event if cancellation does not finish. |
| Event loop pauses | Leases are refreshed; children are not falsely killed in bulk. |
| Ninth child from one parent | Spawn is rejected until one of the eight non-terminal children exits. |
| Different parent/Workspace | Tasks and notifications remain isolated. |
| Child attempts nested spawn | Tool is hidden and runtime validation rejects the call. |

## Files

### New runtime package

- `src/qwenpaw/app/subagents/__init__.py`
- `src/qwenpaw/app/subagents/context.py`
- `src/qwenpaw/app/subagents/hooks.py`
- `src/qwenpaw/app/subagents/manager.py`
- `src/qwenpaw/app/subagents/middleware.py`

### Modified production files

- `src/qwenpaw/agents/tools/agent_management.py`
- `src/qwenpaw/agents/tools/__init__.py`
- `src/qwenpaw/app/_app.py`
- `src/qwenpaw/app/workspace/workspace.py`
- `src/qwenpaw/app/workspace/local_workspace.py`
- `src/qwenpaw/runtime/builder.py`
- `src/qwenpaw/runtime/commands/control/stop_handler.py`
- `src/qwenpaw/app/routers/console.py`
- `src/qwenpaw/app/channels/console/channel.py`
- `src/qwenpaw/hooks/error/error_hook.py`
- `src/qwenpaw/hooks/session/session_hook.py`
- `src/qwenpaw/config/config.py`
- `src/qwenpaw/governance/tool_registry.py`

### Tests

- `tests/unit/app/test_subagent_lifecycle.py`
- `tests/integration/test_spawn_subagent.py`
- `tests/unit/agents/tools/test_agent_management.py`
- `tests/unit/channels/test_console.py`
- `tests/unit/governance/test_policy.py`

## Verification

Against official `origin/main` commit
`af13614c`:

```text
Focused subagent lifecycle, agent-management, Console, and integration suites:
64 passed in 21.19s

git diff --check:
passed
```

The full repository test suite and `pre-commit run --all-files` have not been
run in this verification pass.

### Manual runtime verification

**1. Background subagents start without a `check_agent_task` polling loop**

<img width="856" height="470" alt="WDjMvcgAQ3" src="https://github.com/user-attachments/assets/f5a2345e-8b34-4c98-b194-2c0571e1a744" />

**2. Child completion wakes the parent and delivers the result automatically**

<img width="822" height="636" alt="XDGghYqM3l" src="https://github.com/user-attachments/assets/990fdf65-efba-41d1-9393-1daf05d09347" />

## Scope and known limitations

- Lifecycle records and inbox events are in memory. Process restart does not
  resume children or recover undelivered callbacks.
- This targets QwenPaw's current single-process Workspace model; it is not a
  distributed queue or persistent task scheduler.
- `asyncio.Task.cancel()` is cooperative. A child stuck in non-interruptible
  synchronous code may remain `STALE`; process/tool-level cleanup remains the
  tool runner's responsibility.
- Only one subagent level is supported intentionally.
- Heartbeats are liveness signals, not semantic progress reports.
- Terminal records are retained until delivery is acknowledged (or the parent
  is stopped/Workspace shuts down), prioritizing reliable delivery over TTL
  eviction. A future persistent/distributed implementation should add durable
  retention and cleanup policy.

## Rebase and conflict-resolution note

This branch was rebased after the official Runtime 2.0 fix landed in #5660.
The duplicated #5524 commits, legacy `_CHAT_TASKS` store, duplicate background
routes, and obsolete tests for that store were removed. The remaining changes
are the parent/child manager, heartbeat watchdog, HintBlock delivery, callback
wakeup, cancellation propagation, one-level restriction, and no-polling
behavior.