### PR TITLE
fix: add coding mode project_dir as rw

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -487,6 +487,12 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         action=GovernanceAction.ALLOW,
         reason="Scratch directory access for tmp",
     ),
+    # Coding Mode, project dir
+    GovernanceRule(
+        match="*(CODING_PROJECT_DIR/**)",
+        action=GovernanceAction.ALLOW,
+        reason="Coding project dir",
+    ),
 ]
 
 
@@ -908,27 +914,30 @@ def _findings_source(findings: list[Any]) -> str:
 def load_governance_policy(
     policy_dir: str,
     workspace_dir: str,
+    coding_project_dir: str = "",
 ) -> GovernancePolicy:
     """Load from policy_dir/policy.yaml; return default policy if missing.
 
     Args:
         policy_dir: directory containing policy.yaml
         workspace_dir: used to replace WORKSPACE_DIR placeholders in rules
+        coding_project_dir: used to replace CODING_PROJECT_DIR placeholders
+            in rules; defaults to ``workspace_dir`` when empty
 
     Supports both v1.0 and v2.0 YAML formats.
     """
     path = Path(policy_dir) / "policy.yaml"
     if not path.exists():
-        return _create_default_policy(workspace_dir)
+        return _create_default_policy(workspace_dir, coding_project_dir)
 
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except Exception:
-        return _create_default_policy(workspace_dir)
+        return _create_default_policy(workspace_dir, coding_project_dir)
 
     if not isinstance(data, dict):
-        return _create_default_policy(workspace_dir)
+        return _create_default_policy(workspace_dir, coding_project_dir)
 
     version = data.get("version", "1.0")
     audit_level = data.get("audit_level", "all")
@@ -984,10 +993,11 @@ def load_governance_policy(
         data.get("detection_rules", []),
     )
 
-    # ── Replace WORKSPACE_DIR with actual path ──
+    # ── Replace WORKSPACE_DIR / CODING_PROJECT_DIR with actual paths ──
+    cpd = coding_project_dir or workspace_dir
     if workspace_dir:
-        _resolve_workspace_dir(builtin_rules, workspace_dir)
-        _resolve_workspace_dir(user_rules, workspace_dir)
+        _resolve_placeholders(builtin_rules, workspace_dir, cpd)
+        _resolve_placeholders(user_rules, workspace_dir, cpd)
 
     return GovernancePolicy(
         version=version,
@@ -1006,6 +1016,7 @@ def save_governance_policy(
     policy: GovernancePolicy,
     policy_dir: str,
     workspace_dir: str = "",
+    coding_project_dir: str = "",
 ) -> None:
     """Write policy.yaml (v2.0 format).
 
@@ -1014,14 +1025,17 @@ def save_governance_policy(
         policy_dir: directory to write policy.yaml
         workspace_dir: workspace path, used to restore actual paths back to
                        WORKSPACE_DIR placeholders (keeps yaml portable)
+        coding_project_dir: coding project path, used to restore actual
+                       paths back to CODING_PROJECT_DIR placeholders
     """
     builtin_rules = copy.deepcopy(policy.builtin_rules)
     user_rules = copy.deepcopy(policy.user_rules)
 
-    # ── Restore actual paths to WORKSPACE_DIR placeholders ──
+    # ── Restore actual paths to WORKSPACE_DIR / CODING_PROJECT_DIR ──
     if workspace_dir:
-        _unresolve_workspace_dir(builtin_rules, workspace_dir)
-        _unresolve_workspace_dir(user_rules, workspace_dir)
+        cpd = coding_project_dir or workspace_dir
+        _unresolve_placeholders(builtin_rules, workspace_dir, cpd)
+        _unresolve_placeholders(user_rules, workspace_dir, cpd)
 
     path = Path(policy_dir) / "policy.yaml"
     # NOTE: builtin_rules are NOT written to YAML. They are always loaded
@@ -1088,13 +1102,17 @@ _DEFAULT_SENSITIVE_PATHS: List[str] = [
 ]
 
 
-def _create_default_policy(workspace_dir: str = "") -> GovernancePolicy:
+def _create_default_policy(
+    workspace_dir: str = "",
+    coding_project_dir: str = "",
+) -> GovernancePolicy:
     """Create a policy with full default rules (cold start, v2.0)."""
     builtin_rules = copy.deepcopy(DEFAULT_BUILTIN_RULES)
     user_rules = copy.deepcopy(DEFAULT_USER_RULES)
     if workspace_dir:
-        _resolve_workspace_dir(builtin_rules, workspace_dir)
-        _resolve_workspace_dir(user_rules, workspace_dir)
+        cpd = coding_project_dir or workspace_dir
+        _resolve_placeholders(builtin_rules, workspace_dir, cpd)
+        _resolve_placeholders(user_rules, workspace_dir, cpd)
     return GovernancePolicy(
         version="2.0",
         builtin_rules=builtin_rules,
@@ -1106,17 +1124,47 @@ def _create_default_policy(workspace_dir: str = "") -> GovernancePolicy:
     )
 
 
-def _resolve_workspace_dir(rules: List[GovernanceRule], workspace_dir: str):
-    """Replace WORKSPACE_DIR in rules with actual paths (in-place)."""
+def _resolve_placeholders(
+    rules: List[GovernanceRule],
+    workspace_dir: str,
+    coding_project_dir: str = "",
+):
+    """Replace WORKSPACE_DIR / CODING_PROJECT_DIR placeholders in rules
+    with the actual paths (in-place)."""
     for rule in rules:
-        if "WORKSPACE_DIR" in rule.match:
+        if workspace_dir and "WORKSPACE_DIR" in rule.match:
             rule.match = rule.match.replace("WORKSPACE_DIR", workspace_dir)
+        if coding_project_dir and "CODING_PROJECT_DIR" in rule.match:
+            rule.match = rule.match.replace(
+                "CODING_PROJECT_DIR",
+                coding_project_dir,
+            )
 
 
-def _unresolve_workspace_dir(rules: List[GovernanceRule], workspace_dir: str):
-    """Restore actual paths in rules back to WORKSPACE_DIR placeholders."""
+def _unresolve_placeholders(
+    rules: List[GovernanceRule],
+    workspace_dir: str,
+    coding_project_dir: str = "",
+):
+    """Restore actual paths in rules back to WORKSPACE_DIR /
+    CODING_PROJECT_DIR placeholders (in-place).
+
+    When ``coding_project_dir`` coincides with ``workspace_dir`` the two
+    cannot be distinguished in an already-resolved pattern, so the shared
+    path is restored as ``WORKSPACE_DIR`` (the coding dir is still covered
+    by the workspace rules in that case).
+    """
     for rule in rules:
-        if workspace_dir in rule.match:
+        if (
+            coding_project_dir
+            and coding_project_dir != workspace_dir
+            and coding_project_dir in rule.match
+        ):
+            rule.match = rule.match.replace(
+                coding_project_dir,
+                "CODING_PROJECT_DIR",
+            )
+        if workspace_dir and workspace_dir in rule.match:
             rule.match = rule.match.replace(workspace_dir, "WORKSPACE_DIR")
 
 

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -1154,18 +1154,19 @@ def _unresolve_placeholders(
     path is restored as ``WORKSPACE_DIR`` (the coding dir is still covered
     by the workspace rules in that case).
     """
+    # Build (actual_path, placeholder) pairs, longest path first.
+    # avoiding CODING_PROJECT_DIR is substring of WORKSPACE_DIR
+    pairs: list[tuple[str, str]] = []
+    if coding_project_dir and coding_project_dir != workspace_dir:
+        pairs.append((coding_project_dir, "CODING_PROJECT_DIR"))
+    if workspace_dir:
+        pairs.append((workspace_dir, "WORKSPACE_DIR"))
+    pairs.sort(key=lambda pair: len(pair[0]), reverse=True)
+
     for rule in rules:
-        if (
-            coding_project_dir
-            and coding_project_dir != workspace_dir
-            and coding_project_dir in rule.match
-        ):
-            rule.match = rule.match.replace(
-                coding_project_dir,
-                "CODING_PROJECT_DIR",
-            )
-        if workspace_dir and workspace_dir in rule.match:
-            rule.match = rule.match.replace(workspace_dir, "WORKSPACE_DIR")
+        for actual, placeholder in pairs:
+            if actual and actual in rule.match:
+                rule.match = rule.match.replace(actual, placeholder)
 
 
 def _parse_rules(

--- a/src/qwenpaw/governance/resource_governor.py
+++ b/src/qwenpaw/governance/resource_governor.py
@@ -57,8 +57,15 @@ class ResourceGovernor:
         self,
         workspace_dir: str,
         governance_dir: Optional[str] = None,
+        coding_project_dir: Optional[str] = None,
     ):
         self.workspace_dir = Path(workspace_dir)
+        # Coding project dir (Coding Mode). Falls back to the workspace
+        # when unset so the CODING_PROJECT_DIR policy placeholder always
+        # resolves to a concrete path.
+        self.coding_project_dir = Path(
+            coding_project_dir or workspace_dir,
+        )
         # Policy is stored outside the workspace to prevent agent tampering.
         # Use ``<basename>_<hash>`` so two workspaces with the same basename
         # but different absolute paths (e.g. ``/Users/a/project`` vs
@@ -101,6 +108,7 @@ class ResourceGovernor:
         self._policy = load_governance_policy(
             str(self._policy_dir),
             str(self.workspace_dir),
+            str(self.coding_project_dir),
         )
 
         self._sandbox_capability = probe_sandbox_support()
@@ -120,6 +128,7 @@ class ResourceGovernor:
                     self._policy,
                     str(self._policy_dir),
                     str(self.workspace_dir),
+                    str(self.coding_project_dir),
                 )
             except Exception:
                 logger.exception(
@@ -288,6 +297,14 @@ class ResourceGovernor:
         # Workspace is always readwrite
         mounts.insert(0, MountSpec(path=ws, writable=True))
 
+        # Coding project dir is readwrite by default (Coding Mode). When
+        # it is distinct from the workspace, mount it explicitly so Bash
+        # can write there; the policy ALLOW rule alone is not enough for
+        # sandboxed shell tools.
+        cpd = str(self.coding_project_dir)
+        if cpd and cpd != ws and not any(m.path == cpd for m in mounts):
+            mounts.append(MountSpec(path=cpd, writable=True))
+
         return SandboxConfig(
             mode=detect_platform_mode(),
             workspace_dir=ws,
@@ -352,6 +369,7 @@ class ResourceGovernor:
                 self._policy,
                 str(self._policy_dir),
                 str(self.workspace_dir),
+                str(self.coding_project_dir),
             )
 
     def add_approved_rule(self, tc_spec: ToolCallSpec) -> bool:

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -150,7 +150,13 @@ class AgentBuilder:
                 active_modes = plugins.active_mode_names(ctx)
 
         # Governor (governance policy layer).
-        governor = self._init_governor(workspace_dir)
+        _cm = getattr(agent_config, "coding_mode", None)
+        _project_dir = (
+            _cm.project_dir
+            if _cm and getattr(_cm, "project_dir", None)
+            else None
+        )
+        governor = self._init_governor(workspace_dir, _project_dir)
 
         # Inject governor into local_workspace so list_tools() can
         # wrap tools with PolicyGuardedTool.
@@ -339,10 +345,11 @@ class AgentBuilder:
                 innermost.formatter = formatter
         return model, formatter
 
-    # ------------------------------------------------------- helpers
-
     @staticmethod
-    def _init_governor(workspace_dir: Any) -> Any:
+    def _init_governor(
+        workspace_dir: Any,
+        coding_project_dir: Any = None,
+    ) -> Any:
         """Initialize ResourceGovernor if governance is available.
 
         Returns the started governor, or ``None`` when governance cannot
@@ -353,7 +360,12 @@ class AgentBuilder:
         try:
             from ..governance import ResourceGovernor
 
-            governor = ResourceGovernor(str(workspace_dir))
+            governor = ResourceGovernor(
+                str(workspace_dir),
+                coding_project_dir=(
+                    str(coding_project_dir) if coding_project_dir else None
+                ),
+            )
             governor.start()
             _logger.info("Governance started: dir=%s", workspace_dir)
             return governor

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -83,7 +83,7 @@ class TestDefaultPolicyLoad:
         """Regression: save_governance_policy must not mutate the live
         policy's rule objects.
 
-        ``_unresolve_workspace_dir`` rewrites resolved absolute paths back
+        ``_unresolve_placeholders`` rewrites resolved absolute paths back
         to the ``WORKSPACE_DIR`` placeholder for portability. It must
         operate on copies, not the live rule objects — otherwise the first
         ``add_rule → save`` after a governor start corrupts the in-memory
@@ -114,6 +114,76 @@ class TestDefaultPolicyLoad:
         assert policy.evaluate(_tc("Write", target)).action is (
             GovernanceAction.ALLOW
         )
+
+    def test_coding_project_dir_placeholder_resolved(self):
+        """CODING_PROJECT_DIR placeholders are replaced with the actual
+        coding project dir, and tool calls under it are ALLOWed."""
+        ws = "/home/user/workspace"
+        cpd = "/home/user/coding"
+        policy = _create_default_policy(
+            workspace_dir=ws,
+            coding_project_dir=cpd,
+        )
+        for rule in policy.user_rules:
+            assert (
+                "CODING_PROJECT_DIR" not in rule.match
+            ), f"unresolved placeholder: {rule.match!r}"
+        assert policy.evaluate(_tc("Write", f"{cpd}/script.py")).action is (
+            GovernanceAction.ALLOW
+        )
+        assert policy.evaluate(_tc("Read", f"{cpd}/main.py")).action is (
+            GovernanceAction.ALLOW
+        )
+
+    def test_coding_project_dir_defaults_to_workspace(self):
+        """With no coding_project_dir configured, CODING_PROJECT_DIR
+        resolves to the workspace so the rule is still concrete."""
+        ws = "/home/user/workspace"
+        policy = _create_default_policy(workspace_dir=ws)
+        for rule in policy.user_rules:
+            assert (
+                "CODING_PROJECT_DIR" not in rule.match
+            ), f"unresolved placeholder: {rule.match!r}"
+        assert policy.evaluate(_tc("Write", f"{ws}/script.py")).action is (
+            GovernanceAction.ALLOW
+        )
+
+    def test_coding_project_dir_roundtrip_portable(self, tmp_path):
+        """save→reload keeps the CODING_PROJECT_DIR placeholder in YAML
+        (distinct coding dir), so the policy stays portable across
+        machines and the coding dir remains ALLOWed after reload."""
+        ws = "/home/user/workspace"
+        cpd = "/home/user/coding"
+        policy_dir = tmp_path / "policy"
+        policy_dir.mkdir()
+        policy = _create_default_policy(
+            workspace_dir=ws,
+            coding_project_dir=cpd,
+        )
+        save_governance_policy(
+            policy,
+            str(policy_dir),
+            ws,
+            cpd,
+        )
+
+        # YAML must store the placeholder, not the absolute coding path.
+        yaml_text = (policy_dir / "policy.yaml").read_text(encoding="utf-8")
+        assert "CODING_PROJECT_DIR" in yaml_text
+        assert cpd not in yaml_text
+
+        # In-memory rules are untouched by save (no mutation regression):
+        # the live coding rule must still carry the resolved path, not the
+        # literal CODING_PROJECT_DIR placeholder.
+        for rule in policy.user_rules:
+            assert (
+                "CODING_PROJECT_DIR" not in rule.match
+            ), f"save_governance_policy mutated live rule: {rule.match!r}"
+
+        # Reload reproduces a policy that still ALLOWs the coding dir.
+        reloaded = load_governance_policy(str(policy_dir), ws, cpd)
+        decision = reloaded.evaluate(_tc("Edit", f"{cpd}/app.py"))
+        assert decision.action is GovernanceAction.ALLOW
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -185,6 +185,83 @@ class TestDefaultPolicyLoad:
         decision = reloaded.evaluate(_tc("Edit", f"{cpd}/app.py"))
         assert decision.action is GovernanceAction.ALLOW
 
+    @pytest.mark.parametrize(
+        "ws, cpd, label",
+        [
+            # coding dir nested inside the workspace: cpd is the longer path
+            # and a substring-match of ws (the parent) inside it must not fire.
+            ("/home/u/work", "/home/u/work/coding", "cpd_inside_ws"),
+            # workspace nested inside the coding dir: ws is the longer path;
+            # this is the direction the original bug corrupted.
+            ("/home/u/work/sub", "/home/u/work", "ws_inside_cpd"),
+        ],
+    )
+    def test_unresolve_nested_dirs_replaces_longest_path_first(
+        self,
+        tmp_path,
+        ws,
+        cpd,
+        label,
+    ):
+        """Regression for the parent/child ordering bug in
+        ``_unresolve_placeholders``.
+
+        When one of workspace_dir / coding_project_dir is a parent of the
+        other, the shorter path is a substring of the longer one. The
+        unresolver must replace the longer (more specific) path first;
+        otherwise the shorter path matches inside the longer path's region
+        and corrupts the rule.
+
+        Symptom before the fix: with ``ws=/home/u/work/sub`` and
+        ``cpd=/home/u/work``, the workspace rule
+        ``Read(/home/u/work/sub/**)`` was rewritten via the shorter cpd to
+        ``Read(CODING_PROJECT_DIR/sub/**)`` — the WORKSPACE_DIR placeholder
+        was lost from YAML, the rule became non-portable, and after reload
+        a real workspace write fell through to ASK ("No rule hit").
+        """
+        policy = _create_default_policy(
+            workspace_dir=ws,
+            coding_project_dir=cpd,
+        )
+        policy_dir = tmp_path / "policy"
+        policy_dir.mkdir()
+
+        # Before save: the workspace write is ALLOWed by the default rule.
+        assert (
+            policy.evaluate(_tc("Write", f"{ws}/x.py")).action
+            is GovernanceAction.ALLOW
+        )
+
+        save_governance_policy(policy, str(policy_dir), ws, cpd)
+
+        # The YAML must not leak either absolute path and must carry the
+        # WORKSPACE_DIR placeholder for the workspace rule. A shorter-path
+        # match would have left a CODING_PROJECT_DIR-prefixed half-rewrite
+        # in place of WORKSPACE_DIR.
+        yaml_text = (policy_dir / "policy.yaml").read_text(encoding="utf-8")
+        assert ws not in yaml_text, f"[{label}] workspace path leaked: {ws}"
+        assert cpd not in yaml_text, f"[{label}] coding path leaked: {cpd}"
+        assert "WORKSPACE_DIR" in yaml_text
+
+        # After save: the live in-memory rules are untouched (no mutation
+        # regression) and still ALLOW the workspace write.
+        for rule in policy.user_rules:
+            assert (
+                "WORKSPACE_DIR" not in rule.match
+            ), f"[{label}] save mutated live rule: {rule.match!r}"
+        assert (
+            policy.evaluate(_tc("Write", f"{ws}/x.py")).action
+            is GovernanceAction.ALLOW
+        )
+
+        # Reload reproduces a portable policy that still ALLOWs the workspace
+        # write — the corrupted-rule symptom would surface here as ASK.
+        reloaded = load_governance_policy(str(policy_dir), ws, cpd)
+        decision = reloaded.evaluate(_tc("Write", f"{ws}/x.py"))
+        assert (
+            decision.action is GovernanceAction.ALLOW
+        ), f"[{label}] reload lost workspace ALLOW: {decision.action}"
+
 
 # ---------------------------------------------------------------------------
 # Test: assert_policy with SSH-related Bash commands


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
