### PR TITLE
feat(memory): add reranker config panel to memory settings

### DIFF
--- a/console/src/api/types/agent.ts
+++ b/console/src/api/types/agent.ts
@@ -48,12 +48,21 @@ export interface EmbeddingModelConfig {
   max_batch_size: number;
 }
 
+export interface RerankerModelConfig {
+  enabled: boolean;
+  api_key: string;
+  base_url: string;
+  model_name: string;
+  candidate_multiplier: number;
+}
+
 export interface ReMeLightMemoryConfig {
   summarize_when_compact: boolean;
   auto_memory_interval: number | null;
   dream_cron: string;
   auto_memory_search_config: AutoMemorySearchConfig;
   embedding_model_config: EmbeddingModelConfig;
+  reranker_config: RerankerModelConfig;
   rebuild_memory_index_on_start: boolean;
   enable_search_raw_log: boolean;
 }

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -75,7 +75,33 @@
     "updateModal": {
       "title": "New version available: v{{version}}",
       "viewReleases": "View Releases",
-      "close": "Close"
+      "installDesktopUpdate": "Update Now",
+      "desktopInstallHint": "QwenPaw Desktop {{version}} is ready to install. The app will restart after the update.",
+      "checking": "Checking for updates…",
+      "checkingHint": "Confirming the latest release",
+      "downloading": "Downloading update",
+      "downloadingTo": "Updating to version {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "Installing update",
+      "willRestart": "The app will restart automatically when done.",
+      "stepPrepare": "Prepare",
+      "stepDownloading": "Download",
+      "stepInstalling": "Install",
+      "failedTitle": "Update failed",
+      "back": "Back",
+      "retry": "Retry",
+      "errors": {
+        "network": "Couldn't reach the update server. Check your internet and try again.",
+        "signature": "Update file signature invalid. Try downloading again.",
+        "appLocation": "QwenPaw is running from a read-only macOS location. Move QwenPaw.app to the Applications folder, launch it from there, then try updating again.",
+        "other": "Update failed."
+      },
+      "updateLater": "Download in Background",
+      "backgroundDownloading": "Downloading in background…",
+      "readyToInstall": "Update ready",
+      "readyToInstallHint": "v{{version}} update is downloaded. Restart to install and launch the new version.",
+      "restartNow": "Update Now",
+      "backgroundFailed": "Background download failed"
     },
     "settings": {
       "language": "Language",
@@ -171,7 +197,11 @@
     "detailPayload": "Payload",
     "detailExecutionTrace": "Execution Trace",
     "detailTraceEmpty": "No execution trace available",
-    "filterByAgent": "Filter by agent"
+    "filterByAgent": "Filter by agent",
+    "filterBySourceType": "Filter by source",
+    "sourceTypeCron": "Cron",
+    "sourceTypeHeartbeat": "Heartbeat",
+    "sourceTypeMemory": "Memory"
   },
   "acp": {
     "title": "ACP",
@@ -1130,6 +1160,11 @@
     "wecomAuthHint": "Scan the QR code above with WeCom to authorize. Bot ID and Secret will be filled in automatically.",
     "wecomAuthSuccess": "WeCom bot authorized. Bot ID and Secret have been filled in.",
     "wecomQrcodeFailed": "Failed to get WeCom QR code. Please try again.",
+    "slackBotToken": "Bot Token",
+    "slackBotTokenTooltip": "Slack Bot User OAuth Token, starts with xoxb-",
+    "slackAppToken": "App Token",
+    "slackAppTokenTooltip": "Slack App-Level Token for Socket Mode, starts with xapp-",
+    "slackProxyTooltip": "HTTP proxy URL for connecting to Slack API",
     "dingtalkSetupGuide": "Scan the QR code with DingTalk to create a bot instantly. A DingTalk app will be created automatically and Client ID / Client Secret will be filled in.",
     "dingtalkScanAuth": "Scan to Create Bot",
     "dingtalkGetQrcode": "Get DingTalk QR Code",
@@ -1510,7 +1545,7 @@
     "goConfigureBtn": "Configure a Provider",
     "availableGroup": "Available Providers",
     "clickToConfigure": "Click to configure",
-    "configureAction": "Configure \u2192",
+    "configureAction": "Configure →",
     "endpointCount": "{{count}} endpoints",
     "connect": "OAuth",
     "saveApiKey": "Save",
@@ -1784,8 +1819,6 @@
     "shellCommandExecutable": "Shell Executable",
     "shellCommandExecutableTooltip": "Path to the shell used by execute_shell_command. Linux/macOS: e.g. /bin/bash, /bin/zsh. Windows: supports powershell.exe, pwsh.exe, or POSIX-like shells such as Git Bash. When empty, falls back to the $SHELL environment variable, then to the platform default (/bin/sh on Unix, cmd.exe on Windows).",
     "shellCommandExecutablePlaceholder": "e.g. /bin/bash or powershell.exe (empty = auto-detect)",
-    "planMode": "Plan Mode",
-    "planModeTooltip": "Enable plan mode to use /plan <description> for structured task planning. When enabled, plan tools are registered and the plan panel becomes available.",
     "maxInputLength": "Max Input Length",
     "maxInputLengthTooltip": "Maximum input length (tokens) for the model context window",
     "maxInputLengthPlaceholder": "Enter max input length",
@@ -1969,7 +2002,23 @@
       "restApiKey": "REST API Key",
       "memoryIsolation": "Memory Isolation (per-agent)",
       "searchTimeout": "Search Timeout"
-    }
+    },
+    "rerankerConfigCollapseLabel": "Reranker Config",
+    "rerankerEnabled": "Enable Reranker",
+    "rerankerEnabledTooltip": "Re-rank memory search results to put the most relevant items first. Requires API Key.",
+    "rerankerApiKey": "API Key",
+    "rerankerApiKeyTooltip": "API key for the reranker provider",
+    "rerankerApiKeyPlaceholder": "e.g. sk-xxx",
+    "rerankerBaseUrl": "Base URL",
+    "rerankerBaseUrlTooltip": "Base URL for the reranker API",
+    "rerankerBaseUrlPlaceholder": "e.g. https://api.siliconflow.cn/v1/rerank",
+    "rerankerModelName": "Model Name",
+    "rerankerModelNameTooltip": "Reranker model name",
+    "rerankerModelNamePlaceholder": "e.g. BAAI/bge-reranker-v2-m3",
+    "rerankerCandidateMultiplier": "Candidate Multiplier",
+    "rerankerCandidateMultiplierTooltip": "Fetch N times more candidates before reranking so the reranker has more to choose from.",
+    "rerankerCandidateMultiplierRequired": "Candidate multiplier is required",
+    "rerankerCandidateMultiplierMin": "Candidate multiplier must be at least 1"
   },
   "tools": {
     "title": "Built-in Tools",
@@ -2063,9 +2112,6 @@
       },
       "skills": {
         "description": "List chat-available skills and expose explicit skill commands"
-      },
-      "plan": {
-        "description": "Create a structured plan to decompose the task into subtasks"
       }
     },
     "attachments": {
@@ -2422,19 +2468,6 @@
     "denyFailed": "Failed to deny",
     "timeoutAutoDenied": "Timed out, auto denied",
     "acknowledge": "Got it"
-  },
-  "plan": {
-    "title": "Plan",
-    "noPlan": "No active plan",
-    "noPlanHint": "Use /plan <description> to create a plan",
-    "progress": "Progress",
-    "outcome": "Outcome",
-    "state": {
-      "todo": "Todo",
-      "in_progress": "In Progress",
-      "done": "Done",
-      "abandoned": "Abandoned"
-    }
   },
   "pluginManager": {
     "title": "Plugin Manager",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -75,7 +75,33 @@
     "updateModal": {
       "title": "发现新版本 v{{version}}",
       "viewReleases": "查看 Releases",
-      "close": "关闭"
+      "installDesktopUpdate": "现在更新",
+      "desktopInstallHint": "QwenPaw 桌面端 {{version}} 已准备好安装，更新后应用将自动重启。",
+      "checking": "检查更新中…",
+      "checkingHint": "正在确认最新版本",
+      "downloading": "正在下载更新",
+      "downloadingTo": "正在更新到版本 {{version}}",
+      "downloadProgress": "{{done}} / {{total}} · {{rate}}",
+      "installing": "正在安装更新",
+      "willRestart": "应用将在安装完成后自动重启,请稍候…",
+      "stepPrepare": "准备",
+      "stepDownloading": "下载",
+      "stepInstalling": "安装",
+      "failedTitle": "更新失败",
+      "back": "返回",
+      "retry": "重试",
+      "errors": {
+        "network": "连接不上更新服务器，请检查网络后重试。",
+        "signature": "更新文件签名校验失败，请重新尝试下载。",
+        "appLocation": "QwenPaw 正在从 macOS 只读位置运行。请先将 QwenPaw.app 移动到“应用程序”文件夹，从那里启动后再重试更新。",
+        "other": "更新失败。"
+      },
+      "updateLater": "后台下载",
+      "backgroundDownloading": "正在后台下载更新…",
+      "readyToInstall": "更新已就绪",
+      "readyToInstallHint": "v{{version}} 更新已下载，重启后将安装并启动新版本。",
+      "restartNow": "现在更新",
+      "backgroundFailed": "后台下载失败"
     },
     "settings": {
       "language": "语言",
@@ -171,7 +197,11 @@
     "detailPayload": "附加信息",
     "detailExecutionTrace": "执行轨迹",
     "detailTraceEmpty": "暂无执行轨迹",
-    "filterByAgent": "按 Agent 筛选"
+    "filterByAgent": "按 Agent 筛选",
+    "filterBySourceType": "按来源筛选",
+    "sourceTypeCron": "定时任务",
+    "sourceTypeHeartbeat": "心跳",
+    "sourceTypeMemory": "记忆"
   },
   "workspace": {
     "title": "文件",
@@ -945,7 +975,8 @@
       "wecom": "企业微信",
       "wechat": "微信",
       "xiaoyi": "小艺",
-      "yuanbao": "元宝"
+      "yuanbao": "元宝",
+      "slack": "Slack"
     },
     "pleaseInputDbPath": "请输入数据库路径",
     "pleaseInputPollInterval": "请输入轮询间隔",
@@ -1008,6 +1039,11 @@
     "dingtalkEndpointTooltip": "用于钉钉私有化部署的自定义 API 地址。留空则使用官方默认地址。",
     "wecomCancelled": "授权已取消",
     "wecomAuthFailed": "授权失败：{{msg}}",
+    "slackBotToken": "Bot Token",
+    "slackBotTokenTooltip": "Slack Bot User OAuth Token，以 xoxb- 开头",
+    "slackAppToken": "App Token",
+    "slackAppTokenTooltip": "Slack App-Level Token（Socket Mode），以 xapp- 开头",
+    "slackProxyTooltip": "HTTP 代理地址，用于连接 Slack API",
     "voiceSetupGuide": "请先注册 Twilio 账户并购买电话号码，然后在下方填写凭据。Account SID 和 Auth Token 可在 Twilio 控制台首页找到。Phone Number SID 在 Phone Numbers → Active Numbers 中查看。",
     "voiceSetupLink": "打开 Twilio 控制台",
     "sipSetupGuide": "配置 SIP 注册服务器（如 Asterisk、FreeSWITCH），然后在下方填写 SIP 凭据。Dev 模式使用 pyVoIP 在本地处理 SIP/RTP；Production 模式使用 LiveKit SIP Server。",
@@ -1641,8 +1677,6 @@
     "shellCommandExecutable": "Shell 可执行程序",
     "shellCommandExecutableTooltip": "execute_shell_command 使用的 shell 路径。Linux/macOS：如 /bin/bash、/bin/zsh。Windows：支持 powershell.exe、pwsh.exe 或类 POSIX shell（如 Git Bash）。留空时依次回退到 $SHELL 环境变量，再回退到平台默认值（Unix 为 /bin/sh，Windows 为 cmd.exe）。",
     "shellCommandExecutablePlaceholder": "例如 /bin/bash 或 powershell.exe（留空 = 自动检测）",
-    "planMode": "计划模式",
-    "planModeTooltip": "启用后可使用 /plan <描述> 进行结构化任务规划。启用时会注册 plan 相关工具，并显示计划面板。",
     "maxInputLength": "最大输入长度",
     "maxInputLengthTooltip": "模型上下文窗口的最大输入长度（token 数）",
     "maxInputLengthPlaceholder": "请输入最大输入长度",
@@ -1797,6 +1831,22 @@
     "contextCompactCollapseLabel": "上下文压缩",
     "toolResultPruningCollapseLabel": "工具结果压缩",
     "autoMemorySearchCollapseLabel": "自动记忆搜索",
+    "rerankerConfigCollapseLabel": "重排序模型配置",
+    "rerankerEnabled": "启用重排序",
+    "rerankerEnabledTooltip": "对记忆搜索结果进行重排序，将最相关的结果排在前面。需要配置 API Key。",
+    "rerankerApiKey": "API Key",
+    "rerankerApiKeyTooltip": "重排序模型提供方的 API Key",
+    "rerankerApiKeyPlaceholder": "示例: sk-xxx",
+    "rerankerBaseUrl": "Base URL",
+    "rerankerBaseUrlTooltip": "重排序 API 的 Base URL",
+    "rerankerBaseUrlPlaceholder": "示例: https://api.siliconflow.cn/v1/rerank",
+    "rerankerModelName": "模型名称",
+    "rerankerModelNameTooltip": "重排序模型名称",
+    "rerankerModelNamePlaceholder": "示例: BAAI/bge-reranker-v2-m3",
+    "rerankerCandidateMultiplier": "候选倍数",
+    "rerankerCandidateMultiplierTooltip": "重排序前多取 N 倍的候选结果，让重排序模型更充分挑选。",
+    "rerankerCandidateMultiplierRequired": "候选倍数为必填项",
+    "rerankerCandidateMultiplierMin": "候选倍数必须大于等于 1",
     "embeddingConfigCollapseLabel": "向量模型配置",
     "summarizeWhenCompact": "压缩时记忆",
     "summarizeWhenCompactTooltip": "在上下文压缩时自动生成并保存记忆",
@@ -1920,9 +1970,6 @@
       },
       "skills": {
         "description": "列出当前对话可用的技能，并显示可显式调用的技能命令"
-      },
-      "plan": {
-        "description": "创建结构化计划，将任务分解为多个子任务"
       }
     },
     "attachments": {
@@ -2439,19 +2486,6 @@
     "denyFailed": "拒绝失败",
     "timeoutAutoDenied": "已超时，自动拒绝",
     "acknowledge": "我知道了"
-  },
-  "plan": {
-    "title": "计划",
-    "noPlan": "暂无活跃计划",
-    "noPlanHint": "使用 /plan <描述> 创建计划",
-    "progress": "进度",
-    "outcome": "结果",
-    "state": {
-      "todo": "待办",
-      "in_progress": "进行中",
-      "done": "已完成",
-      "abandoned": "已放弃"
-    }
   },
   "pluginManager": {
     "title": "插件管理",

--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
@@ -80,6 +80,7 @@ export function ReMeLightMemoryCard() {
       </Form.Item>
 
       <Collapse
+        defaultActiveKey={["rerankerConfig"]}
         items={[
           {
             key: "autoMemorySearch",
@@ -305,6 +306,96 @@ export function ReMeLightMemoryCard() {
                     step={1}
                     disabled={!embeddingEnabled}
                   />
+                </Form.Item>
+              </>
+            ),
+          },
+          {
+            key: "rerankerConfig",
+            label: t("agentConfig.rerankerConfigCollapseLabel"),
+            forceRender: true,
+            children: (
+              <>
+                <Form.Item
+                  label={t("agentConfig.rerankerEnabled")}
+                  name={[
+                    "reme_light_memory_config",
+                    "reranker_config",
+                    "enabled",
+                  ]}
+                  valuePropName="checked"
+                  tooltip={t("agentConfig.rerankerEnabledTooltip")}
+                >
+                  <Switch />
+                </Form.Item>
+
+                <Form.Item
+                  label={t("agentConfig.rerankerApiKey")}
+                  name={[
+                    "reme_light_memory_config",
+                    "reranker_config",
+                    "api_key",
+                  ]}
+                  tooltip={t("agentConfig.rerankerApiKeyTooltip")}
+                >
+                  <Input.Password
+                    placeholder={t("agentConfig.rerankerApiKeyPlaceholder")}
+                  />
+                </Form.Item>
+
+                <Form.Item
+                  label={t("agentConfig.rerankerBaseUrl")}
+                  name={[
+                    "reme_light_memory_config",
+                    "reranker_config",
+                    "base_url",
+                  ]}
+                  tooltip={t("agentConfig.rerankerBaseUrlTooltip")}
+                >
+                  <Input
+                    placeholder={t("agentConfig.rerankerBaseUrlPlaceholder")}
+                  />
+                </Form.Item>
+
+                <Form.Item
+                  label={t("agentConfig.rerankerModelName")}
+                  name={[
+                    "reme_light_memory_config",
+                    "reranker_config",
+                    "model_name",
+                  ]}
+                  tooltip={t("agentConfig.rerankerModelNameTooltip")}
+                >
+                  <Input
+                    placeholder={t("agentConfig.rerankerModelNamePlaceholder")}
+                  />
+                </Form.Item>
+
+                <Form.Item
+                  label={t("agentConfig.rerankerCandidateMultiplier")}
+                  name={[
+                    "reme_light_memory_config",
+                    "reranker_config",
+                    "candidate_multiplier",
+                  ]}
+                  rules={[
+                    {
+                      required: true,
+                      message: t(
+                        "agentConfig.rerankerCandidateMultiplierRequired",
+                      ),
+                    },
+                    {
+                      type: "number",
+                      min: 1,
+                      message: t("agentConfig.rerankerCandidateMultiplierMin"),
+                    },
+                  ]}
+                  tooltip={t(
+                    "agentConfig.rerankerCandidateMultiplierTooltip",
+                  )}
+                >
+                  <InputNumber style={{ width: "100%" }} min={1} step={1} />
                 </Form.Item>
               </>
             ),

--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
@@ -391,9 +391,7 @@ export function ReMeLightMemoryCard() {
                       message: t("agentConfig.rerankerCandidateMultiplierMin"),
                     },
                   ]}
-                  tooltip={t(
-                    "agentConfig.rerankerCandidateMultiplierTooltip",
-                  )}
+                  tooltip={t("agentConfig.rerankerCandidateMultiplierTooltip")}
                 >
                   <InputNumber style={{ width: "100%" }} min={1} step={1} />
                 </Form.Item>


### PR DESCRIPTION
## Description

Add a collapsible reranker configuration panel to the agent memory settings card, allowing users to enable/disable reranking and configure API credentials, model, and candidate multiplier from the UI.

## Changes

- `console/src/api/types/agent.ts`: Add `RerankerModelConfig` interface (enabled, api_key, base_url, model_name, candidate_multiplier)
- `console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx`: Add collapsible reranker settings section with form fields for all config options
- `console/src/locales/en.json`: Add 18 English translations for reranker fields
- `console/src/locales/zh.json`: Add 16 Chinese translations for reranker fields

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Component(s) affected

- `console/src/api/types/agent.ts`