### PR TITLE
fix(docker): add init:true to prevent zombie process accumulation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ volumes:
 services:
   qwenpaw:
     image: agentscope/qwenpaw:latest
+    init: true
     container_name: qwenpaw
     restart: always
     ports:


### PR DESCRIPTION
## Description

Add `init: true` to `docker-compose.yml` so that Docker uses tini as PID 1. This prevents zombie process accumulation when Chrome browser processes are started and stopped inside the container.

Without `init: true`, the container has no init process to reap orphaned children. Each browser stop cycle leaves ~8-9 zombie chromium processes that accumulate indefinitely, wasting PID table entries.

This is a well-known issue in the Puppeteer/Chromium ecosystem:
- https://github.com/puppeteer/puppeteer/issues/12854
- https://github.com/puppeteer/puppeteer/issues/615

**Related Issue:** https://github.com/agentscope-ai/QwenPaw/issues/5520

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Build and start the container **without** `init: true`:
   ```bash
   docker compose -f docker-compose.repro.yml up -d
   docker cp test_browser_leak.py repro-browser-leak:/tmp/
   docker exec repro-browser-leak python /tmp/test_browser_leak.py
   ```
   Result: ~8 zombies per cycle, 24 total after 3 cycles.

2. Add `init: true` and repeat:
   ```bash
   docker compose -f docker-compose.repro.yml up -d
   docker exec repro-browser-leak python /tmp/test_browser_leak.py
   ```
   Result: 0 zombies, 0 running chromium after all 3 cycles.

## Additional Notes

`init: true` adds tini (~900 bytes) as PID 1 inside the container. It automatically reaps zombie children, which is the standard best practice for containers that spawn child processes. No application code changes are needed.
