### PR TITLE
fix(skill):market install queue clear

### DIFF
--- a/console/src/pages/Settings/Market/index.tsx
+++ b/console/src/pages/Settings/Market/index.tsx
@@ -371,7 +371,7 @@ function MarketPage() {
       {install.queue.length > 0 && (
         <InstallQueuePanel
           queue={install.queue}
-          onClearCompleted={install.clearCompleted}
+          onClearCompleted={install.clearFinished}
           onCancel={install.cancel}
           onRetry={install.retry}
         />

--- a/console/src/pages/Settings/Market/useMarketInstall.ts
+++ b/console/src/pages/Settings/Market/useMarketInstall.ts
@@ -228,11 +228,16 @@ export function useMarketInstall(opts: UseMarketInstallOptions) {
     [runQueue, updateItem],
   );
 
-  // Only drop the green "completed" rows; keep failed/cancelled so the user
-  // can see what went wrong and decide whether to retry.
-  const clearCompleted = useCallback(() => {
-    setQueue(queueRef.current.filter((it) => it.status !== "completed"));
+  // Drop every finished row (completed/failed/cancelled), including stuck
+  // error messages. Only items still in flight (queued/installing) are kept
+  // so we don't orphan a running install.
+  const clearFinished = useCallback(() => {
+    setQueue(
+      queueRef.current.filter(
+        (it) => it.status === "queued" || it.status === "installing",
+      ),
+    );
   }, [setQueue]);
 
-  return { queue, enqueue, cancel, retry, clearCompleted };
+  return { queue, enqueue, cancel, retry, clearFinished };
 }

--- a/console/src/pages/Settings/Market/useMarketInstall.ts
+++ b/console/src/pages/Settings/Market/useMarketInstall.ts
@@ -228,9 +228,6 @@ export function useMarketInstall(opts: UseMarketInstallOptions) {
     [runQueue, updateItem],
   );
 
-  // Drop every finished row (completed/failed/cancelled), including stuck
-  // error messages. Only items still in flight (queued/installing) are kept
-  // so we don't orphan a running install.
   const clearFinished = useCallback(() => {
     setQueue(
       queueRef.current.filter(


### PR DESCRIPTION
## Description

Now "清空" & "clear" for skill market can clear both completed / failed tasks.

- Previously, only completed tasks are cleared.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

