### PR TITLE
[codex] feat(telegram): support custom API base URL

### DIFF
--- a/console/src/api/types/channel.ts
+++ b/console/src/api/types/channel.ts
@@ -57,6 +57,7 @@ export interface QQConfig extends BaseChannelConfig {
 
 export interface TelegramConfig extends BaseChannelConfig {
   bot_token: string;
+  base_url: string;
   http_proxy: string;
   http_proxy_auth: string;
   show_typing?: boolean;

--- a/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
+++ b/console/src/pages/Control/Channels/components/ChannelDrawer.tsx
@@ -617,6 +617,9 @@ export function ChannelDrawer({
             >
               <Input.Password placeholder="Telegram bot token from BotFather" />
             </Form.Item>
+            <Form.Item name="base_url" label="API Base URL">
+              <Input placeholder="https://tg-api.yourdomain.com" />
+            </Form.Item>
             <Form.Item name="http_proxy" label="HTTP Proxy">
               <Input placeholder="http://127.0.0.1:18118" />
             </Form.Item>

--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -93,6 +93,13 @@ class _PollingReconnectRequested(Exception):
         self.delay = delay
 
 
+def _telegram_base_urls(base_url: str) -> tuple[str, str]:
+    root = (base_url or "").strip().rstrip("/")
+    if not root:
+        return "", ""
+    return f"{root}/bot", f"{root}/file/bot"
+
+
 async def _download_telegram_file(
     *,
     bot: Any,
@@ -134,6 +141,7 @@ async def _resolve_telegram_file_url(
     bot: Any,
     file_id: str,
     bot_token: str,
+    base_url: str = "",
 ) -> str:
     """Resolve the remote URL for a Telegram file.
 
@@ -152,7 +160,9 @@ async def _resolve_telegram_file_url(
         return ""
     if file_path.startswith("http"):
         return file_path
-    return f"https://api.telegram.org/file/bot{bot_token}/{file_path}"
+    _, base_file_url = _telegram_base_urls(base_url)
+    base_file_url = base_file_url or "https://api.telegram.org/file/bot"
+    return f"{base_file_url}{bot_token}/{file_path}"
 
 
 async def _build_content_parts_from_message(
@@ -310,6 +320,7 @@ class TelegramChannel(BaseChannel):
         streaming_enabled: bool = False,
         access_control_dm: bool = False,
         access_control_group: bool = False,
+        base_url: str = "",
     ):
         super().__init__(
             process,
@@ -329,6 +340,7 @@ class TelegramChannel(BaseChannel):
         )
         self.enabled = enabled
         self._bot_token = bot_token
+        self._base_url = (base_url or "").strip().rstrip("/")
         self._http_proxy = http_proxy or ""
         self._http_proxy_auth = http_proxy_auth or ""
         self.bot_prefix = bot_prefix
@@ -397,6 +409,9 @@ class TelegramChannel(BaseChannel):
             return self._http_proxy
 
         builder = Application.builder().token(self._bot_token)
+        base_url, base_file_url = _telegram_base_urls(self._base_url)
+        if base_url:
+            builder = builder.base_url(base_url).base_file_url(base_file_url)
         builder = builder.get_updates_read_timeout(20)
         builder = builder.get_updates_connect_timeout(10)
         proxy = proxy_url()
@@ -568,6 +583,7 @@ class TelegramChannel(BaseChannel):
             process=process,
             enabled=os.getenv("TELEGRAM_CHANNEL_ENABLED", "0") == "1",
             bot_token=os.getenv("TELEGRAM_BOT_TOKEN", ""),
+            base_url=os.getenv("TELEGRAM_BASE_URL", ""),
             http_proxy=os.getenv("TELEGRAM_HTTP_PROXY", ""),
             http_proxy_auth=os.getenv("TELEGRAM_HTTP_PROXY_AUTH", ""),
             bot_prefix=os.getenv("TELEGRAM_BOT_PREFIX", ""),
@@ -608,6 +624,7 @@ class TelegramChannel(BaseChannel):
             process=process,
             enabled=bool(c.get("enabled", False)),
             bot_token=_get_str("bot_token"),
+            base_url=_get_str("base_url"),
             http_proxy=_get_str("http_proxy"),
             http_proxy_auth=_get_str("http_proxy_auth"),
             bot_prefix=_get_str("bot_prefix"),

--- a/src/qwenpaw/cli/channels_cmd.py
+++ b/src/qwenpaw/cli/channels_cmd.py
@@ -540,6 +540,13 @@ def configure_telegram(current_config: TelegramConfig) -> TelegramConfig:
         current_config.enabled = False
         return current_config
 
+    base_url = click.prompt(
+        "Telegram API Base URL (blank for default)",
+        default=current_config.base_url or "",
+        type=str,
+    )
+    current_config.base_url = base_url.strip().rstrip("/")
+
     show_typing = prompt_confirm(
         "Show typing indicator?",
         default=current_config.show_typing is not False,

--- a/src/qwenpaw/cli/doctor_connectivity.py
+++ b/src/qwenpaw/cli/doctor_connectivity.py
@@ -97,12 +97,16 @@ def _probe_matrix(
 
 def _probe_telegram(
     agent_id: str,
-    _cfg: TelegramConfig,
+    cfg: TelegramConfig,
     timeout: float,
 ) -> list[str]:
-    err = _http_get_ok("https://api.telegram.org", timeout)
+    url = (
+        (cfg.base_url or "").strip().rstrip("/")
+        or "https://api.telegram.org"
+    )
+    err = _http_get_ok(url, timeout)
     if err:
-        return [f"{agent_id}: telegram: reach api.telegram.org — {err}"]
+        return [f"{agent_id}: telegram: reach {url} — {err}"]
     return []
 
 

--- a/src/qwenpaw/cli/doctor_connectivity.py
+++ b/src/qwenpaw/cli/doctor_connectivity.py
@@ -100,10 +100,9 @@ def _probe_telegram(
     cfg: TelegramConfig,
     timeout: float,
 ) -> list[str]:
-    url = (
-        (cfg.base_url or "").strip().rstrip("/")
-        or "https://api.telegram.org"
-    )
+    url = (cfg.base_url or "").strip().rstrip(
+        "/",
+    ) or "https://api.telegram.org"
     err = _http_get_ok(url, timeout)
     if err:
         return [f"{agent_id}: telegram: reach {url} — {err}"]

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -287,6 +287,7 @@ class OneBotConfig(BaseChannelConfig):
 
 class TelegramConfig(BaseChannelConfig):
     bot_token: str = ""
+    base_url: str = ""
     http_proxy: str = ""
     http_proxy_auth: str = ""
     show_typing: Optional[bool] = None

--- a/tests/unit/channels/test_telegram.py
+++ b/tests/unit/channels/test_telegram.py
@@ -47,6 +47,17 @@ from qwenpaw.schemas import (
 # =============================================================================
 
 
+def test_telegram_base_urls_derive_api_and_file_prefixes():
+    """Custom root URL should derive Bot API and file API prefixes."""
+    from qwenpaw.app.channels.telegram.channel import _telegram_base_urls
+
+    assert _telegram_base_urls("") == ("", "")
+    assert _telegram_base_urls(" https://tg-api.example.com/ ") == (
+        "https://tg-api.example.com/bot",
+        "https://tg-api.example.com/file/bot",
+    )
+
+
 @pytest.fixture
 def mock_process_handler() -> AsyncMock:
     """Mock process handler that yields simple events."""
@@ -400,6 +411,7 @@ class TestTelegramChannelFromConfig:
 
         assert channel.enabled is True
         assert channel._bot_token == "config_token"
+        assert channel._base_url == ""
         assert channel._http_proxy == "http://config.proxy:8080"
         assert channel._http_proxy_auth == "config_user:config_pass"
         assert channel.bot_prefix == "[ConfigBot]"
@@ -433,6 +445,23 @@ class TestTelegramChannelFromConfig:
 
         assert channel._bot_token == "obj_token"
         assert channel.bot_prefix == "[Obj]"
+
+    def test_from_config_uses_base_url(
+        self,
+        mock_process_handler,
+    ):
+        """from_config should pass custom Telegram API root URL."""
+        from qwenpaw.app.channels.telegram.channel import TelegramChannel
+
+        channel = TelegramChannel.from_config(
+            process=mock_process_handler,
+            config={
+                "bot_token": "config_token",
+                "base_url": " https://tg-api.example.com/ ",
+            },
+        )
+
+        assert channel._base_url == "https://tg-api.example.com"
 
     def test_from_config_defaults(
         self,
@@ -1291,6 +1320,30 @@ class TestTelegramResolveFileUrl:
         )
         assert result == expected
 
+    async def test_resolve_api_url_with_custom_base_url(self):
+        """Should construct custom Telegram file API URL."""
+        from qwenpaw.app.channels.telegram.channel import (
+            _resolve_telegram_file_url,
+        )
+
+        mock_bot = MagicMock()
+        mock_file = MagicMock()
+        mock_file.file_path = "photos/file_123.jpg"
+        mock_bot.get_file = AsyncMock(return_value=mock_file)
+
+        result = await _resolve_telegram_file_url(
+            bot=mock_bot,
+            file_id="file123",
+            bot_token="my_bot_token",
+            base_url="https://tg-api.example.com/",
+        )
+
+        expected = (
+            "https://tg-api.example.com/file/"
+            "botmy_bot_token/photos/file_123.jpg"
+        )
+        assert result == expected
+
     async def test_resolve_error_returns_empty(self):
         """Should return empty string on TelegramError."""
         from qwenpaw.app.channels.telegram.channel import (
@@ -1712,6 +1765,34 @@ class TestTelegramProxyUrl:
             assert (
                 not hasattr(mock_builder, "proxy")
                 or not mock_builder.proxy.called
+            )
+            assert not mock_builder.base_url.called
+            assert not mock_builder.base_file_url.called
+
+    def test_custom_base_url_configures_builder(self, telegram_channel):
+        """Should configure PTB Bot API and file API prefixes."""
+        telegram_channel._base_url = "https://tg-api.example.com"
+        telegram_channel._bot_token = "test_token"
+
+        with patch("telegram.ext.Application.builder") as mock_builder_class:
+            mock_builder = MagicMock()
+            mock_builder_class.return_value = mock_builder
+            mock_builder.token.return_value = mock_builder
+            mock_builder.base_url.return_value = mock_builder
+            mock_builder.base_file_url.return_value = mock_builder
+            mock_builder.get_updates_read_timeout.return_value = mock_builder
+            mock_builder.get_updates_connect_timeout.return_value = (
+                mock_builder
+            )
+            mock_builder.build.return_value = MagicMock()
+
+            telegram_channel._build_application()
+
+            mock_builder.base_url.assert_called_once_with(
+                "https://tg-api.example.com/bot",
+            )
+            mock_builder.base_file_url.assert_called_once_with(
+                "https://tg-api.example.com/file/bot",
             )
 
     def test_proxy_without_auth(self, telegram_channel):

--- a/tests/unit/cli/test_doctor_connectivity.py
+++ b/tests/unit/cli/test_doctor_connectivity.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from qwenpaw.cli import doctor_connectivity
+from qwenpaw.config.config import TelegramConfig
+
+
+def test_probe_telegram_uses_custom_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_get_ok(url: str, timeout: float) -> None:
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return None
+
+    monkeypatch.setattr(doctor_connectivity, "_http_get_ok", _fake_get_ok)
+
+    result = doctor_connectivity._probe_telegram(
+        "default",
+        TelegramConfig(base_url=" https://tg-api.example.com/ "),
+        3.0,
+    )
+
+    assert result == []
+    assert captured == {
+        "url": "https://tg-api.example.com",
+        "timeout": 3.0,
+    }

--- a/tests/unit/cli/test_doctor_connectivity.py
+++ b/tests/unit/cli/test_doctor_connectivity.py
@@ -11,17 +11,17 @@ def test_probe_telegram_uses_custom_base_url(monkeypatch) -> None:
     def _fake_get_ok(url: str, timeout: float) -> None:
         captured["url"] = url
         captured["timeout"] = timeout
-        return None
 
     monkeypatch.setattr(doctor_connectivity, "_http_get_ok", _fake_get_ok)
 
+    # pylint: disable-next=protected-access
     result = doctor_connectivity._probe_telegram(
         "default",
         TelegramConfig(base_url=" https://tg-api.example.com/ "),
         3.0,
     )
 
-    assert result == []
+    assert not result
     assert captured == {
         "url": "https://tg-api.example.com",
         "timeout": 3.0,


### PR DESCRIPTION
## Summary
- Add optional `base_url` to Telegram channel config, env config, CLI setup, console UI, and frontend channel types.
- Configure python-telegram-bot `base_url` and `base_file_url` from a reverse-proxy root so Bot API calls use `/bot<TOKEN>/...` and file calls use `/file/bot<TOKEN>/...`.
- Make Telegram doctor connectivity probe respect the custom root URL.

## Why
Fixes #5630. Users without a direct HTTP/HTTPS proxy can route Telegram Bot API traffic through a reverse proxy such as a Cloudflare Worker.

## User impact
Leaving `base_url` empty preserves the existing official Telegram API behavior. Setting a root such as `https://tg-api.yourdomain.com` routes Telegram API and file URLs through that root.

## Verification
- `uv run --python 3.11 pytest tests/unit/channels/test_telegram.py tests/unit/cli/test_doctor_connectivity.py tests/contract/channels/test_telegram_contract.py tests/integration/test_channel_config.py::test_channel_put_disabled_channel_config tests/integration/test_channel_config.py::test_channel_bulk_put_preserves_unmodified_channels -q` (117 passed; existing async warnings in Telegram tests)
- `cd console && npx eslint src/pages/Control/Channels/components/ChannelDrawer.tsx src/api/types/channel.ts`
- `cd console && npm run build:test`

## Notes
- `cd console && npm run lint` still fails on existing repo-wide lint debt unrelated to this change; the touched frontend files pass targeted ESLint.