### PR TITLE
feat(crons): honor per-request model override

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -38,7 +38,11 @@ except ImportError:
 from .utils.message_request_normalizer import (
     normalize_messages_for_model_request,
 )
-from ..exceptions import ProviderError, ModelFormatterError
+from ..exceptions import (
+    ModelNotFoundException,
+    ProviderError,
+    ModelFormatterError,
+)
 from ..providers import ProviderManager
 from ..providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
 from ..providers.retry_chat_model import (
@@ -1054,8 +1058,55 @@ def _strip_top_level_message_name(
     return messages
 
 
+def _request_model_slot(model_override: str | None) -> Any | None:
+    raw = (model_override or "").strip()
+    if not raw:
+        return None
+
+    provider_id, sep, model_id = raw.partition(":")
+    provider_id = provider_id.strip()
+    model_id = model_id.strip()
+    if not sep or not provider_id or not model_id:
+        raise ProviderError(
+            message=(
+                "Invalid request model override; expected "
+                "'provider:model'."
+            ),
+        )
+
+    from ..config.config import ModelSlotConfig
+
+    return ModelSlotConfig(provider_id=provider_id, model=model_id)
+
+
+def _model_from_slot(
+    model_slot: Any,
+    *,
+    validate_model: bool = False,
+) -> tuple[ChatModelBase, str]:
+    manager = ProviderManager.get_instance()
+    provider = manager.get_provider(model_slot.provider_id)
+    if provider is None:
+        raise ProviderError(
+            message=f"Provider '{model_slot.provider_id}' not found.",
+        )
+    if validate_model and not provider.has_model(model_slot.model):
+        raise ModelNotFoundException(
+            model_name=f"{model_slot.provider_id}/{model_slot.model}",
+            details={
+                "provider_id": model_slot.provider_id,
+                "model_id": model_slot.model,
+            },
+        )
+    return (
+        provider.get_chat_model_instance(model_slot.model),
+        model_slot.provider_id,
+    )
+
+
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
+    model_override: str | None = None,
 ) -> Tuple[ChatModelBase, FormatterBase]:
     """Factory method to create model and formatter instances.
 
@@ -1065,6 +1116,7 @@ def create_model_and_formatter(
     Args:
         agent_id: Optional agent ID to load agent-specific model config.
             If None, tries to get from context, then falls back to global.
+        model_override: Optional request-level ``provider:model`` override.
 
     Returns:
         Tuple of (model_instance, formatter_instance)
@@ -1082,14 +1134,16 @@ def create_model_and_formatter(
         except Exception:
             pass
 
-    # Try to get agent-specific model first
-    model_slot = None
+    # Try request-level override first, then agent-specific model.
+    model_slot = _request_model_slot(model_override)
+    is_request_override = model_slot is not None
     retry_config = None
     rate_limit_config = None
     if agent_id:
         try:
             agent_config = load_agent_config(agent_id)
-            model_slot = agent_config.active_model
+            if model_slot is None:
+                model_slot = agent_config.active_model
             retry_config = RetryConfig(
                 enabled=agent_config.running.llm_retry_enabled,
                 max_retries=agent_config.running.llm_max_retries,
@@ -1108,16 +1162,10 @@ def create_model_and_formatter(
 
     # Create chat model from agent-specific or global config
     if model_slot and model_slot.provider_id and model_slot.model:
-        # Use agent-specific model
-        manager = ProviderManager.get_instance()
-        provider = manager.get_provider(model_slot.provider_id)
-        if provider is None:
-            raise ProviderError(
-                message=f"Provider '{model_slot.provider_id}' not found.",
-            )
-
-        model = provider.get_chat_model_instance(model_slot.model)
-        provider_id = model_slot.provider_id
+        model, provider_id = _model_from_slot(
+            model_slot,
+            validate_model=is_request_override,
+        )
     else:
         # Fallback to global active model
         model = ProviderManager.get_active_chat_model()

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -172,6 +172,7 @@ class CronJobRequest(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    model: Optional[str] = None
     input: Optional[Any] = None
     session_id: Optional[str] = None
     user_id: Optional[str] = None

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -118,12 +118,20 @@ class AgentBuilder:
             request_context,
         )
         ctx.agent_config = agent_config
+        request_model = getattr(getattr(ctx, "request", None), "model", None)
+        has_request_model = isinstance(request_model, str) and bool(
+            request_model.strip()
+        )
 
         # Validate model availability.
         active = agent_config.active_model
-        if not (active and active.provider_id and active.model):
+        if not has_request_model and not (
+            active and active.provider_id and active.model
+        ):
             active = ProviderManager.get_instance().get_active_model()
-        if active is None or not active.provider_id or not active.model:
+        if not has_request_model and (
+            active is None or not active.provider_id or not active.model
+        ):
             raise RuntimeError(
                 "No active model configured; pick one in the UI",
             )
@@ -180,7 +188,10 @@ class AgentBuilder:
 
         # Model + formatter (built before the toolkit so the scroll context
         # strategy, which needs the model for token counting, can wire in).
-        model, _formatter = self.build_model(agent_config)
+        model, _formatter = self.build_model(
+            agent_config,
+            model_override=request_model,
+        )
 
         # Built once and shared: the agent's native offloader, and (when
         # ``offload_dialog`` is on) scroll's optional dialog archive.
@@ -265,13 +276,18 @@ class AgentBuilder:
         if ctx.session_state:
             agent.load_state_dict(ctx.session_state)
 
+        if has_request_model:
+            provider_id, _, model_name = request_model.strip().partition(":")
+        else:
+            provider_id = active.provider_id
+            model_name = active.model
         _logger.info(
             "builder: built agent for session=%s agent=%s"
             " model=%s/%s tools=%d",
             getattr(ctx, "session_id", ""),
             agent_id,
-            active.provider_id,
-            active.model,
+            provider_id,
+            model_name,
             len(agent.toolkit.tool_groups[0].tools),
         )
         return agent
@@ -320,12 +336,17 @@ class AgentBuilder:
 
         return build_default_prompt_manager().build_sync(prompt_ctx)
 
-    def build_model(self, agent_config: Any) -> tuple[Any, Any]:
+    def build_model(
+        self,
+        agent_config: Any,
+        model_override: str | None = None,
+    ) -> tuple[Any, Any]:
         """Create model and formatter using the factory method."""
         from ..agents.model_factory import create_model_and_formatter
 
         model, formatter = create_model_and_formatter(
             agent_id=agent_config.id,
+            model_override=model_override,
         )
         if formatter is not None:
             innermost = model

--- a/src/qwenpaw/schemas.py
+++ b/src/qwenpaw/schemas.py
@@ -255,6 +255,7 @@ class AgentRequest(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    model: Optional[str] = None
     input: List[Message] = Field(default_factory=list)
     session_id: Optional[str] = None
     user_id: Optional[str] = None

--- a/tests/unit/agents/test_model_factory_request_override.py
+++ b/tests/unit/agents/test_model_factory_request_override.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.agents import model_factory
+from qwenpaw.config.config import ModelSlotConfig
+from qwenpaw.exceptions import ModelNotFoundException, ProviderError
+from qwenpaw.schemas import AgentRequest
+
+
+def _running_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        llm_retry_enabled=False,
+        llm_max_retries=0,
+        llm_backoff_base=0.1,
+        llm_backoff_cap=1.0,
+        llm_max_concurrent=1,
+        llm_max_qpm=0,
+        llm_rate_limit_pause=0.0,
+        llm_rate_limit_jitter=0.0,
+        llm_acquire_timeout=1.0,
+    )
+
+
+class FakeProvider:
+    def __init__(self, *model_ids: str) -> None:
+        self._model_ids = set(model_ids)
+        self.calls: list[str] = []
+
+    def has_model(self, model_id: str) -> bool:
+        return model_id in self._model_ids
+
+    def get_chat_model_instance(self, model_id: str) -> SimpleNamespace:
+        self.calls.append(model_id)
+        return SimpleNamespace(model=model_id)
+
+
+class FakeProviderManager:
+    def __init__(
+        self,
+        providers: dict[str, FakeProvider],
+        active_model: ModelSlotConfig | None = None,
+    ) -> None:
+        self._providers = providers
+        self._active_model = active_model
+
+    def get_provider(self, provider_id: str) -> FakeProvider | None:
+        return self._providers.get(provider_id)
+
+    def get_active_model(self) -> ModelSlotConfig | None:
+        return self._active_model
+
+
+def _patch_model_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    manager: FakeProviderManager,
+    *,
+    agent_model: ModelSlotConfig | None = None,
+) -> None:
+    agent_config = SimpleNamespace(
+        active_model=agent_model,
+        running=_running_config(),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda _agent_id: agent_config,
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_instance",
+        lambda: manager,
+    )
+    monkeypatch.setattr(
+        model_factory.ProviderManager,
+        "get_active_chat_model",
+        lambda: SimpleNamespace(model=manager.get_active_model().model),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _model: None,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "TokenRecordingModelWrapper",
+        lambda provider_id, model: SimpleNamespace(
+            provider_id=provider_id,
+            model=model.model,
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "RetryChatModel",
+        lambda inner, retry_config=None, rate_limit_config=None: inner,
+    )
+
+
+def test_agent_request_declares_model_field() -> None:
+    assert "model" in AgentRequest.model_fields
+
+
+def test_request_model_override_wins_over_agent_active_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_provider = FakeProvider("agent-model")
+    override_provider = FakeProvider("override-model")
+    _patch_model_factory(
+        monkeypatch,
+        FakeProviderManager(
+            {
+                "agent-provider": agent_provider,
+                "override-provider": override_provider,
+            },
+        ),
+        agent_model=ModelSlotConfig(
+            provider_id="agent-provider",
+            model="agent-model",
+        ),
+    )
+
+    model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-a",
+        model_override="override-provider:override-model",
+    )
+
+    assert model.provider_id == "override-provider"
+    assert model.model == "override-model"
+    assert override_provider.calls == ["override-model"]
+    assert agent_provider.calls == []
+
+
+def test_empty_request_model_falls_back_to_agent_active_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_provider = FakeProvider("agent-model")
+    _patch_model_factory(
+        monkeypatch,
+        FakeProviderManager({"agent-provider": agent_provider}),
+        agent_model=ModelSlotConfig(
+            provider_id="agent-provider",
+            model="agent-model",
+        ),
+    )
+
+    model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-a",
+        model_override="",
+    )
+
+    assert model.provider_id == "agent-provider"
+    assert model.model == "agent-model"
+    assert agent_provider.calls == ["agent-model"]
+
+
+def test_empty_request_model_falls_back_to_global_active_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_model_factory(
+        monkeypatch,
+        FakeProviderManager(
+            {},
+            active_model=ModelSlotConfig(
+                provider_id="global-provider",
+                model="global-model",
+            ),
+        ),
+    )
+
+    model, _formatter = model_factory.create_model_and_formatter(
+        agent_id="agent-a",
+        model_override="",
+    )
+
+    assert model.provider_id == "global-provider"
+    assert model.model == "global-model"
+
+
+@pytest.mark.parametrize(
+    ("override", "exc_type", "match"),
+    [
+        ("missing-provider:model", ProviderError, "Provider 'missing-provider'"),
+        (
+            "agent-provider:missing-model",
+            ModelNotFoundException,
+            "agent-provider/missing-model",
+        ),
+        ("missing-colon", ProviderError, "provider:model"),
+    ],
+)
+def test_invalid_request_model_override_has_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+    override: str,
+    exc_type: type[Exception],
+    match: str,
+) -> None:
+    _patch_model_factory(
+        monkeypatch,
+        FakeProviderManager({"agent-provider": FakeProvider("agent-model")}),
+    )
+
+    with pytest.raises(exc_type, match=match):
+        model_factory.create_model_and_formatter(model_override=override)

--- a/tests/unit/app/crons/test_models.py
+++ b/tests/unit/app/crons/test_models.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from qwenpaw.app.crons.models import (
+    CronJobRequest,
     CronJobSpec,
     DispatchSpec,
     DispatchTarget,
@@ -93,6 +94,12 @@ def test_cron_job_spec_agent_syncs_request_with_target():
     assert spec.request is not None
     assert spec.request.user_id == "alice"
     assert spec.request.session_id == "console:alice"
+
+
+def test_cron_job_request_declares_model_field():
+    assert "model" in CronJobRequest.model_fields
+    req = CronJobRequest(model="provider:model-name")
+    assert req.model_dump(mode="json")["model"] == "provider:model-name"
 
 
 def test_cron_job_spec_text_rejects_empty_text():


### PR DESCRIPTION
## Summary
- Add explicit `model` fields to `AgentRequest` and cron job requests.
- Pass `request.model` from runtime agent builds into the shared model factory.
- Resolve request-level `provider:model` before agent/global active models, with clear errors for invalid providers or models.

Fixes #5638

## Why
Cron jobs could carry `request.model` in `jobs.json`, but the runtime still selected the agent active model or global active model when building the agent.

## User impact
A cron job can now set `request.model: "provider:model-name"` for that run only. Jobs without `request.model` keep the existing agent active model, then global active model fallback behavior.

## Verification
- `uv sync --python 3.11 --extra test`
- `uv run --python 3.11 pytest tests/unit/agents/test_model_factory_request_override.py tests/unit/agents/test_model_factory_message_normalization.py tests/unit/agents/test_cross_provider_normalization.py tests/unit/app/crons/test_models.py tests/unit/app/crons/test_manager.py tests/integration/test_cron_execution.py -q`
- `uv run --python 3.11 python -m compileall -q src/qwenpaw/schemas.py src/qwenpaw/app/crons/models.py src/qwenpaw/runtime/builder.py src/qwenpaw/agents/model_factory.py tests/unit/agents/test_model_factory_request_override.py tests/unit/app/crons/test_models.py`
- `git diff --check`