### PR TITLE
fix(chat): allow sending attachments without text

### DIFF
--- a/console/src/pages/Chat/ChatPage.test.tsx
+++ b/console/src/pages/Chat/ChatPage.test.tsx
@@ -13,6 +13,8 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/common_setup";
 import ChatPage from "./index";
 import { chatExtensions } from "@/plugins/registry/chatExtensions";
+import { useMessageQueueStore } from "@/stores/messageQueueStore";
+import { useUploadLimitStore } from "@/stores/uploadLimitStore";
 
 // ---------------------------------------------------------------------------
 // Capture AgentScopeRuntimeWebUI options
@@ -27,6 +29,8 @@ const {
   mockGetApiUrl,
   mockSelectedAgent,
   mockSetSelectedAgent,
+  mockSetLastChatId,
+  mockGetLastChatId,
   mockGetTranscriptionProviderType,
 } = vi.hoisted(() => ({
   mockListProviders: vi.fn(),
@@ -36,6 +40,8 @@ const {
   mockGetApiUrl: vi.fn((p: string) => `/api${p}`),
   mockSelectedAgent: vi.fn(() => "default"),
   mockSetSelectedAgent: vi.fn(),
+  mockSetLastChatId: vi.fn(),
+  mockGetLastChatId: vi.fn(() => null),
   mockGetTranscriptionProviderType: vi.fn(),
 }));
 
@@ -63,6 +69,11 @@ vi.mock("../../plugins/PluginContext", () => ({
 
 vi.mock("./components/ChatSessionInitializer", () => ({
   default: () => null,
+}));
+
+vi.mock("./HostBubbles", () => ({
+  HostRequestCard: () => null,
+  HostResponseCard: () => null,
 }));
 
 vi.mock("@agentscope-ai/chat", () => ({
@@ -98,9 +109,24 @@ vi.mock("@/api/modules/chat", () => ({
     stopChat: vi.fn(),
   },
   sessionApi: {
+    lastActiveChatId: null,
+    preferredChatId: null,
+    isSessionSwitching: false,
     getRealIdForSession: vi.fn(() => null),
+    getBackendSessionId: vi.fn((id: string) => id),
+    getEffectiveSessionId: vi.fn((id: string) => id),
+    getSessionIdentity: vi.fn(() => ({ userId: "user-1", channel: "web" })),
+    isUnresolvedLocalSession: vi.fn(() => false),
+    trackNavigatedSession: vi.fn(),
+    triggerResolve: vi.fn(),
     setLastUserMessage: vi.fn(),
     getSessionList: vi.fn(() => Promise.resolve([])),
+  },
+}));
+
+vi.mock("@/api/modules/skill", () => ({
+  skillApi: {
+    listSkills: vi.fn(() => Promise.resolve([])),
   },
 }));
 
@@ -134,6 +160,8 @@ vi.mock("@/stores/agentStore", () => ({
   useAgentStore: vi.fn(() => ({
     selectedAgent: mockSelectedAgent(),
     setSelectedAgent: mockSetSelectedAgent,
+    setLastChatId: mockSetLastChatId,
+    getLastChatId: mockGetLastChatId,
   })),
 }));
 
@@ -147,15 +175,27 @@ vi.mock("./sessionApi", () => ({
     onSessionRemoved: null,
     onSessionSelected: null,
     onSessionCreated: null,
+    lastActiveChatId: null,
+    preferredChatId: null,
+    isSessionSwitching: false,
     getRealIdForSession: vi.fn(() => null),
+    getBackendSessionId: vi.fn((id: string) => id),
+    getEffectiveSessionId: vi.fn((id: string) => id),
+    getSessionIdentity: vi.fn(() => ({ userId: "user-1", channel: "web" })),
+    isUnresolvedLocalSession: vi.fn(() => false),
+    trackNavigatedSession: vi.fn(),
+    triggerResolve: vi.fn(),
     setLastUserMessage: vi.fn(),
   },
 }));
 
 vi.mock("./OptionsPanel/defaultConfig", () => ({
-  default: { theme: { leftHeader: {} }, api: {} },
+  default: {
+    theme: { leftHeader: {}, bubbleList: { userMessageAnchors: {} } },
+    api: {},
+  },
   getDefaultConfig: vi.fn(() => ({
-    theme: { leftHeader: {} },
+    theme: { leftHeader: {}, bubbleList: { userMessageAnchors: {} } },
     welcome: {},
     sender: {},
   })),
@@ -195,6 +235,45 @@ const mockProviders = [
     extra_models: [],
   },
 ];
+const modelPromptTitle =
+  "LLM Model Required — Select in Chat After Configuration";
+const modelPromptSkip = "Skip";
+
+function addSenderTextarea(value = "") {
+  const sender = document.createElement("div");
+  sender.className = "qwenpaw-sender";
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  sender.appendChild(textarea);
+  document.body.appendChild(sender);
+  return textarea;
+}
+
+async function uploadSmallAttachment() {
+  await capturedOptions.sender.attachments.customRequest({
+    file: new File(["content"], "note.txt", { type: "text/plain" }),
+    onSuccess: vi.fn(),
+    onError: vi.fn(),
+    onProgress: vi.fn(),
+  });
+}
+
+async function renderOwnerChat(value = "") {
+  addSenderTextarea(value);
+  renderWithProviders(<ChatPage />, { initialEntries: ["/chat/session-1"] });
+  await screen.findByTestId("chat-ui");
+  await waitFor(() => expect(capturedOptions.sender.beforeUI).toBeUndefined());
+}
+
+async function renderQueueOnlyChat(value = "") {
+  Object.defineProperty(navigator, "locks", {
+    configurable: true,
+    value: { request: vi.fn(() => Promise.resolve(undefined)) },
+  });
+  addSenderTextarea(value);
+  renderWithProviders(<ChatPage />, { initialEntries: ["/chat/session-1"] });
+  await screen.findByTestId("chat-ui");
+}
 
 // ---------------------------------------------------------------------------
 // tests
@@ -203,6 +282,22 @@ describe("ChatPage", () => {
   beforeEach(() => {
     chatExtensions.__resetForTests();
     capturedOptions = null;
+    document.querySelectorAll(".qwenpaw-sender").forEach((node) => {
+      node.remove();
+    });
+    Object.defineProperty(navigator, "locks", {
+      configurable: true,
+      value: undefined,
+    });
+    localStorage.clear();
+    sessionStorage.clear();
+    useMessageQueueStore.setState({
+      queues: {},
+      runStates: {},
+      currentSendingId: null,
+      lastMigratedTo: null,
+    });
+    useUploadLimitStore.setState({ uploadMaxSizeMb: 10 });
     mockListProviders.mockResolvedValue(mockProviders);
     mockGetActiveModels.mockResolvedValue(mockActiveModel);
     mockUploadFile.mockResolvedValue({
@@ -216,6 +311,9 @@ describe("ChatPage", () => {
 
   afterEach(() => {
     chatExtensions.__resetForTests();
+    document.querySelectorAll(".qwenpaw-sender").forEach((node) => {
+      node.remove();
+    });
     vi.clearAllMocks();
   });
 
@@ -248,9 +346,7 @@ describe("ChatPage", () => {
       signal: undefined,
     });
     expect(response.status).toBe(400);
-    expect(
-      await screen.findByText("modelConfig.promptTitle"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(modelPromptTitle)).toBeInTheDocument();
   });
 
   it("shows model config modal when provider API throws", async () => {
@@ -263,9 +359,7 @@ describe("ChatPage", () => {
       signal: undefined,
     });
     expect(response.status).toBe(400);
-    expect(
-      await screen.findByText("modelConfig.promptTitle"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(modelPromptTitle)).toBeInTheDocument();
   });
 
   // ── modal interaction ─────────────────────────────────────────────────────
@@ -277,15 +371,12 @@ describe("ChatPage", () => {
     await screen.findByTestId("chat-ui");
 
     await capturedOptions.api.fetch({ input: [], signal: undefined });
-    await screen.findByText("modelConfig.promptTitle");
+    await screen.findByText(modelPromptTitle);
 
-    await user.click(screen.getByText("modelConfig.skipButton"));
+    await user.click(screen.getByText(modelPromptSkip));
     // antd Modal has animations; wait for DOM removal
     await waitFor(
-      () =>
-        expect(
-          screen.queryByText("modelConfig.skipButton"),
-        ).not.toBeInTheDocument(),
+      () => expect(screen.queryByText(modelPromptSkip)).not.toBeInTheDocument(),
       { timeout: 3000 },
     );
   });
@@ -390,6 +481,54 @@ describe("ChatPage", () => {
     expect(mockUploadFile).toHaveBeenCalledWith(smallFile);
     expect(onSuccess).toHaveBeenCalledWith({ url: "/preview/uploaded.png" });
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("beforeSubmit allows text-only messages", async () => {
+    await renderOwnerChat("hello");
+
+    await expect(capturedOptions.sender.beforeSubmit()).resolves.toBe(true);
+  });
+
+  it("beforeSubmit allows messages with text and attachments", async () => {
+    await renderOwnerChat("hello");
+    await uploadSmallAttachment();
+
+    await expect(capturedOptions.sender.beforeSubmit()).resolves.toBe(true);
+  });
+
+  it("queues attachment-only messages instead of blocking them", async () => {
+    await renderQueueOnlyChat("");
+    await uploadSmallAttachment();
+
+    await expect(capturedOptions.sender.beforeSubmit()).resolves.toBe(false);
+
+    const queue = useMessageQueueStore.getState().getQueue("session-1");
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({
+      text: "",
+      attachments: [
+        {
+          url: "/preview/uploaded.png",
+          name: "note.txt",
+          type: "text/plain",
+        },
+      ],
+    });
+  });
+
+  it("shows a send action for attachment-only input", async () => {
+    await renderOwnerChat("");
+    await uploadSmallAttachment();
+
+    await waitFor(() =>
+      expect(capturedOptions.sender.actionAffix).toBeTruthy(),
+    );
+  });
+
+  it("blocks empty messages without attachments", async () => {
+    await renderOwnerChat("");
+
+    await expect(capturedOptions.sender.beforeSubmit()).resolves.toBe(false);
   });
 
   // ── voice input mode ───────────────────────────────────────────────────────

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -43,6 +43,22 @@
     }
   }
 
+  &.attachmentOnlySendMode :global {
+    .qwenpaw-sender-action-list-presets {
+      display: none;
+    }
+  }
+
+  .attachmentOnlySendButton {
+    color: #fff;
+    background: #ff7f16;
+
+    &:hover {
+      color: #fff;
+      background: #ff9340;
+    }
+  }
+
   /* Custom scrollbar */
   &::-webkit-scrollbar {
     width: 8px;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -7,7 +7,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button, Modal, Result, Tooltip } from "antd";
 import { useAppMessage } from "../../hooks/useAppMessage";
 import { useIsMobile } from "../../hooks/useIsMobile";
-import { ExclamationCircleOutlined, SettingOutlined } from "@ant-design/icons";
+import {
+  ArrowUpOutlined,
+  ExclamationCircleOutlined,
+  SettingOutlined,
+} from "@ant-design/icons";
 import { SparkCopyLine, SparkAttachmentLine } from "@agentscope-ai/icons";
 import { usePlugins } from "../../plugins/PluginContext";
 import { useTranslation } from "react-i18next";
@@ -1150,6 +1154,25 @@ export default function ChatPage() {
       size?: number;
     }[]
   >([]);
+  const [pendingFileCount, setPendingFileCount] = useState(0);
+  const [senderTextValue, setSenderTextValue] = useState("");
+  const setPendingFiles = useCallback(
+    (files: typeof pendingFileListRef.current) => {
+      pendingFileListRef.current = files;
+      setPendingFileCount(files.length);
+    },
+    [],
+  );
+  const getPendingAttachments = useCallback(
+    () =>
+      pendingFileListRef.current.map((f) => ({
+        url: f.url,
+        name: f.name,
+        type: f.type,
+        size: f.size,
+      })),
+    [],
+  );
 
   // Build SDK fileList from QueueItem.attachments
   // SDK reads file.response.url for image_url / file_url (see AgentScopeRuntimeRequestBuilder)
@@ -1581,6 +1604,20 @@ export default function ChatPage() {
     }
   }, []);
 
+  useEffect(() => {
+    const handleInput = (e: Event) => {
+      const target = e.target;
+      if (
+        target instanceof HTMLTextAreaElement &&
+        target.closest('[class*="sender"]')
+      ) {
+        setSenderTextValue(target.value);
+      }
+    };
+    document.addEventListener("input", handleInput, true);
+    return () => document.removeEventListener("input", handleInput, true);
+  }, []);
+
   useMessageHistoryNavigation(chatRef, isChatActive, isComposingRef);
   useChatInputDraft(isChatActive, selectedAgent);
   useChatPasteFromEditor();
@@ -1689,7 +1726,8 @@ export default function ChatPage() {
         : null;
       if (!textarea) return;
       const val = textarea.value.trim();
-      if (!val) return;
+      const pendingAttachments = getPendingAttachments();
+      if (!val && pendingAttachments.length === 0) return;
       e.preventDefault();
       e.stopPropagation();
       if (!chatId) {
@@ -1703,19 +1741,12 @@ export default function ChatPage() {
       useMessageQueueStore.getState().enqueue(queueSessionId, {
         text: val,
         attachments:
-          pendingFileListRef.current.length > 0
-            ? pendingFileListRef.current.map((f) => ({
-                url: f.url,
-                name: f.name,
-                type: f.type,
-                size: f.size,
-              }))
-            : undefined,
+          pendingAttachments.length > 0 ? pendingAttachments : undefined,
         userId: window.currentUserId || DEFAULT_USER_ID,
         channel: window.currentChannel || DEFAULT_CHANNEL,
       });
       // Clear tracked attachments after enqueuing
-      pendingFileListRef.current = [];
+      setPendingFiles([]);
       setTextareaValue(textarea, "");
       // Clear sender attachment preview. Defer to next tick so React commits
       // any pending state updates (e.g. from setTextareaValue) before we
@@ -1725,7 +1756,16 @@ export default function ChatPage() {
     document.addEventListener("keydown", handleEnterEnqueue, true);
     return () =>
       document.removeEventListener("keydown", handleEnterEnqueue, true);
-  }, [isChatActive, queueSessionId]);
+  }, [
+    chatId,
+    getPendingAttachments,
+    isChatActive,
+    isComposingRef,
+    message,
+    queueSessionId,
+    setPendingFiles,
+    t,
+  ]);
 
   const handleQueueRemove = useCallback(
     (id: string) => {
@@ -2227,7 +2267,7 @@ export default function ChatPage() {
         const previewUrl = chatApi.filePreviewUrl(res.url);
         onSuccess({ url: previewUrl });
         // Track uploaded file for queue attachment support
-        pendingFileListRef.current = [
+        setPendingFiles([
           ...pendingFileListRef.current,
           {
             uid: res.url,
@@ -2236,12 +2276,12 @@ export default function ChatPage() {
             type: file.type,
             size: file.size,
           },
-        ];
+        ]);
       } catch (e) {
         onError?.(e instanceof Error ? e : new Error(String(e)));
       }
     },
-    [multimodalCaps, t],
+    [multimodalCaps, setPendingFiles, t],
   );
 
   const options = useMemo(() => {
@@ -2281,16 +2321,17 @@ export default function ChatPage() {
       }));
     const handleBeforeSubmit = async () => {
       if (isComposingRef.current) return false;
+      const textarea = document
+        .querySelector('[class*="sender"]')
+        ?.querySelector("textarea") as HTMLTextAreaElement | null;
+      const val = textarea?.value.trim() ?? "";
+      const pendingAttachments = getPendingAttachments();
+      if (!val && pendingAttachments.length === 0) return false;
       // Single-tab ownership: non-owner tabs are queue-only. Re-route every
       // submit (Enter / send button / programmatic) to the shared queue and
       // abort the actual SDK send. The owner tab will pick the item up via
       // cross-tab broadcast and send it.
       if (!isOwnerRef.current) {
-        const textarea = document
-          .querySelector('[class*="sender"]')
-          ?.querySelector("textarea") as HTMLTextAreaElement | null;
-        const val = textarea?.value.trim() ?? "";
-        if (!val) return false;
         if (!chatId) {
           return false;
         }
@@ -2304,18 +2345,11 @@ export default function ChatPage() {
         useMessageQueueStore.getState().enqueue(queueSessionId, {
           text: val,
           attachments:
-            pendingFileListRef.current.length > 0
-              ? pendingFileListRef.current.map((f) => ({
-                  url: f.url,
-                  name: f.name,
-                  type: f.type,
-                  size: f.size,
-                }))
-              : undefined,
+            pendingAttachments.length > 0 ? pendingAttachments : undefined,
           userId: window.currentUserId || DEFAULT_USER_ID,
           channel: window.currentChannel || DEFAULT_CHANNEL,
         });
-        pendingFileListRef.current = [];
+        setPendingFiles([]);
         if (textarea) setTextareaValue(textarea, "");
         // Clear sender attachment preview (deferred to next tick)
         clearSenderAttachments();
@@ -2326,7 +2360,7 @@ export default function ChatPage() {
       localStorage.removeItem(getDraftStorageKey(selectedAgent));
       draftSuppressed = true;
       // Clear pending attachments when sending directly (not through queue)
-      pendingFileListRef.current = [];
+      setPendingFiles([]);
       return true;
     };
 
@@ -2597,6 +2631,51 @@ export default function ChatPage() {
               {pluginSenderPrefix}
             </>
           ) : undefined,
+        actionAffix:
+          pendingFileCount > 0 && senderTextValue.trim().length === 0 ? (
+            <IconButton
+              className={styles.attachmentOnlySendButton}
+              icon={<ArrowUpOutlined />}
+              bordered={false}
+              aria-label="Send"
+              onClick={() => {
+                const attachments = getPendingAttachments();
+                if (attachments.length === 0) return;
+                const textarea = document
+                  .querySelector('[class*="sender"]')
+                  ?.querySelector("textarea") as HTMLTextAreaElement | null;
+                const val = textarea?.value.trim() ?? "";
+                if (!isOwnerRef.current || chatLoadingRef.current) {
+                  if (!chatId) return;
+                  const currentQ = useMessageQueueStore
+                    .getState()
+                    .getQueue(queueSessionId);
+                  if (currentQ.length >= MAX_QUEUE_SIZE) {
+                    message.warning(
+                      t("chat.queue.queueFull", { max: MAX_QUEUE_SIZE }),
+                    );
+                    return;
+                  }
+                  useMessageQueueStore.getState().enqueue(queueSessionId, {
+                    text: val,
+                    attachments,
+                    userId: window.currentUserId || DEFAULT_USER_ID,
+                    channel: window.currentChannel || DEFAULT_CHANNEL,
+                  });
+                } else {
+                  chatRef.current?.input.submit({
+                    query: val,
+                    fileList: buildFileList({ attachments }),
+                  });
+                  localStorage.removeItem(getDraftStorageKey(selectedAgent));
+                  draftSuppressed = true;
+                }
+                setPendingFiles([]);
+                if (textarea) setTextareaValue(textarea, "");
+                clearSenderAttachments();
+              }}
+            />
+          ) : undefined,
         attachments: {
           multiple: true,
           trigger: function (props: any) {
@@ -2786,8 +2865,16 @@ export default function ChatPage() {
     } as unknown as IAgentScopeRuntimeWebUIOptions;
   }, [
     customFetch,
+    buildFileList,
+    chatId,
     copyResponse,
+    getPendingAttachments,
     handleFileUpload,
+    message,
+    pendingFileCount,
+    queueSessionId,
+    senderTextValue,
+    setPendingFiles,
     t,
     i18n.language,
     isDark,
@@ -2822,11 +2909,15 @@ export default function ChatPage() {
       {/* Main chat area */}
       <div className={styles.chatMainArea}>
         <div
-          className={
-            isWideMode
-              ? `${styles.chatMessagesArea} ${styles.wideMode}`
-              : styles.chatMessagesArea
-          }
+          className={[
+            styles.chatMessagesArea,
+            isWideMode ? styles.wideMode : "",
+            pendingFileCount > 0 && senderTextValue.trim().length === 0
+              ? styles.attachmentOnlySendMode
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
         >
           <AgentScopeRuntimeWebUI
             ref={chatRef}

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -90,8 +90,6 @@ export default defineConfig(({ mode }) => {
         "**/dist/**",
         // 旧测试用 node:test，与 vitest 不兼容，待迁移
         "**/testConnectionMessage.test.ts",
-        // ChatPage test causes worker crash - pre-existing issue, needs more mock setup
-        "**/pages/Chat/ChatPage.test.tsx",
         // Tauri modules require @tauri-apps/api which only exists in desktop builds
         "**/src/tauri/**",
       ],


### PR DESCRIPTION
## Summary
- allow chat submission when uploaded attachments exist even if the text input is empty
- route attachment-only sends through the existing direct-send or message-queue paths
- re-enable and update ChatPage tests, including text-only, text + attachment, attachment-only, and empty-submit coverage

## Why
Fixes #5558. Enterprise WeChat/chat users can upload an attachment and send it without typing filler text, while empty input with no attachment remains blocked.

## Validation
- `npm run test:run -- src/pages/Chat/ChatPage.test.tsx`
- `npx tsc -b --noEmit`
- `npm run test:run`