### PR TITLE
fix(runtime): restore spawn_subagent for Runtime 2.0 (#5523)

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -291,7 +291,11 @@ def collect_final_agent_chat_response(
     to_agent: str,
     timeout: int,
 ) -> Optional[Dict[str, Any]]:
-    """Collect the last SSE payload from inter-agent chat."""
+    """Collect the last non-metadata SSE payload from inter-agent chat.
+
+    Skips trailing ``turn_usage`` events so the caller receives
+    the actual agent response instead of usage telemetry.
+    """
     response_data: Optional[Dict[str, Any]] = None
     with create_agent_api_client(base_url) as client:
         with client.stream(
@@ -305,7 +309,7 @@ def collect_final_agent_chat_response(
             for line in response.iter_lines():
                 if line:
                     parsed = parse_agent_sse_line(line)
-                    if parsed:
+                    if parsed and parsed.get("type") != "turn_usage":
                         response_data = parsed
     return response_data
 
@@ -653,6 +657,7 @@ def _generate_subagent_session_id() -> str:
     return f"sub-{str(uuid4())[:8]}"
 
 
+@tool_descriptor(async_execution=True)
 async def spawn_subagent(
     task: str,
     fork: bool = False,

--- a/src/qwenpaw/app/routers/__init__.py
+++ b/src/qwenpaw/app/routers/__init__.py
@@ -18,6 +18,7 @@ from .tools import router as tools_router
 from ..crons.api import router as cron_router
 from ..chats.api import router as runner_router
 from .console import router as console_router
+from .fork import router as fork_router
 from .token_usage import router as token_usage_router
 from .agent_stats import router as agent_stats_router
 from .auth import router as auth_router
@@ -36,6 +37,7 @@ router = APIRouter()
 router.include_router(agents_router)
 router.include_router(config_router)
 router.include_router(console_router)
+router.include_router(fork_router)
 router.include_router(cron_router)
 router.include_router(local_models_router)
 router.include_router(mcp_oauth_router)

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -6,11 +6,20 @@ import asyncio
 import json
 import logging
 import re
+import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncGenerator, Union
+from typing import Any, AsyncGenerator, Dict, Optional, Union
 
-from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    File,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
@@ -28,6 +37,24 @@ from ..utils import check_upload_size
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/console", tags=["console"])
+
+
+# ── Background task store ──
+
+
+@dataclass
+class _BackgroundTask:
+    """In-memory state for a background chat task."""
+
+    status: str = "submitted"
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    result: Optional[Dict[str, Any]] = None
+    asyncio_task: Optional[asyncio.Task] = None
+
+
+_bg_tasks: Dict[str, _BackgroundTask] = {}
+_bg_lock = asyncio.Lock()
 
 
 class MarkInboxReadRequest(BaseModel):
@@ -461,5 +488,143 @@ async def get_inbox_trace(run_id: str):
 
     trace = await get_trace(run_id)
     if trace is None:
-        raise HTTPException(status_code=404, detail="trace not found")
+        raise HTTPException(
+            status_code=404,
+            detail="trace not found",
+        )
     return trace
+
+
+# ── Background chat task endpoints ──
+
+
+def _parse_sse_payload(line: str) -> Optional[Dict[str, Any]]:
+    """Parse a single SSE data line into a dict."""
+    stripped = line.strip()
+    if stripped.startswith("data: "):
+        try:
+            return json.loads(stripped[6:])
+        except (json.JSONDecodeError, ValueError):
+            return None
+    return None
+
+
+@router.post(
+    "/chat/task",
+    status_code=200,
+    summary="Submit a background chat task",
+)
+async def post_console_chat_task(
+    request_data: Union[AgentRequest, dict],
+    request: Request,
+) -> dict:
+    """Run an agent chat as a background task.
+
+    Returns a ``task_id`` immediately. Poll status via
+    ``GET /console/chat/task/{task_id}``.
+    """
+    workspace = await get_agent_for_request(request)
+    console_channel = await workspace.channel_manager.get_channel("console")
+    if console_channel is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Channel Console not found",
+        )
+
+    task_id = f"task-{uuid.uuid4().hex[:12]}"
+    native_payload = _extract_session_and_payload(request_data)
+    session_id = console_channel.resolve_session_id(
+        sender_id=native_payload["sender_id"],
+        channel_meta=native_payload["meta"],
+    )
+
+    task_timeout: Optional[float] = None
+    if isinstance(request_data, dict):
+        task_timeout = request_data.get("timeout")
+    elif hasattr(request_data, "timeout"):
+        task_timeout = getattr(request_data, "timeout", None)
+
+    bg = _BackgroundTask(
+        status="running",
+        started_at=time.time(),
+    )
+
+    async def _run() -> None:
+        last_response: Optional[Dict[str, Any]] = None
+        try:
+            async for sse_line in console_channel.stream_one(
+                native_payload,
+            ):
+                parsed = _parse_sse_payload(sse_line)
+                if parsed and parsed.get("type") != "turn_usage":
+                    last_response = parsed
+        except asyncio.CancelledError:
+            bg.status = "finished"
+            bg.finished_at = time.time()
+            bg.result = {
+                "status": "failed",
+                "error": {"message": "Task cancelled"},
+            }
+            return
+        except Exception as exc:
+            bg.status = "finished"
+            bg.finished_at = time.time()
+            bg.result = {
+                "status": "failed",
+                "error": {"message": str(exc)},
+            }
+            return
+
+        bg.status = "finished"
+        bg.finished_at = time.time()
+        if last_response is not None:
+            bg.result = {
+                "status": "completed",
+                "session_id": session_id,
+                **last_response,
+            }
+        else:
+            bg.result = {
+                "status": "completed",
+                "session_id": session_id,
+                "output": [],
+            }
+
+    atask = asyncio.create_task(_run())
+    bg.asyncio_task = atask
+
+    if task_timeout is not None and task_timeout > 0:
+
+        async def _timeout_guard() -> None:
+            await asyncio.sleep(task_timeout)
+            if not atask.done():
+                atask.cancel()
+
+        asyncio.create_task(_timeout_guard())
+
+    async with _bg_lock:
+        _bg_tasks[task_id] = bg
+
+    return {"task_id": task_id}
+
+
+@router.get(
+    "/chat/task/{task_id}",
+    status_code=200,
+    summary="Check background chat task status",
+)
+async def get_console_chat_task(task_id: str) -> dict:
+    """Return the current status of a background chat task."""
+    async with _bg_lock:
+        bg = _bg_tasks.get(task_id)
+    if bg is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Task not found: {task_id}",
+        )
+    response: Dict[str, Any] = {"status": bg.status}
+    if bg.started_at is not None:
+        response["started_at"] = bg.started_at
+    if bg.status == "finished" and bg.result is not None:
+        response["result"] = bg.result
+    return response

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -153,6 +153,7 @@ def _create_default_registry() -> ToolRegistry:
     registry.register("ChatWithAgent", "internal", "agent_id")
     registry.register("SubmitToAgent", "internal", "agent_id")
     registry.register("CheckAgentTask", "internal", "task_id")
+    registry.register("SpawnSubagent", "internal", "")
     registry.register("DelegateExternalAgent", "internal", "runner")
     registry.register("RecallHistoryPython", "shell", "source")
     registry.register("MemorySearch", "internal", "")
@@ -182,6 +183,7 @@ def _create_default_registry() -> ToolRegistry:
     registry.register_python_name("chat_with_agent", "ChatWithAgent")
     registry.register_python_name("submit_to_agent", "SubmitToAgent")
     registry.register_python_name("check_agent_task", "CheckAgentTask")
+    registry.register_python_name("spawn_subagent", "SpawnSubagent")
     registry.register_python_name("materialize_skill", "MaterializeSkill")
 
     return registry


### PR DESCRIPTION
## Summary

Fixes #5523 — `spawn_subagent` was present in v1.1.10+ but became unusable after the Runtime 2.0 migration. This PR addresses all four regressions identified in the issue:

1. **Missing runtime tool descriptor** — Added `@tool_descriptor(async_execution=True)` so workspace bootstrap auto-discovers `spawn_subagent`.
2. **Missing governance registry entry** — Registered `SpawnSubagent` as an `internal` tool in the governance `ToolRegistry` with the corresponding `python_name → policy_name` mapping.
3. **Foreground result corruption** — `collect_final_agent_chat_response` now filters out `turn_usage` SSE events, ensuring the caller receives the actual agent response instead of trailing usage telemetry.
4. **Background / fork endpoints missing** — Added `POST /console/chat/task` and `GET /console/chat/task/{task_id}` routes for background task submission and polling. Mounted the existing `fork` router in `routers/__init__.py` so `spawn_subagent(fork=True)` can reach `/api/fork/agent`.

## Files Changed

| File | Change |
|------|--------|
| `src/qwenpaw/agents/tools/agent_management.py` | Add `@tool_descriptor` to `spawn_subagent`; filter `turn_usage` in `collect_final_agent_chat_response` |
| `src/qwenpaw/governance/tool_registry.py` | Register `SpawnSubagent` + python name mapping |
| `src/qwenpaw/app/routers/console.py` | Add background task endpoints (`/chat/task`) |
| `src/qwenpaw/app/routers/__init__.py` | Mount `fork_router` |

## Test Plan

- [x] All 1738 existing unit tests pass (agents/tools, channels, routers, task_tracker)
- [x] Verified `spawn_subagent` appears in `discover_builtin_tool_funcs()` output
- [x] Verified governance `DEFAULT_REGISTRY.get_type('SpawnSubagent')` returns `"internal"`
- [x] Verified `python_to_policy_name('spawn_subagent')` returns `"SpawnSubagent"`
- [x] pre-commit (black, flake8, pylint, mypy) passes on all changed files
- [ ] End-to-end: foreground subagent returns final response (not turn_usage)
- [ ] End-to-end: background subagent returns task_id, status polling works
- [ ] End-to-end: fork subagent reaches `/api/fork/agent`