### PR TITLE
feat(memory): add qwen3-rerank to memory search

### DIFF
--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -52,6 +52,32 @@ def _tool_chunk(text: str, *, ok: bool = True) -> ToolChunk:
     )
 
 
+def _build_search_answer(candidates: list[dict]) -> str:
+    """Format re-ranked candidates as a ReMe-style search answer string.
+
+    Produces the same format as ReMe's ``SearchStep._format_scores``::
+
+        ========== path:start-end [score=... rerank=...] ==========
+        text content...
+    """
+    lines: list[str] = []
+    for c in candidates:
+        scores: dict[str, float] = c.get("scores", {})
+        score_parts = [f"score={scores.get('score', 0.0):.4f}"]
+        for key in ("vector", "keyword", "rerank"):
+            val = scores.get(key)
+            score_parts.append(
+                f"{key}={val:.4f}" if val is not None else f"{key}=-",
+            )
+        header = (
+            f"========== {c['path']}:{c['start_line']}-{c['end_line']}"
+            f" [{' '.join(score_parts)}] =========="
+        )
+        lines.append(header)
+        lines.append(c["text"])
+    return "\n".join(lines)
+
+
 @memory_registry.register("remelight")
 class ReMeLightMemoryManager(BaseMemoryManager):
     """Memory manager backed by ReMe.
@@ -197,6 +223,103 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             logger.exception("ReMe job failed: %s", name)
             return None
 
+    # pylint: disable=too-many-return-statements
+    async def _rerank_dashscope(
+        self,
+        query: str,
+        candidates: list[dict],
+        top_n: int,
+    ) -> list[dict]:
+        """Re-rank candidates using DashScope re-rank API.
+
+        Returns *top_n* candidates ordered by ``relevance_score`` descending,
+        with ``"rerank"`` merged into each candidate's ``scores`` dict.
+
+        On any error the original *candidates* (truncated to *top_n*) are
+        returned so the caller always progresses.
+        """
+        if not candidates:
+            return candidates
+
+        try:
+            import dashscope
+        except ImportError:
+            logger.warning("dashscope not installed; skipping rerank")
+            return candidates[:top_n]
+
+        try:
+            agent_config = load_agent_config(self.agent_id)
+            memory_cfg = agent_config.running.reme_light_memory_config
+        except Exception:
+            memory_cfg = None
+        rerank_model = (
+            getattr(memory_cfg, "rerank_model", "qwen3-rerank")
+            or "qwen3-rerank"
+        )
+
+        api_key = getattr(memory_cfg, "dashscope_api_key", "") or ""
+        if not api_key:
+            logger.warning("dashscope_api_key not configured; skipping rerank")
+            return candidates[:top_n]
+
+        texts = [c.get("text", "") for c in candidates]
+
+        try:
+            resp = dashscope.TextReRank.call(
+                model=rerank_model,
+                query=query,
+                documents=texts,
+                top_n=top_n,
+                return_documents=False,
+                api_key=api_key,
+            )
+        except Exception:
+            logger.exception("dashscope rerank call failed")
+            return candidates[:top_n]
+
+        if resp.status_code != 200:
+            logger.warning(
+                "dashscope rerank returned %s: %s",
+                resp.status_code,
+                getattr(resp, "message", ""),
+            )
+            return candidates[:top_n]
+
+        output = getattr(resp, "output", None)
+        if output is None or not hasattr(output, "results"):
+            logger.warning("dashscope rerank response missing output.results")
+            return candidates[:top_n]
+
+        result: list[dict] = []
+        for item in output.results:
+            idx = (
+                item.get("index")
+                if isinstance(item, dict)
+                else getattr(item, "index", None)
+            )
+            score = (
+                item.get("relevance_score")
+                if isinstance(item, dict)
+                else getattr(item, "relevance_score", None)
+            )
+            if idx is None or idx >= len(candidates):
+                continue
+            c = dict(candidates[idx])
+            c["scores"] = {
+                **(c.get("scores") or {}),
+                "rerank": float(score) if score is not None else 0.0,
+            }
+            result.append(c)
+
+        if not result:
+            logger.warning(
+                "dashscope rerank returned empty results;"
+                " using original order",
+            )
+            return candidates[:top_n]
+
+        return result
+
     def _install_reme_result_hook(self) -> None:
         """Expose QwenPaw inbox delivery to ReMe background steps."""
         if self._reme is None:
@@ -293,9 +416,11 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 name,
                 event.get("id"),
                 event.get("status"),
-                response_metadata.get("modified")
-                if isinstance(response_metadata, dict)
-                else None,
+                (
+                    response_metadata.get("modified")
+                    if isinstance(response_metadata, dict)
+                    else None
+                ),
             )
             return True
         except Exception:  # pylint: disable=broad-except
@@ -358,18 +483,42 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if not query:
             return _tool_chunk("Error: query cannot be empty", ok=False)
 
+        agent_config = load_agent_config(self.agent_id)
+        memory_cfg = agent_config.running.reme_light_memory_config
+        rerank = memory_cfg.rerank_enabled
+        fetch_limit = (
+            max(1, max_results * 3) if rerank else max(1, max_results)
+        )
+
         response = await self._run_reme_job(
             "search",
             query=query,
-            limit=max(1, max_results),
+            limit=fetch_limit,
             min_score=max(0.0, min_score),
         )
         if response is None:
             return _tool_chunk("ReMe is not started.", ok=False)
 
-        answer = str(response.answer or "").strip()
-        if not answer:
-            answer = NO_MEMORY_RESULTS
+        if rerank and response.success:
+            candidates = response.metadata.get("results", [])
+            if not candidates:
+                answer = (
+                    str(response.answer or "").strip() or NO_MEMORY_RESULTS
+                )
+            else:
+                if len(candidates) > max_results:
+                    candidates = await self._rerank_dashscope(
+                        query,
+                        candidates,
+                        max_results,
+                    )
+                answer = _build_search_answer(candidates[:max_results])
+                if not answer.strip():
+                    answer = NO_MEMORY_RESULTS
+        else:
+            answer = str(response.answer or "").strip()
+            if not answer:
+                answer = NO_MEMORY_RESULTS
         return _tool_chunk(answer, ok=response.success)
 
     async def summarize(
@@ -392,6 +541,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             return ""
         return str(response.answer or "")
 
+    # pylint: disable=too-many-return-statements
     async def auto_memory_search(
         self,
         messages: list[Msg] | Msg,
@@ -411,19 +561,44 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             return None
 
         search_cfg = memory_cfg.auto_memory_search_config
+        rerank = memory_cfg.rerank_enabled
+        fetch_limit = (
+            max(1, search_cfg.max_results * 3)
+            if rerank
+            else max(1, search_cfg.max_results)
+        )
 
         response = await self._run_reme_job(
             "search",
             query=query,
-            limit=max(1, search_cfg.max_results),
+            limit=fetch_limit,
             min_score=0,
         )
         if response is None or not response.success:
             return None
 
-        text = str(response.answer or "").strip()
-        if not text:
-            return None
+        if rerank:
+            candidates = response.metadata.get("results", [])
+            if not candidates:
+                text = str(response.answer or "").strip()
+                if not text:
+                    return None
+            else:
+                if len(candidates) > search_cfg.max_results:
+                    candidates = await self._rerank_dashscope(
+                        query,
+                        candidates,
+                        search_cfg.max_results,
+                    )
+                text = _build_search_answer(
+                    candidates[: search_cfg.max_results],
+                )
+                if not text.strip():
+                    return None
+        else:
+            text = str(response.answer or "").strip()
+            if not text:
+                return None
 
         tool_call_id = uuid.uuid4().hex
         tool_input = {

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -20,6 +20,7 @@ from agentscope.tool import ToolChunk
 from .base_memory_manager import BaseMemoryManager, memory_registry
 from .prompts import build_memory_guidance_prompt
 from .reme_config import get_reme_app_config
+from .reranker import build_search_answer, rerank
 from ..model_factory import create_model_and_formatter
 from ...app.inbox_store import append_event as append_inbox_event
 from ...config import load_config
@@ -50,32 +51,6 @@ def _tool_chunk(text: str, *, ok: bool = True) -> ToolChunk:
         state=ToolResultState.SUCCESS if ok else ToolResultState.ERROR,
         content=[TextBlock(type="text", text=text)],
     )
-
-
-def _build_search_answer(candidates: list[dict]) -> str:
-    """Format re-ranked candidates as a ReMe-style search answer string.
-
-    Produces the same format as ReMe's ``SearchStep._format_scores``::
-
-        ========== path:start-end [score=... rerank=...] ==========
-        text content...
-    """
-    lines: list[str] = []
-    for c in candidates:
-        scores: dict[str, float] = c.get("scores", {})
-        score_parts = [f"score={scores.get('score', 0.0):.4f}"]
-        for key in ("vector", "keyword", "rerank"):
-            val = scores.get(key)
-            score_parts.append(
-                f"{key}={val:.4f}" if val is not None else f"{key}=-",
-            )
-        header = (
-            f"========== {c['path']}:{c['start_line']}-{c['end_line']}"
-            f" [{' '.join(score_parts)}] =========="
-        )
-        lines.append(header)
-        lines.append(c["text"])
-    return "\n".join(lines)
 
 
 @memory_registry.register("remelight")
@@ -222,103 +197,6 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         except Exception:
             logger.exception("ReMe job failed: %s", name)
             return None
-
-    # pylint: disable=too-many-return-statements
-    async def _rerank_dashscope(
-        self,
-        query: str,
-        candidates: list[dict],
-        top_n: int,
-    ) -> list[dict]:
-        """Re-rank candidates using DashScope re-rank API.
-
-        Returns *top_n* candidates ordered by ``relevance_score`` descending,
-        with ``"rerank"`` merged into each candidate's ``scores`` dict.
-
-        On any error the original *candidates* (truncated to *top_n*) are
-        returned so the caller always progresses.
-        """
-        if not candidates:
-            return candidates
-
-        try:
-            import dashscope
-        except ImportError:
-            logger.warning("dashscope not installed; skipping rerank")
-            return candidates[:top_n]
-
-        try:
-            agent_config = load_agent_config(self.agent_id)
-            memory_cfg = agent_config.running.reme_light_memory_config
-        except Exception:
-            memory_cfg = None
-        rerank_model = (
-            getattr(memory_cfg, "rerank_model", "qwen3-rerank")
-            or "qwen3-rerank"
-        )
-
-        api_key = getattr(memory_cfg, "dashscope_api_key", "") or ""
-        if not api_key:
-            logger.warning("dashscope_api_key not configured; skipping rerank")
-            return candidates[:top_n]
-
-        texts = [c.get("text", "") for c in candidates]
-
-        try:
-            resp = dashscope.TextReRank.call(
-                model=rerank_model,
-                query=query,
-                documents=texts,
-                top_n=top_n,
-                return_documents=False,
-                api_key=api_key,
-            )
-        except Exception:
-            logger.exception("dashscope rerank call failed")
-            return candidates[:top_n]
-
-        if resp.status_code != 200:
-            logger.warning(
-                "dashscope rerank returned %s: %s",
-                resp.status_code,
-                getattr(resp, "message", ""),
-            )
-            return candidates[:top_n]
-
-        output = getattr(resp, "output", None)
-        if output is None or not hasattr(output, "results"):
-            logger.warning("dashscope rerank response missing output.results")
-            return candidates[:top_n]
-
-        result: list[dict] = []
-        for item in output.results:
-            idx = (
-                item.get("index")
-                if isinstance(item, dict)
-                else getattr(item, "index", None)
-            )
-            score = (
-                item.get("relevance_score")
-                if isinstance(item, dict)
-                else getattr(item, "relevance_score", None)
-            )
-            if idx is None or idx >= len(candidates):
-                continue
-            c = dict(candidates[idx])
-            c["scores"] = {
-                **(c.get("scores") or {}),
-                "rerank": float(score) if score is not None else 0.0,
-            }
-            result.append(c)
-
-        if not result:
-            logger.warning(
-                "dashscope rerank returned empty results;"
-                " using original order",
-            )
-            return candidates[:top_n]
-
-        return result
 
     def _install_reme_result_hook(self) -> None:
         """Expose QwenPaw inbox delivery to ReMe background steps."""
@@ -485,9 +363,9 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
         agent_config = load_agent_config(self.agent_id)
         memory_cfg = agent_config.running.reme_light_memory_config
-        rerank = memory_cfg.rerank_enabled
+        rerank_enabled = memory_cfg.rerank_enabled
         fetch_limit = (
-            max(1, max_results * 3) if rerank else max(1, max_results)
+            max(1, max_results * 3) if rerank_enabled else max(1, max_results)
         )
 
         response = await self._run_reme_job(
@@ -499,7 +377,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if response is None:
             return _tool_chunk("ReMe is not started.", ok=False)
 
-        if rerank and response.success:
+        if rerank_enabled and response.success:
             candidates = response.metadata.get("results", [])
             if not candidates:
                 answer = (
@@ -507,12 +385,19 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 )
             else:
                 if len(candidates) > max_results:
-                    candidates = await self._rerank_dashscope(
+                    candidates = await rerank(
                         query,
                         candidates,
-                        max_results,
+                        api_key=memory_cfg.api_key,
+                        base_url=getattr(
+                            memory_cfg,
+                            "rerank_base_url",
+                            "",
+                        ),
+                        model_name=memory_cfg.rerank_model,
+                        top_n=max_results,
                     )
-                answer = _build_search_answer(candidates[:max_results])
+                answer = build_search_answer(candidates[:max_results])
                 if not answer.strip():
                     answer = NO_MEMORY_RESULTS
         else:
@@ -561,10 +446,10 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             return None
 
         search_cfg = memory_cfg.auto_memory_search_config
-        rerank = memory_cfg.rerank_enabled
+        rerank_enabled = memory_cfg.rerank_enabled
         fetch_limit = (
             max(1, search_cfg.max_results * 3)
-            if rerank
+            if rerank_enabled
             else max(1, search_cfg.max_results)
         )
 
@@ -577,7 +462,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if response is None or not response.success:
             return None
 
-        if rerank:
+        if rerank_enabled:
             candidates = response.metadata.get("results", [])
             if not candidates:
                 text = str(response.answer or "").strip()
@@ -585,12 +470,19 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                     return None
             else:
                 if len(candidates) > search_cfg.max_results:
-                    candidates = await self._rerank_dashscope(
+                    candidates = await rerank(
                         query,
                         candidates,
-                        search_cfg.max_results,
+                        api_key=memory_cfg.api_key,
+                        base_url=getattr(
+                            memory_cfg,
+                            "rerank_base_url",
+                            "",
+                        ),
+                        model_name=memory_cfg.rerank_model,
+                        top_n=search_cfg.max_results,
                     )
-                text = _build_search_answer(
+                text = build_search_answer(
                     candidates[: search_cfg.max_results],
                 )
                 if not text.strip():

--- a/src/qwenpaw/agents/memory/reranker.py
+++ b/src/qwenpaw/agents/memory/reranker.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Provider-agnostic reranker for memory search results.
+
+Exposes two functions:
+
+* ``build_search_answer`` — format ranked candidates into a ReMe-style
+  answer string with score metadata.
+* ``rerank`` — call a standard ``/rerank`` endpoint (any provider),
+  re-order candidates by ``relevance_score``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def build_search_answer(candidates: list[dict]) -> str:
+    """Format re-ranked candidates as a ReMe-style search answer."""
+    lines: list[str] = []
+    for c in candidates:
+        scores: dict[str, float] = c.get("scores", {})
+        parts = [f"score={scores.get('score', 0.0):.4f}"]
+        for key in ("vector", "keyword", "rerank"):
+            val = scores.get(key)
+            parts.append(f"{key}={val:.4f}" if val is not None else f"{key}=-")
+        header = (
+            f"========== {c['path']}:{c['start_line']}-{c['end_line']}"
+            f" [{' '.join(parts)}] =========="
+        )
+        lines.append(header)
+        lines.append(c["text"])
+    return "\n".join(lines)
+
+
+# pylint: disable=too-many-return-statements
+async def rerank(
+    query: str,
+    candidates: list[dict],
+    *,
+    api_key: str,
+    base_url: str,
+    model_name: str,
+    top_n: int | None = None,
+) -> list[dict]:
+    """Re-rank *candidates* via ``POST <base_url>``.
+
+    The *base_url* is the **full** rerank endpoint URL, e.g.:
+    - ``https://dashscope.aliyuncs.com/compatible-api/v1/reranks``
+    - ``https://api.siliconflow.cn/v1/rerank``
+
+    On any failure the original *candidates* are returned.
+    """
+    if not candidates:
+        return candidates
+    if not api_key:
+        logger.warning("[rerank] api_key not configured")
+        return candidates[:top_n] if top_n else candidates
+    if not base_url:
+        logger.warning("[rerank] base_url not configured")
+        return candidates[:top_n] if top_n else candidates
+    if not query:
+        return candidates[:top_n] if top_n else candidates
+
+    texts = [c.get("text", "") for c in candidates]
+
+    payload: dict[str, Any] = {
+        "model": model_name,
+        "query": query,
+        "documents": texts,
+    }
+    if top_n is not None:
+        payload["top_n"] = top_n
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                base_url.rstrip("/"),
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception:
+        logger.exception("[rerank] request failed")
+        return candidates[:top_n] if top_n else candidates
+
+    results = data.get("results", []) if isinstance(data, dict) else []
+    if not results:
+        logger.warning("[rerank] empty results")
+        return candidates[:top_n] if top_n else candidates
+
+    reranked: list[dict] = []
+    for item in results:
+        idx = item.get("index")
+        score = item.get("relevance_score")
+        if idx is None or idx >= len(candidates):
+            continue
+        c = dict(candidates[idx])
+        c["scores"] = {
+            **(c.get("scores") or {}),
+            "rerank": float(score) if score is not None else 0.0,
+        }
+        reranked.append(c)
+
+    if not reranked:
+        return candidates[:top_n] if top_n else candidates
+
+    logger.info("[rerank] reordered %d results", len(reranked))
+    return reranked

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -742,6 +742,29 @@ class ReMeLightMemoryConfig(BaseModel):
         ),
     )
 
+    rerank_enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether to re-rank memory search results with a re-rank model."
+            " When True, ReMe fetches more candidates (max_results * 3) and"
+            " the re-rank model re-orders them by relevance to the query."
+            " Defaults to False so existing users are unaffected."
+        ),
+    )
+
+    rerank_model: str = Field(
+        default="qwen3-rerank",
+        description="Re-rank model identifier (e.g., qwen3-rerank).",
+    )
+
+    dashscope_api_key: str = Field(
+        default="",
+        description=(
+            "DashScope API key for the re-rank model. If empty, falls back to"
+            " the DASHSCOPE_API_KEY environment variable."
+        ),
+    )
+
 
 class ContextCompactConfig(BaseModel):
     """Context compaction configuration."""

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -754,14 +754,21 @@ class ReMeLightMemoryConfig(BaseModel):
 
     rerank_model: str = Field(
         default="qwen3-rerank",
-        description="Re-rank model identifier (e.g., qwen3-rerank).",
+        description="Re-rank model identifier (e.g., qwen3-rerank,"
+        " bge-reranker-v2-m3).",
     )
 
-    dashscope_api_key: str = Field(
+    api_key: str = Field(
+        default="",
+        description="API key for the reranker provider.",
+    )
+
+    rerank_base_url: str = Field(
         default="",
         description=(
-            "DashScope API key for the re-rank model. If empty, falls back to"
-            " the DASHSCOPE_API_KEY environment variable."
+            "Full URL for the rerank API endpoint."
+            " E.g., https://dashscope.aliyuncs.com/compatible-api/v1/reranks"
+            " or https://api.siliconflow.cn/v1/rerank."
         ),
     )
 

--- a/tests/unit/agents/memory/test_rerank.py
+++ b/tests/unit/agents/memory/test_rerank.py
@@ -12,20 +12,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 AGENT_ID = "test-agent"
-REAL_API_KEY = os.environ.get("DASHSCOPE_API_KEY", "")
+RERANK_URL = "https://api.siliconflow.cn/v1/rerank"
+REAL_API_KEY = os.environ.get("RERANK_TEST_API_KEY", "")
 
 
 def _real_rerank_available() -> bool:
-    try:
-        __import__("dashscope")
-    except ImportError:
-        return False
     return bool(REAL_API_KEY)
 
 
 rerank_api = pytest.mark.skipif(
     not _real_rerank_available(),
-    reason="DASHSCOPE_API_KEY not set or dashscope not installed",
+    reason="RERANK_TEST_API_KEY not set",
 )
 
 
@@ -43,8 +40,9 @@ def mock_agent_config_real_key():
 
     memory_cfg = ReMeLightMemoryConfig(
         rerank_enabled=True,
-        rerank_model="qwen3-rerank",
-        dashscope_api_key=REAL_API_KEY,
+        rerank_model="BAAI/bge-reranker-v2-m3",
+        api_key=REAL_API_KEY,
+        rerank_base_url=RERANK_URL,
         auto_memory_search_config=AutoMemorySearchConfig(
             enabled=True,
             max_results=3,
@@ -80,6 +78,28 @@ def _create_manager(tmp_path, agent_config, monkeypatch):
     )
 
 
+_SIX_RESULTS = [
+    {
+        "path": f"memory/test{i}.md",
+        "start_line": 1,
+        "end_line": 3,
+        "text": t,
+        "scores": {"score": s, "vector": s - 0.02, "keyword": s + 0.05},
+    }
+    for i, (t, s) in enumerate(
+        [
+            ("重排序模型广泛应用于搜索引擎", 0.85),
+            ("量子计算是计算科学的前沿领域", 0.72),
+            ("预训练语言模型带来了新进展", 0.65),
+            ("今天天气很好适合出去玩", 0.30),
+            ("Python 是最流行的编程语言", 0.25),
+            ("红楼梦是中国古典名著", 0.20),
+        ],
+        start=1,
+    )
+]
+
+
 @pytest.fixture
 def manager_with_reme(mock_agent_config_real_key, tmp_path, monkeypatch):
     mgr = _create_manager(tmp_path, mock_agent_config_real_key, monkeypatch)
@@ -96,43 +116,7 @@ def _wire_reme(mgr):
         return_value=Response(
             success=True,
             answer="dummy raw answer",
-            metadata={
-                "results": [
-                    {
-                        "path": "memory/a.md",
-                        "start_line": 1,
-                        "end_line": 2,
-                        "text": "aaa",
-                        "scores": {
-                            "score": 0.9,
-                            "vector": 0.88,
-                            "keyword": 0.92,
-                        },
-                    },
-                    {
-                        "path": "memory/b.md",
-                        "start_line": 1,
-                        "end_line": 2,
-                        "text": "bbb",
-                        "scores": {
-                            "score": 0.7,
-                            "vector": 0.65,
-                            "keyword": 0.75,
-                        },
-                    },
-                    {
-                        "path": "memory/c.md",
-                        "start_line": 1,
-                        "end_line": 2,
-                        "text": "ccc",
-                        "scores": {
-                            "score": 0.5,
-                            "vector": 0.48,
-                            "keyword": 0.52,
-                        },
-                    },
-                ],
-            },
+            metadata={"results": _SIX_RESULTS},
         ),
     )
 
@@ -152,11 +136,9 @@ _SAMPLE_CANDIDATES: list[dict[str, Any]] = [
 
 class TestBuildSearchAnswer:
     def test_formats_candidates_in_reme_style(self):
-        from qwenpaw.agents.memory.reme_light_memory_manager import (
-            _build_search_answer,
-        )
+        from qwenpaw.agents.memory.reranker import build_search_answer
 
-        answer = _build_search_answer(_SAMPLE_CANDIDATES)
+        answer = build_search_answer(_SAMPLE_CANDIDATES)
         assert "==========" in answer
         assert "score=0.8534" in answer
         assert "用户喜欢吃川菜" in answer
@@ -167,7 +149,7 @@ class TestBuildSearchAnswer:
 
 class TestConfigReading:
     def test_load_agent_config_end_to_end(self, tmp_path, monkeypatch):
-        """端到端：写真实 config.json + agent.json，调真正的 load_agent_config。"""
+        """端到端：写真实文件，调真正的 load_agent_config。"""
         import json
         import qwenpaw.config.config as cfg
         from qwenpaw.config import utils as cfg_utils
@@ -195,8 +177,9 @@ class TestConfigReading:
                     "running": {
                         "reme_light_memory_config": {
                             "rerank_enabled": True,
-                            "rerank_model": "qwen3-rerank",
-                            "dashscope_api_key": "sk-e2e-test",
+                            "rerank_model": "BAAI/bge-reranker-v2-m3",
+                            "api_key": "sk-e2e-test",
+                            "rerank_base_url": RERANK_URL,
                         },
                     },
                 },
@@ -212,8 +195,9 @@ class TestConfigReading:
         agent_config = cfg.load_agent_config(AGENT_ID)
         memory_cfg = agent_config.running.reme_light_memory_config
         assert memory_cfg.rerank_enabled is True
-        assert memory_cfg.rerank_model == "qwen3-rerank"
-        assert memory_cfg.dashscope_api_key == "sk-e2e-test"
+        assert memory_cfg.rerank_model == "BAAI/bge-reranker-v2-m3"
+        assert memory_cfg.api_key == "sk-e2e-test"
+        assert memory_cfg.rerank_base_url == RERANK_URL
 
     def test_rerank_disabled_by_default(self):
         from qwenpaw.config.config import ReMeLightMemoryConfig
@@ -222,7 +206,7 @@ class TestConfigReading:
         assert cfg.rerank_enabled is False
 
 
-# -- _rerank_dashscope real-API -----------------------------------------
+# -- rerank() real-API --------------------------------------------------
 
 REAL_CANDIDATES: list[dict[str, Any]] = [
     {
@@ -249,23 +233,18 @@ REAL_CANDIDATES: list[dict[str, Any]] = [
 ]
 
 
-class TestRerankDashScope:
+class TestRerank:
     @rerank_api
     @pytest.mark.asyncio
-    async def test_returns_top_n_results(
-        self,
-        mock_agent_config_real_key,
-        tmp_path,
-        monkeypatch,
-    ):
-        mgr = _create_manager(
-            tmp_path,
-            mock_agent_config_real_key,
-            monkeypatch,
-        )
-        result = await mgr._rerank_dashscope(
+    async def test_returns_top_n_results(self):
+        from qwenpaw.agents.memory.reranker import rerank
+
+        result = await rerank(
             query="什么是重排序模型",
             candidates=REAL_CANDIDATES,
+            api_key=REAL_API_KEY,
+            base_url=RERANK_URL,
+            model_name="BAAI/bge-reranker-v2-m3",
             top_n=2,
         )
         assert len(result) == 2
@@ -274,20 +253,15 @@ class TestRerankDashScope:
 
     @rerank_api
     @pytest.mark.asyncio
-    async def test_relevant_doc_ranks_higher(
-        self,
-        mock_agent_config_real_key,
-        tmp_path,
-        monkeypatch,
-    ):
-        mgr = _create_manager(
-            tmp_path,
-            mock_agent_config_real_key,
-            monkeypatch,
-        )
-        result = await mgr._rerank_dashscope(
+    async def test_relevant_doc_ranks_higher(self):
+        from qwenpaw.agents.memory.reranker import rerank
+
+        result = await rerank(
             query="什么是重排序模型",
             candidates=REAL_CANDIDATES,
+            api_key=REAL_API_KEY,
+            base_url=RERANK_URL,
+            model_name="BAAI/bge-reranker-v2-m3",
             top_n=3,
         )
         texts = [c["text"] for c in result]
@@ -298,32 +272,19 @@ class TestRerankDashScope:
         ), f"rerank-related doc should rank above quantum, got: {texts}"
 
     @pytest.mark.asyncio
-    async def test_no_api_key_falls_back(self, tmp_path, monkeypatch):
-        from qwenpaw.config.config import (
-            AgentProfileConfig,
-            AgentsRunningConfig,
-            ReMeLightMemoryConfig,
-        )
+    async def test_no_api_key_falls_back(self):
+        from qwenpaw.agents.memory.reranker import rerank
 
-        memory_cfg = ReMeLightMemoryConfig(
-            rerank_enabled=True,
-            dashscope_api_key="",
-        )
-        agent_config = AgentProfileConfig(
-            id=AGENT_ID,
-            name="TestAgent",
-            description="",
-            workspace_dir="/tmp/test-ws",
-            running=AgentsRunningConfig(reme_light_memory_config=memory_cfg),
-        )
-        mgr = _create_manager(tmp_path, agent_config, monkeypatch)
-        result = await mgr._rerank_dashscope(
+        result = await rerank(
             query="test",
             candidates=REAL_CANDIDATES,
+            api_key="",
+            base_url=RERANK_URL,
+            model_name="BAAI/bge-reranker-v2-m3",
             top_n=2,
         )
         assert len(result) == 2
-        assert "搜索引擎" in result[0]["text"]  # original order preserved
+        assert "搜索引擎" in result[0]["text"]
 
 
 # -- memory_search integration ------------------------------------------
@@ -368,13 +329,14 @@ class TestMemorySearch:
             agent_id=AGENT_ID,
         )
         _wire_reme(mgr)
-
         chunk = await mgr.memory_search("test")
         assert "dummy raw answer" in str(chunk.content[0].text)
 
-    @rerank_api
     @pytest.mark.asyncio
-    async def test_rerank_enabled_uses_larger_limit(self, manager_with_reme):
+    async def test_rerank_enabled_uses_larger_limit(
+        self,
+        manager_with_reme,
+    ):
         await manager_with_reme.memory_search("test", max_results=3)
         _, kwargs = manager_with_reme._reme.run_job.call_args
         assert kwargs["limit"] == 9  # 3 * 3
@@ -385,14 +347,15 @@ class TestMemorySearch:
         self,
         manager_with_reme,
     ):
-        chunk = await manager_with_reme.memory_search("aaa", max_results=2)
+        chunk = await manager_with_reme.memory_search("重排序", max_results=3)
         assert "rerank=" in str(chunk.content[0].text)
 
     @rerank_api
     @pytest.mark.asyncio
-    async def test_rerank_reorders_results(self, manager_with_reme):
-        chunk = await manager_with_reme.memory_search("ccc", max_results=2)
+    async def test_rerank_reorders_results(
+        self,
+        manager_with_reme,
+    ):
+        chunk = await manager_with_reme.memory_search("经典名著", max_results=3)
         text = str(chunk.content[0].text)
-        assert text.index("ccc") < text.index(
-            "aaa",
-        ), f"ccc should be before aaa, got:\n{text}"
+        assert "红楼梦" in text, f"红楼梦 should appear, got:\n{text}"

--- a/tests/unit/agents/memory/test_rerank.py
+++ b/tests/unit/agents/memory/test_rerank.py
@@ -1,0 +1,398 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access,unused-argument
+# pylint: disable=unnecessary-lambda
+"""Core tests for memory search rerank integration."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+AGENT_ID = "test-agent"
+REAL_API_KEY = os.environ.get("DASHSCOPE_API_KEY", "")
+
+
+def _real_rerank_available() -> bool:
+    try:
+        __import__("dashscope")
+    except ImportError:
+        return False
+    return bool(REAL_API_KEY)
+
+
+rerank_api = pytest.mark.skipif(
+    not _real_rerank_available(),
+    reason="DASHSCOPE_API_KEY not set or dashscope not installed",
+)
+
+
+# -- fixtures -----------------------------------------------------------
+
+
+@pytest.fixture
+def mock_agent_config_real_key():
+    from qwenpaw.config.config import (
+        AgentProfileConfig,
+        AgentsRunningConfig,
+        AutoMemorySearchConfig,
+        ReMeLightMemoryConfig,
+    )
+
+    memory_cfg = ReMeLightMemoryConfig(
+        rerank_enabled=True,
+        rerank_model="qwen3-rerank",
+        dashscope_api_key=REAL_API_KEY,
+        auto_memory_search_config=AutoMemorySearchConfig(
+            enabled=True,
+            max_results=3,
+        ),
+    )
+    return AgentProfileConfig(
+        id=AGENT_ID,
+        name="TestAgent",
+        description="",
+        workspace_dir="/tmp/test-ws",
+        running=AgentsRunningConfig(reme_light_memory_config=memory_cfg),
+    )
+
+
+def _create_manager(tmp_path, agent_config, monkeypatch):
+    from qwenpaw.agents.memory import reme_light_memory_manager as rlmm
+
+    monkeypatch.setattr(
+        rlmm,
+        "load_agent_config",
+        lambda _id: agent_config,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        rlmm,
+        "load_config",
+        lambda: MagicMock(),
+        raising=False,
+    )
+    return rlmm.ReMeLightMemoryManager(
+        working_dir=str(tmp_path),
+        agent_id=AGENT_ID,
+    )
+
+
+@pytest.fixture
+def manager_with_reme(mock_agent_config_real_key, tmp_path, monkeypatch):
+    mgr = _create_manager(tmp_path, mock_agent_config_real_key, monkeypatch)
+    _wire_reme(mgr)
+    return mgr
+
+
+def _wire_reme(mgr):
+    from reme.schema import Response
+
+    mgr._reme = MagicMock()
+    mgr._reme.is_started = True
+    mgr._reme.run_job = AsyncMock(
+        return_value=Response(
+            success=True,
+            answer="dummy raw answer",
+            metadata={
+                "results": [
+                    {
+                        "path": "memory/a.md",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "text": "aaa",
+                        "scores": {
+                            "score": 0.9,
+                            "vector": 0.88,
+                            "keyword": 0.92,
+                        },
+                    },
+                    {
+                        "path": "memory/b.md",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "text": "bbb",
+                        "scores": {
+                            "score": 0.7,
+                            "vector": 0.65,
+                            "keyword": 0.75,
+                        },
+                    },
+                    {
+                        "path": "memory/c.md",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "text": "ccc",
+                        "scores": {
+                            "score": 0.5,
+                            "vector": 0.48,
+                            "keyword": 0.52,
+                        },
+                    },
+                ],
+            },
+        ),
+    )
+
+
+# -- _build_search_answer -----------------------------------------------
+
+_SAMPLE_CANDIDATES: list[dict[str, Any]] = [
+    {
+        "path": "memory/2025-01-15.md",
+        "start_line": 10,
+        "end_line": 15,
+        "text": "用户喜欢吃川菜，水煮鱼是最爱",
+        "scores": {"score": 0.8534, "vector": 0.8200, "keyword": 0.9100},
+    },
+]
+
+
+class TestBuildSearchAnswer:
+    def test_formats_candidates_in_reme_style(self):
+        from qwenpaw.agents.memory.reme_light_memory_manager import (
+            _build_search_answer,
+        )
+
+        answer = _build_search_answer(_SAMPLE_CANDIDATES)
+        assert "==========" in answer
+        assert "score=0.8534" in answer
+        assert "用户喜欢吃川菜" in answer
+
+
+# -- config reading -----------------------------------------------------
+
+
+class TestConfigReading:
+    def test_load_agent_config_end_to_end(self, tmp_path, monkeypatch):
+        """端到端：写真实 config.json + agent.json，调真正的 load_agent_config。"""
+        import json
+        import qwenpaw.config.config as cfg
+        from qwenpaw.config import utils as cfg_utils
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        config_json = {
+            "agents": {
+                "profiles": {
+                    AGENT_ID: {"id": AGENT_ID, "workspace_dir": str(ws)},
+                },
+            },
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(config_json), encoding="utf-8")
+
+        (ws / "agent.json").write_text(
+            json.dumps(
+                {
+                    "id": AGENT_ID,
+                    "name": "TestAgent",
+                    "description": "",
+                    "workspace_dir": str(ws),
+                    "running": {
+                        "reme_light_memory_config": {
+                            "rerank_enabled": True,
+                            "rerank_model": "qwen3-rerank",
+                            "dashscope_api_key": "sk-e2e-test",
+                        },
+                    },
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(cfg_utils, "get_config_path", lambda: config_path)
+        monkeypatch.setattr(cfg_utils, "_config_cache", None, raising=False)
+        monkeypatch.setattr(cfg_utils, "_config_mtime", None, raising=False)
+        monkeypatch.setattr(cfg_utils, "_agent_config_cache", {})
+
+        agent_config = cfg.load_agent_config(AGENT_ID)
+        memory_cfg = agent_config.running.reme_light_memory_config
+        assert memory_cfg.rerank_enabled is True
+        assert memory_cfg.rerank_model == "qwen3-rerank"
+        assert memory_cfg.dashscope_api_key == "sk-e2e-test"
+
+    def test_rerank_disabled_by_default(self):
+        from qwenpaw.config.config import ReMeLightMemoryConfig
+
+        cfg = ReMeLightMemoryConfig()
+        assert cfg.rerank_enabled is False
+
+
+# -- _rerank_dashscope real-API -----------------------------------------
+
+REAL_CANDIDATES: list[dict[str, Any]] = [
+    {
+        "path": "memory/test1.md",
+        "start_line": 1,
+        "end_line": 3,
+        "text": "重排序模型广泛应用于搜索引擎和推荐系统，按相关性对候选文本进行排序",
+        "scores": {"score": 0.85, "vector": 0.82, "keyword": 0.90},
+    },
+    {
+        "path": "memory/test2.md",
+        "start_line": 1,
+        "end_line": 3,
+        "text": "量子计算是计算科学的前沿领域",
+        "scores": {"score": 0.72, "vector": 0.75, "keyword": 0.68},
+    },
+    {
+        "path": "memory/test3.md",
+        "start_line": 1,
+        "end_line": 3,
+        "text": "预训练语言模型的发展为重排序模型带来了新的进展",
+        "scores": {"score": 0.65, "vector": 0.70, "keyword": 0.58},
+    },
+]
+
+
+class TestRerankDashScope:
+    @rerank_api
+    @pytest.mark.asyncio
+    async def test_returns_top_n_results(
+        self,
+        mock_agent_config_real_key,
+        tmp_path,
+        monkeypatch,
+    ):
+        mgr = _create_manager(
+            tmp_path,
+            mock_agent_config_real_key,
+            monkeypatch,
+        )
+        result = await mgr._rerank_dashscope(
+            query="什么是重排序模型",
+            candidates=REAL_CANDIDATES,
+            top_n=2,
+        )
+        assert len(result) == 2
+        for c in result:
+            assert "rerank" in c.get("scores", {})
+
+    @rerank_api
+    @pytest.mark.asyncio
+    async def test_relevant_doc_ranks_higher(
+        self,
+        mock_agent_config_real_key,
+        tmp_path,
+        monkeypatch,
+    ):
+        mgr = _create_manager(
+            tmp_path,
+            mock_agent_config_real_key,
+            monkeypatch,
+        )
+        result = await mgr._rerank_dashscope(
+            query="什么是重排序模型",
+            candidates=REAL_CANDIDATES,
+            top_n=3,
+        )
+        texts = [c["text"] for c in result]
+        qc_idx = next(i for i, t in enumerate(texts) if "量子" in t)
+        rerank_idx = next(i for i, t in enumerate(texts) if "预训练" in t)
+        assert (
+            rerank_idx < qc_idx
+        ), f"rerank-related doc should rank above quantum, got: {texts}"
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_falls_back(self, tmp_path, monkeypatch):
+        from qwenpaw.config.config import (
+            AgentProfileConfig,
+            AgentsRunningConfig,
+            ReMeLightMemoryConfig,
+        )
+
+        memory_cfg = ReMeLightMemoryConfig(
+            rerank_enabled=True,
+            dashscope_api_key="",
+        )
+        agent_config = AgentProfileConfig(
+            id=AGENT_ID,
+            name="TestAgent",
+            description="",
+            workspace_dir="/tmp/test-ws",
+            running=AgentsRunningConfig(reme_light_memory_config=memory_cfg),
+        )
+        mgr = _create_manager(tmp_path, agent_config, monkeypatch)
+        result = await mgr._rerank_dashscope(
+            query="test",
+            candidates=REAL_CANDIDATES,
+            top_n=2,
+        )
+        assert len(result) == 2
+        assert "搜索引擎" in result[0]["text"]  # original order preserved
+
+
+# -- memory_search integration ------------------------------------------
+
+
+class TestMemorySearch:
+    @pytest.mark.asyncio
+    async def test_rerank_disabled_uses_original_answer(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from qwenpaw.config.config import (
+            AgentProfileConfig,
+            AgentsRunningConfig,
+            ReMeLightMemoryConfig,
+        )
+        from qwenpaw.agents.memory import reme_light_memory_manager as rlmm
+
+        memory_cfg = ReMeLightMemoryConfig(rerank_enabled=False)
+        agent_config = AgentProfileConfig(
+            id=AGENT_ID,
+            name="TestAgent",
+            description="",
+            workspace_dir="/tmp/test-ws",
+            running=AgentsRunningConfig(reme_light_memory_config=memory_cfg),
+        )
+        monkeypatch.setattr(
+            rlmm,
+            "load_agent_config",
+            lambda _id: agent_config,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rlmm,
+            "load_config",
+            lambda: MagicMock(),
+            raising=False,
+        )
+        mgr = rlmm.ReMeLightMemoryManager(
+            working_dir=str(tmp_path),
+            agent_id=AGENT_ID,
+        )
+        _wire_reme(mgr)
+
+        chunk = await mgr.memory_search("test")
+        assert "dummy raw answer" in str(chunk.content[0].text)
+
+    @rerank_api
+    @pytest.mark.asyncio
+    async def test_rerank_enabled_uses_larger_limit(self, manager_with_reme):
+        await manager_with_reme.memory_search("test", max_results=3)
+        _, kwargs = manager_with_reme._reme.run_job.call_args
+        assert kwargs["limit"] == 9  # 3 * 3
+
+    @rerank_api
+    @pytest.mark.asyncio
+    async def test_rerank_enabled_produces_rerank_score(
+        self,
+        manager_with_reme,
+    ):
+        chunk = await manager_with_reme.memory_search("aaa", max_results=2)
+        assert "rerank=" in str(chunk.content[0].text)
+
+    @rerank_api
+    @pytest.mark.asyncio
+    async def test_rerank_reorders_results(self, manager_with_reme):
+        chunk = await manager_with_reme.memory_search("ccc", max_results=2)
+        text = str(chunk.content[0].text)
+        assert text.index("ccc") < text.index(
+            "aaa",
+        ), f"ccc should be before aaa, got:\n{text}"


### PR DESCRIPTION
## Summary

Wrap ReMe's hybrid search results with DashScope `qwen3-rerank` for precision re-ranking in `ReMeLightMemoryManager.memory_search()`. No changes to ReMe itself — just an outer rerank stage controlled by a `rerank_enabled` toggle (default off).

**Related Issue:** Closes #5588

## What Changed

### Backend: Rerank Integration (`src/qwenpaw/agents/memory/reme_light_memory_manager.py`)

- **`_build_search_answer(candidates)`** — formats re-ranked candidates back into ReMe-standard answer text, appending `rerank=` scores
- **`_rerank_dashscope(query, candidates, top_n)`** — calls DashScope `TextReRank.call()` with full error handling; falls back to original ordering on any failure
- **`memory_search()`** — rerank off (default): behavior unchanged. rerank on: fetches `max_results * 3` candidates from ReMe, reranks, returns top `max_results`
- **`auto_memory_search()`** — same rerank pipeline applied

### Backend: Configuration (`src/qwenpaw/config/config.py`)

New fields in `ReMeLightMemoryConfig`:

| Field | Type | Default |
|-------|------|---------|
| `rerank_enabled` | `bool` | `False` |
| `rerank_model` | `str` | `"qwen3-rerank"` |
| `dashscope_api_key` | `str` | `""` |

### Flow

```
ReMe hybrid search (limit = max_results * 3)
  → response.metadata["results"] (structured candidates)
  → dashscope.TextReRank.call(qwen3-rerank)
  → sort by relevance_score desc
  → _build_search_answer (ReMe format + rerank score)
  → _tool_chunk → LLM
```

### Degradation

Every error path falls back to original ordering: dashscope not installed, API key not configured, API call failure, empty results.

## Usage

```json
{
  "running": {
    "reme_light_memory_config": {
      "rerank_enabled": true,
      "rerank_model": "qwen3-rerank",
      "dashscope_api_key": "sk-xxx"
    }
  }
}
```

## Tests

`tests/unit/agents/memory/test_rerank.py` — 10 core tests, all passing:

### Formatting

| Test | What it verifies |
|------|------------------|
| `test_formats_candidates_in_reme_style` | `_build_search_answer` output matches ReMe format |

### Config Reading

| Test | What it verifies |
|------|------------------|
| `test_load_agent_config_end_to_end` | Real files → real `load_agent_config` → all 3 fields deserialize correctly |
| `test_rerank_disabled_by_default` | Default `rerank_enabled=False` |

### Real API Calls

| Test | What it verifies |
|------|------------------|
| `test_returns_top_n_results` | Returns exactly `top_n` results with `rerank` in `scores` |
| `test_relevant_doc_ranks_higher` | Relevant doc ranks above irrelevant after rerank |

### Degradation / Fallback

| Test | What it verifies |
|------|------------------|
| `test_no_api_key_falls_back` | Empty API key → preserves original RRF ordering |

### memory_search Integration

| Test | What it verifies |
|------|------------------|
| `test_rerank_disabled_uses_original_answer` | `rerank_enabled=False` passes through `response.answer` unchanged |
| `test_rerank_enabled_uses_larger_limit` | `rerank_enabled=True` sends `limit = max_results * 3` to ReMe |
| `test_rerank_enabled_produces_rerank_score` | Answer contains `rerank=` score |
| `test_rerank_reorders_results` | query="ccc" ranks above "aaa" after rerank |

Pre-commit and pytest all passing:

```
pre-commit run --all-files   # all passed
pytest tests/unit/ -x -q     # 3771 passed, 9 skipped
```