### PR TITLE
fix(tui): support CJK / IME input (bump textual to >=8.2.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,11 @@ dependencies = [
     "pillow>=10.0.0",
     "agent-client-protocol>=0.9.0",
     # Streaming-markdown terminal UI for the bundled `qwenpaw` TUI
-    # (v4+ adds the streaming Markdown widget).
-    "textual>=4.0",
+    # (v4+ adds the streaming Markdown widget). 8.2.8 fixes parsing of
+    # multi-codepoint Kitty "associated text" so input methods (Chinese,
+    # Japanese, accents, ...) no longer leak escape sequences into the prompt
+    # (Textualize/textual#6592).
+    "textual>=8.2.8",
     "psutil>=6.0.0",
     "openai>=2.0.0,<=2.33.0",
     # anyio 4.13.0: _deliver_cancellation busy-loop / getpid storm (QwenPaw#2632)


### PR DESCRIPTION
## Description

Typing with an input method (Chinese, Japanese, Korean, accented Latin, ZWJ emoji, …) in the bundled `qwenpaw` TUI leaked a raw terminal escape sequence into the prompt instead of inserting the text. For example, typing `我知道` produced:

```
我[32;;19981:30693:36947u
```

**Root cause (upstream, in Textual).** The TUI runs on Textual, which enables the Kitty keyboard protocol with the `REPORT_ASSOCIATED_TEXT` flag. When an IME commits more than one codepoint at once, the terminal packs them into a single Kitty "associated text" field as **colon-separated codepoints**, e.g. `\x1b[…;…;25105:30693:36947u` for `我知道`. `textual <= 8.2.7` neither matched the colons in its CSI-u parser regex (`_re_extended_key`) nor decoded past the first codepoint (`chr(int(text_str))`), so the whole sequence surfaced as literal text. A single-codepoint commit worked, which is why the first character rendered before the garbage.

**Fix.** This is already fixed upstream in **Textual 8.2.8** ([Textualize/textual#6592](https://github.com/Textualize/textual/pull/6592) — "Fix parsing multiple keys", fixes [Textualize/textual#6562](https://github.com/Textualize/textual/issues/6562)): the parser now matches the colons and emits one key event per codepoint. This PR simply bumps the dependency floor from `textual>=4.0` to `textual>=8.2.8` so the bundled TUI picks up the fix. **No QwenPaw code change is required** (and notably, a local monkeypatch against the 8.2.7 parser would break on 8.2.8, whose `_parse_extended_key` now returns a list — so the dependency bump is the correct fix).

**Related Issue:** N/A — no tracked issue; surfaced via local TUI testing with a Chinese IME.

**Security Considerations:** None. Dependency minimum-version bump only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks (none were auto-fixed)
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed) — not needed
- [x] Ready for review

## Testing

Manual:
1. Install with `textual >= 8.2.8`.
2. Launch `qwenpaw tui` in a terminal that supports the Kitty keyboard protocol (kitty, Ghostty, WezTerm, recent iTerm2).
3. Switch to a Chinese / Japanese IME and type e.g. `我知道`. The text now inserts correctly instead of showing `我[32;;…u`. Accented Latin and emoji that commit multiple codepoints also work.

Verification that the bug is in `<= 8.2.7` and fixed in `8.2.8`, feeding the exact failing sequence through Textual's parser:

```python
from textual._xterm_parser import XTermParser
p = XTermParser()
keys = [e for e in p.feed("\x1b[32;;25105:30693:36947u") if type(e).__name__ == "Key"]
print("".join(k.character or "" for k in keys), f"({len(keys)} key events)")
# textual 8.2.7 -> "" (0 key events; sequence leaks as literal text)
# textual 8.2.8 -> "我知道" (3 key events)
```

Regression check: `shift+enter` / `ctrl+j` (newline), `enter` (send), and `ctrl+i` (inspect) — which depend on the Kitty protocol's disambiguation — continue to work on 8.2.8.

## Local Verification Evidence

```bash
pre-commit run --all-files
# check python ast..........Passed   check toml....Passed   trim trailing whitespace....Passed
# mypy.....Passed   black.....Passed   flake8.....Passed   pylint.....Passed   prettier.....Passed
# (all hooks Passed; no files modified)

pytest tests/unit/cli/tui/
# 96 passed, 1 warning   (on textual 8.2.8)
```

## Additional Notes

`uv.lock` is gitignored in this repo, so the change is limited to `pyproject.toml`.
