### PR TITLE
fix(scroll): strip ⟦…⟧ headline in HTTP history path, not just SSE, add mechanism to 

### DIFF
--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -71,6 +71,9 @@ class HistoryStore:
         # degraded; callers/monitoring can read this.
         self.degraded = False
         self.write_failures = 0
+        # Flipped True by ``close()`` so callers can tell an intentional
+        # teardown race from a real disk outage (see ``closed``).
+        self._closed = False
         try:
             self._open_and_init()
         except sqlite3.DatabaseError as exc:
@@ -472,7 +475,13 @@ class HistoryStore:
                 exc,
             )
 
+    @property
+    def closed(self) -> bool:
+        """True once :meth:`close` has run — the connection is gone."""
+        return self._closed
+
     def close(self) -> None:
+        self._closed = True
         try:
             self._conn.close()
         except sqlite3.Error:

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -108,6 +108,11 @@ class ScrollContextManager:
         result — best-effort) and :meth:`compress` (which must NOT evict when
         this returns ``False``, or it would drop un-persisted turns).
         """
+        # Teardown race: a stop/cancel can close the store while a final
+        # ``on_save`` is still in flight. The connection was retired on
+        # purpose, so skip the write quietly instead of degrading durability.
+        if self._history.closed:
+            return True
         try:
             self._persist_new(agent)
             return True

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -9,6 +9,7 @@ from urllib.parse import unquote, urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from agentscope.message import Msg
+from qwenpaw.agents.context.scroll.serialize import strip_headline
 from qwenpaw.schemas import (
     Message,
     TextContent,
@@ -391,6 +392,17 @@ def strip_injected_skill_block(text: str, role: str) -> str:
     return _INJECTED_SKILL_BLOCK_RE.sub("", text)
 
 
+def clean_display_text(text: str, role: str) -> str:
+    """Hide model-facing artifacts from the transcript: the ``⟦ … ⟧``
+    headline fence and the injected ``<skill>`` block. The SSE stream already
+    strips the headline; the HTTP history path didn't, so it reappeared on
+    reload — do both here so every display path matches. Headline first: the
+    ``<skill>`` regex is ``$``-anchored, so a trailing headline would leave it
+    un-anchored.
+    """
+    return strip_injected_skill_block(strip_headline(text) or "", role)
+
+
 # pylint: disable=too-many-branches,too-many-statements, too-many-nested-blocks
 def agentscope_msg_to_message(
     messages: Union[Msg, List[Msg]],
@@ -448,7 +460,7 @@ def agentscope_msg_to_message(
             text_content = TextContent(
                 delta=False,
                 index=None,
-                text=strip_injected_skill_block(msg.content, role),
+                text=clean_display_text(msg.content, role),
             )
             message.add_content(new_content=text_content)
             results.append(message)
@@ -497,7 +509,7 @@ def agentscope_msg_to_message(
                 text_content = TextContent(
                     delta=False,
                     index=None,
-                    text=strip_injected_skill_block(
+                    text=clean_display_text(
                         block.get("text", ""),
                         role,
                     ),

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -297,6 +297,21 @@ def test_on_save_swallows_write_failure(store: HistoryStore, monkeypatch):
     assert store.degraded is True
 
 
+def test_on_save_after_close_is_quiet_noop(store: HistoryStore):
+    """Teardown race: an on_save after close is skipped quietly, not reported
+    as degraded durability."""
+    mgr = make_manager(store)
+    agent = FakeAgent([user("hi"), assistant("there", headline="h")])
+    store.close()
+    assert store.closed is True
+
+    mgr.on_save(agent, None)  # must not raise "closed database"
+    # Skipped, not failed: durability stays healthy and nothing was persisted.
+    assert store.degraded is False
+    assert store.write_failures == 0
+    assert mgr._persisted_ids == set()
+
+
 # -- optional dialog offload (offload_dialog opt-in) ------------------------
 
 

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from agentscope.message import Msg
+
 from qwenpaw.app.chats.utils import (
     _abspath_from_url,
     _is_local_file_url,
     _resolve_content_url,
+    agentscope_msg_to_message,
+    clean_display_text,
     strip_injected_skill_block,
 )
 from qwenpaw.app.chats.title_generator import _clean_title
@@ -93,6 +97,45 @@ def test_strip_skill_block_skips_non_user_role():
 
 def test_strip_skill_block_skips_when_no_skill_tag():
     assert strip_injected_skill_block("plain text", "user") == "plain text"
+
+
+# ---------------------------------------------------------------------------
+# clean_display_text — headline hidden in the HTTP history path too
+# ---------------------------------------------------------------------------
+
+
+def test_clean_display_text_strips_headline_comment():
+    text = "done\n<!-- ⟦ milestone here ⟧ -->"
+    assert clean_display_text(text, "assistant") == "done"
+
+
+def test_clean_display_text_strips_lookalike_brackets():
+    # Qwen substitutes U+301A/U+301B for the intended U+27E6/U+27E7.
+    assert clean_display_text("ok\n〚 lookalike 〛", "assistant") == "ok"
+
+
+def test_clean_display_text_keeps_plain_text():
+    assert clean_display_text("hello world", "user") == "hello world"
+
+
+def test_clean_display_text_strips_both_skill_and_headline():
+    text = "/run<skill name='x'>body</skill>\n<!-- ⟦ h ⟧ -->"
+    out = clean_display_text(text, "user")
+    assert "<skill" not in out and "⟦" not in out and "/run" in out
+
+
+def test_msg_to_message_hides_headline_in_history_path():
+    """Regression: the GET /chats/{id} path now strips the ⟦…⟧ headline, so it
+    no longer reappears after navigating away from the chat and back."""
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "all set\n<!-- ⟦ shipped ⟧ -->"}],
+    )
+    [message] = agentscope_msg_to_message(msg)
+    rendered = "".join(c.text for c in message.content)
+    assert "⟦" not in rendered and "shipped" not in rendered
+    assert "all set" in rendered
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two scroll/context fixes that surfaced as noisy logs and a UI glitch.

### 1. Stop-during-write no longer logs a false durability error

**Symptom:** Stopping a chat sometimes logged a `ERROR` with `sqlite3.ProgrammingError: Cannot operate on a closed database`, and flipped the history store to "durability degraded".

**Cause:** A teardown race. On stop, the agent closes the history store's SQLite connection, but a final in-flight `on_save` write-through can land *after* that close. It was caught — so nothing crashed — but it was misclassified as a disk outage rather than the expected close race.

**Fix:** `HistoryStore` now exposes a `closed` flag; the manager skips a write-through quietly when the store is already closed. Genuine disk failures still degrade durability and block eviction exactly as before.

### 2. `⟦…⟧` headline no longer reappears after switching tabs

**Symptom:** The hidden milestone headline showed up in the chat after switching to the inbox and back.

**Cause:** Two display paths, only one stripped the headline. The live **SSE stream** stripped it; the **HTTP `GET /chats/{id}`** history path (used when re-loading a chat) did not. Navigating away and back re-fetches over the HTTP path, so the headline leaked back into view.

**Fix:** Strip the headline (and the injected `<skill>` block) in the shared `agentscope_msg_to_message` converter via a new `clean_display_text` helper, so every display path is consistent.

## Testing

- `tests/unit/agents/context/test_scroll_manager.py` — write-through after close is a quiet no-op (not degraded).
- `tests/unit/app/chats/test_utils.py` — headline (incl. Qwen's `〚 〛` lookalike brackets) stripped on the history path; regression test through `agentscope_msg_to_message`.

