### PR TITLE
feat(tui): add live context-usage bar to the status bar

### DIFF
--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -61,6 +61,7 @@ from acp.schema import (
     SseMcpServer,
     TextContentBlock,
     ToolCallUpdate,
+    UsageUpdate,
 )
 from qwenpaw.schemas import (
     AgentRequest,
@@ -935,6 +936,32 @@ class QwenPawACPAgent(Agent):
                     field_meta=usage_meta,
                 ),
             )
+            # Also surface the *current* context occupancy (prompt size vs.
+            # window) over the native ACP ``usage_update`` channel so the TUI
+            # can render a live context-usage bar. ``used`` is the tokens in
+            # context right now (the last call's input); ``size`` is the model
+            # context window. This is distinct from the cumulative ``tok``
+            # tallies carried in the chunk meta above. Skip when either is
+            # unknown — a bar without a denominator is meaningless.
+            usage = usage_meta.get("usage", {})
+            used = int(usage.get("inputTokens", 0) or 0)
+            size = int(usage.get("contextSize", 0) or 0)
+            if used > 0 and size > 0:
+                # Carry the compaction threshold (if known) via ``_meta`` so
+                # the TUI can mark it; usage_update has no field for it.
+                ratio = usage.get("compactRatio")
+                field_meta = None
+                if isinstance(ratio, (int, float)) and 0 < ratio < 1:
+                    field_meta = {"compactRatio": float(ratio)}
+                await self._conn.session_update(
+                    session_id=session_id,
+                    update=UsageUpdate(
+                        sessionUpdate="usage_update",
+                        used=used,
+                        size=size,
+                        field_meta=field_meta,
+                    ),
+                )
 
     @staticmethod
     def _pop_session_usage(
@@ -964,6 +991,12 @@ class QwenPawACPAgent(Agent):
                 "outputTokens": raw.get("completion_tokens", 0),
                 "totalTokens": raw.get("total_tokens", 0),
                 "model": raw.get("model_name") or "",
+                # Context window, so the UI can show how full the *current*
+                # context is (inputTokens / contextSize). 0 = unknown.
+                "contextSize": raw.get("context_size", 0),
+                # Auto-compaction threshold (0-1) so the UI can mark it.
+                # None when compaction is disabled/unknown.
+                "compactRatio": raw.get("compact_threshold"),
             },
         }
 

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -941,27 +941,30 @@ class QwenPawACPAgent(Agent):
             # can render a live context-usage bar. ``used`` is the tokens in
             # context right now (the last call's input); ``size`` is the model
             # context window. This is distinct from the cumulative ``tok``
-            # tallies carried in the chunk meta above. Skip when either is
-            # unknown — a bar without a denominator is meaningless.
+            # tallies carried in the chunk meta above. We emit even with 0s so
+            # the bar clears deterministically when the window or occupancy
+            # becomes unknown (e.g. after a model switch) — the TUI treats 0 as
+            # "hide the bar".
             usage = usage_meta.get("usage", {})
             used = int(usage.get("inputTokens", 0) or 0)
             size = int(usage.get("contextSize", 0) or 0)
-            if used > 0 and size > 0:
-                # Carry the compaction threshold (if known) via ``_meta`` so
-                # the TUI can mark it; usage_update has no field for it.
-                ratio = usage.get("compactRatio")
-                field_meta = None
-                if isinstance(ratio, (int, float)) and 0 < ratio < 1:
-                    field_meta = {"compactRatio": float(ratio)}
-                await self._conn.session_update(
-                    session_id=session_id,
-                    update=UsageUpdate(
-                        sessionUpdate="usage_update",
-                        used=used,
-                        size=size,
-                        field_meta=field_meta,
-                    ),
-                )
+            # Carry the compaction threshold (if known) via ``_meta`` so the
+            # TUI can mark it; usage_update has no field for it. Only attach it
+            # when there's a meaningful bar to mark.
+            ratio = usage.get("compactRatio")
+            field_meta = None
+            valid_ratio = isinstance(ratio, (int, float)) and 0 < ratio < 1
+            if used > 0 and size > 0 and valid_ratio:
+                field_meta = {"compactRatio": float(ratio)}
+            await self._conn.session_update(
+                session_id=session_id,
+                update=UsageUpdate(
+                    sessionUpdate="usage_update",
+                    used=used,
+                    size=size,
+                    field_meta=field_meta,
+                ),
+            )
 
     @staticmethod
     def _pop_session_usage(

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1086,6 +1086,7 @@ def create_model_and_formatter(
     model_slot = None
     retry_config = None
     rate_limit_config = None
+    compact_threshold: Optional[float] = None
     if agent_id:
         try:
             agent_config = load_agent_config(agent_id)
@@ -1103,6 +1104,12 @@ def create_model_and_formatter(
                 jitter_range=agent_config.running.llm_rate_limit_jitter,
                 acquire_timeout=agent_config.running.llm_acquire_timeout,
             )
+            # Surface the auto-compaction threshold so the UI can mark where
+            # context starts getting evicted — only when compaction is on.
+            lcc = agent_config.running.light_context_config
+            ccc = lcc.context_compact_config
+            if getattr(ccc, "enabled", False):
+                compact_threshold = ccc.compact_threshold_ratio
         except Exception:
             pass
 
@@ -1148,7 +1155,11 @@ def create_model_and_formatter(
         model.max_retries = 0
 
     # Wrap with retry logic for transient LLM API errors
-    wrapped_model = TokenRecordingModelWrapper(provider_id, model)
+    wrapped_model = TokenRecordingModelWrapper(
+        provider_id,
+        model,
+        compact_threshold=compact_threshold,
+    )
     wrapped_model = RetryChatModel(
         wrapped_model,
         retry_config=retry_config,

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -644,6 +644,9 @@ class PawApp(App):
         self._tok_out = 0
         self._stream_chars = 0
         self._refresh_tokens()
+        # Clear the context-usage bar too; the next model call on the resumed
+        # session reports fresh occupancy via ``usage_update``.
+        self._status().set(used=0, size=0)
         # Mounted before the load so it sits above the replayed transcript;
         # the replay updates only land once load_session is awaited below.
         await self._mount(
@@ -920,7 +923,13 @@ class PawApp(App):
             await self._mount(PushMessageBox(event.text))
 
         elif isinstance(event, Usage):
-            self._status().set(used=event.used, size=event.size)
+            # ``or 0.0`` so a None threshold is still applied (set() ignores
+            # None), clearing any stale marker — 0.0 renders no tick.
+            self._status().set(
+                used=event.used,
+                size=event.size,
+                ctx_threshold=event.threshold or 0.0,
+            )
 
         elif isinstance(event, TokenUsage):
             # Exact usage for the just-finished call replaces our estimate.

--- a/src/qwenpaw/cli/tui/events.py
+++ b/src/qwenpaw/cli/tui/events.py
@@ -93,10 +93,17 @@ class PlanUpdate:
 
 @dataclass(frozen=True)
 class Usage:
-    """Token-usage metadata for the status bar."""
+    """Token-usage metadata for the status bar.
+
+    ``used``/``size`` are the current tokens-in-context and the model context
+    window. ``threshold`` is the auto-compaction ratio (0-1) when known, so the
+    bar can mark where context starts getting evicted; ``None`` when compaction
+    is disabled or the agent did not report it.
+    """
 
     used: int
     size: int
+    threshold: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/qwenpaw/cli/tui/normalize.py
+++ b/src/qwenpaw/cli/tui/normalize.py
@@ -153,6 +153,20 @@ def _tool_input_text(raw_input: Any) -> str:
     return str(raw_input)
 
 
+def _usage_threshold(update: Any) -> float | None:
+    """Extract the compaction threshold (0-1) from a usage_update's ``_meta``.
+
+    The native ``usage_update`` has no field for it, so the agent rides it in
+    ``_meta.compactRatio``. Returns ``None`` when absent or out of range.
+    """
+    meta = getattr(update, "field_meta", None)
+    if isinstance(meta, dict):
+        raw = meta.get("compactRatio")
+        if isinstance(raw, (int, float)) and 0 < raw < 1:
+            return float(raw)
+    return None
+
+
 # pylint: disable-next=too-many-return-statements
 def normalize_update(update: Any) -> list[TuiEvent]:
     """Convert one ACP ``session_update`` payload into zero or more events.
@@ -225,6 +239,7 @@ def normalize_update(update: Any) -> list[TuiEvent]:
             Usage(
                 used=int(getattr(update, "used", 0) or 0),
                 size=int(getattr(update, "size", 0) or 0),
+                threshold=_usage_threshold(update),
             ),
         ]
 

--- a/src/qwenpaw/cli/tui/widgets/status_bar.py
+++ b/src/qwenpaw/cli/tui/widgets/status_bar.py
@@ -17,6 +17,7 @@ _FIELDS = (
     "session",
     "used",
     "size",
+    "ctx_threshold",
     "tok_in",
     "tok_out",
     "tok_out_approx",
@@ -38,6 +39,91 @@ def _fmt_count(n: int) -> str:
     return f"{n / 1_000_000:.2f}".rstrip("0").rstrip(".") + "M"
 
 
+# --- live context-usage bar -------------------------------------------------
+# Renders e.g. ``  ctx [█████░╵░░] 650k / 1M`` into the status line.
+# ``used``/``size`` are the *current* tokens-in-context and the model context
+# window (distinct from the cumulative ``tok ↑↓`` tallies). A fixed 10-cell
+# track shows how full the window is; the fill colour ramps green -> amber ->
+# red with raw occupancy. When the auto-compaction ``threshold`` is known (it
+# is user-configurable, so the agent reports it), a faint ``╵`` tick marks the
+# cell where context starts getting evicted — watch the fill approach it. The
+# tick is gated on the true ratio (not the rounded fill), so it stays visible
+# right up to the threshold; once occupancy reaches it the tick is absorbed,
+# and when compaction fires the bar simply shrinks. Every glyph is single-cell,
+# so the fill area is always ``_CTX_BAR_WIDTH`` cells and ``line.cell_len``
+# stays correct for the right-alignment math in ``_compose_line``.
+_CTX_BAR_WIDTH = 10  # fill cells
+
+_CTX_GREEN = "#6dff9d"  # plenty of headroom
+_CTX_AMBER = "#ffcf6d"  # window filling up
+_CTX_RED = "#ff6d6d"  # window nearly full
+_CTX_TRACK = "#3a3a3a"  # unfilled track (dim, echoes version badge bg)
+_CTX_MARK = "#6d6d6d"  # auto-compaction threshold tick on the empty track
+_CTX_LABEL = "#8a8a8a"  # "ctx", brackets, "used / size" label
+
+
+def _append_ctx_bar(
+    line: Text,
+    used: int,
+    size: int,
+    threshold: float = 0.0,
+) -> None:
+    """Append a compact context-usage bar to ``line`` (no-op if unknown).
+
+    Degrades gracefully: appends nothing when the window or occupancy is
+    unknown (``size == 0`` or ``used == 0``), so the surrounding layout and the
+    right-alignment math are unchanged. The ratio is clamped to ``[0, 1]`` so a
+    stale ``used > size`` renders a full bar instead of overflowing the
+    fixed-width track. ``threshold`` (0-1) is the configured auto-compaction
+    ratio; when in range and not yet reached, a ``╵`` tick marks that cell.
+    ``threshold == 0`` (or out of range) renders no tick — e.g. compaction
+    disabled, or the threshold is unknown.
+    """
+    if not used or not size:  # window or occupancy unknown -> show nothing
+        return
+
+    # Clamp to [0, 1] so a stale ``used > size`` can't overflow the track.
+    ratio = used / size
+    ratio = 0.0 if ratio < 0.0 else 1.0 if ratio > 1.0 else ratio
+
+    # Colour by how full the window is.
+    if ratio >= 0.85:
+        color = _CTX_RED  # window nearly full
+    elif ratio >= 0.6:
+        color = _CTX_AMBER  # filling up
+    else:
+        color = _CTX_GREEN  # healthy headroom
+
+    # Whole cells only. Round to nearest, but never show a live context as an
+    # empty bar, and never overflow the fixed track.
+    filled = int(ratio * _CTX_BAR_WIDTH + 0.5)
+    if filled == 0:
+        filled = 1
+    elif filled > _CTX_BAR_WIDTH:
+        filled = _CTX_BAR_WIDTH
+    empty = _CTX_BAR_WIDTH - filled
+
+    # Threshold marker cell, shown only while occupancy is still below it (gate
+    # on the true ratio, not the rounded fill, so the tick doesn't vanish
+    # early). ``filled <= mark`` then holds, keeping every repeat count
+    # non-negative and the fill area exactly ``_CTX_BAR_WIDTH`` cells.
+    mark = min(_CTX_BAR_WIDTH - 1, int(threshold * _CTX_BAR_WIDTH + 0.5))
+    show_mark = 0.0 < threshold < 1.0 and ratio < threshold and filled <= mark
+
+    line.append("  ctx ", style=_CTX_LABEL)
+    line.append("[", style=_CTX_LABEL)
+    if show_mark:
+        line.append("█" * filled, style=color)
+        line.append("░" * (mark - filled), style=_CTX_TRACK)
+        line.append("╵", style=_CTX_MARK)
+        line.append("░" * (_CTX_BAR_WIDTH - mark - 1), style=_CTX_TRACK)
+    else:
+        line.append("█" * filled, style=color)
+        line.append("░" * empty, style=_CTX_TRACK)
+    line.append("] ", style=_CTX_LABEL)
+    line.append(f"{_fmt_count(used)} / {_fmt_count(size)}", style=_CTX_LABEL)
+
+
 class StatusBar(Static):
     """A one-line header rendered from a few fields via :meth:`set`."""
 
@@ -49,6 +135,7 @@ class StatusBar(Static):
         self._sb_session = "—"
         self._sb_used = 0
         self._sb_size = 0
+        self._sb_ctx_threshold = 0.0
         self._sb_tok_in = 0
         self._sb_tok_out = 0
         self._sb_tok_out_approx = False
@@ -111,11 +198,15 @@ class StatusBar(Static):
         line.append(f"{self._sb_model}", style="#b48cff")
         line.append("  session:", style="#8a8a8a")
         line.append(f"{str(self._sb_session)[:8]}", style="")
-        if self._sb_used:
-            tokens = _fmt_count(self._sb_used)
-            if self._sb_size:
-                tokens += f"/{_fmt_count(self._sb_size)}"
-            line.append(f"  tokens:{tokens}", style="#8a8a8a")
+        # Live context-usage bar (replaces the old plain ``tokens:`` text).
+        # No-op when used/size are unknown, so the right-alignment math below
+        # is unaffected.
+        _append_ctx_bar(
+            line,
+            self._sb_used,
+            self._sb_size,
+            self._sb_ctx_threshold,
+        )
         if self._sb_tok_in or self._sb_tok_out:
             line.append("  tok", style="#8a8a8a")
             # Show input only once it's known (it can't be estimated live),

--- a/src/qwenpaw/token_usage/model_wrapper.py
+++ b/src/qwenpaw/token_usage/model_wrapper.py
@@ -17,7 +17,12 @@ class TokenRecordingModelWrapper(ChatModelBase):
 
     _usage_by_session: dict[str, dict[str, Any]] = {}
 
-    def __init__(self, provider_id: str, model: ChatModelBase) -> None:
+    def __init__(
+        self,
+        provider_id: str,
+        model: ChatModelBase,
+        compact_threshold: float | None = None,
+    ) -> None:
         # agentscope 2.0 ChatModelBase requires credential/model/parameters.
         # Forward the wrapped model's own values so the base attributes stay
         # consistent (some downstream code reads ``self.model`` for logging).
@@ -31,6 +36,9 @@ class TokenRecordingModelWrapper(ChatModelBase):
         )
         self._model = model
         self._provider_id = provider_id
+        # Auto-compaction threshold (fraction of the window) for the UI, or
+        # None when compaction is disabled/unknown.
+        self._compact_threshold = compact_threshold
 
     def _record_usage(self, usage: ChatUsage | None) -> None:
         """Enqueue a usage event synchronously — never blocks the caller."""
@@ -60,6 +68,13 @@ class TokenRecordingModelWrapper(ChatModelBase):
             "prompt_tokens": pt,
             "completion_tokens": ct,
             "total_tokens": pt + ct,
+            # Context window of the wrapped model, so the UI can show how full
+            # the *current* context is (prompt_tokens / context_size), distinct
+            # from the cumulative session totals. 0 = unknown.
+            "context_size": int(getattr(self._model, "context_size", 0) or 0),
+            # Auto-compaction threshold (fraction of the window) so the UI can
+            # mark where context gets evicted. None = disabled/unknown.
+            "compact_threshold": self._compact_threshold,
         }
         self._store_usage(usage_data)
 

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -360,5 +360,37 @@ def test_usage_meta_includes_model(monkeypatch):
             "outputTokens": 34,
             "totalTokens": 46,
             "model": "qwen-plus",
+            # Absent in the recorded usage -> 0 (window unknown), which the TUI
+            # treats as "hide the context bar".
+            "contextSize": 0,
+            # No compaction threshold recorded -> None (no marker).
+            "compactRatio": None,
         },
     }
+
+
+def test_usage_meta_includes_context_size(monkeypatch):
+    from qwenpaw.token_usage.model_wrapper import TokenRecordingModelWrapper
+
+    monkeypatch.setattr(
+        TokenRecordingModelWrapper,
+        "pop_usage_for_session",
+        classmethod(
+            lambda cls, _session_id: {
+                "model_name": "qwen-plus",
+                "prompt_tokens": 123_000,
+                "completion_tokens": 34,
+                "total_tokens": 123_034,
+                "context_size": 1_000_000,
+                "compact_threshold": 0.8,
+            },
+        ),
+    )
+
+    # The model context window and the compaction threshold flow through so the
+    # TUI can render occupancy (inputTokens / contextSize) and mark the point
+    # where context starts getting evicted.
+    meta = QwenPawACPAgent._pop_session_usage("sess-usage")
+    assert meta["usage"]["inputTokens"] == 123_000
+    assert meta["usage"]["contextSize"] == 1_000_000
+    assert meta["usage"]["compactRatio"] == 0.8

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -394,3 +394,73 @@ def test_usage_meta_includes_context_size(monkeypatch):
     assert meta["usage"]["inputTokens"] == 123_000
     assert meta["usage"]["contextSize"] == 1_000_000
     assert meta["usage"]["compactRatio"] == 0.8
+
+
+def _usage_updates(conn):
+    return [
+        u
+        for _, u in conn.updates
+        if getattr(u, "session_update", None) == "usage_update"
+    ]
+
+
+async def test_emit_usage_emits_usage_update_with_threshold(monkeypatch):
+    from qwenpaw.token_usage.model_wrapper import TokenRecordingModelWrapper
+
+    monkeypatch.setattr(
+        TokenRecordingModelWrapper,
+        "pop_usage_for_session",
+        classmethod(
+            lambda cls, _sid: {
+                "model_name": "qwen-plus",
+                "prompt_tokens": 123_000,
+                "completion_tokens": 34,
+                "total_tokens": 123_034,
+                "context_size": 1_000_000,
+                "compact_threshold": 0.8,
+            },
+        ),
+    )
+    agent = QwenPawACPAgent(agent_id="default")
+    conn = _FakeConn()
+    agent.on_connect(conn)
+
+    await agent._emit_usage_if_available("sess-u")
+
+    ups = _usage_updates(conn)
+    assert len(ups) == 1
+    assert ups[0].used == 123_000
+    assert ups[0].size == 1_000_000
+    assert ups[0].field_meta == {"compactRatio": 0.8}
+
+
+async def test_emit_usage_clears_bar_when_window_unknown(monkeypatch):
+    # used/size == 0 must STILL emit a usage_update so the TUI hides a stale
+    # bar (e.g. after switching to a model with an unknown window) instead of
+    # retaining the previous turn's values.
+    from qwenpaw.token_usage.model_wrapper import TokenRecordingModelWrapper
+
+    monkeypatch.setattr(
+        TokenRecordingModelWrapper,
+        "pop_usage_for_session",
+        classmethod(
+            lambda cls, _sid: {
+                "model_name": "mystery",
+                "prompt_tokens": 0,
+                "completion_tokens": 5,
+                "total_tokens": 5,
+                "context_size": 0,
+            },
+        ),
+    )
+    agent = QwenPawACPAgent(agent_id="default")
+    conn = _FakeConn()
+    agent.on_connect(conn)
+
+    await agent._emit_usage_if_available("sess-u")
+
+    ups = _usage_updates(conn)
+    assert len(ups) == 1
+    assert ups[0].used == 0
+    assert ups[0].size == 0
+    assert ups[0].field_meta is None

--- a/tests/unit/cli/tui/test_normalize.py
+++ b/tests/unit/cli/tui/test_normalize.py
@@ -219,7 +219,31 @@ def test_usage_update():
     out = normalize_update(
         UsageUpdate(session_update="usage_update", used=1200, size=8000),
     )
-    assert out == [E.Usage(used=1200, size=8000)]
+    assert out == [E.Usage(used=1200, size=8000, threshold=None)]
+
+
+def test_usage_update_carries_compaction_threshold():
+    out = normalize_update(
+        UsageUpdate(
+            session_update="usage_update",
+            used=800_000,
+            size=1_000_000,
+            field_meta={"compactRatio": 0.8},
+        ),
+    )
+    assert out == [E.Usage(used=800_000, size=1_000_000, threshold=0.8)]
+
+
+def test_usage_update_ignores_out_of_range_threshold():
+    out = normalize_update(
+        UsageUpdate(
+            session_update="usage_update",
+            used=1,
+            size=2,
+            field_meta={"compactRatio": 1.5},  # not in (0, 1) -> dropped
+        ),
+    )
+    assert out == [E.Usage(used=1, size=2, threshold=None)]
 
 
 def test_available_commands_update():

--- a/tests/unit/cli/tui/test_status_bar.py
+++ b/tests/unit/cli/tui/test_status_bar.py
@@ -7,10 +7,29 @@ from __future__ import annotations
 # pylint: disable=disallowed-name
 
 import pytest
+from rich.text import Text
 
-from qwenpaw.cli.tui.widgets.status_bar import StatusBar, _fmt_count
+from qwenpaw.cli.tui.widgets.status_bar import (
+    _CTX_AMBER,
+    _CTX_GREEN,
+    _CTX_RED,
+    StatusBar,
+    _append_ctx_bar,
+    _fmt_count,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.p1]
+
+
+def _ctx_bar(used: int, size: int, threshold: float = 0.0) -> Text:
+    """Render just the context-usage bar into a fresh Text."""
+    t = Text()
+    _append_ctx_bar(t, used, size, threshold)
+    return t
+
+
+def _ctx_styles(t: Text) -> list[str]:
+    return [str(span.style) for span in t.spans]
 
 
 def test_fmt_count_compacts_large_numbers():
@@ -68,3 +87,106 @@ def test_active_state_uses_spinner_glyph():
     bar.set(state="thinking")
     assert "thinking" in bar.summary
     assert "● thinking" not in bar.summary
+
+
+# --- context-usage bar -------------------------------------------------------
+
+
+def test_ctx_bar_hidden_when_window_or_occupancy_unknown():
+    # Window unknown (size==0): a denominator-less bar is meaningless.
+    assert _ctx_bar(123_000, 0).plain == ""
+    # Occupancy not yet reported (used==0): hidden.
+    assert _ctx_bar(0, 1_000_000).plain == ""
+    # And it stays out of the full status line.
+    bar = StatusBar()
+    bar.set(used=0, size=0)
+    assert "ctx" not in bar.summary
+
+
+def test_ctx_bar_renders_bar_and_label():
+    t = _ctx_bar(123_000, 1_000_000)  # ~12%
+    assert "ctx" in t.plain
+    assert "█" in t.plain  # at least one filled cell
+    assert "123k / 1M" in t.plain  # used / size label via _fmt_count
+    # No percentage and no compaction marker — the bar itself is the signal.
+    assert "%" not in t.plain
+    assert "╵" not in t.plain
+
+
+def test_ctx_bar_color_ramps_with_occupancy():
+    green = _ctx_styles(_ctx_bar(300_000, 1_000_000))  # 30%
+    amber = _ctx_styles(_ctx_bar(700_000, 1_000_000))  # 70%
+    red = _ctx_styles(_ctx_bar(950_000, 1_000_000))  # 95%
+    assert any(_CTX_GREEN in s for s in green)
+    assert any(_CTX_AMBER in s for s in amber)
+    assert any(_CTX_RED in s for s in red)
+
+
+def test_ctx_bar_fill_is_always_ten_cells():
+    # Fill region is exactly the fixed track width across the ratio range,
+    # so line.cell_len stays correct for the status bar's right-alignment.
+    for used, size in [
+        (50, 1_000_000),
+        (300_000, 1_000_000),
+        (1_000_000, 1_000_000),
+        (2_000_000, 1_000_000),
+    ]:
+        plain = _ctx_bar(used, size).plain
+        fill = plain[plain.index("[") + 1 : plain.index("]")]
+        assert len(fill) == 10, (used, size, fill)
+
+
+def test_ctx_bar_clamps_when_used_exceeds_size():
+    t = _ctx_bar(2_000_000, 1_000_000)  # stale over-report
+    # Full bar, red, no overflow of the fixed 10-cell track.
+    assert t.plain.count("█") == 10
+    assert any(_CTX_RED in s for s in _ctx_styles(t))
+
+
+def test_ctx_bar_tiny_ratio_stays_visible():
+    t = _ctx_bar(50, 1_000_000)  # 0.005%
+    assert "█" in t.plain  # at least one cell, never an empty bar
+
+
+def _ctx_fill(t: Text) -> str:
+    """The bracketed fill region of a rendered bar."""
+    p = t.plain
+    return p[p.index("[") + 1 : p.index("]")]
+
+
+def test_ctx_bar_marker_shown_below_threshold():
+    # The tick marks the configured compaction point while occupancy is below.
+    assert "╵" in _ctx_bar(300_000, 1_000_000, 0.8).plain
+
+
+def test_ctx_bar_marker_absorbed_at_and_above_threshold():
+    assert "╵" not in _ctx_bar(800_000, 1_000_000, 0.8).plain  # exactly at
+    assert "╵" not in _ctx_bar(950_000, 1_000_000, 0.8).plain  # above
+
+
+def test_ctx_bar_marker_visible_through_lead_in_zone():
+    # Regression: the tick must stay visible in [0.75, 0.80) (it previously
+    # vanished at 0.75 because visibility was gated on the rounded fill count
+    # rather than the true ratio).
+    for used in (750_000, 760_000, 790_000, 799_000):
+        assert "╵" in _ctx_bar(used, 1_000_000, 0.8).plain, used
+
+
+def test_ctx_bar_marker_position_tracks_threshold():
+    # Marker cell index == round(threshold * width); low fixed occupancy so
+    # the tick is always shown.
+    assert _ctx_fill(_ctx_bar(150_000, 1_000_000, 0.5)).index("╵") == 5
+    assert _ctx_fill(_ctx_bar(150_000, 1_000_000, 0.8)).index("╵") == 8
+    assert _ctx_fill(_ctx_bar(150_000, 1_000_000, 0.9)).index("╵") == 9
+
+
+def test_ctx_bar_no_marker_when_threshold_unknown_or_invalid():
+    # threshold == 0 (compaction disabled / not reported) -> no tick.
+    assert "╵" not in _ctx_bar(300_000, 1_000_000, 0.0).plain
+    # Out-of-range thresholds are ignored too.
+    assert "╵" not in _ctx_bar(300_000, 1_000_000, 1.0).plain
+
+
+def test_ctx_bar_fill_stays_ten_cells_with_marker():
+    for used in (50, 300_000, 750_000, 799_000):
+        assert len(_ctx_fill(_ctx_bar(used, 1_000_000, 0.8))) == 10, used

--- a/tests/unit/token_usage/test_token_usage.py
+++ b/tests/unit/token_usage/test_token_usage.py
@@ -525,6 +525,45 @@ class TestTokenRecordingModelWrapper:
 
         wrapper._record_usage(mock_usage)
 
+    def test_record_usage_includes_context_and_threshold(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Per-call usage carries context_size and compaction threshold."""
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.WORKING_DIR",
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.manager.TOKEN_USAGE_FILE",
+            "test_token_usage.json",
+        )
+        monkeypatch.setattr(
+            "qwenpaw.app.agent_context.get_current_session_id",
+            lambda: "sess-1",
+        )
+
+        mock_model = MagicMock()
+        mock_model.model = "gpt-4"
+        mock_model.context_size = 1_000_000
+
+        wrapper = TokenRecordingModelWrapper(
+            provider_id="openai",
+            model=mock_model,
+            compact_threshold=0.8,
+        )
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 123_000
+        mock_usage.output_tokens = 50
+        wrapper._record_usage(mock_usage)
+
+        stored = TokenRecordingModelWrapper.pop_usage_for_session("sess-1")
+        assert stored is not None
+        assert stored["context_size"] == 1_000_000
+        assert stored["compact_threshold"] == 0.8
+
     def test_pop_usage_for_session(self, monkeypatch):
         """Should pop usage for session."""
         monkeypatch.setattr(


### PR DESCRIPTION
## Description

Adds a live **context-usage bar** to the TUI status bar so it's clear at a glance how full the current model context is — and how close it is to auto-compaction.

Previously the status bar only showed *cumulative* session token counts (`tok ↑/↓`), which sum every API call's input and routinely run into the millions on a long session. That number is easy to mistake for context-window usage, and there was no indication of how full the *current* context was or when compaction would fire. This adds a separate, compact occupancy bar:

```
ctx [█░░░░░░░╵░] 123k / 1M   <- current tokens-in-context / window; the tick marks the compaction threshold
```

- Fixed 10-cell bar; fill colour ramps green -> amber -> red with raw occupancy.
- A single-cell tick marks the configured auto-compaction threshold (`compact_threshold_ratio`), so you can watch the fill approach it. Because that ratio is user-configurable, it is sourced from the agent config rather than hardcoded; the tick is hidden when compaction is disabled or the window/threshold is unknown.
- When auto-compaction fires and evicts history, the bar visibly shrinks.

**Plumbing:** reuses the existing per-call usage side channel. `TokenRecordingModelWrapper` now also carries the model's `context_size` and the agent's `compact_threshold_ratio`; these flow through the ACP server into the native `usage_update` notification (the threshold via `_meta`, since the schema has no field for it), then `normalize` -> `Usage` event -> status bar. The `usage_update` consumer path already existed in the TUI but was never emitted by the server; this completes that wiring.

**Related Issue:** N/A (no tracked issue)

**Security Considerations:** None — UI/telemetry display only; no auth, network, or config-write changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit` locally and it passes (on the changed files)
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest`) and they pass
- [ ] Documentation updated (if needed) — N/A
- [x] Ready for review

## Testing

1. Run the TUI against any model/provider and send a few messages.
2. The status bar shows ` ctx [..bar..] <used> / <window>` reflecting the latest request's prompt size vs. the model context window.
3. With auto-compaction enabled, a tick appears at the configured `compact_threshold_ratio`; as context fills, the bar approaches it, and when compaction fires the bar shrinks.
4. Set `context_compact_config.enabled = false` (or use a model whose window is unknown) -> the tick is omitted.

Automated: new unit tests cover the render math (fill always 10 cells, colour ramp, clamp, min-fill), the marker (position per threshold, visibility through the lead-in zone, absorbed at/above threshold, hidden when unknown), and the threshold plumbing at each hop (wrapper -> usage meta -> `usage_update` `_meta` -> `Usage`).

## Local Verification Evidence

```bash
pre-commit run --files <changed files>
# check python ast..Passed  add-trailing-comma..Passed  mypy..Passed
# black..Passed  flake8..Passed  pylint..Passed  (10.00/10)

pytest tests/unit/cli/tui tests/unit/token_usage tests/unit/agents/test_acp_available_commands.py
# 152 passed, 1 warning
```

Note: the repo-wide `pytest` has 4 failures in `tests/unit/agents/context/` that are pre-existing and unrelated to this change (they fail identically on `main`).

## Additional Notes

The `usage_update` ACP path and the `Usage` TUI event already existed but were never emitted by the server; this PR completes that intended wiring and adds the compaction-threshold marker on top of the occupancy bar.
