### PR TITLE
fix(runtime): ensure cancel_envelope is yielded when task is cancelled

### DIFF
--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -149,7 +149,11 @@ class Runtime:
             try:
                 await hooks.run(Phase.ON_ERROR, ctx)
             except asyncio.CancelledError:
-                pass
+                logger.debug(
+                    "ON_ERROR hooks skipped due to asyncio "
+                    "re-cancellation (session=%s)",
+                    getattr(ctx, "session_id", ""),
+                )
             async for ev in envelope.cancel_envelope():
                 yield ev
             raise

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -140,7 +140,16 @@ class Runtime:
 
         except (asyncio.CancelledError, KeyboardInterrupt) as e:
             ctx.error = e
-            await hooks.run(Phase.ON_ERROR, ctx)
+            # The Task's _must_cancel flag may still be True after
+            # catching CancelledError, causing the next await to raise
+            # CancelledError again.  Wrap ON_ERROR hooks so that
+            # cancel_envelope is always yielded — the frontend SDK
+            # needs the {object:response, status:completed} event to
+            # exit loading state.
+            try:
+                await hooks.run(Phase.ON_ERROR, ctx)
+            except asyncio.CancelledError:
+                pass
             async for ev in envelope.cancel_envelope():
                 yield ev
             raise


### PR DESCRIPTION
## Description

Fix task cancellation leaving the frontend stuck in "processing" state.

When the user clicks "Cancel Task" on an approval card, the backend calls `task.cancel()` on the producer task. Due to asyncio's `_must_cancel` mechanism, the first `await` after catching `CancelledError` in `Runtime.run()` raises again immediately. This prevented `cancel_envelope()` from ever yielding the terminal `{object: "response", status: "completed"}` event. Without this event, the `@agentscope-ai/chat` SDK never exits its loading state, leaving the session permanently stuck in "processing".

The fix wraps `hooks.run(Phase.ON_ERROR, ctx)` in a `try/except CancelledError` so that the re-cancellation is absorbed and `cancel_envelope` always executes.

**Related Issue:** Relates to cancel-task stuck-in-processing bug report

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

1. Start QwenPaw with a valid agent config
2. Send a message that triggers a tool requiring approval (e.g., `read_file` on a sensitive path)
3. When the approval card appears, click "取消任务" (Cancel Task)
4. **Before fix:** Session stuck in "processing" indefinitely
5. **After fix:** Session exits loading state immediately, chat returns to idle

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/runtime/runtime.py
# All checks passed (ast, black, flake8, pylint, mypy, etc.)

# Manual E2E: confirmed cancel task exits processing state correctly