### PR TITLE
feat(console): remove hardcoded 10k input character limit

### DIFF
--- a/console/src/pages/Chat/OptionsPanel/defaultConfig.ts
+++ b/console/src/pages/Chat/OptionsPanel/defaultConfig.ts
@@ -17,7 +17,9 @@ const defaultConfig = {
   },
   sender: {
     attachments: true,
-    maxLength: 10000,
+    // maxLength is intentionally omitted: modern LLMs support 256 k–1 M+ token
+    // context windows, so a hard character cap in the UI is unnecessarily
+    // restrictive.  See: https://github.com/agentscope-ai/QwenPaw/issues/5670
     disclaimer: "Works for you, grows with you",
   },
   welcome: {


### PR DESCRIPTION
## Description

Removes the hardcoded `sender.maxLength: 10000` from `defaultConfig.ts`.

**Problem (Fixes #5670):**
Modern LLMs natively support context windows of 256 k–1 M+ tokens. A hard 10,000-character cap in the input box forces users to:
- Split long text into temporary files just to pass it to the agent
- Send content in multiple messages instead of one
- Lose the convenience of copy-paste for long code, documents, or research

This is especially painful for the target users mentioned in the issue: developers, researchers, and heavy office users.

**Fix:**
`sender.maxLength` is removed from the default config object in
`console/src/pages/Chat/OptionsPanel/defaultConfig.ts`.
The underlying Sender component (from `@agentscope-ai/chat`) imposes **no
limit** when the field is absent, so input length is now bounded only by what
the chosen model can actually accept — not by an arbitrary UI constant.

A comment is left in place of the removed line to explain the intent for future
maintainers.

## Type of Change

- [ ] Bug fix
- [x] New feature / improvement
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally and they pass
- [ ] Documentation updated (if needed) — N/A for this change
- [x] Ready for review

## Testing

**Before:** Typing or pasting more than 10,000 characters into the chat input box was blocked / truncated by the Sender component.

**After:** The chat input box accepts text of any length. Input is limited only by the model's actual context window.

Manual verification steps:
1. Open the QwenPaw console (`qwenpaw app`, then http://127.0.0.1:8088)
2. Paste a block of text exceeding 10,000 characters into the chat input
3. **Before fix:** input is cut off at 10,000 chars
4. **After fix:** full text is accepted and sent to the model

Closes #5670