### PR TITLE
Load skill metadata into system prompt

### DIFF
--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -177,6 +177,7 @@ class AgentBuilder:
         if not hasattr(ctx, "extras") or ctx.extras is None:
             ctx.extras = {}
         ctx.extras["driver_prompt_hints"] = driver_prompt_hints
+        ctx.extras["effective_skills"] = effective_skills
 
         # Model + formatter (built before the toolkit so the scroll context
         # strategy, which needs the model for token counting, can wire in).

--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -267,7 +267,7 @@ class ScrollContextContributor(SyncPromptContributor):
 
 
 class SkillListContributor(SyncPromptContributor):
-    """Inject a bullet list of available skills so the model knows what it can use."""
+    """Inject a bullet list of available skills."""
 
     name = "skill_list"
     priority = 45
@@ -302,13 +302,14 @@ class SkillListContributor(SyncPromptContributor):
         language = extras.get("language", "zh")
         if language == "zh":
             header = (
-                "## 可用 Skills\n\n"
-                "以下skills已启用。需要时加载对应的SKILL.md获取完整内容："
+                "## 可用 Skills\n\n" + "以下skills已启用。" + "需要时加载对应的SKILL.md获取完整内容："
             )
         else:
             header = (
                 "## Available Skills\n\n"
-                "The following skills are enabled. Load a skill's SKILL.md for full instructions when needed:"
+                + "The following skills are enabled. "
+                + "Load a skill's SKILL.md for full "
+                + "instructions when needed:"
             )
 
         return header + "\n" + "\n".join(lines)

--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -266,6 +266,62 @@ class ScrollContextContributor(SyncPromptContributor):
         return build_scroll_system_prompt(language)
 
 
+class SkillListContributor(SyncPromptContributor):
+    """Inject a bullet list of available skills so the model knows what it can use."""
+
+    name = "skill_list"
+    priority = 45
+
+    def contribute_sync(self, ctx: "HookContext") -> str | None:
+        extras = getattr(ctx, "extras", {}) or {}
+        effective_skills: list[str] = extras.get("effective_skills") or []
+        if not effective_skills:
+            return None
+
+        wd = getattr(ctx, "workspace_dir", None)
+        if not wd:
+            return None
+
+        try:
+            from ..agents.skill_system.store import read_skill_manifest
+
+            manifest = read_skill_manifest(Path(wd))
+        except Exception:
+            return None
+
+        skills_data = manifest.get("skills", {})
+        lines: list[str] = []
+        for name in effective_skills:
+            entry = skills_data.get(name, {})
+            meta = entry.get("metadata", {})
+            desc = meta.get("description", "")
+            if not desc:
+                desc = entry.get("description", "")
+            if desc:
+                lines.append(f"- {name}: {desc}")
+            else:
+                lines.append(f"- {name}")
+
+        if not lines:
+            return None
+
+        language = extras.get("language", "en")
+        if language == "zh":
+            header = (
+                "## 可用 Skills\n\n"
+                "以下 skills 已启用。需要时用对应的 skill name 加载其"
+                " SKILL.md 获取完整指引："
+            )
+        else:
+            header = (
+                "## Available Skills\n\n"
+                "The following skills are enabled. Load a skill's"
+                " SKILL.md for full instructions when needed:"
+            )
+
+        return header + "\n" + "\n".join(lines)
+
+
 class EnvContextContributor(SyncPromptContributor):
     """Append the environment context block (time / session / OS)."""
 
@@ -299,6 +355,7 @@ _ALL_CONTRIBUTORS = (
     AgentsMdContributor,
     SoulMdContributor,
     ProfileMdContributor,
+    SkillListContributor,
     MultimodalHintContributor,
     CodingModeContributor,
     ScrollContextContributor,
@@ -320,6 +377,7 @@ __all__ = [
     "AgentsMdContributor",
     "SoulMdContributor",
     "ProfileMdContributor",
+    "SkillListContributor",
     "MultimodalHintContributor",
     "CodingModeContributor",
     "ScrollContextContributor",

--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -282,21 +282,15 @@ class SkillListContributor(SyncPromptContributor):
         if not wd:
             return None
 
-        try:
-            from ..agents.skill_system.store import read_skill_manifest
+        from ..agents.skill_system.store import read_skill_manifest
 
-            manifest = read_skill_manifest(Path(wd))
-        except Exception:
-            return None
-
+        manifest = read_skill_manifest(Path(wd))
         skills_data = manifest.get("skills", {})
         lines: list[str] = []
         for name in effective_skills:
             entry = skills_data.get(name, {})
             meta = entry.get("metadata", {})
             desc = meta.get("description", "")
-            if not desc:
-                desc = entry.get("description", "")
             if desc:
                 lines.append(f"- {name}: {desc}")
             else:
@@ -305,18 +299,16 @@ class SkillListContributor(SyncPromptContributor):
         if not lines:
             return None
 
-        language = extras.get("language", "en")
+        language = extras.get("language", "zh")
         if language == "zh":
             header = (
                 "## 可用 Skills\n\n"
-                "以下 skills 已启用。需要时用对应的 skill name 加载其"
-                " SKILL.md 获取完整指引："
+                "以下skills已启用。需要时加载对应的SKILL.md获取完整内容："
             )
         else:
             header = (
                 "## Available Skills\n\n"
-                "The following skills are enabled. Load a skill's"
-                " SKILL.md for full instructions when needed:"
+                "The following skills are enabled. Load a skill's SKILL.md for full instructions when needed:"
             )
 
         return header + "\n" + "\n".join(lines)


### PR DESCRIPTION
## Description

**Related Issue:** Fixes #5676 

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

The return value of `build_prompt()` function (`src/qwenpaw/runtime/builder.py:L280`) should now have the metadata of available skills.

## Local Verification Evidence

```bash
pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

pytest
=================================================== test session starts ===================================================
platform darwin -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0 -- /Users/me/Documents/codebase/QwenPaw/.venv/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /Users/me/Documents/codebase/QwenPaw
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0, asyncio-1.4.0, hypothesis-6.155.7
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 9 items                                                                                                         

tests/unit/workspace/test_prompt.py::test_prompt_without_agent_id PASSED                                            [ 11%]
tests/unit/workspace/test_prompt.py::test_prompt_with_default_agent_id PASSED                                       [ 22%]
tests/unit/workspace/test_prompt.py::test_prompt_with_custom_agent_id PASSED                                        [ 33%]
tests/unit/workspace/test_prompt.py::test_prompt_with_empty_workspace PASSED                                        [ 44%]
tests/unit/workspace/test_prompt.py::test_prompt_identity_format PASSED                                             [ 55%]
tests/unit/agents/test_prompt_sections.py::test_builder_orders_sections_after_host_anchor PASSED                    [ 66%]
tests/unit/agents/test_prompt_sections.py::test_registry_rejects_invalid_anchor PASSED                              [ 77%]
tests/unit/agents/test_prompt_sections.py::test_builder_filters_by_agent_id PASSED                                  [ 88%]
tests/unit/agents/test_prompt_sections.py::test_builder_skips_empty_and_failed_providers PASSED                     [100%]

==================================================== warnings summary =====================================================
.venv/lib/python3.11/site-packages/opentelemetry/util/_importlib_metadata.py:32
  /Users/me/Documents/codebase/QwenPaw/.venv/lib/python3.11/site-packages/opentelemetry/util/_importlib_metadata.py:32: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    return EntryPoints(ep for group_eps in eps.values() for ep in group_eps)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================== 9 passed, 1 warning in 0.32s ===============================================
```

And I've also rebased on latest main branch.