### PR TITLE
fix: resolve session switch flash and queue alert flicker

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -403,16 +403,6 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         return;
       }
 
-      if (props.embedded) {
-        setSwitchingSessionId(sessionId);
-        window.dispatchEvent(
-          new CustomEvent("qwenpaw:sidebar-select-session", {
-            detail: { sessionId },
-          }),
-        );
-        return;
-      }
-
       // Start a new cancellable switch (aborts any in-flight switch)
       const controller = sessionApi.startNewSwitch();
       setSwitchingSessionId(sessionId);
@@ -425,24 +415,45 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
             sessionId,
             realId,
           );
-          // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
-          // The redirect effect in ChatPage would immediately navigate back
-          // to /coding before session data loads, causing the switch to fail.
-          if (!codingMode) {
-            const targetUrl = buildSessionPath("chat", effectiveId);
-            navigate(targetUrl, { replace: true });
+
+          if (props.embedded) {
+            // Embedded mode: dispatch event after preload completes to avoid
+            // intermediate state where URL changes before session data loads.
+            // This prevents the "flash to fallback page" issue.
+            window.dispatchEvent(
+              new CustomEvent("qwenpaw:sidebar-select-session", {
+                detail: { sessionId, effectiveId },
+              }),
+            );
+          } else {
+            // Non-embedded mode: navigate directly
+            // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
+            // The redirect effect in ChatPage would immediately navigate back
+            // to /coding before session data loads, causing the switch to fail.
+            if (!codingMode) {
+              const targetUrl = buildSessionPath("chat", effectiveId);
+              navigate(targetUrl, { replace: true });
+            }
+            sessionApi.trackNavigatedSession(
+              effectiveId,
+              setLastChatId,
+              selectedAgent,
+            );
+            setCurrentSessionId(sessionId);
           }
-          sessionApi.trackNavigatedSession(
-            effectiveId,
-            setLastChatId,
-            selectedAgent,
-          );
-          setCurrentSessionId(sessionId);
         })
         .catch((err) => {
           if (err?.name === "AbortError") return;
           // On non-abort error, still try to switch normally.
-          setCurrentSessionId(sessionId);
+          if (props.embedded) {
+            window.dispatchEvent(
+              new CustomEvent("qwenpaw:sidebar-select-session", {
+                detail: { sessionId },
+              }),
+            );
+          } else {
+            setCurrentSessionId(sessionId);
+          }
         })
         .finally(() => {
           // Only clean up if this switch was NOT superseded by a newer one

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1186,14 +1186,29 @@ export default function ChatPage() {
   // determined by an exclusive Web Lock keyed by sessionId; when the owner
   // tab closes, another tab acquires the lock and becomes the owner.
   const [isOwner, setIsOwner] = useState(false);
+  const [ownershipResolved, setOwnershipResolved] = useState(false);
   const isOwnerRef = useRef(false);
   isOwnerRef.current = isOwner;
   useEffect(() => {
     setIsOwner(false);
+    setOwnershipResolved(false);
     const ctrl = new AbortController();
-    void holdOwnershipLock(queueSessionId, () => setIsOwner(true), ctrl.signal);
+    void holdOwnershipLock(
+      queueSessionId,
+      () => {
+        setIsOwner(true);
+        setOwnershipResolved(true);
+      },
+      ctrl.signal,
+    );
+    // If the lock callback never fires (e.g. another tab holds it), resolve
+    // after a short delay so the non-owner Alert appears without flashing.
+    const fallbackTimer = setTimeout(() => {
+      setOwnershipResolved(true);
+    }, 300);
     return () => {
       ctrl.abort();
+      clearTimeout(fallbackTimer);
     };
   }, [queueSessionId]);
 
@@ -2566,9 +2581,9 @@ export default function ChatPage() {
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: whisperChecked && !whisperEnabled,
         beforeUI:
-          !isOwner || messageQueue.length > 0 ? (
+          (ownershipResolved && !isOwner) || messageQueue.length > 0 ? (
             <>
-              {!isOwner && (
+              {ownershipResolved && !isOwner && (
                 <Alert
                   type="info"
                   showIcon

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1212,6 +1212,13 @@ export default function ChatPage() {
     };
   }, [queueSessionId]);
 
+  // Whether this tab is confirmed to be a non-owner (queue-only) tab.
+  // Stays false until ownership check completes, preventing a flash of
+  // the "other tab is owner" banner on every session switch.
+  const isQueueOnlyTab = ownershipResolved && !isOwner;
+  const hasQueueItems = messageQueue.length > 0;
+  const showSenderBeforeUI = isQueueOnlyTab || hasQueueItems;
+
   const scheduleNextSend = useCallback(() => {
     if (autoSendTimerRef.current) clearTimeout(autoSendTimerRef.current);
     autoSendTimerRef.current = setTimeout(() => {
@@ -2580,33 +2587,32 @@ export default function ChatPage() {
         ...(i18nConfig as any)?.sender,
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: whisperChecked && !whisperEnabled,
-        beforeUI:
-          (ownershipResolved && !isOwner) || messageQueue.length > 0 ? (
-            <>
-              {ownershipResolved && !isOwner && (
-                <Alert
-                  type="info"
-                  showIcon
-                  banner
-                  message={t("chat.queue.otherTabOwner")}
-                />
-              )}
-              {messageQueue.length > 0 ? (
-                <MessageQueuePanel
-                  items={messageQueue}
-                  runState={runState}
-                  onRemove={handleQueueRemove}
-                  onEdit={handleQueueEdit}
-                  onReorder={handleQueueReorder}
-                  onInterruptAndSend={handleQueueInterruptAndSend}
-                  onClear={handleQueueClear}
-                  onPauseResume={handleQueuePauseResume}
-                  onRetry={handleQueueRetry}
-                  onSkip={handleQueueSkip}
-                />
-              ) : null}
-            </>
-          ) : undefined,
+        beforeUI: showSenderBeforeUI ? (
+          <>
+            {isQueueOnlyTab && (
+              <Alert
+                type="info"
+                showIcon
+                banner
+                message={t("chat.queue.otherTabOwner")}
+              />
+            )}
+            {hasQueueItems ? (
+              <MessageQueuePanel
+                items={messageQueue}
+                runState={runState}
+                onRemove={handleQueueRemove}
+                onEdit={handleQueueEdit}
+                onReorder={handleQueueReorder}
+                onInterruptAndSend={handleQueueInterruptAndSend}
+                onClear={handleQueueClear}
+                onPauseResume={handleQueuePauseResume}
+                onRetry={handleQueueRetry}
+                onSkip={handleQueueSkip}
+              />
+            ) : null}
+          </>
+        ) : undefined,
         prefix:
           whisperEnabled || pluginSenderPrefix.length > 0 ? (
             <>


### PR DESCRIPTION
- ChatSessionDrawer (embedded mode): wait for preloadSession to complete before dispatching sidebar-select-session event, preventing intermediate state where URL changes to /chat (no sessionId) before session data loads.

- Chat page: add ownershipResolved state to defer non-owner Alert rendering until holdOwnershipLock completes, eliminating the flash on every session switch.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
