### PR TITLE
refactor(ci): extract desktop verify into composite actions

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -1,0 +1,21 @@
+name: Get QwenPaw Version
+description: Extract __version__ from src/qwenpaw/__version__.py
+
+outputs:
+  version:
+    description: The extracted version string (e.g. 1.2.3)
+    value: ${{ steps.extract.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: extract
+      shell: bash
+      run: |
+        set -euo pipefail
+        version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)
+        if [ -z "$version" ]; then
+          echo "::error::Failed to extract __version__ from src/qwenpaw/__version__.py"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-legacy-macos/action.yml
+++ b/.github/actions/verify-legacy-macos/action.yml
@@ -1,0 +1,124 @@
+name: Verify Desktop (Legacy macOS)
+description: |
+  Unpack conda-pack zip, start the bundled backend, and run the shared
+  Playwright UI verifier. Stop / cleanup / log upload steps live in the
+  caller workflow because composite actions cannot use `if: always()`.
+
+inputs:
+  dashscope-api-key:
+    description: DashScope API key (empty -> verifier skips LLM round)
+    required: false
+    default: ""
+  version:
+    description: Expected backend version (used for cross-version sanity)
+    required: true
+  runner-python:
+    description: Absolute path to the runner's Python interpreter
+    required: true
+  allow-flaky-llm:
+    description: If 'true', verifier exits 0 on LLM retry exhaustion
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install verify deps (Playwright + Chromium)
+      shell: bash
+      env:
+        RUNNER_PYTHON: ${{ inputs.runner-python }}
+      run: |
+        set -euo pipefail
+        "$RUNNER_PYTHON" -m pip install --upgrade pip
+        "$RUNNER_PYTHON" -m pip install \
+          -r scripts/verify/requirements-verify.txt
+        "$RUNNER_PYTHON" -m playwright install chromium --with-deps
+
+    - name: Verify desktop (Legacy macOS)
+      shell: bash
+      env:
+        QWENPAW_DASHSCOPE_API_KEY: ${{ inputs.dashscope-api-key }}
+        RUNNER_PYTHON: ${{ inputs.runner-python }}
+        EXPECTED_VERSION: ${{ inputs.version }}
+        ALLOW_FLAKY_LLM: ${{ inputs.allow-flaky-llm }}
+      run: |
+        set -euo pipefail
+
+        # 1. Unpack the freshly built zip into an isolated verify dir.
+        mkdir -p dist/verify-legacy
+        unzip -q dist/QwenPaw-*-macOS.zip -d dist/verify-legacy
+        APP="$(find dist/verify-legacy -maxdepth 2 -name '*.app' -type d | head -1)"
+        if [ -z "$APP" ]; then
+          echo "::error::QwenPaw.app not found inside zip"
+          exit 1
+        fi
+        ENV_DIR="$APP/Contents/Resources/env"
+        PYTHON="$ENV_DIR/bin/python"
+
+        # 2. Fix conda-pack paths (mandatory or python crashes on launch).
+        (cd "$ENV_DIR" && ./bin/conda-unpack 2>/dev/null || true)
+
+        # 3. Force only the bundled interpreter to ignore user site-packages.
+        # Keep PYTHONHOME scoped so the runner Python used by Playwright does
+        # not inherit the packaged stdlib path.
+        export PYTHONNOUSERSITE=1
+        export PATH="$ENV_DIR/bin:$PATH"
+        bundled_python() {
+          env PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1 \
+            PATH="$ENV_DIR/bin:$PATH" "$PYTHON" "$@"
+        }
+
+        # 4. SSL certificates — required for DashScope HTTPS calls.
+        CERT_FILE="$(bundled_python -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
+        if [ -n "${CERT_FILE:-}" ] && [ -f "$CERT_FILE" ]; then
+          export SSL_CERT_FILE="$CERT_FILE"
+          export REQUESTS_CA_BUNDLE="$CERT_FILE"
+        fi
+
+        # 5. Init workspace and start the desktop backend in the background.
+        bundled_python -m qwenpaw init --defaults --accept-security
+        # Skip the BootstrapHook onboarding script so the verifier
+        # can drive the agent in normal QA mode (see
+        # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
+        rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
+        nohup env PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1 \
+          PATH="$ENV_DIR/bin:$PATH" \
+          "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
+          > "$RUNNER_TEMP/qwenpaw-desktop-stdout.log" \
+          2> "$RUNNER_TEMP/qwenpaw-desktop-stderr.log" &
+        echo $! > "$RUNNER_TEMP/qwenpaw-desktop.pid"
+
+        # 6. Wait for /api/version (~120s budget).
+        for i in $(seq 1 60); do
+          if curl -sf http://127.0.0.1:8088/api/version >/dev/null; then
+            echo "Server up after ~$((i*2))s"
+            break
+          fi
+          if [ "$i" = "60" ]; then
+            echo "::error::Server did not respond within 120s"
+            exit 1
+          fi
+          sleep 2
+        done
+
+        # 7. Cross-version sanity: backend version must match source.
+        expected="$EXPECTED_VERSION"
+        actual="$(curl -sf http://127.0.0.1:8088/api/version | env -u PYTHONHOME -u PYTHONPATH "$RUNNER_PYTHON" -c 'import sys,json; print(json.load(sys.stdin)["version"])')"
+        if [ "$actual" != "$expected" ]; then
+          echo "::error::Desktop version mismatch: expected=$expected actual=$actual"
+          exit 1
+        fi
+
+        # 8. Run the shared verifier with the runner's python (where
+        #    Playwright + Chromium are installed). The bundled conda-pack
+        #    python stays untouched so we don't pollute the actual env
+        #    that ships to users.
+        extra_flags=()
+        if [ "$ALLOW_FLAKY_LLM" = "true" ]; then
+          extra_flags+=("--allow-flaky-llm")
+        fi
+        env -u PYTHONHOME -u PYTHONPATH "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
+          --base-url http://127.0.0.1:8088 \
+          --ui-mode legacy \
+          --headed \
+          "${extra_flags[@]}"

--- a/.github/actions/verify-legacy-windows/action.yml
+++ b/.github/actions/verify-legacy-windows/action.yml
@@ -1,0 +1,136 @@
+name: Verify Desktop (Legacy Windows)
+description: |
+  Install NSIS-built desktop, start the bundled backend, and run the shared
+  Playwright UI verifier. Stop / cleanup / log upload steps live in the
+  caller workflow because composite actions cannot use `if: always()`.
+
+inputs:
+  dashscope-api-key:
+    description: DashScope API key (empty -> verifier skips LLM round)
+    required: false
+    default: ""
+  version:
+    description: Expected backend version (used for cross-version sanity)
+    required: true
+  runner-python:
+    description: Absolute path to the runner's Python interpreter
+    required: true
+  allow-flaky-llm:
+    description: If 'true', verifier exits 0 on LLM retry exhaustion
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install verify deps (Playwright + Chromium)
+      shell: pwsh
+      env:
+        RUNNER_PYTHON: ${{ inputs.runner-python }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        & $env:RUNNER_PYTHON -m pip install --upgrade pip
+        & $env:RUNNER_PYTHON -m pip install -r scripts/verify/requirements-verify.txt
+        & $env:RUNNER_PYTHON -m playwright install chromium --with-deps
+
+    - name: Verify desktop (Legacy Windows)
+      shell: pwsh
+      env:
+        QWENPAW_DASHSCOPE_API_KEY: ${{ inputs.dashscope-api-key }}
+        RUNNER_PYTHON: ${{ inputs.runner-python }}
+        PYTHONIOENCODING: utf-8
+        EXPECTED_VERSION: ${{ inputs.version }}
+        ALLOW_FLAKY_LLM: ${{ inputs.allow-flaky-llm }}
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        # 1. Locate the freshly built NSIS installer.
+        $installer = Get-ChildItem dist/QwenPaw-Setup-*.exe |
+          Select-Object -First 1
+        if (-not $installer) { throw "No QwenPaw-Setup-*.exe found in dist/" }
+
+        # 2. Silent install to a deterministic ASCII path under RUNNER_TEMP
+        #    so we don't need to reverse-lookup the install location.
+        #    NSIS requires /D=<path> to be the LAST argument and unquoted.
+        $installDir = Join-Path $env:RUNNER_TEMP "QwenPaw-Verify"
+        if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
+        $nsisArgs = "/S /D=$installDir"
+        Write-Host "Installer: $($installer.FullName)"
+        Write-Host "Install dir: $installDir"
+        Start-Process -FilePath $installer.FullName -ArgumentList $nsisArgs -Wait
+
+        # 3. NSIS runs asynchronously even with -Wait; poll for python.exe.
+        $bundledPython = Join-Path $installDir "python.exe"
+        $deadline = (Get-Date).AddSeconds(120)
+        while (-not (Test-Path $bundledPython)) {
+          if ((Get-Date) -gt $deadline) {
+            throw "python.exe not present at $bundledPython after 120s"
+          }
+          Start-Sleep -Seconds 2
+        }
+        Write-Host "Bundled interpreter located: $bundledPython"
+
+        # 4. Initialise workspace and start the desktop backend in the
+        #    background. Use the bundled python so dependencies match the
+        #    actual installed env users will use.
+        $env:PYTHONNOUSERSITE = "1"
+        & $bundledPython -m qwenpaw init --defaults --accept-security
+        if ($LASTEXITCODE -ne 0) { throw "qwenpaw init failed ($LASTEXITCODE)" }
+
+        # Skip the BootstrapHook onboarding script so the verifier
+        # can drive the agent in normal QA mode (see
+        # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
+        $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
+        if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
+
+        $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
+        $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
+        $proc = Start-Process -PassThru -NoNewWindow `
+          -FilePath $bundledPython `
+          -ArgumentList "-m","qwenpaw","app","--host","127.0.0.1","--port","8088" `
+          -RedirectStandardOutput $stdoutLog `
+          -RedirectStandardError $stderrLog
+        $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
+
+        # 5. Wait for /api/version (~120s budget).
+        $ready = $false
+        for ($i = 1; $i -le 60; $i++) {
+          try {
+            $resp = Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version `
+              -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+            if ($resp.StatusCode -eq 200) {
+              Write-Host "Server up after ~$([int]($i*2))s"
+              $ready = $true
+              break
+            }
+          } catch { Start-Sleep -Seconds 2 }
+        }
+        if (-not $ready) {
+          Write-Host "::error::Server did not respond within 120s"
+          exit 1
+        }
+
+        # 6. Cross-version sanity: backend version must match source.
+        $expected = $env:EXPECTED_VERSION
+        $payload = (Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version `
+          -UseBasicParsing -TimeoutSec 10).Content | ConvertFrom-Json
+        $actual = $payload.version
+        if ($actual -ne $expected) {
+          Write-Host "::error::Desktop version mismatch: expected=$expected actual=$actual"
+          exit 1
+        }
+
+        # 7. Run the shared verifier with the runner's python (where
+        #    Playwright + Chromium are installed) so the installed env
+        #    stays untouched.
+        $verifyArgs = @(
+          "scripts/verify/desktop_verify.py",
+          "--base-url", "http://127.0.0.1:8088",
+          "--ui-mode", "legacy",
+          "--headed"
+        )
+        if ($env:ALLOW_FLAKY_LLM -eq "true") {
+          $verifyArgs += "--allow-flaky-llm"
+        }
+        & $env:RUNNER_PYTHON @verifyArgs
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/actions/verify-tauri-macos/action.yml
+++ b/.github/actions/verify-tauri-macos/action.yml
@@ -1,0 +1,45 @@
+name: Verify Desktop (Tauri macOS)
+description: |
+  Unpack Tauri .app zip, launch the shell (open <APP>), and drive the
+  embedded WebKit through the shared Playwright UI verifier. Stop /
+  cleanup / log upload steps live in the caller workflow because
+  composite actions cannot use `if: always()`.
+
+inputs:
+  dashscope-api-key:
+    description: DashScope API key (empty -> verifier skips LLM round)
+    required: false
+    default: ""
+  allow-flaky-llm:
+    description: If 'true', verifier exits 0 on LLM retry exhaustion
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install verify deps (Playwright + WebKit)
+      shell: bash
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        python -m pip install -r scripts/verify/requirements-verify.txt
+        python -m playwright install webkit --with-deps
+
+    - name: Verify desktop (Tauri macOS)
+      shell: bash
+      env:
+        QWENPAW_DASHSCOPE_API_KEY: ${{ inputs.dashscope-api-key }}
+        ALLOW_FLAKY_LLM: ${{ inputs.allow-flaky-llm }}
+      run: |
+        set -euo pipefail
+        source scripts/verify/launch_tauri_macos.sh
+        extra_flags=()
+        if [ "$ALLOW_FLAKY_LLM" = "true" ]; then
+          extra_flags+=("--allow-flaky-llm")
+        fi
+        python scripts/verify/desktop_verify.py \
+          --base-url "$BASE_URL" \
+          --ui-mode tauri-macos \
+          --headed \
+          "${extra_flags[@]}"

--- a/.github/actions/verify-tauri-windows/action.yml
+++ b/.github/actions/verify-tauri-windows/action.yml
@@ -1,0 +1,48 @@
+name: Verify Desktop (Tauri Windows)
+description: |
+  Install NSIS-built Tauri desktop, launch the shell with CDP enabled,
+  and drive the real WebView2 through the shared Playwright UI verifier.
+  Stop / cleanup / log upload steps live in the caller workflow because
+  composite actions cannot use `if: always()`.
+
+inputs:
+  dashscope-api-key:
+    description: DashScope API key (empty -> verifier skips LLM round)
+    required: false
+    default: ""
+  allow-flaky-llm:
+    description: If 'true', verifier exits 0 on LLM retry exhaustion
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install verify deps (Playwright + Chromium)
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        python -m pip install --upgrade pip
+        python -m pip install -r scripts/verify/requirements-verify.txt
+        python -m playwright install chromium --with-deps
+
+    - name: Verify desktop (Tauri Windows)
+      shell: pwsh
+      env:
+        QWENPAW_DASHSCOPE_API_KEY: ${{ inputs.dashscope-api-key }}
+        PYTHONIOENCODING: utf-8
+        ALLOW_FLAKY_LLM: ${{ inputs.allow-flaky-llm }}
+      run: |
+        . scripts/verify/launch_tauri_windows.ps1
+        $verifyArgs = @(
+          "scripts/verify/desktop_verify.py",
+          "--base-url", $env:BASE_URL,
+          "--ui-mode", "tauri-windows",
+          "--headed",
+          "--cdp-url", $env:CDP_URL
+        )
+        if ($env:ALLOW_FLAKY_LLM -eq "true") {
+          $verifyArgs += "--allow-flaky-llm"
+        }
+        python @verifyArgs
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -54,17 +54,7 @@ jobs:
 
       - name: Get version
         id: version
-        shell: pwsh
-        run: |
-          $content = Get-Content src/qwenpaw/__version__.py -Raw
-          if ($content -match '__version__\s*=\s*"([^"]+)"') {
-            $v = $Matches[1]
-          } else {
-            throw "Failed to extract version from __version__.py"
-          }
-          "version<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          $v | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        uses: ./.github/actions/get-version
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -114,110 +104,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install verify deps (Playwright + Chromium)
-        shell: pwsh
-        env:
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-        run: |
-          $ErrorActionPreference = "Stop"
-          & $env:RUNNER_PYTHON -m pip install --upgrade pip
-          & $env:RUNNER_PYTHON -m pip install -r scripts/verify/requirements-verify.txt
-          & $env:RUNNER_PYTHON -m playwright install chromium --with-deps
-
       - name: Verify desktop (Legacy Windows)
         timeout-minutes: 10
-        shell: pwsh
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-          PYTHONIOENCODING: utf-8
-        run: |
-          $ErrorActionPreference = "Stop"
-
-          # 1. Locate the freshly built NSIS installer.
-          $installer = Get-ChildItem dist/QwenPaw-Setup-*.exe |
-            Select-Object -First 1
-          if (-not $installer) { throw "No QwenPaw-Setup-*.exe found in dist/" }
-
-          # 2. Silent install to a deterministic ASCII path under RUNNER_TEMP
-          #    so we don't need to reverse-lookup the install location.
-          #    NSIS requires /D=<path> to be the LAST argument and unquoted.
-          $installDir = Join-Path $env:RUNNER_TEMP "QwenPaw-Verify"
-          if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
-          $nsisArgs = "/S /D=$installDir"
-          Write-Host "Installer: $($installer.FullName)"
-          Write-Host "Install dir: $installDir"
-          Start-Process -FilePath $installer.FullName -ArgumentList $nsisArgs -Wait
-
-          # 3. NSIS runs asynchronously even with -Wait; poll for python.exe.
-          $bundledPython = Join-Path $installDir "python.exe"
-          $deadline = (Get-Date).AddSeconds(120)
-          while (-not (Test-Path $bundledPython)) {
-            if ((Get-Date) -gt $deadline) {
-              throw "python.exe not present at $bundledPython after 120s"
-            }
-            Start-Sleep -Seconds 2
-          }
-          Write-Host "Bundled interpreter located: $bundledPython"
-
-          # 4. Initialise workspace and start the desktop backend in the
-          #    background. Use the bundled python so dependencies match the
-          #    actual installed env users will use.
-          $env:PYTHONNOUSERSITE = "1"
-          & $bundledPython -m qwenpaw init --defaults --accept-security
-          if ($LASTEXITCODE -ne 0) { throw "qwenpaw init failed ($LASTEXITCODE)" }
-
-          # Skip the BootstrapHook onboarding script so the verifier
-          # can drive the agent in normal QA mode (see
-          # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
-          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
-          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
-
-          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
-          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
-          $proc = Start-Process -PassThru -NoNewWindow `
-            -FilePath $bundledPython `
-            -ArgumentList "-m","qwenpaw","app","--host","127.0.0.1","--port","8088" `
-            -RedirectStandardOutput $stdoutLog `
-            -RedirectStandardError $stderrLog
-          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
-
-          # 5. Wait for /api/version (~120s budget).
-          $ready = $false
-          for ($i = 1; $i -le 60; $i++) {
-            try {
-              $resp = Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version `
-                -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
-              if ($resp.StatusCode -eq 200) {
-                Write-Host "Server up after ~$([int]($i*2))s"
-                $ready = $true
-                break
-              }
-            } catch { Start-Sleep -Seconds 2 }
-          }
-          if (-not $ready) {
-            Write-Host "::error::Server did not respond within 120s"
-            exit 1
-          }
-
-          # 6. Cross-version sanity: backend version must match source.
-          $expected = "${{ steps.version.outputs.version }}"
-          $payload = (Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version `
-            -UseBasicParsing -TimeoutSec 10).Content | ConvertFrom-Json
-          $actual = $payload.version
-          if ($actual -ne $expected) {
-            Write-Host "::error::Desktop version mismatch: expected=$expected actual=$actual"
-            exit 1
-          }
-
-          # 7. Run the shared verifier with the runner's python (where
-          #    Playwright + Chromium are installed) so the installed env
-          #    stays untouched.
-          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py `
-            --base-url http://127.0.0.1:8088 `
-            --ui-mode legacy `
-            --headed
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        uses: ./.github/actions/verify-legacy-windows
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          version: ${{ steps.version.outputs.version }}
+          runner-python: ${{ steps.runner-python.outputs.python-path }}
 
       - name: Stop desktop server (Legacy Windows)
         if: always()
@@ -289,7 +182,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-version
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -323,97 +216,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install verify deps (Playwright + Chromium)
-        env:
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-        run: |
-          set -euo pipefail
-          "$RUNNER_PYTHON" -m pip install --upgrade pip
-          "$RUNNER_PYTHON" -m pip install \
-            -r scripts/verify/requirements-verify.txt
-          "$RUNNER_PYTHON" -m playwright install chromium --with-deps
-
       - name: Verify desktop (Legacy macOS)
         timeout-minutes: 10
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-        run: |
-          set -euo pipefail
-
-          # 1. Unpack the freshly built zip into an isolated verify dir.
-          mkdir -p dist/verify-legacy
-          unzip -q dist/QwenPaw-*-macOS.zip -d dist/verify-legacy
-          APP="$(find dist/verify-legacy -maxdepth 2 -name '*.app' -type d | head -1)"
-          if [ -z "$APP" ]; then
-            echo "::error::QwenPaw.app not found inside zip"
-            exit 1
-          fi
-          ENV_DIR="$APP/Contents/Resources/env"
-          PYTHON="$ENV_DIR/bin/python"
-
-          # 2. Fix conda-pack paths (mandatory or python crashes on launch).
-          (cd "$ENV_DIR" && ./bin/conda-unpack 2>/dev/null || true)
-
-          # 3. Force only the bundled interpreter to ignore user site-packages.
-          # Keep PYTHONHOME scoped so the runner Python used by Playwright does
-          # not inherit the packaged stdlib path.
-          export PYTHONNOUSERSITE=1
-          export PATH="$ENV_DIR/bin:$PATH"
-          bundled_python() {
-            env PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1 \
-              PATH="$ENV_DIR/bin:$PATH" "$PYTHON" "$@"
-          }
-
-          # 4. SSL certificates — required for DashScope HTTPS calls.
-          CERT_FILE="$(bundled_python -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
-          if [ -n "${CERT_FILE:-}" ] && [ -f "$CERT_FILE" ]; then
-            export SSL_CERT_FILE="$CERT_FILE"
-            export REQUESTS_CA_BUNDLE="$CERT_FILE"
-          fi
-
-          # 5. Init workspace and start the desktop backend in the background.
-          bundled_python -m qwenpaw init --defaults --accept-security
-          # Skip the BootstrapHook onboarding script so the verifier
-          # can drive the agent in normal QA mode (see
-          # scripts/verify/desktop_verify.py::verify_ui_chat docstring).
-          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
-          nohup env PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1 \
-            PATH="$ENV_DIR/bin:$PATH" \
-            "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
-            > "$RUNNER_TEMP/qwenpaw-desktop-stdout.log" \
-            2> "$RUNNER_TEMP/qwenpaw-desktop-stderr.log" &
-          echo $! > "$RUNNER_TEMP/qwenpaw-desktop.pid"
-
-          # 6. Wait for /api/version (~120s budget).
-          for i in $(seq 1 60); do
-            if curl -sf http://127.0.0.1:8088/api/version >/dev/null; then
-              echo "Server up after ~$((i*2))s"
-              break
-            fi
-            if [ "$i" = "60" ]; then
-              echo "::error::Server did not respond within 120s"
-              exit 1
-            fi
-            sleep 2
-          done
-
-          # 7. Cross-version sanity: backend version must match source.
-          expected="${{ steps.version.outputs.version }}"
-          actual="$(curl -sf http://127.0.0.1:8088/api/version | env -u PYTHONHOME -u PYTHONPATH "$RUNNER_PYTHON" -c 'import sys,json; print(json.load(sys.stdin)["version"])')"
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::Desktop version mismatch: expected=$expected actual=$actual"
-            exit 1
-          fi
-
-          # 8. Run the shared verifier with the runner's python (where
-          #    Playwright + Chromium are installed). The bundled conda-pack
-          #    python stays untouched so we don't pollute the actual env
-          #    that ships to users.
-          env -u PYTHONHOME -u PYTHONPATH "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
-            --base-url http://127.0.0.1:8088 \
-            --ui-mode legacy \
-            --headed
+        uses: ./.github/actions/verify-legacy-macos
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          version: ${{ steps.version.outputs.version }}
+          runner-python: ${{ steps.runner-python.outputs.python-path }}
 
       - name: Stop desktop server (Legacy macOS)
         if: always()
@@ -465,17 +274,7 @@ jobs:
 
       - name: Get version
         id: version
-        shell: pwsh
-        run: |
-          $content = Get-Content src/qwenpaw/__version__.py -Raw
-          if ($content -match '__version__\s*=\s*"([^"]+)"') {
-            $v = $Matches[1]
-          } else {
-            throw "Failed to extract version from __version__.py"
-          }
-          "version<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          $v | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        uses: ./.github/actions/get-version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -536,28 +335,11 @@ jobs:
             --output "dist/QwenPaw-Tauri-${{ steps.version.outputs.version }}-Windows-setup.exe" `
             --pubkey-config console/src-tauri/tauri.version.conf.json
 
-      - name: Install verify deps (Playwright + Chromium)
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          python -m pip install --upgrade pip
-          python -m pip install -r scripts/verify/requirements-verify.txt
-          python -m playwright install chromium --with-deps
-
       - name: Verify desktop (Tauri Windows)
         timeout-minutes: 10
-        shell: pwsh
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-          PYTHONIOENCODING: utf-8
-        run: |
-          . scripts/verify/launch_tauri_windows.ps1
-          python scripts/verify/desktop_verify.py `
-            --base-url $env:BASE_URL `
-            --ui-mode tauri-windows `
-            --headed `
-            --cdp-url $env:CDP_URL
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        uses: ./.github/actions/verify-tauri-windows
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
 
       - name: Stop desktop server (Tauri Windows)
         if: always()
@@ -627,7 +409,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -674,24 +456,11 @@ jobs:
           chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
           bash scripts/pack-tauri/build_macos_pyinstaller.sh
 
-      - name: Install verify deps (Playwright + WebKit)
-        run: |
-          set -euo pipefail
-          python -m pip install --upgrade pip
-          python -m pip install -r scripts/verify/requirements-verify.txt
-          python -m playwright install webkit --with-deps
-
       - name: Verify desktop (Tauri macOS)
         timeout-minutes: 10
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-        run: |
-          set -euo pipefail
-          source scripts/verify/launch_tauri_macos.sh
-          python scripts/verify/desktop_verify.py \
-            --base-url "$BASE_URL" \
-            --ui-mode tauri-macos \
-            --headed
+        uses: ./.github/actions/verify-tauri-macos
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
 
       - name: Stop desktop server (Tauri macOS)
         if: always()
@@ -766,7 +535,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-version
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -844,7 +613,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-version
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-version
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -75,50 +75,13 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install verify deps (Playwright + Chromium)
-        env:
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-        run: |
-          set -euo pipefail
-          "$RUNNER_PYTHON" -m pip install --upgrade pip
-          "$RUNNER_PYTHON" -m pip install \
-            -r scripts/verify/requirements-verify.txt
-          "$RUNNER_PYTHON" -m playwright install chromium --with-deps
-
       - name: Verify desktop (Legacy macOS)
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-        run: |
-          set -euo pipefail
-          mkdir -p dist/verify-legacy
-          unzip -q dist/QwenPaw-*-macOS.zip -d dist/verify-legacy
-          APP="$(find dist/verify-legacy -maxdepth 2 -name '*.app' -type d | head -1)"
-          if [ -z "$APP" ]; then echo "::error::QwenPaw.app not found"; exit 1; fi
-          ENV_DIR="$APP/Contents/Resources/env"
-          PYTHON="$ENV_DIR/bin/python"
-          (cd "$ENV_DIR" && ./bin/conda-unpack 2>/dev/null || true)
-          export PYTHONHOME="$ENV_DIR" PYTHONNOUSERSITE=1
-          export PATH="$ENV_DIR/bin:$PATH"
-          CERT_FILE="$("$PYTHON" -c 'import certifi,sys; sys.stdout.write(certifi.where())' 2>/dev/null || true)"
-          if [ -n "${CERT_FILE:-}" ] && [ -f "$CERT_FILE" ]; then
-            export SSL_CERT_FILE="$CERT_FILE" REQUESTS_CA_BUNDLE="$CERT_FILE"
-          fi
-          "$PYTHON" -m qwenpaw init --defaults --accept-security
-          rm -f "$HOME/.qwenpaw/workspaces/default/BOOTSTRAP.md"
-          nohup "$PYTHON" -m qwenpaw app --host 127.0.0.1 --port 8088 \
-            > "$RUNNER_TEMP/qwenpaw-desktop-stdout.log" \
-            2> "$RUNNER_TEMP/qwenpaw-desktop-stderr.log" &
-          echo $! > "$RUNNER_TEMP/qwenpaw-desktop.pid"
-          for i in $(seq 1 60); do
-            if curl -sf http://127.0.0.1:8088/api/version >/dev/null; then
-              echo "Server up after ~$((i*2))s"; break
-            fi
-            if [ "$i" = "60" ]; then echo "::error::Server timeout"; exit 1; fi
-            sleep 2
-          done
-          "$RUNNER_PYTHON" scripts/verify/desktop_verify.py \
-            --base-url http://127.0.0.1:8088 --ui-mode legacy --headed --allow-flaky-llm
+        uses: ./.github/actions/verify-legacy-macos
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          version: ${{ steps.version.outputs.version }}
+          runner-python: ${{ steps.runner-python.outputs.python-path }}
+          allow-flaky-llm: "true"
 
       - name: Stop desktop server
         if: always()
@@ -143,15 +106,7 @@ jobs:
 
       - name: Get version
         id: version
-        shell: pwsh
-        run: |
-          $content = Get-Content src/qwenpaw/__version__.py -Raw
-          if ($content -match '__version__\s*=\s*"([^"]+)"') {
-            $v = $Matches[1]
-          } else { throw "Failed to extract version" }
-          "version<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          $v | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        uses: ./.github/actions/get-version
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -182,56 +137,13 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install verify deps (Playwright + Chromium)
-        shell: pwsh
-        env:
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-        run: |
-          $ErrorActionPreference = "Stop"
-          & $env:RUNNER_PYTHON -m pip install --upgrade pip
-          & $env:RUNNER_PYTHON -m pip install -r scripts/verify/requirements-verify.txt
-          & $env:RUNNER_PYTHON -m playwright install chromium --with-deps
-
       - name: Verify desktop (Legacy Windows)
-        shell: pwsh
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-          RUNNER_PYTHON: ${{ steps.runner-python.outputs.python-path }}
-          PYTHONIOENCODING: utf-8
-        run: |
-          $ErrorActionPreference = "Stop"
-          $installer = Get-ChildItem dist/QwenPaw-Setup-*.exe | Select-Object -First 1
-          if (-not $installer) { throw "No installer found" }
-          $installDir = Join-Path $env:RUNNER_TEMP "QwenPaw-Verify"
-          if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
-          Start-Process -FilePath $installer.FullName -ArgumentList "/S /D=$installDir" -Wait
-          $bundledPython = Join-Path $installDir "python.exe"
-          $deadline = (Get-Date).AddSeconds(120)
-          while (-not (Test-Path $bundledPython)) {
-            if ((Get-Date) -gt $deadline) { throw "python.exe not found after 120s" }
-            Start-Sleep -Seconds 2
-          }
-          $env:PYTHONNOUSERSITE = "1"
-          & $bundledPython -m qwenpaw init --defaults --accept-security
-          if ($LASTEXITCODE -ne 0) { throw "init failed" }
-          $bootstrapMd = Join-Path $env:USERPROFILE ".qwenpaw\workspaces\default\BOOTSTRAP.md"
-          if (Test-Path $bootstrapMd) { Remove-Item -Force $bootstrapMd }
-          $stdoutLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stdout.log"
-          $stderrLog = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop-stderr.log"
-          $proc = Start-Process -PassThru -NoNewWindow -FilePath $bundledPython `
-            -ArgumentList "-m","qwenpaw","app","--host","127.0.0.1","--port","8088" `
-            -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
-          $proc.Id | Out-File -FilePath (Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid") -Encoding ascii
-          $ready = $false
-          for ($i = 1; $i -le 60; $i++) {
-            try {
-              $r = Invoke-WebRequest -Uri http://127.0.0.1:8088/api/version -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
-              if ($r.StatusCode -eq 200) { Write-Host "Server up"; $ready = $true; break }
-            } catch { Start-Sleep -Seconds 2 }
-          }
-          if (-not $ready) { Write-Host "::error::Server timeout"; exit 1 }
-          & $env:RUNNER_PYTHON scripts/verify/desktop_verify.py --base-url http://127.0.0.1:8088 --ui-mode legacy --headed --allow-flaky-llm
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        uses: ./.github/actions/verify-legacy-windows
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          version: ${{ steps.version.outputs.version }}
+          runner-python: ${{ steps.runner-python.outputs.python-path }}
+          allow-flaky-llm: "true"
 
       - name: Stop desktop server
         if: always()
@@ -259,7 +171,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/get-version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -286,21 +198,12 @@ jobs:
           chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
           bash scripts/pack-tauri/build_macos_pyinstaller.sh
 
-      - name: Install verify deps (Playwright + WebKit)
-        run: |
-          set -euo pipefail
-          python -m pip install --upgrade pip
-          python -m pip install -r scripts/verify/requirements-verify.txt
-          python -m playwright install webkit --with-deps
-
       - name: Verify desktop (Tauri macOS)
         timeout-minutes: 10
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-        run: |
-          set -euo pipefail
-          source scripts/verify/launch_tauri_macos.sh
-          python scripts/verify/desktop_verify.py --base-url "$BASE_URL" --ui-mode tauri-macos --headed --allow-flaky-llm
+        uses: ./.github/actions/verify-tauri-macos
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          allow-flaky-llm: "true"
 
       - name: Stop desktop server
         if: always()
@@ -326,15 +229,7 @@ jobs:
 
       - name: Get version
         id: version
-        shell: pwsh
-        run: |
-          $content = Get-Content src/qwenpaw/__version__.py -Raw
-          if ($content -match '__version__\s*=\s*"([^"]+)"') {
-            $v = $Matches[1]
-          } else { throw "Failed to extract version" }
-          "version<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          $v | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        uses: ./.github/actions/get-version
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -361,29 +256,12 @@ jobs:
         shell: pwsh
         run: ./scripts/pack-tauri/build_win_pyinstaller.ps1
 
-      - name: Install verify deps (Playwright + Chromium)
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          python -m pip install --upgrade pip
-          python -m pip install -r scripts/verify/requirements-verify.txt
-          python -m playwright install chromium --with-deps
-
       - name: Verify desktop (Tauri Windows)
         timeout-minutes: 10
-        shell: pwsh
-        env:
-          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
-          PYTHONIOENCODING: utf-8
-        run: |
-          . scripts/verify/launch_tauri_windows.ps1
-          python scripts/verify/desktop_verify.py `
-            --base-url $env:BASE_URL `
-            --ui-mode tauri-windows `
-            --headed `
-            --cdp-url $env:CDP_URL `
-            --allow-flaky-llm
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+        uses: ./.github/actions/verify-tauri-windows
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+          allow-flaky-llm: "true"
 
       - name: Stop desktop server
         if: always()

--- a/.github/workflows/fork-verify-desktop.yml
+++ b/.github/workflows/fork-verify-desktop.yml
@@ -151,8 +151,8 @@ jobs:
         run: |
           $pidFile = Join-Path $env:RUNNER_TEMP "qwenpaw-desktop.pid"
           if (Test-Path $pidFile) {
-            $pid = (Get-Content $pidFile | Select-Object -First 1).Trim()
-            if ($pid) { taskkill /F /PID $pid 2>$null | Out-Null }
+            $pidValue = (Get-Content $pidFile | Select-Object -First 1).Trim()
+            if ($pidValue) { taskkill /F /PID $pidValue 2>$null | Out-Null }
           }
           exit 0
 
@@ -178,6 +178,9 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
@@ -194,6 +197,19 @@ jobs:
       - name: Build Tauri macOS package
         env:
           NODE_OPTIONS: "--max-old-space-size=8192"
+          # Authenticate the python-build-standalone release lookup in
+          # stage_python_runtime.py to avoid anonymous API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Required for cargo tauri build to produce the *.app.tar.gz
+          # updater archive that generate_update_manifest.py stage
+          # expects at the end of build_macos_pyinstaller.sh. Forks
+          # can use a self-generated minisign key pair — the signed
+          # archive is only consumed by the verify step, never by
+          # real users (who validate updates against the upstream
+          # pubkey baked into tauri.conf.json).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ vars.TAURI_UPDATER_PUBKEY }}
         run: |
           chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
           bash scripts/pack-tauri/build_macos_pyinstaller.sh
@@ -236,6 +252,9 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
@@ -254,7 +273,22 @@ jobs:
 
       - name: Build Tauri Windows package
         shell: pwsh
+        env:
+          # Authenticate the python-build-standalone release lookup in
+          # stage_python_runtime.py to avoid anonymous API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/pack-tauri/build_win_pyinstaller.ps1
+
+      - name: Stage Tauri Windows installer
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem "console/src-tauri/target/release/bundle/nsis/*.exe" |
+            Select-Object -First 1
+          if (-not $installer) { throw "No Tauri Windows installer found" }
+          $target = "dist/QwenPaw-Tauri-${{ steps.version.outputs.version }}-Windows-setup.exe"
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item -Force $installer.FullName $target
+          Write-Host "Staged: $target"
 
       - name: Verify desktop (Tauri Windows)
         timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Extract 5 reusable composite actions from `desktop-release.yml` and `fork-verify-desktop.yml` to eliminate duplicated verify logic between release and fork pipelines:
  - `get-version`: cross-platform version extraction (replaces 10 inline sed/pwsh steps)
  - `verify-legacy-windows`: NSIS install → start → health check → Playwright UI
  - `verify-legacy-macos`: conda-pack unzip → start → health check → Playwright UI
  - `verify-tauri-windows`: NSIS install → launch Tauri shell → CDP connect → Playwright UI
  - `verify-tauri-macos`: .app unzip → launch Tauri shell → WebKit Playwright UI
- Align `fork-verify-desktop.yml` with upstream Tauri auto-updater flow (#4669): add GITHUB_TOKEN, packaging dep, signing secrets env, and Stage step

## Motivation

The same verify logic was copy-pasted 8 times across the two workflows (4 platforms × 2 files). Any verify fix required editing both files identically. After this change, verify logic lives in one place and callers pass inputs (e.g. `allow-flaky-llm`).

## Test plan

- [x] Fork CI: 3 consecutive full-platform runs (12/12 jobs green)
  - Run 1: https://github.com/yutai78786/QwenPaw/actions/runs/28491802190
  - Run 2: https://github.com/yutai78786/QwenPaw/actions/runs/28492706484
  - Run 3: https://github.com/yutai78786/QwenPaw/actions/runs/28493657079
- [x] YAML syntax validation (PyYAML safe_load) for all 7 modified/new files
- [x] No behavioral change to `desktop-release.yml` verify logic (same install/start/verify/stop flow, just moved into actions)