### PR TITLE
fix(governance): strict mode now overrides ALLOW rules to require app…

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -672,6 +672,14 @@ class GovernancePolicy:
 
         # ── Phase 3: Fallback + execution_level threshold ──
         if tool_type == "shell":
+            # STRICT mode: shell commands also require approval
+            if is_strict:
+                return GovernanceDecision(
+                    action=GovernanceAction.ASK,
+                    reason="STRICT mode: all tool calls " "require approval",
+                    findings=findings or None,
+                    source="STRICT mode",
+                )
             return GovernanceDecision(
                 action=GovernanceAction.SANDBOX_FALLBACK,
                 reason="sandbox fallback",

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -563,7 +563,7 @@ class GovernancePolicy:
         """
         return list(self.builtin_rules) + list(self.user_rules)
 
-    def evaluate(  # pylint: disable=too-many-return-statements
+    def evaluate(  # noqa: E501  pylint: disable=too-many-return-statements,too-many-branches
         self,
         tc_spec: ToolCallSpec,
     ) -> GovernanceDecision:
@@ -624,13 +624,26 @@ class GovernancePolicy:
                 )
 
         # ── Phase 2: builtin_rules + user_rules (first-match-wins) ──
+        is_strict = self.execution_level == "strict"
+
         for rule in self.builtin_rules:
             if rule.matches_tool_call(
                 tc_spec,
                 tool_type=tool_type,
             ):
+                action = GovernanceAction(rule.action.value)
+                # STRICT mode: override ALLOW → ASK so every tool
+                # call requires approval (DENY still honoured).
+                if action == GovernanceAction.ALLOW and is_strict:
+                    return GovernanceDecision(
+                        action=GovernanceAction.ASK,
+                        reason="STRICT mode: all tool calls "
+                        "require approval",
+                        findings=findings or None,
+                        source="STRICT mode",
+                    )
                 return GovernanceDecision(
-                    action=GovernanceAction(rule.action.value),
+                    action=action,
                     reason=rule.reason,
                     findings=findings or None,
                     source="builtin-rules",
@@ -641,8 +654,17 @@ class GovernancePolicy:
                 tc_spec,
                 tool_type=tool_type,
             ):
+                action = GovernanceAction(rule.action.value)
+                if action == GovernanceAction.ALLOW and is_strict:
+                    return GovernanceDecision(
+                        action=GovernanceAction.ASK,
+                        reason="STRICT mode: all tool calls "
+                        "require approval",
+                        findings=findings or None,
+                        source="STRICT mode",
+                    )
                 return GovernanceDecision(
-                    action=GovernanceAction(rule.action.value),
+                    action=action,
                     reason=rule.reason,
                     findings=findings or None,
                     source="user-rules",


### PR DESCRIPTION
## Description

Fix strict mode (`execution_level=strict`) not enforcing approval for tool calls that match builtin/user ALLOW rules.

In the three-phase policy evaluation, Phase 2 (rule matching) returned ALLOW immediately when a builtin or user rule matched — without consulting `execution_level`. This caused common "no-risk" operations (e.g. `Read(WORKSPACE_DIR/**)`, `Write(WORKSPACE_DIR/**)`, `GetCurrentTime`, `ListAgents`) to bypass strict mode entirely, since they all have explicit ALLOW rules in `DEFAULT_BUILTIN_RULES`.

Now when `execution_level=strict`, any ALLOW rule match in Phase 2 is overridden to ASK, so every tool call requires user approval as intended. DENY rules are still honoured as a security floor.

**Related Issue:** Relates to user feedback "选择了 strict 但无风险操作自动执行不审批"

**Security Considerations:** This is a security enforcement fix — strict mode was not functioning as documented.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

1. Set `execution_level: strict` in agent config (via Web UI "工具执行安全" → "严格模式")
2. Send any message that triggers a tool call (e.g. "what time is it?" → `GetCurrentTime`, or "read file X" → `Read`)
3. **Before fix:** Low-risk tools execute immediately without approval
4. **After fix:** All tool calls show the approval card, regardless of risk level
5. Verify DENY rules still block (e.g. `rm -rf /` is still denied, not promoted to ASK)

## Local Verification Evidence

```bash
uv run pre-commit run --files src/qwenpaw/governance/policy.py
# All passed (ast, black, flake8, pylint, mypy)

# Manual E2E: strict mode now triggers approval for GetCurrentTime and workspace reads