### PR TITLE
Fix/session switch unify mode logic

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -29,6 +29,8 @@ const {
   mockDeleteChat,
   mockUpdateChat,
   mockGetSessionList,
+  mockNavigate,
+  mockGetEffectiveSessionId,
 } = vi.hoisted(() => ({
   mockCreateSession: vi.fn().mockResolvedValue(undefined),
   mockSetCurrentSessionId: vi.fn(),
@@ -36,6 +38,8 @@ const {
   mockDeleteChat: vi.fn().mockResolvedValue(undefined),
   mockUpdateChat: vi.fn().mockResolvedValue(undefined),
   mockGetSessionList: vi.fn().mockResolvedValue([]),
+  mockNavigate: vi.fn(),
+  mockGetEffectiveSessionId: vi.fn((id: string) => id),
 }));
 
 vi.mock("@agentscope-ai/chat", () => ({
@@ -69,12 +73,13 @@ vi.mock("../../sessionApi", () => ({
     preloadSession: vi.fn().mockResolvedValue({ session: {}, realId: null }),
     finishSessionSwitch: vi.fn(),
     lastNavigatedChatId: null,
+    getEffectiveSessionId: mockGetEffectiveSessionId,
   },
 }));
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
-  return { ...actual, useNavigate: () => vi.fn() };
+  return { ...actual, useNavigate: () => mockNavigate };
 });
 
 vi.mock("react-i18next", () => ({
@@ -214,7 +219,7 @@ describe("ChatSessionDrawer", () => {
     );
   });
 
-  it("clicking a session item calls setCurrentSessionId", async () => {
+  it("clicking a session item navigates to the session path", async () => {
     withSession();
     const user = userEvent.setup();
     renderWithProviders(<ChatSessionDrawer {...defaultProps} />);
@@ -222,7 +227,7 @@ describe("ChatSessionDrawer", () => {
       expect(screen.getByText("Session One")).toBeInTheDocument(),
     );
     await user.click(screen.getByText("Session One"));
-    expect(mockSetCurrentSessionId).toHaveBeenCalledWith("s1");
+    expect(mockNavigate).toHaveBeenCalledWith("/chat/s1");
   });
 
   it("clicking the close button calls onClose", async () => {

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -403,16 +403,6 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         return;
       }
 
-      if (props.embedded) {
-        setSwitchingSessionId(sessionId);
-        window.dispatchEvent(
-          new CustomEvent("qwenpaw:sidebar-select-session", {
-            detail: { sessionId },
-          }),
-        );
-        return;
-      }
-
       // Start a new cancellable switch (aborts any in-flight switch)
       const controller = sessionApi.startNewSwitch();
       setSwitchingSessionId(sessionId);
@@ -425,24 +415,45 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
             sessionId,
             realId,
           );
-          // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
-          // The redirect effect in ChatPage would immediately navigate back
-          // to /coding before session data loads, causing the switch to fail.
-          if (!codingMode) {
-            const targetUrl = buildSessionPath("chat", effectiveId);
-            navigate(targetUrl, { replace: true });
+
+          if (props.embedded) {
+            // Embedded mode: dispatch event after preload completes to avoid
+            // intermediate state where URL changes before session data loads.
+            // This prevents the "flash to fallback page" issue.
+            window.dispatchEvent(
+              new CustomEvent("qwenpaw:sidebar-select-session", {
+                detail: { sessionId, effectiveId },
+              }),
+            );
+          } else {
+            // Non-embedded mode: navigate directly
+            // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
+            // The redirect effect in ChatPage would immediately navigate back
+            // to /coding before session data loads, causing the switch to fail.
+            if (!codingMode) {
+              const targetUrl = buildSessionPath("chat", effectiveId);
+              navigate(targetUrl, { replace: true });
+            }
+            sessionApi.trackNavigatedSession(
+              effectiveId,
+              setLastChatId,
+              selectedAgent,
+            );
+            setCurrentSessionId(sessionId);
           }
-          sessionApi.trackNavigatedSession(
-            effectiveId,
-            setLastChatId,
-            selectedAgent,
-          );
-          setCurrentSessionId(sessionId);
         })
         .catch((err) => {
           if (err?.name === "AbortError") return;
           // On non-abort error, still try to switch normally.
-          setCurrentSessionId(sessionId);
+          if (props.embedded) {
+            window.dispatchEvent(
+              new CustomEvent("qwenpaw:sidebar-select-session", {
+                detail: { sessionId },
+              }),
+            );
+          } else {
+            setCurrentSessionId(sessionId);
+          }
         })
         .finally(() => {
           // Only clean up if this switch was NOT superseded by a newer one

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -29,7 +29,6 @@ import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
 import { useCreateNewSession } from "../../hooks/useCreateNewSession";
 import { useCodingMode } from "../../../../stores/codingModeStore";
-import { useAgentStore } from "../../../../stores/agentStore";
 import ChatSessionItem from "../ChatSessionItem";
 import { getChannelLabel } from "../../../Control/Channels/components";
 import {
@@ -189,7 +188,6 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   const location = useLocation();
   const sdkState = useChatAnywhereSessionsState();
   const { codingMode } = useCodingMode();
-  const { selectedAgent, setLastChatId } = useAgentStore();
 
   const createNewSession = useCreateNewSession();
 
@@ -201,8 +199,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   >([]);
 
   const sessions = props.embedded ? localSessions : sdkState.sessions;
-  const { currentSessionId: sdkCurrentSessionId, setCurrentSessionId } =
-    sdkState;
+  const { currentSessionId: sdkCurrentSessionId } = sdkState;
   // In embedded mode, prefer URL-derived chatId for active-state matching
   // because the SDK context may not be accessible from outside the provider.
   const urlCurrentSessionId = props.embedded
@@ -403,75 +400,19 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         return;
       }
 
-      // Start a new cancellable switch (aborts any in-flight switch)
-      const controller = sessionApi.startNewSwitch();
+      // Both embedded and non-embedded modes use the same switching logic
+      // as simple mode's SidebarSessionList: just navigate to the session
+      // URL. ChatSessionInitializer's useEffect will pick up the URL change
+      // and call setCurrentSessionId(matching.id) to notify the SDK.
+      // This avoids the preload / isSessionSwitching complexity that caused
+      // the "flash to new chat" issue.
       setSwitchingSessionId(sessionId);
-
-      sessionApi
-        .preloadSession(sessionId, controller.signal)
-        .then(({ realId }) => {
-          if (controller.signal.aborted) return;
-          const effectiveId = sessionApi.getEffectiveSessionId(
-            sessionId,
-            realId,
-          );
-
-          if (props.embedded) {
-            // Embedded mode: dispatch event after preload completes to avoid
-            // intermediate state where URL changes before session data loads.
-            // This prevents the "flash to fallback page" issue.
-            window.dispatchEvent(
-              new CustomEvent("qwenpaw:sidebar-select-session", {
-                detail: { sessionId, effectiveId },
-              }),
-            );
-          } else {
-            // Non-embedded mode: navigate directly
-            // Issue #4987: In coding mode, skip URL navigation to /chat/<id>.
-            // The redirect effect in ChatPage would immediately navigate back
-            // to /coding before session data loads, causing the switch to fail.
-            if (!codingMode) {
-              const targetUrl = buildSessionPath("chat", effectiveId);
-              navigate(targetUrl, { replace: true });
-            }
-            sessionApi.trackNavigatedSession(
-              effectiveId,
-              setLastChatId,
-              selectedAgent,
-            );
-            setCurrentSessionId(sessionId);
-          }
-        })
-        .catch((err) => {
-          if (err?.name === "AbortError") return;
-          // On non-abort error, still try to switch normally.
-          if (props.embedded) {
-            window.dispatchEvent(
-              new CustomEvent("qwenpaw:sidebar-select-session", {
-                detail: { sessionId },
-              }),
-            );
-          } else {
-            setCurrentSessionId(sessionId);
-          }
-        })
-        .finally(() => {
-          // Only clean up if this switch was NOT superseded by a newer one
-          if (!controller.signal.aborted) {
-            sessionApi.finishSessionSwitch();
-            setSwitchingSessionId(null);
-          }
-        });
+      const mode = codingMode ? "coding" : "chat";
+      const effectiveId = sessionApi.getEffectiveSessionId(sessionId);
+      const targetPath = buildSessionPath(mode, effectiveId);
+      navigate(targetPath);
     },
-    [
-      currentSessionId,
-      setCurrentSessionId,
-      navigate,
-      codingMode,
-      selectedAgent,
-      setLastChatId,
-      props.embedded,
-    ],
+    [currentSessionId, navigate, codingMode],
   );
 
   // Listen for embedded switch completion so we can clear switchingSessionId.

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -168,6 +168,7 @@ const ChatSessionInitializer: React.FC = () => {
             );
             const targetUrl = buildSessionPath(mode, effectiveId);
             sessionApi.trackNavigatedSession(effectiveId);
+            sessionApi.preferredChatId = effectiveId;
             navigate(targetUrl, { replace: true });
             setCurrentSessionId(sessionId);
           })

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1186,14 +1186,29 @@ export default function ChatPage() {
   // determined by an exclusive Web Lock keyed by sessionId; when the owner
   // tab closes, another tab acquires the lock and becomes the owner.
   const [isOwner, setIsOwner] = useState(false);
+  const [ownershipResolved, setOwnershipResolved] = useState(false);
   const isOwnerRef = useRef(false);
   isOwnerRef.current = isOwner;
   useEffect(() => {
     setIsOwner(false);
+    setOwnershipResolved(false);
     const ctrl = new AbortController();
-    void holdOwnershipLock(queueSessionId, () => setIsOwner(true), ctrl.signal);
+    void holdOwnershipLock(
+      queueSessionId,
+      () => {
+        setIsOwner(true);
+        setOwnershipResolved(true);
+      },
+      ctrl.signal,
+    );
+    // If the lock callback never fires (e.g. another tab holds it), resolve
+    // after a short delay so the non-owner Alert appears without flashing.
+    const fallbackTimer = setTimeout(() => {
+      setOwnershipResolved(true);
+    }, 300);
     return () => {
       ctrl.abort();
+      clearTimeout(fallbackTimer);
     };
   }, [queueSessionId]);
 
@@ -2566,9 +2581,9 @@ export default function ChatPage() {
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: whisperChecked && !whisperEnabled,
         beforeUI:
-          !isOwner || messageQueue.length > 0 ? (
+          (ownershipResolved && !isOwner) || messageQueue.length > 0 ? (
             <>
-              {!isOwner && (
+              {ownershipResolved && !isOwner && (
                 <Alert
                   type="info"
                   showIcon

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1212,6 +1212,13 @@ export default function ChatPage() {
     };
   }, [queueSessionId]);
 
+  // Whether this tab is confirmed to be a non-owner (queue-only) tab.
+  // Stays false until ownership check completes, preventing a flash of
+  // the "other tab is owner" banner on every session switch.
+  const isQueueOnlyTab = ownershipResolved && !isOwner;
+  const hasQueueItems = messageQueue.length > 0;
+  const showSenderBeforeUI = isQueueOnlyTab || hasQueueItems;
+
   const scheduleNextSend = useCallback(() => {
     if (autoSendTimerRef.current) clearTimeout(autoSendTimerRef.current);
     autoSendTimerRef.current = setTimeout(() => {
@@ -2580,33 +2587,32 @@ export default function ChatPage() {
         ...(i18nConfig as any)?.sender,
         beforeSubmit: handleBeforeSubmit,
         allowSpeech: whisperChecked && !whisperEnabled,
-        beforeUI:
-          (ownershipResolved && !isOwner) || messageQueue.length > 0 ? (
-            <>
-              {ownershipResolved && !isOwner && (
-                <Alert
-                  type="info"
-                  showIcon
-                  banner
-                  message={t("chat.queue.otherTabOwner")}
-                />
-              )}
-              {messageQueue.length > 0 ? (
-                <MessageQueuePanel
-                  items={messageQueue}
-                  runState={runState}
-                  onRemove={handleQueueRemove}
-                  onEdit={handleQueueEdit}
-                  onReorder={handleQueueReorder}
-                  onInterruptAndSend={handleQueueInterruptAndSend}
-                  onClear={handleQueueClear}
-                  onPauseResume={handleQueuePauseResume}
-                  onRetry={handleQueueRetry}
-                  onSkip={handleQueueSkip}
-                />
-              ) : null}
-            </>
-          ) : undefined,
+        beforeUI: showSenderBeforeUI ? (
+          <>
+            {isQueueOnlyTab && (
+              <Alert
+                type="info"
+                showIcon
+                banner
+                message={t("chat.queue.otherTabOwner")}
+              />
+            )}
+            {hasQueueItems ? (
+              <MessageQueuePanel
+                items={messageQueue}
+                runState={runState}
+                onRemove={handleQueueRemove}
+                onEdit={handleQueueEdit}
+                onReorder={handleQueueReorder}
+                onInterruptAndSend={handleQueueInterruptAndSend}
+                onClear={handleQueueClear}
+                onPauseResume={handleQueuePauseResume}
+                onRetry={handleQueueRetry}
+                onSkip={handleQueueSkip}
+              />
+            ) : null}
+          </>
+        ) : undefined,
         prefix:
           whisperEnabled || pluginSenderPrefix.length > 0 ? (
             <>


### PR DESCRIPTION
Unifying the switching logic for both modes simplifies `ChatSessionDrawer.handleSessionClick`—transforming it from a complex process involving preloading, an `isSessionSwitching` lock, and `setCurrentSessionId`—into a mechanism identical to that used by the simple-mode `SidebarSessionList`.

Optimize the prompt display logic and implement semantic handling.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
