### PR TITLE
fix: file-only messages bypass no-text debounce

### DIFF
--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -297,6 +297,13 @@ class BaseChannel(ABC):
             for c in (contents or [])
         )
 
+    def _content_has_file(self, contents: List[Any]) -> bool:
+        """True if contents has at least one FILE block."""
+        return any(
+            getattr(c, "type", None) == ContentType.FILE
+            for c in (contents or [])
+        )
+
     def _apply_no_text_debounce(
         self,
         session_id: str,
@@ -312,6 +319,17 @@ class BaseChannel(ABC):
             if self._content_has_audio(content_parts):
                 # Audio-only messages (e.g. voice messages) should be
                 # processed immediately — they are complete user input.
+                pending = self._pending_content_by_session.pop(
+                    session_id,
+                    [],
+                )
+                merged = pending + list(content_parts)
+                return (True, merged)
+            if self._content_has_file(content_parts):
+                # File-only messages should be processed immediately —
+                # they are complete user input (e.g. sending an Excel
+                # file via WeChat Work). Buffering them would cause them
+                # to be silently dropped if no text follows.
                 pending = self._pending_content_by_session.pop(
                     session_id,
                     [],


### PR DESCRIPTION
## Summary

File-only messages (e.g. Excel files sent via WeChat Work) were being silently dropped because they were caught by the no-text debounce logic and never processed when no text message followed.

## Problem

`_apply_no_text_debounce()` in `base.py` only had a bypass for audio-only messages. File-only messages (no text, no audio) were buffered in `_pending_content_by_session` and waited indefinitely for a text message that never came.

This means: **sending a file via WeChat Work (or any channel) with no accompanying text would produce zero response**.

## Root Cause

```python
def _apply_no_text_debounce(self, session_id, content_parts):
    if not self._content_has_text(content_parts):
        if self._content_has_audio(content_parts):
            # Audio bypasses debounce ✓
            return (True, merged)
        # File-only: buffered forever ✗
        self._pending_content_by_session[...].extend(content_parts)
        return (False, [])
```

## Fix

Add `_content_has_file()` check alongside the existing audio check, so file-only messages are processed immediately:

```python
if self._content_has_file(content_parts):
    pending = self._pending_content_by_session.pop(session_id, [])
    merged = pending + list(content_parts)
    return (True, merged)
```

## Reproduction

1. Send a file (e.g. Excel) via WeChat Work to any agent
2. Do not send any text message after
3. Agent receives the file but produces no response

## Impact

- Fixes file uploads via WeChat Work, DingTalk, Telegram, and all channels using the no-text debounce
- No change for text messages or mixed content (text + file)
- Images are handled separately via time-debounce
