### PR TITLE
fix(channel): pass channel instance directly to notification path

### DIFF
--- a/src/qwenpaw/app/approvals/service.py
+++ b/src/qwenpaw/app/approvals/service.py
@@ -73,11 +73,12 @@ class ApprovalService:
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
         self._pending: dict[str, PendingApproval] = {}
-        self._channel_manager: Any | None = None
 
-    def set_channel_manager(self, channel_manager: Any) -> None:
-        """Store a reference to the channel manager for push notifications."""
-        self._channel_manager = channel_manager
+    def set_channel_manager(
+        self,
+        channel_manager: Any,
+    ) -> None:  # noqa: ARG002
+        """Legacy no-op kept for backward compat."""
 
     async def _notify_channel(
         self,
@@ -85,14 +86,14 @@ class ApprovalService:
         channel_body: str,
     ) -> None:
         """Fire-and-forget: push approval notification to channel."""
-        if self._channel_manager is None:
-            return
         if not pending.channel or pending.channel == "console":
             return
+        channel_instance = (pending.extra or {}).get("_channel_instance")
+        if channel_instance is None:
+            return
+        channel_meta = (pending.extra or {}).get("channel_meta")
         try:
-            channel_meta = (pending.extra or {}).get("channel_meta")
-            await self._channel_manager.push_approval_notification(
-                channel=pending.channel,
+            await channel_instance.send_approval_notification(
                 session_id=pending.session_id,
                 user_id=pending.user_id,
                 request_id=pending.request_id,
@@ -168,7 +169,11 @@ class ApprovalService:
             root_session_id[:8],
         )
 
-        if self._channel_manager and channel and channel != "console":
+        if (
+            channel
+            and channel != "console"
+            and (extra or {}).get("_channel_instance")
+        ):
             channel_body = format_channel_approval_body(result)
             asyncio.create_task(
                 self._notify_channel(pending, channel_body),
@@ -229,7 +234,11 @@ class ApprovalService:
             root_session_id[:8],
         )
 
-        if self._channel_manager and channel and channel != "console":
+        if (
+            channel
+            and channel != "console"
+            and (extra or {}).get("_channel_instance")
+        ):
             asyncio.create_task(
                 self._notify_channel(pending, pending.result_summary),
                 name=f"approval-notify-{request_id[:8]}",

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -871,6 +871,7 @@ class BaseChannel(ABC):
         reasoning / message events alongside the normal path.
         """
         request = self._payload_to_request(payload)
+        request.channel_instance = self
 
         if isinstance(payload, dict):
             send_meta = dict(payload.get("meta") or {})

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -871,33 +871,3 @@ class ChannelManager:
             [TextContent(type=ContentType.TEXT, text=text)],
             merged_meta,
         )
-
-    async def push_approval_notification(
-        self,
-        *,
-        channel: str,
-        session_id: str,
-        user_id: str,
-        request_id: str,
-        tool_name: str,
-        severity: str,
-        result_summary: str,
-        channel_meta: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """Push approval notification to a specific channel."""
-        ch = await self.get_channel(channel.lower())
-        if not ch:
-            logger.warning(
-                "push_approval_notification: channel not found: %s",
-                channel,
-            )
-            return
-        await ch.send_approval_notification(
-            session_id=session_id,
-            user_id=user_id,
-            request_id=request_id,
-            tool_name=tool_name,
-            severity=severity,
-            result_summary=result_summary,
-            channel_meta=channel_meta,
-        )

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -592,6 +592,7 @@ async def _ask_user_approval(
                 "tool_source": source,
             },
             "channel_meta": ctx.get("channel_meta"),
+            "_channel_instance": ctx.get("_channel_instance"),
         },
     )
 

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -419,6 +419,11 @@ class AgentBuilder:
             if user_name:
                 rc["user_name"] = user_name
             rc["channel_meta"] = _channel_meta
+        rc["_channel_instance"] = getattr(
+            request,
+            "channel_instance",
+            None,
+        )
         _payload_ctx = (
             getattr(request, "request_context", None) if request else None
         )

--- a/src/qwenpaw/runtime/tool_guard.py
+++ b/src/qwenpaw/runtime/tool_guard.py
@@ -366,6 +366,7 @@ async def _ask_user_approval(
                 "input": dict(input_data or {}),
             },
             "channel_meta": ctx.get("channel_meta"),
+            "_channel_instance": ctx.get("_channel_instance"),
         },
     )
 


### PR DESCRIPTION
## Description

#5601 added approval push notifications via `_channel_manager.push_approval_notification()`,
but the cached manager reference (set once at startup) may not contain the
active channel instances at runtime.

Fix: propagate the processing channel instance through request_context →
pending.extra and call `send_approval_notification` directly — no manager
lookup needed.

- Attach `_channel_instance` to request in `_stream_with_tracker`
- Propagate through builder → tool_adapter/tool_guard → approval extra
- `_notify_channel` uses the instance directly
- Remove dead `push_approval_notification` from ChannelManager

**Related Issue:** Fixes #5696 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
