### PR TITLE
fix(plugins): retain old plugin versions on release and clean up failed load state

### DIFF
--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -90,44 +90,10 @@ jobs:
           ossutil cp "oss://qwenpaw-download/metadata/plugins/index.json" \
             existing-index.json 2>/dev/null || echo '{}' > existing-index.json
 
-          python3 << 'PYTHON'
-          import json
-
-          with open("dist/plugins/index.json") as f:
-              new_index = json.load(f)
-          with open("existing-index.json") as f:
-              old_index = json.load(f)
-
-          # files: same file_id ({plugin_id}-{version}) is overwritten by new;
-          # different file_ids from old are preserved.
-          # Old entries keep their original updated_at (by design).
-          old_files = old_index.get("files", {})
-          new_files = new_index.get("files", {})
-          merged_files = {**old_files, **new_files}
-          new_index["files"] = merged_files
-
-          # platforms.versions: merge version lists (union of all kinds),
-          # new versions first, old versions appended with deduplication.
-          old_platforms = old_index.get("platforms", {})
-          all_kinds = set(list(new_index.get("platforms", {}).keys()) + list(old_platforms.keys()))
-          for kind in all_kinds:
-              old_versions = old_platforms.get(kind, {}).get("versions", [])
-              new_versions = new_index.get("platforms", {}).get(kind, {}).get("versions", [])
-              seen = set(new_versions)
-              merged = list(new_versions)
-              for v in old_versions:
-                  if v not in seen:
-                      merged.append(v)
-                      seen.add(v)
-              if "platforms" not in new_index:
-                  new_index["platforms"] = {}
-              if kind not in new_index["platforms"]:
-                  new_index["platforms"][kind] = {}
-              new_index["platforms"][kind]["versions"] = merged
-
-          with open("dist/plugins/index.json", "w") as f:
-              json.dump(new_index, f, indent=2, ensure_ascii=False)
-          PYTHON
+          python3 scripts/pack/merge_plugin_index.py \
+            --new dist/plugins/index.json \
+            --old existing-index.json \
+            --out dist/plugins/index.json
 
       - name: Upload plugins index (short-cache)
         run: |
@@ -148,23 +114,9 @@ jobs:
           }
           EOF
 
-          python3 << 'PYTHON'
-          import json
-          from datetime import datetime, timezone
-
-          with open("main-index.json", "r", encoding="utf-8") as f:
-              index = json.load(f)
-
-          index.setdefault("products", {})
-          index["products"]["plugins"] = {
-              "name": {"zh-CN": "插件", "en-US": "Plugins"},
-              "index_url": "/metadata/plugins/index.json",
-          }
-          index["updated_at"] = datetime.now(timezone.utc).isoformat()
-
-          with open("main-index.json", "w", encoding="utf-8") as f:
-              json.dump(index, f, indent=2, ensure_ascii=False)
-          PYTHON
+          python3 scripts/pack/patch_main_index.py \
+            --index main-index.json \
+            --out   main-index.json
 
           ossutil cp main-index.json \
             "oss://qwenpaw-download/metadata/index.json" \

--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Sync plugin zips to OSS (long-cache, immutable)
         run: |
+          # nullglob ensures empty globs expand to nothing in this bash session
           shopt -s nullglob
           for kind in bundle tool; do
             while IFS= read -r -d '' f; do
@@ -69,10 +70,9 @@ jobs:
                 --meta "Cache-Control:public, max-age=31536000, immutable"
             done < <(find "dist/plugins/${kind}" -type f -name '*.zip' -print0 2>/dev/null || true)
           done
-          # Remove zips that no longer exist locally so deletions propagate.
+          # One-time cleanup: remove legacy flat zips (pre per-plugin directory layout).
+          # This only targets {kind}/*.zip (flat files), not {kind}/{plugin_id}/*.zip (versioned).
           for kind in bundle tool; do
-            kind_root="dist/plugins/${kind}"
-            # Drop legacy flat zips at {kind}/ (pre per-plugin directory layout).
             remote_flat=$(ossutil ls "oss://qwenpaw-download/files/plugins/${kind}/" -s 2>/dev/null \
               | grep -E "^oss://qwenpaw-download/files/plugins/${kind}/[^/]+\.zip$" \
               | sed 's|.*/||' \
@@ -83,24 +83,51 @@ jobs:
                 "oss://qwenpaw-download/files/plugins/${kind}/${name}" \
                 --force
             done
-            for plugin_dir in "$kind_root"/*/; do
-              [ -d "$plugin_dir" ] || continue
-              plugin_id=$(basename "$plugin_dir")
-              local_names=$(find "$plugin_dir" -maxdepth 1 -type f -name '*.zip' -exec basename {} \; 2>/dev/null | sort || true)
-              remote_names=$(ossutil ls "oss://qwenpaw-download/files/plugins/${kind}/${plugin_id}/" -s 2>/dev/null \
-                | grep -E "^oss://qwenpaw-download/files/plugins/${kind}/${plugin_id}/[^/]+\.zip$" \
-                | sed 's|.*/||' \
-                | sort -u || true)
-              for name in $remote_names; do
-                if ! echo "$local_names" | grep -qx "$name"; then
-                  echo "Removing stale OSS object: ${kind}/${plugin_id}/${name}"
-                  ossutil rm \
-                    "oss://qwenpaw-download/files/plugins/${kind}/${plugin_id}/${name}" \
-                    --force
-                fi
-              done
-            done
           done
+
+      - name: Merge historical versions into index
+        run: |
+          ossutil cp "oss://qwenpaw-download/metadata/plugins/index.json" \
+            existing-index.json 2>/dev/null || echo '{}' > existing-index.json
+
+          python3 << 'PYTHON'
+          import json
+
+          with open("dist/plugins/index.json") as f:
+              new_index = json.load(f)
+          with open("existing-index.json") as f:
+              old_index = json.load(f)
+
+          # files: same file_id ({plugin_id}-{version}) is overwritten by new;
+          # different file_ids from old are preserved.
+          # Old entries keep their original updated_at (by design).
+          old_files = old_index.get("files", {})
+          new_files = new_index.get("files", {})
+          merged_files = {**old_files, **new_files}
+          new_index["files"] = merged_files
+
+          # platforms.versions: merge version lists (union of all kinds),
+          # new versions first, old versions appended with deduplication.
+          old_platforms = old_index.get("platforms", {})
+          all_kinds = set(list(new_index.get("platforms", {}).keys()) + list(old_platforms.keys()))
+          for kind in all_kinds:
+              old_versions = old_platforms.get(kind, {}).get("versions", [])
+              new_versions = new_index.get("platforms", {}).get(kind, {}).get("versions", [])
+              seen = set(new_versions)
+              merged = list(new_versions)
+              for v in old_versions:
+                  if v not in seen:
+                      merged.append(v)
+                      seen.add(v)
+              if "platforms" not in new_index:
+                  new_index["platforms"] = {}
+              if kind not in new_index["platforms"]:
+                  new_index["platforms"][kind] = {}
+              new_index["platforms"][kind]["versions"] = merged
+
+          with open("dist/plugins/index.json", "w") as f:
+              json.dump(new_index, f, indent=2, ensure_ascii=False)
+          PYTHON
 
       - name: Upload plugins index (short-cache)
         run: |

--- a/scripts/pack/merge_plugin_index.py
+++ b/scripts/pack/merge_plugin_index.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Merge a newly built plugin index with a historical one from OSS.
+
+Used by the ``plugins-release.yml`` workflow to preserve old plugin
+versions on the CDN while adding new ones.
+
+Merge rules:
+- ``files``: keyed by file_id (``{plugin_id}-{version}``).  New entries
+  overwrite same-id old entries; different ids from old are preserved.
+- ``platforms.{kind}.versions``: union of new and old version lists,
+  new versions first, old versions appended with deduplication.
+
+Usage::
+
+    python scripts/pack/merge_plugin_index.py \
+        --new  dist/plugins/index.json \
+        --old  existing-index.json \
+        --out  dist/plugins/index.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def merge_indexes(new_index: dict, old_index: dict) -> dict:
+    """Merge *old_index* into *new_index* (mutates and returns *new_index*)."""
+    # files: same file_id is overwritten by new; different ids preserved.
+    old_files = old_index.get("files", {})
+    new_files = new_index.get("files", {})
+    new_index["files"] = {**old_files, **new_files}
+
+    # platforms.versions: union, new first, old appended with dedup.
+    old_platforms = old_index.get("platforms", {})
+    all_kinds = set(
+        list(new_index.get("platforms", {}).keys())
+        + list(old_platforms.keys()),
+    )
+    for kind in all_kinds:
+        old_versions = old_platforms.get(kind, {}).get("versions", [])
+        new_versions = (
+            new_index.get("platforms", {}).get(kind, {}).get("versions", [])
+        )
+        seen = set(new_versions)
+        merged = list(new_versions)
+        for v in old_versions:
+            if v not in seen:
+                merged.append(v)
+                seen.add(v)
+        new_index.setdefault("platforms", {})
+        new_index["platforms"].setdefault(kind, {})
+        new_index["platforms"][kind]["versions"] = merged
+
+    return new_index
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge new and historical plugin indexes.",
+    )
+    parser.add_argument(
+        "--new",
+        required=True,
+        type=Path,
+        help="Path to the newly generated index.json",
+    )
+    parser.add_argument(
+        "--old",
+        required=True,
+        type=Path,
+        help="Path to the existing (historical) index.json",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output path for the merged index.json",
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.new, encoding="utf-8") as f:
+        new_index = json.load(f)
+    with open(args.old, encoding="utf-8") as f:
+        old_index = json.load(f)
+
+    merged = merge_indexes(new_index, old_index)
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(merged, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pack/patch_main_index.py
+++ b/scripts/pack/patch_main_index.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Patch the main OSS metadata index to advertise the plugins product.
+
+Ensures the top-level ``metadata/index.json`` has a ``products.plugins``
+entry pointing to the plugins sub-index.
+
+Usage::
+
+    python scripts/pack/patch_main_index.py \
+        --index main-index.json \
+        --out   main-index.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def patch_index(index: dict) -> dict:
+    """Add/update the ``plugins`` product entry (mutates *index*)."""
+    index.setdefault("products", {})
+    index["products"]["plugins"] = {
+        "name": {"zh-CN": "插件", "en-US": "Plugins"},
+        "index_url": "/metadata/plugins/index.json",
+    }
+    index["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return index
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Patch main metadata index with plugins product entry.",
+    )
+    parser.add_argument(
+        "--index",
+        required=True,
+        type=Path,
+        help="Path to the main index.json",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output path for the patched index.json",
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.index, encoding="utf-8") as f:
+        index = json.load(f)
+
+    patched = patch_index(index)
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(patched, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -418,6 +418,13 @@ class PluginLoader:
 
             plugin_def = module.plugin
 
+            if manifest.qwenpaw_version is not None:
+                qv_dict = manifest.qwenpaw_version.model_dump()
+            else:
+                qv_dict = {
+                    "min": manifest.min_version,
+                    "max": manifest.max_version,
+                }
             manifest_dict = {
                 "id": manifest.id,
                 "name": manifest.name,
@@ -425,13 +432,7 @@ class PluginLoader:
                 "description": manifest.description,
                 "author": manifest.author,
                 "dependencies": manifest.dependencies,
-                "min_version": manifest.min_version,
-                "max_version": manifest.max_version,
-                "qwenpaw_version": (
-                    manifest.qwenpaw_version.model_dump()
-                    if manifest.qwenpaw_version
-                    else None
-                ),
+                "qwenpaw_version": qv_dict,
                 "meta": manifest.meta,
             }
             api = PluginApi(plugin_id, config or {}, manifest_dict)

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -404,48 +404,105 @@ class PluginLoader:
             )
 
         module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        module.__package__ = module_name
-        module.__path__ = [plugin_dir_str]
-        spec.loader.exec_module(module)
 
-        if not hasattr(module, "plugin"):
-            raise AttributeError(
-                "Plugin module must export 'plugin' object",
+        try:
+            sys.modules[module_name] = module
+            module.__package__ = module_name
+            module.__path__ = [plugin_dir_str]
+            spec.loader.exec_module(module)
+
+            if not hasattr(module, "plugin"):
+                raise AttributeError(
+                    "Plugin module must export 'plugin' object",
+                )
+
+            plugin_def = module.plugin
+
+            manifest_dict = {
+                "id": manifest.id,
+                "name": manifest.name,
+                "version": manifest.version,
+                "description": manifest.description,
+                "author": manifest.author,
+                "dependencies": manifest.dependencies,
+                "min_version": manifest.min_version,
+                "max_version": manifest.max_version,
+                "qwenpaw_version": (
+                    manifest.qwenpaw_version.model_dump()
+                    if manifest.qwenpaw_version
+                    else None
+                ),
+                "meta": manifest.meta,
+            }
+            api = PluginApi(plugin_id, config or {}, manifest_dict)
+            api.set_registry(self.registry)
+            self.registry.register_plugin_manifest(plugin_id, manifest_dict)
+
+            if hasattr(plugin_def, "register"):
+                result = plugin_def.register(api)
+                if inspect.iscoroutine(result) or inspect.isawaitable(result):
+                    await result
+            else:
+                raise AttributeError(
+                    "Plugin must implement 'register(api)' method",
+                )
+        except Exception:
+            self._cleanup_failed_load(
+                plugin_id,
+                module_name,
+                source_path,
             )
-
-        plugin_def = module.plugin
-
-        manifest_dict = {
-            "id": manifest.id,
-            "name": manifest.name,
-            "version": manifest.version,
-            "description": manifest.description,
-            "author": manifest.author,
-            "dependencies": manifest.dependencies,
-            "min_version": manifest.min_version,
-            "max_version": manifest.max_version,
-            "qwenpaw_version": (
-                manifest.qwenpaw_version.model_dump()
-                if manifest.qwenpaw_version
-                else None
-            ),
-            "meta": manifest.meta,
-        }
-        api = PluginApi(plugin_id, config or {}, manifest_dict)
-        api.set_registry(self.registry)
-        self.registry.register_plugin_manifest(plugin_id, manifest_dict)
-
-        if hasattr(plugin_def, "register"):
-            result = plugin_def.register(api)
-            if inspect.iscoroutine(result) or inspect.isawaitable(result):
-                await result
-        else:
-            raise AttributeError(
-                "Plugin must implement 'register(api)' method",
-            )
+            raise
 
         return plugin_def
+
+    def _cleanup_failed_load(
+        self,
+        plugin_id: str,
+        module_name: str,
+        source_path: Path,
+    ) -> None:
+        """Roll back side effects after a failed plugin load.
+
+        Mirrors the cleanup logic in ``unload_plugin`` (registry,
+        ``sys.modules``, ``sys.path``) so that a failed load leaves no
+        orphan state that could interfere with other plugins or a
+        subsequent retry.
+        """
+        logger.warning(
+            "Cleaning up failed plugin load for '%s'",
+            plugin_id,
+        )
+
+        # 1. Registry (manifest, providers, hooks, middleware, routes, …)
+        self.registry.unregister_plugin(plugin_id)
+
+        # 2. sys.modules — by module-name prefix
+        prefix = module_name + "."
+        stale = [
+            k for k in sys.modules if k == module_name or k.startswith(prefix)
+        ]
+        for k in stale:
+            sys.modules.pop(k, None)
+
+        # 3. sys.modules — by __file__ path (catches bare imports that
+        #    bypassed the plugin_<id> namespace, e.g. ``import utils``
+        #    after the plugin inserted its dir into sys.path).
+        source_resolved = str(source_path.resolve()) + os.sep
+        stale_by_file = [
+            k
+            for k, mod in list(sys.modules.items())
+            if (mod_file := getattr(mod, "__file__", None)) is not None
+            and os.path.realpath(mod_file).startswith(source_resolved)
+        ]
+        for k in stale_by_file:
+            sys.modules.pop(k, None)
+
+        # 4. sys.path — remove the plugin directory if it was added
+        plugin_dir_real = os.path.realpath(str(source_path))
+        sys.path[:] = [
+            p for p in sys.path if os.path.realpath(p) != plugin_dir_real
+        ]
 
     async def load_plugin(
         self,

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -469,6 +469,12 @@ class PluginLoader:
         ``sys.modules``, ``sys.path``) so that a failed load leaves no
         orphan state that could interfere with other plugins or a
         subsequent retry.
+
+        .. note::
+            NOT thread-safe.  ``sys.modules`` and ``sys.path`` mutations
+            are not guarded by a lock.  This is fine because
+            ``load_all_plugins`` loads plugins sequentially, but callers
+            must not invoke this method concurrently.
         """
         logger.warning(
             "Cleaning up failed plugin load for '%s'",
@@ -489,7 +495,7 @@ class PluginLoader:
         # 3. sys.modules — by __file__ path (catches bare imports that
         #    bypassed the plugin_<id> namespace, e.g. ``import utils``
         #    after the plugin inserted its dir into sys.path).
-        source_resolved = str(source_path.resolve()) + os.sep
+        source_resolved = os.path.realpath(str(source_path)) + os.sep
         stale_by_file = [
             k
             for k, mod in list(sys.modules.items())

--- a/tests/unit/plugins/test_plugin_load_isolation.py
+++ b/tests/unit/plugins/test_plugin_load_isolation.py
@@ -1,0 +1,443 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access
+"""Tests for plugin load-failure isolation.
+
+Verifies that when ``_load_backend_module`` fails at any stage
+(exec_module, missing ``plugin`` attribute, ``register()`` exception),
+the framework cleans up:
+
+- ``sys.modules`` (main module, sub-modules, bare-imported modules)
+- ``sys.path``
+- ``PluginRegistry`` (manifest, hooks, providers, middleware, etc.)
+"""
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub missing agentscope 2.0 modules (same pattern as sibling test file)
+# ---------------------------------------------------------------------------
+_AGENTSCOPE_STUBS = [
+    "agentscope.state",
+]
+for _mod_name in _AGENTSCOPE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        _stub.AgentState = type(
+            "AgentState",
+            (),
+            {},
+        )  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fresh_registry():
+    """Create a fresh PluginRegistry (bypass singleton)."""
+    from qwenpaw.plugins.registry import PluginRegistry
+
+    old_instance = PluginRegistry._instance
+    PluginRegistry._instance = None
+    registry = PluginRegistry()
+    yield registry
+    PluginRegistry._instance = old_instance
+
+
+@pytest.fixture()
+def loader(fresh_registry, tmp_path):
+    """Create a PluginLoader wired to the fresh registry."""
+    from qwenpaw.plugins.loader import PluginLoader
+
+    ldr = PluginLoader(plugin_dirs=[tmp_path])
+    ldr.registry = fresh_registry
+    return ldr
+
+
+def _write_plugin(plugin_dir: Path, plugin_py_code: str) -> Dict:
+    """Write a minimal plugin directory and return the manifest dict."""
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "id": plugin_dir.name,
+        "name": plugin_dir.name,
+        "version": "1.0.0",
+        "entry": {"backend": "plugin.py"},
+        "qwenpaw_version": {"min": "0.1.0", "max": "99.0.0"},
+    }
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(plugin_py_code, encoding="utf-8")
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Tests: sys.modules cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestSysModulesCleanup:
+    """sys.modules must not retain entries from a failed load."""
+
+    @pytest.mark.asyncio
+    async def test_exec_module_failure_cleans_sys_modules(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """If exec_module raises, the module is removed from sys.modules."""
+        plugin_dir = tmp_path / "bad-syntax"
+        _write_plugin(plugin_dir, "raise SyntaxError('intentional')\n")
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+        module_name = f"plugin_{manifest.id.replace('-', '_')}"
+
+        with pytest.raises(SyntaxError):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert module_name not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_missing_plugin_attr_cleans_sys_modules(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """If the module lacks a 'plugin' attribute, sys.modules is cleaned."""
+        plugin_dir = tmp_path / "no-attr"
+        _write_plugin(plugin_dir, "x = 42\n")
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+        module_name = f"plugin_{manifest.id.replace('-', '_')}"
+
+        with pytest.raises(AttributeError, match="plugin"):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert module_name not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_register_failure_cleans_submodules(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Sub-modules written by exec_module are cleaned on failure."""
+        plugin_dir = tmp_path / "sub-mod"
+        (plugin_dir).mkdir()
+        (plugin_dir / "helper.py").write_text(
+            "VALUE = 99\n",
+            encoding="utf-8",
+        )
+        _write_plugin(
+            plugin_dir,
+            "from .helper import VALUE\n"
+            "\n"
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        raise RuntimeError('register boom')\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+        module_name = f"plugin_{manifest.id.replace('-', '_')}"
+        sub_name = f"{module_name}.helper"
+
+        with pytest.raises(RuntimeError, match="register boom"):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert module_name not in sys.modules
+        assert sub_name not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_bare_import_cleaned_by_file_path(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Modules imported via bare ``import`` (after sys.path manipulation)
+        are cleaned via __file__ path scanning."""
+        plugin_dir = tmp_path / "bare-imp"
+        (plugin_dir).mkdir()
+        # A helper that the plugin will import via bare name
+        (plugin_dir / "bare_helper_xyzzy.py").write_text(
+            "MAGIC = 123\n",
+            encoding="utf-8",
+        )
+        _write_plugin(
+            plugin_dir,
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import bare_helper_xyzzy\n"
+            "\n"
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        raise RuntimeError('fail after bare import')\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="fail after bare import"):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert "bare_helper_xyzzy" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# Tests: sys.path cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestSysPathCleanup:
+    @pytest.mark.asyncio
+    async def test_sys_path_cleaned_on_failure(self, loader, tmp_path):
+        """Plugin directory inserted into sys.path is removed on failure."""
+        plugin_dir = tmp_path / "path-pol"
+        _write_plugin(
+            plugin_dir,
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "\n"
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        raise RuntimeError('path pollution test')\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+
+        plugin_dir_real = os.path.realpath(str(plugin_dir))
+        assert plugin_dir_real not in [os.path.realpath(p) for p in sys.path]
+
+        with pytest.raises(RuntimeError, match="path pollution test"):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert plugin_dir_real not in [os.path.realpath(p) for p in sys.path]
+
+
+# ---------------------------------------------------------------------------
+# Tests: PluginRegistry cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCleanup:
+    @pytest.mark.asyncio
+    async def test_manifest_cleaned_on_register_failure(
+        self,
+        loader,
+        fresh_registry,
+        tmp_path,
+    ):
+        """Manifest pre-registered before register() is cleaned on failure."""
+        plugin_dir = tmp_path / "reg-fail"
+        _write_plugin(
+            plugin_dir,
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        raise ValueError('register failed')\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+
+        with pytest.raises(ValueError, match="register failed"):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert fresh_registry.get_plugin_manifest(manifest.id) is None
+
+    @pytest.mark.asyncio
+    async def test_partial_registrations_cleaned_on_failure(
+        self,
+        loader,
+        fresh_registry,
+        tmp_path,
+    ):
+        """Hooks/middleware registered before the exception are cleaned."""
+        plugin_dir = tmp_path / "partial-reg"
+        _write_plugin(
+            plugin_dir,
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        api.register_startup_hook(\n"
+            "            hook_name='orphan_hook',\n"
+            "            callback=lambda: None,\n"
+            "        )\n"
+            "        api.register_middleware(\n"
+            "            middleware_factory=lambda ctx, cfg: None,\n"
+            "        )\n"
+            "        raise RuntimeError('partial failure')\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        from qwenpaw.plugins.architecture import PluginManifest
+
+        manifest = PluginManifest.from_dict(
+            json.loads(
+                (plugin_dir / "plugin.json").read_text(encoding="utf-8"),
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="partial failure"):
+            await loader._load_backend_module(
+                manifest.id,
+                plugin_dir / "plugin.py",
+                plugin_dir,
+                None,
+                manifest,
+            )
+
+        assert len(fresh_registry.get_startup_hooks()) == 0
+        assert len(fresh_registry.get_middleware_factories()) == 0
+        assert fresh_registry.get_plugin_manifest(manifest.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_all_plugins integration
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAllPluginsIsolation:
+    @pytest.mark.asyncio
+    async def test_bad_plugin_does_not_block_good_plugin(
+        self,
+        loader,
+        fresh_registry,
+        tmp_path,
+    ):
+        """A failing plugin does not prevent subsequent plugins from loading,
+        and leaves no residue in the registry."""
+        # Plugin that fails during register()
+        bad_dir = tmp_path / "aaa-bad"
+        _write_plugin(
+            bad_dir,
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        api.register_startup_hook(\n"
+            "            hook_name='orphan',\n"
+            "            callback=lambda: None,\n"
+            "        )\n"
+            "        raise RuntimeError('bad plugin')\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        # Plugin that loads successfully
+        good_dir = tmp_path / "zzz-good"
+        _write_plugin(
+            good_dir,
+            "class P:\n"
+            "    def register(self, api):\n"
+            "        api.register_startup_hook(\n"
+            "            hook_name='good_hook',\n"
+            "            callback=lambda: None,\n"
+            "        )\n"
+            "\n"
+            "plugin = P()\n",
+        )
+
+        loaded = await loader.load_all_plugins()
+
+        # Good plugin loaded successfully
+        assert "zzz-good" in loaded
+        assert loaded["zzz-good"].enabled is True
+
+        # Bad plugin is NOT in loaded dict
+        assert "aaa-bad" not in loaded
+
+        # Registry contains only the good plugin's hook, not the bad one
+        hooks = fresh_registry.get_startup_hooks()
+        hook_names = [h.hook_name for h in hooks]
+        assert "good_hook" in hook_names
+        assert "orphan" not in hook_names
+
+        # No manifest residue from bad plugin
+        assert fresh_registry.get_plugin_manifest("aaa-bad") is None
+        assert fresh_registry.get_plugin_manifest("zzz-good") is not None

--- a/tests/unit/plugins/test_plugin_load_isolation.py
+++ b/tests/unit/plugins/test_plugin_load_isolation.py
@@ -393,7 +393,13 @@ class TestLoadAllPluginsIsolation:
         tmp_path,
     ):
         """A failing plugin does not prevent subsequent plugins from loading,
-        and leaves no residue in the registry."""
+        and leaves no residue in the registry.
+
+        The directory names (aaa-bad, zzz-good) do NOT imply a required
+        load order — Path.iterdir() order is filesystem-dependent.  The
+        assertions only check presence/absence in the loaded dict and
+        registry, which are order-independent.
+        """
         # Plugin that fails during register()
         bad_dir = tmp_path / "aaa-bad"
         _write_plugin(


### PR DESCRIPTION
## Description

This PR addresses two issues in the plugin system:

1. **Plugin release workflow deletes old versions** (`d712851e`): The `plugins-release.yml` workflow previously removed all historical plugin zips from OSS on every release, breaking backward compatibility for clients using older plugin versions. This change removes the per-plugin OSS cleanup loop and adds an index merge step so that same-version zips are overwritten while different versions coexist on the CDN.

2. **Failed plugin load leaves orphan state** (`118889c0`): When `_load_backend_module` failed mid-way (e.g., during `exec_module` or `register()`), residual entries in `sys.modules`, `sys.path`, and `PluginRegistry` were not cleaned up, potentially interfering with subsequent plugin loads or retries. A new `_cleanup_failed_load` method now rolls back all side effects on failure.

**Related Issue:** N/A (proactive fix)

**Security Considerations:** No security implications. The OSS cleanup removal only affects artifact retention; the load isolation fix is purely internal state management.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- **Release workflow**: Trigger `workflow_dispatch` with `upload_to_oss=true` on a test branch; verify that OSS retains zips from previous releases and `index.json` contains merged version entries.
- **Load isolation**: Run `pytest tests/unit/plugins/test_plugin_load_isolation.py -v` — all 8 cases cover `sys.modules`, `sys.path`, registry cleanup, and cross-plugin isolation.

## Additional Notes

- The release workflow change is backward-compatible: existing OSS artifacts are preserved, and the new merge step gracefully handles the case where no prior `index.json` exists (first release).
- The `_cleanup_failed_load` method mirrors the cleanup logic already present in `unload_plugin`, ensuring consistency between load-failure rollback and explicit unload.
- Storage cost on OSS will grow linearly with plugin versions; plugin zips are small and this is acceptable for the current scale. A future yank/archival mechanism can be added if needed.