### PR TITLE
fix(telegram): move typing indicator start to _before_consume_process

### DIFF
--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -451,8 +451,6 @@ class TelegramChannel(BaseChannel):
                 "meta": meta,
             }
             if self._enqueue is not None:
-                self._start_typing(chat_id)
-                self._is_processing[chat_id] = True
                 self._enqueue(native)
             else:
                 logger.warning("telegram: _enqueue not set, message dropped")
@@ -1131,6 +1129,20 @@ class TelegramChannel(BaseChannel):
         if self._is_processing.get(to_handle, False):
             self._start_typing(to_handle)
 
+    async def _before_consume_process(
+        self,
+        request: Any,
+    ) -> None:
+        """Start typing indicator when processing actually begins.
+
+        Called after the no-text debounce check passes, so the typing
+        indicator only starts for messages that will be processed — not
+        for file-only messages buffered while waiting for text input.
+        """
+        to_handle = self.get_to_handle_from_request(request)
+        self._is_processing[to_handle] = True
+        self._start_typing(to_handle)
+
     async def _on_process_completed(
         self,
         request,
@@ -1140,7 +1152,6 @@ class TelegramChannel(BaseChannel):
         """All events done — clear processing flag and stop typing."""
         self._is_processing.pop(to_handle, None)
         self._stop_typing(to_handle)
-        await super()._on_process_completed(request, to_handle, send_meta)
 
     async def _on_consume_error(
         self,


### PR DESCRIPTION
## Description

File-only messages were buffered by no-text debounce without processing, but
`handle_message` started the typing indicator unconditionally before enqueueing —
leaving "typing…" shown for up to 180 s.

Move typing start to `_before_consume_process`, which only fires after the
debounce check passes. Stop logic in `_on_process_completed` / `_on_consume_error`
is unchanged.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
