### PR TITLE
feat: auto-refresh chat on channel session updates

### DIFF
--- a/console/src/components/ConsolePollService/index.tsx
+++ b/console/src/components/ConsolePollService/index.tsx
@@ -59,8 +59,23 @@ export default function ConsolePollService() {
             seen.add(m.id);
             newItems.push({ ...m, dismissAt: now + AUTO_DISMISS_MS });
           }
-          if (newItems.length === 0) return;
-          const toAdd = newItems.slice(-MAX_NEW_PER_POLL);
+          // Dispatch session-update events for channel messages
+          for (const m of newItems) {
+            if (m.text?.startsWith("session_updated:")) {
+              const sid = m.text.slice("session_updated:".length);
+              window.dispatchEvent(
+                new CustomEvent("channel-session-updated", {
+                  detail: { sessionId: sid },
+                }),
+              );
+            }
+          }
+          // Filter out internal notifications from bubble display
+          const bubbleItems = newItems.filter(
+            (m) => !m.text?.startsWith("session_updated:"),
+          );
+          if (bubbleItems.length === 0) return;
+          const toAdd = bubbleItems.slice(-MAX_NEW_PER_POLL);
           setItems((prev) => {
             const merged = [...prev, ...toAdd];
             return merged.slice(-MAX_VISIBLE_BUBBLES);

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1741,6 +1741,20 @@ export default function ChatPage() {
         userId: window.currentUserId || DEFAULT_USER_ID,
         channel: window.currentChannel || DEFAULT_CHANNEL,
       });
+
+  // Refresh chat when a channel message arrives for the current session
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      const targetSid = detail?.sessionId;
+      if (!targetSid || targetSid === chatIdRef.current) {
+        setRefreshKey((prev) => prev + 1);
+      }
+    };
+    window.addEventListener("channel-session-updated", handler);
+    return () =>
+      window.removeEventListener("channel-session-updated", handler);
+  }, []);
       // Clear tracked attachments after enqueuing
       pendingFileListRef.current = [];
       setTextareaValue(textarea, "");

--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from qwenpaw.app.console_push_store import console_push_store
 from pathlib import Path
 
 from typing import (
@@ -440,6 +441,12 @@ class ChannelManager:
 
                 # Process batch (with merge logic)
                 await _process_batch(ch, batch)
+                    # Notify console UI to refresh this session's messages
+                    try:
+                        from qwenpaw.app.console_push_store import console_push_store as _cps
+                        _cps.append(f"session_updated:{session_id}")
+                    except Exception:
+                        pass
 
                 # Update processed count
                 if self._queue_manager is not None:


### PR DESCRIPTION
## Summary

When a message is processed via a channel (e.g. WeChat/WeCom), the Web UI now automatically refreshes the chat to show the new message without requiring a manual page refresh.

## Changes

- **`manager.py`**: After `_process_batch` completes, push a `session_updated:{session_id}` notification through `console_push_store`
- **`ConsolePollService/index.tsx`**: Detect `session_updated:*` messages during poll and dispatch a `channel-session-updated` custom DOM event
- **`Chat/index.tsx`**: Listen for `channel-session-updated` events; increment `refreshKey` when it matches the current session

## Motivation

Messages sent via channels previously only appeared after a manual page refresh. This PR leverages the existing `console_push_store` polling mechanism to signal session updates in real-time (~2.5s delay).
