### PR TITLE
fix(feishu): allow messages from other bots while filtering self-bot loops

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -685,16 +685,16 @@ class FeishuChannel(BaseChannel):
             while len(self._processed_message_ids) > FEISHU_PROCESSED_IDS_MAX:
                 self._processed_message_ids.popitem(last=False)
 
-            sender_type = getattr(sender, "sender_type", "") or ""
-            if sender_type == "bot":
-                return
-
             sender_id_obj = getattr(sender, "sender_id", None)
             sender_id = ""
             if sender_id_obj and getattr(sender_id_obj, "open_id", None):
                 sender_id = str(getattr(sender_id_obj, "open_id", "")).strip()
             if not sender_id:
                 sender_id = f"unknown_{message_id[:8]}"
+
+            sender_type = getattr(sender, "sender_type", "") or ""
+            if sender_type == "bot" and sender_id == self._bot_open_id:
+                return
 
             nickname = (
                 getattr(sender, "name", None)

--- a/tests/unit/channels/test_feishu.py
+++ b/tests/unit/channels/test_feishu.py
@@ -1455,18 +1455,45 @@ class TestFeishuChannelOnMessageComplex:
         await feishu_channel._on_message(mock_message_data)
 
     @pytest.mark.asyncio
-    async def test_on_message_bot_sender_skipped(
+    async def test_on_message_self_bot_sender_skipped(
         self,
         feishu_channel,
         mock_message_data,
     ):
-        """Test bot messages are ignored."""
-        feishu_channel._process = AsyncMock()
+        """Test messages sent by the bot itself are ignored."""
+        captured = {}
+
+        def capture_enqueue(native):
+            captured["native"] = native
+
+        feishu_channel._enqueue = capture_enqueue
+        feishu_channel._bot_open_id = "user_open_id_123"
         mock_message_data.event.sender.sender_type = "bot"
 
         await feishu_channel._on_message(mock_message_data)
 
-        feishu_channel._process.assert_not_called()
+        assert "native" not in captured
+
+    @pytest.mark.asyncio
+    async def test_on_message_other_bot_sender_processed(
+        self,
+        feishu_channel,
+        mock_message_data,
+    ):
+        """Test messages sent by another bot are processed."""
+        captured = {}
+
+        def capture_enqueue(native):
+            captured["native"] = native
+
+        feishu_channel._enqueue = capture_enqueue
+        feishu_channel._bot_open_id = "self_bot_open_id"
+        mock_message_data.event.sender.sender_type = "bot"
+        mock_message_data.event.sender.sender_id.open_id = "other_bot_open_id"
+
+        await feishu_channel._on_message(mock_message_data)
+
+        assert "native" in captured
 
     @pytest.mark.asyncio
     async def test_on_message_empty_data_returns_early(self, feishu_channel):


### PR DESCRIPTION
## Description

Changes:
- `src/qwenpaw/app/channels/feishu/channel.py`
  - Replace the blanket `sender_type == "bot"` filter with a self-bot-only filter (`sender_type == "bot" and sender_id == self._bot_open_id`).
- `tests/unit/channels/test_feishu.py`
  - Remove obsolete `test_on_message_bot_sender_skipped`.
  - Add `test_on_message_self_bot_sender_skipped` and `test_on_message_other_bot_sender_processed`.

**Related Issue:** Fixes #5709 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
