### PR TITLE
fix(website): switch default site language and meta description to English

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -10,7 +10,7 @@
     />
     <meta
       name="description"
-      content="QwenPaw 是千问个人智能体工作台，运行在你自己的环境中。支持本机与云端部署，连接钉钉、飞书、QQ、Discord 等 10+ 频道，支持 Skills 与 MCP 扩展、多智能体协同与记忆管理。QwenPaw is your personal AI agent workstation that runs in your own environment, supports local/cloud deployment, 10+ channels, and extensibility via Skills and MCP."
+      content="QwenPaw is your personal AI agent workstation running in your own environment. It supports local or cloud deployment, connects to 10+ channels including DingTalk, Feishu, QQ, Discord, and Telegram, and is extensible with Skills and MCP for multi-agent collaboration and memory management."
     />
     <link rel="canonical" href="https://qwenpaw.agentscope.io/" />
     <link rel="icon" href="/qwenpaw-symbol.svg" type="image/svg+xml" />

--- a/website/src/i18n/SiteLanguageContext.tsx
+++ b/website/src/i18n/SiteLanguageContext.tsx
@@ -16,7 +16,7 @@ function getInitialLang(): Lang {
     return urlLang;
   }
   const v = localStorage.getItem(LANG_KEY);
-  return v === "en" ? "en" : "zh";
+  return v === "zh" ? "zh" : "en";
 }
 
 export type SiteLanguageContextValue = {

--- a/website/src/i18n/index.ts
+++ b/website/src/i18n/index.ts
@@ -16,7 +16,7 @@ void i18n.use(initReactI18next).init({
     en: { translation: en },
     "pt-BR": { translation: ptBR },
   },
-  lng: "zh",
+  lng: "en",
   fallbackLng: "en",
   interpolation: { escapeValue: false },
 });


### PR DESCRIPTION
## Summary

- Set the website default language to English for first-time visitors
- Update `index.html` `lang` attribute from `zh-CN` to `en`
- Replace the bilingual `meta description` with a pure English version for better search engine snippets
- Align i18n initialization and initial language resolution with the new English-first default

## Changes

| File | Change |
|------|--------|
| `website/index.html` | `lang="en"` + English-only `meta description` |
| `website/src/i18n/index.ts` | Default `lng` changed from `zh` to `en` |
| `website/src/i18n/SiteLanguageContext.tsx` | First-visit default language changed to English |

## Motivation

Google search snippets were showing Chinese descriptions for the homepage. This change makes the default site language and SEO metadata consistent with an English-first experience for new visitors.

Users who previously selected Chinese via the language toggle will still keep their preference via `localStorage`.

## Test plan

- [ ] Open the site in a fresh browser / incognito window and verify the homepage renders in English by default
- [ ] Toggle language to Chinese and refresh the page; verify Chinese is preserved
- [ ] Inspect `index.html` and confirm `lang="en"` and English `meta description`
- [ ] Verify `?lang=zh` still forces Chinese on first load