### PR TITLE
fix(runtime): honor per-request model override

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -9,7 +9,6 @@ Example:
     >>> model, formatter = create_model_and_formatter()
 """
 
-
 import base64
 import logging
 import os
@@ -1066,6 +1065,45 @@ def _strip_top_level_message_name(
     return messages
 
 
+def _resolve_model_slot_override(model_slot_override: Any):
+    """Parse an optional per-request model override into a model slot."""
+    from ..config.config import ModelSlotConfig
+
+    slot = None
+    if isinstance(model_slot_override, ModelSlotConfig):
+        slot = model_slot_override
+    if isinstance(model_slot_override, dict):
+        try:
+            slot = ModelSlotConfig.model_validate(model_slot_override)
+        except Exception:
+            logger.warning(
+                "Ignoring invalid model_slot_override dict: %r",
+                model_slot_override,
+            )
+    if isinstance(model_slot_override, str):
+        # Use partition so version-tagged model names can contain ':'.
+        provider_id, sep, model_name = model_slot_override.partition(":")
+        if sep and provider_id.strip() and model_name.strip():
+            slot = ModelSlotConfig(
+                provider_id=provider_id.strip(),
+                model=model_name.strip(),
+            )
+        else:
+            logger.warning(
+                "Ignoring invalid model_slot_override string: %r",
+                model_slot_override,
+            )
+    if model_slot_override is not None and not isinstance(
+        model_slot_override,
+        (ModelSlotConfig, dict, str),
+    ):
+        logger.warning(
+            "Unsupported model_slot_override type: %s",
+            type(model_slot_override).__name__,
+        )
+    return slot
+
+
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
     model_slot_override: Any = None,
@@ -1092,7 +1130,7 @@ def create_model_and_formatter(
         >>> model, formatter = create_model_and_formatter()
     """
     from ..app.agent_context import get_current_agent_id
-    from ..config.config import ModelSlotConfig, load_agent_config
+    from ..config.config import load_agent_config
 
     # Determine agent_id (parameter > context > None)
     if agent_id is None:
@@ -1132,48 +1170,9 @@ def create_model_and_formatter(
         except Exception:
             pass
 
-    # Apply per-request model override, if any. Takes precedence over the
-    # agent's persisted active_model. Accepts ModelSlotConfig, dict, or
-    # "provider_id:model" string.
-    if model_slot_override is not None:
-        slot: Optional[ModelSlotConfig] = None
-        if isinstance(model_slot_override, ModelSlotConfig):
-            slot = model_slot_override
-        elif isinstance(model_slot_override, dict):
-            try:
-                slot = ModelSlotConfig.model_validate(model_slot_override)
-            except Exception:
-                logger.warning(
-                    "Ignoring invalid model_slot_override dict: %r",
-                    model_slot_override,
-                )
-        elif isinstance(model_slot_override, str):
-            # Use str.partition (not split/rsplit) so the model name itself
-            # may contain ':' (e.g. version tags like 'gpt-4o:2024-08-06');
-            # only the first ':' separates provider_id from model.
-            provider_id, sep, model_name = model_slot_override.partition(":")
-            if sep and provider_id.strip() and model_name.strip():
-                slot = ModelSlotConfig(
-                    provider_id=provider_id.strip(),
-                    model=model_name.strip(),
-                )
-            else:
-                logger.warning(
-                    "Ignoring invalid model_slot_override string: %r",
-                    model_slot_override,
-                )
-        else:
-            logger.warning(
-                "Unsupported model_slot_override type: %s",
-                type(model_slot_override).__name__,
-            )
-        if slot is not None and slot.provider_id and slot.model:
-            model_slot = slot
-        elif slot is not None:
-            logger.warning(
-                "Ignoring empty model_slot_override: %r",
-                model_slot_override,
-            )
+    slot = _resolve_model_slot_override(model_slot_override)
+    if slot is not None and slot.provider_id and slot.model:
+        model_slot = slot
 
     # Create chat model from agent-specific or global config
     if model_slot and model_slot.provider_id and model_slot.model:

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1068,6 +1068,7 @@ def _strip_top_level_message_name(
 
 def create_model_and_formatter(
     agent_id: Optional[str] = None,
+    model_slot_override: Any = None,
 ) -> Tuple[ChatModelBase, FormatterBase]:
     """Factory method to create model and formatter instances.
 
@@ -1077,6 +1078,12 @@ def create_model_and_formatter(
     Args:
         agent_id: Optional agent ID to load agent-specific model config.
             If None, tries to get from context, then falls back to global.
+        model_slot_override: Optional per-request model override. When
+            provided, it takes precedence over the agent's persisted
+            ``active_model``. Accepts a ``ModelSlotConfig``, a dict matching
+            its schema, or a string of the form ``"<provider_id>:<model>"``.
+            The model name itself may contain ``:`` (e.g. version tags);
+            only the first ``:`` is treated as the separator.
 
     Returns:
         Tuple of (model_instance, formatter_instance)
@@ -1085,7 +1092,7 @@ def create_model_and_formatter(
         >>> model, formatter = create_model_and_formatter()
     """
     from ..app.agent_context import get_current_agent_id
-    from ..config.config import load_agent_config
+    from ..config.config import ModelSlotConfig, load_agent_config
 
     # Determine agent_id (parameter > context > None)
     if agent_id is None:
@@ -1124,6 +1131,49 @@ def create_model_and_formatter(
                 compact_threshold = ccc.compact_threshold_ratio
         except Exception:
             pass
+
+    # Apply per-request model override, if any. Takes precedence over the
+    # agent's persisted active_model. Accepts ModelSlotConfig, dict, or
+    # "provider_id:model" string.
+    if model_slot_override is not None:
+        slot: Optional[ModelSlotConfig] = None
+        if isinstance(model_slot_override, ModelSlotConfig):
+            slot = model_slot_override
+        elif isinstance(model_slot_override, dict):
+            try:
+                slot = ModelSlotConfig.model_validate(model_slot_override)
+            except Exception:
+                logger.warning(
+                    "Ignoring invalid model_slot_override dict: %r",
+                    model_slot_override,
+                )
+        elif isinstance(model_slot_override, str):
+            # Use str.partition (not split/rsplit) so the model name itself
+            # may contain ':' (e.g. version tags like 'gpt-4o:2024-08-06');
+            # only the first ':' separates provider_id from model.
+            provider_id, sep, model_name = model_slot_override.partition(":")
+            if sep and provider_id.strip() and model_name.strip():
+                slot = ModelSlotConfig(
+                    provider_id=provider_id.strip(),
+                    model=model_name.strip(),
+                )
+            else:
+                logger.warning(
+                    "Ignoring invalid model_slot_override string: %r",
+                    model_slot_override,
+                )
+        else:
+            logger.warning(
+                "Unsupported model_slot_override type: %s",
+                type(model_slot_override).__name__,
+            )
+        if slot is not None and slot.provider_id and slot.model:
+            model_slot = slot
+        elif slot is not None:
+            logger.warning(
+                "Ignoring empty model_slot_override: %r",
+                model_slot_override,
+            )
 
     # Create chat model from agent-specific or global config
     if model_slot and model_slot.provider_id and model_slot.model:

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for ``create_model_and_formatter`` ``model_slot_override`` parameter."""
+"""Tests for ``create_model_and_formatter`` model override support."""
 
 # pylint: disable=protected-access,redefined-outer-name
 from types import SimpleNamespace
@@ -8,11 +8,12 @@ from unittest.mock import patch
 import pytest
 
 from qwenpaw.agents import model_factory
+from qwenpaw.config import config as config_module
 from qwenpaw.config.config import ModelSlotConfig
 
 
 def _patched_load_agent_config(_agent_id):  # noqa: ARG001
-    """Return a fake agent_config whose ``active_model`` should be overridden."""
+    """Return fake agent config with an overridable active model."""
     return SimpleNamespace(
         active_model=ModelSlotConfig(
             provider_id="default-provider",
@@ -39,7 +40,7 @@ def _patched_load_agent_config(_agent_id):  # noqa: ARG001
 def _patch_dependencies(monkeypatch):
     """Avoid touching the real provider manager / retry wrappers."""
     monkeypatch.setattr(
-        model_factory,
+        config_module,
         "load_agent_config",
         _patched_load_agent_config,
     )
@@ -50,7 +51,9 @@ def _patch_dependencies(monkeypatch):
             get_instance=lambda: SimpleNamespace(
                 get_provider=lambda provider_id: SimpleNamespace(
                     provider_id=provider_id,
-                    get_chat_model_instance=lambda model_name: f"{provider_id}/{model_name}",
+                    get_chat_model_instance=(
+                        lambda model_name: f"{provider_id}/{model_name}"
+                    ),
                 ),
                 get_active_chat_model=lambda: None,
                 get_active_model=lambda: None,
@@ -65,7 +68,7 @@ def _patch_dependencies(monkeypatch):
     monkeypatch.setattr(
         model_factory,
         "TokenRecordingModelWrapper",
-        lambda *_args, **_kwargs: SimpleNamespace(),
+        lambda _provider_id, model, **_kwargs: model,
     )
     monkeypatch.setattr(
         model_factory,
@@ -114,7 +117,7 @@ def test_override_with_string():
 
 
 def test_override_with_string_preserves_colon_in_model_name():
-    """``partition`` only splits on the first ``:``, so version tags survive."""
+    """Version tags in model names survive first-colon-only splitting."""
     with patch.object(model_factory, "RetryConfig") as retry_cls:
         retry_cls.return_value = "rc"
         model, _ = model_factory.create_model_and_formatter(

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``create_model_and_formatter`` ``model_slot_override`` parameter."""
+
+# pylint: disable=protected-access,redefined-outer-name
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.agents import model_factory
+from qwenpaw.config.config import ModelSlotConfig
+
+
+def _patched_load_agent_config(_agent_id):  # noqa: ARG001
+    """Return a fake agent_config whose ``active_model`` should be overridden."""
+    return SimpleNamespace(
+        active_model=ModelSlotConfig(
+            provider_id="default-provider",
+            model="default-model",
+        ),
+        running=SimpleNamespace(
+            llm_retry_enabled=False,
+            llm_max_retries=0,
+            llm_backoff_base=1.0,
+            llm_backoff_cap=10.0,
+            llm_max_concurrent=None,
+            llm_max_qpm=None,
+            llm_rate_limit_pause=None,
+            llm_rate_limit_jitter=None,
+            llm_acquire_timeout=None,
+            light_context_config=SimpleNamespace(
+                context_compact_config=SimpleNamespace(enabled=False),
+            ),
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _patch_dependencies(monkeypatch):
+    """Avoid touching the real provider manager / retry wrappers."""
+    monkeypatch.setattr(
+        model_factory,
+        "load_agent_config",
+        _patched_load_agent_config,
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "ProviderManager",
+        SimpleNamespace(
+            get_instance=lambda: SimpleNamespace(
+                get_provider=lambda provider_id: SimpleNamespace(
+                    provider_id=provider_id,
+                    get_chat_model_instance=lambda model_name: f"{provider_id}/{model_name}",
+                ),
+                get_active_chat_model=lambda: None,
+                get_active_model=lambda: None,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "_create_formatter_instance",
+        lambda _model: "formatter",
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "TokenRecordingModelWrapper",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        model_factory,
+        "RetryChatModel",
+        lambda model, **_kwargs: model,
+    )
+
+
+def test_override_with_model_slot_config():
+    """Passing a ``ModelSlotConfig`` instance overrides ``active_model``."""
+    override = ModelSlotConfig(provider_id="p", model="m")
+
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, fmt = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override=override,
+        )
+
+    assert model == "p/m"
+    assert fmt == "formatter"
+
+
+def test_override_with_dict():
+    """A dict matching the ModelSlotConfig schema is validated."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, _ = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override={"provider_id": "p", "model": "m"},
+        )
+
+    assert model == "p/m"
+
+
+def test_override_with_string():
+    """A ``"provider:model"`` string is parsed via ``str.partition``."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, _ = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override="p:m",
+        )
+
+    assert model == "p/m"
+
+
+def test_override_with_string_preserves_colon_in_model_name():
+    """``partition`` only splits on the first ``:``, so version tags survive."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, _ = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override="openai:gpt-4o:2024-08-06",
+        )
+
+    assert model == "openai/gpt-4o:2024-08-06"
+
+
+def test_override_with_invalid_string_falls_back_to_active_model():
+    """An invalid override string is ignored and the agent's model wins."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, _ = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override="no-colon-here",
+        )
+
+    assert model == "default-provider/default-model"
+
+
+def test_override_with_unsupported_type_falls_back_to_active_model():
+    """Non-str/dict/ModelSlotConfig values are ignored."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, _ = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+            model_slot_override=12345,
+        )
+
+    assert model == "default-provider/default-model"
+
+
+def test_no_override_uses_active_model():
+    """Without an override, the agent's persisted active_model is used."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, _ = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+        )
+
+    assert model == "default-provider/default-model"


### PR DESCRIPTION
## Description
Honor per-request model overrides through `create_model_and_formatter` without changing the agent persisted active model.

The override accepts a `ModelSlotConfig`, a matching dict, or a `<provider_id>:<model>` string. Invalid overrides fall back to the persisted `active_model` with a warning.

## Type of Change
- Bug fix / enhancement

## Components Affected
- Core / Runtime
- Tests

## Testing
```bash
UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python TMPDIR=/tmp \
  uv run --extra test python -m pytest \
  tests/unit/agents/test_create_model_and_formatter_override.py -q
# 7 passed

UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python TMPDIR=/tmp \
  uv run --extra test python -m black --line-length=79 --check \
  src/qwenpaw/agents/model_factory.py \
  tests/unit/agents/test_create_model_and_formatter_override.py
# passed

UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python TMPDIR=/tmp \
  uv run --extra test python -m flake8 \
  src/qwenpaw/agents/model_factory.py \
  tests/unit/agents/test_create_model_and_formatter_override.py
# passed

PYLINTHOME=/tmp/pylint-home UV_CACHE_DIR=/tmp/uv-cache \
  UV_PYTHON_INSTALL_DIR=/tmp/uv-python TMPDIR=/tmp \
  uv run --extra test python -m pylint \
  src/qwenpaw/agents/model_factory.py \
  tests/unit/agents/test_create_model_and_formatter_override.py \
  --disable=W0511,W0718,W0122,C0103,R0913,E0401,E1101,C0415,W0603,R1705,R0914,E0601,W0602,W0604,R0801,R0902,R0903,C0123,W0231,W1113,W0221,R0401,W0632,W0123,C3001,W0201,C0302,W1203,C2801,C0114,C0115,C0116
# 10.00/10
```

## Checklist
- [x] Relevant tests pass locally
- [x] Formatting and lint checks pass locally
- [x] No user-facing docs needed

Towards #5638