### PR TITLE
fix(providers): update GitHub Models to new endpoint and support fine-grained PAT

### DIFF
--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -67,6 +67,8 @@ export interface ProviderInfo {
   thinking_budget_range?: [number, number];
   /** Provider-specific metadata (e.g. base_url_options for region selection). */
   meta?: Record<string, unknown>;
+  /** Accepted API key prefixes. When present, validation accepts any prefix in this list. */
+  api_key_prefixes?: string[];
 }
 
 /** Predefined base URL option exposed via `ProviderInfo.meta.base_url_options`. */

--- a/console/src/pages/Settings/Models/components/cards/ProviderGroupCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/ProviderGroupCard.tsx
@@ -143,8 +143,8 @@ export const ProviderGroupCard = React.memo(function ProviderGroupCard({
                   activeProvider.api_key_prefixes?.length
                     ? `${activeProvider.api_key_prefixes.join(", ")}...`
                     : activeProvider.api_key_prefix
-                      ? `${activeProvider.api_key_prefix}...`
-                      : "sk-..."
+                    ? `${activeProvider.api_key_prefix}...`
+                    : "sk-..."
                 }
                 style={{ flex: 1 }}
               />

--- a/console/src/pages/Settings/Models/components/cards/ProviderGroupCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/ProviderGroupCard.tsx
@@ -140,9 +140,11 @@ export const ProviderGroupCard = React.memo(function ProviderGroupCard({
                 value={apiKeyInput}
                 onChange={(e) => setApiKeyInput(e.target.value)}
                 placeholder={
-                  activeProvider.api_key_prefix
-                    ? `${activeProvider.api_key_prefix}...`
-                    : "sk-..."
+                  activeProvider.api_key_prefixes?.length
+                    ? `${activeProvider.api_key_prefixes.join(", ")}...`
+                    : activeProvider.api_key_prefix
+                      ? `${activeProvider.api_key_prefix}...`
+                      : "sk-..."
                 }
                 style={{ flex: 1 }}
               />

--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -111,9 +111,11 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
                 value={apiKeyInput}
                 onChange={(e) => setApiKeyInput(e.target.value)}
                 placeholder={
-                  provider.api_key_prefix
-                    ? `${provider.api_key_prefix}...`
-                    : "sk-..."
+                  provider.api_key_prefixes?.length
+                    ? `${provider.api_key_prefixes.join(", ")}...`
+                    : provider.api_key_prefix
+                      ? `${provider.api_key_prefix}...`
+                      : "sk-..."
                 }
                 style={{ flex: 1 }}
               />

--- a/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
+++ b/console/src/pages/Settings/Models/components/cards/RemoteProviderCard.tsx
@@ -114,8 +114,8 @@ export const RemoteProviderCard = React.memo(function RemoteProviderCard({
                   provider.api_key_prefixes?.length
                     ? `${provider.api_key_prefixes.join(", ")}...`
                     : provider.api_key_prefix
-                      ? `${provider.api_key_prefix}...`
-                      : "sk-..."
+                    ? `${provider.api_key_prefix}...`
+                    : "sk-..."
                 }
                 style={{ flex: 1 }}
               />

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -265,6 +265,7 @@ interface ProviderConfigModalProps {
     name: string;
     api_key?: string;
     api_key_prefix?: string;
+    api_key_prefixes?: string[];
     base_url?: string;
     is_custom: boolean;
     freeze_url: boolean;
@@ -360,15 +361,27 @@ export function ProviderConfigModal({
     [provider.id, provider.chat_model, effectiveChatModel],
   );
 
+  const validApiKeyPrefixes = useMemo(() => {
+    if (provider.api_key_prefixes && provider.api_key_prefixes.length > 0) {
+      return provider.api_key_prefixes;
+    }
+    if (provider.api_key_prefix) {
+      return [provider.api_key_prefix];
+    }
+    return [];
+  }, [provider.api_key_prefix, provider.api_key_prefixes]);
+
   const apiKeyPlaceholder = useMemo(() => {
     if (provider.api_key) {
       return t("models.leaveBlankKeep");
     }
-    if (provider.api_key_prefix) {
-      return t("models.enterApiKey", { prefix: provider.api_key_prefix });
+    if (validApiKeyPrefixes.length > 0) {
+      return t("models.enterApiKey", {
+        prefix: validApiKeyPrefixes.join(", "),
+      });
     }
     return t("models.enterApiKeyOptional");
-  }, [provider.api_key, provider.api_key_prefix, t]);
+  }, [provider.api_key, validApiKeyPrefixes, t]);
 
   const apiKeyLabel =
     isAnthropicProvider && authMode === "auth_token"
@@ -756,14 +769,16 @@ export function ProviderConfigModal({
               validator: (_, value) => {
                 if (
                   value &&
-                  provider.api_key_prefix &&
+                  validApiKeyPrefixes.length > 0 &&
                   authMode !== "auth_token" &&
-                  !value.startsWith(provider.api_key_prefix)
+                  !validApiKeyPrefixes.some((prefix) =>
+                    value.startsWith(prefix),
+                  )
                 ) {
                   return Promise.reject(
                     new Error(
                       t("models.apiKeyShouldStart", {
-                        prefix: provider.api_key_prefix,
+                        prefix: validApiKeyPrefixes.join(", "),
                       }),
                     ),
                   );

--- a/src/qwenpaw/cli/providers_cmd.py
+++ b/src/qwenpaw/cli/providers_cmd.py
@@ -211,8 +211,17 @@ def configure_provider_api_key_interactive(
         )
         return provider_id
 
+    prefixes = (
+        defn.api_key_prefixes
+        if defn.api_key_prefixes
+        else [defn.api_key_prefix]
+        if defn.api_key_prefix
+        else []
+    )
     hint = (
-        f"prefix: {defn.api_key_prefix}" if defn.api_key_prefix else "optional"
+        f"prefix: {', '.join(prefixes)}"
+        if prefixes
+        else "optional"
     )
     api_key = click.prompt(
         f"API key ({hint})",
@@ -513,9 +522,16 @@ def list_cmd() -> None:
                 f"  {'api_key':16s}: "
                 f"{_mask_api_key(cur_key) or '(not set)'}",
             )
-            if defn.api_key_prefix:
+            prefixes = (
+                defn.api_key_prefixes
+                if defn.api_key_prefixes
+                else [defn.api_key_prefix]
+                if defn.api_key_prefix
+                else []
+            )
+            if prefixes:
                 click.echo(
-                    f"  {'api_key_prefix':16s}: {defn.api_key_prefix}",
+                    f"  {'api_key_prefix':16s}: {', '.join(prefixes)}",
                 )
 
             extra = list(defn.extra_models)

--- a/src/qwenpaw/cli/providers_cmd.py
+++ b/src/qwenpaw/cli/providers_cmd.py
@@ -218,11 +218,7 @@ def configure_provider_api_key_interactive(
         if defn.api_key_prefix
         else []
     )
-    hint = (
-        f"prefix: {', '.join(prefixes)}"
-        if prefixes
-        else "optional"
-    )
+    hint = f"prefix: {', '.join(prefixes)}" if prefixes else "optional"
     api_key = click.prompt(
         f"API key ({hint})",
         default=current_key or "",

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -15,8 +15,8 @@ from openai import APIError
 from pydantic import Field
 
 from qwenpaw.providers.provider import ModelInfo, Provider
-from .capping_formatter import _CappingOpenAIFormatter
-from .capping_formatter import MAX_INLINE_MEDIA_BYTES
+
+from .capping_formatter import MAX_INLINE_MEDIA_BYTES, _CappingOpenAIFormatter
 
 if TYPE_CHECKING:
     from qwenpaw.providers.multimodal_prober import ProbeResult
@@ -103,12 +103,19 @@ class OpenAIProvider(Provider):
         try:
             await client.models.list(timeout=timeout)
             return True, ""
-        except APIError:
-            return False, f"API error when connecting to `{self.base_url}`"
-        except Exception:
+        except APIError as exc:
+            detail = str(exc) or getattr(exc, "message", "")
+            status = getattr(exc, "status_code", "unknown")
             return (
                 False,
-                f"Unknown exception when connecting to `{self.base_url}`",
+                f"API error when connecting to `{self.base_url}` "
+                f"(status={status}): {detail}",
+            )
+        except Exception as exc:
+            return (
+                False,
+                f"Unknown exception when connecting to `{self.base_url}`: "
+                f"{exc}",
             )
 
     async def fetch_models(self, timeout: float = 5) -> List[ModelInfo]:
@@ -279,8 +286,8 @@ class OpenAIProvider(Provider):
             this class of silent failures.
         """
         from .multimodal_prober import (
-            _PROBE_IMAGE_B64,
             _IMAGE_PROBE_PROMPT,
+            _PROBE_IMAGE_B64,
             _is_media_keyword_error,
             evaluate_image_probe_answer,
         )
@@ -362,10 +369,7 @@ class OpenAIProvider(Provider):
         timeout: float = 30,
     ) -> tuple[bool, str]:
         """Probe video support with automatic format fallback."""
-        from .multimodal_prober import (
-            _PROBE_VIDEO_B64,
-            _PROBE_VIDEO_URL,
-        )
+        from .multimodal_prober import _PROBE_VIDEO_B64, _PROBE_VIDEO_URL
 
         logger.info(
             "Video probe start: model=%s url=%s",
@@ -609,3 +613,68 @@ class KiloProvider(_FreeSuffixProviderMixin, OpenAIProvider):
     """Kilo Code provider with dynamic free model detection."""
 
     _FREE_SUFFIX = ":free"
+
+
+class GitHubModelsProvider(OpenAIProvider):
+    """GitHub Models provider.
+
+    GitHub Models exposes an OpenAI-compatible chat completions endpoint at
+    ``https://models.github.ai/inference``.  Unlike many OpenAI-compatible
+    providers it does **not** implement the ``/models`` listing endpoint, so
+    the generic ``OpenAIProvider.check_connection`` (which calls
+    ``client.models.list()``) receives a 404 response.  This override checks
+    connectivity by issuing a minimal chat completion request instead.
+    """
+
+    async def check_connection(self, timeout: float = 5) -> tuple[bool, str]:
+        """Check connectivity via a tiny chat completion request."""
+        # Prefer a built-in model; fall back to a well-known GitHub Models id.
+        model_id = ""
+        for candidate in ("openai/gpt-4o-mini", "gpt-4o-mini"):
+            if any(m.id == candidate for m in self.models):
+                model_id = candidate
+                break
+        if not model_id:
+            model_id = (
+                self.models[0].id if self.models else "openai/gpt-4o-mini"
+            )
+
+        try:
+            client = self._client(timeout=timeout)
+            res = await client.chat.completions.create(
+                model=model_id,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "ping",
+                            },
+                        ],
+                    },
+                ],
+                timeout=timeout,
+                max_tokens=5,
+                stream=True,
+            )
+            try:
+                async for _ in res:
+                    break
+            finally:
+                await res.response.aclose()
+            return True, ""
+        except APIError as exc:
+            detail = str(exc) or getattr(exc, "message", "")
+            status = getattr(exc, "status_code", "unknown")
+            return (
+                False,
+                f"API error when connecting to `{self.base_url}` "
+                f"(status={status}): {detail}",
+            )
+        except Exception as exc:
+            return (
+                False,
+                f"Unknown exception when connecting to `{self.base_url}`: "
+                f"{exc}",
+            )

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -154,6 +154,14 @@ class ProviderInfo(BaseModel):
         default="",
         description="Expected prefix for the API key (e.g., 'sk-')",
     )
+    api_key_prefixes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "List of accepted API key prefixes. "
+            "When non-empty, validation accepts any prefix in this list; "
+            "otherwise it falls back to api_key_prefix."
+        ),
+    )
     is_local: bool = Field(
         default=False,
         description="Whether this provider is for a local hosting platform",
@@ -326,6 +334,13 @@ class Provider(ProviderInfo, ABC):
             self.chat_model = str(config["chat_model"])
         if "api_key_prefix" in config and config["api_key_prefix"] is not None:
             self.api_key_prefix = str(config["api_key_prefix"])
+        if (
+            "api_key_prefixes" in config
+            and config["api_key_prefixes"] is not None
+        ):
+            self.api_key_prefixes = [
+                str(p) for p in config["api_key_prefixes"] if p is not None
+            ]
         if (
             "generate_kwargs" in config
             and config["generate_kwargs"] is not None
@@ -570,6 +585,7 @@ class Provider(ProviderInfo, ABC):
             models=[m.model_dump() for m in self.models],
             extra_models=[m.model_dump() for m in self.extra_models],
             api_key_prefix=self.api_key_prefix,
+            api_key_prefixes=self.api_key_prefixes,
             is_local=self.is_local,
             is_custom=self.is_custom,
             support_model_discovery=self.support_model_discovery,

--- a/src/qwenpaw/providers/provider.py
+++ b/src/qwenpaw/providers/provider.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Type
-from pydantic import BaseModel, Field
-from pydantic import ConfigDict
 
 from agentscope.model import ChatModelBase
+from pydantic import BaseModel, ConfigDict, Field
+
 from qwenpaw.exceptions import ProviderError
 
 if TYPE_CHECKING:
@@ -565,11 +565,23 @@ class Provider(ProviderInfo, ABC):
 
     async def get_info(self, mock_secret: bool = True) -> ProviderInfo:
         """Return a ProviderInfo instance with the provider's details."""
-        api_key = (
-            self.api_key_prefix + "*" * 6
-            if mock_secret and self.api_key
-            else self.api_key
-        )
+        if mock_secret and self.api_key:
+            # Determine which prefix to show in the masked key.
+            # If api_key_prefixes is set, pick the one matching the
+            # actual key; otherwise fall back to api_key_prefix.
+            prefix_for_mask = self.api_key_prefix
+            if self.api_key_prefixes:
+                prefix_for_mask = next(
+                    (
+                        p
+                        for p in self.api_key_prefixes
+                        if self.api_key.startswith(p)
+                    ),
+                    self.api_key_prefix,
+                )
+            api_key = prefix_for_mask + "*" * 6
+        else:
+            api_key = self.api_key
         # Serialize models/extra_models to plain dicts so that
         # ProviderInfo constructs fresh ModelInfo instances using
         # the class in its own module scope.  This avoids pydantic

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1256,10 +1256,11 @@ GITHUB_MODELS_MODELS: List[ModelInfo] = [
 PROVIDER_GITHUB_MODELS = OpenAIProvider(
     id="github-models",
     name="GitHub Models",
-    base_url="https://models.inference.ai.azure.com",
+    base_url="https://models.github.ai/inference",
     api_key_prefix="ghp_",
+    api_key_prefixes=["ghp_", "github_pat_"],
     models=GITHUB_MODELS_MODELS,
-    freeze_url=True,
+    freeze_url=False,
     meta={
         "is_free_tier": True,
     },

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -4,44 +4,39 @@ It provides a unified interface to manage providers, such as listing available
 providers, adding/removing custom providers, and fetching provider details."""
 
 import asyncio
+import json
+import logging
 import os
 from typing import Dict, List
-import logging
-import json
-
-from pydantic import BaseModel
 
 from agentscope.model import ChatModelBase
-from qwenpaw.exceptions import (
-    ModelNotFoundException,
-)
+from pydantic import BaseModel
 
-from ..constant import SECRET_DIR
+from qwenpaw.exceptions import ModelNotFoundException
+
 from ..config.config import ModelSlotConfig
+from ..constant import SECRET_DIR
 from ..exceptions import ProviderError
-from .anthropic_provider import AnthropicProvider
-from .dashscope_provider import DashScopeProvider
-from .gemini_provider import GeminiProvider
-from .ollama_provider import OllamaProvider
-from .openai_provider import (
-    OpenAIProvider,
-    OpenCodeProvider,
-    KiloProvider,
-)
-from .openai_response_provider import OpenAIResponseProvider
-from .lmstudio_provider import LMStudioProvider
-from .provider import (
-    ModelInfo,
-    Provider,
-    ProviderInfo,
-)
-from .openrouter_provider import OpenRouterProvider
 from ..security.secret_store import (
     PROVIDER_SECRET_FIELDS,
     decrypt_dict_fields,
     encrypt_dict_fields,
     is_encrypted,
 )
+from .anthropic_provider import AnthropicProvider
+from .dashscope_provider import DashScopeProvider
+from .gemini_provider import GeminiProvider
+from .lmstudio_provider import LMStudioProvider
+from .ollama_provider import OllamaProvider
+from .openai_provider import (
+    GitHubModelsProvider,
+    KiloProvider,
+    OpenAIProvider,
+    OpenCodeProvider,
+)
+from .openai_response_provider import OpenAIResponseProvider
+from .openrouter_provider import OpenRouterProvider
+from .provider import ModelInfo, Provider, ProviderInfo
 
 logger = logging.getLogger(__name__)
 
@@ -1220,7 +1215,7 @@ PROVIDER_OPENROUTER = OpenRouterProvider(
 
 GITHUB_MODELS_MODELS: List[ModelInfo] = [
     ModelInfo(
-        id="gpt-4o-mini",
+        id="openai/gpt-4o-mini",
         name="GPT-4o Mini",
         supports_image=True,
         supports_video=False,
@@ -1228,32 +1223,16 @@ GITHUB_MODELS_MODELS: List[ModelInfo] = [
         is_free=True,
     ),
     ModelInfo(
-        id="gpt-4o",
+        id="openai/gpt-4o",
         name="GPT-4o",
         supports_image=True,
         supports_video=False,
         probe_source="documentation",
         is_free=True,
     ),
-    ModelInfo(
-        id="Meta-Llama-3.1-405B-Instruct",
-        name="Llama 3.1 405B",
-        supports_image=False,
-        supports_video=False,
-        probe_source="documentation",
-        is_free=True,
-    ),
-    ModelInfo(
-        id="Meta-Llama-3.1-8B-Instruct",
-        name="Llama 3.1 8B",
-        supports_image=False,
-        supports_video=False,
-        probe_source="documentation",
-        is_free=True,
-    ),
 ]
 
-PROVIDER_GITHUB_MODELS = OpenAIProvider(
+PROVIDER_GITHUB_MODELS = GitHubModelsProvider(
     id="github-models",
     name="GitHub Models",
     base_url="https://models.github.ai/inference",

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -51,7 +51,9 @@ async def test_check_connection_api_error_returns_false(monkeypatch) -> None:
     ok, msg = await provider.check_connection(timeout=1)
 
     assert ok is False
-    assert msg == f"API error when connecting to `{provider.base_url}`"
+    assert msg.startswith(
+        f"API error when connecting to `{provider.base_url}`",
+    )
 
 
 async def test_list_model_normalizes_and_deduplicates(monkeypatch) -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -795,3 +795,41 @@ def test_max_inline_media_bytes_defaults_when_absent(
     model = provider.get_chat_model_instance(model_id)
     assert isinstance(model.formatter, formatter_cls)
     assert model.formatter.max_bytes == 2 * 1024 * 1024
+
+
+async def test_github_models_provider_uses_new_endpoint_and_prefixes(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider("github-models")
+
+    assert provider is not None
+    assert isinstance(provider, OpenAIProvider)
+    assert provider.base_url == "https://models.github.ai/inference"
+    assert provider.freeze_url is False
+    assert provider.api_key_prefix == "ghp_"
+    assert provider.api_key_prefixes == ["ghp_", "github_pat_"]
+
+    info = await provider.get_info()
+    assert info.base_url == "https://models.github.ai/inference"
+    assert info.freeze_url is False
+    assert info.api_key_prefix == "ghp_"
+    assert info.api_key_prefixes == ["ghp_", "github_pat_"]
+
+
+async def test_update_config_persists_api_key_prefixes(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider("github-models")
+    assert provider is not None
+
+    manager.update_provider(
+        "github-models",
+        {"api_key_prefixes": ["ghp_", "github_pat_"]},
+    )
+
+    provider = manager.get_provider("github-models")
+    assert provider.api_key_prefixes == ["ghp_", "github_pat_"]
+    info = await provider.get_info()
+    assert info.api_key_prefixes == ["ghp_", "github_pat_"]

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -6,23 +6,23 @@ import json
 from types import SimpleNamespace
 
 import pytest
-from qwenpaw.exceptions import (
-    ModelNotFoundException,
-)
 
 import qwenpaw.providers.provider_manager as provider_manager_module
-from qwenpaw.exceptions import ProviderError
-from qwenpaw.providers.anthropic_provider import AnthropicProvider
 from qwenpaw.config.config import ModelSlotConfig
+from qwenpaw.exceptions import ModelNotFoundException, ProviderError
+from qwenpaw.local_models.llamacpp import LlamaCppServerSetupResult
+from qwenpaw.providers.anthropic_provider import AnthropicProvider
 from qwenpaw.providers.capping_formatter import (
     _CappingAnthropicFormatter,
     _CappingGeminiFormatter,
     _CappingOpenAIFormatter,
 )
-from qwenpaw.providers.openai_provider import OpenAIProvider
+from qwenpaw.providers.openai_provider import (
+    GitHubModelsProvider,
+    OpenAIProvider,
+)
 from qwenpaw.providers.provider import ModelInfo
 from qwenpaw.providers.provider_manager import ProviderManager
-from qwenpaw.local_models.llamacpp import LlamaCppServerSetupResult
 
 LEGACY_PROVIDER = {
     "providers": {
@@ -805,6 +805,7 @@ async def test_github_models_provider_uses_new_endpoint_and_prefixes(
 
     assert provider is not None
     assert isinstance(provider, OpenAIProvider)
+    assert isinstance(provider, GitHubModelsProvider)
     assert provider.base_url == "https://models.github.ai/inference"
     assert provider.freeze_url is False
     assert provider.api_key_prefix == "ghp_"

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -285,7 +285,7 @@ Manage environment variables used by tools and skills at runtime.
 ```bash
 qwenpaw env list
 qwenpaw env set TAVILY_API_KEY "tvly-xxxxxxxx"
-qwenpaw env set GITHUB_TOKEN "ghp_xxxxxxxx"
+qwenpaw env set GITHUB_TOKEN "ghp_xxxxxxxx"  # fine-grained PATs starting with github_pat_ are also supported
 qwenpaw env delete TAVILY_API_KEY
 ```
 

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -272,7 +272,7 @@ qwenpaw models set-llm          # 切换到其他 Ollama 模型
 ```bash
 qwenpaw env list
 qwenpaw env set TAVILY_API_KEY "tvly-xxxxxxxx"
-qwenpaw env set GITHUB_TOKEN "ghp_xxxxxxxx"
+qwenpaw env set GITHUB_TOKEN "ghp_xxxxxxxx"  # 也支持以 github_pat_ 开头的 fine-grained PAT
 qwenpaw env delete TAVILY_API_KEY
 ```
 


### PR DESCRIPTION
Description

Update the GitHub Models provider integration to address three issues:
Endpoint migration: The old Azure-hosted endpoint https://models.inference.ai.azure.com is deprecated. Migrated to the new official endpoint https://models.github.ai/inference.
Fine-grained PAT support: Previously only classic PATs (ghp_ prefix) were accepted. Now fine-grained PATs (github_pat_ prefix) with models:read scope are also supported via a new api_key_prefixes mechanism.
Connection test fix: The new endpoint does not expose a /models listing API, causing check_connection() to fail with 404. Introduced GitHubModelsProvider subclass that uses a lightweight chat completion request instead.
Built-in model IDs updated: The new endpoint requires vendor/model-name format (e.g., openai/gpt-4o-mini). Retired unavailable Llama/DeepSeek models from the built-in list.

Security Considerations

API key validation now supports multiple prefix patterns, maintaining the same security guarantee (keys must start with a known prefix)
No secrets are logged or exposed; the api_key_prefixes field only contains prefix strings, not actual keys
freeze_url changed from True to False to allow users to customize the endpoint if needed

Testing

Unit Tests:
test_github_models_provider_uses_new_endpoint_and_prefixes — verifies new endpoint, freeze_url=False, and dual prefix support
test_update_config_persists_api_key_prefixes — verifies api_key_prefixes survives config update round-trip
All 30 provider unit tests pass

End-to-End Verification:
Started python -m qwenpaw app with the new code
Configured GitHub Models with a fine-grained PAT (github_pat_ prefix, models:read scope)
Connection test passed (no more 404 error)
Successfully chatted with openai/gpt-4o-mini via QA Agent
<img width="769" height="263" alt="{D106B836-0769-423B-B1C5-6905129F5AEF}" src="https://github.com/user-attachments/assets/d7e10d56-970b-4515-82e2-1029c61f02ec" />

