### PR TITLE
feat(chat): support selecting and auto-copying message text (#5712)

### DIFF
--- a/console/src/pages/Chat/HostBubbles.test.tsx
+++ b/console/src/pages/Chat/HostBubbles.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getContainedSelectionText } from "./HostBubblesSelection";
+
+function selectRange(start: Node, end: Node) {
+  const range = document.createRange();
+  range.setStart(start, 0);
+  range.setEnd(end, end.textContent?.length ?? 0);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  return selection;
+}
+
+describe("HostBubbles selectable message text", () => {
+  it("returns selected text when the selection stays inside one card", () => {
+    const root = document.createElement("div");
+    const text = document.createTextNode("select me");
+    root.appendChild(text);
+    document.body.appendChild(root);
+
+    const selection = selectRange(text, text);
+
+    expect(getContainedSelectionText(root, selection)).toBe("select me");
+  });
+
+  it("ignores selections that cross outside the message card", () => {
+    const root = document.createElement("div");
+    const inside = document.createTextNode("inside");
+    const outside = document.createTextNode(" outside");
+    root.appendChild(inside);
+    document.body.append(root, outside);
+
+    const selection = selectRange(inside, outside);
+
+    expect(getContainedSelectionText(root, selection)).toBe("");
+  });
+});

--- a/console/src/pages/Chat/HostBubbles.tsx
+++ b/console/src/pages/Chat/HostBubbles.tsx
@@ -49,6 +49,9 @@ import type {
   ChatRequestData,
   ChatResponseData,
 } from "../../plugins/registry/types";
+import { getContainedSelectionText } from "./HostBubblesSelection";
+import { copyText } from "./utils";
+import styles from "./index.module.less";
 
 function sortByOrder<T extends { item: { order?: number } }>(arr: T[]): T[] {
   return arr
@@ -201,6 +204,42 @@ function DefaultHostResponseCard({
   );
 }
 
+function SelectableMessageCard(props: { children: React.ReactNode }) {
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const lastCopiedTextRef = React.useRef("");
+
+  const copySelection = React.useCallback(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const selectedText = getContainedSelectionText(root, window.getSelection());
+    if (!selectedText || selectedText === lastCopiedTextRef.current) {
+      return;
+    }
+    lastCopiedTextRef.current = selectedText;
+    void copyText(selectedText).catch(() => {
+      lastCopiedTextRef.current = "";
+    });
+  }, []);
+
+  const handleMouseUp = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      copySelection();
+    },
+    [copySelection],
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.selectableMessageCard}
+      onMouseUp={handleMouseUp}
+    >
+      {props.children}
+    </div>
+  );
+}
+
 export function HostRequestCard(props: { data: ChatRequestData }) {
   const extScalar = useChatScalarSnapshot();
   const extLists = useChatListSnapshot();
@@ -242,11 +281,13 @@ export function HostRequestCard(props: { data: ChatRequestData }) {
     );
 
   const fallback = () => (
-    <VendorRequestCard
-      data={props.data as AnyCardProps}
-      contentPrepend={contentPrepend as AnyCardProps}
-      contentAppend={contentAppend as AnyCardProps}
-    />
+    <SelectableMessageCard>
+      <VendorRequestCard
+        data={props.data as AnyCardProps}
+        contentPrepend={contentPrepend as AnyCardProps}
+        contentAppend={contentAppend as AnyCardProps}
+      />
+    </SelectableMessageCard>
   );
 
   if (renderFn) {
@@ -309,12 +350,14 @@ export function HostResponseCard(props: {
     );
 
   const fallback = () => (
-    <DefaultHostResponseCard
-      data={props.data as unknown as IAgentScopeRuntimeResponse}
-      isLast={props.isLast}
-      contentPrepend={contentPrepend}
-      contentAppend={contentAppend}
-    />
+    <SelectableMessageCard>
+      <DefaultHostResponseCard
+        data={props.data as unknown as IAgentScopeRuntimeResponse}
+        isLast={props.isLast}
+        contentPrepend={contentPrepend}
+        contentAppend={contentAppend}
+      />
+    </SelectableMessageCard>
   );
 
   if (renderFn) {

--- a/console/src/pages/Chat/HostBubblesSelection.ts
+++ b/console/src/pages/Chat/HostBubblesSelection.ts
@@ -1,0 +1,15 @@
+export function getContainedSelectionText(
+  root: HTMLElement,
+  selection: Selection | null,
+): string {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+    return "";
+  }
+  const range = selection.getRangeAt(0);
+  const startNode = range.startContainer;
+  const endNode = range.endContainer;
+  if (!root.contains(startNode) || !root.contains(endNode)) {
+    return "";
+  }
+  return selection.toString().trim();
+}

--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -378,6 +378,14 @@
 }
 /* End #6583 */
 
+.selectableMessageCard {
+  user-select: text;
+
+  :global(*) {
+    user-select: text;
+  }
+}
+
 /* ---- Rate-limit guidance banner ---- */
 .rateLimitBanner {
   display: flex;

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -42,6 +42,17 @@ describe("Chat message markdown layout styles", () => {
     expect(rule).toMatch(/overflow-x:\s*auto/);
     expect(rule).toMatch(/max-width:\s*100%/);
   });
+
+  it("allows selecting text inside chat message cards", () => {
+    const markerIndex = stylesSource.indexOf(".selectableMessageCard");
+    const rule = stylesSource.slice(
+      markerIndex,
+      stylesSource.indexOf("}", markerIndex) + 1,
+    );
+
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(rule).toMatch(/user-select:\s*text/);
+  });
 });
 
 describe("Chat attachment preview styles", () => {


### PR DESCRIPTION
## Description

Fixes #5712.

Chat request and response cards currently do not provide a reliable
select-to-copy workflow. This PR adds a host-side selectable wrapper around
both card types:

- left-button text selections are copied automatically;
- collapsed selections and selections crossing outside the card are ignored;
- duplicate mouse-up events for the same text do not trigger repeated copies;
- plugin render boundaries and vendor card actions remain unchanged;
- message text explicitly uses `user-select: text`.

The branch is a single clean commit rebased onto current `main` (`d8efbbb7`).
The selectable wrapper now composes with the host-rendered response card added
by #6911, preserving its media, tool, reasoning, and renderable-code-block
paths. The unrelated footer-hover behavior and local `todo.md` are not part of
the PR.

**Related Issue:** Fixes #5712

**Security Considerations:** Clipboard writes contain only text explicitly
selected by the user within one message card.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Console TypeScript and Prettier checks pass
- [x] Relevant Vitest tests pass
- [x] Documentation updated (not needed; direct UI behavior)
- [x] Ready for review

## Testing

```bash
cd console
npm run test:run -- \
  src/pages/Chat/HostBubbles.test.tsx \
  src/pages/Chat/index.module.test.ts \
  src/components/RenderableCodeBlock/RenderableCodeBlock.test.tsx \
  src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx \
  src/components/Chat/ToolCards/shared/toolCards.module.test.ts
# Test Files 5 passed
# Tests 29 passed

npm run format:check
# tsc -b --noEmit passed
# All matched files use Prettier code style
```

## Evidence

The focused DOM tests prove that text fully contained in a message card is
accepted and a selection crossing outside the card is rejected. The CSS
regression confirms that the card and descendants remain text-selectable. The
RenderableCodeBlock suite verifies the conflict resolution preserves #6911's
new response rendering behavior, while the ToolCard suites preserve #6890's
multiline tool-output behavior.

## Additional Notes

The implementation was AI-assisted and reviewed against current `main`
(`d8efbbb7`), the existing plugin card wrappers, Issue #5712, #6911's response
renderer, #6890's multiline tool-output styles, and the focused frontend suite.
