### PR TITLE
feat(config,agents): env var resolution for config + dialog log sanitization

### DIFF
--- a/src/qwenpaw/agents/offloader.py
+++ b/src/qwenpaw/agents/offloader.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timedelta
@@ -24,6 +25,39 @@ if TYPE_CHECKING:
     from agentscope.message import Msg, ToolResultBlock
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Secret sanitization — redact known API-key / token patterns from dialog
+# logs before persisting to disk, preventing permanent leakage through
+# tool-result passthrough (e.g. grep_search → agent.json keys).
+# ---------------------------------------------------------------------------
+
+_SECRET_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"sk-[a-zA-Z0-9]{20,}"), "sk-xxxxxxxxxxxx"),
+    (re.compile(r"ghp_[a-zA-Z0-9]{30,}"), "ghp_xxxxxxxxxxxx"),
+    (re.compile(r"github_pat_[a-zA-Z0-9_]{50,}"), "github_pat_xxxxxxxxxxxx"),
+    (re.compile(r"tvly-(dev-)?[a-zA-Z0-9_-]{20,}"), "tvly-xxxxxxxxxxxx"),
+    (re.compile(r"mkt_[a-zA-Z0-9]{20,}"), "mkt_xxxxxxxxxxxx"),
+    (re.compile(r"agent-world-[a-zA-Z0-9]{30,}"), "agent-world-xxxxxxxxxxxx"),
+    (re.compile(r"dashscope-[a-zA-Z0-9]{30,}"), "dashscope-xxxxxxxxxxxx"),
+]
+
+
+def _sanitize_secrets(data: object) -> object:
+    """Recursively redact known secret patterns in string values.
+
+    Dict keys, non-string values, and strings that do not match any
+    pattern are passed through unchanged.
+    """
+    if isinstance(data, dict):
+        return {k: _sanitize_secrets(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_sanitize_secrets(x) for x in data]
+    if isinstance(data, str):
+        for pattern, replacement in _SECRET_PATTERNS:
+            data = pattern.sub(replacement, data)
+        return data
+    return data
 
 
 class QwenPawOffloader:
@@ -91,7 +125,11 @@ class QwenPawOffloader:
             ) as f:
                 for msg in sorted_msgs:
                     await f.write(
-                        json.dumps(msg.to_dict(), ensure_ascii=False) + "\n",
+                        json.dumps(
+                            _sanitize_secrets(msg.to_dict()),
+                            ensure_ascii=False,
+                        )
+                        + "\n",
                     )
             last_path = filepath
             logger.info(
@@ -130,7 +168,7 @@ class QwenPawOffloader:
             content = str(output)
 
         async with aiofiles.open(filepath, mode="w", encoding="utf-8") as f:
-            await f.write(content)
+            await f.write(_sanitize_secrets(content))
 
         logger.info("Offloaded tool result to %s", filepath)
         return filepath

--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import plistlib
+import re
 import shutil
 import socket
 import subprocess
@@ -80,6 +81,43 @@ def _normalize_working_dir_bound_paths(data: object) -> object:
             return [_walk(x, key) for x in obj]
         if key in {"workspace_dir", "media_dir"}:
             return _rewrite_path_value(obj)
+        return obj
+
+    return _walk(data, None)
+
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _resolve_env_vars(data: object) -> object:
+    """Recursively resolve ``${ENV_VAR}`` placeholders in string values.
+
+    Non-string values and strings without ``${...}`` patterns are left
+    unchanged for backward compatibility. Environment variables that
+    are not set are logged as warnings and left unsubstituted so the
+    user has an explicit signal.
+    """
+
+    def _walk(obj: object, _key: str | None = None) -> object:
+        if isinstance(obj, dict):
+            return {k: _walk(v, str(k)) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [_walk(x, _key) for x in obj]
+        if isinstance(obj, str) and "${" in obj:
+
+            def _replacer(m: re.Match) -> str:
+                var_name = m.group(1)
+                val = os.environ.get(var_name)
+                if val is None:
+                    logger.warning(
+                        "Environment variable '%s' referenced in config "
+                        "but not set; keeping placeholder.",
+                        var_name,
+                    )
+                    return m.group(0)
+                return val
+
+            return _ENV_VAR_PATTERN.sub(_replacer, obj)
         return obj
 
     return _walk(data, None)
@@ -551,6 +589,7 @@ def _load_and_validate_config(
 ) -> Config:
     """Load and validate config data, handling validation errors."""
     data = _normalize_working_dir_bound_paths(data)
+    data = _resolve_env_vars(data)
     # Backward compat: top-level last_api_host / last_api_port -> last_api
     if "last_api_host" in data or "last_api_port" in data:
         la = data.setdefault("last_api", {})
@@ -645,6 +684,7 @@ def strict_validate_config_file(
         return False, f"unreadable or invalid JSON — {config_path}"
 
     data = _normalize_working_dir_bound_paths(data)
+    data = _resolve_env_vars(data)
     if "last_api_host" in data or "last_api_port" in data:
         la = data.setdefault("last_api", {})
         if "host" not in la and "last_api_host" in data:

--- a/tests/unit/agents/test_offloader_sanitize.py
+++ b/tests/unit/agents/test_offloader_sanitize.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``_sanitize_secrets`` in agents/offloader.py."""
+
+from __future__ import annotations
+
+from qwenpaw.agents.offloader import _sanitize_secrets
+
+
+def test_redacts_sk_api_key():
+    data = {"text": "api_key: sk-abc123def456ghi789jkl012mno345pqr"}
+    result = _sanitize_secrets(data)
+    assert "sk-xxxxxxxxxxxx" in result["text"]
+    assert "sk-abc123" not in result["text"]
+
+
+def test_redacts_ghp_token():
+    data = {"text": "token: ghp_abcdef1234567890ghijklmnopqrstuv"}
+    result = _sanitize_secrets(data)
+    assert "ghp_xxxxxxxxxxxx" in result["text"]
+
+
+def test_redacts_github_pat_fine_grained():
+    data = {
+        "text": (
+            "github_pat_11ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv"
+        ),
+    }
+    result = _sanitize_secrets(data)
+    assert "github_pat_xxxxxxxxxxxx" in result["text"]
+
+
+def test_passes_through_safe_content():
+    data = {"text": "hello world", "count": 42}
+    result = _sanitize_secrets(data)
+    assert result == {"text": "hello world", "count": 42}
+
+
+def test_handles_nested_dicts_and_lists():
+    data = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "key: sk-abc123def456ghi789jkl012mno345pqr",
+            },
+            {"role": "assistant", "content": "normal reply"},
+        ],
+        "metadata": {"safe": True},
+    }
+    result = _sanitize_secrets(data)
+    assert "sk-xxxxxxxxxxxx" in result["messages"][0]["content"]
+    assert result["messages"][1]["content"] == "normal reply"
+
+
+def test_handles_plain_string_input():
+    result = _sanitize_secrets(
+        "use token ghp_abc123def4567890ghijklmnopqrstuv here",
+    )
+    assert "ghp_xxxxxxxxxxxx" in result
+    assert "ghp_abc123" not in result
+
+
+def test_preserves_non_string_types():
+    data = {"flag": True, "num": 3.14, "null_val": None}
+    result = _sanitize_secrets(data)
+    assert result == {"flag": True, "num": 3.14, "null_val": None}

--- a/tests/unit/config/test_env_var_resolution.py
+++ b/tests/unit/config/test_env_var_resolution.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``_resolve_env_vars`` in config/utils.py."""
+
+from __future__ import annotations
+
+import os
+
+from qwenpaw.config.utils import _resolve_env_vars
+
+
+def test_resolves_single_env_var():
+    os.environ["TEST_VAR_A"] = "resolved-a"
+    try:
+        data = {"api_key": "${TEST_VAR_A}"}
+        result = _resolve_env_vars(data)
+        assert result == {"api_key": "resolved-a"}
+    finally:
+        del os.environ["TEST_VAR_A"]
+
+
+def test_leaves_non_placeholder_strings():
+    data = {"name": "plain-text", "host": "127.0.0.1"}
+    assert _resolve_env_vars(data) == {
+        "name": "plain-text",
+        "host": "127.0.0.1",
+    }
+
+
+def test_leaves_non_string_values():
+    data = {"port": 8080, "enabled": True, "tags": ["a", "b"]}
+    assert _resolve_env_vars(data) == {
+        "port": 8080,
+        "enabled": True,
+        "tags": ["a", "b"],
+    }
+
+
+def test_keeps_placeholder_when_env_var_missing():
+    os.environ.pop("MISSING_VAR_XYZ", None)
+    data = {"token": "${MISSING_VAR_XYZ}"}
+    assert _resolve_env_vars(data) == {"token": "${MISSING_VAR_XYZ}"}
+
+
+def test_resolves_nested_dict_values():
+    os.environ["TEST_NESTED"] = "nested-val"
+    try:
+        data = {
+            "channel": {
+                "discord": {"bot_token": "${TEST_NESTED}"},
+                "feishu": {"app_secret": "plain"},
+            },
+        }
+        result = _resolve_env_vars(data)
+        assert result["channel"]["discord"]["bot_token"] == "nested-val"
+        assert result["channel"]["feishu"]["app_secret"] == "plain"
+    finally:
+        del os.environ["TEST_NESTED"]
+
+
+def test_resolves_list_values():
+    os.environ["TEST_LIST"] = "list-val"
+    try:
+        data = {"tokens": ["${TEST_LIST}", "static"]}
+        result = _resolve_env_vars(data)
+        assert result == {"tokens": ["list-val", "static"]}
+    finally:
+        del os.environ["TEST_LIST"]
+
+
+def test_does_not_resolve_env_var_in_dict_key():
+    os.environ["KEY_VAR"] = "should-not-work"
+    try:
+        data = {"${KEY_VAR}": "value"}
+        result = _resolve_env_vars(data)
+        assert result == {"${KEY_VAR}": "value"}
+    finally:
+        del os.environ["KEY_VAR"]
+
+
+def test_multiple_placeholders_in_one_string():
+    os.environ["HOST"] = "localhost"
+    os.environ["PORT"] = "5432"
+    try:
+        data = {"url": "postgres://${HOST}:${PORT}/db"}
+        result = _resolve_env_vars(data)
+        assert result == {"url": "postgres://localhost:5432/db"}
+    finally:
+        del os.environ["HOST"]
+        del os.environ["PORT"]


### PR DESCRIPTION
PR for #5705. Implements two of the three security improvements proposed in the issue.

## Env var placeholders in config

Any string field in `agent.json` can now use `${ENV_VAR}` syntax:

```
"app_secret": "${QWENPAW_FEISHU_APP_SECRET}"
```

This means channel tokens (Discord, Feishu, Telegram) no longer need to be stored as plaintext.

Missing env vars keep the placeholder and log a warning, so existing configs work as-is. Only values are resolved, never dict keys.

## Dialog log sanitization

Before persisting to `dialog/*.jsonl` and `tool_results/*.txt`, seven API-key patterns are redacted:

- `sk-*`
- `ghp_*`
- `github_pat_*`
- `tvly-*`
- `mkt_*`
- `agent-world-*`
- `dashscope-*`

This prevents permanent leakage when an agent reads a sensitive file (e.g. `grep_search` on `agent.json`) and the raw tool output lands in the dialog archive.

Only the on-disk copy is sanitized. In-memory values stay untouched so tools continue to work.

## Not included

ReMe log sanitization (Plan C from #5705). The ReMe module lives in a separate `reme-ai` package — will follow up there.

## Tests

- 15 new unit tests (8 for env var resolution, 7 for sanitization)
- 659 existing tests, zero regressions
- pre-commit clean (mypy / black / flake8 / pylint)
