### PR TITLE
fix(ci): guard empty extra_flags expansion for bash 3.2 on macOS

### DIFF
--- a/.github/actions/verify-legacy-macos/action.yml
+++ b/.github/actions/verify-legacy-macos/action.yml
@@ -121,4 +121,4 @@ runs:
           --base-url http://127.0.0.1:8088 \
           --ui-mode legacy \
           --headed \
-          "${extra_flags[@]}"
+          ${extra_flags[@]+"${extra_flags[@]}"}

--- a/.github/actions/verify-tauri-macos/action.yml
+++ b/.github/actions/verify-tauri-macos/action.yml
@@ -42,4 +42,4 @@ runs:
           --base-url "$BASE_URL" \
           --ui-mode tauri-macos \
           --headed \
-          "${extra_flags[@]}"
+          ${extra_flags[@]+"${extra_flags[@]}"}


### PR DESCRIPTION
## Summary

- The latest `desktop-release` run on upstream (run 28578303513) failed on `build-macos` and `build-tauri-macos` with `line ...: extra_flags[@]: unbound variable` immediately after the LLM/health check.
- Root cause: `.github/actions/verify-legacy-macos/action.yml` and `.github/actions/verify-tauri-macos/action.yml` expand an empty `extra_flags` array via `"${extra_flags[@]}"` under `set -euo pipefail`. The macOS runners ship system bash 3.2, which treats that expansion as an unbound variable and exits 1.
- Switching to the bash 3.2 compatible form `${arr[@]+"${arr[@]}"}` expands to nothing when the array is empty and to the array otherwise, keeping the strict flag semantics intact.
- Windows composite actions are unaffected (PowerShell syntax). `fork-verify-desktop` sidestepped this in PR #5681 because it defaults to `allow-flaky-llm: 'true'` (the array is never empty on the fork path).

## Verification

Two full-platform runs on the fork, both 4/4 pass:

1. Repro + fix validation — temporarily flipped the four `fork-verify-desktop` jobs to `allow-flaky-llm: "false"` to reproduce the original failure with the fix on top of it: https://github.com/yutai78786/QwenPaw/actions/runs/28582238853
2. Regression — reverted to `allow-flaky-llm: "true"` and re-ran to confirm no regression: https://github.com/yutai78786/QwenPaw/actions/runs/28583787303

## Test plan

- [x] Reproduce empty-array behavior locally on macOS `/bin/bash` (3.2).
- [x] Fork strict mode (`allow-flaky-llm=false`) — 4/4 desktop jobs green.
- [x] Fork regular mode (`allow-flaky-llm=true`) — 4/4 desktop jobs green.