### PR TITLE
fix(security): redact secrets in persisted dialog artifacts

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -15,6 +15,7 @@ from .utils.context_stats import format_history_str
 from ..config.config import load_agent_config, get_model_max_input_length
 from ..constant import DEBUG_HISTORY_FILE, MAX_LOAD_HISTORY_COUNT
 from ..exceptions import SystemCommandException
+from ..security.redaction import redact_secrets
 
 if TYPE_CHECKING:
     from agentscope.agent import Agent
@@ -931,7 +932,11 @@ class CommandHandler(ConversationCommandHandlerMixin):
             with open(history_file, "w", encoding="utf-8") as f:
                 for msg in dump_messages:
                     f.write(
-                        json.dumps(msg.to_dict(), ensure_ascii=False) + "\n",
+                        json.dumps(
+                            redact_secrets(msg.to_dict()),
+                            ensure_ascii=False,
+                        )
+                        + "\n",
                     )
 
             logger.info(

--- a/src/qwenpaw/agents/offloader.py
+++ b/src/qwenpaw/agents/offloader.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING
 import aiofiles
 import aiofiles.os
 
+from ..security.redaction import redact_secrets, redact_text
+
 if TYPE_CHECKING:
     from agentscope.message import Msg, ToolResultBlock
 
@@ -91,7 +93,11 @@ class QwenPawOffloader:
             ) as f:
                 for msg in sorted_msgs:
                     await f.write(
-                        json.dumps(msg.to_dict(), ensure_ascii=False) + "\n",
+                        json.dumps(
+                            redact_secrets(msg.to_dict()),
+                            ensure_ascii=False,
+                        )
+                        + "\n",
                     )
             last_path = filepath
             logger.info(
@@ -133,7 +139,7 @@ class QwenPawOffloader:
             content = str(output)
 
         async with aiofiles.open(filepath, mode="w", encoding="utf-8") as f:
-            await f.write(content)
+            await f.write(redact_text(content))
 
         logger.info("Offloaded tool result to %s", filepath)
         return filepath

--- a/src/qwenpaw/security/redaction.py
+++ b/src/qwenpaw/security/redaction.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Secret redaction helpers for persisted logs and debug artifacts."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_SECRET_PATTERNS = (
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    re.compile(r"ghp_[A-Za-z0-9]{30,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{50,}"),
+    re.compile(r"tvly-(?:dev-)?[A-Za-z0-9_-]{20,}"),
+    re.compile(r"mkt_[A-Za-z0-9]{20,}"),
+    re.compile(r"agent-world-[A-Za-z0-9]{30,}"),
+)
+
+
+def _mask_secret(match: re.Match[str]) -> str:
+    value = match.group(0)
+    if len(value) <= 8:
+        return "****"
+    return f"{value[:4]}****{value[-4:]}"
+
+
+def redact_text(text: str) -> str:
+    """Redact known secret token formats inside *text*."""
+    redacted = text
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub(_mask_secret, redacted)
+    return redacted
+
+
+def redact_secrets(value: Any) -> Any:
+    """Recursively redact known secret token formats in JSON-like data."""
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, dict):
+        return {key: redact_secrets(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [redact_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_secrets(item) for item in value)
+    return value

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -6,12 +6,13 @@ import pytest
 from agentscope.message import Msg, TextBlock
 
 from qwenpaw.agents.command_handler import CommandHandler
+from qwenpaw.constant import DEBUG_HISTORY_FILE
 
 
 def _make_agent():
     """Build a minimal fake agent satisfying CommandHandler's expectations."""
     agent = MagicMock()
-    agent.state = SimpleNamespace(context=[], session_id="session-1")
+    agent.state = SimpleNamespace(context=[], session_id="session-1", summary="")
     agent.memory_manager = None
     return agent
 
@@ -221,6 +222,26 @@ async def test_memorize_rejects_invalid_count() -> None:
 
     memory_manager.auto_memory.assert_not_awaited()
     assert "Invalid Count" in msg.get_text_content()
+
+
+@pytest.mark.asyncio
+async def test_dump_history_redacts_secret_tokens(tmp_path) -> None:
+    agent = _make_agent()
+    handler = CommandHandler(agent_name="QwenPaw", agent=agent)
+    # pylint: disable=protected-access
+    handler._get_agent_config = lambda: SimpleNamespace(
+        workspace_dir=str(tmp_path),
+    )
+    secret = "sk-abcdefghijklmnopqrstuvwxyz"
+
+    msg = await handler._process_dump_history(
+        [_msg("assistant", f"tool output token={secret}")],
+    )
+
+    body = (tmp_path / DEBUG_HISTORY_FILE).read_text(encoding="utf-8")
+    assert "History Dumped" in msg.get_text_content()
+    assert secret not in body
+    assert "sk-a****wxyz" in body
 
 
 def _make_config(

--- a/tests/unit/agents/test_offloader_redaction.py
+++ b/tests/unit/agents/test_offloader_redaction.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""QwenPaw offloader redacts secrets before persistence."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from agentscope.message import Msg, TextBlock
+
+from qwenpaw.agents.offloader import QwenPawOffloader
+
+
+@pytest.mark.asyncio
+async def test_offload_context_redacts_dialog_jsonl(tmp_path):
+    offloader = QwenPawOffloader(
+        dialog_path=str(tmp_path / "dialog"),
+        tool_results_dir=str(tmp_path / "tool_results"),
+    )
+    secret = "sk-abcdefghijklmnopqrstuvwxyz"
+    msg = Msg(
+        name="tool",
+        role="assistant",
+        content=[TextBlock(type="text", text=f"token={secret}")],
+    )
+
+    path = await offloader.offload_context("session-1", [msg])
+
+    body = Path(path).read_text(encoding="utf-8")
+    payload = json.loads(body)
+    assert secret not in body
+    assert "sk-a****wxyz" in str(payload)
+
+
+@pytest.mark.asyncio
+async def test_offload_tool_result_redacts_text_file(tmp_path):
+    offloader = QwenPawOffloader(
+        dialog_path=str(tmp_path / "dialog"),
+        tool_results_dir=str(tmp_path / "tool_results"),
+    )
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz123456"
+    tool_result = SimpleNamespace(output=f"token={secret}")
+
+    path = await offloader.offload_tool_result("session-1", tool_result)
+
+    body = Path(path).read_text(encoding="utf-8")
+    assert secret not in body
+    assert "ghp_****3456" in body

--- a/tests/unit/security/test_redaction.py
+++ b/tests/unit/security/test_redaction.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Secret redaction helpers."""
+
+from qwenpaw.security.redaction import redact_secrets, redact_text
+
+
+def test_redact_text_masks_known_secret_patterns():
+    text = (
+        "openai=sk-abcdefghijklmnopqrstuvwxyz "
+        "github=ghp_abcdefghijklmnopqrstuvwxyz123456"
+    )
+
+    redacted = redact_text(text)
+
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in redacted
+    assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in redacted
+    assert "sk-a****wxyz" in redacted
+    assert "ghp_****3456" in redacted
+
+
+def test_redact_secrets_recurses_json_like_values():
+    value = {
+        "nested": [
+            {
+                "token": (
+                    "github_pat_"
+                    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_123456"
+                ),
+            },
+        ],
+    }
+
+    redacted = redact_secrets(value)
+
+    assert "github_pat_abcdefghijklmnopqrstuvwxyz" not in str(redacted)
+    assert "gith****3456" in redacted["nested"][0]["token"]

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,23 @@
+# Issue Todo
+
+## PR Health Check
+
+- [x] #5731: no failed checks or review comments; PR body updated to match template.
+- [x] #5739: no failed checks or review comments; PR body updated to match template.
+- [x] #5740: no failed checks or review comments; PR body updated to match template.
+
+## Ranked Actionable Issues
+
+1. #5705 Secret safety: high merge probability, maintainer welcomed contribution, can be split into small security PRs.
+2. #5737 CLI non-GUI operation improvements: useful but broad; needs careful scoping before implementation.
+3. #5718 Auto switch model: useful but overlaps existing fallback PRs, higher conflict risk.
+4. #5657 Loop detection: valuable but design-sensitive and likely needs maintainer alignment.
+5. #5667 Workspace file browser entry: user-facing frontend work, useful but larger QA surface.
+
+## Selected Work
+
+- [x] #5705 dialog/debug artifact redaction
+  - Add reusable pattern-based secret redaction.
+  - Redact `dialog/*.jsonl` offloads.
+  - Redact `/dump_history` debug JSONL exports.
+  - Redact offloaded tool-result text files.


### PR DESCRIPTION
## Description
Redact common secret token formats before writing persisted conversation/debug artifacts. This covers legacy `dialog/*.jsonl` offloads, `/dump_history` JSONL exports, and offloaded tool-result text files.

## Type of Change
- Bug fix / security hardening

## Components Affected
- Core / Agents
- Security
- Tests

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python TMPDIR=/tmp /home/guoziyang/.local/bin/uv run --extra test python -m pytest tests/unit/security/test_redaction.py tests/unit/agents/test_offloader_redaction.py tests/unit/agents/test_command_handler.py -q` — 17 passed
- `git diff --check`

## Checklist
- [x] Relevant tests pass locally
- [x] Does not change live agent messages, only persisted artifacts
- [x] Keeps secrets partially identifiable using first 4 and last 4 characters

Addresses the dialog log redaction part of #5705.