### PR TITLE
Protect active turn from scroll context eviction

### DIFF
--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -186,13 +186,23 @@ class ScrollContextManager:
         # visible, so it isn't evicted yet. It gets indexed in a later round
         # once it moves fully onto the compress side.
         tail_ids = {m.id for m in tail}
+        active_tail = self._active_turn_tail(agent)
+        active_ids = {m.id for m in active_tail}
         middle = [
             m
             for m in real(to_compress[self._pinned :])
-            if m.id not in tail_ids
+            if m.id not in tail_ids and m.id not in active_ids
         ]
         if not middle:
             return
+        if active_tail:
+            head_ids = {m.id for m in head}
+            active_tail = [
+                m for m in active_tail if m.id not in head_ids
+            ]
+            kept_ids = set(active_ids)
+            tail = [m for m in tail if m.id not in kept_ids]
+            tail.extend(active_tail)
 
         # 3b) Optional legacy archive of the evicted turns (opt-in). The full
         #     turns are already durable in history.db; this is a redundant
@@ -316,6 +326,29 @@ class ScrollContextManager:
                 self._seq_by_id[mid] = (min(lo, seq), max(hi, seq))
 
     # -- eviction ------------------------------------------------------------
+
+    def _active_turn_tail(self, agent: Any) -> list[Msg]:
+        """Return the current user turn and its in-progress assistant tail.
+
+        AgentScope's token-based split may evict the latest user request when
+        a long tool-running turn exceeds the reserve budget. Under scroll that
+        is unsafe: the model then only sees the eviction index and may answer
+        an older pinned message instead of the active task. Keep the latest
+        real user message and everything after it live until the turn finishes.
+        """
+        context = list(getattr(agent.state, "context", []) or [])
+        for idx in range(len(context) - 1, -1, -1):
+            msg = context[idx]
+            mid = getattr(msg, "id", None)
+            if mid in self._synthetic_ids:
+                continue
+            if getattr(msg, "role", None) == "user":
+                return [
+                    m
+                    for m in context[idx:]
+                    if getattr(m, "id", None) not in self._synthetic_ids
+                ]
+        return []
 
     def _rebuild_context(
         self,

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -197,9 +197,7 @@ class ScrollContextManager:
             return
         if active_tail:
             head_ids = {m.id for m in head}
-            active_tail = [
-                m for m in active_tail if m.id not in head_ids
-            ]
+            active_tail = [m for m in active_tail if m.id not in head_ids]
             kept_ids = set(active_ids)
             tail = [m for m in tail if m.id not in kept_ids]
             tail.extend(active_tail)


### PR DESCRIPTION
# 避免 scroll 压缩折叠当前 active turn

## 背景

我在使用 QwenPaw `v2.0.0b2` 的 `scroll` 上下文策略时，遇到一次比较严重的上下文错乱。

具体表现是：用户发送 `/heartbeat` 后，QwenPaw 已经开始执行心跳任务，并完成了读取 `HEARTBEAT.md`、读取当天日报、执行 Tavily 搜索等步骤。但在任务后半段触发 scroll 压缩后，当前 `/heartbeat` 任务被折叠进 `conversation_history`，live context 中只保留了较早的一条用户消息「你好呀」和压缩索引。最终模型没有主动 recall 当前任务，而是直接对旧消息「你好呀」生成了闲聊回复。

这导致用户看到的结果像是模型“失忆”：

```text
用户当前输入：/heartbeat
实际最终回复：你好呀，欧尼酱！今天周四，想起今天要做点啥不？
```

本地排查确认：

- `/heartbeat` 本身和工具结果都已经写入 `history.db`
- 任务没有 timeout
- 任务没有 CancelledError
- 元宝频道没有断连
- 问题发生在 scroll 压缩后，当前 active turn 没有留在 live context 中

## 问题原因

当前 scroll 压缩逻辑大致是：

```text
head = pinned head
tail = AgentScope 根据 reserve_ratio 切出的 recent tail
middle = to_compress[pinned:] - tail
live context = head + compressed index + tail
```

这个策略对普通长对话是合理的，但对工具链较长的 active turn 有风险。

当当前 turn 本身比较长，例如 `/heartbeat` 触发多轮搜索和多次工具调用时，AgentScope 的 token-based split 可能会把当前用户请求和当前 assistant 工具链一起放入 `to_compress`。随后 scroll 会把它们折叠进 index，只在 live context 留下压缩索引。

如果模型没有主动通过 `recall_history_python` 展开这段历史，就可能基于更早的 pinned message 继续生成，从而出现“回复旧消息”的现象。

## 本次修复内容

本 PR 只做第一阶段修复：**保护当前 active turn，避免它被 scroll 压缩驱逐出 live context。**

实现思路：

1. 在 `ScrollContextManager.compress()` 中，仍然先使用 AgentScope 的 `_split_context_for_compression()` 得到 `to_compress` 和 `to_reserve`。
2. 从当前 `agent.state.context` 中找到最后一条真实用户消息。
3. 将这条用户消息以及它之后的所有真实消息视为当前 active turn。
4. 从 `middle` 中排除这些 active turn 消息。
5. 将 active turn 合并回 `tail`，确保压缩后的 live context 仍然包含当前用户请求和当前 assistant 工具链。

修复后，压缩结构变为：

```text
live context = pinned head + compressed index + preserved active turn / recent tail
```

这样即使当前任务中途触发 scroll 压缩，模型在下一次 reasoning 时仍然可以直接看到当前请求，例如 `/heartbeat`，而不会只看到旧消息和一个压缩索引。

## 为什么只做第一阶段

我认为 scroll 压缩方案要真正稳定，最好分三阶段改进：

### 第一阶段：active turn 保护

目标：

- 当前最新 user request 不应被驱逐
- 当前 assistant 工具链不应整体被折叠进 index
- 压缩后 live context 必须保留当前任务的基本连续性

这是本 PR 实现的部分。

它能解决我遇到的核心问题：当前 `/heartbeat` 被折叠后，模型回复旧消息。

### 第二阶段：active-turn summary

active turn 保护虽然能避免任务丢失，但如果当前工具链非常长，完全保留 active turn 可能会带来 token 压力。

更理想的增强是：当 active turn 太长时，生成一个专门的、不可折叠的 active-turn summary，例如：

```text
Current request: /heartbeat
Progress:
- read HEARTBEAT.md
- read HeartBeatLog/2026-07/心跳日报_07-02.md
- ran Tavily searches for ...
Next step:
- continue heartbeat task and produce final heartbeat result
```

这样可以在保留当前任务语义的同时，避免把大量工具结果全部塞回 live context。

### 第三阶段：recall guard / fallback

scroll 的长期价值在于完整历史可召回，但目前 recall 主要依赖模型主动判断。

更稳的方案是增加 guard：

- 如果当前回复依赖被压缩内容，但 live context 中没有当前任务或 active summary，应强制 recall
- 如果 recall 失败，不应继续生成看似确定的回答
- 模型应明确说明无法取回必要上下文，而不是基于旧消息继续回答

这能进一步降低“未 recall 却继续回答”的风险。

## 本 PR 的边界

这次只修第一阶段，也就是 active turn 保护。

我没有实现：

- active-turn summary
- recall guard
- recall 失败 fallback
- 更智能的 index headline
- 更完整的测试矩阵

原因是这些改动涉及更复杂的上下文策略设计、摘要生成策略和 recall 行为约束。我个人能力有限，担心一次性改太多会引入新的问题。因此这次 PR 先提交一个小范围、低风险、能直接修复当前任务丢失问题的补丁。

后续第二、第三阶段，我希望官方维护者或社区中更熟悉 QwenPaw / AgentScope 上下文机制的开发者继续推进。

## 预期收益

这个补丁可以降低以下场景的风险：

- `/heartbeat` 等命令型任务中途触发 scroll 压缩
- 多工具调用任务在最终总结前触发压缩
- 频道会话长期复用后，旧 pinned message 干扰当前任务
- 当前请求被折叠进 history.db 后，模型未 recall 而回复旧消息

修复后，即使 scroll 压缩触发，当前 active turn 仍然留在 live context 中，模型更容易继续完成当前任务。

## 风险和取舍

这个修复的主要取舍是：为了保证当前任务不丢，压缩后可能会多保留一些最新消息。

可能影响：

- 对特别长的 active turn，压缩后的 live context 仍可能较大
- 某些特殊续跑场景中，“最后一条 user message 到末尾”的保护范围可能偏保守

但相比“当前任务被折叠，模型直接回复旧消息”，我认为这是更安全的取舍。

后续如果实现 active-turn summary，可以进一步缓解 token 压力。

## 本地验证

我在本地做了最小模拟验证：

```text
old user: 你好呀
old assistant: 旧回复
current user: /heartbeat
current assistant: 读取 HEARTBEAT.md; Tavily 搜索中
```

模拟 AgentScope split 将当前 turn 放入 `to_compress` 后，修复逻辑会：

```text
middle = old assistant
tail = current user + current assistant
```

也就是说，当前 `/heartbeat` 和当前 assistant 工具链不会再被折叠进 index。

同时本地执行了 Python 语法检查，未发现语法错误。

## 总结

这个 PR 是一个小范围防御性修复：让 scroll 压缩不要驱逐当前 active turn。

它不是 scroll 上下文策略的完整最终形态，只是第一阶段修复。完整改善 scroll 体验，我认为仍需要后续继续实现：

1. active turn 保护
2. active-turn summary
3. recall guard / fallback

本次 PR 只完成第 1 点。第 2、3 点希望官方或社区中更有经验的开发者继续完善。
