### PR TITLE
fix(channel): add consumer timeout and typing auto-stop to prevent agent hang

### DIFF
--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -429,8 +429,34 @@ class ChannelManager:
                     except asyncio.QueueEmpty:
                         break
 
-                # Process batch (with merge logic)
-                await _process_batch(ch, batch)
+                # Process batch (with merge logic), with a generous
+                # timeout to prevent a stuck agent from blocking the
+                # consumer forever (e.g. MCP tool hangs).
+                try:
+                    await asyncio.wait_for(
+                        _process_batch(ch, batch),
+                        timeout=300.0,  # 5 minutes
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "Process batch timed out after 300s: "
+                        "channel=%s session=%s",
+                        channel_id,
+                        session_id[:30],
+                    )
+                    # Attempt to stop typing indicator for WeChat
+                    if hasattr(ch, "_stop_typing_for_user"):
+                        to_handle = ch.get_to_handle_from_request(
+                            ch._payload_to_request(batch[0]),
+                        )
+                        user_id = (
+                            ch._parse_user_id_from_handle(to_handle)
+                            if hasattr(ch, "_parse_user_id_from_handle")
+                            else ""
+                        )
+                        if user_id:
+                            ch._stop_typing_for_user(user_id)
+                    continue
 
                 # Update processed count
                 if self._queue_manager is not None:

--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1634,9 +1634,23 @@ class WeChatChannel(BaseChannel):
         stop_called = False
 
         async def refresh_typing():
-            """Refresh typing indicator every 5 seconds."""
+            """Refresh typing indicator every 5 seconds.
+
+            Auto-stops after MAX_TYPING_SECONDS to prevent the
+            indicator from running forever if the agent hangs.
+            """
             logger.debug("wechat refresh_typing started for %s", user_id)
+            started_at = time.monotonic()
+            MAX_TYPING_SECONDS = 300  # 5 minutes
             while not stop_event.is_set():
+                elapsed = time.monotonic() - started_at
+                if elapsed > MAX_TYPING_SECONDS:
+                    logger.warning(
+                        "wechat refresh_typing: max duration "
+                        "exceeded for %s, auto-stopping",
+                        user_id,
+                    )
+                    break
                 client = self._client
                 if client is None:
                     logger.debug(
@@ -1659,6 +1673,20 @@ class WeChatChannel(BaseChannel):
                     )
                 except asyncio.TimeoutError:
                     pass
+
+            # Auto-send stop typing if we exited due to max duration
+            if not stop_called:
+                client = self._client
+                if client:
+                    try:
+                        await client.sendtyping(
+                            user_id,
+                            ticket,
+                            status=2,
+                        )
+                    except Exception:
+                        pass
+
             logger.debug("wechat refresh_typing stopped for %s", user_id)
 
         # Create the background refresh task.

--- a/src/qwenpaw/app/channels/wechat/channel.py
+++ b/src/qwenpaw/app/channels/wechat/channel.py
@@ -1674,7 +1674,7 @@ class WeChatChannel(BaseChannel):
                 except asyncio.TimeoutError:
                     pass
 
-            # Auto-send stop typing if we exited due to max duration
+            # Auto-send stop typing if stop() wasn't called (e.g. max duration reached)
             if not stop_called:
                 client = self._client
                 if client:


### PR DESCRIPTION
## Summary

Prevent agent hang by adding consumer timeout and typing indicator auto-stop safety net.

Closes #5748

## Changes

- `src/qwenpaw/app/channels/manager.py`: Wrapped `_process_batch` with `asyncio.wait_for` (300s timeout). On timeout, logs error, stops typing indicator, and continues processing next messages.
- `src/qwenpaw/app/channels/wechat/channel.py`: Added `MAX_TYPING_SECONDS = 300` to the `refresh_typing()` loop. Auto-stops typing indicator after 5 minutes even if the agent hangs.

## Testing

- [x] Syntax check passes (`python3 -m py_compile`)
- [x] Timeout path correctly stops typing indicator before continuing