### PR TITLE
fix(console): route plugin market details through link guard

### DIFF
--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
+import { invoke, isTauri } from "@/test/tauri-mock";
+import { MarketPluginList } from "./MarketPluginList";
+
+const hoisted = vi.hoisted(() => ({
+  plugins: [] as MarketPluginEntry[],
+  handleInstall: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en" },
+  }),
+}));
+
+vi.mock("../hooks/useMarketPlugins", () => ({
+  useMarketPlugins: () => ({
+    loading: false,
+    error: null,
+    plugins: hoisted.plugins,
+    total: hoisted.plugins.length,
+    page: 1,
+    pageSize: 20,
+    category: undefined,
+    installingId: null,
+    qwenpawVersion: "2.0.0",
+    isCompatible: () => true,
+    handleSearch: vi.fn(),
+    handleCategoryChange: vi.fn(),
+    handlePageChange: vi.fn(),
+    handleRefresh: vi.fn(),
+    handleInstall: hoisted.handleInstall,
+  }),
+}));
+
+function makePlugin(detailsUrl: string): MarketPluginEntry {
+  return {
+    id: "@agentscope/demo",
+    display_name: "Demo plugin",
+    developer: "AgentScope",
+    owner: "agentscope",
+    version: "1.0.0",
+    logo_url: null,
+    downloads: 10,
+    view_count: 20,
+    details_url: detailsUrl,
+    locales: {
+      en: {
+        description: "Demo description",
+        category: "General",
+      },
+    },
+  };
+}
+
+describe("MarketPluginList", () => {
+  const windowOpen = vi.fn();
+
+  beforeEach(() => {
+    hoisted.plugins.length = 0;
+    hoisted.handleInstall.mockReset();
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+    isTauri.mockReturnValue(false);
+    windowOpen.mockReset();
+    vi.spyOn(window, "open").mockImplementation(windowOpen);
+    window.history.replaceState(null, "", "/");
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("opens plugin details through the shared external-link guard", () => {
+    hoisted.plugins.push(
+      makePlugin("https://platform.agentscope.io/plugins/agentscope/demo"),
+    );
+
+    render(<MarketPluginList onInstalled={vi.fn()} />);
+    fireEvent.click(screen.getByText("pluginManager.marketDetails"));
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://platform.agentscope.io/plugins/agentscope/demo",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("does not open unsupported plugin details URL schemes", () => {
+    hoisted.plugins.push(makePlugin("javascript:alert(1)"));
+
+    render(<MarketPluginList onInstalled={vi.fn()} />);
+    fireEvent.click(screen.getByText("pluginManager.marketDetails"));
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -13,6 +13,7 @@ import {
 } from "antd";
 import { Download, ExternalLink, Package, RefreshCw } from "lucide-react";
 import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
+import { openExternalLink } from "@/utils/openExternalLink";
 import { useMarketPlugins } from "../hooks/useMarketPlugins";
 import styles from "./OfficialPluginList.module.less";
 import marketStyles from "./MarketPluginList.module.less";
@@ -225,7 +226,7 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
                     type="default"
                     size="small"
                     icon={<ExternalLink size={14} />}
-                    onClick={() => window.open(entry.details_url!, "_blank")}
+                    onClick={() => openExternalLink(entry.details_url!)}
                   >
                     {t("pluginManager.marketDetails")}
                   </Button>


### PR DESCRIPTION
﻿## Description

### What Problem This Solves

Fixes an issue where the plugin market Details button opened a market-provided `details_url` with `window.open()` directly instead of using the console's shared external-link guard.

The rest of the console already has a centralized external-link path in `openExternalLink()`. That helper is the "front gate" for outbound links: it validates supported protocols, applies `noopener,noreferrer` for browser opens, and routes desktop opens through the Tauri/pywebview-aware opener.

Before this change, the plugin market Details button had a small side door:

```tsx
window.open(entry.details_url!, "_blank")
```

That meant a plugin market entry could provide a Details URL such as:

```text
javascript:alert(1)
```

and the Details button would pass it straight to `window.open()` instead of following the same no-op guard used by the shared external-link flow.

### Why This Change Was Made

This change keeps the behavior narrow: normal HTTPS plugin detail links still open, but unsupported schemes now stop at the existing external-link allowlist.

The fix does not create a new URL policy. It reuses the helper that the console already trusts for external navigation:

```tsx
openExternalLink(entry.details_url!)
```

That keeps the plugin market surface aligned with the rest of the console, including browser fallback behavior and desktop-specific opener behavior.

### User Impact

Users can still click Details for normal plugin market entries and open the plugin detail page as before.

The difference is that market-provided plugin detail URLs now pass through the same guarded path as other external console links. In practical terms, this avoids a validation bypass on a UI surface whose URL value comes from the plugin market response rather than from local static code.

### Evidence

Added focused regression coverage in `console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx` for both the allowed and blocked paths.

The tests verify that a normal HTTPS details URL opens through the shared guarded path with the expected browser options:

```text
https://platform.agentscope.io/plugins/agentscope/demo
```

Resulting call:

```text
window.open(url, "_blank", "noopener,noreferrer")
```

The tests also verify that an unsupported market-provided URL scheme is blocked:

```text
javascript:alert(1)
```

Result:

```text
window.open is not called
Tauri invoke is not called
```

Existing `openExternalLink.test.ts` coverage continues to validate the helper's unsafe-scheme handling, ambiguous HTTP URLs, browser fallback, Tauri command delegation, and pywebview behavior.

### Possible Call Chain / Impact

```text
User clicks plugin market Details
  -> MarketPluginList Details button
  -> entry.details_url from plugin market response
  -> openExternalLink(...)
  -> protocol validation + runtime-specific opener
```

This PR only changes the plugin market Details button. It does not change plugin installation, compatibility checks, market fetching, plugin metadata parsing, menu links, or the existing external-link helper allowlist.

**Related Issue:** No linked issue; this is a small focused bug fix.

**Security Considerations:** Security-adjacent URL handling. This does not add new allowed protocols; it reuses the existing `openExternalLink` allowlist and runtime-specific opener behavior for market-provided plugin detail URLs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Focused unit coverage:

- `MarketPluginList.test.tsx` verifies the Details button still opens a normal HTTPS plugin details URL through the shared external-link path.
- `MarketPluginList.test.tsx` verifies an unsupported market-provided URL scheme such as `javascript:alert(1)` does not call `window.open()` or the Tauri invoke path.
- Existing `openExternalLink.test.ts` continues to cover unsafe schemes, ambiguous HTTP URLs, browser fallback, Tauri command delegation, and pywebview behavior.

## Local Verification Evidence

```powershell
cd console
npm ci
```

Completed successfully. npm reported existing dependency/audit warnings, but install completed.

```powershell
npx prettier --check src/pages/Settings/PluginManager/components/MarketPluginList.tsx src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
```

Passed:

```text
All matched files use Prettier code style!
```

```powershell
npx tsc -b --noEmit
```

Passed.

```powershell
$env:NODE_OPTIONS='--max-old-space-size=4096'
npx vitest run src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx src/utils/openExternalLink.test.ts
```

Passed:

```text
Test Files  2 passed (2)
Tests       25 passed (25)
```

```powershell
git diff --check
```

Passed.

Full `npm run format:check` was not used as passing evidence because the current repository reports existing Prettier warnings across many unrelated files.

## Additional Notes

Other direct `window.open` call sites still exist in the console, but they are separate surfaces. This PR intentionally stays scoped to the plugin market `details_url` path because that value comes from the market API response and already has a shared helper available for protocol validation and runtime-specific handling.
