### PR TITLE
fix(chat): prioritize built-in slash commands

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2394,6 +2394,11 @@ export default function ChatPage() {
     const i18nConfig = getDefaultConfig(t);
     const commandSuggestions: CommandSuggestion[] = [
       {
+        command: "/new",
+        value: "new",
+        description: "",
+      },
+      {
         command: "/clear",
         value: "clear",
         description: t("chat.commands.clear.description"),
@@ -2420,7 +2425,7 @@ export default function ChatPage() {
       },
     ];
     const reservedCommands = new Set(
-      commandSuggestions.map((item) => item.value.trim()),
+      commandSuggestions.map((item) => item.command.slice(1).trim()),
     );
     const loopSkillNames = new Set(
       useLoopStore.getState().availableSkills.map((s) => s.name),


### PR DESCRIPTION
## Description

Fixes the chat slash-command suggestion conflict where typing an exact built-in command such as `/new` could be autocompleted to a longer skill command like `/news`.

This PR keeps the change scoped to the existing chat suggestion logic:
- Adds `/new` to the built-in chat command suggestions.
- Reserves built-in command names using the displayed slash command name instead of the internal suggestion value, so skill suggestions such as `/news` cannot override exact built-in commands.

## Type of Change

- Bug fix

## Components Affected

- Console

## Testing

```bash
PATH=/home/guoziyang/.nvm/versions/node/v24.15.0/bin:$PATH npm run format:check
# tsc -b --noEmit passed
# All matched files use Prettier code style
```

## Checklist

- [x] Ran formatting/type checks
- [x] Kept the diff scoped to chat slash-command suggestions

Closes #5529
