### PR TITLE
fix(config): make agent resilient to invalid MCP client config

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1613,6 +1613,8 @@ class MCPClientConfig(BaseModel):
         if isinstance(raw_transport, str):
             normalized = raw_transport.strip().lower()
             transport_alias_map = {
+                "streamable_http": "streamable_http",
+                "streamable-http": "streamable_http",
                 "streamablehttp": "streamable_http",
                 "http": "streamable_http",
                 "stdio": "stdio",
@@ -2365,6 +2367,13 @@ def load_agent_config(  # pylint: disable=too-many-branches,too-many-statements
             data = _normalize_working_dir_bound_paths(data)
         except Exception:
             pass
+
+        # Pre-validate MCP clients: skip invalid ones so a
+        # single misconfigured MCP client does not prevent the
+        # entire agent from loading.
+        from .utils import sanitize_mcp_clients
+
+        sanitize_mcp_clients(data, agent_id)
 
         agent_config = AgentProfileConfig(**data)
 

--- a/src/qwenpaw/config/utils.py
+++ b/src/qwenpaw/config/utils.py
@@ -890,3 +890,41 @@ def is_qwenpaw_running() -> bool:
 
     except Exception:
         return False
+
+
+def sanitize_mcp_clients(
+    data: dict,
+    agent_id: str,
+) -> None:
+    """Drop invalid MCP client entries in-place.
+
+    Iterates over ``data["mcp"]["clients"]`` and removes
+    entries that fail ``MCPClientConfig`` validation so that
+    one broken MCP client does not prevent the whole agent
+    from loading.
+    """
+    from .config import MCPClientConfig
+
+    mcp = data.get("mcp")
+    if not isinstance(mcp, dict):
+        return
+    clients = mcp.get("clients")
+    if not isinstance(clients, dict):
+        return
+    bad_keys: list[str] = []
+    for key, val in clients.items():
+        if not isinstance(val, dict):
+            bad_keys.append(key)
+            continue
+        try:
+            MCPClientConfig.model_validate(
+                {**val, "name": key},
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"Agent '{agent_id}': skipping invalid "
+                f"MCP client '{key}': {exc}",
+            )
+            bad_keys.append(key)
+    for key in bad_keys:
+        del clients[key]


### PR DESCRIPTION
## Description

A single misconfigured MCP client (e.g. `"transport": "streamable-http"` instead of `"streamable_http"`) causes the entire `AgentProfileConfig` Pydantic validation to fail. Because Pydantic v2's `ValidationError` inherits from `ValueError`, the `GET /api/agents/{agentId}` endpoint catches it as a 404, which blocks the frontend from loading the agent and prevents all chat functionality.

This PR applies two layers of defense:

1. **Transport alias**: add `"streamable-http"` (and the canonical `"streamable_http"`) to the transport alias map in `MCPClientConfig._normalize_legacy_fields`. This is the most commonly encountered variant — reported as issues in Claude Code ([#45836](https://github.com/anthropics/claude-code/issues/45836)) and Cursor forum alike.

2. **Config resilience**: introduce `sanitize_mcp_clients()` in `config/utils.py`, called by `load_agent_config()` before constructing `AgentProfileConfig`. It pre-validates each MCP client entry individually; invalid entries are dropped with a warning log rather than crashing the entire agent config load.

**Root cause chain:**

```
user writes "streamable-http" in agent.json
  → MCPClientConfig Literal validation fails
    → AgentProfileConfig(**data) raises ValidationError (subclass of ValueError)
      → agents router catches ValueError → HTTP 404
        → frontend cannot load agent → chat completely broken
```

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Changes

### `src/qwenpaw/config/config.py`

- Added `"streamable_http"` and `"streamable-http"` to `transport_alias_map` in `MCPClientConfig._normalize_legacy_fields`
- Added call to `sanitize_mcp_clients()` in `load_agent_config()` before `AgentProfileConfig(**data)`

### `src/qwenpaw/config/utils.py`

- Added `sanitize_mcp_clients(data, agent_id)` function that iterates over MCP client entries, validates each individually, and removes invalid ones with a warning log

### `tests/unit/config/test_mcp_config_resilience.py`

- 9 parametrized tests for transport alias normalization (stdio, sse, streamable_http, streamable-http, Streamable-HTTP, STREAMABLE-HTTP, streamablehttp, http, HTTP)
- 5 tests for `sanitize_mcp_clients` (valid kept, invalid dropped, no-mcp noop, non-dict noop, non-dict entry dropped)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest`) and they pass (14/14)
- [x] Ready for review

## Testing

```bash
# Run the new tests
pytest tests/unit/config/test_mcp_config_resilience.py -v

# Reproduce the original bug (before fix):
# 1. Add an MCP client with "transport": "streamable-http" in agent.json
# 2. Try to load the agent via API → 404
# After fix: agent loads normally, bad MCP client is skipped with warning
```

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/config/config.py src/qwenpaw/config/utils.py
# All checks passed

pytest tests/unit/config/test_mcp_config_resilience.py -v
# 14 passed in 0.10s
```
