### PR TITLE
fix(website): update blog developer day collection and add blog GA tracking

### DIFF
--- a/website/public/blog/qwenpaw-developer-day-collection.en.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.en.md
@@ -1,15 +1,19 @@
 ---
 title: "QwenPaw Developer Day Collection"
-date: 2026-07-01
+date: 2026-07-02
 author: QwenPaw Team
 tags: [QwenPaw, developer-day]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "Replay archive from QwenPaw developer day sessions — in-depth technical talks and practical insights for every QwenPaw developer and enthusiast."
 ---
 
-Last updated June 30, 2026
+Last updated July 2, 2026
 
 ---
+
+**07-02 QwenPaw Developer Day: QwenPaw 2.0 Runtime Deep Dive**
+
+Meeting link: https://shanji.dingtalk.com/app/transcribes/76327569643334393537303636305f323034353035363233375f30
 
 **06-30 QwenPaw Developer Day: QwenPaw 2.0 Driver Deep Dive**
 

--- a/website/public/blog/qwenpaw-developer-day-collection.zh.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.zh.md
@@ -1,15 +1,19 @@
 ---
 title: "QwenPaw 开发者日会合集"
-date: 2026-06-30
+date: 2026-07-02
 author: QwenPaw Team
 tags: [QwenPaw, 日会合集]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "QwenPaw团队召开开发者日会，为每一位 QwenPaw 开发者与爱好者提供一份兼具理论深度与落地价值的完整技术交流档案。"
 ---
 
-最近更新 2026 年 6 月 30 日
+最近更新 2026 年 7 月 2 日
 
 ---
+
+**07-02 QwenPaw 开发者日会：QwenPaw 2.0 Runtime 模块详解**
+
+会议链接：https://shanji.dingtalk.com/app/transcribes/76327569643334393537303636305f323034353035363233375f30
 
 **06-30 QwenPaw 开发者日会：QwenPaw 2.0 Driver 模块详解**
 

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from "react-i18next";
 import { loadSiteConfig, type SiteConfig, defaultConfig } from "@/config";
 import { SiteConfigProvider } from "@/config-context";
 import { SiteLayout } from "@/components/SiteLayout";
+import { GA_ID, loadGoogleAnalytics } from "@/lib/analytics";
 import "@/index.css";
-
-const GA_ID = "G-BEX1XSB9KE";
 
 // Lazy load page components for better performance
 const Home = lazy(() => import("@/pages/Home"));
@@ -15,69 +14,6 @@ const Blog = lazy(() => import("@/pages/Blog"));
 const BlogPost = lazy(() => import("@/pages/Blog/Post"));
 const ReleaseNotes = lazy(() => import("@/pages/ReleaseNotes"));
 const Downloads = lazy(() => import("@/pages/Downloads"));
-
-declare global {
-  interface Window {
-    dataLayer: unknown[];
-    gtag?: (...args: unknown[]) => void;
-  }
-}
-
-/**
- * Load Google Analytics script asynchronously
- * @param id - Google Analytics measurement ID
- */
-function loadGoogleAnalytics(id: string) {
-  // Skip if already loaded or in development
-  if (window.gtag || import.meta.env.DEV) {
-    if (import.meta.env.DEV) {
-      console.log("[GA] Skipped in development environment");
-    }
-    return;
-  }
-
-  console.log("[GA] Starting to load Google Analytics...");
-
-  // Initialize dataLayer
-  window.dataLayer = window.dataLayer || [];
-  function gtag(...args: unknown[]) {
-    window.dataLayer.push(args);
-  }
-  window.gtag = gtag;
-
-  // Configure GA
-  gtag("js", new Date());
-  gtag("config", id);
-
-  // Load GA script with timeout protection
-  const script = document.createElement("script");
-  script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
-  script.async = true;
-
-  let isLoaded = false;
-  const timeoutId = setTimeout(() => {
-    if (!isLoaded) {
-      console.warn("[GA] Load timeout - removing script");
-      script.remove();
-      delete window.gtag;
-    }
-  }, 6000);
-
-  script.onload = () => {
-    isLoaded = true;
-    clearTimeout(timeoutId);
-    console.log("[GA] Loaded successfully");
-  };
-
-  script.onerror = () => {
-    isLoaded = true;
-    clearTimeout(timeoutId);
-    console.warn("[GA] Failed to load (may be blocked)");
-    delete window.gtag;
-  };
-
-  document.head.appendChild(script);
-}
 
 /**
  * Initial loading fallback component

--- a/website/src/components/ScrollToTop.tsx
+++ b/website/src/components/ScrollToTop.tsx
@@ -1,14 +1,22 @@
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { trackPageView } from "@/lib/analytics";
+
+const BLOG_POST_PATH = /^\/blog\/[^/]+$/;
 
 /** Reset window scroll on route change (SPA default keeps previous scroll position). */
 export function ScrollToTop() {
-  const { pathname, hash } = useLocation();
+  const { pathname, hash, search } = useLocation();
 
   useEffect(() => {
     if (hash) return;
     window.scrollTo(0, 0);
   }, [pathname, hash]);
+
+  useEffect(() => {
+    if (BLOG_POST_PATH.test(pathname)) return;
+    trackPageView(`${pathname}${search}`);
+  }, [pathname, search]);
 
   return null;
 }

--- a/website/src/lib/analytics.ts
+++ b/website/src/lib/analytics.ts
@@ -1,0 +1,93 @@
+export const GA_ID = "G-BEX1XSB9KE";
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/**
+ * Load Google Analytics script asynchronously.
+ * Skipped in development and when gtag is already present.
+ */
+export function loadGoogleAnalytics(id: string) {
+  if (window.gtag || import.meta.env.DEV) {
+    if (import.meta.env.DEV) {
+      console.log("[GA] Skipped in development environment");
+    }
+    return;
+  }
+
+  console.log("[GA] Starting to load Google Analytics...");
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag(...args: unknown[]) {
+    window.dataLayer.push(args);
+  }
+  window.gtag = gtag;
+
+  gtag("js", new Date());
+  gtag("config", id);
+
+  const script = document.createElement("script");
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+  script.async = true;
+
+  let isLoaded = false;
+  const timeoutId = setTimeout(() => {
+    if (!isLoaded) {
+      console.warn("[GA] Load timeout - removing script");
+      script.remove();
+      delete window.gtag;
+    }
+  }, 6000);
+
+  script.onload = () => {
+    isLoaded = true;
+    clearTimeout(timeoutId);
+    console.log("[GA] Loaded successfully");
+  };
+
+  script.onerror = () => {
+    isLoaded = true;
+    clearTimeout(timeoutId);
+    console.warn("[GA] Failed to load (may be blocked)");
+    delete window.gtag;
+  };
+
+  document.head.appendChild(script);
+}
+
+/** Report a SPA route change as a page view. */
+export function trackPageView(pagePath: string, pageTitle?: string) {
+  if (!window.gtag) return;
+
+  window.gtag("config", GA_ID, {
+    page_path: pagePath,
+    ...(pageTitle ? { page_title: pageTitle } : {}),
+  });
+}
+
+/** Record a blog article page view with article metadata. */
+export function trackBlogPostView(params: {
+  slug: string;
+  title: string;
+  lang: string;
+}) {
+  if (!window.gtag) return;
+
+  const pagePath = `/blog/${params.slug}`;
+
+  window.gtag("config", GA_ID, {
+    page_path: pagePath,
+    page_title: params.title,
+  });
+
+  window.gtag("event", "blog_view", {
+    blog_slug: params.slug,
+    blog_title: params.title,
+    blog_lang: params.lang,
+    page_path: pagePath,
+  });
+}

--- a/website/src/pages/Blog/Post.tsx
+++ b/website/src/pages/Blog/Post.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/parseBlogMarkdown";
 import { MermaidBlock } from "@/components/MermaidBlock";
 import { ImageZoom } from "@/components/ImageZoom";
+import { trackBlogPostView } from "@/lib/analytics";
 
 /** Turn plain "Meeting link: https://…" lines into markdown links for session lists. */
 function linkifySessionUrls(body: string): string {
@@ -82,6 +83,11 @@ export default function BlogPost() {
         setPost(null);
       } else {
         setPost(parsed);
+        trackBlogPostView({
+          slug,
+          title: parsed.frontmatter.title,
+          lang: isZh ? "zh" : "en",
+        });
       }
       setLoading(false);
     });


### PR DESCRIPTION
## Summary

- 更新 QwenPaw 开发者日会合集博客（中/英），新增 **07-02 Runtime 模块详解** 场次及会议链接，并将文章日期与「最近更新」时间调整为 2026-07-02
- 将 Google Analytics 逻辑从 `App.tsx` 抽离至 `lib/analytics.ts`，便于复用
- 在 SPA 路由切换时上报普通页面浏览（`ScrollToTop`），博客详情页单独上报 `blog_view` 事件，携带 slug、标题、语言等元数据

## Changes

| 区域 | 说明 |
|------|------|
| `public/blog/qwenpaw-developer-day-collection.{en,zh}.md` | 新增 07-02 场次，更新 frontmatter 日期 |
| `src/lib/analytics.ts` | 新增 GA 加载、`trackPageView`、`trackBlogPostView` |
| `src/components/ScrollToTop.tsx` | 非博客详情页路由变化时上报 page view |
| `src/pages/Blog/Post.tsx` | 文章加载成功后上报 `blog_view` 事件 |
| `src/App.tsx` | 移除内联 GA 代码，改为引用 `analytics` 模块 |

## Test plan

- [ ] 本地访问 `/blog/qwenpaw-developer-day-collection`，确认 07-02 场次及会议链接正常展示（中/英）
- [ ] 生产环境打开任意非博客页面，切换路由，确认 GA 收到 page view（可用浏览器 Network 或 GA DebugView）
- [ ] 打开一篇博客详情页，确认上报 `blog_view` 事件，且 `blog_slug` / `blog_title` / `blog_lang` 字段正确
- [ ] 确认开发环境（`import.meta.env.DEV`）不加载 GA 脚本