### PR TITLE
fix(agents): surface malformed tool-call input to model

### DIFF
--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -91,7 +91,8 @@ def _coerce_raw_tool_input(raw: str, block: Any) -> str | None:
         # for no-param tool calls: "{}trailing" raises "Extra data", but
         # raw_decode can recover the leading valid object.
         try:
-            recovered, _ = _json_decoder.raw_decode(raw)
+            start = json.decoder.WHITESPACE.match(raw, 0).end()
+            recovered, _ = _json_decoder.raw_decode(raw, start)
             if not isinstance(recovered, dict):
                 raise json.JSONDecodeError(
                     "recovered value is not a JSON object",

--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -78,47 +78,6 @@ def _tool_call_json_error_result(block: Any) -> Any | None:
     )
 
 
-def _coerce_raw_tool_input(raw: str, block: Any) -> str | None:
-    """Return a JSON string for raw tool input, or None if unrecoverable."""
-    try:
-        json.loads(raw)
-        return raw
-    except (json.JSONDecodeError, ValueError) as exc:
-        if raw == "":
-            return "{}"
-
-        # Some models (e.g. DeepSeek-V4-Flash) append garbage after valid JSON
-        # for no-param tool calls: "{}trailing" raises "Extra data", but
-        # raw_decode can recover the leading valid object.
-        try:
-            start = json.decoder.WHITESPACE.match(raw, 0).end()
-            recovered, _ = _json_decoder.raw_decode(raw, start)
-            if not isinstance(recovered, dict):
-                raise json.JSONDecodeError(
-                    "recovered value is not a JSON object",
-                    raw,
-                    0,
-                ) from exc
-        except (json.JSONDecodeError, ValueError):
-            logger.warning(
-                "tool_call input is not valid JSON; "
-                "marking call failed with synthetic result: id=%r, name=%r, "
-                "input_preview=%s",
-                _block_attr(block, "id"),
-                _block_attr(block, "name"),
-                repr(raw[:120]),
-            )
-            return None
-
-    logger.info(
-        "tool_call input had trailing garbage; recovered via raw_decode: "
-        "id=%r, name=%r",
-        _block_attr(block, "id"),
-        _block_attr(block, "name"),
-    )
-    return json.dumps(recovered, ensure_ascii=False)
-
-
 def extract_tool_ids(msg) -> tuple[set[str], set[str]]:
     """Return (tool_call_ids, tool_result_ids) found in a single message.
 
@@ -172,6 +131,17 @@ def _reorder_tool_results(msgs: list) -> list:
     result_msg_ids: set[int] = set()
     for msg in msgs:
         if isinstance(msg.content, list):
+            # Keep a message that carries its own tool_call in place (e.g. an
+            # AgentScope 2.0 self-paired assistant msg
+            # [text, tool_call, tool_result]); only standalone tool_result
+            # messages are movable. Skipping a self-carrying msg here would
+            # drop it, since its own tool_call can never re-insert it.
+            has_own_call = any(
+                _is_tool_call(block) and _block_attr(block, "id")
+                for block in msg.content
+            )
+            if has_own_call:
+                continue
             for block in msg.content:
                 if _is_tool_result(block) and _block_attr(block, "id"):
                     results_by_id.setdefault(
@@ -216,16 +186,24 @@ def _remove_unpaired_tool_messages(msgs: list) -> list:
 
     i = 0
     while i < len(msgs):
-        use_ids, _ = extract_tool_ids(msgs[i])
+        use_ids, own_results = extract_tool_ids(msgs[i])
         if not use_ids:
             i += 1
             continue
-        required = set(use_ids)
+        # A self-paired message satisfies (some of) its own tool_calls with the
+        # tool_results in the same message; only the remainder must be covered
+        # by following messages.
+        required = set(use_ids) - own_results
         j = i + 1
         result_indices: list[int] = []
         while j < len(msgs) and required:
-            _, r = extract_tool_ids(msgs[j])
+            uj, r = extract_tool_ids(msgs[j])
             if not r:
+                break
+            # A following message that also carries tool_calls (e.g. another
+            # self-paired turn) is not a result-provider for this one; stop
+            # rather than consuming it.
+            if uj:
                 break
             required -= r
             result_indices.append(j)
@@ -245,8 +223,10 @@ def _remove_unpaired_tool_messages(msgs: list) -> list:
     for idx, msg in enumerate(msgs):
         if idx in to_remove:
             continue
-        _, r = extract_tool_ids(msg)
-        if r and not r.issubset(surviving_use_ids):
+        u, r = extract_tool_ids(msg)
+        # A tool_result is paired if some surviving tool_call uses its id --
+        # including a tool_call in the same (self-paired) message.
+        if r and not r.issubset(surviving_use_ids | u):
             to_remove.add(idx)
 
     return [msg for idx, msg in enumerate(msgs) if idx not in to_remove]
@@ -385,7 +365,14 @@ def _repair_empty_tool_inputs(
                         try:
                             parsed = json.loads(raw_str)
                         except json.JSONDecodeError:
-                            parsed, _ = _json_decoder.raw_decode(raw_str)
+                            start = json.decoder.WHITESPACE.match(
+                                raw_str,
+                                0,
+                            ).end()
+                            parsed, _ = _json_decoder.raw_decode(
+                                raw_str,
+                                start,
+                            )
                         if isinstance(parsed, dict) and parsed:
                             # All agentscope 2.0 formatters expect
                             # ToolCallBlock.input to be a JSON string
@@ -425,7 +412,7 @@ def _repair_empty_tool_inputs(
     return result if changed else msgs
 
 
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches,too-many-statements
 def _coerce_tool_inputs_to_json(msgs: list) -> list:
     """Ensure every tool_call block's ``input`` field is a valid JSON string.
 
@@ -480,11 +467,52 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
             coerced_input: str = raw if isinstance(raw, str) else "{}"
 
             if isinstance(raw, str):
-                coerced = _coerce_raw_tool_input(raw, block)
-                if coerced is None:
-                    drop_block = True
-                else:
-                    coerced_input = coerced
+                try:
+                    json.loads(raw)
+                    coerced_input = raw  # already a valid JSON string
+                except (json.JSONDecodeError, ValueError) as exc:
+                    if raw == "":
+                        coerced_input = "{}"
+                    else:
+                        # Some models (e.g. DeepSeek-V4-Flash) append garbage
+                        # after valid JSON for no-param tool calls: "{
+                        # }trailing" json.loads raises "Extra data" but
+                        # raw_decode can recover the leading valid object.
+                        try:
+                            start = json.decoder.WHITESPACE.match(
+                                raw,
+                                0,
+                            ).end()
+                            recovered, _ = _json_decoder.raw_decode(
+                                raw,
+                                start,
+                            )
+                            if not isinstance(recovered, dict):
+                                raise json.JSONDecodeError(
+                                    "recovered value is not a JSON object",
+                                    raw,
+                                    0,
+                                ) from exc
+                            coerced_input = json.dumps(
+                                recovered,
+                                ensure_ascii=False,
+                            )
+                            logger.info(
+                                "tool_call input had trailing garbage; "
+                                "recovered via raw_decode: id=%r, name=%r",
+                                _block_attr(block, "id"),
+                                _block_attr(block, "name"),
+                            )
+                        except (json.JSONDecodeError, ValueError):
+                            logger.warning(
+                                "tool_call input is not valid JSON; "
+                                "marking call failed with synthetic result: "
+                                "id=%r, name=%r, input_preview=%s",
+                                _block_attr(block, "id"),
+                                _block_attr(block, "name"),
+                                repr(raw[:120]),
+                            )
+                            drop_block = True
             elif isinstance(raw, (dict, list)):
                 coerced_input = json.dumps(raw, ensure_ascii=False)
             else:

--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -34,19 +34,48 @@ def _is_tool_result(block: Any) -> bool:
     return _block_attr(block, "type") in _TOOL_RESULT_TYPES
 
 
-def _tool_call_json_error_text(block: Any) -> dict[str, str]:
+def _tool_call_json_error_text(block: Any) -> str:
     """Build model-visible feedback for an invalid tool-call input."""
     name = str(_block_attr(block, "name") or "unknown")
-    call_id = str(_block_attr(block, "id") or "unknown")
-    return {
-        "type": "text",
-        "text": (
-            f"Tool call `{name}` was not executed because its JSON "
-            "arguments were invalid or incomplete. Please retry with valid "
-            "JSON arguments, and split large payloads into smaller tool "
-            f"calls if needed. (tool_call_id: `{call_id}`)"
-        ),
-    }
+    return (
+        f"Tool call `{name}` was not executed because its JSON "
+        "arguments were invalid or incomplete. Please retry with valid "
+        "JSON arguments, and split large payloads into smaller tool calls "
+        "if needed."
+    )
+
+
+def _mark_tool_call_as_failed(block: Any) -> None:
+    """Keep a failed tool_call in the request with safe empty input."""
+    if isinstance(block, dict):
+        block["input"] = "{}"
+        block["state"] = "finished"
+        return
+
+    from agentscope.message import ToolCallState
+
+    block.input = "{}"
+    block.state = ToolCallState.FINISHED
+
+
+def _tool_call_json_error_result(block: Any) -> Any | None:
+    """Build a synthetic error result for an invalid tool-call input."""
+    call_id = _block_attr(block, "id")
+    if not call_id:
+        return None
+
+    from agentscope.message import TextBlock, ToolResultBlock, ToolResultState
+
+    name = str(_block_attr(block, "name") or "unknown")
+    return ToolResultBlock(
+        type="tool_result",
+        id=str(call_id),
+        name=name,
+        output=[
+            TextBlock(type="text", text=_tool_call_json_error_text(block)),
+        ],
+        state=ToolResultState.ERROR,
+    )
 
 
 def _coerce_raw_tool_input(raw: str, block: Any) -> str | None:
@@ -72,7 +101,7 @@ def _coerce_raw_tool_input(raw: str, block: Any) -> str | None:
         except (json.JSONDecodeError, ValueError):
             logger.warning(
                 "tool_call input is not valid JSON; "
-                "replacing block with feedback: id=%r, name=%r, "
+                "marking call failed with synthetic result: id=%r, name=%r, "
                 "input_preview=%s",
                 _block_attr(block, "id"),
                 _block_attr(block, "name"),
@@ -410,17 +439,20 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
     * ``dict`` / ``list`` → ``json.dumps``.
     * Empty string ``""`` → ``"{}"`` (treat as no-args call).
     * Non-empty non-JSON string (e.g. truncated streaming artefact) →
-      replace the tool call with model-visible text feedback so the next
-      request can see the failed call.  Replacing with ``{}`` would cause the
-      tool to be called with wrong/empty arguments, which is worse.
+      keep the call with safe empty input and append a synthetic error
+      ``tool_result`` so the next request sees a normal tool_call/tool_result
+      pair instead of retrying the bad arguments.
     """
+    malformed_tool_ids: set[str] = set()
+    kept_msgs: list = []
+
     for msg in msgs:
         if not isinstance(getattr(msg, "content", None), list):
+            kept_msgs.append(msg)
             continue
 
         new_blocks: list = []
         changed_this_msg = False
-        malformed_tool_ids: set[str] = set()
 
         for block in msg.content:
             if (
@@ -462,7 +494,11 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
                 block_id = _block_attr(block, "id")
                 if block_id:
                     malformed_tool_ids.add(block_id)
-                new_blocks.append(_tool_call_json_error_text(block))
+                _mark_tool_call_as_failed(block)
+                new_blocks.append(block)
+                error_result = _tool_call_json_error_result(block)
+                if error_result is not None:
+                    new_blocks.append(error_result)
                 changed_this_msg = True
                 continue
 
@@ -477,8 +513,12 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
 
         if changed_this_msg:
             msg.content = new_blocks
+            if not new_blocks:
+                continue
 
-    return msgs
+        kept_msgs.append(msg)
+
+    return kept_msgs if len(kept_msgs) != len(msgs) else msgs
 
 
 def _sanitize_tool_messages(msgs: list) -> list:

--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -34,6 +34,61 @@ def _is_tool_result(block: Any) -> bool:
     return _block_attr(block, "type") in _TOOL_RESULT_TYPES
 
 
+def _tool_call_json_error_text(block: Any) -> dict[str, str]:
+    """Build model-visible feedback for an invalid tool-call input."""
+    name = str(_block_attr(block, "name") or "unknown")
+    call_id = str(_block_attr(block, "id") or "unknown")
+    return {
+        "type": "text",
+        "text": (
+            f"Tool call `{name}` was not executed because its JSON "
+            "arguments were invalid or incomplete. Please retry with valid "
+            "JSON arguments, and split large payloads into smaller tool "
+            f"calls if needed. (tool_call_id: `{call_id}`)"
+        ),
+    }
+
+
+def _coerce_raw_tool_input(raw: str, block: Any) -> str | None:
+    """Return a JSON string for raw tool input, or None if unrecoverable."""
+    try:
+        json.loads(raw)
+        return raw
+    except (json.JSONDecodeError, ValueError) as exc:
+        if raw == "":
+            return "{}"
+
+        # Some models (e.g. DeepSeek-V4-Flash) append garbage after valid JSON
+        # for no-param tool calls: "{}trailing" raises "Extra data", but
+        # raw_decode can recover the leading valid object.
+        try:
+            recovered, _ = _json_decoder.raw_decode(raw)
+            if not isinstance(recovered, dict):
+                raise json.JSONDecodeError(
+                    "recovered value is not a JSON object",
+                    raw,
+                    0,
+                ) from exc
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(
+                "tool_call input is not valid JSON; "
+                "replacing block with feedback: id=%r, name=%r, "
+                "input_preview=%s",
+                _block_attr(block, "id"),
+                _block_attr(block, "name"),
+                repr(raw[:120]),
+            )
+            return None
+
+    logger.info(
+        "tool_call input had trailing garbage; recovered via raw_decode: "
+        "id=%r, name=%r",
+        _block_attr(block, "id"),
+        _block_attr(block, "name"),
+    )
+    return json.dumps(recovered, ensure_ascii=False)
+
+
 def extract_tool_ids(msg) -> tuple[set[str], set[str]]:
     """Return (tool_call_ids, tool_result_ids) found in a single message.
 
@@ -355,9 +410,9 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
     * ``dict`` / ``list`` → ``json.dumps``.
     * Empty string ``""`` → ``"{}"`` (treat as no-args call).
     * Non-empty non-JSON string (e.g. truncated streaming artefact) →
-      **drop the block** so ``_remove_unpaired_tool_messages`` can clean up
-      the orphaned tool_result.  Replacing with ``{}`` would cause the tool
-      to be called with wrong/empty arguments, which is worse.
+      replace the tool call with model-visible text feedback so the next
+      request can see the failed call.  Replacing with ``{}`` would cause the
+      tool to be called with wrong/empty arguments, which is worse.
     """
     for msg in msgs:
         if not isinstance(getattr(msg, "content", None), list):
@@ -365,8 +420,20 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
 
         new_blocks: list = []
         changed_this_msg = False
+        malformed_tool_ids: set[str] = set()
 
         for block in msg.content:
+            if (
+                _is_tool_result(block)
+                and _block_attr(
+                    block,
+                    "id",
+                )
+                in malformed_tool_ids
+            ):
+                changed_this_msg = True
+                continue
+
             if not _is_tool_call(block):
                 new_blocks.append(block)
                 continue
@@ -380,45 +447,11 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
             coerced_input: str = raw if isinstance(raw, str) else "{}"
 
             if isinstance(raw, str):
-                try:
-                    json.loads(raw)
-                    coerced_input = raw  # already a valid JSON string
-                except (json.JSONDecodeError, ValueError) as exc:
-                    if raw == "":
-                        coerced_input = "{}"
-                    else:
-                        # Some models (e.g. DeepSeek-V4-Flash) append garbage
-                        # after valid JSON for no-param tool calls: "{
-                        # }trailing" json.loads raises "Extra data" but
-                        # raw_decode can recover the leading valid object.
-                        try:
-                            recovered, _ = _json_decoder.raw_decode(raw)
-                            if not isinstance(recovered, dict):
-                                raise json.JSONDecodeError(
-                                    "recovered value is not a JSON object",
-                                    raw,
-                                    0,
-                                ) from exc
-                            coerced_input = json.dumps(
-                                recovered,
-                                ensure_ascii=False,
-                            )
-                            logger.info(
-                                "tool_call input had trailing garbage; "
-                                "recovered via raw_decode: id=%r, name=%r",
-                                _block_attr(block, "id"),
-                                _block_attr(block, "name"),
-                            )
-                        except (json.JSONDecodeError, ValueError):
-                            logger.warning(
-                                "tool_call input is not valid JSON; "
-                                "dropping block: id=%r, name=%r, "
-                                "input_preview=%s",
-                                _block_attr(block, "id"),
-                                _block_attr(block, "name"),
-                                repr(raw[:120]),
-                            )
-                            drop_block = True
+                coerced = _coerce_raw_tool_input(raw, block)
+                if coerced is None:
+                    drop_block = True
+                else:
+                    coerced_input = coerced
             elif isinstance(raw, (dict, list)):
                 coerced_input = json.dumps(raw, ensure_ascii=False)
             else:
@@ -426,8 +459,12 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
                 coerced_input = "{}"
 
             if drop_block:
+                block_id = _block_attr(block, "id")
+                if block_id:
+                    malformed_tool_ids.add(block_id)
+                new_blocks.append(_tool_call_json_error_text(block))
                 changed_this_msg = True
-                continue  # omit from new_blocks
+                continue
 
             if coerced_input != raw:
                 if isinstance(block, dict):

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -14,6 +14,14 @@ Covers:
 import json
 from unittest.mock import MagicMock
 
+from agentscope.message import (
+    TextBlock,
+    ToolCallBlock,
+    ToolCallState,
+    ToolResultBlock,
+    ToolResultState,
+)
+
 from qwenpaw.agents.utils.tool_message_utils import (
     _coerce_tool_inputs_to_json,
     _dedup_tool_blocks,
@@ -52,6 +60,27 @@ def _text_blocks(msg):
         for block in msg.content
         if isinstance(block, dict) and block.get("type") == "text"
     ]
+
+
+def _tool_result_blocks(msg):
+    return [
+        block
+        for block in msg.content
+        if isinstance(block, ToolResultBlock)
+        or (isinstance(block, dict) and block.get("type") == "tool_result")
+    ]
+
+
+def _first_text(block):
+    output = getattr(block, "output", [])
+    first = output[0]
+    if isinstance(first, TextBlock):
+        return first.text
+    return first["text"]
+
+
+def _state_value(state):
+    return getattr(state, "value", state)
 
 
 # ---------------------------------------------------------------------------
@@ -420,7 +449,7 @@ class TestCoerceToolInputsRawDecode:
         assert len(result[0].content) == 1
         assert json.loads(result[0].content[0]["input"]) == {"key": "val"}
 
-    def test_completely_invalid_json_becomes_visible_feedback(self):
+    def test_completely_invalid_json_becomes_error_tool_result(self):
         msg = _msg(
             [
                 {
@@ -432,13 +461,45 @@ class TestCoerceToolInputsRawDecode:
             ],
         )
         result = _coerce_tool_inputs_to_json([msg])
-        texts = _text_blocks(result[0])
-        assert len(texts) == 1
-        assert "Tool call `t` was not executed" in texts[0]["text"]
-        assert "valid JSON arguments" in texts[0]["text"]
-        assert "totally not json" not in texts[0]["text"]
+        assert result[0].content[0]["input"] == "{}"
+        assert result[0].content[0]["state"] == "finished"
+        results = _tool_result_blocks(result[0])
+        assert len(results) == 1
+        assert isinstance(results[0], ToolResultBlock)
+        assert results[0].id == "id1"
+        assert _state_value(results[0].state) == ToolResultState.ERROR.value
+        text = _first_text(results[0])
+        assert "Tool call `t` was not executed" in text
+        assert "valid JSON arguments" in text
+        assert "tool_call_id" not in text
+        assert "id1" not in text
+        assert "totally not json" not in text
 
-    def test_non_dict_recovered_value_becomes_visible_feedback(self):
+    def test_pydantic_block_invalid_json_becomes_error_tool_result(self):
+        msg = _msg(
+            [
+                ToolCallBlock(
+                    type="tool_call",
+                    id="id1",
+                    name="t",
+                    input="not json",
+                ),
+            ],
+        )
+
+        result = _coerce_tool_inputs_to_json([msg])
+
+        call = result[0].content[0]
+        assert isinstance(call, ToolCallBlock)
+        assert call.input == "{}"
+        assert _state_value(call.state) == ToolCallState.FINISHED.value
+        results = _tool_result_blocks(result[0])
+        assert len(results) == 1
+        assert isinstance(results[0], ToolResultBlock)
+        assert results[0].id == "id1"
+        assert _state_value(results[0].state) == ToolResultState.ERROR.value
+
+    def test_non_dict_recovered_value_becomes_error_tool_result(self):
         """raw_decode recovering a non-dict should not create a tool call."""
         for bad_input in ["42trailing", '"hello"garbage', "[1,2,3]extra"]:
             msg = _msg(
@@ -452,10 +513,11 @@ class TestCoerceToolInputsRawDecode:
                 ],
             )
             result = _coerce_tool_inputs_to_json([msg])
-            texts = _text_blocks(result[0])
-            assert len(texts) == 1
-            assert "Tool call `t` was not executed" in texts[0]["text"]
-            assert bad_input not in texts[0]["text"]
+            results = _tool_result_blocks(result[0])
+            assert len(results) == 1
+            text = _first_text(results[0])
+            assert "Tool call `t` was not executed" in text
+            assert bad_input not in text
 
 
 # ---------------------------------------------------------------------------
@@ -530,7 +592,7 @@ class TestSanitizeToolMessages:
             u, _ = extract_tool_ids(m)
             assert "id1" not in u
 
-    def test_malformed_tool_call_pair_becomes_visible_feedback(self):
+    def test_malformed_tool_call_pair_becomes_error_tool_result(self):
         msgs = [
             _msg(
                 [
@@ -551,12 +613,18 @@ class TestSanitizeToolMessages:
         result = _sanitize_tool_messages(msgs)
 
         assert len(result) == 1
-        texts = _text_blocks(result[0])
-        assert len(texts) == 1
-        assert "Tool call `write_file` was not executed" in texts[0]["text"]
+        assert result[0].content[0]["input"] == "{}"
+        assert result[0].content[0]["state"] == "finished"
+        results = _tool_result_blocks(result[0])
+        assert len(results) == 1
+        assert results[0].id == "call_bad_json"
+        text = _first_text(results[0])
+        assert "Tool call `write_file` was not executed" in text
+        assert "tool_call_id" not in text
+        assert "call_bad_json" not in text
         uses, results = extract_tool_ids(result[0])
-        assert uses == set()
-        assert results == set()
+        assert uses == {"call_bad_json"}
+        assert results == {"call_bad_json"}
 
     def test_empty_messages_returns_empty(self):
         result = _sanitize_tool_messages([])

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -46,6 +46,14 @@ def _tool_result(tid):
     return {"type": "tool_result", "id": tid}
 
 
+def _text_blocks(msg):
+    return [
+        block
+        for block in msg.content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+
+
 # ---------------------------------------------------------------------------
 # extract_tool_ids
 # ---------------------------------------------------------------------------
@@ -412,7 +420,7 @@ class TestCoerceToolInputsRawDecode:
         assert len(result[0].content) == 1
         assert json.loads(result[0].content[0]["input"]) == {"key": "val"}
 
-    def test_completely_invalid_json_drops_block(self):
+    def test_completely_invalid_json_becomes_visible_feedback(self):
         msg = _msg(
             [
                 {
@@ -424,10 +432,14 @@ class TestCoerceToolInputsRawDecode:
             ],
         )
         result = _coerce_tool_inputs_to_json([msg])
-        assert len(result[0].content) == 0
+        texts = _text_blocks(result[0])
+        assert len(texts) == 1
+        assert "Tool call `t` was not executed" in texts[0]["text"]
+        assert "valid JSON arguments" in texts[0]["text"]
+        assert "totally not json" not in texts[0]["text"]
 
-    def test_non_dict_recovered_value_drops_block(self):
-        """raw_decode recovering a non-dict (int, list, string) should drop."""
+    def test_non_dict_recovered_value_becomes_visible_feedback(self):
+        """raw_decode recovering a non-dict should not create a tool call."""
         for bad_input in ["42trailing", '"hello"garbage', "[1,2,3]extra"]:
             msg = _msg(
                 [
@@ -440,9 +452,10 @@ class TestCoerceToolInputsRawDecode:
                 ],
             )
             result = _coerce_tool_inputs_to_json([msg])
-            assert (
-                len(result[0].content) == 0
-            ), f"Expected block to be dropped for input: {bad_input!r}"
+            texts = _text_blocks(result[0])
+            assert len(texts) == 1
+            assert "Tool call `t` was not executed" in texts[0]["text"]
+            assert bad_input not in texts[0]["text"]
 
 
 # ---------------------------------------------------------------------------
@@ -516,6 +529,34 @@ class TestSanitizeToolMessages:
         for m in result:
             u, _ = extract_tool_ids(m)
             assert "id1" not in u
+
+    def test_malformed_tool_call_pair_becomes_visible_feedback(self):
+        msgs = [
+            _msg(
+                [
+                    {
+                        "type": "tool_call",
+                        "id": "call_bad_json",
+                        "name": "write_file",
+                        "input": (
+                            '{"file_path": "/tmp/out.py", '
+                            '"content": "unterminated'
+                        ),
+                    },
+                ],
+            ),
+            _msg([_tool_result("call_bad_json")]),
+        ]
+
+        result = _sanitize_tool_messages(msgs)
+
+        assert len(result) == 1
+        texts = _text_blocks(result[0])
+        assert len(texts) == 1
+        assert "Tool call `write_file` was not executed" in texts[0]["text"]
+        uses, results = extract_tool_ids(result[0])
+        assert uses == set()
+        assert results == set()
 
     def test_empty_messages_returns_empty(self):
         result = _sanitize_tool_messages([])

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -479,7 +479,7 @@ class TestCoerceToolInputsRawDecode:
             "path": "README.md",
         }
 
-    def test_completely_invalid_json_becomes_error_tool_result(self):
+    def test_completely_invalid_json_drops_block(self):
         msg = _msg(
             [
                 {

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -54,14 +54,6 @@ def _tool_result(tid):
     return {"type": "tool_result", "id": tid}
 
 
-def _text_blocks(msg):
-    return [
-        block
-        for block in msg.content
-        if isinstance(block, dict) and block.get("type") == "text"
-    ]
-
-
 def _tool_result_blocks(msg):
     return [
         block
@@ -448,6 +440,25 @@ class TestCoerceToolInputsRawDecode:
         result = _coerce_tool_inputs_to_json([msg])
         assert len(result[0].content) == 1
         assert json.loads(result[0].content[0]["input"]) == {"key": "val"}
+
+    def test_object_with_leading_whitespace_and_trailing_garbage_recovered(
+        self,
+    ):
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "t",
+                    "input": '\n  {"path": "README.md"}extra',
+                },
+            ],
+        )
+        result = _coerce_tool_inputs_to_json([msg])
+        assert len(result[0].content) == 1
+        assert json.loads(result[0].content[0]["input"]) == {
+            "path": "README.md",
+        }
 
     def test_completely_invalid_json_becomes_error_tool_result(self):
         msg = _msg(

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -367,6 +367,25 @@ class TestRepairEmptyToolInputs:
         result = _repair_empty_tool_inputs([msg])
         assert json.loads(result[0].content[0]["input"]) == {"key": "value"}
 
+    def test_recovers_raw_input_with_leading_whitespace_and_trailing_garbage(
+        self,
+    ):
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "t",
+                    "input": {},
+                    "raw_input": '\n  {"path": "README.md"}trailing garbage',
+                },
+            ],
+        )
+        result = _repair_empty_tool_inputs([msg])
+        assert json.loads(result[0].content[0]["input"]) == {
+            "path": "README.md",
+        }
+
     def test_non_dict_raw_decode_does_not_repair(self):
         """raw_decode recovering a non-dict should not overwrite input."""
         msg = _msg(
@@ -640,3 +659,33 @@ class TestSanitizeToolMessages:
     def test_empty_messages_returns_empty(self):
         result = _sanitize_tool_messages([])
         assert result == []
+
+    def test_self_paired_message_kept_when_another_block_unpaired(self):
+        # An AgentScope 2.0 self-paired assistant message carries its own
+        # tool_use and matching tool_result (plus text). When an *unrelated*
+        # unpaired tool_use elsewhere triggers sanitation, the valid
+        # self-paired turn must NOT be dropped (previously it was silently
+        # removed, losing the text and leaving an unpaired tool_use).
+        self_paired = _msg(
+            [
+                {"type": "text", "text": "keep me"},
+                _tool_use("paired"),
+                _tool_result("paired"),
+            ],
+        )
+        msgs = [
+            _msg([_tool_use("orphan")]),  # unpaired -> triggers sanitation
+            self_paired,
+            _msg("regular message"),
+        ]
+
+        result = _sanitize_tool_messages(msgs)
+
+        assert self_paired in result, "self-paired message must be preserved"
+        # The unpaired orphan tool_use is still removed.
+        remaining_uses: set = set()
+        for m in result:
+            u, _ = extract_tool_ids(m)
+            remaining_uses |= u
+        assert "orphan" not in remaining_uses
+        assert "paired" in remaining_uses


### PR DESCRIPTION
## Description

Fixes #5717.

When a Runtime 2.0 history entry contains a malformed non-empty
`tool_call.input`, the shared request normalizer currently drops the malformed
tool call and then removes the orphaned result from the cloned model request.
That hides the failed attempt from the model, so the next turn can repeat the
same logical tool call.

This PR changes the shared tool-message sanitization layer to replace an
unrecoverable malformed tool call with a model-visible assistant text block
stating that the tool call was not executed because its JSON arguments were
invalid. Existing pairing cleanup then removes the orphaned `tool_result`.

**Related Issue:** Fixes #5717

**Security Considerations:** No credential or auth changes. The visible
feedback does not include the raw tool arguments; logging keeps only the
existing short preview.

## Root Cause

The request clone was made syntactically valid for providers, but the model lost
the semantic failure signal. Persisted malformed history could therefore be
sanitized again on every next request without teaching the model that the prior
tool call failed before execution.

## Scope

- Affected: shared Runtime 2.0 tool-message sanitization in
  `tool_message_utils.py`.
- Not affected: channel-specific code, frontend code, provider-specific
  formatting branches.
- Intentional limit: this does not add provider-specific fuzzy JSON repair
  heuristics; valid leading JSON recovery remains unchanged.

## Verification Matrix

- Malformed `tool_call` + `tool_result` history: covered by regression test.
- Valid JSON string inputs: unchanged.
- Recoverable leading JSON with trailing garbage: unchanged.
- Provider/channel-specific paths: not applicable; fix is before formatter
  dispatch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `.venv/bin/pytest tests/unit/agents/utils/test_tool_message_utils.py -q`
- `.venv/bin/pytest tests/unit/agents/test_message_request_normalizer.py -q`
- `env BLACK_CACHE_DIR=/tmp/black-cache PYLINTHOME=/tmp/pylint .venv/bin/pre-commit run --all-files`

## Local Verification Evidence

```bash
.venv/bin/pytest tests/unit/agents/utils/test_tool_message_utils.py -q
# 50 passed in 0.62s

.venv/bin/pytest tests/unit/agents/test_message_request_normalizer.py -q
# 21 passed in 0.29s

env BLACK_CACHE_DIR=/tmp/black-cache PYLINTHOME=/tmp/pylint .venv/bin/pre-commit run --all-files
# Passed: check python ast, yaml/toml/json checks, secret check, trailing whitespace,
# add trailing commas, mypy, black, flake8, pylint, prettier.
```

## Additional Notes

This is a shared Runtime 2.0 history/normalization fix, not a channel or
provider-specific workaround.
