### PR TITLE
feat: add request timeout, retry and AbortSignal support

### DIFF
--- a/console/src/api/request.test.ts
+++ b/console/src/api/request.test.ts
@@ -154,4 +154,227 @@ describe("request", () => {
       expect.any(Object),
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // Timeout handling
+  // ---------------------------------------------------------------------------
+
+  it("aborts request after default timeout (30s)", async () => {
+    vi.useFakeTimers();
+    const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        // Listen for abort signal
+        if (options?.signal) {
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          });
+        }
+      });
+    });
+
+    const requestPromise = request("/slow-endpoint");
+    vi.advanceTimersByTime(30000);
+
+    await expect(requestPromise).rejects.toThrow("Request timeout");
+    expect(abortSpy).toHaveBeenCalled();
+
+    abortSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("respects custom timeout option", async () => {
+    vi.useFakeTimers();
+    const abortSpy = vi.spyOn(AbortController.prototype, "abort");
+
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          });
+        }
+      });
+    });
+
+    const requestPromise = request("/slow-endpoint", { timeout: 5000 });
+    vi.advanceTimersByTime(5000);
+
+    await expect(requestPromise).rejects.toThrow("Request timeout");
+    expect(abortSpy).toHaveBeenCalled();
+
+    abortSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("completes successfully before timeout", async () => {
+    vi.useFakeTimers();
+    mockFetch(200, { data: "ok" });
+
+    const requestPromise = request("/fast-endpoint", { timeout: 10000 });
+    vi.advanceTimersByTime(100);
+
+    const result = await requestPromise;
+    expect(result).toEqual({ data: "ok" });
+
+    vi.useRealTimers();
+  });
+
+  it("passes AbortSignal to fetch", async () => {
+    mockFetch(200, { data: "ok" });
+    await request("/models");
+
+    const fetchOptions = (fetch as any).mock.calls[0][1];
+    expect(fetchOptions.signal).toBeDefined();
+    expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("retries on timeout when retries option is set", async () => {
+    vi.useFakeTimers();
+    let attemptCount = 0;
+
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      attemptCount++;
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          });
+        }
+      });
+    });
+
+    const requestPromise = request("/flaky-endpoint", {
+      timeout: 1000,
+      retries: 2,
+      retryDelay: 100,
+    });
+
+    // First attempt timeout
+    vi.advanceTimersByTime(1000);
+    await vi.advanceTimersByTimeAsync(100); // retry delay
+
+    // Second attempt timeout
+    vi.advanceTimersByTime(1000);
+    await vi.advanceTimersByTimeAsync(100); // retry delay
+
+    // Third attempt timeout
+    vi.advanceTimersByTime(1000);
+
+    await expect(requestPromise).rejects.toThrow("Request timeout");
+    expect(attemptCount).toBe(3); // initial + 2 retries
+
+    vi.useRealTimers();
+  });
+
+  it("succeeds on retry after initial timeout", async () => {
+    vi.useFakeTimers();
+    let attemptCount = 0;
+
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      attemptCount++;
+      return new Promise((resolve, reject) => {
+        if (attemptCount === 1) {
+          // First attempt: timeout
+          if (options?.signal) {
+            options.signal.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted", "AbortError"),
+              );
+            });
+          }
+        } else {
+          // Second attempt: success
+          resolve({
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { get: () => "application/json" },
+            json: () => Promise.resolve({ data: "success" }),
+            text: () => Promise.resolve(JSON.stringify({ data: "success" })),
+          } as unknown as Response);
+        }
+      });
+    });
+
+    const requestPromise = request("/flaky-endpoint", {
+      timeout: 1000,
+      retries: 1,
+      retryDelay: 100,
+    });
+
+    // First attempt timeout
+    vi.advanceTimersByTime(1000);
+    await vi.advanceTimersByTimeAsync(100); // retry delay
+
+    const result = await requestPromise;
+    expect(result).toEqual({ data: "success" });
+    expect(attemptCount).toBe(2);
+
+    vi.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // External AbortSignal handling
+  // ---------------------------------------------------------------------------
+
+  it("does not send request when caller signal is already aborted", async () => {
+    mockFetch(200, { data: "ok" });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      request("/models", { signal: controller.signal }),
+    ).rejects.toThrow("aborted");
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not retry when caller manually aborts (not timeout)", async () => {
+    let attemptCount = 0;
+
+    global.fetch = vi.fn().mockImplementation((_url, options) => {
+      attemptCount++;
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          });
+        }
+      });
+    });
+
+    const callerController = new AbortController();
+    const requestPromise = request("/cancel-endpoint", {
+      timeout: 30000,
+      retries: 3,
+      signal: callerController.signal,
+    });
+
+    // Simulate caller aborting immediately (not a timeout)
+    callerController.abort();
+
+    await expect(requestPromise).rejects.toThrow("aborted");
+    expect(attemptCount).toBe(1); // no retries for external abort
+  });
+
+  it("cleans up abort listener on caller signal after successful request", async () => {
+    mockFetch(200, { data: "ok" });
+
+    const callerController = new AbortController();
+    const removeSpy = vi.spyOn(
+      callerController.signal,
+      "removeEventListener",
+    );
+
+    await request("/models", { signal: callerController.signal });
+
+    expect(removeSpy).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+    removeSpy.mockRestore();
+  });
 });

--- a/console/src/api/request.test.ts
+++ b/console/src/api/request.test.ts
@@ -364,17 +364,11 @@ describe("request", () => {
     mockFetch(200, { data: "ok" });
 
     const callerController = new AbortController();
-    const removeSpy = vi.spyOn(
-      callerController.signal,
-      "removeEventListener",
-    );
+    const removeSpy = vi.spyOn(callerController.signal, "removeEventListener");
 
     await request("/models", { signal: callerController.signal });
 
-    expect(removeSpy).toHaveBeenCalledWith(
-      "abort",
-      expect.any(Function),
-    );
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
     removeSpy.mockRestore();
   });
 });

--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -57,48 +57,132 @@ function buildHeaders(method?: string, extra?: HeadersInit): Headers {
   return headers;
 }
 
+export interface RequestOptions extends RequestInit {
+  /** Request timeout in milliseconds. Defaults to 30000 (30 seconds). */
+  timeout?: number;
+  /** Number of retry attempts on timeout. Defaults to 0 (no retry). */
+  retries?: number;
+  /** Delay between retries in milliseconds. Defaults to 1000 (1 second). */
+  retryDelay?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30000;
+const DEFAULT_RETRIES = 0;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
 export async function request<T = unknown>(
   path: string,
-  options: RequestInit = {},
+  options: RequestOptions = {},
 ): Promise<T> {
   const url = getApiUrl(path);
   const method = options.method || "GET";
   const headers = buildHeaders(method, options.headers);
+  const {
+    timeout = DEFAULT_TIMEOUT_MS,
+    retries = DEFAULT_RETRIES,
+    retryDelay = DEFAULT_RETRY_DELAY_MS,
+    signal: callerSignal,
+    ...fetchOptions
+  } = options;
 
-  const response = await fetch(url, {
-    ...options,
-    headers,
-  });
+  // Early exit: caller's signal already aborted before we even start
+  if (callerSignal?.aborted) {
+    throw new DOMException("The operation was aborted", "AbortError");
+  }
 
-  if (!response.ok) {
-    if (response.status === 401) {
-      clearAuthToken();
-      if (window.location.pathname !== "/login") {
-        window.location.href = "/login";
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    // Create AbortController for timeout handling
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeout);
+
+    // Wire caller's signal to our controller so external abort also works
+    let onCallerAbort: (() => void) | undefined;
+    if (callerSignal) {
+      if (callerSignal.aborted) {
+        controller.abort();
+      } else {
+        onCallerAbort = () => controller.abort();
+        callerSignal.addEventListener("abort", onCallerAbort, { once: true });
       }
-      throw new Error("Not authenticated");
     }
 
-    const text = await response.text().catch(() => "");
-    const contentType = response.headers.get("content-type") || "";
-    const errorMessage = getErrorMessageFromBody(text, contentType);
+    try {
+      const response = await fetch(url, {
+        ...fetchOptions,
+        headers,
+        signal: controller.signal,
+      });
 
-    // Preserve raw body for parseErrorDetail() to extract structured fields
-    const finalMessage = errorMessage
-      ? `${errorMessage} - ${text}`
-      : `Request failed: ${response.status} ${response.statusText}`;
+      if (!response.ok) {
+        if (response.status === 401) {
+          clearAuthToken();
+          if (window.location.pathname !== "/login") {
+            window.location.href = "/login";
+          }
+          throw new Error("Not authenticated");
+        }
 
-    throw new Error(finalMessage);
+        const text = await response.text().catch(() => "");
+        const contentType = response.headers.get("content-type") || "";
+        const errorMessage = getErrorMessageFromBody(text, contentType);
+
+        // Preserve raw body for parseErrorDetail() to extract structured fields
+        const finalMessage = errorMessage
+          ? `${errorMessage} - ${text}`
+          : `Request failed: ${response.status} ${response.statusText}`;
+
+        throw new Error(finalMessage);
+      }
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        return (await response.text()) as unknown as T;
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      if (
+        error instanceof DOMException &&
+        error.name === "AbortError" &&
+        !timedOut
+      ) {
+        // External abort (caller cancelled): do not retry, rethrow as-is
+        throw error;
+      }
+
+      if (error instanceof DOMException && error.name === "AbortError") {
+        // Timeout-triggered abort
+        lastError = new Error(
+          `Request timeout after ${timeout}ms: ${method} ${path}`,
+        );
+
+        // Retry if we have attempts remaining
+        if (attempt < retries) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelay));
+          continue;
+        }
+      } else {
+        // Non-timeout errors should not retry
+        throw error;
+      }
+    } finally {
+      clearTimeout(timeoutId);
+      if (onCallerAbort && callerSignal) {
+        callerSignal.removeEventListener("abort", onCallerAbort);
+      }
+    }
   }
 
-  if (response.status === 204) {
-    return undefined as T;
-  }
-
-  const contentType = response.headers.get("content-type") || "";
-  if (!contentType.includes("application/json")) {
-    return (await response.text()) as unknown as T;
-  }
-
-  return (await response.json()) as T;
+  // All retries exhausted
+  throw lastError;
 }


### PR DESCRIPTION
- Add configurable timeout (default 30s) with AbortController
- Add retries and retryDelay options for timeout retry
- Respect external AbortSignal: pre-aborted signals fail fast
- Distinguish timeout abort from caller abort to avoid unwanted retries
- Clean up abort listeners per request attempt to prevent leaks
- Strip custom options before passing to fetch
- Add unit tests covering timeout, retry and signal behavior

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
