### PR TITLE
fix: add timezone.utc to datetime.fromtimestamp in AgentMdManager

### DIFF
--- a/src/qwenpaw/agents/memory/agent_md_manager.py
+++ b/src/qwenpaw/agents/memory/agent_md_manager.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Agent Markdown manager for reading and writing markdown files in working
 and memory directories."""
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from ..utils.file_handling import read_text_file_with_encoding_fallback
@@ -129,10 +129,10 @@ class AgentMdManager:
                         "size": stat.st_size,
                         "path": str(f),
                         "created_time": datetime.fromtimestamp(
-                            stat.st_ctime,
+                            stat.st_ctime, tz=timezone.utc
                         ).isoformat(),
                         "modified_time": datetime.fromtimestamp(
-                            stat.st_mtime,
+                            stat.st_mtime, tz=timezone.utc
                         ).isoformat(),
                     },
                 )
@@ -190,10 +190,10 @@ class AgentMdManager:
             "size": stat.st_size,
             "path": str(file_path),
             "created_time": datetime.fromtimestamp(
-                stat.st_ctime,
+                stat.st_ctime, tz=timezone.utc
             ).isoformat(),
             "modified_time": datetime.fromtimestamp(
-                stat.st_mtime,
+                stat.st_mtime, tz=timezone.utc
             ).isoformat(),
         }
 

--- a/src/qwenpaw/agents/memory/agent_md_manager.py
+++ b/src/qwenpaw/agents/memory/agent_md_manager.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Agent Markdown manager for reading and writing markdown files in working
 and memory directories."""
+
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -129,10 +130,12 @@ class AgentMdManager:
                         "size": stat.st_size,
                         "path": str(f),
                         "created_time": datetime.fromtimestamp(
-                            stat.st_ctime, tz=timezone.utc
+                            stat.st_ctime,
+                            tz=timezone.utc,
                         ).isoformat(),
                         "modified_time": datetime.fromtimestamp(
-                            stat.st_mtime, tz=timezone.utc
+                            stat.st_mtime,
+                            tz=timezone.utc,
                         ).isoformat(),
                     },
                 )
@@ -190,10 +193,12 @@ class AgentMdManager:
             "size": stat.st_size,
             "path": str(file_path),
             "created_time": datetime.fromtimestamp(
-                stat.st_ctime, tz=timezone.utc
+                stat.st_ctime,
+                tz=timezone.utc,
             ).isoformat(),
             "modified_time": datetime.fromtimestamp(
-                stat.st_mtime, tz=timezone.utc
+                stat.st_mtime,
+                tz=timezone.utc,
             ).isoformat(),
         }
 


### PR DESCRIPTION
The  calls in list_working_mds() and
list_memory_mds() did not pass , producing naive
ISO datetime strings without timezone suffix (e.g. "2026-07-03T13:50:15" instead of "...T13:50:15+00:00").

When the frontend parses these naive strings, some JavaScript environments interpret them as local time rather than UTC, causing an offset equal to the user's timezone (e.g. +8 hours for Asia/Shanghai). This manifested as incorrect "X 小时前" relative timestamps in the workspace file list.

Fix: add  to all four fromtimestamp() calls and
import  from datetime.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
