### PR TITLE
fix(crons): record run timestamps in job timezone

### DIFF
--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Literal, Optional, Union
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from apscheduler.events import (
     EVENT_JOB_MAX_INSTANCES,
@@ -462,7 +463,7 @@ class CronManager(ManagerBase):
         self._states[job.id] = st
 
         record = CronExecutionRecord(
-            run_at=datetime.now(timezone.utc),
+            run_at=self._now_in_job_timezone(job),
             status="skipped",
             error=error_msg,
             trigger="scheduled",
@@ -591,11 +592,27 @@ class CronManager(ManagerBase):
             job,
             trigger="scheduled",
         )
+
         # refresh next_run
         aps_job = self._scheduler.get_job(job_id)
         st = self._states.get(job_id, CronJobState())
         st.next_run_at = aps_job.next_run_time if aps_job else None
         self._states[job_id] = st
+
+    @staticmethod
+    def _now_in_job_timezone(job: CronJobSpec) -> datetime:
+        tz_name = job.schedule.timezone or "UTC"
+        try:
+            tz = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, ValueError):
+            logger.warning(
+                "Invalid cron job timezone, using UTC: job_id=%s "
+                "timezone=%s",
+                job.id,
+                tz_name,
+            )
+            tz = timezone.utc
+        return datetime.now(tz)
 
     async def _heartbeat_callback(self) -> None:
         """Run one heartbeat (HEARTBEAT.md as query, optional dispatch)."""
@@ -688,7 +705,7 @@ class CronManager(ManagerBase):
                 )
                 raise
             finally:
-                st.last_run_at = datetime.now(timezone.utc)
+                st.last_run_at = self._now_in_job_timezone(job)
                 self._states[job.id] = st
                 record = CronExecutionRecord(
                     run_at=st.last_run_at,

--- a/tests/unit/app/crons/test_manager.py
+++ b/tests/unit/app/crons/test_manager.py
@@ -13,12 +13,13 @@ concurrent writes — already fixed upstream).
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from qwenpaw.app.crons.manager import CronManager
-from qwenpaw.app.crons.models import CronJobState
+from qwenpaw.app.crons.models import CronJobState, ScheduleSpec
 from tests.unit.app.conftest import (
     InMemoryJobRepository,
     make_cron_job_spec,
@@ -196,6 +197,33 @@ async def test_get_state_returns_default_for_unknown_job(manager: CronManager):
     state = manager.get_state("ghost")
     assert isinstance(state, CronJobState)
     assert state.last_status is None
+
+
+@pytest.mark.asyncio
+async def test_execute_once_records_last_run_in_job_timezone(
+    manager: CronManager,
+    repo: InMemoryJobRepository,
+):
+    spec = make_cron_job_spec(job_id="tz-job")
+    spec = spec.model_copy(
+        update={
+            "schedule": ScheduleSpec(
+                type="cron",
+                cron="0 3 * * *",
+                timezone="Asia/Shanghai",
+            ),
+        },
+    )
+    await repo.upsert_job(spec)
+    manager._executor.execute = AsyncMock(return_value={})
+
+    await manager._execute_once(spec, trigger="manual")
+
+    state = manager.get_state("tz-job")
+    history = await manager.get_history("tz-job")
+    assert state.last_run_at is not None
+    assert state.last_run_at.utcoffset() == timedelta(hours=8)
+    assert history[0].run_at == state.last_run_at
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #5779.

Cron execution timestamps now use the job configured `schedule.timezone`, so
`last_run_at` and cron history `run_at` are consistent with scheduler-derived
`next_run_at`.

## Type of Change

- [x] Bug fix

## Components Affected

- [x] Backend cron manager
- [x] Cron state and history timestamps
- [ ] Console UI
- [ ] Provider/channel behavior

## Root Cause

`next_run_at` comes from APScheduler and already carries the job timezone, but
`last_run_at` and skipped execution records were created with
`datetime.now(timezone.utc)` in `CronManager`.

## Scope

The fix lives in the shared cron manager state/history layer instead of CLI or
console formatting. It adds one helper that resolves `job.schedule.timezone`
and uses it for normal execution timestamps and skipped execution history.

## Checklist

- [x] Followed existing cron manager structure
- [x] Added a focused unit test
- [x] Kept the PR scoped to cron timestamp semantics

## Testing

- `.venv/bin/pytest tests/unit/app/crons -q` - 55 passed
- `.venv/bin/pre-commit run --files src/qwenpaw/app/crons/manager.py tests/unit/app/crons/test_manager.py` - passed
- `.venv/bin/pre-commit run --all-files` - failed on existing unrelated pylint errors in `src/qwenpaw/sandbox/windows_sandbox.py` at lines 1091 and 1133 (`E1120: No value for argument value in constructor call`)

## Local Verification Evidence

The new regression test first failed on current behavior because
`last_run_at.utcoffset()` was UTC, then passed after recording timestamps in
`Asia/Shanghai` for an Asia/Shanghai cron job.

## Verification Matrix

- Cron state `last_run_at`: covered
- Cron history `run_at`: covered
- `next_run_at`: unchanged, still provided by APScheduler
- Console/UI: not affected
- Providers/channels: not applicable
