### PR TITLE
fix: three bug fixes (#5709, #5773, #5784)

### DIFF
--- a/console/src/pages/Agent/Config/index.tsx
+++ b/console/src/pages/Agent/Config/index.tsx
@@ -51,7 +51,7 @@ function AgentConfigPage() {
           return api.listProviders().then((providers) => {
             for (const p of providers) {
               const all = [...(p.models ?? []), ...(p.extra_models ?? [])];
-              const m = all.find((m) => m.id === info.active_llm?.model);
+              const m = all.find((m) => m.id === info.active_llm?.model && p.id === info.active_llm?.provider_id);
               if (m?.max_input_length) {
                 setMaxInputLength(m.max_input_length);
                 return;

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -448,7 +448,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         )
         tool_result_msg = Msg(
             name=agent_name or self.agent_id,
-            role="assistant",
+            role="tool",
             metadata={
                 QWENPAW_MESSAGE_TAG_KEY: AUTO_MEMORY_SEARCH_MESSAGE_TAG,
             },

--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -686,7 +686,30 @@ class FeishuChannel(BaseChannel):
                 self._processed_message_ids.popitem(last=False)
 
             sender_type = getattr(sender, "sender_type", "") or ""
-            if sender_type == "bot":
+
+            # Extract content and mentions early so we can check whether
+            # the current bot is @-mentioned before deciding to drop a bot
+            # message (issue #5709: bot-to-bot @mention was being discarded).
+            content_raw = getattr(message, "content", None) or ""
+            mentions_raw = getattr(message, "mentions", None) or []
+            is_bot_mentioned = False
+            bot_mention_keys: List[str] = []
+            if "@_all" in content_raw:
+                is_bot_mentioned = True
+            if self._bot_open_id and mentions_raw:
+                for m in mentions_raw:
+                    m_id = getattr(m, "id", None)
+                    if not m_id:
+                        continue
+                    m_open_id = getattr(m_id, "open_id", None) or ""
+                    if m_open_id == self._bot_open_id:
+                        is_bot_mentioned = True
+                        key = getattr(m, "key", None) or ""
+                        if key:
+                            bot_mention_keys.append(key)
+
+            # Drop bot messages unless the current bot is @-mentioned.
+            if sender_type == "bot" and not is_bot_mentioned:
                 return
 
             sender_id_obj = getattr(sender, "sender_id", None)
@@ -713,24 +736,6 @@ class FeishuChannel(BaseChannel):
             msg_type = str(
                 getattr(message, "message_type", "text") or "text",
             ).strip()
-            content_raw = getattr(message, "content", None) or ""
-
-            mentions_raw = getattr(message, "mentions", None) or []
-            is_bot_mentioned = False
-            bot_mention_keys: List[str] = []
-            if "@_all" in content_raw:
-                is_bot_mentioned = True
-            if self._bot_open_id and mentions_raw:
-                for m in mentions_raw:
-                    m_id = getattr(m, "id", None)
-                    if not m_id:
-                        continue
-                    m_open_id = getattr(m_id, "open_id", None) or ""
-                    if m_open_id == self._bot_open_id:
-                        is_bot_mentioned = True
-                        key = getattr(m, "key", None) or ""
-                        if key:
-                            bot_mention_keys.append(key)
 
             content_parts: List[Any] = []
             text_parts: List[str] = []


### PR DESCRIPTION
## 修复内容

### fix(console): match model by both id and provider_id (#5784)
- **根因：** `console/src/pages/Agent/Config/index.tsx:54` — `Array.find()` 只匹配 `model.id`，不校验 `provider_id`
- **修复：** 增加 `p.id === info.active_llm?.provider_id` 条件
- **影响：** 同名模型跨 provider 时，前端压缩阈值显示正确的 `max_input_length`

### fix(memory): use role='tool' for auto_memory_search tool_result (#5773)
- **根因：** `reme_light_memory_manager.py:451` — `tool_result_msg` 使用 `role="assistant"`，OCG provider 严格校验 role 导致拒绝
- **修复：** 改为 `role="tool"`（OpenAI 标准格式）
- **影响：** OCG (OpenCode Go) channel 的 auto_memory_search 恢复正常

### fix(feishu): check @mention before dropping bot messages (#5709)
- **根因：** `channel.py:689` — `sender_type == "bot"` 时无条件 return，在 `is_bot_mentioned` 检查之前
- **修复：** 将 `content_raw`/`mentions_raw` 提取和 `is_bot_mentioned` 检查提前到 bot 过滤之前
- **影响：** 飞书群内 bot @mention 当前 bot 时不再被静默丢弃

## 检查清单
- [x] 本地语法验证通过
- [x] 仅改动 issue 相关代码
- [x] 代码风格符合项目规范

---
🤖 此 PR 由 QwenPaw 自动修复流水线生成，请人工审核后合并。