### PR TITLE
fix(agents): stop dropping self-paired tool messages during sanitation

### DIFF
--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -87,11 +87,11 @@ def _reorder_tool_results(msgs: list) -> list:
     result_msg_ids: set[int] = set()
     for msg in msgs:
         if isinstance(msg.content, list):
-            # A message that carries its own tool_call (e.g. an AgentScope 2.0
-            # self-paired assistant msg [text, tool_call, tool_result]) must stay
-            # in place; only standalone tool_result messages are movable. Moving
-            # a self-carrying msg would skip it here and never re-insert it,
-            # silently dropping the whole turn.
+            # Keep a message that carries its own tool_call in place (e.g. an
+            # AgentScope 2.0 self-paired assistant msg
+            # [text, tool_call, tool_result]); only standalone tool_result
+            # messages are movable. Skipping a self-carrying msg here would
+            # drop it, since its own tool_call can never re-insert it.
             has_own_call = any(
                 _is_tool_call(block) and _block_attr(block, "id")
                 for block in msg.content

--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -87,6 +87,17 @@ def _reorder_tool_results(msgs: list) -> list:
     result_msg_ids: set[int] = set()
     for msg in msgs:
         if isinstance(msg.content, list):
+            # A message that carries its own tool_call (e.g. an AgentScope 2.0
+            # self-paired assistant msg [text, tool_call, tool_result]) must stay
+            # in place; only standalone tool_result messages are movable. Moving
+            # a self-carrying msg would skip it here and never re-insert it,
+            # silently dropping the whole turn.
+            has_own_call = any(
+                _is_tool_call(block) and _block_attr(block, "id")
+                for block in msg.content
+            )
+            if has_own_call:
+                continue
             for block in msg.content:
                 if _is_tool_result(block) and _block_attr(block, "id"):
                     results_by_id.setdefault(
@@ -131,16 +142,24 @@ def _remove_unpaired_tool_messages(msgs: list) -> list:
 
     i = 0
     while i < len(msgs):
-        use_ids, _ = extract_tool_ids(msgs[i])
+        use_ids, own_results = extract_tool_ids(msgs[i])
         if not use_ids:
             i += 1
             continue
-        required = set(use_ids)
+        # A self-paired message satisfies (some of) its own tool_calls with the
+        # tool_results in the same message; only the remainder must be covered
+        # by following messages.
+        required = set(use_ids) - own_results
         j = i + 1
         result_indices: list[int] = []
         while j < len(msgs) and required:
-            _, r = extract_tool_ids(msgs[j])
+            uj, r = extract_tool_ids(msgs[j])
             if not r:
+                break
+            # A following message that also carries tool_calls (e.g. another
+            # self-paired turn) is not a result-provider for this one; stop
+            # rather than consuming it.
+            if uj:
                 break
             required -= r
             result_indices.append(j)
@@ -160,8 +179,10 @@ def _remove_unpaired_tool_messages(msgs: list) -> list:
     for idx, msg in enumerate(msgs):
         if idx in to_remove:
             continue
-        _, r = extract_tool_ids(msg)
-        if r and not r.issubset(surviving_use_ids):
+        u, r = extract_tool_ids(msg)
+        # A tool_result is paired if some surviving tool_call uses its id --
+        # including a tool_call in the same (self-paired) message.
+        if r and not r.issubset(surviving_use_ids | u):
             to_remove.add(idx)
 
     return [msg for idx, msg in enumerate(msgs) if idx not in to_remove]

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -520,3 +520,33 @@ class TestSanitizeToolMessages:
     def test_empty_messages_returns_empty(self):
         result = _sanitize_tool_messages([])
         assert result == []
+
+    def test_self_paired_message_kept_when_another_block_unpaired(self):
+        # An AgentScope 2.0 self-paired assistant message carries its own
+        # tool_use and matching tool_result (plus text). When an *unrelated*
+        # unpaired tool_use elsewhere triggers sanitation, the valid
+        # self-paired turn must NOT be dropped (previously it was silently
+        # removed, losing the text and leaving an unpaired tool_use).
+        self_paired = _msg(
+            [
+                {"type": "text", "text": "keep me"},
+                _tool_use("paired"),
+                _tool_result("paired"),
+            ],
+        )
+        msgs = [
+            _msg([_tool_use("orphan")]),  # unpaired -> triggers sanitation
+            self_paired,
+            _msg("regular message"),
+        ]
+
+        result = _sanitize_tool_messages(msgs)
+
+        assert self_paired in result, "self-paired message must be preserved"
+        # The unpaired orphan tool_use is still removed.
+        remaining_uses: set = set()
+        for m in result:
+            u, _ = extract_tool_ids(m)
+            remaining_uses |= u
+        assert "orphan" not in remaining_uses
+        assert "paired" in remaining_uses


### PR DESCRIPTION
## Description

When a model request contains an unpaired tool block, `_sanitize_tool_messages` runs `_reorder_tool_results` + `_remove_unpaired_tool_messages` to repair ordering/pairing. In that path, a **valid** AgentScope 2.0 *self-paired* assistant message — one that carries its own `tool_call` and matching `tool_result` in the same `Msg` (`[text, tool_call, tool_result]`) — was **silently dropped**, losing the text and the whole turn from the request sent to the model.

Root cause (two functions):
- `_reorder_tool_results` treated every result-bearing message as a movable result-carrier, skipping it to re-insert after a `tool_call` in *another* message; for a self-paired message the call is in the *same* (skipped) message, so it was never re-inserted.
- `_remove_unpaired_tool_messages` only scanned *following* messages for a `tool_call`'s results, so a self-paired message's own `tool_result` never satisfied its own use and the message was judged unpaired.

Fix: keep messages that carry their own `tool_call` in place during reordering; satisfy a message's `tool_call`s from its own `tool_result`s first (and don't consume a following self-paired message as a result provider); and let a message's own `tool_call`s pair its own `tool_result`s in the final sweep.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Component(s) Affected

- [x] Core (`src/qwenpaw/agents/utils/tool_message_utils.py`)
- [x] Tests

## Checklist

- [x] Run and pass `pre-commit run --all-files` (on the changed files — see evidence)
- [x] Run and pass relevant tests (`pytest`)
- [x] No documentation change needed (internal sanitation helper)

## Testing

Added `TestSanitizeToolMessages::test_self_paired_message_kept_when_another_block_unpaired`: a batch with an unrelated unpaired `tool_call` plus a valid self-paired `[text, tool_call, tool_result]` message. Before the fix the self-paired message is dropped; after, it is preserved (and the unpaired orphan is still removed). Classic separate `tool_call`/`tool_result` pairs, result-before-call reordering, and orphan removal remain unchanged.

## Local Verification Evidence

```
$ pre-commit run --files src/qwenpaw/agents/utils/tool_message_utils.py tests/unit/agents/utils/test_tool_message_utils.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
(yaml/xml/toml/json/prettier: no matching files -> Skipped)
```

```
$ pytest tests/unit/agents/utils/test_tool_message_utils.py tests/unit/agents/test_message_request_normalizer.py -q
71 passed
```
