### PR TITLE
[codex] Include ACP modules in desktop bundle

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -120,6 +120,8 @@ a = Analysis(
         *collect_submodules("qwenpaw.cli"),
         # All channel adapters (imported on-demand at runtime)
         *collect_submodules("qwenpaw.app.channels"),
+        # ACP runner support is lazily imported by delegate_external_agent.
+        *collect_submodules("qwenpaw.agents.acp"),
         # ASGI app entry points
         "qwenpaw.app._app",
         "qwenpaw.app.multi_agent_manager",


### PR DESCRIPTION
﻿## Description

Include the lazily imported ACP runner modules in the Tauri PyInstaller backend bundle. The frozen desktop backend currently misses `qwenpaw.agents.acp.service`, so `delegate_external_agent` can fail before it reaches runner configuration.

**Related Issue:** N/A

**Security Considerations:** Packaging-only change; no new auth, credential, or network handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Verified the PyInstaller spec includes `collect_submodules("qwenpaw.agents.acp")`.
- Verified `qwenpaw.agents.acp.service` is importable from the source tree using the bundled QwenPaw Python runtime with `PYTHONPATH=src`.
- Ran `git diff --check -- scripts/pack-tauri/qwenpaw.spec`.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Not run; this draft PR only touches the PyInstaller spec and the local venv is missing pytest/pre-commit tooling.

pytest
# Not run; local .venv reports: No module named pytest.

python -c "from pathlib import Path; text=Path('scripts/pack-tauri/qwenpaw.spec').read_text(encoding='utf-8'); assert 'collect_submodules(\"qwenpaw.agents.acp\")' in text"
# Passed.

PYTHONPATH=src C:/Users/jinglin/AppData/Local/QwenPaw/python.exe -c "import importlib.util; assert importlib.util.find_spec('qwenpaw.agents.acp.service') is not None"
# Passed.

git diff --check -- scripts/pack-tauri/qwenpaw.spec
# Passed.
```

## Additional Notes

The desktop sidecar uses PyInstaller and `delegate_external_agent` reaches ACP service through lazy imports, so static analysis does not reliably collect the ACP service/client/server modules unless `qwenpaw.agents.acp` is explicitly included.
