### PR TITLE
fix(providers): retry streaming OpenAI APIError with body status codes

### DIFF
--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -110,6 +110,7 @@ def _get_openai_retryable() -> tuple[type[Exception], ...]:
                 openai.RateLimitError,
                 openai.APITimeoutError,
                 openai.APIConnectionError,
+                openai.InternalServerError,
             )
         except ImportError:
             _openai_retryable = ()
@@ -147,6 +148,40 @@ def _get_httpx_retryable() -> tuple[type[Exception], ...]:
     return _httpx_retryable
 
 
+def _extract_status_code(exc: Exception) -> int | None:
+    """Best-effort HTTP status extraction from SDK exceptions.
+
+    Streaming SSE errors are raised as plain ``openai.APIError`` without a
+    ``status_code`` attribute; the gateway status is often only present in
+    ``body`` (e.g. ``{"status_code": 502, "error": {...}}``).
+    """
+    status = getattr(exc, "status_code", None)
+    if status is not None:
+        try:
+            return int(status)
+        except (TypeError, ValueError):
+            pass
+
+    body = getattr(exc, "body", None)
+    if not isinstance(body, dict):
+        return None
+
+    for container in (body, body.get("error")):
+        if not isinstance(container, dict):
+            continue
+        raw = container.get("status_code")
+        if raw is None:
+            raw = container.get("code")
+        if raw is None:
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            continue
+
+    return None
+
+
 def _is_retryable(exc: Exception) -> bool:
     """Return *True* if *exc* should trigger a retry."""
     retryable = (
@@ -157,7 +192,7 @@ def _is_retryable(exc: Exception) -> bool:
     if retryable and isinstance(exc, retryable):
         return True
 
-    status = getattr(exc, "status_code", None)
+    status = _extract_status_code(exc)
     if status is not None and status in RETRYABLE_STATUS_CODES:
         return True
 
@@ -166,7 +201,7 @@ def _is_retryable(exc: Exception) -> bool:
 
 def _is_rate_limit(exc: Exception) -> bool:
     """Return *True* if *exc* is specifically a 429 rate-limit error."""
-    return getattr(exc, "status_code", None) == 429
+    return _extract_status_code(exc) == 429
 
 
 def _is_missing_reasoning_content_error(exc: Exception) -> bool:
@@ -177,7 +212,7 @@ def _is_missing_reasoning_content_error(exc: Exception) -> bool:
     conversation history was produced by a non-reasoning model, these
     fields are absent and the API rejects the request with a 400.
     """
-    if getattr(exc, "status_code", None) != 400:
+    if _extract_status_code(exc) != 400:
         return False
     return "reasoning_content" in str(exc)
 

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -106,11 +106,15 @@ def _get_openai_retryable() -> tuple[type[Exception], ...]:
         try:
             import openai
 
-            _openai_retryable = (
-                openai.RateLimitError,
-                openai.APITimeoutError,
-                openai.APIConnectionError,
-                openai.InternalServerError,
+            _openai_retryable = tuple(
+                cls
+                for cls in (
+                    openai.RateLimitError,
+                    openai.APITimeoutError,
+                    openai.APIConnectionError,
+                    getattr(openai, "InternalServerError", None),
+                )
+                if cls is not None
             )
         except ImportError:
             _openai_retryable = ()

--- a/tests/unit/providers/test_retry_chat_model.py
+++ b/tests/unit/providers/test_retry_chat_model.py
@@ -8,6 +8,7 @@ from typing import Any, AsyncGenerator, cast
 import pytest
 
 from qwenpaw.providers.model_capability_cache import get_capability_cache
+from qwenpaw.providers.rate_limiter import _limiters
 from qwenpaw.providers.retry_chat_model import (
     RETRYABLE_STATUS_CODES,
     RetryChatModel,
@@ -116,19 +117,47 @@ def test_is_retryable_streaming_openai_api_error_with_body_status() -> None:
         request=None,
         body=body,
     )
-    assert getattr(exc, "status_code", None) is None
+    assert _is_retryable(exc) is True
+
+
+def test_is_retryable_streaming_openai_api_error_504_timeout() -> None:
+    openai = pytest.importorskip("openai")
+
+    body = {
+        "error": {
+            "message": "Request timeout: WriteTimeout",
+            "type": "timeout_error",
+            "code": 504,
+            "request_id": "1408263304014e1c90a09e1990d79c0a",
+        },
+        "status_code": 504,
+    }
+    exc = openai.APIError(
+        'API错误(504): {"error": {...}, "status_code": 504}',
+        request=None,
+        body=body,
+    )
+    assert _extract_status_code(exc) == 504
     assert _is_retryable(exc) is True
 
 
 def test_is_retryable_openai_internal_server_error() -> None:
     openai = pytest.importorskip("openai")
     httpx = pytest.importorskip("httpx")
+    internal_server_error = getattr(openai, "InternalServerError", None)
+    if internal_server_error is None:
+        pytest.skip("openai.InternalServerError unavailable")
+    assert internal_server_error is not None
 
     response = httpx.Response(
         502,
         request=httpx.Request("POST", "http://example.com/v1/chat"),
     )
-    exc = openai.InternalServerError("bad gateway", response=response, body=None)
+    exc = internal_server_error(
+        "bad gateway",
+        response=response,
+        body=None,
+    )
     assert _is_retryable(exc) is True
 
 
@@ -173,30 +202,35 @@ class _TransientStreamRetryModel:
 
 @pytest.mark.asyncio
 async def test_stream_retries_transient_openai_api_error() -> None:
-    inner = _TransientStreamRetryModel()
-    model = RetryChatModel(
-        inner,  # type: ignore[arg-type]
-        retry_config=RetryConfig(
-            enabled=True,
-            max_retries=2,
-            backoff_base=0.01,
-            backoff_cap=0.01,
-        ),
-        rate_limit_config=RateLimitConfig(
-            max_concurrent=1,
-            max_qpm=0,
-            pause_seconds=1.0,
-            jitter_range=0.0,
-            acquire_timeout=10.0,
-        ),
-    )
+    pytest.importorskip("openai")
+    _limiters.clear()
+    try:
+        inner = _TransientStreamRetryModel()
+        model = RetryChatModel(
+            inner,  # type: ignore[arg-type]
+            retry_config=RetryConfig(
+                enabled=True,
+                max_retries=2,
+                backoff_base=0.01,
+                backoff_cap=0.01,
+            ),
+            rate_limit_config=RateLimitConfig(
+                max_concurrent=1,
+                max_qpm=0,
+                pause_seconds=1.0,
+                jitter_range=0.0,
+                acquire_timeout=10.0,
+            ),
+        )
 
-    result = await model(messages=[{"role": "user", "content": "hi"}])
-    stream = cast(AsyncGenerator[Any, None], result)
-    chunks = [chunk async for chunk in stream]
+        result = await model(messages=[{"role": "user", "content": "hi"}])
+        stream = cast(AsyncGenerator[Any, None], result)
+        chunks = [chunk async for chunk in stream]
 
-    assert [chunk.content for chunk in chunks] == ["partial", "ok"]
-    assert inner.calls == 2
+        assert [chunk.content for chunk in chunks] == ["partial", "ok"]
+        assert inner.calls == 2
+    finally:
+        _limiters.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/providers/test_retry_chat_model.py
+++ b/tests/unit/providers/test_retry_chat_model.py
@@ -15,6 +15,7 @@ from qwenpaw.providers.retry_chat_model import (
     RateLimitConfig,
     _compute_backoff,
     _extract_retry_after,
+    _extract_status_code,
     _inject_reasoning_content,
     _is_missing_reasoning_content_error,
     _is_rate_limit,
@@ -77,6 +78,125 @@ def test_is_retryable_non_retryable_code() -> None:
 
 def test_is_retryable_no_status_code() -> None:
     assert _is_retryable(Exception("plain")) is False
+
+
+def test_extract_status_code_from_body_top_level() -> None:
+    exc = Exception()
+    exc.body = {"status_code": 502}  # type: ignore[attr-defined]
+    assert _extract_status_code(exc) == 502
+
+
+def test_extract_status_code_from_body_error_object() -> None:
+    exc = Exception()
+    exc.body = {  # type: ignore[attr-defined]
+        "error": {
+            "message": "Internal error: ReadError",
+            "code": 500,
+            "status_code": 500,
+        },
+        "status_code": 500,
+    }
+    assert _extract_status_code(exc) == 500
+
+
+def test_is_retryable_streaming_openai_api_error_with_body_status() -> None:
+    openai = pytest.importorskip("openai")
+
+    body = {
+        "error": {
+            "message": "Internal error: ReadError",
+            "type": "internal_error",
+            "code": 500,
+            "status_code": 500,
+        },
+        "status_code": 500,
+    }
+    exc = openai.APIError(
+        "API错误(502): Internal error: ReadError",
+        request=None,
+        body=body,
+    )
+    assert getattr(exc, "status_code", None) is None
+    assert _is_retryable(exc) is True
+
+
+def test_is_retryable_openai_internal_server_error() -> None:
+    openai = pytest.importorskip("openai")
+    httpx = pytest.importorskip("httpx")
+
+    response = httpx.Response(
+        502,
+        request=httpx.Request("POST", "http://example.com/v1/chat"),
+    )
+    exc = openai.InternalServerError("bad gateway", response=response, body=None)
+    assert _is_retryable(exc) is True
+
+
+async def _failing_stream_api_error() -> AsyncGenerator[Any, None]:
+    openai = pytest.importorskip("openai")
+    yield SimpleNamespace(content="partial")
+    body = {
+        "error": {
+            "message": "Internal error: ReadError",
+            "code": 500,
+            "status_code": 500,
+        },
+        "status_code": 500,
+    }
+    raise openai.APIError(
+        "API错误(502): Internal error: ReadError",
+        request=None,
+        body=body,
+    )
+
+
+class _TransientStreamRetryModel:
+    model = "transient-stream-test"
+    stream = True
+    context_size = 32768
+    parameters = None
+    _provider_id = "unit"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        self.calls += 1
+        if self.calls == 1:
+            return _failing_stream_api_error()
+        return _successful_stream()
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_transient_openai_api_error() -> None:
+    inner = _TransientStreamRetryModel()
+    model = RetryChatModel(
+        inner,  # type: ignore[arg-type]
+        retry_config=RetryConfig(
+            enabled=True,
+            max_retries=2,
+            backoff_base=0.01,
+            backoff_cap=0.01,
+        ),
+        rate_limit_config=RateLimitConfig(
+            max_concurrent=1,
+            max_qpm=0,
+            pause_seconds=1.0,
+            jitter_range=0.0,
+            acquire_timeout=10.0,
+        ),
+    )
+
+    result = await model(messages=[{"role": "user", "content": "hi"}])
+    stream = cast(AsyncGenerator[Any, None], result)
+    chunks = [chunk async for chunk in stream]
+
+    assert [chunk.content for chunk in chunks] == ["partial", "ok"]
+    assert inner.calls == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
---

## Summary

修复流式 SSE 错误场景下 `openai.APIError` 无法触发 LLM 自动重试的问题。

当 自定义 的 AI 网关在长连接流式响应中途返回 5xx 错误时，OpenAI SDK 会抛出裸 `openai.APIError`（无 `status_code` 属性，状态码仅存在于 `body` 中）。原有 `_is_retryable()` 只检查 `exc.status_code` 和有限的异常类型，导致 `502 ReadError` 等瞬时错误被直接判定为不可重试，跳过重试循环并向上抛出 `MODEL_EXECUTION_FAILED`。

**本次修改：**
- 新增 `_extract_status_code()`，从 `exc.status_code` 及 `exc.body` / `body.error` 中提取 HTTP 状态码
- 将 `openai.InternalServerError` 加入可重试异常类型
- 补充单元测试，覆盖 body 状态码提取、流式 APIError 重试判定及 `_wrap_stream` 端到端重试

---

## Problem / Root Cause

### 现象

LLM 流式调用过程中，网关返回 `502 Internal error: ReadError`，qwenpaw 配置了异常重试（`llm_retry_enabled=true`，默认 `LLM_MAX_RETRIES=3`），但错误发生后**没有**出现 `LLM stream failed ... Retrying in Xs` 日志，请求直接失败。

<img width="910" height="210" alt="image" src="https://github.com/user-attachments/assets/0b7b1794-d76c-4abb-8cb7-4fdea694bce0" />


### 错误堆栈

```
2026-07-05 16:46:58 | ERROR | qwenpaw/app/runner/runner.py:908 | Error in query handler: [422] MODEL_EXECUTION_FAILED: Error occurred during execution of model: deepseek-v4-flash
(Details: /tmp/qwenpaw_query_error_6gynr7wn.json)
Traceback (most recent call last):
  File "qwenpaw/app/runner/runner.py", line 856, in query_handler
    async for msg, last in _stream_printing_messages_interruptible(
  File "qwenpaw/app/runner/runner.py", line 101, in _stream_printing_messages_interruptible
    raise exception from None
  File "agentscope/agent/_agent_base.py", line 455, in __call__
    reply_msg = await self.reply(*args, **kwargs)
  File "agentscope/agent/_agent_meta.py", line 130, in async_wrapper
    current_output = await original_func(...)
  File "qwenpaw/agents/react_agent.py", line 1458, in reply
    return await super().reply(...)
  File "agentscope/agent/_react_agent.py", line 437, in reply
    msg_reasoning = await self._reasoning(tool_choice)
  File "qwenpaw/agents/react_agent.py", line 1052, in _reasoning
    msg = await super()._reasoning(tool_choice=tool_choice)
  File "qwenpaw/agents/tool_guard_mixin.py", line 796, in _reasoning
    return await super()._reasoning(...)
  File "agentscope/agent/_react_agent.py", line 586, in _reasoning
    async for content_chunk in res:
  File "qwenpaw/providers/retry_chat_model.py", line 541, in _wrap_stream
    raise failed_exc
  File "qwenpaw/providers/retry_chat_model.py", line 524, in _wrap_stream
    async for chunk in self._consume_stream_with_slot(
  File "qwenpaw/providers/retry_chat_model.py", line 368, in _consume_stream_with_slot
    async for chunk in stream:
  File "qwenpaw/token_usage/model_wrapper.py", line 105, in _wrap_stream
    async for chunk in stream:
  File "qwenpaw/providers/openai_chat_model_compat.py", line 366, in _parse_openai_stream_response
    async for parsed in super()._parse_openai_stream_response(
  File "agentscope/model/_openai_model.py", line 388, in _parse_openai_stream_response
    async for item in stream:
  File "qwenpaw/providers/openai_chat_model_compat.py", line 166, in __anext__
    item = await self._ctx_stream.__anext__()
  File "openai/_streaming.py", line 155, in __anext__
    return await self._iterator.__anext__()
  File "openai/_streaming.py", line 205, in __stream__
    raise APIError(
openai.APIError: API错误(502): Internal error: ReadError
```

### 网关返回的错误体（SSE 流内 error JSON）

```json
{
  "error": {
    "message": "Internal error: ReadError",
    "type": "internal_error",
    "code": 500,
    "status_code": 500
  },
  "status_code": 500
}
```

### 根因分析

| 检查项 | 实际情况 | 结果 |
|---|---|---|
| 异常类型 | `openai.APIError`（非 `InternalServerError`） | 不在 `_get_openai_retryable()` 列表中 |
| `exc.status_code` | `None`（SSE 流内错误不设置该属性） | 无法匹配 `RETRYABLE_STATUS_CODES` |
| `exc.body.status_code` | `500` / 消息文本含 `502` | 原逻辑未读取 body |
| 重试日志 | 无 `Retrying in Xs` 输出 | `_is_retryable()` 返回 `False`，直接 `raise` |

原有 `_is_retryable()` 逻辑：

```python
def _is_retryable(exc: Exception) -> bool:
    # 仅匹配 RateLimitError / APITimeoutError / APIConnectionError
    if isinstance(exc, retryable):
        return True
    # 仅检查 exc.status_code 属性
    status = getattr(exc, "status_code", None)
    if status is not None and status in RETRYABLE_STATUS_CODES:
        return True
    return False
```

`RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504, 529}` 虽已包含 502，但对流式 `APIError` 从未生效。

---

## Fix

```python
def _extract_status_code(exc: Exception) -> int | None:
    """从 exc.status_code 或 exc.body / body.error 提取 HTTP 状态码。"""
    ...

def _is_retryable(exc: Exception) -> bool:
    if isinstance(exc, retryable):
        return True
    status = _extract_status_code(exc)  # 替代 getattr(exc, "status_code")
    if status is not None and status in RETRYABLE_STATUS_CODES:
        return True
    return False
```

同时将 `openai.InternalServerError` 加入 `_get_openai_retryable()`。

---

## Test Plan

- [x] `test_extract_status_code_from_body_top_level` — 从 `body.status_code` 提取
- [x] `test_extract_status_code_from_body_error_object` — 从 `body.error.status_code` 提取
- [x] `test_is_retryable_streaming_openai_api_error_with_body_status` — 模拟 `API错误(502): Internal error: ReadError`
- [x] `test_is_retryable_openai_internal_server_error` — `InternalServerError(502)` 可重试
- [x] `test_stream_retries_transient_openai_api_error` — `_wrap_stream` 流中途失败后自动重试成功
- [ ] CI: `pytest tests/unit/providers/test_retry_chat_model.py`

---

## Related Context

- Provider: `company` / Model: `deepseek-v4-flash`
- 错误发生在流式中途（`event_count=5847, has_response=True`），属于网关上游 `ReadError` 导致的瞬时 5xx
- 默认重试配置：`LLM_MAX_RETRIES=3`，退避 `1s → 2s → 4s`（上限 10s）

---
