### PR TITLE
Fix/timestamp always visible &&  Double /api prefix

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -180,20 +180,10 @@
   }
 }
 
-/* Message actions: hide by default on hover-capable devices, always visible on touch */
-@media (hover: hover) {
-  .chatMessagesArea :global {
-    [class*="bubble-footer"] {
-      opacity: 0;
-      transition: opacity 0.2s;
-    }
-
-    [class*="bubble-end"]:hover [class*="bubble-footer"],
-    [class*="bubble-start"]:hover [class*="bubble-footer"],
-    [class*="bubble-footer"]:hover,
-    [class*="bubble-footer"]:focus-within {
-      opacity: 1;
-    }
+/* Message actions: always visible (timestamps are useful at a glance). */
+.chatMessagesArea :global {
+  [class*="bubble-footer"] {
+    opacity: 1;
   }
 }
 

--- a/console/src/stores/loopStore.ts
+++ b/console/src/stores/loopStore.ts
@@ -40,7 +40,7 @@ interface CommandsResponse {
 export async function fetchAvailableLoopSkills(): Promise<void> {
   try {
     const res = await request<CommandsResponse>(
-      "/api/workspace/commands/available",
+      "/workspace/commands/available",
     );
     const commands = res?.commands ?? [];
     const loopSkills: LoopSkillInfo[] = commands


### PR DESCRIPTION
Fixes #5769, Fixes #5793.

The request() function in console/src/api/request.ts already adds
the /api prefix via getApiUrl(). The call to fetch available commands
was passing "/api/workspace/commands/available", resulting in a
double-prefixed path "/api/api/workspace/commands/available" → 404.
Changed to "/workspace/commands/available" to match the pattern used
by all other API calls in the codebase.

Removed the `opacity: 0` and hover-triggered display logic for `bubble-footer` under `@media (hover: hover)`; it is now set to `opacity: 1` at all times to ensure the timestamp remains visible for the user.



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
