### PR TITLE
fix(runtime): remove stale language arg from _process_memory_section call

### DIFF
--- a/src/qwenpaw/runtime/prompt_contributors.py
+++ b/src/qwenpaw/runtime/prompt_contributors.py
@@ -240,12 +240,10 @@ class WorkspacePromptFilesContributor(SyncPromptContributor):
         except Exception as e:
             logger.warning("Failed to process heartbeat: %s", e)
         memory_manager = extras.get("memory_manager")
-        language = extras.get("language", "zh")
         try:
             content = _process_memory_section(
                 content,
                 memory_manager,
-                language,
             )
         except Exception as e:
             logger.warning("Failed to process memory section: %s", e)


### PR DESCRIPTION
## Description

Fix a pre-commit regression in `WorkspacePromptFilesContributor` where
`_process_memory_section` was called with a stale third `language`
argument.

PR #5396 introduced `WorkspacePromptFilesContributor._process_agents_md`,
which passed `(content, memory_manager, language)` to
`_process_memory_section`. That signature was valid in Runtime 2.0, but
memory refactor #5450 changed the helper to accept only
`(content, memory_manager)` because `BaseMemoryManager.get_memory_prompt()`
no longer takes a language parameter. Each memory manager now resolves
language internally from `agent_config`.

The stale call site caused mypy and pylint failures:

```
src/qwenpaw/runtime/prompt_contributors.py:245: error: Too many arguments for "_process_memory_section"  [call-arg]
src/qwenpaw/runtime/prompt_contributors.py:245:22: E1121: Too many positional arguments for function call
```

This change aligns `WorkspacePromptFilesContributor` with the existing
`AgentsMdContributor` call pattern in the same file.

**Related Issue:** Regression from #5396 (introduced) / #5450 (signature change)

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Changes

| File | Change |
|------|--------|
| `src/qwenpaw/runtime/prompt_contributors.py` | Remove unused `language` extraction and the extra argument in `WorkspacePromptFilesContributor._process_agents_md` |

## Background: why `language` is no longer passed here

| Era | `_process_memory_section` signature | Memory prompt source |
|-----|--------------------------------------|----------------------|
| Runtime 2.0 (#5078) | `(content, memory_manager, language)` | `memory_manager.get_memory_prompt(language)` |
| After #5450 | `(content, memory_manager)` | `memory_manager.get_memory_prompt()` — language read inside each manager from `agent_config` |

v1.1.2 used a different model (`memory_prompt_enabled` toggle in
`PromptBuilder`) and did not pass language into this helper. The
`language` field on `PromptBuilder` was added later (#3548) and then
removed from `get_memory_prompt()` during the auto-memory lifecycle
refactor (#5450).

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. **Static checks** — Run targeted hooks on the changed file:

   ```bash
   pre-commit run mypy --files src/qwenpaw/runtime/prompt_contributors.py
   pre-commit run pylint --files src/qwenpaw/runtime/prompt_contributors.py
   pre-commit run --all-files
   ```

2. **Runtime behavior** — Start an agent with a configured
   `system_prompt_files` list that includes `AGENTS.md` and verify the
   memory guidance section is still appended correctly for both `zh` and
   `en` agent profiles (language selection is handled by the memory
   manager, not this helper).

## Local Verification Evidence

```bash
pre-commit run mypy --files src/qwenpaw/runtime/prompt_contributors.py
# Passed

pre-commit run pylint --files src/qwenpaw/runtime/prompt_contributors.py
# Passed
```

## Suggested PR Title

```
fix(runtime): remove stale language arg from _process_memory_section call
```

## Suggested Commit Message

```
fix(runtime): align WorkspacePromptFilesContributor memory call with #5450 API

PR #5396 introduced a third `language` argument to
`_process_memory_section`, but the helper was narrowed to two parameters
in #5450 when memory managers started resolving language internally.
Remove the stale argument to fix mypy/pylint pre-commit failures.
```
