### PR TITLE
fix(yuanbao): prevent connection failures from empty api_domain and missing proto descriptors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ include-package-data = true
     "security/skill_scanner/rules/**",
     "security/skill_scanner/data/**",
     "docs/*.md",
+    "app/channels/yuanbao/proto/**",
 ]
 
 [build-system]

--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -55,6 +55,7 @@ _data_dirs = [
     ("security/tool_guard/rules", "qwenpaw/security/tool_guard/rules"),
     ("security/skill_scanner/rules", "qwenpaw/security/skill_scanner/rules"),
     ("security/skill_scanner/data", "qwenpaw/security/skill_scanner/data"),
+    ("app/channels/yuanbao/proto", "qwenpaw/app/channels/yuanbao/proto"),
 ]
 datas = [
     (str(SRC / src), dst) for src, dst in _data_dirs if (SRC / src).is_dir()

--- a/src/qwenpaw/app/channels/yuanbao/auth.py
+++ b/src/qwenpaw/app/channels/yuanbao/auth.py
@@ -125,7 +125,7 @@ class TokenManager:
 
     async def _do_fetch(self) -> SignTokenResult:
         """Execute the sign-token API call with retry logic."""
-        domain = self.api_domain or DEFAULT_API_DOMAIN
+        domain = self.api_domain
         # Strip scheme if user accidentally included it
         if domain.startswith("https://"):
             domain = domain.removeprefix("https://")
@@ -133,8 +133,6 @@ class TokenManager:
             domain = domain.removeprefix("http://")
         # Strip trailing slash
         domain = domain.rstrip("/")
-        if not domain:
-            domain = DEFAULT_API_DOMAIN
         url = f"https://{domain}{SIGN_TOKEN_PATH}"
         session = await self._get_session()
 

--- a/src/qwenpaw/app/channels/yuanbao/auth.py
+++ b/src/qwenpaw/app/channels/yuanbao/auth.py
@@ -125,7 +125,7 @@ class TokenManager:
 
     async def _do_fetch(self) -> SignTokenResult:
         """Execute the sign-token API call with retry logic."""
-        domain = self.api_domain
+        domain = self.api_domain or DEFAULT_API_DOMAIN
         # Strip scheme if user accidentally included it
         if domain.startswith("https://"):
             domain = domain.removeprefix("https://")
@@ -133,6 +133,8 @@ class TokenManager:
             domain = domain.removeprefix("http://")
         # Strip trailing slash
         domain = domain.rstrip("/")
+        if not domain:
+            domain = DEFAULT_API_DOMAIN
         url = f"https://{domain}{SIGN_TOKEN_PATH}"
         session = await self._get_session()
 

--- a/src/qwenpaw/app/channels/yuanbao/channel.py
+++ b/src/qwenpaw/app/channels/yuanbao/channel.py
@@ -173,7 +173,7 @@ class YuanbaoChannel(BaseChannel):
         self.enabled = enabled
         self.app_id = app_id
         self.app_secret = app_secret
-        self.api_domain = api_domain
+        self.api_domain = api_domain or DEFAULT_API_DOMAIN
         self.bot_prefix = bot_prefix
         self._workspace_dir = (
             Path(workspace_dir).expanduser() if workspace_dir else None


### PR DESCRIPTION
## Description

Add fallback to DEFAULT_API_DOMAIN when api_domain is empty string, preventing invalid URL.

Bundle conn.json and biz.json in pip wheel (pyproject.toml package-data) and PyInstaller desktop builds (qwenpaw.spec data-dirs), fixing WebSocket AuthBind encoding failures caused by missing protobuf descriptors

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
