### PR TITLE
fix(providers): restore OpenRouter OAuth router dropped in Runtime 2.0

### DIFF
--- a/src/qwenpaw/app/routers/__init__.py
+++ b/src/qwenpaw/app/routers/__init__.py
@@ -31,6 +31,7 @@ from .backup import router as backup_router
 from .git import router as git_router
 from .coding_project import router as coding_project_router
 from .access_control import router as access_control_router
+from .provider_oauth import router as provider_oauth_router
 
 router = APIRouter()
 
@@ -62,6 +63,7 @@ router.include_router(backup_router)
 router.include_router(git_router)
 router.include_router(coding_project_router)
 router.include_router(access_control_router)
+router.include_router(provider_oauth_router)
 
 
 def create_agent_scoped_router() -> APIRouter:

--- a/tests/unit/app/routers/test_provider_oauth_router.py
+++ b/tests/unit/app/routers/test_provider_oauth_router.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for provider OAuth router registration."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.routers import router as api_router
+
+
+def test_openrouter_oauth_start_is_registered() -> None:
+    """POST /api/providers/openrouter/oauth/start must not 405."""
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api")
+    client = TestClient(app)
+
+    response = client.post("/api/providers/openrouter/oauth/start")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["flow_type"] == "browser_redirect"
+    assert payload["authorize_url"].startswith("https://openrouter.ai/auth")
+    assert payload["state"]


### PR DESCRIPTION
# PR: fix(providers): restore OpenRouter OAuth router dropped in Runtime 2.0

**Branch:** `dev/weirui/0706fixv2`

## Description

Restore provider OAuth endpoints that were accidentally dropped during the
Runtime 2.0 router refactor (#5078).

Since v1.1.12, `POST /api/providers/openrouter/oauth/start` returns
`405 Method Not Allowed` instead of starting the OAuth flow. The
`provider_oauth.py` router file still exists, but
`provider_oauth_router` was removed from `routers/__init__.py` when
Runtime 2.0 landed. Without a matching POST route, requests fall through
to the SPA GET catch-all in `_app.py`, which matches the path but only
allows GET — hence the 405.

This change re-registers `provider_oauth_router` and adds a regression
test to ensure the OpenRouter OAuth start endpoint stays mounted.

**Related Issue:** Regression from #5078 (Runtime 2.0 modular architecture)

**Security Considerations:** N/A — restores previously shipped OAuth
behavior; no new auth surface.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Changes

| File | Change |
|------|--------|
| `src/qwenpaw/app/routers/__init__.py` | Re-import and include `provider_oauth_router` |
| `tests/unit/app/routers/test_provider_oauth_router.py` | Add regression test for `POST /api/providers/openrouter/oauth/start` |

## Root Cause

```
v1.1.12 (36db83b0)  → provider_oauth_router registered ✓
Runtime 2.0 (86d4a3f9) → provider_oauth_router removed ✗
Current               → POST hits SPA GET catch-all → 405
```

Affected endpoints (all in `provider_oauth.py`):

- `POST   /api/providers/{provider_id}/oauth/start`
- `GET    /api/providers/{provider_id}/oauth/callback`
- `GET    /api/providers/{provider_id}/oauth/status`

## Test Plan

- [x] Unit test: `pytest tests/unit/app/routers/test_provider_oauth_router.py -v`
- [ ] Manual: click "Connect with OAuth" for OpenRouter in Models page
- [ ] Manual: verify popup opens `https://openrouter.ai/auth?...`
- [ ] Manual: complete OAuth and confirm API key is saved
- [ ] Manual: verify status polling returns `completed`

## How to Verify Locally

```bash
conda activate QwenPaw
pytest tests/unit/app/routers/test_provider_oauth_router.py -v

# After starting the server:
curl -X POST http://127.0.0.1:<port>/api/providers/openrouter/oauth/start
# Expected: 200 with authorize_url, state, flow_type
```
