### PR TITLE
test(unit): inbox module unit tests — PR-A1

### DIFF
--- a/src/qwenpaw/app/inbox_store.py
+++ b/src/qwenpaw/app/inbox_store.py
@@ -17,7 +17,13 @@ _MAX_EVENTS = 5000
 def _load_events() -> list[dict[str, Any]]:
     if not _INBOX_PATH.exists():
         return []
-    data = json.loads(_INBOX_PATH.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(_INBOX_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        # Corrupted or unreadable inbox file — treat as empty rather than
+        # crashing every subsequent read. The next append_event will
+        # atomically replace the file with a valid payload.
+        return []
     if not isinstance(data, list):
         return []
     return [item for item in data if isinstance(item, dict)]

--- a/src/qwenpaw/app/inbox_store.py
+++ b/src/qwenpaw/app/inbox_store.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 import uuid
 from typing import Any
 
 from ..constant import WORKING_DIR
+
+logger = logging.getLogger(__name__)
 
 _INBOX_PATH = WORKING_DIR / "inbox_events.json"
 _LOCK = asyncio.Lock()
@@ -19,10 +22,16 @@ def _load_events() -> list[dict[str, Any]]:
         return []
     try:
         data = json.loads(_INBOX_PATH.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as exc:
         # Corrupted or unreadable inbox file — treat as empty rather than
         # crashing every subsequent read. The next append_event will
-        # atomically replace the file with a valid payload.
+        # atomically replace the file with a valid payload. Log the
+        # error so permission/disk-full issues are not silently lost.
+        logger.warning(
+            "Failed to load inbox events from %s: %s",
+            _INBOX_PATH,
+            exc,
+        )
         return []
     if not isinstance(data, list):
         return []

--- a/tests/unit/app/inbox/test_inbox_store.py
+++ b/tests/unit/app/inbox/test_inbox_store.py
@@ -2,12 +2,11 @@
 # pylint: disable=redefined-outer-name,protected-access,unused-argument
 """Unit tests for qwenpaw.app.inbox_store.
 
-Real file IO through a monkeypatched ``_INBOX_PATH`` — no over-mocking.
+Real file IO through a monkeypatched ``_INBOX_PATH`` -- no over-mocking.
 Covers: append_event, list_events filters/pagination, mark_read,
 mark_all_read, delete_event (incl. run_id reference tracking), and the
 5000-event cap.
 """
-
 from __future__ import annotations
 
 import json
@@ -16,6 +15,12 @@ from pathlib import Path
 import pytest
 
 from qwenpaw.app import inbox_store
+
+# p0: critical user flows (CRUD, pagination, mark_read); p2: error paths
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.p0,
+]
 
 
 @pytest.fixture
@@ -200,16 +205,27 @@ async def test_list_events_empty_when_no_file(inbox_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_list_events_handles_invalid_json_file(
-    inbox_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-):
+async def test_list_events_handles_non_list_json(inbox_path: Path):
+    """Valid JSON that isn't a list → returns [] via the isinstance
+    guard (not the except branch)."""
     inbox_path.write_text("not a json list", encoding="utf-8")
     events = await inbox_store.list_events()
-    # _load_events returns [] for non-list JSON; but raw string raises.
-    # Verify the behaviour: invalid file either returns [] or the loader
-    # filters non-dict items. A bare string is not a list, so [].
     assert events == []
+
+
+@pytest.mark.asyncio
+async def test_list_events_handles_malformed_json(
+    inbox_path: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Genuinely malformed JSON → caught by the except branch, returns [],
+    and logs a warning (so permission/disk errors aren't silently
+    swallowed). Regression for the #5809 review feedback."""
+    inbox_path.write_text("{bad", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        events = await inbox_store.list_events()
+    assert events == []
+    assert any("Failed to load" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/app/inbox/test_inbox_store.py
+++ b/tests/unit/app/inbox/test_inbox_store.py
@@ -7,6 +7,7 @@ Covers: append_event, list_events filters/pagination, mark_read,
 mark_all_read, delete_event (incl. run_id reference tracking), and the
 5000-event cap.
 """
+
 from __future__ import annotations
 
 import json

--- a/tests/unit/app/inbox/test_inbox_store.py
+++ b/tests/unit/app/inbox/test_inbox_store.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,protected-access,unused-argument
 """Unit tests for qwenpaw.app.inbox_store.
 
 Real file IO through a monkeypatched ``_INBOX_PATH`` — no over-mocking.
@@ -70,12 +70,22 @@ async def test_append_event_defaults_agent_id(inbox_path: Path):
 @pytest.mark.asyncio
 async def test_append_event_prepends_newest_first(inbox_path: Path):
     await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="1",
-        event_type="e", status="ok", title="first", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="1",
+        event_type="e",
+        status="ok",
+        title="first",
+        body="b",
     )
     await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="2",
-        event_type="e", status="ok", title="second", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="2",
+        event_type="e",
+        status="ok",
+        title="second",
+        body="b",
     )
     events = await inbox_store.list_events(limit=10)
     assert len(events) == 2
@@ -87,8 +97,13 @@ async def test_append_event_prepends_newest_first(inbox_path: Path):
 async def test_append_event_carries_payload(inbox_path: Path):
     payload = {"run_id": "run-xyz", "extra": [1, 2, 3]}
     event = await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="1",
-        event_type="e", status="ok", title="t", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="1",
+        event_type="e",
+        status="ok",
+        title="t",
+        body="b",
         payload=payload,
     )
     assert event["payload"] == payload
@@ -102,16 +117,31 @@ async def test_append_event_carries_payload(inbox_path: Path):
 async def _seed_events(inbox_path: Path) -> None:
     """Seed a mix of events for filter tests."""
     await inbox_store.append_event(
-        agent_id="A", source_type="cron", source_id="1",
-        event_type="dispatch", status="success", title="t1", body="b",
+        agent_id="A",
+        source_type="cron",
+        source_id="1",
+        event_type="dispatch",
+        status="success",
+        title="t1",
+        body="b",
     )
     await inbox_store.append_event(
-        agent_id="B", source_type="manual", source_id="2",
-        event_type="note", status="pending", title="t2", body="b",
+        agent_id="B",
+        source_type="manual",
+        source_id="2",
+        event_type="note",
+        status="pending",
+        title="t2",
+        body="b",
     )
     await inbox_store.append_event(
-        agent_id="A", source_type="cron", source_id="3",
-        event_type="dispatch", status="error", title="t3", body="b",
+        agent_id="A",
+        source_type="cron",
+        source_id="3",
+        event_type="dispatch",
+        status="error",
+        title="t3",
+        body="b",
     )
 
 
@@ -169,7 +199,10 @@ async def test_list_events_empty_when_no_file(inbox_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_list_events_handles_invalid_json_file(inbox_path: Path, monkeypatch: pytest.MonkeyPatch):
+async def test_list_events_handles_invalid_json_file(
+    inbox_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
     inbox_path.write_text("not a json list", encoding="utf-8")
     events = await inbox_store.list_events()
     # _load_events returns [] for non-list JSON; but raw string raises.
@@ -247,17 +280,29 @@ async def test_delete_event_tracks_run_id_reference(inbox_path: Path):
     """Two events share the same run_id. Deleting one should report that
     the run_id is still referenced by the other event."""
     await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="1",
-        event_type="e", status="ok", title="t", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="1",
+        event_type="e",
+        status="ok",
+        title="t",
+        body="b",
         payload={"run_id": "run-shared"},
     )
     await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="2",
-        event_type="e", status="ok", title="t", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="2",
+        event_type="e",
+        status="ok",
+        title="t",
+        body="b",
         payload={"run_id": "run-shared"},
     )
     events = await inbox_store.list_events(limit=1)
-    deleted, run_id, still_ref = await inbox_store.delete_event(events[0]["id"])
+    deleted, run_id, still_ref = await inbox_store.delete_event(
+        events[0]["id"],
+    )
     assert deleted is True
     assert run_id == "run-shared"
     assert still_ref is True
@@ -266,12 +311,19 @@ async def test_delete_event_tracks_run_id_reference(inbox_path: Path):
 @pytest.mark.asyncio
 async def test_delete_event_run_id_not_referenced_after_last(inbox_path: Path):
     await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="1",
-        event_type="e", status="ok", title="t", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="1",
+        event_type="e",
+        status="ok",
+        title="t",
+        body="b",
         payload={"run_id": "run-solo"},
     )
     events = await inbox_store.list_events(limit=1)
-    deleted, run_id, still_ref = await inbox_store.delete_event(events[0]["id"])
+    deleted, run_id, still_ref = await inbox_store.delete_event(
+        events[0]["id"],
+    )
     assert deleted is True
     assert run_id == "run-solo"
     assert still_ref is False
@@ -287,8 +339,13 @@ async def test_append_event_caps_at_5000(inbox_path: Path):
     # Append more than _MAX_EVENTS to confirm the tail is trimmed.
     for _ in range(inbox_store._MAX_EVENTS + 50):
         await inbox_store.append_event(
-            agent_id="a", source_type="t", source_id="1",
-            event_type="e", status="ok", title="t", body="b",
+            agent_id="a",
+            source_type="t",
+            source_id="1",
+            event_type="e",
+            status="ok",
+            title="t",
+            body="b",
         )
     events = await inbox_store.list_events(limit=inbox_store._MAX_EVENTS + 100)
     assert len(events) == inbox_store._MAX_EVENTS
@@ -303,8 +360,13 @@ async def test_append_event_caps_at_5000(inbox_path: Path):
 async def test_append_event_large_payload_round_trips(inbox_path: Path):
     big_payload = {"k": "v" * 50_000}
     event = await inbox_store.append_event(
-        agent_id="a", source_type="t", source_id="1",
-        event_type="e", status="ok", title="t", body="b",
+        agent_id="a",
+        source_type="t",
+        source_id="1",
+        event_type="e",
+        status="ok",
+        title="t",
+        body="b",
         payload=big_payload,
     )
     assert len(event["payload"]["k"]) == 50_000

--- a/tests/unit/app/inbox/test_inbox_store.py
+++ b/tests/unit/app/inbox/test_inbox_store.py
@@ -1,0 +1,313 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Unit tests for qwenpaw.app.inbox_store.
+
+Real file IO through a monkeypatched ``_INBOX_PATH`` — no over-mocking.
+Covers: append_event, list_events filters/pagination, mark_read,
+mark_all_read, delete_event (incl. run_id reference tracking), and the
+5000-event cap.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.app import inbox_store
+
+
+@pytest.fixture
+def inbox_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the module-level _INBOX_PATH to a tmp file."""
+    target = tmp_path / "inbox_events.json"
+    monkeypatch.setattr(inbox_store, "_INBOX_PATH", target)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# append_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_event_creates_file_and_returns_event(inbox_path: Path):
+    event = await inbox_store.append_event(
+        agent_id="agent-1",
+        source_type="cron",
+        source_id="job-1",
+        event_type="dispatch",
+        status="success",
+        title="Job ran",
+        body="ok",
+    )
+    assert inbox_path.exists()
+    data = json.loads(inbox_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["id"] == event["id"]
+    assert event["agent_id"] == "agent-1"
+    assert event["read"] is False
+    assert event["severity"] == "info"
+    assert event["payload"] == {}
+
+
+@pytest.mark.asyncio
+async def test_append_event_defaults_agent_id(inbox_path: Path):
+    event = await inbox_store.append_event(
+        agent_id=None,
+        source_type="manual",
+        source_id=None,
+        event_type="note",
+        status="info",
+        title="t",
+        body="b",
+    )
+    assert event["agent_id"] == "default"
+    assert event["source_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_append_event_prepends_newest_first(inbox_path: Path):
+    await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="1",
+        event_type="e", status="ok", title="first", body="b",
+    )
+    await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="2",
+        event_type="e", status="ok", title="second", body="b",
+    )
+    events = await inbox_store.list_events(limit=10)
+    assert len(events) == 2
+    assert events[0]["source_id"] == "2"
+    assert events[1]["source_id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_append_event_carries_payload(inbox_path: Path):
+    payload = {"run_id": "run-xyz", "extra": [1, 2, 3]}
+    event = await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="1",
+        event_type="e", status="ok", title="t", body="b",
+        payload=payload,
+    )
+    assert event["payload"] == payload
+
+
+# ---------------------------------------------------------------------------
+# list_events: filters + pagination
+# ---------------------------------------------------------------------------
+
+
+async def _seed_events(inbox_path: Path) -> None:
+    """Seed a mix of events for filter tests."""
+    await inbox_store.append_event(
+        agent_id="A", source_type="cron", source_id="1",
+        event_type="dispatch", status="success", title="t1", body="b",
+    )
+    await inbox_store.append_event(
+        agent_id="B", source_type="manual", source_id="2",
+        event_type="note", status="pending", title="t2", body="b",
+    )
+    await inbox_store.append_event(
+        agent_id="A", source_type="cron", source_id="3",
+        event_type="dispatch", status="error", title="t3", body="b",
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_events_filter_by_source_type(inbox_path: Path):
+    await _seed_events(inbox_path)
+    events = await inbox_store.list_events(source_type="cron")
+    assert len(events) == 2
+    assert all(e["source_type"] == "cron" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_list_events_filter_by_status(inbox_path: Path):
+    await _seed_events(inbox_path)
+    events = await inbox_store.list_events(status="error")
+    assert len(events) == 1
+    assert events[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_list_events_filter_by_agent_id(inbox_path: Path):
+    await _seed_events(inbox_path)
+    events = await inbox_store.list_events(agent_id="A")
+    assert len(events) == 2
+    assert all(e["agent_id"] == "A" for e in events)
+
+
+@pytest.mark.asyncio
+async def test_list_events_unread_only(inbox_path: Path):
+    await _seed_events(inbox_path)
+    # Mark the first (newest) as read.
+    events = await inbox_store.list_events(limit=1)
+    await inbox_store.mark_read([events[0]["id"]])
+
+    unread = await inbox_store.list_events(unread_only=True)
+    assert len(unread) == 2
+    assert all(not e["read"] for e in unread)
+
+
+@pytest.mark.asyncio
+async def test_list_events_pagination(inbox_path: Path):
+    await _seed_events(inbox_path)
+    page1 = await inbox_store.list_events(limit=2, offset=0)
+    page2 = await inbox_store.list_events(limit=2, offset=2)
+    assert len(page1) == 2
+    assert len(page2) == 1
+    assert page1[0]["source_id"] == "3"  # newest first
+    assert page2[0]["source_id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_list_events_empty_when_no_file(inbox_path: Path):
+    events = await inbox_store.list_events()
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_list_events_handles_invalid_json_file(inbox_path: Path, monkeypatch: pytest.MonkeyPatch):
+    inbox_path.write_text("not a json list", encoding="utf-8")
+    events = await inbox_store.list_events()
+    # _load_events returns [] for non-list JSON; but raw string raises.
+    # Verify the behaviour: invalid file either returns [] or the loader
+    # filters non-dict items. A bare string is not a list, so [].
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# mark_read / mark_all_read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_read_returns_count_of_newly_read(inbox_path: Path):
+    await _seed_events(inbox_path)
+    events = await inbox_store.list_events(limit=2)
+    updated = await inbox_store.mark_read([events[0]["id"], events[1]["id"]])
+    assert updated == 2
+
+
+@pytest.mark.asyncio
+async def test_mark_read_idempotent(inbox_path: Path):
+    await _seed_events(inbox_path)
+    events = await inbox_store.list_events(limit=1)
+    first = await inbox_store.mark_read([events[0]["id"]])
+    second = await inbox_store.mark_read([events[0]["id"]])
+    assert first == 1
+    assert second == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_read_empty_list_returns_zero(inbox_path: Path):
+    assert await inbox_store.mark_read([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_mark_all_read(inbox_path: Path):
+    await _seed_events(inbox_path)
+    updated = await inbox_store.mark_all_read()
+    assert updated == 3
+    # Second call is idempotent.
+    assert await inbox_store.mark_all_read() == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_event (with run_id reference tracking)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_event_returns_false_for_empty_id(inbox_path: Path):
+    deleted, run_id, still_ref = await inbox_store.delete_event("")
+    assert (deleted, run_id, still_ref) == (False, None, False)
+
+
+@pytest.mark.asyncio
+async def test_delete_event_removes_event(inbox_path: Path):
+    await _seed_events(inbox_path)
+    events = await inbox_store.list_events(limit=1)
+    deleted, _, _ = await inbox_store.delete_event(events[0]["id"])
+    assert deleted is True
+    remaining = await inbox_store.list_events()
+    assert len(remaining) == 2
+
+
+@pytest.mark.asyncio
+async def test_delete_event_returns_false_for_missing_id(inbox_path: Path):
+    deleted, run_id, still_ref = await inbox_store.delete_event("ghost-id")
+    assert (deleted, run_id, still_ref) == (False, None, False)
+
+
+@pytest.mark.asyncio
+async def test_delete_event_tracks_run_id_reference(inbox_path: Path):
+    """Two events share the same run_id. Deleting one should report that
+    the run_id is still referenced by the other event."""
+    await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="1",
+        event_type="e", status="ok", title="t", body="b",
+        payload={"run_id": "run-shared"},
+    )
+    await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="2",
+        event_type="e", status="ok", title="t", body="b",
+        payload={"run_id": "run-shared"},
+    )
+    events = await inbox_store.list_events(limit=1)
+    deleted, run_id, still_ref = await inbox_store.delete_event(events[0]["id"])
+    assert deleted is True
+    assert run_id == "run-shared"
+    assert still_ref is True
+
+
+@pytest.mark.asyncio
+async def test_delete_event_run_id_not_referenced_after_last(inbox_path: Path):
+    await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="1",
+        event_type="e", status="ok", title="t", body="b",
+        payload={"run_id": "run-solo"},
+    )
+    events = await inbox_store.list_events(limit=1)
+    deleted, run_id, still_ref = await inbox_store.delete_event(events[0]["id"])
+    assert deleted is True
+    assert run_id == "run-solo"
+    assert still_ref is False
+
+
+# ---------------------------------------------------------------------------
+# 5000-event cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_event_caps_at_5000(inbox_path: Path):
+    # Append more than _MAX_EVENTS to confirm the tail is trimmed.
+    for _ in range(inbox_store._MAX_EVENTS + 50):
+        await inbox_store.append_event(
+            agent_id="a", source_type="t", source_id="1",
+            event_type="e", status="ok", title="t", body="b",
+        )
+    events = await inbox_store.list_events(limit=inbox_store._MAX_EVENTS + 100)
+    assert len(events) == inbox_store._MAX_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# large payload write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_event_large_payload_round_trips(inbox_path: Path):
+    big_payload = {"k": "v" * 50_000}
+    event = await inbox_store.append_event(
+        agent_id="a", source_type="t", source_id="1",
+        event_type="e", status="ok", title="t", body="b",
+        payload=big_payload,
+    )
+    assert len(event["payload"]["k"]) == 50_000
+
+    events = await inbox_store.list_events(limit=1)
+    assert len(events[0]["payload"]["k"]) == 50_000

--- a/tests/unit/app/inbox/test_inbox_trace_store.py
+++ b/tests/unit/app/inbox/test_inbox_trace_store.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,protected-access,unused-argument
+# pylint: disable=use-implicit-booleaness-not-comparison
 """Unit tests for qwenpaw.app.inbox_trace_store.
 
 Real file IO through a monkeypatched ``_TRACE_DIR`` — no over-mocking.
@@ -130,7 +131,7 @@ async def test_append_trace_events_creates_trace_if_missing(trace_dir: Path):
         [{"at": 1.0, "event": {"x": 1}}],
     )
     data = json.loads(
-        (trace_dir / "run-bootstrap.json").read_text(encoding="utf-8")
+        (trace_dir / "run-bootstrap.json").read_text(encoding="utf-8"),
     )
     assert len(data["events"]) == 1
 
@@ -289,7 +290,14 @@ class _FakeSession:
     def __init__(self, state: dict | Exception):
         self._state = state
 
-    async def get_session_state_dict(self, session_id, user_id, channel, *, allow_not_exist):
+    async def get_session_state_dict(
+        self,
+        session_id,
+        user_id,
+        channel,
+        *,
+        allow_not_exist,
+    ):
         if isinstance(self._state, Exception):
             raise self._state
         return self._state
@@ -299,7 +307,10 @@ class _FakeSession:
 async def test_read_session_messages_no_session_returns_empty(trace_dir: Path):
     runner = SimpleNamespace(session=None)
     out = await trace_store.read_session_messages(
-        runner=runner, session_id="s", user_id="u", channel="c"
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
     )
     assert out == []
 
@@ -307,29 +318,37 @@ async def test_read_session_messages_no_session_returns_empty(trace_dir: Path):
 @pytest.mark.asyncio
 async def test_read_session_messages_exception_returns_empty(trace_dir: Path):
     runner = SimpleNamespace(
-        session=_FakeSession(RuntimeError("session backend down"))
+        session=_FakeSession(RuntimeError("session backend down")),
     )
     out = await trace_store.read_session_messages(
-        runner=runner, session_id="s", user_id="u", channel="c"
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
     )
     assert out == []
 
 
 @pytest.mark.asyncio
-async def test_read_session_messages_extracts_context_messages(trace_dir: Path):
+async def test_read_session_messages_extracts_context_messages(
+    trace_dir: Path,
+):
     state = {
         "agent": {
             "state": {
                 "context": [
                     {"role": "user", "content": "hi"},
                     {"role": "assistant", "content": "hello"},
-                ]
-            }
-        }
+                ],
+            },
+        },
     }
     runner = SimpleNamespace(session=_FakeSession(state))
     out = await trace_store.read_session_messages(
-        runner=runner, session_id="s", user_id="u", channel="c"
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
     )
     assert len(out) == 2
     assert out[0]["role"] == "user"
@@ -337,11 +356,16 @@ async def test_read_session_messages_extracts_context_messages(trace_dir: Path):
 
 
 @pytest.mark.asyncio
-async def test_read_session_messages_missing_context_returns_empty(trace_dir: Path):
+async def test_read_session_messages_missing_context_returns_empty(
+    trace_dir: Path,
+):
     state = {"agent": {"state": {}}}
     runner = SimpleNamespace(session=_FakeSession(state))
     out = await trace_store.read_session_messages(
-        runner=runner, session_id="s", user_id="u", channel="c"
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
     )
     assert out == []
 
@@ -352,17 +376,31 @@ async def test_read_session_messages_missing_context_returns_empty(trace_dir: Pa
 
 
 @pytest.mark.asyncio
-async def test_append_trace_from_session_delta_appends_only_new(trace_dir: Path):
+async def test_append_trace_from_session_delta_appends_only_new(
+    trace_dir: Path,
+):
     state = {
         "agent": {
             "state": {
                 "context": [
-                    {"role": "user", "content": "m1", "created_at": "2024-01-02T03:04:05"},
-                    {"role": "assistant", "content": "m2", "created_at": "2024-01-02T03:04:06"},
-                    {"role": "user", "content": "m3", "created_at": "2024-01-02T03:04:07"},
-                ]
-            }
-        }
+                    {
+                        "role": "user",
+                        "content": "m1",
+                        "created_at": "2024-01-02T03:04:05",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "m2",
+                        "created_at": "2024-01-02T03:04:06",
+                    },
+                    {
+                        "role": "user",
+                        "content": "m3",
+                        "created_at": "2024-01-02T03:04:07",
+                    },
+                ],
+            },
+        },
     }
     runner = SimpleNamespace(session=_FakeSession(state))
     await trace_store.create_trace("run-delta")
@@ -378,7 +416,9 @@ async def test_append_trace_from_session_delta_appends_only_new(trace_dir: Path)
     assert len(delta) == 2
     assert delta[0]["content"] == "m2"
     assert delta[1]["content"] == "m3"
-    data = json.loads((trace_dir / "run-delta.json").read_text(encoding="utf-8"))
+    data = json.loads(
+        (trace_dir / "run-delta.json").read_text(encoding="utf-8"),
+    )
     assert len(data["events"]) == 2
     # Parsed timestamps should be floats, not None (ISO strings are parseable).
     assert isinstance(data["events"][0]["at"], float)
@@ -391,9 +431,9 @@ async def test_append_trace_from_session_delta_baseline_zero(trace_dir: Path):
             "state": {
                 "context": [
                     {"role": "user", "content": "only"},
-                ]
-            }
-        }
+                ],
+            },
+        },
     }
     runner = SimpleNamespace(session=_FakeSession(state))
     await trace_store.create_trace("run-delta-0")
@@ -409,8 +449,12 @@ async def test_append_trace_from_session_delta_baseline_zero(trace_dir: Path):
 
 
 @pytest.mark.asyncio
-async def test_append_trace_from_session_delta_negative_baseline_clamped(trace_dir: Path):
-    state = {"agent": {"state": {"context": [{"content": "a"}, {"content": "b"}]}}}
+async def test_append_trace_from_session_delta_negative_baseline_clamped(
+    trace_dir: Path,
+):
+    state = {
+        "agent": {"state": {"context": [{"content": "a"}, {"content": "b"}]}},
+    }
     runner = SimpleNamespace(session=_FakeSession(state))
     await trace_store.create_trace("run-neg")
     delta = await trace_store.append_trace_from_session_delta(
@@ -451,7 +495,9 @@ async def test_finalize_trace_records_error_message(trace_dir: Path):
 
 
 @pytest.mark.asyncio
-async def test_finalize_trace_without_error_keeps_field_absent(trace_dir: Path):
+async def test_finalize_trace_without_error_keeps_field_absent(
+    trace_dir: Path,
+):
     await trace_store.create_trace("run-1")
     await trace_store.finalize_trace("run-1", status="success")
     data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))

--- a/tests/unit/app/inbox/test_inbox_trace_store.py
+++ b/tests/unit/app/inbox/test_inbox_trace_store.py
@@ -1,0 +1,518 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Unit tests for qwenpaw.app.inbox_trace_store.
+
+Real file IO through a monkeypatched ``_TRACE_DIR`` — no over-mocking.
+Covers: create_trace, append_trace_events (normalization, pydantic
+model_dump, non-dict filtering, default timestamps), flatten_session_messages,
+parse_session_timestamp, read_session_messages (with a fake runner),
+append_trace_from_session_delta (baseline→delta calc), finalize_trace,
+get_trace, delete_trace, and low-level _to_jsonable / _read_trace edges.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.app import inbox_trace_store as trace_store
+
+
+@pytest.fixture
+def trace_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect module-level _TRACE_DIR to a tmp directory."""
+    target = tmp_path / "inbox_traces"
+    monkeypatch.setattr(trace_store, "_TRACE_DIR", target)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# _to_jsonable
+# ---------------------------------------------------------------------------
+
+
+def test_to_jsonable_primitives_passthrough():
+    assert trace_store._to_jsonable(None) is None
+    assert trace_store._to_jsonable("s") == "s"
+    assert trace_store._to_jsonable(1) == 1
+    assert trace_store._to_jsonable(1.5) == 1.5
+    assert trace_store._to_jsonable(True) is True
+
+
+def test_to_jsonable_list_and_dict_recursive():
+    payload = {"a": [1, {"b": "c"}], "n": None}
+    out = trace_store._to_jsonable(payload)
+    assert out == {"a": [1, {"b": "c"}], "n": None}
+
+
+def test_to_jsonable_dict_keys_stringified():
+    out = trace_store._to_jsonable({1: "a", 2: "b"})
+    assert out == {"1": "a", "2": "b"}
+
+
+def test_to_jsonable_pydantic_like_model_dump():
+    class FakeModel:
+        def model_dump(self, mode: str = "python"):
+            return {"k": "v", "mode": mode}
+
+    out = trace_store._to_jsonable(FakeModel())
+    assert out == {"k": "v", "mode": "json"}
+
+
+def test_to_jsonable_falls_back_to_repr():
+    class _Weird:
+        pass
+
+    out = trace_store._to_jsonable(_Weird())
+    assert isinstance(out, dict)
+    assert "repr" in out
+    assert "_Weird" in out["repr"]
+
+
+# ---------------------------------------------------------------------------
+# create_trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_trace_writes_initial_payload(trace_dir: Path):
+    await trace_store.create_trace("run-1", meta={"agent": "a"})
+    path = trace_dir / "run-1.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["run_id"] == "run-1"
+    assert data["status"] == "running"
+    assert data["completed_at"] is None
+    assert data["meta"] == {"agent": "a"}
+    assert data["events"] == []
+    assert isinstance(data["created_at"], float)
+
+
+@pytest.mark.asyncio
+async def test_create_trace_default_meta_is_empty_dict(trace_dir: Path):
+    await trace_store.create_trace("run-2")
+    data = json.loads((trace_dir / "run-2.json").read_text(encoding="utf-8"))
+    assert data["meta"] == {}
+
+
+# ---------------------------------------------------------------------------
+# append_trace_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_appends_to_existing(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    await trace_store.append_trace_events(
+        "run-1",
+        [{"at": 1.0, "event": {"text": "first"}}],
+    )
+    await trace_store.append_trace_events(
+        "run-1",
+        [{"at": 2.0, "event": {"text": "second"}}],
+    )
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    events = data["events"]
+    assert len(events) == 2
+    assert events[0]["event"]["text"] == "first"
+    assert events[1]["event"]["text"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_creates_trace_if_missing(trace_dir: Path):
+    # _read_trace returns a default payload when the file is missing, so
+    # append_trace_events bootstraps the trace on first call.
+    await trace_store.append_trace_events(
+        "run-bootstrap",
+        [{"at": 1.0, "event": {"x": 1}}],
+    )
+    data = json.loads(
+        (trace_dir / "run-bootstrap.json").read_text(encoding="utf-8")
+    )
+    assert len(data["events"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_defaults_at_timestamp(trace_dir: Path):
+    before = time.time()
+    await trace_store.create_trace("run-1")
+    await trace_store.append_trace_events(
+        "run-1",
+        [{"event": {"text": "no-at"}}],
+    )
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    at = data["events"][0]["at"]
+    assert isinstance(at, float)
+    assert at >= before
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_filters_non_dict_items(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    await trace_store.append_trace_events(
+        "run-1",
+        [
+            {"at": 1.0, "event": {"keep": True}},
+            "not-a-dict",
+            42,
+            None,
+        ],
+    )
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert len(data["events"]) == 1
+    assert data["events"][0]["event"] == {"keep": True}
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_normalizes_pydantic_event(trace_dir: Path):
+    class FakeModel:
+        def model_dump(self, mode: str = "python"):
+            return {"role": "assistant", "content": "hi"}
+
+    await trace_store.create_trace("run-1")
+    await trace_store.append_trace_events(
+        "run-1",
+        [{"at": 1.0, "event": FakeModel()}],
+    )
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert data["events"][0]["event"] == {
+        "role": "assistant",
+        "content": "hi",
+    }
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_empty_list_is_noop(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    # Empty input should not raise and should not mutate the file.
+    await trace_store.append_trace_events("run-1", [])
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert data["events"] == []
+
+
+@pytest.mark.asyncio
+async def test_append_trace_events_all_non_dict_is_noop(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    await trace_store.append_trace_events("run-1", ["x", 1, None])
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert data["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# flatten_session_messages
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_session_messages_non_list_returns_empty():
+    assert trace_store.flatten_session_messages("not a list") == []
+    assert trace_store.flatten_session_messages(None) == []
+    assert trace_store.flatten_session_messages({"a": 1}) == []
+
+
+def test_flatten_session_messages_dicts_kept_as_is():
+    msgs = [{"role": "user", "content": "hi"}, {"role": "assistant"}]
+    assert trace_store.flatten_session_messages(msgs) == msgs
+
+
+def test_flatten_session_messages_nested_list_unwraps_first_dict():
+    # agentscope sometimes returns [[{message}], ...] — unwrap first dict.
+    msgs = [[{"role": "user", "content": "x"}], [{"role": "assistant"}]]
+    flat = trace_store.flatten_session_messages(msgs)
+    assert flat == [{"role": "user", "content": "x"}, {"role": "assistant"}]
+
+
+def test_flatten_session_messages_skips_empty_or_non_dict_inner_lists():
+    msgs = [{"a": 1}, [], [42, "str"], {"b": 2}]
+    flat = trace_store.flatten_session_messages(msgs)
+    # Empty inner list and inner list whose first item isn't a dict are
+    # skipped; bare dicts are kept.
+    assert flat == [{"a": 1}, {"b": 2}]
+
+
+# ---------------------------------------------------------------------------
+# parse_session_timestamp
+# ---------------------------------------------------------------------------
+
+
+def test_parse_session_timestamp_iso():
+    from datetime import datetime
+
+    raw = "2024-01-02T03:04:05"
+    ts = trace_store.parse_session_timestamp(raw)
+    assert ts is not None
+    # Compare against the same naive-datetime interpretation (tz-independent).
+    assert ts == pytest.approx(datetime.fromisoformat(raw).timestamp())
+
+
+def test_parse_session_timestamp_iso_with_fractional():
+    from datetime import datetime
+
+    raw = "2024-01-02T03:04:05.123456"
+    ts = trace_store.parse_session_timestamp(raw)
+    assert ts is not None
+    assert ts == pytest.approx(datetime.fromisoformat(raw).timestamp())
+
+
+def test_parse_session_timestamp_space_separated_with_microseconds():
+    ts = trace_store.parse_session_timestamp("2024-01-02 03:04:05.123456")
+    assert ts is not None
+
+
+def test_parse_session_timestamp_space_separated_seconds():
+    ts = trace_store.parse_session_timestamp("2024-01-02 03:04:05")
+    assert ts is not None
+
+
+def test_parse_session_timestamp_invalid_returns_none():
+    assert trace_store.parse_session_timestamp("not a date") is None
+
+
+def test_parse_session_timestamp_empty_returns_none():
+    assert trace_store.parse_session_timestamp("") is None
+    assert trace_store.parse_session_timestamp("   ") is None
+
+
+def test_parse_session_timestamp_non_string_returns_none():
+    assert trace_store.parse_session_timestamp(None) is None
+    assert trace_store.parse_session_timestamp(123) is None
+
+
+# ---------------------------------------------------------------------------
+# read_session_messages (with a fake runner)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self, state: dict | Exception):
+        self._state = state
+
+    async def get_session_state_dict(self, session_id, user_id, channel, *, allow_not_exist):
+        if isinstance(self._state, Exception):
+            raise self._state
+        return self._state
+
+
+@pytest.mark.asyncio
+async def test_read_session_messages_no_session_returns_empty(trace_dir: Path):
+    runner = SimpleNamespace(session=None)
+    out = await trace_store.read_session_messages(
+        runner=runner, session_id="s", user_id="u", channel="c"
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_read_session_messages_exception_returns_empty(trace_dir: Path):
+    runner = SimpleNamespace(
+        session=_FakeSession(RuntimeError("session backend down"))
+    )
+    out = await trace_store.read_session_messages(
+        runner=runner, session_id="s", user_id="u", channel="c"
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_read_session_messages_extracts_context_messages(trace_dir: Path):
+    state = {
+        "agent": {
+            "state": {
+                "context": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ]
+            }
+        }
+    }
+    runner = SimpleNamespace(session=_FakeSession(state))
+    out = await trace_store.read_session_messages(
+        runner=runner, session_id="s", user_id="u", channel="c"
+    )
+    assert len(out) == 2
+    assert out[0]["role"] == "user"
+    assert out[1]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_read_session_messages_missing_context_returns_empty(trace_dir: Path):
+    state = {"agent": {"state": {}}}
+    runner = SimpleNamespace(session=_FakeSession(state))
+    out = await trace_store.read_session_messages(
+        runner=runner, session_id="s", user_id="u", channel="c"
+    )
+    assert out == []
+
+
+# ---------------------------------------------------------------------------
+# append_trace_from_session_delta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_append_trace_from_session_delta_appends_only_new(trace_dir: Path):
+    state = {
+        "agent": {
+            "state": {
+                "context": [
+                    {"role": "user", "content": "m1", "created_at": "2024-01-02T03:04:05"},
+                    {"role": "assistant", "content": "m2", "created_at": "2024-01-02T03:04:06"},
+                    {"role": "user", "content": "m3", "created_at": "2024-01-02T03:04:07"},
+                ]
+            }
+        }
+    }
+    runner = SimpleNamespace(session=_FakeSession(state))
+    await trace_store.create_trace("run-delta")
+    delta = await trace_store.append_trace_from_session_delta(
+        run_id="run-delta",
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
+        baseline_count=1,
+    )
+    # Only the 2 messages beyond the baseline should be returned & appended.
+    assert len(delta) == 2
+    assert delta[0]["content"] == "m2"
+    assert delta[1]["content"] == "m3"
+    data = json.loads((trace_dir / "run-delta.json").read_text(encoding="utf-8"))
+    assert len(data["events"]) == 2
+    # Parsed timestamps should be floats, not None (ISO strings are parseable).
+    assert isinstance(data["events"][0]["at"], float)
+
+
+@pytest.mark.asyncio
+async def test_append_trace_from_session_delta_baseline_zero(trace_dir: Path):
+    state = {
+        "agent": {
+            "state": {
+                "context": [
+                    {"role": "user", "content": "only"},
+                ]
+            }
+        }
+    }
+    runner = SimpleNamespace(session=_FakeSession(state))
+    await trace_store.create_trace("run-delta-0")
+    delta = await trace_store.append_trace_from_session_delta(
+        run_id="run-delta-0",
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
+        baseline_count=0,
+    )
+    assert len(delta) == 1
+
+
+@pytest.mark.asyncio
+async def test_append_trace_from_session_delta_negative_baseline_clamped(trace_dir: Path):
+    state = {"agent": {"state": {"context": [{"content": "a"}, {"content": "b"}]}}}
+    runner = SimpleNamespace(session=_FakeSession(state))
+    await trace_store.create_trace("run-neg")
+    delta = await trace_store.append_trace_from_session_delta(
+        run_id="run-neg",
+        runner=runner,
+        session_id="s",
+        user_id="u",
+        channel="c",
+        baseline_count=-5,
+    )
+    # Negative baseline is clamped to 0, so both messages are returned.
+    assert len(delta) == 2
+
+
+# ---------------------------------------------------------------------------
+# finalize_trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_trace_sets_status_and_completed_at(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    before = time.time()
+    await trace_store.finalize_trace("run-1", status="success")
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert data["status"] == "success"
+    assert isinstance(data["completed_at"], float)
+    assert data["completed_at"] >= before
+
+
+@pytest.mark.asyncio
+async def test_finalize_trace_records_error_message(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    await trace_store.finalize_trace("run-1", status="error", error="boom")
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert data["status"] == "error"
+    assert data["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_finalize_trace_without_error_keeps_field_absent(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    await trace_store.finalize_trace("run-1", status="success")
+    data = json.loads((trace_dir / "run-1.json").read_text(encoding="utf-8"))
+    assert "error" not in data
+
+
+# ---------------------------------------------------------------------------
+# get_trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_trace_returns_none_when_missing(trace_dir: Path):
+    assert await trace_store.get_trace("ghost") is None
+
+
+@pytest.mark.asyncio
+async def test_get_trace_returns_payload(trace_dir: Path):
+    await trace_store.create_trace("run-1", meta={"k": "v"})
+    out = await trace_store.get_trace("run-1")
+    assert out is not None
+    assert out["run_id"] == "run-1"
+    assert out["meta"] == {"k": "v"}
+
+
+@pytest.mark.asyncio
+async def test_get_trace_on_invalid_json_raises(trace_dir: Path):
+    # _read_trace raises ValueError for non-dict JSON. get_trace forwards
+    # that — callers must not silently swallow corrupted trace files.
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    (trace_dir / "run-bad.json").write_text("[]", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid trace file"):
+        await trace_store.get_trace("run-bad")
+
+
+# ---------------------------------------------------------------------------
+# delete_trace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_trace_returns_false_for_empty_id(trace_dir: Path):
+    assert await trace_store.delete_trace("") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_trace_returns_false_when_missing(trace_dir: Path):
+    assert await trace_store.delete_trace("ghost") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_trace_removes_file_and_returns_true(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    path = trace_dir / "run-1.json"
+    assert path.exists()
+    assert await trace_store.delete_trace("run-1") is True
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_trace_idempotent(trace_dir: Path):
+    await trace_store.create_trace("run-1")
+    assert await trace_store.delete_trace("run-1") is True
+    assert await trace_store.delete_trace("run-1") is False

--- a/tests/unit/app/inbox/test_inbox_trace_store.py
+++ b/tests/unit/app/inbox/test_inbox_trace_store.py
@@ -10,6 +10,7 @@ parse_session_timestamp, read_session_messages (with a fake runner),
 append_trace_from_session_delta (baseline→delta calc), finalize_trace,
 get_trace, delete_trace, and low-level _to_jsonable / _read_trace edges.
 """
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary

Add unit tests for the `inbox` module (`inbox_store.py` + `inbox_trace_store.py`) — 64 cases, all green. Also fixes a source bug in `_load_events` where corrupted JSON would crash every subsequent read.

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Problem / Motivation

Backend line coverage was 42% at end of June. The `inbox` module had zero unit tests despite being on the heartbeat → inbox write path (heavy traffic, real users). During test writing, a real bug was found: `_load_events` called `json.loads()` without exception handling, so a single corrupted bytes write would crash every subsequent `list_events` / `mark_read` / `mark_all_read` / `delete_event` — the inbox becomes permanently unreadable until manual cleanup.

## Proposed Solution

Two test files, 64 cases:
- `tests/unit/app/inbox/test_inbox_store.py` (22 cases) — append_event, list/pagination, status filter, mark_read/mark_all_read, delete, atomic save, large payload write
- `tests/unit/app/inbox/test_inbox_trace_store.py` (42 cases) — `_to_jsonable` (primitives, list/dict recursion, key stringification, pydantic `model_dump`, repr fallback), `create_trace`, `append_trace_events`, `flatten_session_messages`, `parse_session_timestamp` (both formats + invalid), `read_session_messages`, `append_trace_from_session_delta` (baseline→delta, negative baseline clamped), `finalize_trace`, `get_trace`, `delete_trace`

**Source fix**: `src/qwenpaw/app/inbox_store.py` `_load_events` now wraps `json.loads()` in `try/except (json.JSONDecodeError, OSError)` returning `[]`. The next `append_event` atomically replaces the file via tmp-rename.

Style: real file IO via `tmp_path` + `monkeypatch.setattr` on module-level `_INBOX_PATH` / `_TRACE_DIR`. No `importorskip`, no `type:ignore`. Matches `tests/unit/app/chats` and `tests/unit/app/crons` patterns.

## Alternatives Considered

- Mock the file IO (rejected — real atomic-rename path is where bugs hide)
- Split into `test_models.py` (rejected — no dedicated model classes; dicts only, so model-ish logic is tested in the store test files)

## Additional Context

Part of the July backend test plan (PR-A1). Follows the chats/crons template. Tests verified green with `/Users/remy/work/QwenPaw/.venv/bin/python -m pytest tests/unit/app/inbox/ -q`.

## Willing to Contribute

- [x] I am willing to open a PR for this feature (after discussion).

## Verification

- **Tests**: 64 cases, all green locally (`pytest tests/unit/app/inbox/ -q`)
- **CI**: pre-commit + Unit/Contract/Integrated Tests passing
- **Source changes**: 1 bug fix — `inbox_store.py::_load_events` now catches JSONDecodeError/OSError (corrupt file no longer crashes every subsequent read)
- **Commits**: 2 commits (tests + source fix + pre-commit formatting) — see commit history for the fix trail
