### PR TITLE
[codex] Bundle Node runtime for ACP desktop

### DIFF
--- a/console/src-tauri/capabilities/default.json
+++ b/console/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "desktop-updater-check",
     "desktop-updater-install",
     "devtools",
+    "dialog:allow-open",
     "dialog:allow-save",
     "open-external-link",
     "tray"

--- a/console/src-tauri/src/backend/command.rs
+++ b/console/src-tauri/src/backend/command.rs
@@ -74,6 +74,15 @@ pub(super) fn create(app: &tauri::AppHandle) -> Result<Command, String> {
              installation will be unavailable"
         );
     }
+    if let Some(node_runtime) = packaged_node_runtime(app) {
+        log::info!("[backend] bundled node runtime: {}", node_runtime.display());
+        command = command.env(
+            "QWENPAW_DESKTOP_NODE_RUNTIME",
+            node_runtime.to_string_lossy().to_string(),
+        );
+    } else {
+        log::warn!("[backend] bundled node runtime not found");
+    }
     Ok(command)
 }
 
@@ -92,6 +101,22 @@ fn packaged_python_runtime(app: &tauri::AppHandle) -> Option<PathBuf> {
         vec![base.join("bin").join("python3"), base.join("bin").join("python")]
     };
     candidates.into_iter().find(|path| path.is_file())
+}
+
+#[cfg(not(debug_assertions))]
+fn packaged_node_runtime(app: &tauri::AppHandle) -> Option<PathBuf> {
+    let root = app
+        .path()
+        .resource_dir()
+        .ok()?
+        .join("binaries")
+        .join("node-runtime");
+    let node = if cfg!(windows) {
+        root.join("node.exe")
+    } else {
+        root.join("bin").join("node")
+    };
+    node.is_file().then_some(root)
 }
 
 #[cfg(not(debug_assertions))]

--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -39,7 +39,11 @@
       "../../scripts/pack/assets/icon.icns",
       "../../scripts/pack/assets/icon.ico"
     ],
-    "resources": ["binaries/qwenpaw-backend", "binaries/python-runtime"],
+    "resources": [
+      "binaries/qwenpaw-backend",
+      "binaries/python-runtime",
+      "binaries/node-runtime"
+    ],
     "windows": {
       "webviewInstallMode": {
         "type": "downloadBootstrapper",

--- a/console/src/api/modules/acp.ts
+++ b/console/src/api/modules/acp.ts
@@ -1,14 +1,28 @@
 import { request } from "../request";
-import type { ACPAgentConfig, ACPConfig } from "../types";
+import type {
+  ACPAgentConfig,
+  ACPConfig,
+  ACPNodeRuntimeStatus,
+  ACPNodeRuntimeUpdate,
+} from "../types";
 
 export const acpApi = {
   getACPConfig: () => request<ACPConfig>("/config/acp"),
+
+  getACPNodeRuntime: () =>
+    request<ACPNodeRuntimeStatus>("/config/acp/node-runtime"),
 
   getACPAgentConfig: (agentName: string) =>
     request<ACPAgentConfig>(`/config/acp/${encodeURIComponent(agentName)}`),
 
   updateACPConfig: (body: ACPConfig) =>
     request<ACPConfig>("/config/acp", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
+
+  updateACPNodeRuntime: (body: ACPNodeRuntimeUpdate) =>
+    request<ACPNodeRuntimeStatus>("/config/acp/node-runtime", {
       method: "PUT",
       body: JSON.stringify(body),
     }),

--- a/console/src/api/types/acp.ts
+++ b/console/src/api/types/acp.ts
@@ -14,5 +14,28 @@ export interface ACPAgentConfig {
 }
 
 export interface ACPConfig {
+  node_path?: string;
   agents: Record<string, ACPAgentConfig>;
+}
+
+export interface ACPNodeRuntimeCandidate {
+  key: string;
+  label: string;
+  node_path: string;
+  npx_path: string;
+  node_version: string;
+  npx_version: string;
+  available: boolean;
+  reason_code: string;
+  reason: string;
+}
+
+export interface ACPNodeRuntimeStatus {
+  node_path: string;
+  effective_node_path: string;
+  candidates: ACPNodeRuntimeCandidate[];
+}
+
+export interface ACPNodeRuntimeUpdate {
+  node_path: string;
 }

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -255,7 +255,27 @@
     "deleteTitle": "Delete {{name}}",
     "deleteConfirm": "Delete this ACP agent? This action cannot be undone.",
     "deleteSuccess": "ACP agent deleted",
-    "deleteFailed": "Failed to delete ACP agent"
+    "deleteFailed": "Failed to delete ACP agent",
+    "nodeSettings": "Node Settings",
+    "nodePath": "Node path",
+    "chooseOtherNode": "Choose another Node...",
+    "selectNodePath": "Select Node path",
+    "nodePathPrompt": "Enter the node executable path",
+    "nodeSaved": "Node settings saved",
+    "nodeLoadFailed": "Failed to load Node settings",
+    "nodeSaveFailed": "Node path is unavailable",
+    "nodeRuntime": {
+      "bundled": "Bundled Node",
+      "system": "System Node",
+      "custom": "Custom Node"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "System Node was not detected",
+      "nodeMissing": "Node path does not exist",
+      "npxMissing": "npx was not found",
+      "versionCheckFailed": "Version check failed",
+      "unavailable": "Unavailable"
+    }
   },
   "voiceTranscription": {
     "title": "Voice Transcription",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -1171,7 +1171,27 @@
     "deleteTitle": "Hapus {{name}}",
     "deleteConfirm": "Hapus agen ACP ini? Tindakan ini tidak dapat dibatalkan.",
     "deleteSuccess": "Agen ACP berhasil dihapus",
-    "deleteFailed": "Gagal menghapus agen ACP"
+    "deleteFailed": "Gagal menghapus agen ACP",
+    "nodeSettings": "Pengaturan Node",
+    "nodePath": "Path Node",
+    "chooseOtherNode": "Pilih Node lain...",
+    "selectNodePath": "Pilih path Node",
+    "nodePathPrompt": "Masukkan path file executable node",
+    "nodeSaved": "Pengaturan Node tersimpan",
+    "nodeLoadFailed": "Gagal memuat pengaturan Node",
+    "nodeSaveFailed": "Path Node tidak tersedia",
+    "nodeRuntime": {
+      "bundled": "Node bawaan",
+      "system": "Node sistem",
+      "custom": "Node kustom"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "Node sistem tidak terdeteksi",
+      "nodeMissing": "Path Node tidak ada",
+      "npxMissing": "npx tidak ditemukan",
+      "versionCheckFailed": "Pemeriksaan versi gagal",
+      "unavailable": "Tidak tersedia"
+    }
   },
   "sessions": {
     "title": "Sesi",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2216,7 +2216,27 @@
     "deleteTitle": "{{name}} を削除",
     "deleteConfirm": "この ACP Agent を削除しますか？この操作は元に戻せません。",
     "deleteSuccess": "ACP Agent を削除しました",
-    "deleteFailed": "ACP Agent の削除に失敗しました"
+    "deleteFailed": "ACP Agent の削除に失敗しました",
+    "nodeSettings": "Node 設定",
+    "nodePath": "Node パス",
+    "chooseOtherNode": "別の Node を選択...",
+    "selectNodePath": "Node パスを選択",
+    "nodePathPrompt": "node 実行ファイルのパスを入力してください",
+    "nodeSaved": "Node 設定を保存しました",
+    "nodeLoadFailed": "Node 設定の読み込みに失敗しました",
+    "nodeSaveFailed": "Node パスを利用できません",
+    "nodeRuntime": {
+      "bundled": "同梱 Node",
+      "system": "システム Node",
+      "custom": "カスタム Node"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "システム Node が検出されませんでした",
+      "nodeMissing": "Node パスが存在しません",
+      "npxMissing": "npx が見つかりません",
+      "versionCheckFailed": "バージョン確認に失敗しました",
+      "unavailable": "利用不可"
+    }
   },
   "backup": {
     "title": "バックアップ",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -138,7 +138,27 @@
     "deleteTitle": "Excluir {{name}}",
     "deleteConfirm": "Excluir este agente ACP? Esta acao nao pode ser desfeita.",
     "deleteSuccess": "Agente ACP excluido",
-    "deleteFailed": "Falha ao excluir agente ACP"
+    "deleteFailed": "Falha ao excluir agente ACP",
+    "nodeSettings": "Configuracoes do Node",
+    "nodePath": "Caminho do Node",
+    "chooseOtherNode": "Escolher outro Node...",
+    "selectNodePath": "Selecionar caminho do Node",
+    "nodePathPrompt": "Informe o caminho do executavel node",
+    "nodeSaved": "Configuracoes do Node salvas",
+    "nodeLoadFailed": "Falha ao carregar configuracoes do Node",
+    "nodeSaveFailed": "Caminho do Node indisponivel",
+    "nodeRuntime": {
+      "bundled": "Node embutido",
+      "system": "Node do sistema",
+      "custom": "Node personalizado"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "Node do sistema nao detectado",
+      "nodeMissing": "Caminho do Node nao existe",
+      "npxMissing": "npx nao encontrado",
+      "versionCheckFailed": "Falha na verificacao de versao",
+      "unavailable": "Indisponivel"
+    }
   },
   "voiceTranscription": {
     "title": "Transcricao de Voz",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2231,7 +2231,27 @@
     "deleteTitle": "Удалить {{name}}",
     "deleteConfirm": "Удалить этот ACP агент? Это действие нельзя отменить.",
     "deleteSuccess": "ACP агент удалён",
-    "deleteFailed": "Не удалось удалить ACP агент"
+    "deleteFailed": "Не удалось удалить ACP агент",
+    "nodeSettings": "Настройки Node",
+    "nodePath": "Путь к Node",
+    "chooseOtherNode": "Выбрать другой Node...",
+    "selectNodePath": "Выбрать путь к Node",
+    "nodePathPrompt": "Введите путь к исполняемому файлу node",
+    "nodeSaved": "Настройки Node сохранены",
+    "nodeLoadFailed": "Не удалось загрузить настройки Node",
+    "nodeSaveFailed": "Путь к Node недоступен",
+    "nodeRuntime": {
+      "bundled": "Встроенный Node",
+      "system": "Системный Node",
+      "custom": "Пользовательский Node"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "Системный Node не обнаружен",
+      "nodeMissing": "Путь к Node не существует",
+      "npxMissing": "npx не найден",
+      "versionCheckFailed": "Проверка версии не удалась",
+      "unavailable": "Недоступно"
+    }
   },
   "backup": {
     "title": "Резервные копии",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -361,7 +361,27 @@
     "argsHelp": "Mỗi dòng một tham số",
     "env": "Biến môi trường",
     "envHelp": "Dùng định dạng KEY=VALUE, mỗi dòng một biến",
-    "envInvalid": "Định dạng không hợp lệ, dùng KEY=VALUE"
+    "envInvalid": "Định dạng không hợp lệ, dùng KEY=VALUE",
+    "nodeSettings": "Cài đặt Node",
+    "nodePath": "Đường dẫn Node",
+    "chooseOtherNode": "Chọn Node khác...",
+    "selectNodePath": "Chọn đường dẫn Node",
+    "nodePathPrompt": "Nhập đường dẫn file thực thi node",
+    "nodeSaved": "Đã lưu cài đặt Node",
+    "nodeLoadFailed": "Không tải được cài đặt Node",
+    "nodeSaveFailed": "Đường dẫn Node không khả dụng",
+    "nodeRuntime": {
+      "bundled": "Node tích hợp",
+      "system": "Node hệ thống",
+      "custom": "Node tuỳ chỉnh"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "Không phát hiện Node hệ thống",
+      "nodeMissing": "Đường dẫn Node không tồn tại",
+      "npxMissing": "Không tìm thấy npx",
+      "versionCheckFailed": "Kiểm tra phiên bản thất bại",
+      "unavailable": "Không khả dụng"
+    }
   },
   "voiceTranscription": {
     "title": "Phiên âm giọng nói",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -355,7 +355,27 @@
     "deleteTitle": "删除 {{name}}",
     "deleteConfirm": "确定删除该 ACP Agent 吗？此操作不可撤销。",
     "deleteSuccess": "ACP Agent 已删除",
-    "deleteFailed": "ACP Agent 删除失败"
+    "deleteFailed": "ACP Agent 删除失败",
+    "nodeSettings": "Node 设置",
+    "nodePath": "Node 路径",
+    "chooseOtherNode": "选择其他 Node...",
+    "selectNodePath": "选择 Node 路径",
+    "nodePathPrompt": "请输入 node 可执行文件路径",
+    "nodeSaved": "Node 设置已保存",
+    "nodeLoadFailed": "Node 设置加载失败",
+    "nodeSaveFailed": "Node 路径不可用",
+    "nodeRuntime": {
+      "bundled": "内置 Node",
+      "system": "系统 Node",
+      "custom": "自定义 Node"
+    },
+    "nodeRuntimeReason": {
+      "systemNodeMissing": "未检测到系统 Node",
+      "nodeMissing": "Node 路径不存在",
+      "npxMissing": "未找到 npx",
+      "versionCheckFailed": "版本检查失败",
+      "unavailable": "不可用"
+    }
   },
   "skills": {
     "title": "技能",

--- a/console/src/pages/Agent/ACP/index.module.less
+++ b/console/src/pages/Agent/ACP/index.module.less
@@ -1,3 +1,20 @@
+.headerActions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.nodeSettings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nodeLabel {
+  font-size: 14px;
+  font-weight: 500;
+}
+
 @media (max-width: 768px) {
   .pageHeader {
     flex-direction: column;
@@ -19,6 +36,11 @@
       width: 100%;
       justify-content: flex-start;
     }
+  }
+
+  .headerActions {
+    width: 100%;
+    flex-wrap: wrap;
   }
 
   .channelsGridMobile {

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -67,8 +67,7 @@ function formatNodeOption(
 
 function formatNodeReason(reasonCode: string, t: TFunction): string {
   return t(
-    NODE_RUNTIME_REASON_KEYS[reasonCode] ||
-      "acp.nodeRuntimeReason.unavailable",
+    NODE_RUNTIME_REASON_KEYS[reasonCode] || "acp.nodeRuntimeReason.unavailable",
   );
 }
 

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../../api/types";
 import { useAgentStore } from "../../../stores/agentStore";
 import { isDesktopTauriRuntime } from "../../../utils/openExternalLink";
+import { parseErrorDetail } from "../../../utils/error";
 import { ACPCard } from "./components/ACPCard";
 import {
   ACPDrawer,
@@ -57,13 +58,48 @@ function formatNodeOption(
     NODE_RUNTIME_LABEL_KEYS[candidate.key] || NODE_RUNTIME_LABEL_KEYS.custom,
   );
   const version = candidate.node_version ? ` (${candidate.node_version})` : "";
-  const detail =
-    candidate.node_path ||
-    t(
-      NODE_RUNTIME_REASON_KEYS[candidate.reason_code] ||
-        "acp.nodeRuntimeReason.unavailable",
-    );
+  const reason = formatNodeReason(candidate.reason_code, t);
+  const detail = candidate.available
+    ? candidate.node_path
+    : [candidate.node_path, reason].filter(Boolean).join(" - ");
   return `${label}${version}${detail ? `  ${detail}` : ""}`;
+}
+
+function formatNodeReason(reasonCode: string, t: TFunction): string {
+  return t(
+    NODE_RUNTIME_REASON_KEYS[reasonCode] ||
+      "acp.nodeRuntimeReason.unavailable",
+  );
+}
+
+function getNodeRuntimeErrorMessage(error: unknown, t: TFunction): string {
+  const detail = parseErrorDetail(error);
+  const reasonCode =
+    typeof detail?.reason_code === "string" ? detail.reason_code : "";
+  const reasonKey = NODE_RUNTIME_REASON_KEYS[reasonCode];
+  return reasonKey ? t(reasonKey) : t("acp.nodeSaveFailed");
+}
+
+function sameNodePath(left: string, right: string): boolean {
+  if (!left || !right) return false;
+  const normalize = (value: string) =>
+    value.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  return normalize(left) === normalize(right);
+}
+
+function getSelectedNodeValue(
+  status: ACPNodeRuntimeStatus | null,
+): string | undefined {
+  if (!status) return undefined;
+  if (status.node_path) {
+    const configured = status.candidates.find(
+      (candidate) =>
+        sameNodePath(candidate.node_path, status.node_path) ||
+        candidate.key === "custom",
+    );
+    return configured?.node_path || status.node_path;
+  }
+  return status.effective_node_path || undefined;
 }
 
 function ACPPage() {
@@ -160,6 +196,11 @@ function ACPPage() {
     [nodeRuntime, t],
   );
 
+  const selectedNodeValue = useMemo(
+    () => getSelectedNodeValue(nodeRuntime),
+    [nodeRuntime],
+  );
+
   const pickNodePath = useCallback(async () => {
     if (isDesktopTauriRuntime()) {
       const { open } = await import("@tauri-apps/plugin-dialog");
@@ -194,7 +235,7 @@ function ACPPage() {
         message.success(t("acp.nodeSaved"));
       } catch (error) {
         console.error("Failed to update ACP Node runtime:", error);
-        message.error(t("acp.nodeSaveFailed"));
+        message.error(getNodeRuntimeErrorMessage(error, t));
         void fetchNodeRuntime();
       } finally {
         setNodeRuntimeSaving(false);
@@ -407,7 +448,7 @@ function ACPPage() {
         <div className={stylesACP.nodeSettings}>
           <label className={stylesACP.nodeLabel}>{t("acp.nodePath")}</label>
           <Select
-            value={nodeRuntime?.effective_node_path || undefined}
+            value={selectedNodeValue}
             options={nodeOptions}
             loading={nodeRuntimeLoading || nodeRuntimeSaving}
             onChange={(value) => saveNodePath(String(value))}

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Form, Modal } from "@agentscope-ai/design";
+import { Button, Form, Modal, Select } from "@agentscope-ai/design";
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/PageHeader";
 import api from "../../../api";
@@ -7,8 +8,11 @@ import { useAppMessage } from "../../../hooks/useAppMessage";
 import {
   ACP_DEFAULT_STDIO_BUFFER_LIMIT_BYTES,
   type ACPAgentConfig,
+  type ACPNodeRuntimeCandidate,
+  type ACPNodeRuntimeStatus,
 } from "../../../api/types";
 import { useAgentStore } from "../../../stores/agentStore";
+import { isDesktopTauriRuntime } from "../../../utils/openExternalLink";
 import { ACPCard } from "./components/ACPCard";
 import {
   ACPDrawer,
@@ -26,12 +30,41 @@ const BUILTIN_ACP_ORDER = [
   "claude_code",
   "codex",
 ] as const;
+const OTHER_NODE_VALUE = "__other_node__";
+const NODE_RUNTIME_LABEL_KEYS: Record<string, string> = {
+  bundled: "acp.nodeRuntime.bundled",
+  system: "acp.nodeRuntime.system",
+  custom: "acp.nodeRuntime.custom",
+};
+const NODE_RUNTIME_REASON_KEYS: Record<string, string> = {
+  node_missing: "acp.nodeRuntimeReason.nodeMissing",
+  npx_missing: "acp.nodeRuntimeReason.npxMissing",
+  system_node_missing: "acp.nodeRuntimeReason.systemNodeMissing",
+  version_check_failed: "acp.nodeRuntimeReason.versionCheckFailed",
+};
 
 function isBuiltinACPAgent(key: string): boolean {
   return BUILTIN_ACP_ORDER.includes(key as (typeof BUILTIN_ACP_ORDER)[number]);
 }
 
 type FilterType = "all" | "builtin" | "custom";
+
+function formatNodeOption(
+  candidate: ACPNodeRuntimeCandidate,
+  t: TFunction,
+): string {
+  const label = t(
+    NODE_RUNTIME_LABEL_KEYS[candidate.key] || NODE_RUNTIME_LABEL_KEYS.custom,
+  );
+  const version = candidate.node_version ? ` (${candidate.node_version})` : "";
+  const detail =
+    candidate.node_path ||
+    t(
+      NODE_RUNTIME_REASON_KEYS[candidate.reason_code] ||
+        "acp.nodeRuntimeReason.unavailable",
+    );
+  return `${label}${version}${detail ? `  ${detail}` : ""}`;
+}
 
 function ACPPage() {
   const { t } = useTranslation();
@@ -44,6 +77,12 @@ function ACPPage() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [isCreateMode, setIsCreateMode] = useState(false);
+  const [nodeModalOpen, setNodeModalOpen] = useState(false);
+  const [nodeRuntime, setNodeRuntime] = useState<ACPNodeRuntimeStatus | null>(
+    null,
+  );
+  const [nodeRuntimeLoading, setNodeRuntimeLoading] = useState(false);
+  const [nodeRuntimeSaving, setNodeRuntimeSaving] = useState(false);
   const [form] = Form.useForm<Record<string, unknown>>();
 
   const fetchACP = useCallback(async () => {
@@ -61,6 +100,18 @@ function ACPPage() {
   useEffect(() => {
     fetchACP();
   }, [fetchACP, selectedAgent]);
+
+  const fetchNodeRuntime = useCallback(async () => {
+    setNodeRuntimeLoading(true);
+    try {
+      setNodeRuntime(await api.getACPNodeRuntime());
+    } catch (error) {
+      console.error("Failed to load ACP Node runtime:", error);
+      message.error(t("acp.nodeLoadFailed"));
+    } finally {
+      setNodeRuntimeLoading(false);
+    }
+  }, [message, t]);
 
   const orderedKeys = useMemo(() => {
     const keys = Object.keys(agents);
@@ -93,6 +144,69 @@ function ACPPage() {
 
     return [...enabledCards, ...disabledCards];
   }, [agents, orderedKeys, filter]);
+
+  const nodeOptions = useMemo(
+    () => [
+      ...(nodeRuntime?.candidates || []).map((candidate) => ({
+        label: formatNodeOption(candidate, t),
+        value: candidate.node_path || `__missing_${candidate.key}`,
+        disabled: !candidate.available,
+      })),
+      {
+        label: t("acp.chooseOtherNode"),
+        value: OTHER_NODE_VALUE,
+      },
+    ],
+    [nodeRuntime, t],
+  );
+
+  const pickNodePath = useCallback(async () => {
+    if (isDesktopTauriRuntime()) {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const selected = await open({
+        multiple: false,
+        directory: false,
+        title: t("acp.selectNodePath"),
+      });
+      if (Array.isArray(selected)) return selected[0] || null;
+      return selected || null;
+    }
+
+    const value = window.prompt(
+      t("acp.nodePathPrompt"),
+      nodeRuntime?.effective_node_path || "",
+    );
+    return value?.trim() || null;
+  }, [nodeRuntime?.effective_node_path, t]);
+
+  const saveNodePath = useCallback(
+    async (value: string) => {
+      let nodePath = value;
+      if (nodePath === OTHER_NODE_VALUE) {
+        const selected = await pickNodePath();
+        if (!selected) return;
+        nodePath = selected;
+      }
+
+      setNodeRuntimeSaving(true);
+      try {
+        setNodeRuntime(await api.updateACPNodeRuntime({ node_path: nodePath }));
+        message.success(t("acp.nodeSaved"));
+      } catch (error) {
+        console.error("Failed to update ACP Node runtime:", error);
+        message.error(t("acp.nodeSaveFailed"));
+        void fetchNodeRuntime();
+      } finally {
+        setNodeRuntimeSaving(false);
+      }
+    },
+    [fetchNodeRuntime, message, pickNodePath, t],
+  );
+
+  const handleNodeSettingsClick = () => {
+    setNodeModalOpen(true);
+    void fetchNodeRuntime();
+  };
 
   const handleCardClick = (key: string) => {
     const config = agents[key];
@@ -239,9 +353,14 @@ function ACPPage() {
           </div>
         }
         extra={
-          <Button type="primary" onClick={handleCreateClick}>
-            {t("acp.create")}
-          </Button>
+          <div className={stylesACP.headerActions}>
+            <Button onClick={handleNodeSettingsClick}>
+              {t("acp.nodeSettings")}
+            </Button>
+            <Button type="primary" onClick={handleCreateClick}>
+              {t("acp.create")}
+            </Button>
+          </div>
         }
       />
       <div className={styles.channelsContainer}>
@@ -278,6 +397,25 @@ function ACPPage() {
         onSubmit={handleSubmit}
         onDelete={handleDelete}
       />
+      <Modal
+        title={t("acp.nodeSettings")}
+        open={nodeModalOpen}
+        onCancel={() => setNodeModalOpen(false)}
+        footer={null}
+        destroyOnHidden
+      >
+        <div className={stylesACP.nodeSettings}>
+          <label className={stylesACP.nodeLabel}>{t("acp.nodePath")}</label>
+          <Select
+            value={nodeRuntime?.effective_node_path || undefined}
+            options={nodeOptions}
+            loading={nodeRuntimeLoading || nodeRuntimeSaving}
+            onChange={(value) => saveNodePath(String(value))}
+            placeholder={t("acp.nodePath")}
+            style={{ width: "100%" }}
+          />
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/console/src/pages/Agent/ACP/index.tsx
+++ b/console/src/pages/Agent/ACP/index.tsx
@@ -72,11 +72,32 @@ function formatNodeReason(reasonCode: string, t: TFunction): string {
 }
 
 function getNodeRuntimeErrorMessage(error: unknown, t: TFunction): string {
-  const detail = parseErrorDetail(error);
+  const detail = parseNodeRuntimeErrorDetail(error);
   const reasonCode =
     typeof detail?.reason_code === "string" ? detail.reason_code : "";
   const reasonKey = NODE_RUNTIME_REASON_KEYS[reasonCode];
   return reasonKey ? t(reasonKey) : t("acp.nodeSaveFailed");
+}
+
+function parseNodeRuntimeErrorDetail(
+  error: unknown,
+): Record<string, unknown> | null {
+  if (error instanceof Error) {
+    const idx = error.message.lastIndexOf(" - ");
+    if (idx !== -1) {
+      try {
+        const parsed = JSON.parse(error.message.slice(idx + 3)) as {
+          detail?: unknown;
+        };
+        if (typeof parsed.detail === "object" && parsed.detail !== null) {
+          return parsed.detail as Record<string, unknown>;
+        }
+      } catch {
+        // Fall through to the shared parser below.
+      }
+    }
+  }
+  return parseErrorDetail(error);
 }
 
 function sameNodePath(left: string, right: string): boolean {

--- a/console/src/utils/error.ts
+++ b/console/src/utils/error.ts
@@ -2,7 +2,7 @@ export function parseErrorDetail(error: unknown): Record<string, any> | null {
   if (!(error instanceof Error)) return null;
   const msg = error.message;
   // Try " - " separator first (from request.ts formatted errors)
-  const idx = msg.lastIndexOf(" - ");
+  const idx = msg.indexOf(" - ");
   if (idx !== -1) {
     try {
       const parsed = JSON.parse(msg.slice(idx + 3));

--- a/console/src/utils/error.ts
+++ b/console/src/utils/error.ts
@@ -2,7 +2,7 @@ export function parseErrorDetail(error: unknown): Record<string, any> | null {
   if (!(error instanceof Error)) return null;
   const msg = error.message;
   // Try " - " separator first (from request.ts formatted errors)
-  const idx = msg.indexOf(" - ");
+  const idx = msg.lastIndexOf(" - ");
   if (idx !== -1) {
     try {
       const parsed = JSON.parse(msg.slice(idx + 3));

--- a/scripts/pack-tauri/build_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_pyinstaller.ps1
@@ -209,6 +209,12 @@ Write-Host "== Staging bundled Python runtime ==" -ForegroundColor Yellow
 Assert-LastExit "Failed to stage bundled Python runtime"
 Write-Host ""
 
+Write-Host "== Staging bundled Node runtime ==" -ForegroundColor Yellow
+& $PYTHON_BIN (Join-Path $REPO_ROOT "scripts\pack-tauri\stage_node_runtime.py") `
+    --dest (Join-Path $BINARIES_DIR "node-runtime")
+Assert-LastExit "Failed to stage bundled Node runtime"
+Write-Host ""
+
 Write-Host "=========================================" -ForegroundColor Cyan
 Write-Host "PyInstaller Build Complete!" -ForegroundColor Green
 Write-Host "=========================================" -ForegroundColor Cyan

--- a/scripts/pack-tauri/build_pyinstaller.sh
+++ b/scripts/pack-tauri/build_pyinstaller.sh
@@ -144,6 +144,11 @@ echo "== Staging bundled Python runtime =="
     --dest "${BINARIES_DIR}/python-runtime"
 echo ""
 
+echo "== Staging bundled Node runtime =="
+"$PYTHON_BIN" "${REPO_ROOT}/scripts/pack-tauri/stage_node_runtime.py" \
+    --dest "${BINARIES_DIR}/node-runtime"
+echo ""
+
 echo "========================================="
 echo "PyInstaller Build Complete!"
 echo "========================================="

--- a/scripts/pack-tauri/stage_node_runtime.py
+++ b/scripts/pack-tauri/stage_node_runtime.py
@@ -85,7 +85,9 @@ def _validate_tar_members(tar: tarfile.TarFile, workdir: Path) -> None:
         try:
             target.relative_to(root)
         except ValueError:
-            raise SystemExit(f"tar member escapes target: {member.name}") from None
+            raise SystemExit(
+                f"tar member escapes target: {member.name}",
+            ) from None
 
 
 def main() -> None:

--- a/scripts/pack-tauri/stage_node_runtime.py
+++ b/scripts/pack-tauri/stage_node_runtime.py
@@ -65,6 +65,7 @@ def _extract(archive: Path, suffix: str, workdir: Path) -> Path:
             try:
                 tar.extractall(workdir, filter="data")
             except TypeError:
+                _validate_tar_members(tar, workdir)
                 tar.extractall(workdir)
 
     roots = [
@@ -75,6 +76,16 @@ def _extract(archive: Path, suffix: str, workdir: Path) -> Path:
     if len(roots) != 1:
         raise SystemExit("failed to locate extracted Node.js directory")
     return roots[0]
+
+
+def _validate_tar_members(tar: tarfile.TarFile, workdir: Path) -> None:
+    root = workdir.resolve()
+    for member in tar.getmembers():
+        target = (root / member.name).resolve()
+        try:
+            target.relative_to(root)
+        except ValueError:
+            raise SystemExit(f"tar member escapes target: {member.name}") from None
 
 
 def main() -> None:

--- a/scripts/pack-tauri/stage_node_runtime.py
+++ b/scripts/pack-tauri/stage_node_runtime.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Stage a Node.js runtime for the Tauri desktop bundle."""
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+DEFAULT_NODE_VERSION = "v22.20.0"
+NODE_DIST_URL = "https://nodejs.org/dist"
+
+
+def _target() -> tuple[str, str, str]:
+    system = platform.system()
+    machine = platform.machine().lower()
+    arch = {
+        "amd64": "x64",
+        "x86_64": "x64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }.get(machine)
+    if arch is None:
+        raise SystemExit(f"unsupported machine architecture: {machine!r}")
+    if system == "Windows":
+        return "win", arch, "zip"
+    if system == "Darwin":
+        return "darwin", arch, "tar.xz"
+    if system == "Linux":
+        return "linux", arch, "tar.xz"
+    raise SystemExit(f"unsupported platform: {system!r}")
+
+
+def _node_exe(dest: Path) -> Path:
+    if platform.system() == "Windows":
+        return dest / "node.exe"
+    return dest / "bin" / "node"
+
+
+def _npx_exe(dest: Path) -> Path:
+    if platform.system() == "Windows":
+        return dest / "npx.cmd"
+    return dest / "bin" / "npx"
+
+
+def _http_get(url: str) -> bytes:
+    request = urllib.request.Request(url)
+    request.add_header("User-Agent", "qwenpaw-build")
+    with urllib.request.urlopen(request, timeout=120) as response:
+        return response.read()
+
+
+def _extract(archive: Path, suffix: str, workdir: Path) -> Path:
+    if suffix == "zip":
+        with zipfile.ZipFile(archive) as zip_file:
+            zip_file.extractall(workdir)
+    else:
+        with tarfile.open(archive, "r:xz") as tar:
+            try:
+                tar.extractall(workdir, filter="data")
+            except TypeError:
+                tar.extractall(workdir)
+
+    roots = [
+        path
+        for path in workdir.iterdir()
+        if path.is_dir() and path.name.startswith("node-")
+    ]
+    if len(roots) != 1:
+        raise SystemExit("failed to locate extracted Node.js directory")
+    return roots[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dest", required=True)
+    parser.add_argument(
+        "--node-version",
+        default=os.environ.get("QWENPAW_NODE_VERSION", DEFAULT_NODE_VERSION),
+    )
+    args = parser.parse_args()
+
+    version = args.node_version
+    platform_name, arch, suffix = _target()
+    target = f"{platform_name}-{arch}"
+    dest = Path(args.dest).resolve()
+    marker = dest / ".node-runtime-version"
+
+    if (
+        _node_exe(dest).is_file()
+        and _npx_exe(dest).is_file()
+        and marker.is_file()
+        and marker.read_text(encoding="utf-8").strip() == f"{version}-{target}"
+    ):
+        print(f"node-runtime already staged ({version}-{target}); skipping")
+        return
+
+    archive_name = f"node-{version}-{target}.{suffix}"
+    url = f"{NODE_DIST_URL}/{version}/{archive_name}"
+    print(f"Staging Node.js {version} for {target}...")
+    print(f"Downloading {url}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        archive = tmpdir / archive_name
+        archive.write_bytes(_http_get(url))
+        extracted = _extract(archive, suffix, tmpdir)
+
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.mkdir(parents=True, exist_ok=True)
+        for item in extracted.iterdir():
+            shutil.move(str(item), dest / item.name)
+
+    if not _node_exe(dest).is_file() or not _npx_exe(dest).is_file():
+        raise SystemExit("staging failed: node or npx missing")
+    marker.write_text(f"{version}-{target}", encoding="utf-8")
+    print(f"Staged node-runtime at {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qwenpaw/agents/acp/node_runtime.py
+++ b/src/qwenpaw/agents/acp/node_runtime.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from ...constant import WORKING_DIR
+
+DESKTOP_NODE_RUNTIME_ENV = "QWENPAW_DESKTOP_NODE_RUNTIME"
+NPM_CACHE_ENV = "NPM_CONFIG_CACHE"
+
+
+class ACPNodeRuntimeCandidate(BaseModel):
+    key: str
+    label: str
+    node_path: str = ""
+    npx_path: str = ""
+    node_version: str = ""
+    npx_version: str = ""
+    available: bool = False
+    reason_code: str = ""
+    reason: str = ""
+
+
+class ACPNodeRuntimeStatus(BaseModel):
+    node_path: str = ""
+    effective_node_path: str = ""
+    candidates: list[ACPNodeRuntimeCandidate] = Field(default_factory=list)
+
+
+def get_node_runtime_status(node_path: str = "") -> ACPNodeRuntimeStatus:
+    candidates: list[ACPNodeRuntimeCandidate] = []
+    configured = node_path.strip()
+
+    bundled_path = _bundled_node_path()
+    if bundled_path:
+        candidates.append(
+            resolve_node_runtime(
+                str(bundled_path),
+                key="bundled",
+                label="bundled",
+            ),
+        )
+
+    system_node = shutil.which("node")
+    if system_node:
+        _append_unique(
+            candidates,
+            resolve_node_runtime(
+                system_node,
+                key="system",
+                label="system",
+            ),
+        )
+    else:
+        candidates.append(
+            ACPNodeRuntimeCandidate(
+                key="system",
+                label="system",
+                reason_code="system_node_missing",
+                reason="System Node was not detected",
+            ),
+        )
+
+    if configured and not any(
+        _same_path(configured, candidate.node_path) for candidate in candidates
+    ):
+        candidates.append(
+            resolve_node_runtime(
+                configured,
+                key="custom",
+                label="custom",
+            ),
+        )
+
+    effective = _effective_node_path(configured, candidates)
+    return ACPNodeRuntimeStatus(
+        node_path=configured,
+        effective_node_path=effective,
+        candidates=candidates,
+    )
+
+
+def resolve_node_runtime(
+    node_path: str,
+    *,
+    key: str = "custom",
+    label: str = "custom",
+) -> ACPNodeRuntimeCandidate:
+    node = _normalize_node_path(node_path)
+    candidate = ACPNodeRuntimeCandidate(
+        key=key,
+        label=label,
+        node_path=str(node) if node else node_path,
+    )
+    if not node or not node.is_file():
+        candidate.reason_code = "node_missing"
+        candidate.reason = "Node path does not exist"
+        return candidate
+
+    env = _prepend_path(dict(os.environ), node.parent)
+    node_version, error = _version(str(node), env)
+    if error:
+        candidate.reason_code = "version_check_failed"
+        candidate.reason = error
+        return candidate
+
+    npx = _npx_path(node)
+    if not npx:
+        candidate.node_version = node_version
+        candidate.reason_code = "npx_missing"
+        candidate.reason = "npx was not found"
+        return candidate
+
+    npx_version, error = _version(str(npx), env)
+    if error:
+        candidate.node_version = node_version
+        candidate.npx_path = str(npx)
+        candidate.reason_code = "version_check_failed"
+        candidate.reason = error
+        return candidate
+
+    candidate.node_version = node_version
+    candidate.npx_path = str(npx)
+    candidate.npx_version = npx_version
+    candidate.available = True
+    return candidate
+
+
+def build_acp_process_env(base_env: dict[str, str]) -> dict[str, str]:
+    from ...config import load_config
+
+    env = dict(base_env)
+    status = get_node_runtime_status(load_config().acp.node_path)
+    if status.effective_node_path:
+        env = _prepend_path(env, Path(status.effective_node_path).parent)
+    env.setdefault(NPM_CACHE_ENV, str(WORKING_DIR / "npm-cache"))
+    return env
+
+
+def _effective_node_path(
+    configured: str,
+    candidates: list[ACPNodeRuntimeCandidate],
+) -> str:
+    if configured:
+        for candidate in candidates:
+            if candidate.available and _same_path(
+                configured,
+                candidate.node_path,
+            ):
+                return candidate.node_path
+    for key in ("bundled", "system"):
+        for candidate in candidates:
+            if candidate.key == key and candidate.available:
+                return candidate.node_path
+    return ""
+
+
+def _bundled_node_path() -> Path | None:
+    root = os.environ.get(DESKTOP_NODE_RUNTIME_ENV, "").strip()
+    if not root:
+        return None
+    return _normalize_node_path(_strip_windows_extended_prefix(root))
+
+
+def _normalize_node_path(value: str) -> Path | None:
+    path = Path(os.path.expandvars(value)).expanduser()
+    if path.is_dir():
+        path = path / ("node.exe" if os.name == "nt" else "bin/node")
+    return path
+
+
+def _strip_windows_extended_prefix(value: str) -> str:
+    if os.name != "nt":
+        return value
+    if value.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + value[8:]
+    if value.startswith("\\\\?\\"):
+        return value[4:]
+    return value
+
+
+def _npx_path(node: Path) -> Path | None:
+    names = ["npx.cmd", "npx.exe"] if os.name == "nt" else ["npx"]
+    for name in names:
+        candidate = node.parent / name
+        if candidate.is_file():
+            return candidate
+    found = shutil.which("npx", path=str(node.parent))
+    return Path(found) if found else None
+
+
+def _prepend_path(env: dict[str, str], path: Path) -> dict[str, str]:
+    key = _path_env_key(env)
+    existing = env.get(key, "")
+    env[key] = (
+        os.pathsep.join([str(path), existing]) if existing else str(path)
+    )
+    for other in list(env):
+        if other != key and other.lower() == "path":
+            env.pop(other)
+    return env
+
+
+def _path_env_key(env: dict[str, str]) -> str:
+    key = "Path" if os.name == "nt" else "PATH"
+    for name in env:
+        if name.lower() == "path":
+            key = name
+    return key
+
+
+def _version(executable: str, env: dict[str, str]) -> tuple[str, str]:
+    creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+            creationflags=creationflags,
+            check=False,
+        )
+    except Exception as exc:
+        return "", f"{Path(executable).name} --version failed: {exc}"
+    if result.returncode != 0:
+        return (
+            "",
+            (result.stderr or result.stdout or "version check failed").strip(),
+        )
+    return (result.stdout or result.stderr).strip(), ""
+
+
+def _append_unique(
+    candidates: list[ACPNodeRuntimeCandidate],
+    candidate: ACPNodeRuntimeCandidate,
+) -> None:
+    if candidate.node_path and any(
+        _same_path(candidate.node_path, existing.node_path)
+        for existing in candidates
+    ):
+        return
+    candidates.append(candidate)
+
+
+def _same_path(left: str, right: str) -> bool:
+    if not left or not right:
+        return False
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(
+        os.path.abspath(right),
+    )

--- a/src/qwenpaw/agents/acp/node_runtime.py
+++ b/src/qwenpaw/agents/acp/node_runtime.py
@@ -135,11 +135,36 @@ def build_acp_process_env(base_env: dict[str, str]) -> dict[str, str]:
     from ...config import load_config
 
     env = dict(base_env)
-    status = get_node_runtime_status(load_config().acp.node_path)
-    if status.effective_node_path:
-        env = _prepend_path(env, Path(status.effective_node_path).parent)
+    node_path = _effective_node_path_for_process(
+        load_config().acp.node_path,
+        env,
+    )
+    if node_path:
+        env = _prepend_path(env, node_path.parent)
     env.setdefault(NPM_CACHE_ENV, str(WORKING_DIR / "npm-cache"))
     return env
+
+
+def _effective_node_path_for_process(
+    node_path: str,
+    env: dict[str, str],
+) -> Path | None:
+    configured = node_path.strip()
+    if configured:
+        node = _normalize_node_path(configured)
+        if _runtime_files_available(node):
+            return node
+
+    bundled = _bundled_node_path()
+    if _runtime_files_available(bundled):
+        return bundled
+
+    system_node = shutil.which("node", path=env.get(_path_env_key(env)))
+    if system_node:
+        node = _normalize_node_path(system_node)
+        if _runtime_files_available(node):
+            return node
+    return None
 
 
 def _effective_node_path(
@@ -192,6 +217,10 @@ def _npx_path(node: Path) -> Path | None:
             return candidate
     found = shutil.which("npx", path=str(node.parent))
     return Path(found) if found else None
+
+
+def _runtime_files_available(node: Path | None) -> bool:
+    return bool(node and node.is_file() and _npx_path(node))
 
 
 def _prepend_path(env: dict[str, str], path: Path) -> dict[str, str]:

--- a/src/qwenpaw/agents/acp/node_runtime.py
+++ b/src/qwenpaw/agents/acp/node_runtime.py
@@ -95,9 +95,9 @@ def resolve_node_runtime(
     candidate = ACPNodeRuntimeCandidate(
         key=key,
         label=label,
-        node_path=str(node) if node else node_path,
+        node_path=str(node),
     )
-    if not node or not node.is_file():
+    if not node.is_file():
         candidate.reason_code = "node_missing"
         candidate.reason = "Node path does not exist"
         return candidate
@@ -192,7 +192,7 @@ def _bundled_node_path() -> Path | None:
     return _normalize_node_path(_strip_windows_extended_prefix(root))
 
 
-def _normalize_node_path(value: str) -> Path | None:
+def _normalize_node_path(value: str) -> Path:
     path = Path(os.path.expandvars(value)).expanduser()
     if path.is_dir():
         path = path / ("node.exe" if os.name == "nt" else "bin/node")
@@ -255,7 +255,7 @@ def _version(executable: str, env: dict[str, str]) -> tuple[str, str]:
             creationflags=creationflags,
             check=False,
         )
-    except Exception as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
         return "", f"{Path(executable).name} --version failed: {exc}"
     if result.returncode != 0:
         return (

--- a/src/qwenpaw/agents/acp/service.py
+++ b/src/qwenpaw/agents/acp/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import os
+import shutil
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
@@ -20,6 +21,7 @@ from .core import (
     ACPConfigurationError,
     ACPSessionError,
 )
+from .node_runtime import build_acp_process_env
 
 MessageHandler = Callable[[dict[str, Any], bool], Awaitable[None]]
 
@@ -40,6 +42,14 @@ def _kill_process_tree(pid: int) -> None:
         parent.kill()
     except psutil.NoSuchProcess:
         pass
+
+
+def _resolve_process_command(command: str, env: dict[str, str]) -> str:
+    path = next(
+        (value for key, value in env.items() if key.lower() == "path"),
+        None,
+    )
+    return shutil.which(command, path=path) or command
 
 
 @dataclass
@@ -286,13 +296,19 @@ class ACPService:
         )
         exit_stack = AsyncExitStack()
         try:
+            process_env = build_acp_process_env(
+                {**os.environ, **agent_config.env},
+            )
             conn, process = await exit_stack.enter_async_context(
                 spawn_agent_process(
                     client,
-                    agent_config.command,
+                    _resolve_process_command(
+                        agent_config.command,
+                        process_env,
+                    ),
                     *agent_config.args,
                     cwd=cwd,
-                    env={**os.environ, **agent_config.env},
+                    env=process_env,
                     transport_kwargs={
                         "limit": agent_config.stdio_buffer_limit_bytes,
                     },

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
@@ -446,7 +447,8 @@ async def put_acp_config(
 )
 async def get_acp_node_runtime() -> ACPNodeRuntimeStatus:
     """Return global ACP Node runtime status."""
-    return get_node_runtime_status(load_config().acp.node_path)
+    node_path = load_config().acp.node_path
+    return await asyncio.to_thread(get_node_runtime_status, node_path)
 
 
 @router.put(
@@ -461,7 +463,7 @@ async def put_acp_node_runtime(
     """Update global ACP Node runtime path."""
     node_path = body.node_path.strip()
     if node_path:
-        candidate = resolve_node_runtime(node_path)
+        candidate = await asyncio.to_thread(resolve_node_runtime, node_path)
         if not candidate.available:
             raise HTTPException(
                 status_code=400,
@@ -474,7 +476,7 @@ async def put_acp_node_runtime(
     config = load_config()
     config.acp.node_path = node_path
     save_config(config)
-    return get_node_runtime_status(config.acp.node_path)
+    return await asyncio.to_thread(get_node_runtime_status, config.acp.node_path)
 
 
 @router.get(

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -477,7 +477,8 @@ async def put_acp_node_runtime(
     config.acp.node_path = node_path
     save_config(config)
     return await asyncio.to_thread(
-        get_node_runtime_status, config.acp.node_path
+        get_node_runtime_status,
+        config.acp.node_path,
     )
 
 

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -476,7 +476,9 @@ async def put_acp_node_runtime(
     config = load_config()
     config.acp.node_path = node_path
     save_config(config)
-    return await asyncio.to_thread(get_node_runtime_status, config.acp.node_path)
+    return await asyncio.to_thread(
+        get_node_runtime_status, config.acp.node_path
+    )
 
 
 @router.get(
@@ -598,8 +600,6 @@ async def put_heartbeat(
     save_agent_config(agent.agent_id, agent.config)
 
     # Reschedule heartbeat (async, non-blocking)
-    import asyncio
-
     async def reschedule_in_background():
         try:
             if agent.cron_manager is not None:
@@ -625,7 +625,6 @@ async def run_heartbeat_now(request: Request) -> Any:
     """Trigger one heartbeat run in background for quick testing."""
     from ..agent_context import get_agent_for_request
     from ..crons.heartbeat import run_heartbeat_once
-    import asyncio
     import logging
 
     workspace = await get_agent_for_request(request)

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -38,6 +38,11 @@ from ...config.config import (
     WecomConfig,
 )
 from ...agents.acp.core import ACPConfig, ACPAgentConfig
+from ...agents.acp.node_runtime import (
+    ACPNodeRuntimeStatus,
+    get_node_runtime_status,
+    resolve_node_runtime,
+)
 
 from .schemas_config import (
     ChannelHealthResponse,
@@ -72,6 +77,10 @@ _ALLOWED_ACP_TOOL_PARSE_MODES = {
     "update_detail",
     "call_detail",
 }
+
+
+class ACPNodeRuntimeUpdate(BaseModel):
+    node_path: str = ""
 
 
 @router.get(
@@ -427,6 +436,39 @@ async def put_acp_config(
     save_agent_config(agent.agent_id, agent.config)
     schedule_agent_reload(request, agent.agent_id)
     return agent.config.acp
+
+
+@router.get(
+    "/acp/node-runtime",
+    response_model=ACPNodeRuntimeStatus,
+    summary="Get ACP Node runtime",
+    description="Return configured and detected Node runtimes for ACP",
+)
+async def get_acp_node_runtime() -> ACPNodeRuntimeStatus:
+    """Return global ACP Node runtime status."""
+    return get_node_runtime_status(load_config().acp.node_path)
+
+
+@router.put(
+    "/acp/node-runtime",
+    response_model=ACPNodeRuntimeStatus,
+    summary="Update ACP Node runtime",
+    description="Update the global Node runtime used by ACP subprocesses",
+)
+async def put_acp_node_runtime(
+    body: ACPNodeRuntimeUpdate = Body(...),
+) -> ACPNodeRuntimeStatus:
+    """Update global ACP Node runtime path."""
+    node_path = body.node_path.strip()
+    if node_path:
+        candidate = resolve_node_runtime(node_path)
+        if not candidate.available:
+            raise HTTPException(status_code=400, detail=candidate.reason)
+
+    config = load_config()
+    config.acp.node_path = node_path
+    save_config(config)
+    return get_node_runtime_status(config.acp.node_path)
 
 
 @router.get(

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -463,7 +463,13 @@ async def put_acp_node_runtime(
     if node_path:
         candidate = resolve_node_runtime(node_path)
         if not candidate.available:
-            raise HTTPException(status_code=400, detail=candidate.reason)
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "reason_code": candidate.reason_code,
+                    "reason": candidate.reason,
+                },
+            )
 
     config = load_config()
     config.acp.node_path = node_path

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -109,6 +109,7 @@ def _get_default_acp_agents() -> Dict[str, ACPAgentConfig]:
 class ACPConfig(BaseModel):
     """ACP (Agent Communication Protocol) configuration."""
 
+    node_path: str = ""
     agents: Dict[str, ACPAgentConfig] = Field(
         default_factory=_get_default_acp_agents,
     )


### PR DESCRIPTION
## Description

Bundle a Node.js runtime with the Tauri desktop package and add a small ACP Node settings entry so built-in ACP agents that run through `npx` can work without requiring users to install Node separately.

**Related Issue:** N/A

**Security Considerations:** ACP only prepends the selected Node directory to the ACP child process `PATH`; it does not modify the user/system PATH. Custom Node paths are validated by running `node --version` and `npx --version` before saving.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `python -m compileall src\\qwenpaw\\agents\\acp\\node_runtime.py src\\qwenpaw\\agents\\acp\\service.py src\\qwenpaw\\app\\routers\\config.py src\\qwenpaw\\config\\config.py scripts\\pack-tauri\\stage_node_runtime.py`
- `python -c "import json, pathlib; files=list(pathlib.Path('console/src/locales').glob('*.json')); [json.load(open(f, encoding='utf-8')) for f in files]; print('locales ok', len(files))"`
- `git diff --check`
- `python scripts\\pack-tauri\\stage_node_runtime.py --help`
- Verified local `node` / `npx` detection with the ACP Node runtime helper
- Triggered `QwenPaw Desktop Build` on the fork branch for Tauri Windows/macOS packaging

## Local Verification Evidence

```bash
python -m compileall src\\qwenpaw\\agents\\acp\\node_runtime.py src\\qwenpaw\\agents\\acp\\service.py src\\qwenpaw\\app\\routers\\config.py src\\qwenpaw\\config\\config.py scripts\\pack-tauri\\stage_node_runtime.py
# passed

python -c "import json, pathlib; files=list(pathlib.Path('console/src/locales').glob('*.json')); [json.load(open(f, encoding='utf-8')) for f in files]; print('locales ok', len(files))"
# locales ok 7

git diff --check
# passed
```

`pre-commit run --all-files`, full `pytest`, and frontend type/lint were not run locally. `console/node_modules` is not installed in this checkout; desktop packaging verification is running in GitHub Actions on the fork branch.

## Additional Notes

The desktop bundle includes the Node runtime only, not ACP npm packages. Existing ACP commands such as `npx -y @zed-industries/codex-acp` still resolve packages at runtime through npm/npx.
