### PR TITLE
chore(release): bump to 1.1.12.post3 and pin ACP version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "modelscope>=1.35.0",
     "huggingface_hub>=0.20.0",
     "pillow>=10.0.0",
-    "agent-client-protocol>=0.9.0",
+    "agent-client-protocol>=0.9.0,<0.11.0",
     "psutil>=6.0.0",
     "openai>=2.0.0,<=2.33.0",
     # anyio 4.13.0: _deliver_cancellation busy-loop / getpid storm (QwenPaw#2632)

--- a/scripts/pack-tauri/build_pyinstaller.ps1
+++ b/scripts/pack-tauri/build_pyinstaller.ps1
@@ -138,7 +138,7 @@ Write-Host "Project dependencies installed with full extras" -ForegroundColor Gr
 if (-not (Test-PythonImport "from acp import Agent")) {
     Write-Host "Fixing agent-client-protocol namespace..."
     Uninstall-PythonPackage "acp"
-    Install-PythonPackages -Packages @("agent-client-protocol")
+    Install-PythonPackages -Packages @("agent-client-protocol>=0.9.0,<0.11.0")
     Write-Host "agent-client-protocol installed" -ForegroundColor Green
 }
 

--- a/scripts/pack-tauri/build_pyinstaller.sh
+++ b/scripts/pack-tauri/build_pyinstaller.sh
@@ -76,7 +76,7 @@ echo "Project dependencies installed with full extras"
 if ! "$PYTHON_BIN" -c "from acp import Agent" 2> /dev/null; then
     echo "Fixing agent-client-protocol namespace..."
     uninstall_python_package acp
-    install_python_packages agent-client-protocol
+    install_python_packages "agent-client-protocol>=0.9.0,<0.11.0"
 fi
 echo ""
 

--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.1.12.post2"
+__version__ = "1.1.12.post3"


### PR DESCRIPTION
## Summary

- Pin `agent-client-protocol` to `>=0.9.0,<0.11.0` to avoid breaking import errors from newer ACP releases (fixes agentscope-ai/QwenPaw#5816).
- Bump version to `1.1.12.post3` for a patch release on the 1.1.12 line.
- Sync PyInstaller build scripts with the same ACP constraint.

Based on `v1.1.12.post2`; does **not** include 2.0 changes from `main`.

Ref: agentscope-ai/QwenPaw#5798

## Test plan

- [ ] `pre-commit run --all-files`
- [ ] `pytest` (smoke on 1.1.12 line)
- [ ] After merge: create GitHub Release `v1.1.12.post3` to trigger PyPI publish


Made with [Cursor](https://cursor.com)