### PR TITLE
fix(console): match active provider for context threshold

### DIFF
--- a/console/src/pages/Agent/Config/index.tsx
+++ b/console/src/pages/Agent/Config/index.tsx
@@ -54,13 +54,16 @@ function AgentConfigPage() {
       .then((info) => {
         if (info.active_llm) {
           return api.listProviders().then((providers) => {
-            for (const p of providers) {
-              const all = [...(p.models ?? []), ...(p.extra_models ?? [])];
-              const m = all.find((m) => m.id === info.active_llm?.model);
-              if (m?.max_input_length) {
-                setMaxInputLength(m.max_input_length);
-                return;
-              }
+            const activeProvider = providers.find(
+              (p) => p.id === info.active_llm?.provider_id,
+            );
+            const all = [
+              ...(activeProvider?.models ?? []),
+              ...(activeProvider?.extra_models ?? []),
+            ];
+            const m = all.find((m) => m.id === info.active_llm?.model);
+            if (m?.max_input_length) {
+              setMaxInputLength(m.max_input_length);
             }
           });
         }


### PR DESCRIPTION
## Description

Fixes #5784.

Agent Config previously looked up the active model by `model.id` across all providers. When multiple providers expose the same model id with different `max_input_length` values, the context compression threshold could display the value from the first matching provider instead of the active provider.

This PR resolves the active provider first, then looks up the active model within that provider's `models` and `extra_models`.

## Type of Change

- Bug fix

## Component(s) Affected

- Console (frontend web UI)

## Testing

- `npx prettier --check src/pages/Agent/Config/index.tsx`
- `npx eslint src/pages/Agent/Config/index.tsx`
- `npx tsc -b --noEmit`

## Local Verification Evidence

```bash
npx prettier --check src/pages/Agent/Config/index.tsx
# All matched files use Prettier code style!

npx eslint src/pages/Agent/Config/index.tsx
# passed

npx tsc -b --noEmit
# passed
```

## Notes

- `pre-commit run --all-files` was not run locally because `pre-commit` is not installed in this Windows environment.
- `pytest` was not run because this change is limited to the Console frontend.
