### PR TITLE
fix(feishu): send markdown images as image parts

### DIFF
--- a/src/qwenpaw/app/channels/feishu/channel.py
+++ b/src/qwenpaw/app/channels/feishu/channel.py
@@ -193,6 +193,74 @@ _MSG_TYPE_LABEL: Dict[str, str] = {
 }
 
 
+_MARKDOWN_IMAGE_RE = re.compile(
+    r"!\[(?P<alt>[^\]\n]*)\]\("
+    r"\s*(?P<url><[^>\n]+>|[^)\s]+)"
+    r"(?:\s+(?:\"[^\"]*\"|'[^']*'|\([^)]*\)))?\s*\)",
+)
+
+
+def _normalize_markdown_image_url(raw_url: str) -> str:
+    """Return the image destination from a Markdown image link."""
+    url = (raw_url or "").strip()
+    if url.startswith("<") and url.endswith(">"):
+        url = url[1:-1].strip()
+    return url
+
+
+def _is_sendable_image_url(url: str) -> bool:
+    """Only extract image links that Feishu's image sender can resolve."""
+    if url.startswith(("http://", "https://", "file://", "data:")):
+        return True
+    try:
+        return Path(url).expanduser().exists()
+    except (OSError, ValueError):
+        return False
+
+
+def _extract_markdown_image_parts(
+    text: str,
+) -> Tuple[str, List[OutgoingContentPart]]:
+    """Split sendable Markdown image links out of a text body."""
+    if "![" not in text:
+        return text, []
+
+    image_parts: List[OutgoingContentPart] = []
+    chunks: List[str] = []
+    cursor = 0
+
+    def append_text_chunk(chunk: str) -> None:
+        if (
+            chunks
+            and chunk[:1] in (" ", "\t")
+            and chunks[-1].endswith((" ", "\t"))
+        ):
+            chunk = chunk.lstrip(" \t")
+        chunks.append(chunk)
+
+    for match in _MARKDOWN_IMAGE_RE.finditer(text):
+        url = _normalize_markdown_image_url(match.group("url"))
+        if not url or not _is_sendable_image_url(url):
+            continue
+        append_text_chunk(text[cursor : match.start()])
+        image_parts.append(
+            ImageContent(
+                type=ContentType.IMAGE,
+                image_url=url,
+            ),
+        )
+        cursor = match.end()
+
+    if not image_parts:
+        return text, []
+
+    append_text_chunk(text[cursor:])
+    cleaned = "".join(chunks)
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned, image_parts
+
+
 class FeishuChannel(BaseChannel):
     """Feishu/Lark channel: WebSocket receive, Open API send.
 
@@ -1207,9 +1275,11 @@ class FeishuChannel(BaseChannel):
             quoted_lines.append(f"[quoted {label}]")
         for hint in error_hints:
             quoted_lines.append(
-                f"[quoted {hint[1:]}"
-                if hint.startswith("[")
-                else f"[quoted {hint}]",
+                (
+                    f"[quoted {hint[1:]}"
+                    if hint.startswith("[")
+                    else f"[quoted {hint}]"
+                ),
             )
         # Prepend all quoted lines before existing text_parts.
         text_parts[:0] = quoted_lines
@@ -1933,7 +2003,13 @@ class FeishuChannel(BaseChannel):
                 p.get("refusal") if isinstance(p, dict) else None
             )
             if t == ContentType.TEXT and text_val:
-                text_parts.append(text_val or "")
+                (
+                    cleaned_text,
+                    markdown_image_parts,
+                ) = _extract_markdown_image_parts(str(text_val))
+                if cleaned_text:
+                    text_parts.append(cleaned_text)
+                media_parts.extend(markdown_image_parts)
             elif t == ContentType.REFUSAL and refusal_val:
                 text_parts.append(refusal_val or "")
             elif t in (


### PR DESCRIPTION
## Description

Feishu does not render standard Markdown image syntax inside text/post messages. This PR splits sendable Markdown image links from Feishu outbound text parts and sends them through the existing native image upload/send path, while preserving the remaining text body.

**Related Issue:** Fixes #2792

**Security Considerations:** No channel auth, env/config, or permission handling changes. Markdown image links are only extracted when the existing Feishu image sender can resolve them (`http://`, `https://`, `file://`, `data:`, or an existing local path).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [x] **Contract test** exists in `tests/contract/channels/test_feishu_contract.py` (REQUIRED)
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_feishu.py` for complex internal logic

## Testing

- `pre-commit run --files src/qwenpaw/app/channels/feishu/channel.py`
- `python -m pytest tests/unit/channels/test_feishu.py -q`
- `python -m pytest tests/contract/channels/test_feishu_contract.py -q`
- `python -m pytest tests/contract/channels/test_feishu_contract.py -v --tb=short`
- `python -m pytest tests/unit/channels/test_feishu.py -v --tb=short`

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/app/channels/feishu/channel.py
# Passed: check-ast, encoding pragma, private key detection, trailing whitespace,
# add-trailing-comma, mypy, black, flake8, pylint

python -m pytest tests/unit/channels/test_feishu.py -q
# 161 passed

python -m pytest tests/contract/channels/test_feishu_contract.py -q
# 23 passed, 1 skipped

python -m pytest tests/contract/channels/test_feishu_contract.py -v --tb=short
# 23 passed, 1 skipped

python -m pytest tests/unit/channels/test_feishu.py -v --tb=short
# 161 passed
```

## Checks Not Marked Complete

`pre-commit run --all-files` was attempted locally on Windows/Python 3.13, but did not pass due to issues outside this PR's Feishu change:

```text
src/qwenpaw/cli/shutdown_cmd.py: mypy arg-type errors
tests/unit/providers/test_provider_class_identity.py: pylint unused-argument warnings
```

The GitHub `Pre-commit Checks / run` job for this PR is passing.

`./scripts/check-channels.sh feishu` was attempted with Git Bash, but the script's environment probe currently checks `import copaw`; this checkout installs/imports `qwenpaw`, not `copaw`, so the script falls into its install branch and fails in this local venv. I therefore left the script checklist item unchecked and ran the Feishu contract/unit checks directly.

## Additional Notes

This PR keeps the fix in the Feishu outbound path and reuses the existing `_send_image()` implementation for upload/send behavior.