### PR TITLE
fix(channels): timeout hung message batches

### DIFF
--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -35,6 +35,10 @@ OnLastDispatch = Optional[Callable[[str, str, str], None]]
 # Default max size per channel queue
 _CHANNEL_QUEUE_MAXSIZE = 1000
 
+# Hard cap for one per-session batch. This keeps a hung LLM/tool call from
+# blocking all later messages in the same queue indefinitely.
+_PROCESS_BATCH_TIMEOUT_S = 300.0
+
 
 async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
     """Merge if needed and process one payload (native or request)."""
@@ -438,8 +442,24 @@ class ChannelManager:
                     except asyncio.QueueEmpty:
                         break
 
-                # Process batch (with merge logic)
-                await _process_batch(ch, batch)
+                # Process batch (with merge logic). A stuck LLM/tool call
+                # must not block this per-session queue forever.
+                try:
+                    await asyncio.wait_for(
+                        _process_batch(ch, batch),
+                        timeout=_PROCESS_BATCH_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "Consumer batch timeout after %.1fs: "
+                        "channel=%s session=%s priority=%s batch_size=%s",
+                        _PROCESS_BATCH_TIMEOUT_S,
+                        channel_id,
+                        session_id[:30],
+                        priority_level,
+                        len(batch),
+                    )
+                    continue
 
                 # Update processed count
                 if self._queue_manager is not None:


### PR DESCRIPTION
## Description

Adds a hard timeout around one per-session channel batch so a hung LLM/tool call cannot block all later messages in the same queue indefinitely. When a batch exceeds the timeout, the consumer logs the timeout and continues to the next queued payload.

**Related Issue:** Fixes #1675

**Security Considerations:** No auth, permission, sandbox, file guard, or credential handling changes. This only bounds queue processing time for channel message batches.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pre-commit run --files src/qwenpaw/app/channels/manager.py`
- `python -m pytest tests/unit/channels/test_base_core.py -q`
- Local smoke: temporarily set `_PROCESS_BATCH_TIMEOUT_S = 0.05`, enqueue one payload whose `consume_one()` hangs, then enqueue a second payload for the same queue. Verified the second payload is processed after the first times out.

I did not run `./scripts/check-channels.sh --changed` locally because this Windows environment does not have a working Bash/WSL shell. This PR changes the shared channel queue manager rather than a single concrete channel contract.

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/app/channels/manager.py
# Passed: check-ast, encoding pragma, private key detection, trailing whitespace,
# add-trailing-comma, mypy, black, flake8, pylint

python -m pytest tests/unit/channels/test_base_core.py -q
# 68 passed, 1 skipped

# Local smoke output
['hang', 'next']
1
```

## Additional Notes

The timeout is intentionally scoped to one QueueKey consumer path. Different sessions and priorities already have separate queues; this change prevents one stuck batch from silencing later messages for the same QueueKey forever.
