### PR TITLE
feat: add avatar field to agent profile config

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -44,6 +44,7 @@ class AgentSummary(BaseModel):
     id: str
     name: str
     description: str
+    avatar: str | None = None
     workspace_dir: str
     enabled: bool
     active_model: ModelSlotConfig | None = None
@@ -72,6 +73,7 @@ class CreateAgentRequest(BaseModel):
     id: str | None = None
     name: str
     description: str = ""
+    avatar: str | None = None
     workspace_dir: str | None = None
     language: str | None = None
     skill_names: list[str] | None = None
@@ -186,6 +188,7 @@ async def list_agents() -> AgentListResponse:
                     id=agent_id,
                     name=agent_config.name,
                     description=description,
+                    avatar=agent_config.avatar,
                     workspace_dir=agent_ref.workspace_dir,
                     enabled=getattr(agent_ref, "enabled", True),
                     active_model=active_model,
@@ -197,6 +200,7 @@ async def list_agents() -> AgentListResponse:
                     id=agent_id,
                     name=agent_id.title(),
                     description="",
+                    avatar=None,
                     workspace_dir=agent_ref.workspace_dir,
                     enabled=getattr(agent_ref, "enabled", True),
                 ),
@@ -331,6 +335,7 @@ async def create_agent(
         id=new_id,
         name=request.name,
         description=request.description,
+        avatar=request.avatar,
         workspace_dir=str(workspace_dir),
         language=language,
         channels=ChannelConfig(),

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1383,6 +1383,10 @@ class AgentProfileConfig(BaseModel):
     id: str = Field(..., description="Unique agent ID")
     name: str = Field(..., description="Human-readable agent name")
     description: str = Field(default="", description="Agent description")
+    avatar: Optional[str] = Field(
+        default=None,
+        description="URL or path to agent's avatar image (shown in console)",
+    )
     workspace_dir: str = Field(
         default="",
         description="Path to agent's workspace (optional, for reference)",


### PR DESCRIPTION
- Add optional `avatar` field to AgentProfileConfig for per-agent avatar images
- Add `avatar` to AgentSummary and CreateAgentRequest
- Wire through the create/list agent APIs
- Frontend already supports avatar with fallback to default image

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
