### PR TITLE
fix(gemini): sanitize const Schema Field for Gemini Tool Parameters

### DIFF
--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -94,6 +94,9 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
     - ``{"type": "null"}`` appearing as a standalone schema: replaced with
       ``{"type": "object"}`` because the Gemini API (and many third-party
       proxies) do not accept ``null`` as a functionDeclaration property type.
+    - ``const``: not supported by the Gemini SDK's ``Schema`` pydantic
+      model (raises ``extra_forbidden``); rewritten to an ``enum`` with a
+      single value, which is semantically equivalent and is supported.
     - All nested sub-schemas are processed recursively.
     """
     if not isinstance(schema, dict):
@@ -111,6 +114,14 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
         schema["type"] = "object"
 
     schema.pop("additionalProperties", None)
+
+    # JSON Schema ``const`` is not a recognized field on the Gemini SDK's
+    # ``Schema`` pydantic model and triggers an ``extra_forbidden``
+    # validation error. Rewrite it as a single-value ``enum``, which is
+    # semantically equivalent and is supported by Gemini.
+    if "const" in schema:
+        const_value = schema.pop("const")
+        schema.setdefault("enum", [const_value])
 
     if "anyOf" in schema and isinstance(schema["anyOf"], list):
         any_of = schema["anyOf"]


### PR DESCRIPTION
## Description

Fixed a `pydantic.ValidationError` raised when constructing GenerateContentConfig for tools whose JSON Schema parameters contain a const field, which the google-genai SDK's Schema model does not support. Updated `_sanitize_schema_for_gemini` to convert `const: value` into an equivalent single-value `enum: [value]` before building Gemini tool schemas, so tools emitted by MCP servers or Pydantic models with fixed-value parameters now work correctly with GeminiChatModel.

**Related Issue:** Fixes #5774

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
