### PR TITLE
feat(coding-mode): allow selecting hidden folders in project browser

### DIFF
--- a/console/src/components/ProjectSelectModal/index.tsx
+++ b/console/src/components/ProjectSelectModal/index.tsx
@@ -13,6 +13,8 @@ import { useState, useRef, useEffect } from "react";
 import { Modal, Tabs, Input, Button, Alert, List } from "antd";
 import {
   ChevronRight,
+  Eye,
+  EyeOff,
   Folder,
   FolderOpen,
   FolderSymlink,
@@ -437,6 +439,7 @@ function OpenDirTab({ onSelect }: { onSelect: (path: string) => void }) {
   const [data, setData] = useState<BrowseDirsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const navSeq = useRef(0);
 
@@ -446,7 +449,7 @@ function OpenDirTab({ onSelect }: { onSelect: (path: string) => void }) {
     setLoading(true);
     setError(null);
     codingProjectApi
-      .browseDirs(path)
+      .browseDirs(path, showHidden)
       .then((res) => {
         if (seq !== navSeq.current) return;
         setData(res);
@@ -465,6 +468,13 @@ function OpenDirTab({ onSelect }: { onSelect: (path: string) => void }) {
     navigate("~");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Re-fetch current directory when the hidden-folders toggle changes.
+  // navSeq already discards stale responses, so unconditional re-fetch is safe.
+  useEffect(() => {
+    navigate(browsePath);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showHidden]);
 
   const breadcrumbParts = data?.current.split("/").filter(Boolean) ?? [];
 
@@ -494,6 +504,14 @@ function OpenDirTab({ onSelect }: { onSelect: (path: string) => void }) {
           onClick={() => navigate(browsePath)}
         >
           {t("codingMode.openDirRefresh")}
+        </Button>
+        <Button
+          size="small"
+          type={showHidden ? "primary" : "text"}
+          icon={showHidden ? <Eye size={13} /> : <EyeOff size={13} />}
+          onClick={() => setShowHidden((v) => !v)}
+        >
+          {t("codingMode.openDirHiddenFolders")}
         </Button>
       </div>
 

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2665,7 +2665,8 @@
     "openDirLoading": "Loading...",
     "openDirEmpty": "No subdirectories here",
     "openDirHome": "Home",
-    "openDirRefresh": "Refresh"
+    "openDirRefresh": "Refresh",
+    "openDirHiddenFolders": "Hidden Folders"
   },
   "market": {
     "searchPlaceholder": "Search skills across platforms",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -1009,7 +1009,8 @@
     "openDirLoading": "Memuat...",
     "openDirEmpty": "Tidak ada subdirektori",
     "openDirHome": "Beranda",
-    "openDirRefresh": "Segarkan"
+    "openDirRefresh": "Segarkan",
+    "openDirHiddenFolders": "Folder Tersembunyi"
   },
   "market": {
     "searchPlaceholder": "Cari skill di berbagai platform",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2539,7 +2539,8 @@
     "openDirLoading": "読み込み中...",
     "openDirEmpty": "サブディレクトリがありません",
     "openDirHome": "ホーム",
-    "openDirRefresh": "更新"
+    "openDirRefresh": "更新",
+    "openDirHiddenFolders": "隠しフォルダ"
   },
   "market": {
     "searchPlaceholder": "プラットフォームを横断してスキルを検索",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2596,7 +2596,8 @@
     "openDirLoading": "Carregando...",
     "openDirEmpty": "Sem subdiretórios",
     "openDirHome": "Início",
-    "openDirRefresh": "Atualizar"
+    "openDirRefresh": "Atualizar",
+    "openDirHiddenFolders": "Pastas Ocultas"
   },
   "market": {
     "searchPlaceholder": "Buscar habilidades em várias plataformas",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2551,7 +2551,8 @@
     "openDirLoading": "Загрузка...",
     "openDirEmpty": "Нет подкаталогов",
     "openDirHome": "Домой",
-    "openDirRefresh": "Обновить"
+    "openDirRefresh": "Обновить",
+    "openDirHiddenFolders": "Скрытые папки"
   },
   "market": {
     "searchPlaceholder": "Поиск навыков по платформам",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -695,7 +695,14 @@
     "workspaceDesc": "Dùng thư mục workspace của agent hiện tại",
     "cloneUrl": "URL Git Repository",
     "cloneUrlPlaceholder": "https://github.com/user/repo.git",
-    "cloneName": "Tên dự án (tùy chọn)"
+    "cloneName": "Tên dự án (tùy chọn)",
+    "openDirDesc": "Mở thư mục cục bộ hiện có — không sao chép tệp",
+    "openDirBtn": "Mở Thư Mục Này",
+    "openDirLoading": "Đang tải...",
+    "openDirEmpty": "Không có thư mục con",
+    "openDirHome": "Trang chủ",
+    "openDirRefresh": "Làm mới",
+    "openDirHiddenFolders": "Thư mục ẩn"
   },
   "agentConfig": {
     "title": "Cấu hình",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2684,7 +2684,8 @@
     "openDirLoading": "加载中...",
     "openDirEmpty": "此目录下没有子目录",
     "openDirHome": "主目录",
-    "openDirRefresh": "刷新"
+    "openDirRefresh": "刷新",
+    "openDirHiddenFolders": "隐藏文件夹"
   },
   "market": {
     "searchPlaceholder": "在多平台中搜索技能",


### PR DESCRIPTION
Fix #5785 — the OpenDirTab component never passed showHidden to the backend browse-dirs API, so dot-prefixed directories were always filtered.

- Add showHidden state and Eye/EyeOff toggle button in toolbar
- Pass showHidden to codingProjectApi.browseDirs()
- Re-fetch current directory on toggle (unconditional, navSeq guards races)
- Add openDirShowHidden/openDirHideHidden i18n keys for 7 languages
- Backfill missing openDir* keys in vi.json

<img width="1579" height="1230" alt="image" src="https://github.com/user-attachments/assets/64bce454-4cf9-45b6-95c5-cabf143eb22f" />
<img width="1579" height="1230" alt="image" src="https://github.com/user-attachments/assets/5b8ff885-e478-4095-ab15-d0c1c2558d9e" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
