### PR TITLE
Fix pet plugin approval monkey-patch missing scope parameter 

### DIFF
--- a/plugins/bundle/qwenpaw-pet/patch_approval.py
+++ b/plugins/bundle/qwenpaw-pet/patch_approval.py
@@ -30,7 +30,10 @@ def patch_approval_service() -> None:
         return
 
     from qwenpaw.app.approvals.service import ApprovalService
-    from qwenpaw.security.tool_guard.approval import ApprovalDecision
+    from qwenpaw.security.tool_guard.approval import (
+        ApprovalDecision,
+        ApprovalScope,
+    )
 
     _ORIG_CREATE_PENDING = ApprovalService.create_pending
     _ORIG_RESOLVE_REQUEST = ApprovalService.resolve_request
@@ -62,8 +65,18 @@ def patch_approval_service() -> None:
             )
         return pending
 
-    async def resolve_request_wrapped(self, request_id: str, decision: Any):
-        resolved = await _ORIG_RESOLVE_REQUEST(self, request_id, decision)
+    async def resolve_request_wrapped(
+        self,
+        request_id: str,
+        decision: Any,
+        scope: ApprovalScope | None = None,
+    ):
+        resolved = await _ORIG_RESOLVE_REQUEST(
+            self,
+            request_id,
+            decision,
+            scope=scope,
+        )
         if resolved is None:
             return None
         try:


### PR DESCRIPTION
## Description

he qwenpaw-pet plugin wraps ApprovalService.resolve_request but its signature was outdated. The approve route passes scope=scope, which caused a TypeError and blocked approvals. Deny still worked because it does not pass scope.

This updates resolve_request_wrapped to accept and forward scope to the original method.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
