### PR TITLE
feat(console, chat): remove default mode  of session approval level

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2041,9 +2041,7 @@
       "auto": "Auto Mode",
       "autoDesc": "Only tools explicitly marked for approval require approval (default)",
       "off": "Off Mode",
-      "offDesc": "Disable all tool approvals, all tools execute automatically",
-      "inherit": "Default Mode",
-      "inheritDesc": "Use the agent's tool execution security level as default"
+      "offDesc": "Disable all tool approvals, all tools execute automatically"
     },
     "saveLevelSuccess": "Tool execution security level saved",
     "saveLevelFailed": "Failed to save tool execution security level",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1900,9 +1900,7 @@
       "auto": "自动模式",
       "autoDesc": "仅被明确标记为需要审批的工具才会要求审批（默认）",
       "off": "关闭模式",
-      "offDesc": "关闭所有工具审批，所有工具自动执行",
-      "inherit": "默认模式",
-      "inheritDesc": "默认使用Agent的工具执行安全级别"
+      "offDesc": "关闭所有工具审批，所有工具自动执行"
     },
     "saveLevelSuccess": "工具执行安全级别已保存",
     "saveLevelFailed": "保存工具执行安全级别失败",

--- a/console/src/pages/Chat/components/ApprovalLevelToggle.tsx
+++ b/console/src/pages/Chat/components/ApprovalLevelToggle.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Dropdown, Tag, Tooltip } from "antd";
 import type { MenuProps } from "antd";
 import { Shield, Ban, AlertTriangle, CheckCircle } from "lucide-react";
@@ -6,8 +12,6 @@ import { DownOutlined } from "@ant-design/icons";
 import { useTranslation } from "react-i18next";
 
 export type ToolExecutionLevel = "STRICT" | "SMART" | "AUTO" | "OFF";
-
-type SessionApprovalLevel = ToolExecutionLevel | null;
 
 const LEVELS: readonly ToolExecutionLevel[] = [
   "STRICT",
@@ -30,67 +34,85 @@ function storageKey(chatId: string): string {
   return `approval_level-${chatId}`;
 }
 
+function normalizeLevel(raw: string | undefined): ToolExecutionLevel {
+  const upper = (raw || "AUTO").toUpperCase();
+  return LEVELS.includes(upper as ToolExecutionLevel)
+    ? (upper as ToolExecutionLevel)
+    : "AUTO";
+}
+
 interface ApprovalLevelToggleProps {
-  chatId: string | undefined;
-  onChange?: (level: SessionApprovalLevel) => void;
+  /** Use queueSessionId (chatId ?? "new") for consistent storage key */
+  sessionId: string;
+  /** Default level from GET /workspace/running-config */
+  runningConfigApprovalLevel: ToolExecutionLevel;
+  /** null = no session override, backend uses running-config */
+  onChange?: (sessionOverride: ToolExecutionLevel | null) => void;
 }
 
 const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
-  chatId,
+  sessionId,
+  runningConfigApprovalLevel,
   onChange,
 }) => {
   const { t } = useTranslation();
-  const [sessionLevel, setSessionLevel] = useState<SessionApprovalLevel>(null);
+  const [sessionLevel, setSessionLevel] = useState<ToolExecutionLevel | null>(
+    null,
+  );
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const prevSessionIdRef = useRef<string>(sessionId);
 
   useEffect(() => {
-    if (!chatId) {
-      setSessionLevel(null);
-      return;
+    const prevSessionId = prevSessionIdRef.current;
+
+    // Migrate from temporary sessionId (including "new" or localId) to real backend chatId
+    // This happens when:
+    // 1. "new" -> real UUID (first message sent)
+    // 2. localId (timestamp-random) -> real UUID (session resolved)
+    if (prevSessionId !== sessionId) {
+      const isLocalId = (id: string) =>
+        id === "new" || /^\d{13}-[a-z0-9]{7}$/.test(id);
+      const isRealId = (id: string) => id.length === 36 && id.includes("-");
+
+      // Migrate if transitioning from local/temp to real
+      if (isLocalId(prevSessionId) && isRealId(sessionId)) {
+        const prevLevel = localStorage.getItem(storageKey(prevSessionId));
+        if (prevLevel && LEVELS.includes(prevLevel as ToolExecutionLevel)) {
+          localStorage.setItem(storageKey(sessionId), prevLevel);
+          localStorage.removeItem(storageKey(prevSessionId));
+        }
+      }
     }
-    const saved = localStorage.getItem(storageKey(chatId));
+
+    prevSessionIdRef.current = sessionId;
+
+    const saved = localStorage.getItem(storageKey(sessionId));
     if (saved && LEVELS.includes(saved as ToolExecutionLevel)) {
       setSessionLevel(saved as ToolExecutionLevel);
     } else {
       setSessionLevel(null);
     }
-  }, [chatId]);
+  }, [sessionId]);
+
+  const effectiveLevel = sessionLevel ?? runningConfigApprovalLevel;
+  const meta = LEVEL_META[effectiveLevel];
+
+  useEffect(() => {
+    onChangeRef.current?.(sessionLevel);
+  }, [sessionLevel]);
 
   const handleSelect = useCallback(
-    (level: SessionApprovalLevel) => {
-      if (!chatId) return;
+    (level: ToolExecutionLevel) => {
       setSessionLevel(level);
-      if (level === null) {
-        localStorage.removeItem(storageKey(chatId));
-      } else {
-        localStorage.setItem(storageKey(chatId), level);
-      }
-      onChange?.(level);
+      localStorage.setItem(storageKey(sessionId), level);
+      onChangeRef.current?.(level);
     },
-    [chatId, onChange],
+    [sessionId],
   );
 
-  const isOverridden = sessionLevel !== null;
-  const meta = isOverridden ? LEVEL_META[sessionLevel] : null;
-
   const menuItems: MenuProps["items"] = useMemo(() => {
-    const items: MenuProps["items"] = [
-      {
-        key: "inherit",
-        label: (
-          <div>
-            <div>
-              {t("agentConfig.toolExecutionLevel.inherit", "Default Mode")}
-            </div>
-            <div style={{ fontSize: 12, color: "#999", marginTop: 2 }}>
-              {t("agentConfig.toolExecutionLevel.inheritDesc", "")}
-            </div>
-          </div>
-        ),
-        icon: <Shield size={14} style={{ color: "#999", marginTop: 4 }} />,
-        onClick: () => handleSelect(null),
-      },
-      { type: "divider" },
-    ];
+    const items: MenuProps["items"] = [];
 
     for (const lv of LEVELS) {
       const m = LEVEL_META[lv];
@@ -124,16 +146,15 @@ const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
   return (
     <Tooltip title={t("agentConfig.toolExecutionLevelTitle")}>
       <Dropdown
-        menu={{ items: menuItems, selectedKeys: [sessionLevel ?? "inherit"] }}
+        menu={{ items: menuItems, selectedKeys: [effectiveLevel] }}
         trigger={["click"]}
       >
         <Tag
           style={{
             cursor: "pointer",
             userSelect: "none",
-            borderColor: meta?.color,
-            color: meta?.color,
-            opacity: isOverridden ? 1 : 0.6,
+            borderColor: meta.color,
+            color: meta.color,
             transition: "all 0.2s",
             display: "inline-flex",
             alignItems: "center",
@@ -141,13 +162,11 @@ const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
             lineHeight: "22px",
           }}
         >
-          {meta?.icon ?? <Shield size={12} />}
-          {isOverridden
-            ? t(
-                `agentConfig.toolExecutionLevel.${sessionLevel.toLowerCase()}`,
-                sessionLevel,
-              )
-            : t("agentConfig.toolExecutionLevel.inherit", "Default Mode")}
+          {meta.icon}
+          {t(
+            `agentConfig.toolExecutionLevel.${effectiveLevel.toLowerCase()}`,
+            effectiveLevel,
+          )}
           <DownOutlined style={{ fontSize: 10 }} />
         </Tag>
       </Dropdown>
@@ -155,4 +174,5 @@ const ApprovalLevelToggle: React.FC<ApprovalLevelToggleProps> = ({
   );
 };
 
+export { normalizeLevel };
 export default ApprovalLevelToggle;

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -105,6 +105,7 @@ import { getLastEditorCopy } from "../Coding/lastEditorCopy";
 import { useUploadLimitStore } from "../../stores/uploadLimitStore";
 import MessageQueuePanel from "./components/MessageQueuePanel";
 import ApprovalLevelToggle, {
+  normalizeLevel,
   type ToolExecutionLevel,
 } from "./components/ApprovalLevelToggle";
 import {
@@ -1140,7 +1141,8 @@ export default function ChatPage() {
   const extLists = useChatListSnapshot();
   const [refreshKey, setRefreshKey] = useState(0);
   const runtimeLoadingBridgeRef = useRef<RuntimeLoadingBridgeApi | null>(null);
-  const queueSessionId = chatId ?? "new";
+  // Use sessionApi.lastActiveChatId when available to avoid "new" collision
+  const queueSessionId = chatId ?? sessionApi.lastActiveChatId ?? "new";
   const queueSessionIdRef = useRef(queueSessionId);
   queueSessionIdRef.current = queueSessionId;
   const messageQueue =
@@ -1151,6 +1153,27 @@ export default function ChatPage() {
   const prevQueueLenRef = useRef(messageQueue.length);
 
   const sessionApprovalLevelRef = useRef<ToolExecutionLevel | null>(null);
+  const [runningConfigApprovalLevel, setRunningConfigApprovalLevel] =
+    useState<ToolExecutionLevel>("AUTO");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const config = await agentApi.getAgentRunningConfig();
+        if (!cancelled) {
+          setRunningConfigApprovalLevel(normalizeLevel(config.approval_level));
+        }
+      } catch {
+        if (!cancelled) {
+          setRunningConfigApprovalLevel("AUTO");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAgent, refreshKey]);
 
   // Track pending attachments for queue support
   const pendingFileListRef = useRef<
@@ -2260,7 +2283,7 @@ export default function ChatPage() {
         }
       }
 
-      // Inject session-level approval_level into request_context
+      // Session override only; otherwise backend uses running-config approval_level
       const sessionLevel = sessionApprovalLevelRef.current;
       if (sessionLevel) {
         const rc =
@@ -2787,9 +2810,10 @@ export default function ChatPage() {
         ),
         actionAffix: (
           <ApprovalLevelToggle
-            chatId={chatId}
-            onChange={(level) => {
-              sessionApprovalLevelRef.current = level;
+            sessionId={queueSessionId}
+            runningConfigApprovalLevel={runningConfigApprovalLevel}
+            onChange={(sessionOverride) => {
+              sessionApprovalLevelRef.current = sessionOverride;
             }}
           />
         ),
@@ -2996,6 +3020,8 @@ export default function ChatPage() {
     scheduleHistoryClear,
     consoleSkills,
     selectedAgent,
+    runningConfigApprovalLevel,
+    queueSessionId,
     onFileCardClick,
     whisperChecked,
     whisperEnabled,


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

https://github.com/agentscope-ai/QwenPaw/pull/5832


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
