### PR TITLE
fix(tools): support pipe-separated literals in grep_search

### DIFF
--- a/src/qwenpaw/agents/tools/file_search.py
+++ b/src/qwenpaw/agents/tools/file_search.py
@@ -151,7 +151,11 @@ def _compile_search_pattern(
     if is_regex:
         expr = pattern
     elif "|" in pattern:
-        expr = "|".join(re.escape(part) for part in pattern.split("|") if part)
+        parts = [part for part in pattern.split("|") if part]
+        if not parts:
+            expr = re.escape(pattern)
+        else:
+            expr = "|".join(re.escape(part) for part in parts)
     else:
         expr = re.escape(pattern)
     return re.compile(expr, flags)

--- a/src/qwenpaw/agents/tools/file_search.py
+++ b/src/qwenpaw/agents/tools/file_search.py
@@ -137,6 +137,26 @@ def _make_response(text: str) -> ToolChunk:
     )
 
 
+def _compile_search_pattern(
+    pattern: str,
+    is_regex: bool,
+    flags: int,
+) -> "re.Pattern[str]":
+    """Compile a grep pattern.
+
+    When *is_regex* is False, the pattern is treated as a literal string.
+    Pipe-separated alternatives (``a|b|c``) are supported as OR matching,
+    similar to ``grep -E``, with each alternative escaped individually.
+    """
+    if is_regex:
+        expr = pattern
+    elif "|" in pattern:
+        expr = "|".join(re.escape(part) for part in pattern.split("|") if part)
+    else:
+        expr = re.escape(pattern)
+    return re.compile(expr, flags)
+
+
 def _resolve_search_root(
     path: Optional[str],
     require_dir: bool = False,
@@ -519,10 +539,7 @@ async def grep_search(
 
     flags = 0 if case_sensitive else re.IGNORECASE
     try:
-        regex = re.compile(
-            pattern if is_regex else re.escape(pattern),
-            flags,
-        )
+        regex = _compile_search_pattern(pattern, is_regex, flags)
     except re.error as e:
         return _make_response(f"Error: Invalid regex pattern — {e}")
 

--- a/tests/unit/agents/tools/test_file_search.py
+++ b/tests/unit/agents/tools/test_file_search.py
@@ -62,11 +62,21 @@ def test_compile_search_pattern_literal():
 
 
 def test_compile_search_pattern_pipe_alternatives():
-    pattern = "服务期|服务期限|合同有效期|合同期限|协议期限|供应有效期|有效直至|服务周期|履约期限"
+    pattern = "keyword_a|keyword_b|keyword_c|keyword_d|keyword_e"
     regex = _compile_search_pattern(pattern, is_regex=False, flags=0)
-    assert regex.search("本合同保持其有效直至")
-    assert regex.search("合同有效期为一年")
-    assert not regex.search("完全不相关的内容")
+    assert regex.search("the item remains keyword_d")
+    assert regex.search("field keyword_c is set")
+    assert not regex.search("completely unrelated content")
+
+
+def test_compile_search_pattern_pipe_only():
+    regex = _compile_search_pattern("||", is_regex=False, flags=0)
+    assert not regex.search("any line")
+    assert regex.search("a||b")
+
+    single = _compile_search_pattern("|", is_regex=False, flags=0)
+    assert single.search("a|b")
+    assert not single.search("any line")
 
 
 def test_compile_search_pattern_pipe_preserves_regex_metacharacters():
@@ -720,9 +730,10 @@ def test_walk_and_grep_context_line_at_file_end_edge(temp_dir):
 def test_walk_and_grep_pipe_alternatives_literal(temp_dir):
     """Pipe-separated literals should match any alternative."""
     (temp_dir / "file.txt").write_text(
-        "本合同保持其有效直至\n合同有效期为一年\n",
+        "the item remains keyword_d\nfield keyword_c is set\n",
+        encoding="utf-8",
     )
-    pattern = "服务期|服务期限|有效直至|合同有效期"
+    pattern = "keyword_a|keyword_b|keyword_d|keyword_c"
     regex = _compile_search_pattern(pattern, is_regex=False, flags=0)
     matches, status = _walk_and_grep(
         temp_dir / "file.txt",

--- a/tests/unit/agents/tools/test_file_search.py
+++ b/tests/unit/agents/tools/test_file_search.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from qwenpaw.agents.tools.file_search import (
+    _compile_search_pattern,
     _is_text_file,
     _MAX_MATCHES,
     _MAX_OUTPUT_CHARS,
@@ -47,6 +48,38 @@ class FakeCancelAfter(FakeCancel):
     def is_set(self) -> bool:
         self._checks += 1
         return self._checks > self.after
+
+
+# ---------------------------------------------------------------------------
+# _compile_search_pattern tests
+# ---------------------------------------------------------------------------
+
+
+def test_compile_search_pattern_literal():
+    regex = _compile_search_pattern("hello", is_regex=False, flags=0)
+    assert regex.search("hello world")
+    assert not regex.search("hi world")
+
+
+def test_compile_search_pattern_pipe_alternatives():
+    pattern = "服务期|服务期限|合同有效期|合同期限|协议期限|供应有效期|有效直至|服务周期|履约期限"
+    regex = _compile_search_pattern(pattern, is_regex=False, flags=0)
+    assert regex.search("本合同保持其有效直至")
+    assert regex.search("合同有效期为一年")
+    assert not regex.search("完全不相关的内容")
+
+
+def test_compile_search_pattern_pipe_preserves_regex_metacharacters():
+    regex = _compile_search_pattern("a.b|c.d", is_regex=False, flags=0)
+    assert regex.search("a.b")
+    assert regex.search("c.d")
+    assert not regex.search("axb")
+
+
+def test_compile_search_pattern_regex_mode():
+    regex = _compile_search_pattern(r"foo|bar", is_regex=True, flags=0)
+    assert regex.search("foo")
+    assert regex.search("bar")
 
 
 # ---------------------------------------------------------------------------
@@ -682,6 +715,24 @@ def test_walk_and_grep_context_line_at_file_end_edge(temp_dir):
         "---",
     ]
     assert matches == expected
+
+
+def test_walk_and_grep_pipe_alternatives_literal(temp_dir):
+    """Pipe-separated literals should match any alternative."""
+    (temp_dir / "file.txt").write_text(
+        "本合同保持其有效直至\n合同有效期为一年\n",
+    )
+    pattern = "服务期|服务期限|有效直至|合同有效期"
+    regex = _compile_search_pattern(pattern, is_regex=False, flags=0)
+    matches, status = _walk_and_grep(
+        temp_dir / "file.txt",
+        regex,
+        0,
+        FakeCancel(),
+        None,
+    )
+    assert status == "ok"
+    assert len(matches) == 2
 
 
 def test_walk_and_grep_regex_metacharacters(temp_dir):


### PR DESCRIPTION
---

## Summary

修复 `grep_search` 在默认 `is_regex=False` 时，使用 `|` 分隔的多关键词 pattern 无法命中任何结果的问题。

当 Agent 使用 `grep_search` 批量搜索多个同义/近义关键词（如 `keyword_a|keyword_b|keyword_c`）时，工具返回 `No matches found`；但单独搜索其中一个关键词，或使用底层 `grep -E`，均能正常命中。根因是 `re.escape()` 作用于整段 pattern，将 `|` 转义为字面量 `\|`，导致正则 OR 语义失效。

**本次修改：**
- 新增 `_compile_search_pattern()`，在 `is_regex=False` 时按 `|` 拆分各备选词并分别 `re.escape`，再拼接为 OR 正则
- `grep_search` 改用该函数编译 pattern，行为对齐 `grep -E`
- 补充单元测试，覆盖多关键词 OR 匹配、正则元字符转义及 `_walk_and_grep` 集成场景

---

## Problem / Root Cause

### 现象

在 Markdown 文件中批量搜索多个关键词时，`grep_search` 返回无匹配：

```
pattern: keyword_a|keyword_b|keyword_c|keyword_d|keyword_e
result:  No matches found
```
<img width="927" height="323" alt="image" src="https://github.com/user-attachments/assets/02ad988b-79eb-45d8-9611-883e073fde83" />

但以下两种方式均能命中目标行：

- 单独搜索 `keyword_d` → 命中
- 终端 `grep -E 'keyword_a|keyword_b|keyword_d'` → 命中
<img width="976" height="545" alt="image" src="https://github.com/user-attachments/assets/147151d1-f7f8-4c2e-8018-d723c103c194" />

### 复现案例（脱敏，节选）

**1. 准备测试文件 `sample.md`（片段，非全文）：**

```markdown
... preceding content omitted ...

> ...some indented quoted paragraph... the item remains keyword_d
next line continues with unrelated text...

... following content omitted ...
```

> 说明：目标关键词 `keyword_d` 出现在一行内；该行可能以 `>` 开头（引用块），且前后还有其他文本。这与业务内容无关，仅用于验证 OR 匹配。

**2. 调用 `grep_search`（`is_regex=False`，默认）：**

```
pattern: keyword_a|keyword_b|keyword_c|keyword_d|keyword_e
path:    sample.md
→ No matches found
```

**3. 对照组 A — 单关键词：**

```
pattern: keyword_d
path:    sample.md
→ sample.md:42:> ...the item remains keyword_d
```

**4. 对照组 B — 底层 grep：**

```bash
grep -nE 'keyword_a|keyword_b|keyword_c|keyword_d|keyword_e' sample.md
# → 42:> ...the item remains keyword_d
```

**5. 最小 Python 复现（无需真实文件）：**

```python
import re

pattern = "keyword_a|keyword_b|keyword_c|keyword_d"
line = "> ...some text... the item remains keyword_d"

# 修复前（grep_search 原逻辑）
assert not re.search(re.escape(pattern), line)

# 修复后
fixed = "|".join(re.escape(p) for p in pattern.split("|"))
assert re.search(fixed, line)
```

### 根因分析

| 检查项 | 实际情况 | 结果 |
|---|---|---|
| `is_regex` 默认值 | `False`（字面量模式） | 整段 pattern 走 `re.escape()` |
| pattern 中的 `\|` | 被转义为 `\|` 字面量 | OR 语义丢失 |
| 编译后正则 | `keyword_a\\|keyword_b\\|...\\|keyword_d\\|...` | 匹配含 `\|` 的整串字面量 |
| 单关键词搜索 | 无 `\|`，正常转义 | 可命中 |
| 底层 `grep -E` | 将 `\|` 视为 OR | 可命中 |

原有 `grep_search` 编译逻辑：

```python
regex = re.compile(
    pattern if is_regex else re.escape(pattern),
    flags,
)
```

`re.escape("keyword_d")` → `keyword_d` ✅  
`re.escape("foo|bar")` → `foo\\|bar` ❌（`|` 变成字面量）

---

## Fix

```python
def _compile_search_pattern(pattern: str, is_regex: bool, flags: int) -> re.Pattern[str]:
    if is_regex:
        expr = pattern
    elif "|" in pattern:
        expr = "|".join(re.escape(part) for part in pattern.split("|") if part)
    else:
        expr = re.escape(pattern)
    return re.compile(expr, flags)
```

`grep_search` 中替换为：

```python
regex = _compile_search_pattern(pattern, is_regex, flags)
```

示例：`"a.b|c.d"` 在 `is_regex=False` 时编译为 `a\\.b|c\\.d`，既支持 OR，又避免 `.` 被当作通配符。

---

## Test Plan

- [x] `test_compile_search_pattern_literal` — 单关键词字面量匹配
- [x] `test_compile_search_pattern_pipe_alternatives` — 多关键词 OR 匹配
- [x] `test_compile_search_pattern_pipe_preserves_regex_metacharacters` — `a.b|c.d` 各段独立转义
- [x] `test_compile_search_pattern_regex_mode` — `is_regex=True` 时行为不变
- [x] `test_walk_and_grep_pipe_alternatives_literal` — `_walk_and_grep` 多关键词文件搜索
- [x] 本地 pre-commit 通过（black / flake8 / pylint / mypy）
- [ ] CI: `pytest tests/unit/agents/tools/test_file_search.py`

---

## Related Context

- 典型触发路径：Agent 对长文档做批量关键词检索，一次传入多个同义/近义词（`|` 分隔）
- 完整正则语法（如 `foo.*bar`）仍需设置 `is_regex=True`

---
