### PR TITLE
feat(desktop): auto-detect local paths in chat output and open file explorer on click

### DIFF
--- a/console/src-tauri/capabilities/default.json
+++ b/console/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "dialog:allow-open",
     "dialog:allow-save",
     "open-external-link",
+    "open-in-explorer",
     "tray"
   ]
 }

--- a/console/src-tauri/permissions/open-in-explorer.toml
+++ b/console/src-tauri/permissions/open-in-explorer.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "open-in-explorer"
+description = "Allows the frontend to open a local path in the system file explorer."
+commands.allow = ["open_in_explorer"]

--- a/console/src-tauri/src/explorer.rs
+++ b/console/src-tauri/src/explorer.rs
@@ -1,0 +1,197 @@
+//! Tauri command for opening a local path in the system file explorer.
+//!
+//! Security: the path is validated to be absolute, free of traversal
+//! sequences, and confirmed to exist on disk before any shell command
+//! is spawned.
+
+use std::path::{Path, PathBuf};
+
+/// Characters that must never appear in a validated path — they could
+/// enable shell injection or are simply nonsensical in a file path.
+/// Backslash is allowed on Windows (path separator) but forbidden elsewhere.
+#[cfg(target_os = "windows")]
+const FORBIDDEN_CHARS: &[char] = &[
+    '|', '&', ';', '$', '`', '(', ')', '{', '}', '<', '>', '!',
+    '\'', '"', '\n', '\r', '\0',
+];
+#[cfg(not(target_os = "windows"))]
+const FORBIDDEN_CHARS: &[char] = &[
+    '|', '&', ';', '$', '`', '(', ')', '{', '}', '<', '>', '!', '\\',
+    '\'', '"', '\n', '\r', '\0',
+];
+
+/// Open the system file explorer at the given local path.
+///
+/// - If `path` points to a file, the parent directory is opened and the
+///   file is selected (platform-permitting).
+/// - If `path` points to a directory, that directory is opened directly.
+#[tauri::command]
+pub(crate) fn open_in_explorer(path: String) -> Result<(), String> {
+    let cleaned = validate_path(&path)?;
+
+    #[cfg(target_os = "windows")]
+    return open_windows(&cleaned);
+
+    #[cfg(target_os = "macos")]
+    return open_macos(&cleaned);
+
+    #[cfg(target_os = "linux")]
+    return open_linux(&cleaned);
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = cleaned;
+        Err("unsupported platform".into())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// Trim whitespace, reject dangerous inputs, and canonicalize the path.
+fn validate_path(raw: &str) -> Result<PathBuf, String> {
+    let trimmed = raw.trim();
+
+    if trimmed.is_empty() {
+        return Err("path is empty".into());
+    }
+
+    // Reject control characters and shell meta-characters.
+    if trimmed.chars().any(|c| c.is_control() || FORBIDDEN_CHARS.contains(&c)) {
+        return Err("path contains forbidden characters".into());
+    }
+
+    // Reject path traversal.
+    if trimmed.contains("..") {
+        return Err("path contains traversal sequence (..)".into());
+    }
+
+    let path = Path::new(trimmed);
+
+    // Must be absolute.
+    if !path.is_absolute() {
+        return Err("path is not absolute".into());
+    }
+
+    // Must exist on disk.
+    if !path.exists() {
+        return Err(format!("path does not exist: {}", trimmed));
+    }
+
+    Ok(path.to_path_buf())
+}
+
+// ---------------------------------------------------------------------------
+// Platform implementations
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+fn open_windows(path: &Path) -> Result<(), String> {
+    use std::process::Command;
+
+    if path.is_dir() {
+        Command::new("explorer.exe")
+            .arg(path.as_os_str())
+            .spawn()
+            .map_err(|e| format!("failed to open explorer: {e}"))?;
+    } else {
+        // /select, opens the parent folder with the file highlighted.
+        let select_arg = format!("/select,{}", path.display());
+        Command::new("explorer.exe")
+            .arg(&select_arg)
+            .spawn()
+            .map_err(|e| format!("failed to open explorer: {e}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn open_macos(path: &Path) -> Result<(), String> {
+    use std::process::Command;
+
+    // `open -R` reveals the file/directory in Finder.
+    Command::new("open")
+        .arg("-R")
+        .arg(path.as_os_str())
+        .spawn()
+        .map_err(|e| format!("failed to open Finder: {e}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn open_linux(path: &Path) -> Result<(), String> {
+    use std::process::Command;
+
+    let target = if path.is_dir() {
+        path.to_path_buf()
+    } else {
+        path.parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| path.to_path_buf())
+    };
+
+    Command::new("xdg-open")
+        .arg(target.as_os_str())
+        .spawn()
+        .map_err(|e| format!("failed to open file manager: {e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reject_empty_path() {
+        assert!(validate_path("").is_err());
+        assert!(validate_path("   ").is_err());
+    }
+
+    #[test]
+    fn reject_relative_paths() {
+        assert!(validate_path("foo/bar").is_err());
+        assert!(validate_path("./foo").is_err());
+        assert!(validate_path("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn reject_traversal_in_absolute_path() {
+        assert!(validate_path("/home/user/../../etc/passwd").is_err());
+        assert!(validate_path("C:\\Users\\..\\..\\Windows").is_err());
+    }
+
+    #[test]
+    fn reject_shell_metacharacters() {
+        assert!(validate_path("/home/user; rm -rf /").is_err());
+        assert!(validate_path("/home/user|cat /etc/passwd").is_err());
+        assert!(validate_path("/home/user$(whoami)").is_err());
+        assert!(validate_path("/home/user`id`").is_err());
+    }
+
+    #[test]
+    fn reject_control_characters() {
+        assert!(validate_path("/home/user/\x00file").is_err());
+        assert!(validate_path("/home/user/\nfile").is_err());
+    }
+
+    #[test]
+    fn reject_nonexistent_path() {
+        // An absolute path that almost certainly does not exist.
+        assert!(validate_path("/this/path/does/not/exist/qwenpaw_test").is_err());
+    }
+
+    #[test]
+    fn accept_existing_directory() {
+        // /tmp should exist on all Unix-like systems; skip on Windows.
+        #[cfg(not(target_os = "windows"))]
+        {
+            let result = validate_path("/tmp");
+            assert!(result.is_ok(), "expected /tmp to be accepted");
+        }
+    }
+}

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod backend;
 mod backend_download;
+mod explorer;
 mod external_link;
 mod updates;
 mod tray;
@@ -30,6 +31,7 @@ pub fn run() {
             backend::backend_startup_error,
             backend::restart_backend,
             external_link::open_external_link,
+            explorer::open_in_explorer,
             updates::check_desktop_update,
             updates::install_desktop_update,
             updates::download_desktop_update,

--- a/console/src/components/Chat/LocalPathLinks.module.less
+++ b/console/src/components/Chat/LocalPathLinks.module.less
@@ -1,0 +1,37 @@
+/**
+ * Styles for the LocalPathLinkifier injected path links.
+ *
+ * These are global (non-module) selectors because the <a> elements are
+ * created via raw DOM APIs inside the MutationObserver, not by React —
+ * so CSS-module class-name hashing does not apply.  We scope them under
+ * `.qwenpaw-local-path-link` which is unique enough to avoid collisions.
+ */
+
+:global {
+  .qwenpaw-local-path-link {
+    color: var(--ant-color-link, #1677ff);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+    cursor: pointer;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.9em;
+    padding: 0 2px;
+    border-radius: 3px;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .qwenpaw-local-path-link:hover {
+    background-color: var(--ant-color-primary-bg, rgba(22, 119, 255, 0.08));
+    color: var(--ant-color-link-hover, #4096ff);
+  }
+
+  .qwenpaw-local-path-link:active {
+    background-color: var(
+      --ant-color-primary-bg-hover,
+      rgba(22, 119, 255, 0.15)
+    );
+  }
+}

--- a/console/src/components/Chat/LocalPathLinks.tsx
+++ b/console/src/components/Chat/LocalPathLinks.tsx
@@ -1,0 +1,232 @@
+/**
+ * LocalPathLinkifier — post-processes rendered chat message DOM to turn
+ * detected local file paths into clickable links that open the system
+ * file explorer via the Tauri `open_in_explorer` command.
+ *
+ * Only active inside the Desktop app (guarded by `isDesktopApp()`).
+ */
+import { useEffect, useRef } from "react";
+import { isDesktopApp } from "../../tauri/backendRuntime";
+import { findLocalPaths, openInExplorer } from "../../utils/localPathDetector";
+// Side-effect import: injects :global CSS for .qwenpaw-local-path-link.
+import "./LocalPathLinks.module.less";
+
+/** CSS class applied to injected path-link anchors. */
+const LINK_CLASS = "qwenpaw-local-path-link";
+
+/** Data attribute storing the original path on each injected anchor. */
+const DATA_PATH_ATTR = "data-local-path";
+
+/** Marker attribute to avoid re-processing the same subtree. */
+const PROCESSED_ATTR = "data-qwenpaw-paths";
+
+/**
+ * Tags whose text content should NOT be scanned — code blocks (not inline
+ * code, which the markdown renderer may wrap paths in), existing links, and
+ * form elements must remain untouched.
+ *
+ * NOTE: `CODE` is intentionally NOT listed here.  Inline `<code>` elements
+ * produced by the markdown renderer (e.g. backtick-wrapped paths) SHOULD be
+ * linkified.  Only `<pre><code>` blocks are skipped via the `isInsidePreCode`
+ * check below.
+ */
+const SKIP_PARENT_TAGS = new Set([
+  "PRE",
+  "A",
+  "TEXTAREA",
+  "INPUT",
+  "SCRIPT",
+  "STYLE",
+]);
+
+/**
+ * Walk the subtree rooted at `node`, looking for text nodes that contain
+ * local file paths.  Each detected path is wrapped in an `<a>` element.
+ *
+ * Returns true if any replacement was made (so the caller can mark the
+ * subtree as processed).
+ */
+function linkifyTextNode(root: Node): boolean {
+  let didReplace = false;
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+
+  // Collect candidates first to avoid mutating the tree while walking.
+  const candidates: Text[] = [];
+  let current: Text | null;
+  while ((current = walker.nextNode() as Text | null)) {
+    // Skip text nodes inside code blocks / links / etc.
+    let parent: HTMLElement | null = current.parentElement;
+    let shouldSkip = false;
+    while (parent && parent !== root) {
+      if (SKIP_PARENT_TAGS.has(parent.tagName)) {
+        shouldSkip = true;
+        break;
+      }
+      // Skip <code> only when it is inside a <pre> (i.e. a fenced code block).
+      // Inline <code> (backtick-wrapped text in markdown) should still be
+      // linkified so that paths rendered as `C:\foo\bar` become clickable.
+      if (
+        parent.tagName === "CODE" &&
+        parent.parentElement?.tagName === "PRE"
+      ) {
+        shouldSkip = true;
+        break;
+      }
+      // Also skip if already inside one of our injected links.
+      if (parent.classList?.contains(LINK_CLASS)) {
+        shouldSkip = true;
+        break;
+      }
+      parent = parent.parentElement;
+    }
+    if (shouldSkip) continue;
+
+    if (current.nodeValue && findLocalPaths(current.nodeValue).length > 0) {
+      candidates.push(current);
+    }
+  }
+
+  for (const textNode of candidates) {
+    const text = textNode.nodeValue;
+    if (!text) continue;
+
+    const matches = findLocalPaths(text);
+    if (matches.length === 0) continue;
+
+    const fragment = document.createDocumentFragment();
+    let cursor = 0;
+
+    for (const match of matches) {
+      // Text before the match.
+      if (match.start > cursor) {
+        fragment.appendChild(
+          document.createTextNode(text.slice(cursor, match.start)),
+        );
+      }
+
+      // The link element.
+      const anchor = document.createElement("a");
+      anchor.className = LINK_CLASS;
+      anchor.setAttribute(DATA_PATH_ATTR, match.path);
+      anchor.href = "#";
+      anchor.textContent = match.path;
+      fragment.appendChild(anchor);
+
+      cursor = match.end;
+    }
+
+    // Remaining text after the last match.
+    if (cursor < text.length) {
+      fragment.appendChild(document.createTextNode(text.slice(cursor)));
+    }
+
+    textNode.parentNode?.replaceChild(fragment, textNode);
+    didReplace = true;
+  }
+
+  return didReplace;
+}
+
+/**
+ * React component that mounts a MutationObserver on the chat messages
+ * container and linkifies any local paths found in rendered text.
+ *
+ * Place this inside the chat page so it can find the message list via
+ * a CSS selector.
+ */
+export function LocalPathLinkifier() {
+  const observerRef = useRef<MutationObserver | null>(null);
+  const clickHandlerRef = useRef<((e: MouseEvent) => void) | null>(null);
+
+  useEffect(() => {
+    if (!isDesktopApp()) return;
+
+    // We observe document.body so the observer works regardless of CSS
+    // module class-name hashing.  The PROCESSED_ATTR guard keeps the
+    // scan cheap — each element is processed at most once.
+    const root = document.body;
+    if (!root) return;
+
+    // --- MutationObserver: scan new / changed subtrees -----------------
+    const processElement = (el: HTMLElement) => {
+      // Skip already-processed elements (their text hasn't changed).
+      if (el.getAttribute?.(PROCESSED_ATTR) === "1") return;
+      // Skip code blocks (<pre><code>) and our own injected links.
+      // NOTE: inline <code> is NOT skipped — paths wrapped in backticks by
+      // the markdown renderer should still be linkified.
+      if (el.tagName === "PRE" || el.classList?.contains(LINK_CLASS)) return;
+      if (el.tagName === "CODE" && el.parentElement?.tagName === "PRE") return;
+
+      linkifyTextNode(el);
+      el.setAttribute?.(PROCESSED_ATTR, "1");
+    };
+
+    const processMutations = (mutations: MutationRecord[]) => {
+      for (const mutation of mutations) {
+        // New nodes added to the DOM.
+        if (mutation.type === "childList") {
+          for (const node of mutation.addedNodes) {
+            if (node.nodeType !== Node.ELEMENT_NODE) continue;
+            processElement(node as HTMLElement);
+          }
+        }
+        // Text content changed inside an existing element.
+        if (
+          mutation.type === "characterData" &&
+          mutation.target.nodeType === Node.TEXT_NODE
+        ) {
+          const parent = (mutation.target as Text).parentElement;
+          if (parent) {
+            // Clear the processed flag so the element gets re-scanned.
+            parent.removeAttribute?.(PROCESSED_ATTR);
+            processElement(parent);
+          }
+        }
+      }
+    };
+
+    const observer = new MutationObserver(processMutations);
+    observer.observe(root, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    observerRef.current = observer;
+
+    // Initial scan for content already present (do NOT mark body as
+    // processed — that would prevent the observer from handling future
+    // mutations on body's descendants).
+    linkifyTextNode(root);
+
+    // --- Click delegation ----------------------------------------------
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.classList?.contains(LINK_CLASS)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const path = target.getAttribute(DATA_PATH_ATTR);
+      if (path) {
+        void openInExplorer(path);
+      }
+    };
+
+    document.addEventListener("click", handleClick, true);
+    clickHandlerRef.current = handleClick;
+
+    // --- Cleanup -------------------------------------------------------
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+      if (clickHandlerRef.current) {
+        document.removeEventListener("click", clickHandlerRef.current, true);
+        clickHandlerRef.current = null;
+      }
+    };
+  }, []);
+
+  // This component renders nothing visible.
+  return null;
+}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -57,6 +57,7 @@ import { ChatScalar, ChatList } from "../../plugins/registry/slotKeys";
 import { HostRequestCard, HostResponseCard } from "./HostBubbles";
 import { withGenericFallback } from "../../components/Chat/ToolCards/adapters/v1Adapter";
 import { applyApprovalLevelToRequestBody } from "./approvalPayload";
+import { LocalPathLinkifier } from "../../components/Chat/LocalPathLinks";
 
 interface ApprovalMessageData {
   requestId: string;
@@ -3064,6 +3065,8 @@ export default function ChatPage() {
             key={refreshKey}
             options={options}
           />
+          {/* Post-processes rendered markdown to linkify local paths */}
+          <LocalPathLinkifier />
         </div>
 
         {/* Rate-limit guidance banner */}

--- a/console/src/utils/localPathDetector.test.ts
+++ b/console/src/utils/localPathDetector.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Tauri APIs before importing the module under test.
+import { invoke, isTauri } from "../test/tauri-mock";
+
+import {
+  findLocalPaths,
+  isLocalPath,
+  normalizeLocalPath,
+  openInExplorer,
+} from "./localPathDetector";
+
+describe("isLocalPath", () => {
+  it("recognizes Windows drive paths", () => {
+    expect(isLocalPath("C:\\Users\\alice\\file.txt")).toBe(true);
+    expect(isLocalPath("D:/projects/src")).toBe(true);
+    expect(isLocalPath("c:\\temp")).toBe(true);
+  });
+
+  it("recognizes Unix absolute paths", () => {
+    expect(isLocalPath("/home/alice/file.txt")).toBe(true);
+    expect(isLocalPath("/usr/local/bin/node")).toBe(true);
+    expect(isLocalPath("/tmp")).toBe(true);
+  });
+
+  it("recognizes home-directory shorthand", () => {
+    expect(isLocalPath("~/Documents/report.pdf")).toBe(true);
+    expect(isLocalPath("~/.config/settings.json")).toBe(true);
+  });
+
+  it("rejects URLs with schemes", () => {
+    expect(isLocalPath("https://example.com/path")).toBe(false);
+    expect(isLocalPath("http://localhost:3000")).toBe(false);
+    expect(isLocalPath("ftp://files.example.com/data")).toBe(false);
+  });
+
+  it("rejects relative paths", () => {
+    expect(isLocalPath("foo/bar")).toBe(false);
+    expect(isLocalPath("./src/main.ts")).toBe(false);
+    expect(isLocalPath("../config.json")).toBe(false);
+  });
+
+  it("rejects empty or whitespace-only strings", () => {
+    expect(isLocalPath("")).toBe(false);
+    expect(isLocalPath("   ")).toBe(false);
+  });
+});
+
+describe("findLocalPaths", () => {
+  it("finds Windows paths in mixed text", () => {
+    const text = "Saved to C:\\Users\\alice\\output.txt and also D:/backup.zip";
+    const results = findLocalPaths(text);
+    expect(results).toHaveLength(2);
+    expect(results[0].path).toBe("C:\\Users\\alice\\output.txt");
+    expect(results[1].path).toBe("D:/backup.zip");
+  });
+
+  it("finds Unix paths in mixed text", () => {
+    const text = "The config is at /etc/nginx/nginx.conf for details.";
+    const results = findLocalPaths(text);
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].path).toBe("/etc/nginx/nginx.conf");
+  });
+
+  it("finds ~/ paths", () => {
+    const text = "You can find it in ~/Downloads/file.tar.gz.";
+    const results = findLocalPaths(text);
+    expect(results).toHaveLength(1);
+    expect(results[0].path).toBe("~/Downloads/file.tar.gz");
+  });
+
+  it("strips trailing punctuation from detected paths", () => {
+    const text = "Check /home/user/report.pdf.";
+    const results = findLocalPaths(text);
+    expect(results).toHaveLength(1);
+    // Trailing period should be stripped.
+    expect(results[0].path).not.toMatch(/\.$/);
+  });
+
+  it("returns empty array for text without paths", () => {
+    expect(findLocalPaths("Hello world")).toEqual([]);
+    expect(findLocalPaths("https://example.com")).toEqual([]);
+  });
+
+  it("finds multiple paths in a single string", () => {
+    const text = "First: /home/a.txt, Second: C:\\b.txt, Third: ~/c.txt";
+    const results = findLocalPaths(text);
+    expect(results.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not treat prose slashes as Unix paths", () => {
+    expect(findLocalPaths("IMAP/SMTP protocol")).toEqual([]);
+    expect(findLocalPaths("CI/CD pipeline")).toEqual([]);
+    expect(findLocalPaths("Terraform/OpenTofu tools")).toEqual([]);
+    expect(findLocalPaths("使用 IMAP/SMTP 管理邮件")).toEqual([]);
+    expect(findLocalPaths("频道/会话发送消息")).toEqual([]);
+    expect(findLocalPaths("定时/周期性任务管理")).toEqual([]);
+  });
+
+  it("still detects real Unix paths after whitespace", () => {
+    const results = findLocalPaths("see /tmp/file.txt and /home/user/doc");
+    expect(results).toHaveLength(2);
+    expect(results[0].path).toBe("/tmp/file.txt");
+    expect(results[1].path).toBe("/home/user/doc");
+  });
+});
+
+describe("normalizeLocalPath", () => {
+  it("strips trailing periods and commas", () => {
+    expect(normalizeLocalPath("/home/user/file.txt.")).toBe(
+      "/home/user/file.txt",
+    );
+    expect(normalizeLocalPath("C:\\Users\\test,")).toBe("C:\\Users\\test");
+  });
+
+  it("strips trailing question marks and exclamation marks", () => {
+    expect(normalizeLocalPath("~/docs/readme?")).toBe("~/docs/readme");
+    expect(normalizeLocalPath("/usr/bin!")).toBe("/usr/bin");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeLocalPath("  /home/user  ")).toBe("/home/user");
+  });
+
+  it("preserves internal punctuation", () => {
+    expect(normalizeLocalPath("/home/user/my-file_v2.txt")).toBe(
+      "/home/user/my-file_v2.txt",
+    );
+  });
+});
+
+describe("openInExplorer", () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    isTauri.mockReturnValue(false);
+    invoke.mockResolvedValue(undefined);
+    delete (window as any).__TAURI_INTERNALS__;
+    delete (window as any).pywebview;
+    sessionStorage.clear();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op outside the desktop app", async () => {
+    await openInExplorer("/home/user/file.txt");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("invokes the Tauri command inside the desktop app", async () => {
+    isTauri.mockReturnValue(true);
+
+    await openInExplorer("/home/user/file.txt");
+
+    expect(invoke).toHaveBeenCalledWith("open_in_explorer", {
+      path: "/home/user/file.txt",
+    });
+  });
+
+  it("normalizes the path before invoking", async () => {
+    isTauri.mockReturnValue(true);
+
+    await openInExplorer("  C:\\Users\\test.txt.  ");
+
+    expect(invoke).toHaveBeenCalledWith("open_in_explorer", {
+      path: "C:\\Users\\test.txt",
+    });
+  });
+
+  it("logs a warning when the Tauri command fails", async () => {
+    isTauri.mockReturnValue(true);
+    invoke.mockRejectedValue(new Error("permission denied"));
+
+    await openInExplorer("/home/user/file.txt");
+
+    expect(console.warn).toHaveBeenCalledWith(
+      "[local-path] open_in_explorer failed:",
+      expect.any(Error),
+    );
+  });
+
+  it("uses the pywebview bridge when available", async () => {
+    const openInExplorerMock = vi.fn().mockResolvedValue(true);
+    (window as any).pywebview = {
+      api: {
+        open_in_explorer: openInExplorerMock,
+      },
+    };
+    // Simulate pywebview desktop detection via URL parameter.
+    window.history.replaceState(null, "", "/?desktop=1");
+
+    await openInExplorer("/home/user/file.txt");
+
+    expect(openInExplorerMock).toHaveBeenCalledWith("/home/user/file.txt");
+    // Tauri invoke should NOT be called when pywebview bridge handles it.
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Tauri when pywebview bridge lacks open_in_explorer", async () => {
+    (window as any).pywebview = {
+      api: {
+        // No open_in_explorer method.
+        open_external_link: vi.fn(),
+      },
+    };
+    isTauri.mockReturnValue(true);
+
+    await openInExplorer("/home/user/file.txt");
+
+    expect(invoke).toHaveBeenCalledWith("open_in_explorer", {
+      path: "/home/user/file.txt",
+    });
+  });
+});

--- a/console/src/utils/localPathDetector.ts
+++ b/console/src/utils/localPathDetector.ts
@@ -1,0 +1,162 @@
+/**
+ * Local file-path detection and explorer-opening utilities.
+ *
+ * Detects absolute local paths (Windows, Unix, ~/…) in plain text so the
+ * chat UI can render them as clickable links that open the system file
+ * explorer via the Tauri `open_in_explorer` command.
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { isDesktopApp } from "../tauri/backendRuntime";
+import { getPyWebViewApi } from "./pywebview";
+
+// ---------------------------------------------------------------------------
+// Path detection regex
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches a Windows drive path: `C:\…` or `C:/…`.
+ * The drive letter is case-insensitive.  We require at least one segment
+ * after the drive root to avoid matching stray single letters.
+ */
+const WINDOWS_DRIVE_RE = /\b[A-Za-z]:[\\/][^\s<>:"|?*\x00-\x1f]{1,200}/g;
+
+/**
+ * Characters that terminate a path segment.  Includes whitespace, the path
+ * separator itself, ASCII punctuation that is unlikely in real paths, and
+ * common CJK punctuation so that prose like `IMAP/SMTP` or `CI/CD` is not
+ * swallowed into a bogus path match.
+ */
+const PATH_SEGMENT_CHARS =
+  "[^\\s/<>|&;,'\"`$(){}!，、。：；？！（）【】《》「」『』“”‘’—…\\x00-\\x1f]{1,200}";
+
+/**
+ * Common Unix root directories.  A single-segment absolute path such as `/tmp`
+ * or `/home` is accepted only when it is one of these known roots; otherwise
+ * we require at least two segments (`/a/b`).  This prevents `/SMTP` in
+ * `IMAP/SMTP` from being treated as a path.
+ */
+const KNOWN_UNIX_ROOTS =
+  "(?:usr|bin|etc|var|opt|tmp|home|Users|root|lib|srv|mnt|media|dev|proc|sys|run|boot)";
+
+/**
+ * Matches a Unix absolute path starting with `/`.
+ *
+ * - The leading `/` must not be preceded by `:` (URLs like `http://...`) or
+ *   by a word character (prose separators like `IMAP/SMTP`).
+ * - The path must either have at least two segments or start with a known
+ *   root directory (`/tmp`, `/home`, `/Users`, ...).
+ * - CJK punctuation is treated as a segment terminator.
+ */
+const UNIX_ABSOLUTE_RE = new RegExp(
+  `(?<![:/\\\\w])\\/(?:(?:${PATH_SEGMENT_CHARS}\\/){1,10}${PATH_SEGMENT_CHARS}|${KNOWN_UNIX_ROOTS}(?:\\/${PATH_SEGMENT_CHARS})?)`,
+  "g",
+);
+
+/**
+ * Matches a home-directory shorthand: `~/…`.
+ */
+const HOME_TILDE_RE = /~\/[^\s<>|&;'"`$(){}!\x00-\x1f]{1,200}/g;
+
+/** Trailing punctuation that is almost certainly NOT part of the path. */
+const TRAILING_PUNCT_RE = /[.,;:!?)]+$/;
+
+/**
+ * Combined regex that matches any of the three path styles.
+ * Built once and reused; `lastIndex` is reset before every use because the
+ * component regexes carry the `g` flag.
+ */
+const LOCAL_PATH_RE = new RegExp(
+  `(?:${WINDOWS_DRIVE_RE.source})|(?:${UNIX_ABSOLUTE_RE.source})|(?:${HOME_TILDE_RE.source})`,
+  "g",
+);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface LocalPathMatch {
+  /** The detected path string (trimmed of trailing punctuation). */
+  path: string;
+  /** Start index of the match in the original text. */
+  start: number;
+  /** End index (exclusive) of the match in the original text. */
+  end: number;
+}
+
+/** Return true when `text` looks like a single local file path. */
+export function isLocalPath(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  LOCAL_PATH_RE.lastIndex = 0;
+  const m = LOCAL_PATH_RE.exec(trimmed);
+  if (!m) return false;
+  // The match should span the entire trimmed text.
+  return m.index === 0 && m[0].length === trimmed.length;
+}
+
+/** Find all local-path occurrences in `text`. */
+export function findLocalPaths(text: string): LocalPathMatch[] {
+  const results: LocalPathMatch[] = [];
+  LOCAL_PATH_RE.lastIndex = 0;
+
+  let m: RegExpExecArray | null;
+  while ((m = LOCAL_PATH_RE.exec(text)) !== null) {
+    const raw = m[0];
+    const cleaned = raw.replace(TRAILING_PUNCT_RE, "");
+    if (cleaned.length > 0) {
+      results.push({
+        path: cleaned,
+        start: m.index,
+        end: m.index + cleaned.length,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Normalize a detected path:
+ * - Strip trailing punctuation that likely isn't part of the path.
+ * - Keep the original separator style (no conversion).
+ */
+export function normalizeLocalPath(raw: string): string {
+  return raw.trim().replace(TRAILING_PUNCT_RE, "");
+}
+
+// ---------------------------------------------------------------------------
+// Explorer opener
+// ---------------------------------------------------------------------------
+
+/**
+ * Ask the desktop backend to open the given path in the system file explorer.
+ *
+ * Supports both the Tauri and legacy pywebview desktop runtimes.
+ * Only works inside the Desktop app (`isDesktopApp()`).  In the browser this
+ * is a no-op so callers don't need to guard the call site.
+ */
+export async function openInExplorer(path: string): Promise<void> {
+  if (!isDesktopApp()) return;
+
+  const normalized = normalizeLocalPath(path);
+  if (!normalized) return;
+
+  // Try the legacy pywebview bridge first (it takes precedence when present).
+  const pywebviewApi = getPyWebViewApi();
+  if (pywebviewApi?.open_in_explorer) {
+    try {
+      await pywebviewApi.open_in_explorer(normalized);
+      return;
+    } catch (err) {
+      console.warn("[local-path] pywebview open_in_explorer failed:", err);
+      return;
+    }
+  }
+
+  // Fall back to the Tauri command.
+  try {
+    await invoke("open_in_explorer", { path: normalized });
+  } catch (err) {
+    console.warn("[local-path] open_in_explorer failed:", err);
+  }
+}

--- a/console/src/vite-env.d.ts
+++ b/console/src/vite-env.d.ts
@@ -13,6 +13,7 @@ declare module "*.less" {
 
 interface PyWebViewAPI {
   open_external_link?: (url: string) => void;
+  open_in_explorer?: (path: string) => Promise<boolean>;
   save_file?: (
     url: string,
     filename: string,

--- a/src/qwenpaw/cli/desktop_cmd.py
+++ b/src/qwenpaw/cli/desktop_cmd.py
@@ -38,6 +38,66 @@ class WebViewAPI:
             return
         webbrowser.open(url)
 
+    def open_in_explorer(self, path: str) -> bool:
+        """Open the system file explorer at the given local path.
+
+        If *path* points to a file, the parent directory is opened and
+        the file is selected (platform-permitting).  If it points to a
+        directory, that directory is opened directly.
+
+        Returns True on success, False on validation failure or error.
+        """
+        import platform
+        import re
+
+        trimmed = path.strip()
+        error = self._validate_explorer_path(trimmed, re)
+        if error:
+            logger.warning("[open_in_explorer] %s", error)
+            return False
+
+        try:
+            system = platform.system()
+            if system == "Windows":
+                if os.path.isdir(trimmed):
+                    subprocess.Popen(["explorer.exe", trimmed])
+                else:
+                    subprocess.Popen(
+                        ["explorer.exe", f"/select,{trimmed}"],
+                    )
+            elif system == "Darwin":
+                subprocess.Popen(["open", "-R", trimmed])
+            else:
+                # Linux / other Unix — open parent directory.
+                target = (
+                    trimmed
+                    if os.path.isdir(trimmed)
+                    else os.path.dirname(trimmed) or trimmed
+                )
+                subprocess.Popen(["xdg-open", target])
+            return True
+        except Exception:
+            logger.exception("[open_in_explorer] failed to open path")
+            return False
+
+    @staticmethod
+    def _validate_explorer_path(trimmed: str, re_mod) -> str | None:
+        """Return an error string if the path is invalid, else None."""
+        if not trimmed:
+            return "path is empty"
+        if re_mod.search(
+            r'[\x00-\x1f|&;$`(){}<>!\'"\n\r]',
+            trimmed,
+        ):
+            return "path contains forbidden characters"
+        if ".." in trimmed:
+            return "path contains traversal sequence (..)"
+        if not os.path.isabs(trimmed):
+            return "path is not absolute"
+        if not os.path.exists(trimmed):
+            return f"path does not exist: {trimmed}"
+        return None
+
     def save_file(
         self,
         url: str,
@@ -175,6 +235,9 @@ def desktop_cmd(
     port_file = str(WORKING_DIR / "desktop_port")
     port, held_socket = get_stable_port(port_file, host)
     url = f"http://{host}:{port}"
+    # Tag the URL so the frontend can detect it's running inside the
+    # pywebview desktop shell (mirrors what the Tauri bootstrap does).
+    desktop_url = f"{url}?desktop=1"
     click.echo(f"Starting QwenPaw app on {url} (port {port})")
     logger.info("Server subprocess starting...")
 
@@ -244,7 +307,7 @@ def desktop_cmd(
                 api = WebViewAPI()
                 webview.create_window(
                     "QwenPaw Desktop",
-                    url,
+                    desktop_url,
                     width=1280,
                     height=800,
                     text_select=True,


### PR DESCRIPTION
## Summary

Closes #4830

This PR adds the ability to automatically detect local file/directory paths in QwenPaw Desktop chat messages and render them as clickable links. Clicking a link opens the path in the system file explorer.

## What's Changed

### Backend / Desktop Runtime
- Added Tauri command `open_in_explorer` (`console/src-tauri/src/explorer.rs`) with cross-platform support (Windows, macOS, Linux).
- Added `open-in-explorer.toml` permission and wired the command into `lib.rs`.
- Added pywebview bridge `open_in_explorer` in `src/qwenpaw/cli/desktop_cmd.py`.
- Appended `?desktop=1` to the pywebview URL so the frontend can detect the desktop runtime.

### Frontend
- Added `console/src/utils/localPathDetector.ts`:
  - Detects Windows drive paths (`C:\...`), Unix absolute paths (`/home/...`), and home shorthand (`~/...`).
  - Provides `openInExplorer()` helper that dispatches to pywebview bridge when available, otherwise Tauri `invoke`.
  - Includes unit tests in `console/src/utils/localPathDetector.test.ts`.
- Added `console/src/components/Chat/LocalPathLinks.tsx`:
  - Uses `MutationObserver` to post-process rendered chat messages.
  - Wraps detected paths in styled anchors; skips `<pre><code>` blocks, existing links, and form elements.
  - Active only when `isDesktopApp()` returns true.
- Integrated the linkifier into `console/src/pages/Chat/index.tsx`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing
- `npm run format:check` passes.
- `npx vitest run console/src/utils/localPathDetector.test.ts --pool=vmThreads` passes (24 tests).
- Manually verified that:
  - Absolute Windows/Unix/home paths in chat are rendered as clickable links.
  - Clicking opens the system file explorer.
  - Prose text with slashes is not linkified.
