### PR TITLE
fix(runtime): persist interrupted turn state and suppress empty cancel messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.4.0.8",
+    "reme-ai==0.4.0.9",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.4.0.7",
+    "reme-ai==0.4.0.8",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,7 @@ description = "QwenPaw is a **personal assistant** that runs in your own environ
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "agentscope==2.0.2",
-    # agentscope-runtime is no longer needed: agentscope 2.0 ships the
-    # runtime (`agentscope.app`, `agentscope.session`, `agentscope.app._schema`)
-    # in-tree, replacing the standalone agentscope-runtime package.
+    "agentscope==2.0.4",
     "httpx>=0.27.0",
     "packaging>=24.0",
     "discord-py>=2.3",

--- a/src/qwenpaw/_compat/message.py
+++ b/src/qwenpaw/_compat/message.py
@@ -180,4 +180,8 @@ def msg_from_dict(data: Mapping[str, Any]) -> Any:
     if "name" not in payload:
         payload["name"] = payload.get("role") or "assistant"
 
+    # ``metadata`` must be a dict; legacy sessions may store ``None``.
+    if payload.get("metadata") is None:
+        payload["metadata"] = {}
+
     return Msg.model_validate(payload)

--- a/src/qwenpaw/agents/memory/reme_config.py
+++ b/src/qwenpaw/agents/memory/reme_config.py
@@ -38,6 +38,7 @@ def build_reme_app_config(
             "workspace_dir": working_dir,
             "metadata_dir": reme_config.metadata_dir,
             "session_dir": reme_config.session_dir,
+            "mem_session_dir": reme_config.mem_session_dir,
             "resource_dir": reme_config.resource_dir,
             "daily_dir": reme_config.daily_dir,
             "digest_dir": reme_config.digest_dir,
@@ -602,6 +603,7 @@ def _base_components() -> dict[str, Any]:
             "default": {
                 "backend": "openai",
                 "model": "",
+                "dimensions": 1024,
                 "credential": {"api_key": "", "base_url": ""},
                 "parameters": {},
             },
@@ -634,9 +636,6 @@ def _apply_embedding_config(
 ) -> None:
     """Map QwenPaw embedding config into ReMe component config."""
     components = cfg["components"]
-    parameters: dict[str, Any] = {}
-    if embedding_config.use_dimensions:
-        parameters["dimensions"] = embedding_config.dimensions
     embedding_store_name = (
         "default" if _is_embedding_enabled(embedding_config) else ""
     )
@@ -645,8 +644,8 @@ def _apply_embedding_config(
         {
             "backend": embedding_config.backend,
             "model": embedding_config.model_name,
+            "dimensions": embedding_config.dimensions,
             "credential": _embedding_credential(embedding_config),
-            "parameters": parameters,
         },
     )
     components["embedding_store"]["default"].update(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -661,7 +661,14 @@ class ReMeLightMemoryConfig(BaseModel):
     )
     session_dir: str = Field(
         default="mem_session",
-        description="Subdirectory for persisted agent sessions",
+        description=(
+            "Subdirectory for ReMe source conversation logs used by "
+            "auto-memory"
+        ),
+    )
+    mem_session_dir: str = Field(
+        default="mem_agent",
+        description="Subdirectory for ReMe internal memory-agent sessions",
     )
     resource_dir: str = Field(
         default="resource",

--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: Remove _flatten_json_schema and _sanitize_schema_for_gemini once
-# agentscope >= 2.0.3 is released (these are upstreamed into
-# GeminiChatModel._format_tools in newer versions).
+#  agentscope >= 2.0.5 is released (these are upstreamed into
+#  GeminiChatModel._format_tools in newer versions).
 
 
 def _flatten_json_schema(schema: dict) -> dict:
@@ -524,8 +524,8 @@ class _GeminiChatModelCompat:
             _qp_default_headers = default_headers
             _qp_extra_config_kwargs = extra_config_kwargs
 
-            # TODO: Remove this override once agentscope >= 2.0.3 is
-            # released (upstream _format_tools will handle sanitization).
+            # TODO: Remove this override once agentscope >= 2.0.5 is
+            #  released (upstream _format_tools will handle sanitization).
             def _format_tools(self, tools, tool_choice):
                 if tools:
                     sanitized = []

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -777,6 +777,55 @@ class Envelope:
         yield self._tag_seq(self._response)
         self._finalized = True
 
+    # ------------------------------------------------------------------
+    # Partial content extraction (used by cancel-save)
+    # ------------------------------------------------------------------
+
+    def collect_partial_blocks(self) -> list[tuple[str, str]]:
+        """Return ``(block_type, content)`` tuples for streaming content
+        accumulated in this envelope that has **not** been finalized.
+
+        * ``("thinking", text)`` — from reasoning blocks whose envelope
+          status is still ``InProgress`` (i.e. the interrupted iteration).
+        * ``("text", text)`` — from text blocks (reset on every tool-call
+          start, so they belong to the current iteration only).
+
+        This is a public-API entry point so that callers (e.g.
+        ``Runtime._try_save_on_cancel``) do not need to reach into
+        private state.
+        """
+        from ..schemas import RunStatus
+
+        result: list[tuple[str, str]] = []
+
+        for state in self._reasoning_blocks.values():
+            env = state.get("envelope")
+            if env is not None and env.status == RunStatus.Completed:
+                continue
+            text = state.get("text", "")
+            if text:
+                result.append(("thinking", text))
+
+        for state in self._text_blocks.values():
+            text = state.get("text", "")
+            if text:
+                result.append(("text", text))
+
+        return result
+
+    def collect_tool_output(self) -> dict[str, str]:
+        """Return ``{call_id: accumulated_output}`` for tool calls that
+        received partial results before the stream was interrupted.
+
+        Only includes entries where ``output_text_acc`` is non-empty.
+        """
+        result: dict[str, str] = {}
+        for call_id, state in self._tool_calls.items():
+            output = state.get("output_text_acc", "")
+            if output:
+                result[call_id] = output
+        return result
+
     @property
     def response(self) -> Any:
         return self._response

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -756,15 +756,31 @@ class Envelope:
             yield obj
 
     async def _finalize_response(self) -> AsyncGenerator[Any, None]:
-        from ..schemas import RunStatus
+        from ..schemas import ContentType, RunStatus, TextContent
 
         if self._finalized:
             return
 
         if self._message_started:
-            self._completed_message.status = RunStatus.Completed
-            self._response.output.append(self._completed_message)
-            yield self._tag_seq(self._completed_message)
+            # Back-fill any partially accumulated text blocks that were
+            # not finalized (TEXT_BLOCK_END never fired, e.g. on cancel).
+            if not self._completed_message.content:
+                for state in self._text_blocks.values():
+                    text = state.get("text", "")
+                    if text:
+                        self._completed_message.content.append(
+                            TextContent(
+                                type=ContentType.TEXT,
+                                text=text,
+                                delta=False,
+                                index=state.get("index", 0),
+                            ),
+                        )
+
+            if self._completed_message.content:
+                self._completed_message.status = RunStatus.Completed
+                self._response.output.append(self._completed_message)
+                yield self._tag_seq(self._completed_message)
 
         if self._error_text:
             self._response.status = RunStatus.Failed

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -56,6 +56,7 @@ class Runtime:
         hooks = self.workspace.plugins.hook_registry
 
         envelope = Envelope(session_id=ctx.session_id)
+        ctx._envelope = envelope  # pylint: disable=protected-access
         skip_agent = False
 
         try:
@@ -199,6 +200,10 @@ class Runtime:
     async def _try_save_on_cancel(self, ctx: HookContext) -> None:
         """Best-effort session save on cancellation.
 
+        Before snapshotting, any partial streaming content accumulated in
+        the ``Envelope`` is injected into the agent's context so the
+        interrupted turn's text is not lost on reload.
+
         ``state_dict()`` is called synchronously to snapshot the agent
         state *before* any further event-loop iteration.  The I/O write
         is wrapped in ``asyncio.shield`` so it completes even when the
@@ -216,6 +221,10 @@ class Runtime:
         if session is None:
             return
         try:
+            envelope = getattr(ctx, "_envelope", None)
+            if envelope is not None:
+                self._inject_partial_response(agent, envelope)
+
             from ._state_utils import StateProxy
 
             proxy = StateProxy()
@@ -236,8 +245,6 @@ class Runtime:
                 ctx.session_id,
             )
         except asyncio.CancelledError:
-            # The outer await was re-cancelled, but the shielded inner
-            # task is still running and will likely complete successfully.
             logger.info(
                 "cancel-save: outer await re-cancelled, inner save "
                 "continues in background (session=%s)",
@@ -249,6 +256,160 @@ class Runtime:
                 ctx.session_id,
                 exc_info=True,
             )
+
+    # pylint: disable=too-many-branches
+    @staticmethod
+    def _inject_partial_response(agent: Any, envelope: Any) -> None:
+        """Inject accumulated streaming content from *envelope* into the
+        agent's context so a cancel-save includes the partial response.
+
+        Two responsibilities:
+
+        1. **Partial text/thinking** — uses ``Envelope.collect_partial_blocks``
+           to obtain content from the *interrupted* reasoning iteration, with
+           a deduplication guard against double-saving.
+
+        2. **Dangling tool calls** — AgentScope's
+           ``_close_unfinished_tool_calls`` normally patches the context in a
+           ``finally`` block, but its ``yield`` statements fail when the
+           generator is being closed.  We replicate the context-mutation logic
+           here (without yields) so that every tool call has a matching
+           ``ToolResultBlock`` on reload.
+        """
+        # pylint: disable=too-many-nested-blocks
+        try:
+            from agentscope.message import TextBlock, ThinkingBlock
+
+            # --- 1) Partial text/thinking injection ---
+            partial = envelope.collect_partial_blocks()
+            injected = 0
+
+            if partial:
+                agent_state = getattr(agent, "state", None)
+                ctx_list = (
+                    getattr(agent_state, "context", None)
+                    if agent_state
+                    else None
+                )
+                existing_texts: set[str] = set()
+                if ctx_list and len(ctx_list) > 0:
+                    last = ctx_list[-1]
+                    if getattr(last, "role", None) == "assistant":
+                        for blk in getattr(last, "content", []) or []:
+                            if getattr(blk, "type", None) == "text":
+                                existing_texts.add(
+                                    getattr(blk, "text", ""),
+                                )
+                            elif getattr(blk, "type", None) == "thinking":
+                                existing_texts.add(
+                                    getattr(blk, "thinking", ""),
+                                )
+
+                blocks: list = []
+                for btype, content in partial:
+                    if content in existing_texts:
+                        continue
+                    if btype == "thinking":
+                        blocks.append(ThinkingBlock(thinking=content))
+                    else:
+                        blocks.append(TextBlock(text=content))
+                if blocks:
+                    # pylint: disable=protected-access
+                    agent._save_to_context(blocks)
+                injected = len(blocks)
+
+            # --- 2) Close dangling tool calls ---
+            closed = Runtime._close_dangling_tool_calls(agent, envelope)
+
+            if injected or closed:
+                logger.info(
+                    "cancel-save: injected %d partial block(s), "
+                    "closed %d dangling tool call(s)",
+                    injected,
+                    closed,
+                )
+        except Exception:
+            logger.debug(
+                "cancel-save: partial response injection failed",
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _close_dangling_tool_calls(agent: Any, envelope: Any) -> int:
+        """Ensure every ``ToolCallBlock`` in the context has a matching
+        ``ToolResultBlock``.
+
+        AgentScope's ``_close_unfinished_tool_calls`` patches the context
+        inside a generator ``finally`` block, but its ``yield`` statements
+        trigger ``RuntimeError`` when the generator is being torn down.
+        We replicate the mutation-only logic so dangling tool calls are
+        properly closed before ``state_dict()`` is called.
+
+        Returns the number of tool calls closed.
+        """
+        from agentscope.message import (
+            ToolCallBlock,
+            ToolCallState,
+            ToolResultBlock,
+            ToolResultState,
+        )
+
+        state = getattr(agent, "state", None)
+        context = getattr(state, "context", None) if state else None
+        if not context:
+            return 0
+
+        last_msg = context[-1]
+        if getattr(last_msg, "role", None) != "assistant":
+            return 0
+        if getattr(last_msg, "name", None) != getattr(agent, "name", ""):
+            return 0
+
+        content = getattr(last_msg, "content", None)
+        if not isinstance(content, list):
+            return 0
+
+        # Find tool calls without matching results.
+        awaiting: dict[str, int] = {}
+        for idx, block in enumerate(content):
+            if isinstance(block, ToolCallBlock):
+                awaiting[block.id] = idx
+            elif isinstance(block, ToolResultBlock):
+                awaiting.pop(block.id, None)
+
+        if not awaiting:
+            return 0
+
+        # Incorporate any partial output accumulated in the envelope.
+        envelope_tool_output = envelope.collect_tool_output()
+
+        interruption_msg = (
+            "<system-reminder>The tool call has been interrupted by "
+            "the user.</system-reminder>"
+        )
+
+        closed = 0
+        for call_id, idx in awaiting.items():
+            block = content[idx]
+            block.state = ToolCallState.FINISHED
+
+            output = envelope_tool_output.get(call_id, "")
+            if output:
+                output += "\n" + interruption_msg
+            else:
+                output = interruption_msg
+
+            content.append(
+                ToolResultBlock(
+                    id=call_id,
+                    name=block.name,
+                    output=output,
+                    state=ToolResultState.INTERRUPTED,
+                ),
+            )
+            closed += 1
+
+        return closed
 
     @staticmethod
     def _normalize(request: Any) -> Any:

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -212,6 +212,24 @@ class Runtime:
         runs to completion in the background; the ``proxy`` owns an
         independent copy of the data so ``agent.close()`` in the
         ``finally`` block cannot corrupt it.
+
+        .. note:: Why hardcoded instead of a hook?
+
+           This runs *outside* the ``try/except`` that wraps
+           ``hooks.run(Phase.ON_ERROR)``, so it executes even when
+           re-cancellation skips all ON_ERROR hooks.  The synchronous
+           parts (inject + state_dict) complete before any ``await``,
+           and ``asyncio.shield`` protects the I/O — guarantees that a
+           generic hook framework cannot provide.
+
+        TODO: Currently only ``SessionSaveHook`` has a cancel-path
+         equivalent here.  Other ``POST_RESPONSE`` hooks (e.g.
+         ``CronMemoryRestoreHook``) and plugin-registered hooks are
+         skipped on /stop.  A future improvement should unify the
+         cancel and normal paths — e.g. via a dedicated ``ON_CANCEL``
+         phase with per-hook shield execution — so plugins can
+         participate in the cancel lifecycle.  ``ctx._envelope`` should
+         also be promoted to a first-class ``HookContext`` field.
         """
         agent = getattr(ctx, "agent", None)
         if agent is None:

--- a/src/qwenpaw/runtime/runtime.py
+++ b/src/qwenpaw/runtime/runtime.py
@@ -154,6 +154,11 @@ class Runtime:
                     "re-cancellation (session=%s)",
                     getattr(ctx, "session_id", ""),
                 )
+
+            # Persist agent state so the interrupted turn is not lost.
+            # asyncio.shield protects the save from task re-cancellation.
+            await self._try_save_on_cancel(ctx)
+
             async for ev in envelope.cancel_envelope():
                 yield ev
             raise
@@ -190,6 +195,60 @@ class Runtime:
             await hooks.run(Phase.FINALLY, ctx)
 
     # ----------------------------------------------------------------- helpers
+
+    async def _try_save_on_cancel(self, ctx: HookContext) -> None:
+        """Best-effort session save on cancellation.
+
+        ``state_dict()`` is called synchronously to snapshot the agent
+        state *before* any further event-loop iteration.  The I/O write
+        is wrapped in ``asyncio.shield`` so it completes even when the
+        outer task's ``_must_cancel`` flag triggers a re-cancellation on
+        the next ``await``.  In that case the shielded inner task still
+        runs to completion in the background; the ``proxy`` owns an
+        independent copy of the data so ``agent.close()`` in the
+        ``finally`` block cannot corrupt it.
+        """
+        agent = getattr(ctx, "agent", None)
+        if agent is None:
+            return
+        workspace = getattr(ctx, "workspace", None)
+        session = getattr(workspace, "session", None) if workspace else None
+        if session is None:
+            return
+        try:
+            from ._state_utils import StateProxy
+
+            proxy = StateProxy()
+            proxy.data = agent.state_dict()
+            request = ctx.request
+            user_id = getattr(request, "user_id", "") or ctx.session_id
+            channel = getattr(request, "channel", "") or ""
+            await asyncio.shield(
+                session.save_session_state(
+                    session_id=ctx.session_id,
+                    user_id=user_id,
+                    channel=channel,
+                    agent=proxy,
+                ),
+            )
+            logger.info(
+                "cancel-save: persisted interrupted turn (session=%s)",
+                ctx.session_id,
+            )
+        except asyncio.CancelledError:
+            # The outer await was re-cancelled, but the shielded inner
+            # task is still running and will likely complete successfully.
+            logger.info(
+                "cancel-save: outer await re-cancelled, inner save "
+                "continues in background (session=%s)",
+                ctx.session_id,
+            )
+        except Exception:
+            logger.debug(
+                "cancel-save: failed (session=%s)",
+                ctx.session_id,
+                exc_info=True,
+            )
 
     @staticmethod
     def _normalize(request: Any) -> Any:

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -118,13 +118,6 @@ You can customize paths and behavior via environment variables:
 | `QWENPAW_TOOL_GUARD_ENABLED` | `true`  | Whether to enable tool guard                       |
 | `QWENPAW_SKILL_SCAN_MODE`    | `warn`  | Skill scanning mode (`block` / `warn` / `off`)     |
 
-**Memory & Retrieval:**
-
-| Variable               | Default | Description                                                     |
-| ---------------------- | ------- | --------------------------------------------------------------- |
-| `FTS_ENABLED`          | `true`  | Whether to enable BM25 full-text search                         |
-| `MEMORY_STORE_BACKEND` | `auto`  | Memory storage backend (`auto` / `local` / `chroma` / `sqlite`) |
-
 Example — use a different working dir for this shell:
 
 ```bash
@@ -421,23 +414,28 @@ Controls agent runtime behavior, retry strategies, context management, and memor
 
 **ReMeLight Memory Configuration (`reme_light_memory_config` object):**
 
-| Field                           | Type        | Default        | Description                                                                           |
-| ------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------- |
-| `summarize_when_compact`        | bool        | `true`         | Whether to enable memory summarization during compaction                              |
-| `auto_memory_interval`          | int \| null | `1`            | Auto memory every N user queries. `1` runs after every user message; null disables it |
-| `dream_cron`                    | string      | `"0 23 * * *"` | Cron expression for dream-based memory optimization (empty to disable)                |
-| `rebuild_memory_index_on_start` | bool        | `false`        | Whether to rebuild memory search index on startup                                     |
-| `recursive_file_watcher`        | bool        | `false`        | Whether to watch memory directory recursively                                         |
-| `auto_memory_search_config`     | object      | _(see below)_  | Auto memory search configuration                                                      |
-| `embedding_model_config`        | object      | _(see below)_  | Embedding model configuration                                                         |
+| Field                           | Type        | Default          | Description                                                                                                        |
+| ------------------------------- | ----------- | ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `metadata_dir`                  | string      | `"mem_metadata"` | Subdirectory for ReMe persistent state                                                                             |
+| `session_dir`                   | string      | `"mem_session"`  | Subdirectory for ReMe source conversation logs used by auto-memory                                                 |
+| `mem_session_dir`               | string      | `"mem_agent"`    | Subdirectory for ReMe internal memory-agent sessions                                                               |
+| `resource_dir`                  | string      | `"resource"`     | Subdirectory for external assets                                                                                   |
+| `daily_dir`                     | string      | `"memory"`       | Subdirectory for daily memory                                                                                      |
+| `digest_dir`                    | string      | `"digest"`       | Subdirectory for digest memory                                                                                     |
+| `enable_search_raw_log`         | bool        | `false`          | Whether to enable raw log search                                                                                   |
+| `summarize_when_compact`        | bool        | `true`           | Whether to enable memory summarization during compaction                                                           |
+| `auto_memory_interval`          | int \| null | `5`              | Auto memory every N user queries. `None` or `<= 0` disables periodic auto memory                                   |
+| `dream_cron`                    | string      | `"0 23 * * *"`   | Cron expression for dream-based memory optimization (empty to disable)                                             |
+| `auto_memory_search_config`     | object      | _(see below)_    | Auto memory search configuration                                                                                   |
+| `embedding_model_config`        | object      | _(see below)_    | Embedding model configuration                                                                                      |
+| `rebuild_memory_index_on_start` | bool        | `false`          | Whether to clear and rebuild the memory search index when the agent starts; otherwise only new changes are indexed |
 
 **Auto Memory Search Configuration (`reme_light_memory_config.auto_memory_search_config` object):**
 
-| Field         | Type  | Default | Description                                              |
-| ------------- | ----- | ------- | -------------------------------------------------------- |
-| `enabled`     | bool  | `false` | Whether to auto search memory on every conversation turn |
-| `max_results` | int   | `1`     | Maximum results for auto memory search                   |
-| `timeout`     | float | `10.0`  | Timeout in seconds for auto memory search                |
+| Field         | Type | Default | Description                                              |
+| ------------- | ---- | ------- | -------------------------------------------------------- |
+| `enabled`     | bool | `false` | Whether to auto search memory on every conversation turn |
+| `max_results` | int  | `2`     | Maximum results for auto memory search                   |
 
 **Embedding Configuration (`reme_light_memory_config.embedding_model_config` object):**
 
@@ -464,7 +462,10 @@ Vector retrieval is enabled only when the selected backend has the minimum runna
 
 When the enable condition is not met, ReMe still keeps keyword indexes and wikilink graph indexes, but the embedding vector index is disabled.
 
-These settings can also be changed in the Console under **Agent → Runtime Config**. Changes apply to new LLM requests after saving; restarting the service is not required.
+These settings can also be changed in the Console under **Agent → Runtime Config**. Fields read directly from
+`agent.json`, such as auto-memory cadence and auto-search limits, apply to later turns after saving. Embedded ReMe
+component settings, such as directories and embedding configuration, require restarting the agent process so the ReMe
+application is constructed with the new configuration.
 
 ---
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -87,13 +87,6 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
 | `QWENPAW_TOOL_GUARD_ENABLED` | `true`  | 是否启用工具守卫                         |
 | `QWENPAW_SKILL_SCAN_MODE`    | `warn`  | 技能扫描模式（`block` / `warn` / `off`） |
 
-**记忆与检索：**
-
-| 变量                   | 默认值 | 说明                                                   |
-| ---------------------- | ------ | ------------------------------------------------------ |
-| `FTS_ENABLED`          | `true` | 是否启用 BM25 全文检索                                 |
-| `MEMORY_STORE_BACKEND` | `auto` | 记忆存储后端（`auto` / `local` / `chroma` / `sqlite`） |
-
 ---
 
 ## 配置文件结构
@@ -374,23 +367,28 @@ MCP（模型上下文协议）允许智能体连接外部服务（如 Filesystem
 
 **ReMeLight 记忆配置（`reme_light_memory_config` 对象）：**
 
-| 字段                            | 类型        | 默认值         | 说明                                                                     |
-| ------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------ |
-| `summarize_when_compact`        | bool        | `true`         | 是否在上下文压缩时启用记忆总结                                           |
-| `auto_memory_interval`          | int \| null | `1`            | 每隔 N 次用户查询触发自动记忆。`1` 表示每条用户消息后触发；null 表示禁用 |
-| `dream_cron`                    | string      | `"0 23 * * *"` | 梦境记忆优化任务的 Cron 表达式（空字符串禁用）                           |
-| `rebuild_memory_index_on_start` | bool        | `false`        | 启动时是否重建记忆搜索索引                                               |
-| `recursive_file_watcher`        | bool        | `false`        | 是否递归监控记忆目录                                                     |
-| `auto_memory_search_config`     | object      | _（见下方）_   | 自动记忆搜索配置                                                         |
-| `embedding_model_config`        | object      | _（见下方）_   | Embedding 模型配置                                                       |
+| 字段                            | 类型        | 默认值           | 说明                                                                 |
+| ------------------------------- | ----------- | ---------------- | -------------------------------------------------------------------- |
+| `metadata_dir`                  | string      | `"mem_metadata"` | ReMe 持久状态子目录                                                  |
+| `session_dir`                   | string      | `"mem_session"`  | ReMe auto-memory 使用的来源对话日志子目录                            |
+| `mem_session_dir`               | string      | `"mem_agent"`    | ReMe 内部 memory-agent 会话子目录                                    |
+| `resource_dir`                  | string      | `"resource"`     | 外部资源子目录                                                       |
+| `daily_dir`                     | string      | `"memory"`       | 每日记忆子目录                                                       |
+| `digest_dir`                    | string      | `"digest"`       | digest 记忆子目录                                                    |
+| `enable_search_raw_log`         | bool        | `false`          | 是否启用原始日志搜索                                                 |
+| `summarize_when_compact`        | bool        | `true`           | 是否在上下文压缩时启用记忆总结                                       |
+| `auto_memory_interval`          | int \| null | `5`              | 每隔 N 次用户查询触发自动记忆。`None` 或 `<= 0` 表示禁用周期自动记忆 |
+| `dream_cron`                    | string      | `"0 23 * * *"`   | 梦境记忆优化任务的 Cron 表达式（空字符串禁用）                       |
+| `auto_memory_search_config`     | object      | _（见下方）_     | 自动记忆搜索配置                                                     |
+| `embedding_model_config`        | object      | _（见下方）_     | Embedding 模型配置                                                   |
+| `rebuild_memory_index_on_start` | bool        | `false`          | Agent 启动时是否清空并重建记忆搜索索引；否则只监控并索引新的文件变化 |
 
 **自动记忆搜索配置（`reme_light_memory_config.auto_memory_search_config` 对象）：**
 
-| 字段          | 类型  | 默认值  | 说明                             |
-| ------------- | ----- | ------- | -------------------------------- |
-| `enabled`     | bool  | `false` | 是否在每轮对话时自动执行记忆搜索 |
-| `max_results` | int   | `1`     | 自动搜索时最多返回的结果数       |
-| `timeout`     | float | `10.0`  | 自动搜索超时时间（秒）           |
+| 字段          | 类型 | 默认值  | 说明                             |
+| ------------- | ---- | ------- | -------------------------------- |
+| `enabled`     | bool | `false` | 是否在每轮对话时自动执行记忆搜索 |
+| `max_results` | int  | `2`     | 自动搜索时最多返回的结果数       |
 
 **Embedding 配置（`reme_light_memory_config.embedding_model_config` 对象）：**
 
@@ -417,7 +415,8 @@ MCP（模型上下文协议）允许智能体连接外部服务（如 Filesystem
 
 不满足启用条件时，ReMe 仍会保留关键词索引和 wikilink 图谱索引，但不会启用 embedding 向量索引。
 
-这些配置也可以在控制台的 **智能体 → 运行配置** 页面中修改。保存后会对新的 LLM 请求生效，不需要重启服务。
+这些配置也可以在控制台的 **智能体 → 运行配置** 页面中修改。直接从 `agent.json` 读取的字段，例如自动记忆间隔和自动搜索条数，
+保存后会在后续对话轮次生效。目录和 Embedding 等嵌入式 ReMe 组件配置需要重启 Agent 进程，让 ReMe 应用用新配置重新构造。
 
 ---
 

--- a/website/public/docs/memory-evolving-and-proactive.en.md
+++ b/website/public/docs/memory-evolving-and-proactive.en.md
@@ -1,218 +1,260 @@
 # Agent Memory Evolving & Proactive Interaction (Beta)
 
-> **Beta Feature**: Agent Memory Evolving & Proactive Interaction is an experimental QwenPaw capability built around the new [ReMe](https://github.com/agentscope-ai/ReMe) memory architecture. The goal is to let an agent accumulate, refine, retrieve, and act on long-term memory without model fine-tuning. The implementation and product integration are still evolving; feedback is welcome on [GitHub](https://github.com/agentscope-ai/QwenPaw/issues).
+> **Beta Feature**: QwenPaw's ReMeLight memory manager embeds [ReMe](https://github.com/agentscope-ai/ReMe) as an in-process application. Auto Memory, Auto Resource, Auto Dream, search, and ReMe's low-level proactive topic reader are ReMe jobs. QwenPaw's `/proactive` command is a separate runtime feature that reads recent chat sessions and optional screen context.
 
-QwenPaw uses ReMe as a file-native long-term memory layer. Conversations and resources are first saved as readable Markdown memory cards, then periodically distilled into durable digest memories. Proactive interaction is built on top of those memories: the agent can notice topics that deserve attention and decide whether to remind, follow up, or offer a useful next step.
+QwenPaw stores memory as files under the agent workspace. Conversations are saved as JSONL source logs, useful conversation facts are written to daily Markdown notes, resources can be converted into daily notes, and Auto Dream periodically integrates reusable abstractions into digest memory.
 
 ---
 
-## Core Idea
-
-The new memory loop is centered on four capabilities:
+## Actual Flow
 
 ```mermaid
 graph LR
-    A[Auto Memory<br/>Conversation -> Daily memory] --> C[Auto Dream<br/>Daily -> Digest]
-    B[Auto Resource<br/>Resource -> Daily memory] --> C
-    C --> D[Proactive<br/>Interest topics -> Agent action]
-    D -.->|New interaction creates new memory| A
+    A[Conversation turns] --> B[MemoryMiddleware]
+    B --> C[ReMe auto_memory job]
+    C --> D[mem_session/dialog/*.jsonl]
+    C --> E[memory/<date>/<note>.md]
+    R[resource/<date>/*] --> S[resource_watch_loop]
+    S --> T[ReMe auto_resource job]
+    T --> E
+    E --> U[ReMe auto_dream job]
+    U --> V[digest/personal|procedure|wiki/*.md]
+    U --> W[memory/<date>/interests.yaml]
 ```
 
-| Phase              | Module        | What it does                                                                                                        | Main output                                     |
-| ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| **Accumulate**     | Auto Memory   | Turns useful conversation context into daily memory cards and keeps raw dialogue as traceable source material.      | `memory/<date>/<session_id>.md`                 |
-| **Read Resources** | Auto Resource | Turns external files into daily resource cards linked back to the original resources.                               | `memory/<date>/<resource_card>.md`              |
-| **Consolidate**    | Auto Dream    | Extracts long-term memory units from daily notes, integrates them into digest nodes, and generates interest topics. | `digest/*/*.md`, `memory/<date>/interests.yaml` |
-| **Serve**          | Proactive     | Reads interest topics and exposes them to the upper-level agent, which decides whether and how to remind the user.  | Structured proactive topics                     |
+| Capability           | Code path                                                    | Trigger                                                                                                     | Main output                                                                            |
+| -------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------- | --------------------------------------------------------- |
+| Auto Memory          | `ReMeLightMemoryManager.auto_memory()` -> ReMe `auto_memory` | `MemoryMiddleware` after every configured number of user turns, and before context compression when enabled | `mem_session/dialog/<session_id>.jsonl`, `memory/<date>/<note>.md`, `memory/<date>.md` |
+| Auto Resource        | ReMe `resource_watch_loop` -> `auto_resource`                | Embedded ReMe background watcher for `resource_dir`                                                         | `memory/<date>/<resource_note>.md`                                                     |
+| Auto Dream           | `ReMeLightMemoryManager.dream()` -> ReMe `auto_dream`        | `/dream` command or `dream_cron` scheduler                                                                  | `digest/*/*.md`, `memory/<date>/interests.yaml`                                        |
+| ReMe proactive job   | ReMe `proactive`                                             | Direct ReMe job call only                                                                                   | Metadata/content from `memory/<date>/interests.yaml`                                   |
+| QwenPaw `/proactive` | `src/qwenpaw/agents/memory/proactive`                        | `/proactive [minutes                                                                                        | on                                                                                     | off]` idle loop | A proactive chat request sent through `/api/console/chat` |
 
-This makes memory evolution a data flow rather than a single summary file: raw sessions and resources stay available, daily cards preserve what happened, digest nodes hold reusable knowledge, and proactive topics provide the bridge from memory to action.
+The important boundary is that `memory/<date>/interests.yaml` is produced by Auto Dream and can be read by ReMe's `proactive` job, but QwenPaw's current `/proactive` implementation does not call that job.
 
 ---
 
-## Memory as Files
+## File Layout
 
-ReMe stores memory directly in a workspace. Files are readable and editable by both users and agents, with frontmatter and wikilinks used for metadata and relationships.
+The embedded ReMe config comes from `src/qwenpaw/agents/memory/reme_config.py` and the user-facing defaults come from `ReMeLightMemoryConfig`.
 
 ```text
 <workspace>/
-├── mem_metadata/   # Indexes, graph data, catalogs, and persistent system state
-├── mem_session/    # Raw conversations and agent sessions
+├── mem_metadata/   # ReMe persistent state, indexes, catalogs
+├── mem_session/    # Source conversation logs used by auto-memory
 │   └── dialog/
 │       └── <session_id>.jsonl
-├── resource/       # External source materials, grouped by date
+├── mem_agent/      # Internal ReMe memory-agent sessions
+├── resource/       # External assets watched by Auto Resource
 │   └── YYYY-MM-DD/
 │       └── <resource>.<ext>
-├── memory/         # Lightly processed daily memory cards and day indexes
+├── memory/         # Daily memory notes and day indexes
 │   ├── YYYY-MM-DD.md
 │   └── YYYY-MM-DD/
-│       ├── <session_id>.md
-│       ├── <resource_card>.md
+│       ├── <note>.md
 │       └── interests.yaml
-└── digest/         # Long-term memory nodes
+└── digest/         # Long-term digest memory
     ├── personal/
     ├── procedure/
     └── wiki/
 ```
 
-The split is intentional:
-
-- `mem_session/` and `resource/` keep the original evidence.
-- `memory/` keeps concise, human-readable records for a specific day.
-- `digest/` keeps reusable long-term memory such as preferences, workflows, and knowledge.
-- `mem_metadata/` keeps indexes for search, wikilink traversal, and incremental processing.
+Default directory names are configurable through `metadata_dir`, `session_dir`, `mem_session_dir`, `resource_dir`, `daily_dir`, and `digest_dir`.
 
 ---
 
 ## Auto Memory
 
-Auto Memory is the conversation entry point. It saves the original dialogue and turns long-term valuable information into a daily memory card.
+Auto Memory is invoked by `MemoryMiddleware`, not directly on every model call. The middleware:
 
-```text
-Conversation messages
-  -> mem_session/dialog/<session_id>.jsonl
-  -> memory/<date>/<session_id>.md
-  -> memory/<date>.md
-```
+- skips automation requests whose source is `cron` or `heartbeat`;
+- optionally injects auto memory search context before model calls when `auto_memory_search_config.enabled` is true;
+- collects user-turn markers after replies;
+- flushes pending turns after `auto_memory_interval` user turns;
+- also flushes before context compression when `summarize_when_compact` is true and compression is about to happen.
 
-It records information that is likely to help future work:
+`auto_memory_interval` defaults to `5`. `None`, `0`, or a negative value disables periodic auto-memory.
 
-| Type                | Examples                                                            |
-| ------------------- | ------------------------------------------------------------------- |
-| User preferences    | Language style, collaboration habits, recurring constraints         |
-| Key facts           | Project background, important numbers, confirmed decisions          |
-| Process decisions   | What was tried, why a route was chosen, which options were rejected |
-| Current state       | What is done, what is blocked, what should happen next              |
-| Reusable experience | Commands, debugging paths, workflows, lessons learned               |
+When flushed, QwenPaw calls ReMe's `auto_memory` job with:
 
-Auto Memory does not try to rewrite the whole long-term knowledge base directly. Its job is to create a trustworthy daily layer. Later, Auto Dream decides what deserves to become durable digest memory.
+| Field         | Source                                                    |
+| ------------- | --------------------------------------------------------- |
+| `messages`    | Selected conversation messages for the pending user turns |
+| `session_id`  | Agent session id                                          |
+| `memory_hint` | Optional hint passed by caller                            |
 
-Typical integration:
+ReMe's `AutoMemoryStep` then:
 
-| Trigger                     | Purpose                                                              |
-| --------------------------- | -------------------------------------------------------------------- |
-| After-reply hook            | Capture useful conversation results while the session is still fresh |
-| Session-end or compact hook | Preserve important context before it is lost                         |
-| On-demand call              | Let an agent explicitly save a memory-relevant interaction           |
+1. validates that `session_id` is present and valid;
+2. saves or appends sanitized source messages to `mem_session/dialog/<session_id>.jsonl`;
+3. removes tool-result blocks and base64 data blocks from the saved source log;
+4. chooses the note date from an explicit date, message timestamps, or the configured timezone's current date;
+5. looks for an existing daily note whose frontmatter has the same `session_id` or `source_conversation`;
+6. creates at most one note for a new session, or updates the existing note for that session;
+7. ensures frontmatter contains `session_id` and `source_conversation`;
+8. may rename the note from frontmatter `name`;
+9. refreshes the day index at `memory/<date>.md`;
+10. returns metadata including `date`, `path`, `created`, `modified`, `n_messages`, `source_conversation`, and `index`.
+
+If the job succeeds but no note was changed, QwenPaw does not push an inbox event for `auto_memory`. Otherwise it pushes an inbox event titled `Auto-memory result`.
 
 ---
 
 ## Auto Resource
 
-Auto Resource is the resource entry point. It watches or receives changes under `resource/<date>/`, reads the source files, and creates daily resource cards.
+QwenPaw configures a ReMe background job named `resource_watch_loop`. It watches `resource_dir` and dispatches change batches to `auto_resource`.
+
+Watched suffixes are:
 
 ```text
-resource/<date>/<resource_file>
-  -> memory/<date>/<generated_name>.md
-  -> source_resource: [[resource/<date>/<resource_file>]]
-  -> memory/<date>.md
+md, txt, json, jsonl, csv, yaml, html
 ```
 
-It is designed for making files useful to memory, not just storing them. A resource card may capture:
-
-- the core content of the file;
-- its structure, fields, sections, and tables;
-- important names, dates, numbers, and conclusions;
-- why the material matters to the current work;
-- follow-up actions or deadlines.
-
-When a resource changes, Auto Resource updates the linked daily card through `source_resource`. When a resource is deleted, the corresponding daily note can be cleaned up. The original file remains in `resource/`, so the memory card stays traceable.
-
-Current ReMe Beta behavior is most suitable for text-like resources such as Markdown, text, JSON, JSONL, CSV, YAML, and HTML.
+Each change item may contain `path` or `file_path` and a `change` value such as `added`, `modified`, or `deleted`. The ReMe step interprets changed resource files into daily notes. QwenPaw pushes an `Auto-resource result` inbox event only when the job reports a real modification.
 
 ---
 
 ## Auto Dream
 
-Auto Dream is the self-evolution step. It reads changed daily inputs for a date, extracts long-term memory units, integrates them into `digest/`, and writes proactive topic candidates into `interests.yaml`.
+Auto Dream is exposed in QwenPaw through:
 
-```text
-memory/<date>.md
-memory/<date>/**/*.md
-  -> extract memory units and topic candidates
-  -> integrate memory units into digest/
-  -> write memory/<date>/interests.yaml
-```
+- `/dream [hint]`, handled by `CommandHandler._process_dream()`;
+- the scheduler configured by `dream_cron`, default `0 23 * * *`;
+- `ReMeLightMemoryManager.dream(date="", hint="")`.
 
-Digest memory is organized by memory type:
+QwenPaw runs the ReMe job named `auto_dream` with `needs_llm=True`, so the embedded ReMe app refreshes its LLM component from the active QwenPaw model before the job runs.
 
-| Digest bucket | What belongs there                                           | Evolution role          |
-| ------------- | ------------------------------------------------------------ | ----------------------- |
-| `personal/`   | User preferences, long-term facts, collaboration constraints | Personalization         |
-| `procedure/`  | Workflows, runbooks, debugging methods, lessons learned      | Reusable task execution |
-| `wiki/`       | Domain knowledge, concepts, observations, decisions          | Knowledge base          |
+The embedded job configuration uses these defaults:
 
-Auto Dream uses four stages:
+| Parameter              | Default | Meaning                                      |
+| ---------------------- | ------: | -------------------------------------------- |
+| `date`                 |    `""` | Empty means today in the configured timezone |
+| `hint`                 |    `""` | Optional user/operator hint                  |
+| `scan_days`            |     `2` | Scan target date and recent days             |
+| `max_units`            |     `5` | Maximum extracted reusable memory units      |
+| `topic_count`          |     `3` | Maximum final interest topics                |
+| `topic_diversity_days` |     `7` | Avoid repeating topics from recent days      |
 
-| Stage     | Responsibility                                                                                                             |
-| --------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Extract   | Refresh the day index, compare daily files with the dream catalog, and extract changed memory units plus topic candidates. |
-| Integrate | Search related digest nodes, then create, corroborate, refine, or correct one digest node per memory unit.                 |
-| Topics    | De-duplicate and select the day's actionable interest topics, avoiding repeated topics from recent days.                   |
-| Finish    | Checkpoint successfully processed files and return a summary of scanned, changed, integrated, and topic counts.            |
+Auto Dream runs four ReMe steps:
 
-The integration step is where memory self-evolution happens. A new unit may create a new digest node, strengthen an existing one, refine its conditions and steps, or correct outdated information. Sources are linked back with workspace-relative wikilinks such as `derived_from:: [[memory/<date>/<session>.md]]`.
+| Step                   | Actual behavior                                                                                                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dream_extract_step`   | Refreshes day indexes, compares daily files against the dream catalog, deletes missing catalog entries, and extracts reusable memory units plus topic candidates only from changed daily inputs. |
+| `dream_integrate_step` | Integrates each extracted unit into one digest node. It uses `node_search`, `read`, `frontmatter_read`, `write`, `edit`, and `frontmatter_update`.                                               |
+| `dream_topics_step`    | Selects and de-duplicates interest topics, writes `memory/<date>/interests.yaml`, and refreshes the day index.                                                                                   |
+| `dream_finish_step`    | Upserts successful changed paths, interest files, and day indexes into the dream catalog, persists the catalog, and returns a summary.                                                           |
 
-Auto Dream does not rewrite daily notes. Daily memory remains the factual record; digest memory is the abstract, reusable layer.
+If there are no changed daily inputs, extract finishes with a no-change response. If an LLM is unavailable, extract or integrate fails because those steps require an LLM.
+
+Digest nodes are stored by bucket:
+
+| Bucket       | What belongs there                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| `personal/`  | User, team, or project identity, preferences, conventions, constraints, and avoid-rules                |
+| `procedure/` | How-to workflows, runbooks, recipes, methods, and executable patterns                                  |
+| `wiki/`      | Definitions, principles, observations, decisions as precedent, factual claims, and catch-all knowledge |
+
+Integration actions are `CREATE`, `CORROBORATE`, `REFINE`, or `CORRECT`. The integration prompts require workspace-relative wikilinks such as `derived_from:: [[memory/<date>/<note>.md]]` so digest memory remains traceable to daily material.
+
+When Auto Dream completes, QwenPaw pushes an inbox event titled `Auto-dream result`.
 
 ---
 
-## Proactive
+## Interest Topics and ReMe Proactive Job
 
-Proactive is the reading interface for active assistance. It does not re-analyze daily files and does not call an LLM by itself. It reads:
+`dream_topics_step` writes:
 
 ```text
 memory/<date>/interests.yaml
 ```
 
-The file is generated by Auto Dream's Topics stage. A typical topic contains a title, reason, evidence, keywords, and source paths. QwenPaw can use these topics to decide whether to:
+The YAML payload contains:
 
-- remind the user about an unfinished or time-sensitive item;
-- follow up on a topic the user repeatedly cared about;
-- suggest a next step for an ongoing project;
-- retrieve fresh information before sending a proactive message.
+| Field            | Meaning                                                                     |
+| ---------------- | --------------------------------------------------------------------------- |
+| `date`           | Target date                                                                 |
+| `topic_count`    | Requested maximum topic count                                               |
+| `diversity_days` | Recent-day duplicate avoidance window                                       |
+| `topics`         | Selected topics with `title`, `reason`, `evidence`, `keywords`, and `paths` |
 
-The boundary is important: ReMe exposes what may be worth attention; QwenPaw decides whether to interrupt the user, when to do it, and how to phrase the message.
+ReMe also defines a `proactive` job implemented by `proactive_step`. That job only reads `memory/<date>/interests.yaml`. It accepts:
 
-If `interests.yaml` does not exist, Proactive treats it as a normal empty state. This usually means Auto Dream has not produced topics for that date yet.
+| Parameter         | Default | Meaning                           |
+| ----------------- | ------: | --------------------------------- |
+| `date`            |    `""` | Empty means today                 |
+| `include_content` |  `true` | Include raw YAML text in metadata |
 
----
-
-## Search and Reuse
-
-ReMe maintains indexes in the background so agents can reuse memory by search and graph traversal. The indexer watches Markdown, JSONL, and resource changes, then updates:
-
-- chunk indexes for file content;
-- BM25 keyword indexes;
-- embedding indexes for semantic recall;
-- wikilink graph indexes for relationship expansion.
-
-Retrieval can combine keyword matching, vector recall, and reciprocal-rank fusion. In QwenPaw, this means the agent can search both recent daily context and long-term digest memory instead of relying only on whatever is currently in the prompt.
+If the interests file is missing, the ReMe proactive job returns a normal skipped result.
 
 ---
 
-## Recommended Mental Model
+## QwenPaw `/proactive`
 
-Use the memory loop this way:
+QwenPaw's current `/proactive` command is implemented under `src/qwenpaw/agents/memory/proactive`. It is separate from ReMe's `proactive` job.
 
-| Step | Action                                        | Result                                                             |
-| ---- | --------------------------------------------- | ------------------------------------------------------------------ |
-| 1    | Let Auto Memory capture useful conversations. | The agent remembers what happened and why it mattered.             |
-| 2    | Put useful files under the resource flow.     | External materials become searchable daily memory.                 |
-| 3    | Let Auto Dream run regularly.                 | Daily records become durable personal, procedure, and wiki memory. |
-| 4    | Let Proactive read `interests.yaml`.          | The agent can surface timely, memory-grounded follow-ups.          |
+Command behavior:
 
-> **One-line summary**: save conversations and resources as daily evidence, distill durable knowledge into digest nodes, then use interest topics to drive proactive assistance.
+```text
+/proactive           # enable with default 30 minute idle threshold
+/proactive on        # enable with default 30 minute idle threshold
+/proactive 45        # enable with a 45 minute idle threshold
+/proactive off       # cancel the background monitoring task
+```
+
+When enabled, QwenPaw stores an in-memory `ProactiveConfig` for the session and starts a background loop. The loop:
+
+- wakes every 30 seconds;
+- skips while the agent has active tasks;
+- reads the latest chat update time;
+- waits until the session has been idle for the configured number of minutes;
+- avoids retrying more than once per 60 seconds;
+- skips if the latest message is already an unanswered `[PROACTIVE]` message;
+- runs the proactive responder.
+
+The responder builds context from recent chat sessions, not from `interests.yaml`:
+
+- reads chat metadata from `workspace.chat_manager`;
+- keeps sessions updated within the last 7 days, or the latest 5 sessions when fewer than 5 match the date window;
+- loads up to 100 recent text messages, capped at 50,000 characters;
+- filters system messages, non-text blocks, and prior proactive helper requests;
+- optionally analyzes a desktop screenshot when the active model supports multimodal input.
+
+It then asks a temporary `ProactiveAssistant` agent to extract 1 to 3 likely tasks from that context, executes up to the first 3 task queries using tools, and sends a user-facing proactive request through:
+
+```text
+POST <agent-api-base>/api/console/chat
+session_id = proactive_mode:<active_agent_id>
+text starts with "[Agent proactive_helper requesting]"
+```
+
+The final user-facing prompt instructs the agent response to begin with `[PROACTIVE]`.
+
+The command warning is accurate: proactive mode may read historical session memory and may take screenshots when multimodal screen analysis is available. The proactive agent uses tool protection bypass mode through its own temporary agent/tool setup.
+
+---
+
+## Search and Indexing
+
+The embedded ReMe app starts an `index_update_loop` background job. Search indexing watches:
+
+| Config                          | Indexed directories                       | Suffixes      |
+| ------------------------------- | ----------------------------------------- | ------------- |
+| `enable_search_raw_log = false` | `daily_dir`, `digest_dir`                 | `md`          |
+| `enable_search_raw_log = true`  | `daily_dir`, `digest_dir`, `resource_dir` | `md`, `jsonl` |
+
+The QwenPaw `memory_search` tool runs ReMe's `search` job with `query`, `limit`, and `min_score`. The job is configured as hybrid workspace search with vector recall, BM25 keyword recall, RRF fusion, and wikilink expansion. The storage backend in QwenPaw's embedded ReMe config is local.
 
 ---
 
 ## Current Status
 
-This document reflects the new ReMe file-native design used for QwenPaw's next memory-evolution integration. Compared with the earlier ReMeLight design, the main changes are:
+This document describes the current code paths:
 
-- memory is no longer centered on one `MEMORY.md` file;
-- resources are first-class memory inputs through Auto Resource;
-- long-term memory is split into `personal`, `procedure`, and `wiki` digest nodes;
-- proactive behavior is driven by `memory/<date>/interests.yaml` generated by Auto Dream;
-- search and wikilinks are part of the memory substrate rather than an optional add-on.
+- ReMeLight is implemented by `ReMeLightMemoryManager` and embedded `get_reme_app_config()`;
+- Auto Memory is turn-count based and defaults to every 5 user turns;
+- Auto Dream runs by `/dream` or `dream_cron`;
+- ReMe writes `interests.yaml`, and ReMe has a low-level reader for it;
+- QwenPaw `/proactive` currently uses recent chat/session/screen context rather than ReMe interest topics;
+- Auto Memory, Auto Resource, and Auto Dream results may be delivered to the inbox when they produce reportable output.
 
-The feature remains Beta, and exact UI switches, schedules, and product defaults may continue to change as QwenPaw integrates the new ReMe runtime.
+The feature remains Beta, but the behavior above is the behavior represented by the current code.

--- a/website/public/docs/memory-evolving-and-proactive.zh.md
+++ b/website/public/docs/memory-evolving-and-proactive.zh.md
@@ -1,218 +1,260 @@
 # 智能体记忆进化与主动交互（Beta）
 
-> **Beta 功能**：智能体记忆进化与主动交互是 QwenPaw 基于新版 [ReMe](https://github.com/agentscope-ai/ReMe) 记忆架构建设的实验性能力。目标是在不微调模型的情况下，让 Agent 能够积累、整理、检索并主动使用长期记忆。当前实现和产品集成仍在持续迭代，如果你有建议，欢迎在 [GitHub](https://github.com/agentscope-ai/QwenPaw/issues) 反馈。
+> **Beta 功能**：QwenPaw 的 ReMeLight memory manager 会把 [ReMe](https://github.com/agentscope-ai/ReMe) 作为进程内应用嵌入。Auto Memory、Auto Resource、Auto Dream、搜索，以及 ReMe 底层的 proactive topic 读取能力都是 ReMe job。QwenPaw 的 `/proactive` 命令是另一条运行时逻辑，它读取近期 chat session 和可选屏幕上下文。
 
-QwenPaw 使用 ReMe 作为文件化长期记忆层。对话和资源会先被保存为可读、可编辑、可追溯的 Markdown 记忆卡片，再定期沉淀为长期 digest 记忆。主动交互建立在这些记忆之上：Agent 可以发现值得关注的主题，并决定是否提醒、追问或给出下一步建议。
+QwenPaw 将记忆保存为 agent workspace 下的文件。对话先保存为 JSONL 来源日志，有价值的对话事实写入 daily Markdown note，资源可以转换成 daily note，Auto Dream 再定期把可复用抽象整合进 digest 记忆。
 
 ---
 
-## 核心思路
-
-新版记忆进化围绕四个能力形成闭环：
+## 实际流程
 
 ```mermaid
 graph LR
-    A[Auto Memory<br/>对话 -> Daily 记忆] --> C[Auto Dream<br/>Daily -> Digest]
-    B[Auto Resource<br/>资源 -> Daily 记忆] --> C
-    C --> D[Proactive<br/>兴趣主题 -> Agent 行动]
-    D -.->|新交互继续产生新记忆| A
+    A[Conversation turns] --> B[MemoryMiddleware]
+    B --> C[ReMe auto_memory job]
+    C --> D[mem_session/dialog/*.jsonl]
+    C --> E[memory/<date>/<note>.md]
+    R[resource/<date>/*] --> S[resource_watch_loop]
+    S --> T[ReMe auto_resource job]
+    T --> E
+    E --> U[ReMe auto_dream job]
+    U --> V[digest/personal|procedure|wiki/*.md]
+    U --> W[memory/<date>/interests.yaml]
 ```
 
-| 阶段       | 模块          | 做什么                                                              | 主要产物                                        |
-| ---------- | ------------- | ------------------------------------------------------------------- | ----------------------------------------------- |
-| **积累**   | Auto Memory   | 将有长期价值的对话上下文整理成 daily 记忆卡片，并保留原始对话来源。 | `memory/<date>/<session_id>.md`                 |
-| **读资源** | Auto Resource | 将外部文件解读成 daily 资源卡片，并链接回原始资源。                 | `memory/<date>/<resource_card>.md`              |
-| **沉淀**   | Auto Dream    | 从 daily 记忆中抽取长期记忆单元，整合进 digest，并生成兴趣主题。    | `digest/*/*.md`、`memory/<date>/interests.yaml` |
-| **服务**   | Proactive     | 读取兴趣主题并暴露给上层 Agent，由 Agent 决定是否以及如何提醒用户。 | 结构化主动主题                                  |
+| 能力                 | 代码路径                                                     | 触发方式                                                                | 主要产物                                                                               |
+| -------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------- | ------------------------------------------------ |
+| Auto Memory          | `ReMeLightMemoryManager.auto_memory()` -> ReMe `auto_memory` | `MemoryMiddleware` 按配置的用户轮次数触发；启用时也会在上下文压缩前触发 | `mem_session/dialog/<session_id>.jsonl`、`memory/<date>/<note>.md`、`memory/<date>.md` |
+| Auto Resource        | ReMe `resource_watch_loop` -> `auto_resource`                | 嵌入式 ReMe 后台 watcher 监听 `resource_dir`                            | `memory/<date>/<resource_note>.md`                                                     |
+| Auto Dream           | `ReMeLightMemoryManager.dream()` -> ReMe `auto_dream`        | `/dream` 命令或 `dream_cron` 调度                                       | `digest/*/*.md`、`memory/<date>/interests.yaml`                                        |
+| ReMe proactive job   | ReMe `proactive`                                             | 仅在直接调用 ReMe job 时运行                                            | `memory/<date>/interests.yaml` 的 metadata/content                                     |
+| QwenPaw `/proactive` | `src/qwenpaw/agents/memory/proactive`                        | `/proactive [minutes                                                    | on                                                                                     | off]` 空闲循环 | 通过 `/api/console/chat` 发送的主动 chat request |
 
-因此，记忆进化不再是写入一个单独的总结文件，而是一条文件化数据流：原始会话和资源保留证据，daily 卡片记录当天发生了什么，digest 节点保存可复用知识，proactive 主题把记忆转化为行动线索。
+关键边界：`memory/<date>/interests.yaml` 由 Auto Dream 生成，也可以被 ReMe 的 `proactive` job 读取；但 QwenPaw 当前 `/proactive` 实现不会调用这个 job，也不会直接消费 `interests.yaml`。
 
 ---
 
-## Memory as Files
+## 文件布局
 
-ReMe 直接在 workspace 中存储记忆。文件对用户和 Agent 都可读、可编辑，frontmatter 和 wikilink 用来表达元数据与关系。
+嵌入式 ReMe 配置来自 `src/qwenpaw/agents/memory/reme_config.py`，面向用户的默认值来自 `ReMeLightMemoryConfig`。
 
 ```text
 <workspace>/
-├── mem_metadata/   # 索引、图谱、catalog 和持久化系统状态
-├── mem_session/    # 原始对话和 Agent session
+├── mem_metadata/   # ReMe 持久状态、索引、catalog
+├── mem_session/    # Auto Memory 使用的来源对话日志
 │   └── dialog/
 │       └── <session_id>.jsonl
-├── resource/       # 外部原始资料，按日期组织
+├── mem_agent/      # ReMe 内部 memory-agent session
+├── resource/       # Auto Resource 监听的外部资料
 │   └── YYYY-MM-DD/
 │       └── <resource>.<ext>
-├── memory/         # 浅加工的日记卡片和当天索引
+├── memory/         # Daily memory notes 和 day index
 │   ├── YYYY-MM-DD.md
 │   └── YYYY-MM-DD/
-│       ├── <session_id>.md
-│       ├── <resource_card>.md
+│       ├── <note>.md
 │       └── interests.yaml
-└── digest/         # 长期记忆节点
+└── digest/         # 长期 digest 记忆
     ├── personal/
     ├── procedure/
     └── wiki/
 ```
 
-这个分层有明确边界：
-
-- `mem_session/` 和 `resource/` 保留原始证据；
-- `memory/` 保留当天发生过什么，内容简洁、可读、可追溯；
-- `digest/` 保留可复用的长期记忆，例如偏好、流程和知识；
-- `mem_metadata/` 保留搜索、wikilink 图谱和增量处理需要的索引状态。
+默认目录名可通过 `metadata_dir`、`session_dir`、`mem_session_dir`、`resource_dir`、`daily_dir`、`digest_dir` 配置。
 
 ---
 
 ## Auto Memory
 
-Auto Memory 是对话记忆入口。它保存原始对话，并将有长期价值的信息整理成 daily 记忆卡片。
+Auto Memory 由 `MemoryMiddleware` 调用，不是每次 model call 都直接运行。Middleware 会：
 
-```text
-Conversation messages
-  -> mem_session/dialog/<session_id>.jsonl
-  -> memory/<date>/<session_id>.md
-  -> memory/<date>.md
-```
+- 跳过来源为 `cron` 或 `heartbeat` 的自动化请求；
+- 当 `auto_memory_search_config.enabled` 为 true 时，在模型调用前注入自动记忆搜索上下文；
+- 在回复后收集 user-turn marker；
+- 累计到 `auto_memory_interval` 个用户轮次后 flush；
+- 当 `summarize_when_compact` 为 true 且即将压缩上下文时，也会先 flush pending turns。
 
-它会记录未来可能还会用到的信息：
+`auto_memory_interval` 默认是 `5`。`None`、`0` 或负数会禁用周期性 Auto Memory。
 
-| 类型       | 示例                                     |
-| ---------- | ---------------------------------------- |
-| 用户偏好   | 语言风格、协作习惯、长期约束             |
-| 关键事实   | 项目背景、重要数字、明确决策             |
-| 过程决定   | 尝试过什么、为什么这样选、哪些方案被放弃 |
-| 当前状态   | 做到哪一步、卡在哪里、下一步是什么       |
-| 可复用经验 | 命令、排查路径、工作流、经验教训         |
+Flush 时，QwenPaw 调用 ReMe 的 `auto_memory` job，并传入：
 
-Auto Memory 不直接重写整个长期知识库。它的职责是建立可信的 daily 层；之后由 Auto Dream 判断哪些内容值得成为长期 digest 记忆。
+| 字段          | 来源                              |
+| ------------- | --------------------------------- |
+| `messages`    | pending user turns 对应的会话消息 |
+| `session_id`  | Agent session id                  |
+| `memory_hint` | 调用方可选提示                    |
 
-典型触发方式：
+ReMe 的 `AutoMemoryStep` 随后会：
 
-| 触发方式                    | 目的                                |
-| --------------------------- | ----------------------------------- |
-| after-reply hook            | 在会话上下文仍然新鲜时沉淀有用结果  |
-| session-end 或 compact hook | 在上下文丢失或压缩前保存重要信息    |
-| 按需调用                    | 让 Agent 显式保存某次值得记忆的交互 |
+1. 校验 `session_id` 存在且合法；
+2. 将清洗后的来源消息保存或追加到 `mem_session/dialog/<session_id>.jsonl`；
+3. 从保存的来源日志中移除 tool-result block 和 base64 data block；
+4. 从显式 date、消息时间戳或配置时区的当前日期中选择 note date；
+5. 查找 frontmatter 中 `session_id` 或 `source_conversation` 匹配的已有 daily note；
+6. 新 session 最多创建一条 note，已有 session 更新同一条 note；
+7. 确保 frontmatter 包含 `session_id` 和 `source_conversation`；
+8. 可能根据 frontmatter `name` 重命名 note；
+9. 刷新 `memory/<date>.md` day index；
+10. 返回 `date`、`path`、`created`、`modified`、`n_messages`、`source_conversation`、`index` 等 metadata。
+
+如果 job 成功但没有实际修改 note，QwenPaw 不会为 `auto_memory` 推送 inbox event。否则会推送标题为 `Auto-memory result` 的 inbox event。
 
 ---
 
 ## Auto Resource
 
-Auto Resource 是资源记忆入口。它监听或接收 `resource/<date>/` 下的变化，读取原始文件，并生成 daily 资源卡片。
+QwenPaw 配置了名为 `resource_watch_loop` 的 ReMe 后台 job。它监听 `resource_dir`，并把变更批次派发给 `auto_resource`。
+
+监听的后缀是：
 
 ```text
-resource/<date>/<resource_file>
-  -> memory/<date>/<generated_name>.md
-  -> source_resource: [[resource/<date>/<resource_file>]]
-  -> memory/<date>.md
+md, txt, json, jsonl, csv, yaml, html
 ```
 
-它的目标不是简单存档文件，而是让资料变成可用记忆。资源卡片通常会提炼：
-
-- 文件的核心内容；
-- 章节、字段、表格等结构；
-- 重要名称、日期、数字和结论；
-- 这份资料与当前工作的关系；
-- 后续行动项或截止时间。
-
-资源更新时，Auto Resource 会通过 `source_resource` 找到对应 daily 卡片并更新；资源删除时，也可以清理对应 daily note。原始文件仍然保留在 `resource/` 中，因此每张资源卡片都能追溯来源。
-
-当前 ReMe Beta 更适合处理文本类资源，例如 Markdown、text、JSON、JSONL、CSV、YAML 和 HTML。
+每个 change item 可以包含 `path` 或 `file_path`，以及类似 `added`、`modified`、`deleted` 的 `change` 值。ReMe step 会将变化的资源文件解读成 daily note。只有当 job 报告确实发生修改时，QwenPaw 才会推送 `Auto-resource result` inbox event。
 
 ---
 
 ## Auto Dream
 
-Auto Dream 是记忆自进化步骤。它读取某一天发生变化的 daily 输入，抽取长期记忆单元，整合进 `digest/`，并把主动主题候选写入 `interests.yaml`。
+QwenPaw 通过以下入口暴露 Auto Dream：
 
-```text
-memory/<date>.md
-memory/<date>/**/*.md
-  -> 抽取 memory units 和 topic candidates
-  -> 整合 memory units 到 digest/
-  -> 写入 memory/<date>/interests.yaml
-```
+- `/dream [hint]`，由 `CommandHandler._process_dream()` 处理；
+- `dream_cron` 配置的调度器，默认 `0 23 * * *`；
+- `ReMeLightMemoryManager.dream(date="", hint="")`。
 
-Digest 记忆按类型组织：
+QwenPaw 运行名为 `auto_dream` 的 ReMe job，并设置 `needs_llm=True`，因此嵌入式 ReMe 会在 job 运行前用 QwenPaw 当前 active model 刷新自己的 LLM component。
 
-| Digest bucket | 存什么                              | 进化作用       |
-| ------------- | ----------------------------------- | -------------- |
-| `personal/`   | 用户偏好、长期事实、协作约束        | 个性化         |
-| `procedure/`  | 工作流、runbook、排查方法、经验教训 | 可复用任务执行 |
-| `wiki/`       | 领域知识、概念、观察、决策先例      | 知识库         |
+嵌入式 job 配置使用这些默认值：
 
-Auto Dream 包含四个阶段：
+| 参数                   | 默认值 | 含义                              |
+| ---------------------- | -----: | --------------------------------- |
+| `date`                 |   `""` | 空值表示配置时区里的今天          |
+| `hint`                 |   `""` | 可选用户/操作者提示               |
+| `scan_days`            |    `2` | 扫描目标日期及最近日期            |
+| `max_units`            |    `5` | 最多抽取的可复用 memory units     |
+| `topic_count`          |    `3` | 最多最终 interest topics          |
+| `topic_diversity_days` |    `7` | 避免重复最近几天已经出现的 topics |
 
-| 阶段      | 职责                                                                                                 |
-| --------- | ---------------------------------------------------------------------------------------------------- |
-| Extract   | 刷新当天索引，对比 daily 文件和 dream catalog，只从变化文件中抽取 memory units 与 topic candidates。 |
-| Integrate | 搜索相关 digest 节点，并对每个 memory unit 执行创建、佐证、细化或纠错。                              |
-| Topics    | 对当天兴趣主题去重、筛选，并避免和最近几天的主题重复。                                               |
-| Finish    | 对成功处理的文件做 checkpoint，并返回 scanned、changed、integrated、topics 等摘要。                  |
+Auto Dream 运行四个 ReMe steps：
 
-真正的记忆自进化发生在 Integrate 阶段：新的 unit 可能创建新 digest 节点，也可能强化已有节点、细化适用条件和步骤，或修正过时信息。来源通过 workspace-relative wikilink 追溯，例如 `derived_from:: [[memory/<date>/<session>.md]]`。
+| Step                   | 实际行为                                                                                                                                              |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dream_extract_step`   | 刷新 day indexes，对比 daily files 和 dream catalog，删除缺失的 catalog entries，只从变化的 daily 输入中抽取可复用 memory units 和 topic candidates。 |
+| `dream_integrate_step` | 将每个抽取出的 unit 整合进一个 digest node。会使用 `node_search`、`read`、`frontmatter_read`、`write`、`edit`、`frontmatter_update`。                 |
+| `dream_topics_step`    | 选择并去重 interest topics，写入 `memory/<date>/interests.yaml`，并刷新 day index。                                                                   |
+| `dream_finish_step`    | 将成功处理的 changed paths、interest files 和 day indexes upsert 到 dream catalog，持久化 catalog，并返回 summary。                                   |
 
-Auto Dream 不改写 daily 正文。daily 是事实和现场记录，digest 才是抽象后的长期记忆层。
+如果没有变化的 daily 输入，extract 会以 no-change 响应结束。如果 LLM 不可用，extract 或 integrate 会失败，因为这些 step 需要 LLM。
+
+Digest node 按 bucket 存储：
+
+| Bucket       | 存什么                                                     |
+| ------------ | ---------------------------------------------------------- |
+| `personal/`  | 用户、团队或项目身份、偏好、约定、约束、avoid-rules        |
+| `procedure/` | How-to 工作流、runbook、recipe、方法、可执行模式           |
+| `wiki/`      | 定义、原则、观察、作为先例的决策、事实 claim，以及兜底知识 |
+
+Integration action 包括 `CREATE`、`CORROBORATE`、`REFINE`、`CORRECT`。整合 prompt 要求使用 workspace-relative wikilink，例如 `derived_from:: [[memory/<date>/<note>.md]]`，让 digest 记忆可以追溯到 daily material。
+
+Auto Dream 完成后，QwenPaw 会推送标题为 `Auto-dream result` 的 inbox event。
 
 ---
 
-## Proactive
+## Interest Topics 和 ReMe Proactive Job
 
-Proactive 是主动服务的读取接口。它本身不重新分析 daily 文件，也不调用 LLM，只读取：
+`dream_topics_step` 写入：
 
 ```text
 memory/<date>/interests.yaml
 ```
 
-该文件由 Auto Dream 的 Topics 阶段生成。一个典型 topic 会包含标题、原因、证据、关键词和来源路径。QwenPaw 可以基于这些 topic 决定是否：
+YAML payload 包含：
 
-- 提醒用户某个未完成或有时效性的事项；
-- 跟进用户近期反复关注的话题；
-- 为正在进行的项目建议下一步；
-- 在主动消息前检索最新信息。
+| 字段             | 含义                                                                   |
+| ---------------- | ---------------------------------------------------------------------- |
+| `date`           | 目标日期                                                               |
+| `topic_count`    | 请求的最大 topic 数                                                    |
+| `diversity_days` | 最近日期去重窗口                                                       |
+| `topics`         | 选出的 topics，包含 `title`、`reason`、`evidence`、`keywords`、`paths` |
 
-这里的边界很重要：ReMe 负责暴露“今天可能值得关注什么”，QwenPaw 负责判断是否打扰用户、什么时候打扰，以及用什么方式表达。
+ReMe 还定义了一个由 `proactive_step` 实现的 `proactive` job。这个 job 只读取 `memory/<date>/interests.yaml`。它接受：
 
-如果 `interests.yaml` 不存在，Proactive 会把它视为正常空状态。通常这表示当天还没有 Auto Dream 结果。
+| 参数              | 默认值 | 含义                             |
+| ----------------- | -----: | -------------------------------- |
+| `date`            |   `""` | 空值表示今天                     |
+| `include_content` | `true` | 在 metadata 中包含原始 YAML 文本 |
 
----
-
-## 搜索与复用
-
-ReMe 会在后台维护索引，让 Agent 可以通过搜索和图谱关系复用记忆。索引器会监听 Markdown、JSONL 和资源变化，并更新：
-
-- 文件内容的 chunk 索引；
-- BM25 关键词索引；
-- embedding 语义召回索引；
-- wikilink 图谱索引。
-
-检索可以结合关键词匹配、向量召回和 RRF 融合。在 QwenPaw 中，这意味着 Agent 不只能依赖当前 prompt，也可以搜索近期 daily 上下文和长期 digest 记忆。
+如果 interests 文件不存在，ReMe proactive job 会返回正常的 skipped result。
 
 ---
 
-## 推荐理解方式
+## QwenPaw `/proactive`
 
-可以这样理解和使用整条记忆链路：
+QwenPaw 当前 `/proactive` 命令实现位于 `src/qwenpaw/agents/memory/proactive`，它和 ReMe 的 `proactive` job 是两套逻辑。
 
-| 步骤 | 动作                                 | 结果                                                           |
-| ---- | ------------------------------------ | -------------------------------------------------------------- |
-| 1    | 让 Auto Memory 捕获有价值的对话。    | Agent 记住发生了什么，以及为什么重要。                         |
-| 2    | 让有用文件进入 resource 流程。       | 外部资料变成可搜索的 daily 记忆。                              |
-| 3    | 让 Auto Dream 定期运行。             | Daily 记录沉淀为 durable 的 personal、procedure 和 wiki 记忆。 |
-| 4    | 让 Proactive 读取 `interests.yaml`。 | Agent 可以基于记忆给出及时的后续提醒或建议。                   |
+命令行为：
 
-> **一句话总结**：对话和资源先成为 daily 证据，长期价值再沉淀进 digest 节点，最后由兴趣主题驱动主动服务。
+```text
+/proactive           # 使用默认 30 分钟空闲阈值启用
+/proactive on        # 使用默认 30 分钟空闲阈值启用
+/proactive 45        # 使用 45 分钟空闲阈值启用
+/proactive off       # 取消后台 monitoring task
+```
+
+启用后，QwenPaw 会为 session 保存一个内存态 `ProactiveConfig`，并启动后台循环。该循环会：
+
+- 每 30 秒 wake 一次；
+- agent 有 active tasks 时跳过；
+- 读取最新 chat update time；
+- 等待 session 空闲达到配置分钟数；
+- 60 秒内不重复尝试；
+- 如果最后一条消息已经是未回应的 `[PROACTIVE]` 消息，则跳过；
+- 运行 proactive responder。
+
+Responder 构造上下文时读取近期 chat sessions，而不是读取 `interests.yaml`：
+
+- 通过 `workspace.chat_manager` 读取 chat metadata；
+- 保留最近 7 天更新过的 sessions；如果不足 5 个，则取最新 5 个 sessions；
+- 加载最多 100 条近期文本消息，总字符上限 50,000；
+- 过滤 system messages、非文本 blocks，以及之前 proactive helper 发出的请求；
+- 当 active model 支持多模态时，可选分析桌面截图。
+
+随后它让临时 `ProactiveAssistant` agent 从上下文中抽取 1 到 3 个可能任务，最多执行前 3 个任务 query，并通过以下接口发送面向用户的 proactive request：
+
+```text
+POST <agent-api-base>/api/console/chat
+session_id = proactive_mode:<active_agent_id>
+text starts with "[Agent proactive_helper requesting]"
+```
+
+最终面向用户的 prompt 要求 agent 回复以 `[PROACTIVE]` 开头。
+
+命令中的 warning 与代码一致：proactive mode 可能读取历史 session memory，并且在多模态屏幕分析可用时可能截图。Proactive agent 通过自己的临时 agent/tool setup 使用 tool protection bypass mode。
+
+---
+
+## 搜索与索引
+
+嵌入式 ReMe app 会启动 `index_update_loop` 后台 job。搜索索引监听：
+
+| 配置                            | 索引目录                                  | 后缀          |
+| ------------------------------- | ----------------------------------------- | ------------- |
+| `enable_search_raw_log = false` | `daily_dir`、`digest_dir`                 | `md`          |
+| `enable_search_raw_log = true`  | `daily_dir`、`digest_dir`、`resource_dir` | `md`、`jsonl` |
+
+QwenPaw 的 `memory_search` tool 会运行 ReMe 的 `search` job，参数是 `query`、`limit`、`min_score`。该 job 配置为 hybrid workspace search，包含向量召回、BM25 keyword 召回、RRF 融合和 wikilink expansion。QwenPaw 嵌入式 ReMe 配置里的存储后端是 local。
 
 ---
 
 ## 当前状态
 
-本文档反映的是 QwenPaw 记忆进化下一阶段集成的新版 ReMe 文件化设计。相比早期 ReMeLight 方案，主要变化是：
+本文档描述当前代码路径：
 
-- 记忆不再围绕单个 `MEMORY.md` 文件组织；
-- 资源通过 Auto Resource 成为一等记忆输入；
-- 长期记忆拆分为 `personal`、`procedure`、`wiki` 三类 digest 节点；
-- 主动服务由 Auto Dream 生成的 `memory/<date>/interests.yaml` 驱动；
-- 搜索和 wikilink 是记忆底座的一部分，而不是额外附加能力。
+- ReMeLight 由 `ReMeLightMemoryManager` 和嵌入式 `get_reme_app_config()` 实现；
+- Auto Memory 基于用户轮次数触发，默认每 5 个用户轮次一次；
+- Auto Dream 通过 `/dream` 或 `dream_cron` 运行；
+- ReMe 会写入 `interests.yaml`，也有读取它的底层 job；
+- QwenPaw `/proactive` 当前使用近期 chat/session/screen context，而不是 ReMe interest topics；
+- Auto Memory、Auto Resource、Auto Dream 产生可报告输出时，可能投递到 inbox。
 
-该能力仍处于 Beta 阶段。随着 QwenPaw 接入新版 ReMe runtime，具体 UI 开关、调度时间和产品默认值可能继续调整。
+该能力仍处于 Beta 阶段，但以上行为与当前代码实现一致。

--- a/website/public/docs/memory.en.md
+++ b/website/public/docs/memory.en.md
@@ -236,6 +236,7 @@ Memory configuration is located in `agent.json` under `running.reme_light_memory
 | ------------------------------- | ------------------------------------------------------------------------------ | ---------------- |
 | `metadata_dir`                  | ReMe persistent state directory for indexes, catalogs, graph data, and caches  | `"mem_metadata"` |
 | `session_dir`                   | Directory for saved source conversations                                       | `"mem_session"`  |
+| `mem_session_dir`               | Directory for ReMe internal memory-agent sessions                              | `"mem_agent"`    |
 | `resource_dir`                  | Directory watched by `auto_resource`                                           | `"resource"`     |
 | `daily_dir`                     | Directory for daily memory notes                                               | `"memory"`       |
 | `digest_dir`                    | Directory for dream/digest memory                                              | `"digest"`       |
@@ -268,7 +269,7 @@ Embedding configuration for vector semantic search, located in `running.reme_lig
 | `api_key`          | API key for the embedding provider. Required for OpenAI-compatible and Gemini backends         | ``       |
 | `base_url`         | Optional custom API URL for OpenAI-compatible backends. For Ollama, this is passed as the host | ``       |
 | `model_name`       | Embedding model name                                                                           | ``       |
-| `dimensions`       | Vector dimensions for initializing vector DB                                                   | `1024`   |
+| `dimensions`       | Embedding vector dimensions                                                                    | `1024`   |
 | `enable_cache`     | Whether to enable Embedding cache                                                              | `true`   |
 | `use_dimensions`   | Whether to pass dimensions parameter in API                                                    | `false`  |
 | `max_cache_size`   | Maximum Embedding cache entries                                                                | `10000`  |

--- a/website/public/docs/memory.zh.md
+++ b/website/public/docs/memory.zh.md
@@ -186,6 +186,7 @@ graph LR
 | ------------------------------- | ------------------------------------------------------------------------ | ---------------- |
 | `metadata_dir`                  | ReMe 持久状态目录，用于保存索引、catalog、graph 和缓存                   | `"mem_metadata"` |
 | `session_dir`                   | 来源对话保存目录                                                         | `"mem_session"`  |
+| `mem_session_dir`               | ReMe 内部 memory-agent 会话目录                                          | `"mem_agent"`    |
 | `resource_dir`                  | `auto_resource` 监听的资源目录                                           | `"resource"`     |
 | `daily_dir`                     | 每日记忆目录                                                             | `"memory"`       |
 | `digest_dir`                    | dream/digest 记忆目录                                                    | `"digest"`       |
@@ -217,7 +218,7 @@ Embedding 配置用于向量语义搜索，位于 `running.reme_light_memory_con
 | `api_key`          | Embedding 服务的 API Key。OpenAI 兼容和 Gemini 后端必填                               | ``       |
 | `base_url`         | OpenAI 兼容后端的可选自定义 API 地址；Ollama 后端会作为 host 传递                     | ``       |
 | `model_name`       | Embedding 模型名称                                                                    | ``       |
-| `dimensions`       | 向量维度，用于初始化向量数据库                                                        | `1024`   |
+| `dimensions`       | Embedding 向量维度                                                                    | `1024`   |
 | `enable_cache`     | 是否启用 Embedding 缓存                                                               | `true`   |
 | `use_dimensions`   | 是否在 API 请求中传递 dimensions 参数                                                 | `false`  |
 | `max_cache_size`   | Embedding 缓存最大条目数                                                              | `10000`  |


### PR DESCRIPTION
## Description

This PR updates QwenPaw for the AgentScope 2.0.4 and ReMe 0.4.0.8 integration path, and adds runtime/session handling needed for safer interruption behavior. It also refreshes the ReMeLight memory documentation so the docs match the current implementation instead of the earlier high-level design.

## Themed Change Summary

### 1. Dependency Upgrades

- Bumps `agentscope` from `2.0.2` to `2.0.4`.
- Bumps `reme-ai` from `0.4.0.7` to `0.4.0.9`.
- Removes the stale inline note about the standalone `agentscope-runtime` package from `pyproject.toml`.

### 2. Runtime Cancel-Save Support

- Adds `Envelope.collect_partial_blocks()` so the runtime can extract in-progress streaming content before a cancellation fully tears down the run.
- Adds `Envelope.collect_tool_output()` so partial tool output accumulated before interruption can be preserved.
- Stores the active `Envelope` on the runtime hook context while a run is active.
- On `asyncio.CancelledError`, attempts a best-effort session save before emitting the cancellation envelope.
- Uses `asyncio.shield()` around `session.save_session_state()` so the save can continue even if the outer task is re-cancelled.
- Snapshots the agent via `state_dict()` into a `StateProxy` before the async save, avoiding mutation/corruption from later cleanup.
- Injects unfinished assistant text and thinking blocks into the agent context before saving, with a deduplication guard to avoid double-saving content already present in the final assistant message.
- Closes dangling tool calls by appending interrupted `ToolResultBlock`s for any `ToolCallBlock` that does not yet have a matching result.
- Preserves any partial tool output and appends an interruption reminder so reloaded sessions have a valid tool-call/result structure.

### 3. ReMeLight Memory Configuration

- Adds `mem_session_dir` to QwenPaw's ReMeLight config and passes it into the embedded ReMe application config.
- Clarifies that `session_dir` stores source conversation logs used by auto-memory.
- Introduces `mem_agent` as the default ReMe internal memory-agent session directory.
- Updates embedded ReMe embedding config to pass `dimensions` as a top-level `as_embedding` field, matching the ReMe 0.4.0.8 component API.
- Keeps vector search enablement behavior unchanged: vector indexing is enabled only when the embedding backend has the required model and credentials.

### 4. Gemini Provider Compatibility Notes

- Updates TODO comments around Gemini tool-schema sanitization to reflect that the local compatibility override is still needed until a later AgentScope version.
- Moves the removal target from `agentscope >= 2.0.3` to `agentscope >= 2.0.5`.

### 5. Configuration Documentation

- Removes obsolete memory/retrieval environment variables from the config docs.
- Documents the current ReMeLight directory fields:
  - `metadata_dir`
  - `session_dir`
  - `mem_session_dir`
  - `resource_dir`
  - `daily_dir`
  - `digest_dir`
- Updates `auto_memory_interval` documentation to the current default of `5`, with `None` or `<= 0` disabling periodic auto-memory.
- Updates `auto_memory_search_config.max_results` documentation to the current default of `2`.
- Clarifies that some runtime config values apply after saving, while embedded ReMe component settings such as directories and embedding config require restarting the agent process.
- Applies these config documentation updates in both English and Chinese docs.

### 6. Memory, Auto Dream, Proactive, and Search Documentation

- Rewrites the memory-evolving/proactive documentation around the actual current code paths rather than the earlier conceptual flow.
- Documents the file layout used by embedded ReMe:
  - source conversation logs under `mem_session/dialog/*.jsonl`
  - internal memory-agent sessions under `mem_agent`
  - daily notes and day indexes under `memory`
  - digest memory under `digest/personal`, `digest/procedure`, and `digest/wiki`
- Explains the Auto Memory trigger path through `MemoryMiddleware`, including turn-count flushing and pre-compaction flushing.
- Documents Auto Memory output behavior, including source-log persistence, daily-note updates, day-index refresh, and inbox event behavior.
- Documents the Auto Resource background watcher and supported resource suffixes.
- Documents Auto Dream entry points (`/dream`, `dream_cron`, and `ReMeLightMemoryManager.dream()`), default job parameters, four ReMe steps, digest buckets, and traceability through wikilinks.
- Clarifies the boundary between ReMe's low-level `proactive` job and QwenPaw's current `/proactive` command.
- Documents that QwenPaw `/proactive` currently uses recent chat/session context and optional screen context instead of directly consuming `memory/<date>/interests.yaml`.
- Documents ReMe search/indexing behavior, including watched directories, raw-log search behavior, hybrid search, BM25, vector recall, RRF fusion, and wikilink expansion.
- Applies the memory/proactive documentation updates in both English and Chinese docs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactoring / compatibility

## Component(s) Affected

- [x] Core / Backend (runtime, config, providers)
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Security Considerations

- Cancel-save preserves interrupted assistant/tool state but does not introduce new external network access or new credential handling.
- The runtime now persists partial tool output on cancellation, including an explicit interruption marker, so restored context remains structurally valid.
- The proactive documentation explicitly calls out that QwenPaw proactive mode may read historical session memory and may analyze screenshots when multimodal screen analysis is available.

## Testing

- Not run as part of this PR-description update.

## Additional Notes

- The PR includes both implementation changes and substantial documentation updates because the ReMeLight docs were out of sync with the current embedded ReMe behavior.
- One known follow-up is to revisit the legacy `use_dimensions` user-facing option: ReMe 0.4.0.8 expects `dimensions` as a top-level embedding component field, while some UI/docs wording may still imply that `use_dimensions=false` skips sending dimensions.
