### PR TITLE
fix(packaging): add static project.urls for GitHub dependency graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://qwenpaw.agentscope.io/"
 Repository = "https://github.com/agentscope-ai/QwenPaw"
-Documentation = "https://qwenpaw.agentscope.io/"
+Documentation = "https://qwenpaw.agentscope.io/docs/"
 Issues = "https://github.com/agentscope-ai/QwenPaw/issues"
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ dependencies = [
     "ast-grep-cli>=0.20",
 ]
 
+[project.urls]
+Homepage = "https://qwenpaw.agentscope.io/"
+Repository = "https://github.com/agentscope-ai/QwenPaw"
+Documentation = "https://qwenpaw.agentscope.io/"
+Issues = "https://github.com/agentscope-ai/QwenPaw/issues"
+
 [tool.setuptools.dynamic]
 version = {attr = "qwenpaw.__version__.__version__"}
 


### PR DESCRIPTION
## Summary

- Add static `[project.urls]` to `pyproject.toml` so GitHub can associate the PyPI package `qwenpaw` with this repository.
- The [Dependents page](https://github.com/agentscope-ai/QwenPaw/network/dependents) is currently empty because PyPI metadata has no `Repository` URL and GitHub only indexes static manifest fields (it does not run build backends).

## Context

GitHub's dependency graph links dependents by matching package names in public `requirements.txt` / `pyproject.toml` files to a published package whose metadata points back to a GitHub repo. Without a static `Repository` URL, that link is never established—even when public repos already declare `qwenpaw` as a dependency.

Reference: [collective/icalendar#1035](https://github.com/collective/icalendar/issues/1035)

## Test plan

- [x] `tomllib` parses `pyproject.toml` successfully
- [x] `pre-commit run --file pyproject.toml` passes
- [ ] After merge, cut a new PyPI release so updated metadata is published
- [ ] Wait for GitHub reindex (may take days) and verify Dependents page updates


Made with [Cursor](https://cursor.com)