### PR TITLE
feat(tools): add show_file option to grep_search

### DIFF
--- a/src/qwenpaw/agents/tools/file_search.py
+++ b/src/qwenpaw/agents/tools/file_search.py
@@ -167,11 +167,70 @@ def _resolve_search_root(
     return search_root
 
 
+def _append_output_line(
+    matches: list[str],
+    total_chars: int,
+    line: str,
+) -> tuple[bool, int]:
+    """Append *line* to *matches* if limits allow."""
+    if len(matches) >= _MAX_MATCHES:
+        return False, total_chars
+    projected_total = total_chars + len(line) + 1
+    if projected_total > _MAX_OUTPUT_CHARS:
+        return False, total_chars
+    matches.append(line)
+    return True, projected_total
+
+
+def _format_grep_line(
+    disp_path: str,
+    ln: int,
+    content: str,
+    is_hit: bool,
+    *,
+    show_file: bool,
+) -> str:
+    prefix = ">" if is_hit else " "
+    if show_file:
+        return f"{disp_path}:{ln}:{prefix} {content}"
+    return f"{ln}:{prefix} {content}"
+
+
+def _emit_file_header_if_needed(
+    disp_path: str,
+    *,
+    show_file: bool,
+    single_file: bool,
+    headers_emitted: set[str],
+    matches: list[str],
+    total_chars: int,
+) -> tuple[bool, int]:
+    """Emit a file header when *show_file* is False and multiple files match."""
+    if show_file or single_file or disp_path in headers_emitted:
+        return True, total_chars
+
+    if headers_emitted and not (matches and matches[-1] == "---"):
+        success, total_chars = _append_output_line(matches, total_chars, "---")
+        if not success:
+            return False, total_chars
+
+    success, total_chars = _append_output_line(matches, total_chars, disp_path)
+    if not success:
+        return False, total_chars
+
+    headers_emitted.add(disp_path)
+    return True, total_chars
+
+
 def _emit_match_entries(
     entries: list[tuple[int, str, bool]],
     disp_path: str,
     matches: list[str],
     total_chars: int,
+    *,
+    show_file: bool,
+    single_file: bool,
+    headers_emitted: set[str],
 ) -> tuple[bool, int]:
     """Append a batch of context entries to matches.
 
@@ -189,16 +248,31 @@ def _emit_match_entries(
         Tuple of (success, new_total_chars). Success is True if all entries
         were appended, False if limits were reached.
     """
+    if not entries:
+        return True, total_chars
+
+    success, total_chars = _emit_file_header_if_needed(
+        disp_path,
+        show_file=show_file,
+        single_file=single_file,
+        headers_emitted=headers_emitted,
+        matches=matches,
+        total_chars=total_chars,
+    )
+    if not success:
+        return False, total_chars
+
     for ln, content, is_hit in entries:
-        if len(matches) >= _MAX_MATCHES:
+        entry = _format_grep_line(
+            disp_path,
+            ln,
+            content,
+            is_hit,
+            show_file=show_file,
+        )
+        success, total_chars = _append_output_line(matches, total_chars, entry)
+        if not success:
             return False, total_chars
-        prefix = ">" if is_hit else " "
-        entry = f"{disp_path}:{ln}:{prefix} {content}"
-        projected_total = total_chars + len(entry) + 1
-        if projected_total > _MAX_OUTPUT_CHARS:
-            return False, total_chars
-        total_chars = projected_total
-        matches.append(entry)
 
     return True, total_chars
 
@@ -210,6 +284,10 @@ def _output_context_for_hit(
     context_lines: int,
     matches: list[str],
     total_chars: int,
+    *,
+    show_file: bool,
+    single_file: bool,
+    headers_emitted: set[str],
 ) -> tuple[bool, int]:
     """Output context lines around a hit.
 
@@ -255,19 +333,18 @@ def _output_context_for_hit(
         display_path,
         matches,
         total_chars,
+        show_file=show_file,
+        single_file=single_file,
+        headers_emitted=headers_emitted,
     )
     if not success:
         return False, total_chars
 
     # Append separator if needed
     if context_lines > 0:
-        if len(matches) >= _MAX_MATCHES:
+        success, total_chars = _append_output_line(matches, total_chars, "---")
+        if not success:
             return False, total_chars
-        projected_total = total_chars + 4
-        if projected_total > _MAX_OUTPUT_CHARS:
-            return False, total_chars
-        matches.append("---")
-        total_chars = projected_total
 
     return True, total_chars
 
@@ -283,6 +360,7 @@ def _walk_and_grep(  # noqa: C901  pylint: disable=too-many-branches,too-many-lo
     context_lines: int,
     cancel: threading.Event,
     include_pattern: "str | None",
+    show_file: bool = True,
 ) -> tuple[list[str], str]:
     """Walk *search_root*, grep every text file, return ``(lines, status)``.
 
@@ -296,6 +374,7 @@ def _walk_and_grep(  # noqa: C901  pylint: disable=too-many-branches,too-many-lo
     matches: list[str] = []
     total_chars = 0
     status = "ok"
+    headers_emitted: set[str] = set()
 
     if single_file:
         file_iter: list[Path] = [search_root]
@@ -373,6 +452,9 @@ def _walk_and_grep(  # noqa: C901  pylint: disable=too-many-branches,too-many-lo
                                 context_lines,
                                 matches,
                                 total_chars,
+                                show_file=show_file,
+                                single_file=single_file,
+                                headers_emitted=headers_emitted,
                             )
                             if not success:
                                 status = (
@@ -395,6 +477,9 @@ def _walk_and_grep(  # noqa: C901  pylint: disable=too-many-branches,too-many-lo
                                 context_lines,
                                 matches,
                                 total_chars,
+                                show_file=show_file,
+                                single_file=single_file,
+                                headers_emitted=headers_emitted,
                             )
                             if not success:
                                 status = (
@@ -423,6 +508,9 @@ def _walk_and_grep(  # noqa: C901  pylint: disable=too-many-branches,too-many-lo
                         context_lines,
                         matches,
                         total_chars,
+                        show_file=show_file,
+                        single_file=single_file,
+                        headers_emitted=headers_emitted,
                     )
                     if not success:
                         status = (
@@ -489,9 +577,15 @@ async def grep_search(
     case_sensitive: bool = True,
     context_lines: int = 0,
     include_pattern: Optional[str] = None,
+    show_file: bool = True,
 ) -> ToolChunk:
     """Search file contents by pattern, recursively. Relative paths resolve
     from WORKING_DIR. Output format: ``path:line_number: content``.
+
+    When *show_file* is False, each match line omits the file path prefix
+    (``line_number:> content``).  For multi-file searches, the file path
+    is printed once before that file's matches, with ``---`` separating
+    file groups.
 
     Args:
         pattern (`str`):
@@ -508,6 +602,10 @@ async def grep_search(
         include_pattern (`str`, optional):
             Only search files whose **name** matches this glob
             (e.g. ``"*.py"``).  Defaults to None (all text files).
+        show_file (`bool`, optional):
+            Include the file path on every output line.  Defaults to True.
+            When False, multi-file results group matches by file with the
+            path shown once per file and ``---`` between file groups.
     """
     if not pattern:
         return _make_response("Error: No search `pattern` provided.")
@@ -536,6 +634,7 @@ async def grep_search(
                 context_lines,
                 cancel,
                 include_pattern,
+                show_file,
             )
         except Exception as exc:
             return [], f"error: {exc}"

--- a/tests/unit/agents/tools/test_file_search.py
+++ b/tests/unit/agents/tools/test_file_search.py
@@ -734,3 +734,89 @@ def test_walk_and_grep_first_match_exceeds_output_limit(temp_dir):
         assert len(matches) == 0
     finally:
         fs._MAX_OUTPUT_CHARS = original_limit
+
+
+def test_walk_and_grep_show_file_default_unchanged(temp_dir):
+    """Default show_file=True keeps the existing per-line path format."""
+    (temp_dir / "file.txt").write_text("line one\nline two\nline three\n")
+    regex = re.compile(r"two")
+    matches, status = _walk_and_grep(
+        temp_dir / "file.txt",
+        regex,
+        0,
+        FakeCancel(),
+        None,
+    )
+    assert status == "ok"
+    assert matches == ["file.txt:2:> line two"]
+
+
+def test_walk_and_grep_show_file_false_single_file(temp_dir):
+    """show_file=False on a single file omits path prefix and headers."""
+    (temp_dir / "file.txt").write_text("line one\nline two\nline three\n")
+    regex = re.compile(r"two")
+    matches, status = _walk_and_grep(
+        temp_dir / "file.txt",
+        regex,
+        0,
+        FakeCancel(),
+        None,
+        show_file=False,
+    )
+    assert status == "ok"
+    assert matches == ["2:> line two"]
+
+
+def test_walk_and_grep_show_file_false_multi_file(temp_dir):
+    """show_file=False groups multi-file results with one header per file."""
+    (temp_dir / "a.txt").write_text("match_a\n")
+    (temp_dir / "b.txt").write_text("match_b\n")
+    regex = re.compile(r"match_")
+    matches, status = _walk_and_grep(
+        temp_dir,
+        regex,
+        0,
+        FakeCancel(),
+        None,
+        show_file=False,
+    )
+    assert status == "ok"
+    assert matches == [
+        "a.txt",
+        "1:> match_a",
+        "---",
+        "b.txt",
+        "1:> match_b",
+    ]
+
+
+def test_walk_and_grep_show_file_false_with_context(temp_dir):
+    """show_file=False with context uses --- within and between file groups."""
+    (temp_dir / "a.txt").write_text(
+        "line zero\nline one\nline two HIT\nline three\nline four\n",
+    )
+    (temp_dir / "b.txt").write_text("aaa\nbbb HIT\nccc\n")
+    regex = re.compile(r"HIT")
+    matches, status = _walk_and_grep(
+        temp_dir,
+        regex,
+        2,
+        FakeCancel(),
+        None,
+        show_file=False,
+    )
+    assert status == "ok"
+    assert matches == [
+        "a.txt",
+        "1:  line zero",
+        "2:  line one",
+        "3:> line two HIT",
+        "4:  line three",
+        "5:  line four",
+        "---",
+        "b.txt",
+        "1:  aaa",
+        "2:> bbb HIT",
+        "3:  ccc",
+        "---",
+    ]

--- a/website/public/docs/mcp.en.md
+++ b/website/public/docs/mcp.en.md
@@ -260,6 +260,7 @@ QwenPaw provides a set of ready-to-use built-in tools that agents can directly c
   - `case_sensitive`: Case-sensitive matching (default True)
   - `context_lines`: Context lines before/after match (default 0, max 5)
   - `include_pattern`: Filter by filename, e.g. "\*.py"
+  - `show_file`: Include file path on every output line (default True). When False, multi-file results group by file with the path shown once per file and `---` between file groups
 - `glob_search`: Supports recursive patterns like `**/*.json`
 
 **Command Execution**

--- a/website/public/docs/mcp.zh.md
+++ b/website/public/docs/mcp.zh.md
@@ -280,6 +280,7 @@ QwenPaw 提供了一组开箱即用的内置工具，智能体可以直接调用
   - `case_sensitive`：是否区分大小写（默认 True）
   - `context_lines`：显示匹配行前后的上下文行数（默认 0，最大 5）
   - `include_pattern`：按文件名筛选，如 "\*.py"
+  - `show_file`：是否在每行输出文件名（默认 True）；设为 False 时多文件按文件分组，每文件仅展示一次文件名，文件组之间以 `---` 分隔
 - `glob_search`：支持递归模式如 `**/*.json`
 
 **命令执行**


### PR DESCRIPTION
---

## Summary

为 `grep_search` 新增 `show_file` 参数（默认 `True`），解决长文件名在输出中重复出现、挤占有效匹配内容的问题。

当 `show_file=False` 时：
- **单文件**：每行输出 `行号:> 内容`（对齐 `grep -h -n`）
- **多文件**：按文件顺序分组，每个文件仅在首行展示一次文件名，命中行不再重复路径；文件组之间以 `---` 分隔

**本次修改：**
- 新增 `_format_grep_line()`、`_emit_file_header_if_needed()`、`_append_output_line()`
- `_walk_and_grep` / `grep_search` 新增 `show_file` 参数并贯通格式化逻辑
- 补充单元测试与 MCP 文档

---

## Problem / Root Cause

### 现象

在路径较长的 Markdown 文档中搜索关键词时，每行输出都包含完整文件名：

```text
very/long/path/一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名.md:2784:   匹配到的文本
very/long/path/一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名.md:2784:   匹配到的文本
very/long/path/一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名.md:2784:> 匹配到的文本
very/long/path/一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名.md:2784:   匹配到的文本
very/long/path/一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名一个很长的文件名.md:2784:    匹配到的文本
```

<img width="1037" height="555" alt="image" src="https://github.com/user-attachments/assets/b206e870-2fd4-4735-a53b-7152d4c9bb0e" />


长路径在 token 预算中占比过高，Agent 难以聚焦实际匹配文本。

### 根因分析

| 维度 | 当前行为 | 问题 |
|------|---------|------|
| 输出格式 | `_emit_match_entries` 硬编码 `f"{disp_path}:{ln}:..."` | 每行重复完整路径 |
| 多文件搜索 | 同上 | 路径重复次数 = 命中行数 |
| GNU grep 对比 | `grep -h` 可省略文件名 | 工具缺少等价选项 |

---

## Fix

新增 `show_file: bool = True`（默认保持向后兼容）：

```python
# show_file=True（默认）
path/to/file.md:42:> matched line

# show_file=False，单文件
42:> matched line

# show_file=False，多文件
path/to/file_a.md
42:> matched line
---
path/to/file_b.md
10:> another match
```

实现要点：
- `_format_grep_line()` 按 `show_file` 决定是否包含路径前缀
- `_emit_file_header_if_needed()` 在多文件模式下为每个文件输出一次 header，文件组间插入 `---`（若上一行已是 `---` 则跳过，避免重复分隔）
- header 与分隔符均计入 `_MAX_MATCHES` / `_MAX_OUTPUT_CHARS`

---

## Test Plan

- [x] `test_walk_and_grep_show_file_default_unchanged` — 默认行为不变
- [x] `test_walk_and_grep_show_file_false_single_file` — 单文件省略路径
- [x] `test_walk_and_grep_show_file_false_multi_file` — 多文件分组 + 文件间 `---`
- [x] `test_walk_and_grep_show_file_false_with_context` — 带 context 时分组与分隔正确
- [x] 全量 `tests/unit/agents/tools/test_file_search.py`（37 passed）
- [x] 本地 pre-commit 通过（black / flake8 / pylint / mypy）
- [ ] 上游 CI（maintainer approve 后）

---

## Related Context
- 与 GNU `grep -h` / `-n` 行为对齐；多文件分组展示为工具层增强
