### PR TITLE
fix(agents): recover whitespace-prefixed tool-call JSON arguments

### DIFF
--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -300,7 +300,14 @@ def _repair_empty_tool_inputs(
                         try:
                             parsed = json.loads(raw_str)
                         except json.JSONDecodeError:
-                            parsed, _ = _json_decoder.raw_decode(raw_str)
+                            start = json.decoder.WHITESPACE.match(
+                                raw_str,
+                                0,
+                            ).end()
+                            parsed, _ = _json_decoder.raw_decode(
+                                raw_str,
+                                start,
+                            )
                         if isinstance(parsed, dict) and parsed:
                             # All agentscope 2.0 formatters expect
                             # ToolCallBlock.input to be a JSON string
@@ -392,7 +399,14 @@ def _coerce_tool_inputs_to_json(msgs: list) -> list:
                         # }trailing" json.loads raises "Extra data" but
                         # raw_decode can recover the leading valid object.
                         try:
-                            recovered, _ = _json_decoder.raw_decode(raw)
+                            start = json.decoder.WHITESPACE.match(
+                                raw,
+                                0,
+                            ).end()
+                            recovered, _ = _json_decoder.raw_decode(
+                                raw,
+                                start,
+                            )
                             if not isinstance(recovered, dict):
                                 raise json.JSONDecodeError(
                                     "recovered value is not a JSON object",

--- a/tests/unit/agents/utils/test_tool_message_utils.py
+++ b/tests/unit/agents/utils/test_tool_message_utils.py
@@ -338,6 +338,25 @@ class TestRepairEmptyToolInputs:
         result = _repair_empty_tool_inputs([msg])
         assert json.loads(result[0].content[0]["input"]) == {"key": "value"}
 
+    def test_recovers_raw_input_with_leading_whitespace_and_trailing_garbage(
+        self,
+    ):
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "t",
+                    "input": {},
+                    "raw_input": '\n  {"path": "README.md"}trailing garbage',
+                },
+            ],
+        )
+        result = _repair_empty_tool_inputs([msg])
+        assert json.loads(result[0].content[0]["input"]) == {
+            "path": "README.md",
+        }
+
     def test_non_dict_raw_decode_does_not_repair(self):
         """raw_decode recovering a non-dict should not overwrite input."""
         msg = _msg(
@@ -411,6 +430,25 @@ class TestCoerceToolInputsRawDecode:
         result = _coerce_tool_inputs_to_json([msg])
         assert len(result[0].content) == 1
         assert json.loads(result[0].content[0]["input"]) == {"key": "val"}
+
+    def test_object_with_leading_whitespace_and_trailing_garbage_recovered(
+        self,
+    ):
+        msg = _msg(
+            [
+                {
+                    "type": "tool_use",
+                    "id": "id1",
+                    "name": "t",
+                    "input": '\n  {"path": "README.md"}extra',
+                },
+            ],
+        )
+        result = _coerce_tool_inputs_to_json([msg])
+        assert len(result[0].content) == 1
+        assert json.loads(result[0].content[0]["input"]) == {
+            "path": "README.md",
+        }
 
     def test_completely_invalid_json_drops_block(self):
         msg = _msg(


### PR DESCRIPTION
## Description

Recover tool-call JSON arguments when stored `input` or `raw_input` starts with JSON whitespace and then contains a valid JSON object followed by trailing garbage.

### What Problem This Solves

`tool_message_utils` already has two fallback paths for malformed-but-recoverable tool-call arguments:

- `_repair_empty_tool_inputs()` repairs an empty `input` field from `raw_input`
- `_coerce_tool_inputs_to_json()` recovers a leading JSON object before dropping malformed trailing bytes

Both paths first try strict `json.loads()`. That is the right first step for clean JSON, but it rejects inputs with extra trailing bytes. When that happens, the code falls back to `JSONDecoder.raw_decode(...)` so it can recover the first valid JSON object.

The missing edge case is leading JSON whitespace. `json.loads()` accepts leading whitespace, but `raw_decode(...)` starts parsing at the index it is given. Before this PR, both fallback paths passed index `0`, so an otherwise recoverable payload like this was not recovered:

```text
\n  {"path": "README.md"}trailing garbage
```

In practice, that means a recoverable tool-call argument can be left empty or dropped before the next provider request. For users, the visible effect is a tool call that should still have arguments, but is normalized as if the arguments were missing or unrecoverable.

### Why This Change Was Made

This mirrors the JSON recovery boundary that was accepted in #5766 for `safe_json_loads`: strict parsing is tried first, then the fallback starts from the first JSON whitespace-adjusted document index before recovering the leading object.

The fix belongs in `qwenpaw.agents.utils.tool_message_utils` because this module owns the tool-call repair/coercion step before messages are submitted to model providers. Keeping the repair here makes historical sessions, streamed tool-call artifacts, and provider request normalization follow the same recovery rule.

### Narrow Change

The implementation intentionally stays small and conservative:

- it only changes the `raw_decode` start index in the two existing recovery paths
- it does not accept arbitrary leading non-whitespace garbage
- it does not convert recovered scalar/list values into tool arguments
- unrecoverable malformed payloads are still dropped or left unchanged according to the existing path
- normal JSON strings continue through the existing `json.loads()` path

### Evidence

The regression tests cover both affected fallback paths:

```text
_repair_empty_tool_inputs:
raw_input='\n  {"path": "README.md"}trailing garbage'
```

```text
_coerce_tool_inputs_to_json:
input='\n  {"path": "README.md"}extra'
```

After this change, both paths recover the leading object as:

```python
{"path": "README.md"}
```

Existing tests still cover the unchanged behavior for ordinary trailing-garbage recovery, completely invalid JSON, and non-dict recovered values.

### Possible Call Chain / Impact

```text
historical session or streamed tool-call artifact
  -> normalize_messages_for_model_request(...)
  -> _sanitize_tool_messages(...)
  -> _repair_empty_tool_inputs(...) / _coerce_tool_inputs_to_json(...)
  -> json.loads(...) fails on trailing garbage
  -> raw_decode fallback previously starts at index 0
  -> leading whitespace causes recovery to fail
  -> tool arguments remain empty or the tool-call block is dropped
```

This PR only changes the fallback start index for JSON whitespace. It does not broaden recovery to arbitrary leading garbage, scalar/list payloads, or otherwise unrecoverable malformed tool-call inputs.

**Related Issue:** Relates to #5766

**Security Considerations:** No new tool execution surface or permission behavior. This only normalizes already-recorded tool-call argument strings before provider submission; unrecoverable or non-object payloads continue to be rejected/dropped.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The new regression tests cover both recovery paths:

- `_repair_empty_tool_inputs` recovers `raw_input='\n  {"path": "README.md"}trailing garbage'`
- `_coerce_tool_inputs_to_json` recovers `input='\n  {"path": "README.md"}extra'`

Existing tests continue to cover the unchanged behavior for normal trailing-garbage recovery, completely invalid JSON, and non-dict recovered values.

## Local Verification Evidence

```bash
D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-qwenpaw-py3.11 pytest tests/unit/agents/utils/test_tool_message_utils.py tests/unit/agents/test_message_request_normalizer.py -q
# 72 passed

git diff --check
# passed

D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-qwenpaw-py3.11 pre-commit run --files src/qwenpaw/agents/utils/tool_message_utils.py tests/unit/agents/utils/test_tool_message_utils.py
# passed
```

`pre-commit run --all-files` has not been run locally for this PR.

Channel-specific checklist items are not applicable because this PR does not change any channel implementation or contract surface.

## Additional Notes

Possible call chain / impact:

```text
historical session or streamed tool-call artifact
  -> normalize_messages_for_model_request(...)
  -> _sanitize_tool_messages(...)
  -> _repair_empty_tool_inputs(...) / _coerce_tool_inputs_to_json(...)
  -> json.loads(...) fails on trailing garbage
  -> raw_decode fallback previously starts at index 0
  -> leading whitespace causes recovery to fail
  -> tool arguments remain empty or the tool-call block is dropped
```

This PR only changes the fallback start index for JSON whitespace. It does not broaden recovery to arbitrary leading garbage, scalar/list payloads, or otherwise unrecoverable malformed tool-call inputs.
