### PR TITLE
fix(scroll): label un-headlined evicted spans in the eviction index

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -463,6 +463,16 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 # Already gated: the adapter only supplies an offloader when
                 # ``offload_dialog`` is on, so this archives iff configured.
                 offloader=self._offloader,
+                summarize_unheadlined=getattr(
+                    sc,
+                    "summarize_unheadlined_evictions",
+                    True,
+                ),
+                summarize_timeout_s=getattr(
+                    sc,
+                    "summarize_eviction_timeout_seconds",
+                    20,
+                ),
             )
         except Exception:
             logger.exception("Failed to build scroll manager for /compact")

--- a/src/qwenpaw/agents/context/__init__.py
+++ b/src/qwenpaw/agents/context/__init__.py
@@ -203,6 +203,16 @@ def build_scroll_components(
             offloader=(
                 offloader if getattr(sc, "offload_dialog", False) else None
             ),
+            summarize_unheadlined=getattr(
+                sc,
+                "summarize_unheadlined_evictions",
+                True,
+            ),
+            summarize_timeout_s=getattr(
+                sc,
+                "summarize_eviction_timeout_seconds",
+                20,
+            ),
         )
         cap = ToolResultCapMiddleware(
             history=history,

--- a/src/qwenpaw/agents/context/scroll/eviction_index.py
+++ b/src/qwenpaw/agents/context/scroll/eviction_index.py
@@ -125,19 +125,28 @@ class EvictionIndex:
         *,
         seq_lo: int,
         seq_hi: int,
+        fallback_lines: list[Line] | None = None,
     ) -> None:
         """Drop one eviction onto Tier 0 as a new block, then run the carry.
 
         ``leaves`` are the evicted milestone turns; ``seq_lo``/``seq_hi`` is
         the *full* evicted span (tool results and unheadlined turns
         included) so a range query recovers everything.
+
+        ``fallback_lines`` stands in for a span that produced no ``leaves`` (a
+        legacy 1.x span, or a tool-heavy stretch the model never headlined):
+        generated ``Line`` entries — each a seq sub-range with a synthesized
+        headline — that tile the span the way real milestones would. Empty or
+        ``None`` keeps the bare ``(no milestone)`` marker. The full turns stay
+        recoverable by the block's seq span either way.
         """
         lines = [
             Line(lf.seq, lf.seq, lf.headline, lf.headline) for lf in leaves
         ]
         if not lines:
-            # An eviction with no headlined turns is still addressable by span.
-            lines = [Line(seq_lo, seq_hi, "(no milestone)", "(no milestone)")]
+            lines = fallback_lines or [
+                Line(seq_lo, seq_hi, "(no milestone)", "(no milestone)"),
+            ]
         if not self._tiers:
             self._tiers.append([])
         self._tiers[0].append(Block(seq_lo, seq_hi, lines))

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import sqlite3
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -30,7 +32,7 @@ from ....constant import (
     SYNTHETIC_USER_MESSAGE_TAGS,
 )
 from . import _as_internals as as_internals
-from .eviction_index import EvictionIndex, Leaf
+from .eviction_index import EvictionIndex, Leaf, Line
 from .history import HistoryStore
 from .serialize import msg_to_entries
 
@@ -40,6 +42,114 @@ logger = logging.getLogger(__name__)
 # Doubles as the idempotence marker: an output starting with it is already a
 # stub and is never folded (or counted as reclaimable) again.
 _FOLD_MARK = "[scroll folded]"
+
+# Labelling an evicted span with no model headline: split it into numbered
+# sections (each a real seq sub-range the harness owns) and have one model call
+# write one headline per section. The model never emits a seq, so it can't
+# mis-address one.
+_INDEX_PROMPT = (
+    "You are indexing a stretch of conversation that scrolled out of a live "
+    "context window, so a future reader can find things in it again. It is "
+    "already split into numbered sections below.\n\n"
+    "For EACH numbered section write exactly ONE headline: at most ~15 words, "
+    "in the same language as the conversation, naming the single most "
+    "important fact, decision, result, or request in it. Output one per line "
+    "as `<n>: <headline>` where <n> is the section number. Cover every "
+    "section; no quotes, no extra prose, no blank lines."
+)
+_SUMMARY_INPUT_CHARS = 6000  # cap on the text sent to the model
+_SUMMARY_LINE_CHARS = 200  # mirrors serialize._HEADLINE_MAX
+_SUMMARY_MAX_LINES = 6  # ceiling on sections per span
+
+# One reply line: ``2: headline`` / ``[2] headline`` / ``2. headline``.
+_HEADLINE_LINE_RE = re.compile(r"^\[?\s*(\d+)\s*\]?\s*[:.：、)]?\s*(.+)$")
+
+
+@dataclass
+class _Section:
+    """A section of an evicted span: a real seq sub-range, the ``text`` shown
+    to the model, and an extractive ``fallback`` if the model skips it."""
+
+    seq_lo: int
+    seq_hi: int
+    text: str
+    fallback: str
+
+
+def _clean_headline(text: str) -> str:
+    """One index-safe line: first line, with quotes/``⟦⟧``/trailing
+    punctuation stripped."""
+    line = (text or "").strip().splitlines()[0] if text.strip() else ""
+    line = line.strip().strip("\"'`“”‘’")
+    line = line.replace("⟦", "").replace("⟧", "")
+    while line and line[-1] in ".,;:!?":
+        line = line[:-1].rstrip()
+    return line[:_SUMMARY_LINE_CHARS]
+
+
+def _headlines_by_section(raw: str, count: int) -> dict[int, str]:
+    """Map ``<n>: headline`` reply lines to section ``n`` (1-based). Bare lines
+    (no ``<n>:``) fill the next free section in order."""
+    out: dict[int, str] = {}
+    nxt = 1
+    for raw_line in (raw or "").splitlines():
+        stripped = raw_line.strip().lstrip("-*•").strip()
+        if not stripped:
+            continue
+        m = _HEADLINE_LINE_RE.match(stripped)
+        head = _clean_headline(m.group(2) if m else stripped)
+        n = int(m.group(1)) if m else 0
+        if not 1 <= n <= count:  # missing/out-of-range → next free section
+            while nxt <= count and nxt in out:
+                nxt += 1
+            n = nxt
+        if head and 1 <= n <= count:
+            out.setdefault(n, head)
+    return out
+
+
+def _safe_attr(obj: Any, name: str) -> Any:
+    """``getattr`` that returns ``None`` instead of raising for
+    ``ChatResponse`` (a dict whose ``__getattr__`` is ``dict.__getitem__``)."""
+    if isinstance(obj, dict):
+        return obj.get(name)
+    try:
+        return getattr(obj, name, None)
+    except (AttributeError, KeyError, TypeError):
+        return None
+
+
+def _response_text(obj: Any) -> str:
+    """Best-effort text from a ``ChatResponse``-like object or stream chunk."""
+    if obj is None or isinstance(obj, str):
+        return obj or ""
+    text = _safe_attr(obj, "text")
+    if isinstance(text, str) and text:
+        return text
+    content = _safe_attr(obj, "content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        for item in content:
+            got = (
+                item.get("text")
+                if isinstance(item, dict)
+                else _safe_attr(item, "text")
+            )
+            if isinstance(got, str) and got:
+                return got
+    return ""
+
+
+async def _consume_model_response(model: Any, messages: list) -> str:
+    """Await ``model(messages)`` and return its text, streaming or not."""
+    response = await model(messages)
+    if not hasattr(response, "__aiter__"):
+        return _response_text(response)
+    text = ""
+    async for chunk in response:
+        text = _response_text(chunk) or text
+    return text
 
 
 class ScrollContextManager:
@@ -59,10 +169,16 @@ class ScrollContextManager:
         agent_id: str | None = None,
         capped_results: dict[str, int] | None = None,
         offloader: Any = None,
+        summarize_unheadlined: bool = False,
+        summarize_timeout_s: int = 20,
     ) -> None:
         self._history = history
         self._session_id = session_id
         self._agent_id = agent_id
+        # Label an un-headlined evicted span with generated headlines instead
+        # of ``(no milestone)``. Off unless the wiring passes the config value.
+        self._summarize_unheadlined = summarize_unheadlined
+        self._summarize_timeout_s = summarize_timeout_s
         # Dialog archive: when an offloader is wired (``offload_dialog``, on by
         # default), evicted turns are also written to ``dialog/{date}.jsonl``
         # for external consumers. ``history.db`` remains the source of truth.
@@ -266,7 +382,7 @@ class ScrollContextManager:
 
             # 4) Fold the evicted middle into the index as a new Tier 0
             #    block.
-            self._index_evicted(middle)
+            await self._index_evicted(agent, middle)
             self._rebuild_context(agent, tail)
             self.last_compress["evicted"] = len(middle)
             tokens = await self._live_tokens(agent)
@@ -558,12 +674,12 @@ class ScrollContextManager:
         self._synthetic_ids.add(placeholder.id)
         agent.state.context = [placeholder] + tail
 
-    def _index_evicted(self, middle: list[Msg]) -> None:
+    async def _index_evicted(self, agent: Any, middle: list[Msg]) -> None:
         """Append the evicted middle to the index as one fresh Tier 0 block.
 
-        The block spans every evicted ``seq`` (so a range query recovers the
-        full turns, tool results included); its leaves are the model turns
-        that carry a headline.
+        The block spans every evicted ``seq``; its leaves are the model turns
+        that carry a headline. A span with no headlined turn is labelled by
+        generated headlines when enabled, else the bare ``(no milestone)``.
         """
         leaves: list[Leaf] = []
         lo: int | None = None
@@ -579,11 +695,136 @@ class ScrollContextManager:
                 leaves.append(leaf)
         if lo is None or hi is None:  # no known seq (shouldn't happen)
             return
+        fallback_lines = None
+        if not leaves and self._summarize_unheadlined:
+            fallback_lines = await self._summarize_span(
+                agent,
+                middle,
+                span_lo=lo,
+                span_hi=hi,
+            )
         self._index.add_eviction(
             leaves,
             seq_lo=lo,
             seq_hi=hi,
+            fallback_lines=fallback_lines,
         )
+
+    async def _summarize_span(
+        self,
+        agent: Any,
+        middle: list[Msg],
+        *,
+        span_lo: int,
+        span_hi: int,
+    ) -> list[Line] | None:
+        """Index an un-headlined span into ``Line`` entries, or ``None``.
+
+        One model call labels the harness-owned sections. Best-effort: a
+        missing/uncallable model, timeout, or any error yields ``None`` and the
+        caller keeps ``(no milestone)`` — the turns stay durable and recallable
+        regardless.
+        """
+        model = getattr(agent, "model", None)
+        if not callable(model):
+            return None
+        sections = self._segment_span(middle, span_lo=span_lo, span_hi=span_hi)
+        if not sections:
+            return None
+        body = "\n\n".join(
+            f"[{i}]\n{s.text}" for i, s in enumerate(sections, start=1)
+        )[:_SUMMARY_INPUT_CHARS]
+        messages = [
+            Msg(
+                name="system",
+                role="system",
+                content=[TextBlock(type="text", text=_INDEX_PROMPT)],
+            ),
+            Msg(
+                name="user",
+                role="user",
+                content=[TextBlock(type="text", text=body)],
+            ),
+        ]
+        try:
+            raw = await asyncio.wait_for(
+                _consume_model_response(model, messages),
+                timeout=self._summarize_timeout_s,
+            )
+        except Exception:  # noqa: BLE001 - cosmetic label, never break evict
+            # ``CancelledError`` is a BaseException, so it still propagates.
+            logger.warning(
+                "scroll: un-headlined span index failed; "
+                "labelling it (no milestone)",
+                exc_info=True,
+            )
+            return None
+        # Attach each headline to its section's real seq range; a skipped
+        # section keeps its extractive fallback.
+        heads = _headlines_by_section(raw or "", len(sections))
+        return [
+            Line(s.seq_lo, s.seq_hi, head, head)
+            for i, s in enumerate(sections, start=1)
+            for head in [heads.get(i) or s.fallback]
+            if head
+        ]
+
+    def _segment_span(
+        self,
+        middle: list[Msg],
+        *,
+        span_lo: int,
+        span_hi: int,
+    ) -> list[_Section]:
+        """Split an evicted span into sections at ``user``-turn boundaries (one
+        exchange each), so every section's seq range comes from the persisted
+        turns, not the model. Exchanges beyond ``_SUMMARY_MAX_LINES`` are
+        merged into that many contiguous groups.
+        """
+        groups: list[list[Msg]] = []
+        for m in middle:
+            if not (m.get_text_content() or "").strip():
+                continue
+            role = getattr(m, "role", "") or getattr(m, "name", "")
+            if role == "user" or not groups:
+                groups.append([m])
+            else:
+                groups[-1].append(m)
+        if not groups:
+            return []
+        if (
+            len(groups) > _SUMMARY_MAX_LINES
+        ):  # fold to <= MAX contiguous groups
+            per = -(-len(groups) // _SUMMARY_MAX_LINES)  # ceil
+            groups = [
+                [m for g in groups[i : i + per] for m in g]
+                for i in range(0, len(groups), per)
+            ]
+        sections: list[_Section] = []
+        for group in groups:
+            lo: int | None = None
+            hi: int | None = None
+            for m in group:
+                mid = getattr(m, "id", None) or str(id(m))
+                rng = self._seq_by_id.get(mid)
+                if rng:
+                    lo = rng[0] if lo is None else min(lo, rng[0])
+                    hi = rng[1] if hi is None else max(hi, rng[1])
+            text = "\n".join(
+                f"{getattr(m, 'role', '') or getattr(m, 'name', '')}: "
+                f"{(m.get_text_content() or '').strip()}"
+                for m in group
+            )
+            first = (group[0].get_text_content() or "").strip()
+            sections.append(
+                _Section(
+                    seq_lo=lo if lo is not None else span_lo,
+                    seq_hi=hi if hi is not None else span_hi,
+                    text=text,
+                    fallback=_clean_headline(first) or "(no milestone)",
+                ),
+            )
+        return sections
 
     def describe_index(self) -> str:
         """The eviction-index tier/span map for the ``/compact`` reply (empty

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -31,6 +31,7 @@ from ....constant import (
     QWENPAW_MESSAGE_TAG_KEY,
     SYNTHETIC_USER_MESSAGE_TAGS,
 )
+from ....utils.model_response import consume_model_response
 from . import _as_internals as as_internals
 from .eviction_index import EvictionIndex, Leaf, Line
 from .history import HistoryStore
@@ -106,50 +107,6 @@ def _headlines_by_section(raw: str, count: int) -> dict[int, str]:
         if head and 1 <= n <= count:
             out.setdefault(n, head)
     return out
-
-
-def _safe_attr(obj: Any, name: str) -> Any:
-    """``getattr`` that returns ``None`` instead of raising for
-    ``ChatResponse`` (a dict whose ``__getattr__`` is ``dict.__getitem__``)."""
-    if isinstance(obj, dict):
-        return obj.get(name)
-    try:
-        return getattr(obj, name, None)
-    except (AttributeError, KeyError, TypeError):
-        return None
-
-
-def _response_text(obj: Any) -> str:
-    """Best-effort text from a ``ChatResponse``-like object or stream chunk."""
-    if obj is None or isinstance(obj, str):
-        return obj or ""
-    text = _safe_attr(obj, "text")
-    if isinstance(text, str) and text:
-        return text
-    content = _safe_attr(obj, "content")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        for item in content:
-            got = (
-                item.get("text")
-                if isinstance(item, dict)
-                else _safe_attr(item, "text")
-            )
-            if isinstance(got, str) and got:
-                return got
-    return ""
-
-
-async def _consume_model_response(model: Any, messages: list) -> str:
-    """Await ``model(messages)`` and return its text, streaming or not."""
-    response = await model(messages)
-    if not hasattr(response, "__aiter__"):
-        return _response_text(response)
-    text = ""
-    async for chunk in response:
-        text = _response_text(chunk) or text
-    return text
 
 
 class ScrollContextManager:
@@ -748,7 +705,7 @@ class ScrollContextManager:
         ]
         try:
             raw = await asyncio.wait_for(
-                _consume_model_response(model, messages),
+                consume_model_response(model, messages),
                 timeout=self._summarize_timeout_s,
             )
         except Exception:  # noqa: BLE001 - cosmetic label, never break evict

--- a/src/qwenpaw/app/chats/title_generator.py
+++ b/src/qwenpaw/app/chats/title_generator.py
@@ -18,9 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from qwenpaw.exceptions import AppBaseException
+from qwenpaw.utils.model_response import consume_model_response
 
 from .models import ChatUpdate
 
@@ -39,82 +40,6 @@ TITLE_PROMPT = (
 
 MAX_INPUT_CHARS = 500
 MAX_TITLE_CHARS = 60
-
-
-def _safe_attr(obj: Any, name: str) -> Any:
-    """``getattr(obj, name, None)`` that also returns ``None`` for
-    dict-like objects whose ``__getattr__`` raises ``KeyError`` for
-    missing keys.
-
-    ``agentscope.model.ChatResponse`` extends ``dict`` with
-    ``__getattr__ = dict.__getitem__``, so ``getattr(response, "text",
-    None)`` raises ``KeyError`` instead of returning ``None`` —
-    Python's ``getattr`` default only swallows ``AttributeError``.
-    Use ``dict.get`` for dict instances and a try/except for everything
-    else.
-    """
-    if isinstance(obj, dict):
-        return obj.get(name)
-    try:
-        return getattr(obj, name, None)
-    except (AttributeError, KeyError, TypeError):
-        return None
-
-
-def _first_text_in_list(items: list) -> str:
-    """Return the first text fragment from a list-of-blocks ``content``."""
-    for item in items:
-        if isinstance(item, dict) and isinstance(item.get("text"), str):
-            return item["text"]
-        inner = _safe_attr(item, "text")
-        if isinstance(inner, str):
-            return inner
-    return ""
-
-
-def _extract_text_from_response(response: Any) -> str:
-    """Pull text out of a ``ChatResponse``-like object or stream chunk.
-
-    Same shape as ``skills_stream._extract_text_from_response`` plus a
-    fallback for the list-of-text-blocks shape returned by some providers.
-    Streaming chunks (consumed by :func:`_consume_model_response`) carry
-    the same ``.content`` shape, so this function handles both.
-    """
-    if response is None:
-        return ""
-    if isinstance(response, str):
-        return response
-    text = _safe_attr(response, "text")
-    if isinstance(text, str) and text:
-        return text
-    content = _safe_attr(response, "content")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        return _first_text_in_list(content)
-    return ""
-
-
-async def _consume_model_response(model: Any, messages: list) -> str:
-    """Await ``model(messages)`` and return its text content.
-
-    Some providers (e.g. ``dashscope/qwen3-max``) return an
-    ``async_generator`` that streams response chunks; others return a
-    non-streaming ``ChatResponse``-like object. This helper handles both,
-    mirroring the streaming/non-streaming branch in
-    ``app/routers/skills_stream.py``. Streaming chunks are assumed to
-    carry the cumulative text seen so far, so the latest non-empty
-    chunk wins.
-    """
-    response = await model(messages)
-    if hasattr(response, "__aiter__"):
-        accumulated = ""
-        async for chunk in response:
-            text = _extract_text_from_response(chunk)
-            if text:
-                accumulated = text
-        return accumulated
-    return _extract_text_from_response(response)
 
 
 def _clean_title(raw: str) -> str:
@@ -199,7 +124,7 @@ async def generate_and_update_title(
         ]
 
         raw_title = await asyncio.wait_for(
-            _consume_model_response(model, messages),
+            consume_model_response(model, messages),
             timeout=timeout,
         )
         title = _clean_title(raw_title)

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -890,6 +890,31 @@ class ScrollContextConfig(BaseModel):
         ),
     )
 
+    summarize_unheadlined_evictions: bool = Field(
+        default=True,
+        description=(
+            "When an evicted span carries NO model headline, generate a "
+            "one-line summary of it (via the active model) to use as its "
+            "eviction-index entry instead of a bare ``(no milestone)`` line. "
+            "Keeps the index readable for legacy 1.x conversations (whose "
+            "turns predate headlines) and for tool-heavy spans the model "
+            "never headlined. The full turns stay recallable either way; "
+            "this only affects the descriptive label. Best-effort — a "
+            "model/timeout failure falls back to ``(no milestone)`` and never "
+            "blocks eviction. Costs one extra model call per such eviction."
+        ),
+    )
+
+    summarize_eviction_timeout_seconds: int = Field(
+        default=20,
+        ge=1,
+        description=(
+            "Per-eviction timeout for the un-headlined-span summary call "
+            "above. On timeout the span keeps a ``(no milestone)`` label; "
+            "eviction itself is never delayed beyond this."
+        ),
+    )
+
 
 class LightContextConfig(BaseModel):
     """Light context manager configuration."""

--- a/src/qwenpaw/governance/generalize.py
+++ b/src/qwenpaw/governance/generalize.py
@@ -19,8 +19,15 @@ import logging
 from fnmatch import fnmatch
 from typing import Any, Optional
 
+from ..utils.model_response import (
+    consume_model_response,
+    extract_response_text,
+)
 from .tool_registry import DEFAULT_REGISTRY
 from .policy import _parse_match
+
+# Historical private name kept for existing callers/tests.
+_extract_response_text = extract_response_text
 
 logger = logging.getLogger(__name__)
 
@@ -161,46 +168,6 @@ def _is_safe_generalization(
     return True
 
 
-def _extract_response_text(response: Any) -> str:
-    """Pull text out of a ``ChatResponse``-like object or stream chunk.
-
-    ``agentscope.model.ChatResponse`` extends ``dict`` with
-    ``__getattr__ = dict.__getitem__``, so ``getattr(response, "text",
-    None)`` raises ``KeyError`` instead of returning ``None``; we use
-    ``dict.get`` for dicts and a try/except otherwise. Mirrors the
-    extraction in ``app/chats/title_generator.py``.
-    """
-    if response is None:
-        return ""
-    if isinstance(response, str):
-        return response
-
-    def _safe_attr(obj: Any, name: str) -> Any:
-        if isinstance(obj, dict):
-            return obj.get(name)
-        try:
-            return getattr(obj, name, None)
-        except (AttributeError, KeyError, TypeError):
-            return None
-
-    text = _safe_attr(response, "text")
-    if isinstance(text, str) and text:
-        return text
-    content = _safe_attr(response, "content")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        for item in content:
-            text_item = (
-                item.get("text")
-                if isinstance(item, dict)
-                else _safe_attr(item, "text")
-            )
-            if isinstance(text_item, str):
-                return text_item
-    return ""
-
-
 def _build_model(agent_id: Optional[str]) -> Any:
     """Build a fresh chat-model instance for *agent_id*.
 
@@ -237,15 +204,7 @@ async def _consume_model_text(
     family, where setting ``parameters.thinking_enable`` on the instance is
     masked or ignored.
     """
-    response = await model(messages, **call_kwargs)
-    if hasattr(response, "__aiter__"):
-        accumulated = ""
-        async for chunk in response:
-            text = _extract_response_text(chunk)
-            if text:
-                accumulated = text
-        return accumulated
-    return _extract_response_text(response)
+    return await consume_model_response(model, messages, **call_kwargs)
 
 
 def _extract_pattern(raw: str) -> str:

--- a/src/qwenpaw/utils/model_response.py
+++ b/src/qwenpaw/utils/model_response.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Read text out of a chat-model response, defensively.
+
+``agentscope.model.ChatResponse`` extends ``dict`` with
+``__getattr__ = dict.__getitem__``, so ``getattr(resp, "text", None)`` raises
+``KeyError`` instead of defaulting — and providers differ over whether a reply
+is a single response or a stream of chunks. Every call site that reads a model
+reply needs the same handling, so it lives here once.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def safe_attr(obj: Any, name: str) -> Any:
+    """``getattr(obj, name, None)`` that also returns ``None`` for dict-like
+    objects whose ``__getattr__`` raises ``KeyError`` (e.g. ``ChatResponse``,
+    whose ``__getattr__`` is ``dict.__getitem__``)."""
+    if isinstance(obj, dict):
+        return obj.get(name)
+    try:
+        return getattr(obj, name, None)
+    except (AttributeError, KeyError, TypeError):
+        return None
+
+
+def _first_text_in_list(items: list) -> str:
+    """First text fragment from a list-of-blocks ``content``."""
+    for item in items:
+        got = (
+            item.get("text")
+            if isinstance(item, dict)
+            else safe_attr(item, "text")
+        )
+        if isinstance(got, str):
+            return got
+    return ""
+
+
+def extract_response_text(response: Any) -> str:
+    """Pull text out of a ``ChatResponse``-like object or a stream chunk.
+
+    Handles the ``.text`` scalar, a ``.content`` string, and the
+    list-of-text-blocks shape some providers return.
+    """
+    if response is None:
+        return ""
+    if isinstance(response, str):
+        return response
+    text = safe_attr(response, "text")
+    if isinstance(text, str) and text:
+        return text
+    content = safe_attr(response, "content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return _first_text_in_list(content)
+    return ""
+
+
+async def consume_model_response(
+    model: Any,
+    messages: list,
+    **call_kwargs: Any,
+) -> str:
+    """Await ``model(messages, **call_kwargs)`` and return its text, streaming
+    or not.
+
+    Some providers stream (an ``async_generator`` whose chunks carry the
+    cumulative text — the last non-empty wins); others return one response.
+    """
+    response = await model(messages, **call_kwargs)
+    if not hasattr(response, "__aiter__"):
+        return extract_response_text(response)
+    text = ""
+    async for chunk in response:
+        text = extract_response_text(chunk) or text
+    return text

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -8,6 +8,7 @@ degraded-durability fail-safe (no eviction when a write fails), and retention.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from agentscope.message import (
@@ -606,6 +607,201 @@ async def test_empty_middle_still_compacts_index_under_pressure(
     )
     # The active turn is still live, after the placeholder.
     assert agent.state.context[-1].id == ctx[-1].id
+
+
+# -- generated headlines for un-headlined evicted spans ---------------------
+
+
+class _CallableModel(FakeModel):
+    """A ``FakeModel`` that is also callable as a chat model.
+
+    ``reply`` is the text an index call returns (``<n>: headline`` section
+    lines by convention); set it to an ``Exception`` instance to have the call
+    raise (to exercise the fallback). ``call_count`` records how many times it
+    was invoked as a chat model — so a test can assert the index path was (or
+    was not) taken. ``last_body`` captures the user message (the numbered
+    sections the harness assembled) of the last call."""
+
+    def __init__(self, tokens, reply="1: a legacy 1.x decision", **kw):
+        super().__init__(tokens, **kw)
+        self._reply = reply
+        self.call_count = 0
+        self.last_body = ""
+
+    async def __call__(self, messages, *args, **kwargs):
+        self.call_count += 1
+        self.last_body = messages[-1].get_text_content()
+        if isinstance(self._reply, Exception):
+            raise self._reply
+        return SimpleNamespace(text=self._reply)
+
+
+def _agent_with_callable_model(
+    ctx,
+    reply="1: a legacy 1.x decision",
+    tokens=200,
+):
+    agent = FakeAgent(ctx, tokens=tokens)
+    agent.model = _CallableModel(tokens, reply=reply)
+    return agent
+
+
+def _index_headline_lines(mgr) -> list[str]:
+    """The ``·`` headline lines of the eviction-index map (text after ⟦)."""
+    return [ln for ln in mgr._index.describe().splitlines() if "·" in ln]
+
+
+async def test_unheadlined_span_gets_generated_summary(store: HistoryStore):
+    """An evicted span with no headline is labelled by the model's synthesized
+    headline instead of the bare ``(no milestone)`` marker."""
+    ctx = [
+        user("what was the old plan"),
+        assistant("we shipped v1 without milestones"),  # NO headline
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=True)
+    agent = _agent_with_callable_model(
+        ctx,
+        reply="1: shipped v1 sans milestones",
+    )
+    agent._split_return = (ctx[:2], ctx[2:])
+    await mgr.compress(agent)
+    index = mgr._index.describe()
+    assert "shipped v1 sans milestones" in index
+    assert "(no milestone)" not in index
+    assert agent.model.call_count == 1
+
+
+async def test_unheadlined_span_tiled_into_multiple_headlines(
+    store: HistoryStore,
+):
+    """A longer un-headlined span is tiled into several harness-addressed
+    headlines, each its own ``·`` line — structurally like real milestones.
+    The model only writes ``<n>: headline``; the seqs are the harness's."""
+    ctx = [
+        user("q1 about billing"),
+        assistant("answered billing"),  # NO headline
+        user("q2 about shipping"),
+        assistant("answered shipping"),  # NO headline
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=True)
+    agent = _agent_with_callable_model(
+        ctx,
+        reply=(
+            "1: billing question resolved\n" "2: shipping question resolved"
+        ),
+    )
+    agent._split_return = (ctx[:4], ctx[4:])
+    await mgr.compress(agent)
+    index = mgr._index.describe()
+    assert "billing question resolved" in index
+    assert "shipping question resolved" in index
+    # Two distinct headline lines, not one coarse summary.
+    assert len(_index_headline_lines(mgr)) == 2
+    # The harness split the span into numbered sections for the model.
+    assert "[1]" in agent.model.last_body
+    assert "[2]" in agent.model.last_body
+
+
+async def test_skipped_section_keeps_extractive_fallback(store: HistoryStore):
+    """A section the model omits is still labelled — the harness fills it with
+    an extractive fallback drawn from that section's own text, never
+    ``(no milestone)`` for a section that had content."""
+    ctx = [
+        user("distinctive-billing-question"),
+        assistant("answered billing"),  # NO headline
+        user("distinctive-shipping-question"),
+        assistant("answered shipping"),  # NO headline
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=True)
+    # Model labels section 1 only; section 2 must fall back to its own content.
+    agent = _agent_with_callable_model(ctx, reply="1: billing resolved")
+    agent._split_return = (ctx[:4], ctx[4:])
+    await mgr.compress(agent)
+    index = mgr._index.describe()
+    assert "billing resolved" in index  # model's headline for section 1
+    assert "distinctive-shipping-question" in index  # fallback for section 2
+    assert len(_index_headline_lines(mgr)) == 2
+
+
+async def test_bare_reply_lines_map_positionally(store: HistoryStore):
+    """A reply without ``<n>:`` prefixes still lines up: bare headline lines
+    are assigned to sections in order."""
+    ctx = [
+        user("old thing"),
+        assistant("did old thing"),  # NO headline
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=True)
+    agent = _agent_with_callable_model(
+        ctx,
+        reply="This stretch was about the old thing",
+    )
+    agent._split_return = (ctx[:2], ctx[2:])
+    await mgr.compress(agent)
+    index = mgr._index.describe()
+    assert "This stretch was about the old thing" in index
+    assert "(no milestone)" not in index
+    assert len(_index_headline_lines(mgr)) == 1
+
+
+async def test_headlined_span_never_calls_summary_model(store: HistoryStore):
+    """A span that already has a headline uses it as the leaf — no index
+    call is made (leaves present)."""
+    ctx = [
+        user("task"),
+        assistant("step", headline="did-step"),
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=True)
+    agent = _agent_with_callable_model(ctx)
+    agent._split_return = (ctx[:2], ctx[2:])
+    await mgr.compress(agent)
+    assert "did-step" in mgr._index.describe()
+    assert agent.model.call_count == 0
+
+
+async def test_unheadlined_span_falls_back_when_summary_fails(
+    store: HistoryStore,
+):
+    """A model/timeout error must never abort eviction — the span keeps the
+    ``(no milestone)`` marker and the evicted count is unaffected."""
+    ctx = [
+        user("old thing"),
+        assistant("did old thing"),  # NO headline
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=True)
+    agent = _agent_with_callable_model(ctx, reply=RuntimeError("model down"))
+    agent._split_return = (ctx[:2], ctx[2:])
+    await mgr.compress(agent)
+    assert "(no milestone)" in mgr._index.describe()
+    assert mgr.last_compress["evicted"] == 2
+
+
+async def test_summary_disabled_keeps_no_milestone(store: HistoryStore):
+    """With the flag off the span stays ``(no milestone)`` and the model is
+    never called — the default behaviour is preserved."""
+    ctx = [
+        user("old thing"),
+        assistant("did old thing"),  # NO headline
+        user("next question"),
+        assistant("recent"),
+    ]
+    mgr = make_manager(store, summarize_unheadlined=False)
+    agent = _agent_with_callable_model(ctx)
+    agent._split_return = (ctx[:2], ctx[2:])
+    await mgr.compress(agent)
+    assert "(no milestone)" in mgr._index.describe()
+    assert agent.model.call_count == 0
 
 
 def test_seq_by_tcid_round_trips_through_checkpoint(store: HistoryStore):

--- a/tests/unit/utils/test_model_response.py
+++ b/tests/unit/utils/test_model_response.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=unused-argument
+"""Tests for the shared chat-model response helpers."""
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.utils.model_response import (
+    consume_model_response,
+    extract_response_text,
+    safe_attr,
+)
+
+
+class _DictLike(dict):
+    """agentscope ``ChatResponse`` shape: ``__getattr__`` is dict lookup, so a
+    missing key raises ``KeyError`` from ``getattr`` instead of defaulting."""
+
+    __getattr__ = dict.__getitem__
+
+
+def test_safe_attr_swallows_dict_getattr_keyerror():
+    assert safe_attr(_DictLike({"content": "x"}), "text") is None
+    assert safe_attr({"text": "hi"}, "text") == "hi"
+    assert safe_attr(SimpleNamespace(text="obj"), "text") == "obj"
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        (None, ""),
+        ("hello", "hello"),
+        ({"text": "hi"}, "hi"),
+        ({"content": "hi"}, "hi"),
+        ({"content": [{"type": "text", "text": "chunk"}]}, "chunk"),
+        ({}, ""),
+        (SimpleNamespace(text="obj-text"), "obj-text"),
+        (_DictLike({"content": "fallback"}), "fallback"),
+    ],
+    ids=[
+        "none",
+        "str",
+        "dict-text",
+        "dict-content-str",
+        "dict-content-list",
+        "dict-empty",
+        "obj-text-attr",
+        "chatresponse-getattr-keyerror",
+    ],
+)
+def test_extract_response_text(response, expected):
+    assert extract_response_text(response) == expected
+
+
+async def test_consume_non_streaming():
+    async def model(messages, **kw):
+        return SimpleNamespace(text="done")
+
+    assert await consume_model_response(model, []) == "done"
+
+
+async def test_consume_streaming_takes_last_non_empty_chunk():
+    async def model(messages, **kw):
+        async def gen():
+            for t in ("par", "partial", ""):
+                yield SimpleNamespace(text=t)
+
+        return gen()
+
+    assert await consume_model_response(model, []) == "partial"
+
+
+async def test_consume_forwards_call_kwargs():
+    seen = {}
+
+    async def model(messages, **kw):
+        seen.update(kw)
+        return SimpleNamespace(text="ok")
+
+    await consume_model_response(model, [], disable_thinking=True)
+    assert seen == {"disable_thinking": True}


### PR DESCRIPTION
## Summary

Legacy QwenPaw 1.x  session history — and any tool-heavy stretch the model never
headlined — carry no `⟦ … ⟧` milestones. When those turns were evicted under
scroll compaction, the eviction index recorded a single bare line:

```
[seq 1–8]
  · seq 1–8  ⟦ (no milestone) ⟧
```

That is uninformative both for the user's `/compact` output and for the
model's own in-context recall map. This PR labels such spans with generated
headlines instead, while keeping seq addressing entirely under harness
control.

## Problem

The scroll eviction index is built from headlines the model emits at the end
of a turn. Spans with **no** headline (all of a pre-headline 1.x session, or a
run of un-annotated tool turns) collapse to `(no milestone)`. The turns stay
durable and recallable by seq/keyword, but the map gives the model nothing to
navigate by — it can only blind-search.

## Approach

When an evicted span has **no headline leaves**, the manager now generates the
labels with **one** model call — but the model never touches seq numbers:

1. **Harness segments the span.** It splits the evicted turns into numbered
   sections at **user-turn boundaries** (each user request + the turns
   answering it = one exchange, a natural topic unit). Every section's
   `seq_lo`/`seq_hi` comes straight from the persisted turns. Too many
   exchanges are folded into at most `_SUMMARY_MAX_LINES` contiguous groups.
2. **Model writes only headlines.** The prompt shows the numbered sections and
   asks for one `<n>: <headline>` line each. The model cannot emit — and so
   cannot mis-address — a seq; it only labels sections the harness assembled.
3. **Harness re-attaches seqs.** Each headline is mapped back to its section's
   real seq sub-range, producing index lines structurally identical to a span
   of real milestones.

**Before → after** (real `qwen3-max` run over a simulated 1.x conversation):

```
- · seq 1–8  ⟦ (no milestone) ⟧
+ · seq 1–2  ⟦ 北京明天多云转晴，最高26℃最低18℃ ⟧
+ · seq 3–4  ⟦ 订后天早班北京南至上海虹桥G1次高铁二等座 ⟧
+ · seq 5–6  ⟦ 信用卡多扣32.7元系三笔境外订阅汇率四舍五入汇差 ⟧
+ · seq 7–8  ⟦ 建议改用免货币转换费信用卡并开启实时交易提醒 ⟧
```

