### PR TITLE
fix(driver): honor off approval level for driver policy

### DIFF
--- a/src/qwenpaw/drivers/handler.py
+++ b/src/qwenpaw/drivers/handler.py
@@ -39,6 +39,39 @@ from .time import current_policy_time
 logger = logging.getLogger(__name__)
 
 
+def _approval_level_disables_approval(
+    request_context: dict[str, str] | None,
+) -> bool:
+    """Return True when the active tool approval level is OFF."""
+    if not request_context:
+        return False
+
+    from ..security.tool_guard.execution_level import ToolExecutionLevel
+
+    session_raw = request_context.get("approval_level")
+    if session_raw:
+        return ToolExecutionLevel.from_config(str(session_raw)).is_disabled()
+
+    agent_id = str(request_context.get("agent_id") or "")
+    if not agent_id:
+        return False
+    try:
+        from ..config.config import load_agent_config
+
+        profile = load_agent_config(agent_id)
+        return ToolExecutionLevel.from_config(
+            getattr(profile, "approval_level", None),
+        ).is_disabled()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning(
+            "DriverHandler: failed to resolve approval_level for agent=%s "
+            "(%s); keeping Driver policy approval enabled",
+            agent_id,
+            exc,
+        )
+        return False
+
+
 class DriverHandler(ABC):
     def __init__(
         self,
@@ -128,6 +161,13 @@ class DriverHandler(ABC):
                 operation,
             )
         if effect == POLICY_EFFECT_ASK:
+            if _approval_level_disables_approval(context.request_context):
+                logger.info(
+                    "DriverHandler: auto-allowing Driver policy ASK for "
+                    "%s because approval_level=OFF",
+                    self._card.name,
+                )
+                return context
             await self._request_approval(context)
         return context
 

--- a/tests/integration/test_driver_mcp_policy_flow.py
+++ b/tests/integration/test_driver_mcp_policy_flow.py
@@ -135,3 +135,43 @@ async def test_driver_mcp_policy_ask_approve_resumes_client_call(
     assert result.ok is True
     assert result.value == {"echo": {"text": "ok"}}
     assert FakeStdIOClient.instances[0].calls == [("echo", {"text": "ok"})]
+
+
+@pytest.mark.asyncio
+async def test_driver_mcp_policy_ask_is_auto_allowed_when_approval_level_off(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    service = ApprovalService()
+    monkeypatch.setattr(
+        "qwenpaw.app.approvals.get_approval_service",
+        lambda: service,
+    )
+    manager = await _registry_with_policy(
+        tmp_path,
+        [PolicyRule(subject="*", effect="ask")],
+    )
+    capability = next(
+        item
+        for item in await manager.list_capabilities(kind="tool")
+        if item.name == "echo"
+    )
+
+    result = await manager.invoke_capability(
+        DriverInvocation(
+            capability.capability_id,
+            {"text": "ok"},
+            {
+                "session_id": "s1",
+                "agent_id": "agent",
+                "user_id": "alice",
+                "approval_level": "OFF",
+            },
+        ),
+    )
+
+    assert result.ok is True
+    assert result.value == {"echo": {"text": "ok"}}
+    assert FakeStdIOClient.instances[0].calls == [("echo", {"text": "ok"})]
+    assert service._pending == {}


### PR DESCRIPTION
## Description

This PR fixes a case where selecting **OFF / 关闭模式** still allowed Driver policy approvals, such as MCP tool access policies with `ask`, to show approval popups. Driver policy now treats an effective `approval_level=OFF` as "do not ask" for `ASK` decisions, while explicit `DENY` policies still block execution.

**Related Issue:** Fixes #5846

**Security Considerations:** This change only applies when the user has explicitly selected `OFF` approval mode. It does not weaken `AUTO`, `SMART`, or `STRICT`, and Driver policy `deny` decisions remain enforced.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Configure or use an MCP/Driver tool whose Driver access policy evaluates to `ask`.
2. Set the chat approval level to **OFF / 关闭模式**.
3. Invoke the MCP/Driver tool.
4. Confirm the tool runs without creating an approval popup.
5. Switch back to `AUTO` or another non-OFF mode and confirm the same `ask` policy still requires approval.

## Local Verification Evidence

```bash
pre-commit run --all-files
# Not run locally.

$env:PYTHONPATH='src'; $env:PYTHONIOENCODING='utf-8'; conda run -n daqing python -m pytest tests/integration/test_driver_mcp_policy_flow.py
# 3 passed in 0.35s

$env:PYTHONPATH='src'; $env:PYTHONIOENCODING='utf-8'; conda run -n daqing python -m pytest tests/unit/governance/test_off_mode_sandbox.py
# 8 passed in 0.11s
```

## Additional Notes

No channel behavior is changed, so the channel-specific checklist is not applicable.
