### PR TITLE
fix(scroll): anchor the live turn with a seam banner in the eviction index

### DIFF
--- a/src/qwenpaw/agents/context/scroll/eviction_index.py
+++ b/src/qwenpaw/agents/context/scroll/eviction_index.py
@@ -30,6 +30,28 @@ from dataclasses import dataclass
 # block and folds the other (_TIER_CAP - 1) into one block a tier higher.
 _TIER_CAP = 10
 
+# The seam banner closing the index placeholder. It is the LAST thing the model
+# reads before the live tail, so the structural signal sits right where the
+# confusion happens: the placeholder is a ``user`` message and so is the real
+# request that follows it (two consecutive ``user`` turns — the one shape we
+# can't avoid, since Anthropic requires the first body message to be ``user``
+# and can't take a ``system`` message mid-context). A weak model (GLM/DeepSeek)
+# otherwise latches onto a ``⟦headline⟧`` in the map above and answers it. This
+# banner is a positional delimiter — the same trick hermes-agent uses with its
+# ``[CONTEXT SUMMARY]`` label — telling the model, at the seam, which side is
+# archive and which side is the request. Constant text, so it never breaks the
+# placeholder's KV-cache prefix.
+_LIVE_TURN_BANNER = [
+    "",
+    "═══════════════ END OF ARCHIVED INDEX ═══════════════",
+    "The CURRENT LIVE TURN is the message(s) that follow this one. Answer the "
+    "most recent USER message there — NEVER a ⟦headline⟧ listed in the map "
+    "above; those are archived, not requests. If your current request is not "
+    "visible in the live turn, recall it first (see above); if recall cannot "
+    "retrieve it, say so — never answer an older message as if it were the "
+    "request.",
+]
+
 
 @dataclass(frozen=True)
 class Leaf:
@@ -255,11 +277,12 @@ class EvictionIndex:
         out = [
             "<system-info>",
             "[context compressed] The turns below were evicted from the live "
-            "window but remain durable in conversation_history. This is their "
-            "index: read it top (oldest) to bottom (most recently "
-            "compressed); "
-            "the recent live turns follow below. Each "
-            "'·' line is a seq span you can re-expand.",
+            "window but remain durable in conversation_history. This is an "
+            "ARCHIVED MAP for reference only — NOT the live conversation. "
+            "Read it top (oldest) to bottom (most recently compressed); the "
+            "live "
+            "turns follow after the banner at the end. Each '·' line is a seq "
+            "span you can re-expand.",
             "",
             "Re-expand a span with the recall_history tool: "
             'recall_history(op="expand", lo, hi) for the full turns (seq is '
@@ -268,13 +291,12 @@ class EvictionIndex:
             "(sessions, custom SQL) use a more advanced Python recall tool "
             "if one is available to you.",
             "",
-            "If the user's CURRENT request is not visible among the live "
-            "turns below, do NOT answer an older visible message as if it "
-            "were the request — recall the missing span first; if recall "
-            "cannot retrieve it, say so explicitly instead of guessing.",
-            "",
         ]
         out.extend(self._tier_lines())
+        # The seam banner closes the block right before the live tail — the
+        # structural anchor that keeps the model answering the request below,
+        # not a headline in the map above.
+        out.extend(_LIVE_TURN_BANNER)
         out.append("</system-info>")
         return "\n".join(out)
 

--- a/tests/unit/agents/context/test_eviction_index.py
+++ b/tests/unit/agents/context/test_eviction_index.py
@@ -38,6 +38,31 @@ def test_single_eviction_is_addressable():
     assert "seq 5" in out
 
 
+def test_render_closes_with_live_turn_banner():
+    """The seam banner is the structural anchor: it must be the LAST thing in
+    the placeholder (after every tier), so it sits right before the live tail —
+    telling the model the request is below, not a headline in the map above."""
+    idx = EvictionIndex(session_id="s")
+    _add(idx, 5, "old headline")
+    out = idx.render()
+    assert "CURRENT LIVE TURN" in out
+    assert "END OF ARCHIVED INDEX" in out
+    # The banner comes after the archived turns, not before them.
+    assert out.index("old headline") < out.index("CURRENT LIVE TURN")
+    # And it stays inside the system-info envelope, last before the close tag.
+    assert out.index("CURRENT LIVE TURN") < out.index("</system-info>")
+
+
+def test_describe_omits_the_model_facing_banner():
+    """``describe()`` feeds the user-facing /compact reply — it should show the
+    tier/span map only, not the model-only 'answer THIS' banner."""
+    idx = EvictionIndex(session_id="s")
+    _add(idx, 5, "old headline")
+    described = idx.describe()
+    assert "old headline" in described
+    assert "CURRENT LIVE TURN" not in described
+
+
 def test_eviction_without_headline_still_has_a_span():
     idx = EvictionIndex(session_id="s")
     idx.add_eviction([], seq_lo=10, seq_hi=14)


### PR DESCRIPTION
## Description

After `scroll` compresses old turns, the context looks like:

```
System(prompt)
User  → eviction index (a map of archived turns, each with a ⟦headline⟧)
User  → the real current request
Assistant …
```

The index and the request are **both `user` messages** (the index can't be a `system` message — Anthropic needs the first body message to be `user`). Since the index sits right before the request and lists old `⟦headlines⟧`, weaker models (GLM, DeepSeek) sometimes answer an old headline instead of the current request (e.g. ask "what is GitHub", agent starts answering the earlier "what time is it").

**Fix: clearly label where the archive ends and the live turn begins.**

```
┌─ System ──────────────────────────────────────────────────────
│  <system prompt…>
│
├─ User → eviction index (archived map) ────────────────────────
│  <system-info>
│  [context compressed] This is an ARCHIVED MAP for reference only
│  — NOT the live conversation. Read it top (oldest) to bottom.
│  Each '·' line is a seq span you can re-expand with recall_history.
│
│  ===== Tier 0 (recently compressed) =====
│    [seq 1–2]
│      · seq 2  ⟦ user asked what time it is ⟧
│    [seq 3–5]
│      · seq 5  ⟦ answered: it's 14:20 ⟧
│
│  ═══════════ END OF ARCHIVED INDEX ═══════════        ← seam banner (new)
│  The CURRENT LIVE TURN is the message(s) below. Answer the most
│  recent USER message there — NEVER a ⟦headline⟧ in the map above;
│  those are archived, not requests.
│  </system-info>
│
├─ User → the real current request ─────────────────────────────
│  What is GitHub?                            ← sits right under the banner
│
└─ Assistant ───────────────────────────────────────────────────
   <starts explaining GitHub…>
```

Now the "answer the message below, not a headline above" signal is the last line before the real request — right where the confusion happens. Before, that guard was buried at the top of the index. Same idea as hermes-agent's end-of-summary marker. `describe()` (the `/compact` reply shown to users) is unchanged — the banner is model-only, and it's constant text so KV-cache is unaffected.

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Two new cases in `tests/unit/agents/context/test_eviction_index.py`:

- `test_render_closes_with_live_turn_banner` — banner appears after the archived turns, inside `</system-info>`.
- `test_describe_omits_the_model_facing_banner` — the `/compact` reply stays banner-free.

## Local Verification Evidence

```bash
python -m flake8 src/qwenpaw/agents/context/scroll/eviction_index.py tests/unit/agents/context/test_eviction_index.py
# clean, exit 0

python -m pytest tests/unit/agents/context/ tests/unit/runtime/test_builtin_commands_scroll.py tests/unit/runtime/test_scroll_recall_gate.py -q
# 181 passed
```