### PR TITLE
fix(Matrix): token login failure due to duplicate auth parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "aiofiles>=24.1.0",
     "paho-mqtt>=2.0.0",
     "wecom-aibot-python-sdk==1.0.2",
-    "matrix-nio>=0.24.0",
+    "matrix-nio>=0.25.0",
     "shortuuid>=1.0.0",
     "google-genai>=1.67.0",
     "tzdata>=2024.1",

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -158,37 +158,6 @@ CURRENT_MESSAGE_MARKER = "[Current message - respond to this]"
 DEFAULT_HISTORY_LIMIT = 50
 
 
-class QwenPawMatrixClient(AsyncClient):
-    """Keep query-token auth for homeservers/proxies that drop auth headers."""
-
-    async def send(
-        self,
-        method: str,
-        path: str,
-        data: Any = None,
-        headers: Optional[Dict[str, str]] = None,
-        trace_context: Optional[Any] = None,
-        timeout: Optional[float] = None,
-    ) -> Any:
-        if self.access_token and "access_token=" not in path:
-            url = urllib.parse.urlparse(path)
-            query = urllib.parse.parse_qs(url.query)
-            query["access_token"] = [self.access_token]
-            path = urllib.parse.urlunparse(
-                url._replace(
-                    query=urllib.parse.urlencode(query, doseq=True),
-                ),
-            )
-        return await super().send(
-            method,
-            path,
-            data,
-            headers,
-            trace_context,
-            timeout,
-        )
-
-
 @dataclass
 class HistoryEntry:
     """A buffered room message that didn't mention the bot."""
@@ -474,7 +443,7 @@ class MatrixChannel(BaseChannel):
         client_config = self._build_client_config(
             encryption=self.encryption,
         )
-        self._client = QwenPawMatrixClient(
+        self._client = AsyncClient(
             self.homeserver,
             # Keep user neutral before auth; token/whoami or login response
             # will set the canonical MXID.

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -681,7 +681,7 @@ class TestMatrixChannelStartStop:
     ):
         """Test that start creates and configures AsyncClient."""
         with patch(
-            "qwenpaw.app.channels.matrix.channel.QwenPawMatrixClient",
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
             return_value=mock_async_client,
         ):
             await matrix_channel.start()
@@ -697,7 +697,7 @@ class TestMatrixChannelStartStop:
     ):
         """Test that start creates sync task."""
         with patch(
-            "qwenpaw.app.channels.matrix.channel.QwenPawMatrixClient",
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
             return_value=mock_async_client,
         ):
             await matrix_channel.start()
@@ -712,7 +712,7 @@ class TestMatrixChannelStartStop:
     ):
         """Test that stop cancels sync task."""
         with patch(
-            "qwenpaw.app.channels.matrix.channel.QwenPawMatrixClient",
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
             return_value=mock_async_client,
         ):
             await matrix_channel.start()
@@ -725,7 +725,7 @@ class TestMatrixChannelStartStop:
     async def test_stop_closes_client(self, matrix_channel, mock_async_client):
         """Test that stop closes the client."""
         with patch(
-            "qwenpaw.app.channels.matrix.channel.QwenPawMatrixClient",
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
             return_value=mock_async_client,
         ):
             await matrix_channel.start()


### PR DESCRIPTION
## Description

- Remove the QwenPawMatrixClient subclass and use AsyncClient directly
- Update matrix-nio version requirement to >=0.25.0

The subclass was injecting access_token into query parameters, but matrix-nio 0.25.x already handles authentication correctly in its _send() method by adding the Authorization header and stripping query param tokens. The override was causing both to be sent simultaneously, triggering the Matrix server error: M_MISSING_TOKEN: Mixing Authorization headers and access_token query parameters.


**Related Issue:** Fixes #5868 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
