### PR TITLE
fix: auto-enable preview mode for image files in coding session

### DIFF
--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -269,7 +269,61 @@ export default function TabbedEditor({
    */
   const [previewPaths, setPreviewPaths] = useState<Set<string>>(new Set());
 
+  /**
+   * Tracks files that the user has manually toggled preview mode for.
+   * Prevents the auto-preview useEffect from overriding user's choice.
+   */
+  const userToggledPathsRef = useRef<Set<string>>(new Set());
+
+  /**
+   * Clean up userToggledPathsRef when tabs are closed.
+   * Prevents memory leak and ensures reopened files get auto-preview again.
+   */
+  useEffect(() => {
+    const openPaths = new Set(tabs.map((t) => t.path));
+    const toRemove: string[] = [];
+
+    for (const path of userToggledPathsRef.current) {
+      if (!openPaths.has(path)) {
+        toRemove.push(path);
+      }
+    }
+
+    for (const path of toRemove) {
+      userToggledPathsRef.current.delete(path);
+    }
+  }, [tabs]);
+
+  /**
+   * Auto-enable preview mode for newly opened previewable files.
+   * Binary files (images, PDF) have no meaningful code representation,
+   * so they should default to preview mode instead of showing raw bytes.
+   * Skips files that the user has manually toggled.
+   */
+  useEffect(() => {
+    const newPreviewPaths = new Set(previewPaths);
+    let hasChanges = false;
+
+    for (const tab of tabs) {
+      // Skip if user has manually toggled this file
+      if (userToggledPathsRef.current.has(tab.path)) {
+        continue;
+      }
+      // Auto-enable preview for new previewable files
+      if (isPreviewable(tab.path) && !newPreviewPaths.has(tab.path)) {
+        newPreviewPaths.add(tab.path);
+        hasChanges = true;
+      }
+    }
+
+    if (hasChanges) {
+      setPreviewPaths(newPreviewPaths);
+    }
+  }, [tabs, previewPaths]);
+
   const togglePreview = useCallback((path: string) => {
+    // Mark this file as user-toggled so auto-preview won't override
+    userToggledPathsRef.current.add(path);
     setPreviewPaths((prev) => {
       const next = new Set(prev);
       if (next.has(path)) {
@@ -281,7 +335,7 @@ export default function TabbedEditor({
     });
   }, []);
 
-  // Default is Code mode; user manually toggles to Preview via the Eye button.
+  // Previewable files auto-enter preview mode; user can toggle back to Code via Eye button.
 
   /**
    * Paths currently being reverted via Undo — suppress watcher-triggered diffs


### PR DESCRIPTION
- Add useEffect to automatically enable preview mode for previewable files (images, PDF, markdown, CSV)
- Track user-toggled files with useRef to prevent auto-preview from overriding manual switches
- Clean up userToggledPathsRef when tabs are closed to prevent memory leaks
- Fixes #5863: Images now display correctly instead of showing binary code

<img width="1584" height="1226" alt="image" src="https://github.com/user-attachments/assets/688c1f25-ee5d-4a79-9853-d9bf3b7912ed" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
