### PR TITLE
fix(stop): isolate /stop by user_id to prevent cross-user task cancellation

### DIFF
--- a/src/qwenpaw/app/chats/manager.py
+++ b/src/qwenpaw/app/chats/manager.py
@@ -255,12 +255,20 @@ class ChatManager:
         self,
         session_id: str,
         channel: str,
+        user_id: str | None = None,
     ) -> str | None:
         """Get chat_id by session_id and channel.
 
         Args:
             session_id: Normalized session ID (e.g. "console:user1")
             channel: Channel name
+            user_id: Optional user ID. When provided, only chats owned by
+                this user are considered. This isolates users that share the
+                same session_id (e.g. members of the same group chat, or
+                different DM users whose conversation_id suffix collides), so
+                a /stop from one user never cancels another user's task.
+                When None/empty, all matching chats are considered
+                (backward-compatible behavior).
 
         Returns:
             chat_id (UUID) of most recent chat if found, None otherwise
@@ -271,21 +279,27 @@ class ChatManager:
         """
         async with self._lock:
             chats = await self._repo.filter_chats(channel=channel)
+            # Single pass: match session_id, and when a user_id is given,
+            # also require it to match. An empty/None user_id means "no user
+            # filter" (backward-compatible).
             matching_chats = [
-                chat for chat in chats if chat.session_id == session_id
+                chat
+                for chat in chats
+                if chat.session_id == session_id
+                and (not user_id or chat.user_id == user_id)
             ]
 
             if not matching_chats:
                 logger.debug(
                     f"No chat found for session={session_id[:30]} "
-                    f"channel={channel}",
+                    f"channel={channel} user_id={user_id}",
                 )
                 return None
 
             most_recent = max(matching_chats, key=lambda c: c.updated_at)
             logger.debug(
                 f"Found chat_id={most_recent.id} "
-                f"for session={session_id[:30]} "
+                f"for session={session_id[:30]} user_id={user_id} "
                 f"(from {len(matching_chats)} matches)",
             )
             return most_recent.id

--- a/src/qwenpaw/runtime/commands/control/stop_handler.py
+++ b/src/qwenpaw/runtime/commands/control/stop_handler.py
@@ -45,15 +45,20 @@ class StopCommandHandler(BaseControlCommandHandler):
 
         logger.info(
             f"/stop command: current_session={context.session_id[:30]} "
-            f"target_session={target_session_id[:30]}",
+            f"target_session={target_session_id[:30]} "
+            f"user_id={context.user_id}",
         )
 
         workspace = context.workspace
         channel_id = context.channel.channel
 
+        # Scope the lookup to the requesting user so users sharing the same
+        # session_id (group members, or DM users whose conversation_id suffix
+        # collides) can only stop their own task.
         chat_id = await workspace.chat_manager.get_chat_id_by_session(
             target_session_id,
             channel_id,
+            user_id=context.user_id,
         )
 
         if chat_id is None:


### PR DESCRIPTION
## Problem
`/stop` resolved the target task only by `(session_id, channel)`, ignoring the
requesting user. In DingTalk DM chats every user shares the same
`conversation_id` suffix (the bot id), so their `session_id` collides and one
user's `/stop` could cancel another user's running task (issue #5835). The same
class of bug affects any channel where multiple users share one `session_id`
(e.g. group-chat members).

## Root Cause
- `session_id` for DingTalk is the last 8 chars of `conversation_id`, which is
  identical across DM users of the same bot.
- `ChatManager.get_chat_id_by_session()` filtered only by `session_id + channel`
  and returned the most recently updated chat — potentially another user's.
- `user_id` was already stored on every `ChatSpec` but was never used for this
  lookup, even though debounce/webhook keys already isolate by sender.

## Fix
- Add an optional `user_id` parameter to `ChatManager.get_chat_id_by_session()`.
  When provided, only chats owned by that user match; when empty/None the
  behavior is unchanged (backward compatible).
- `StopCommandHandler` now passes `context.user_id`, so a `/stop` only cancels
  the caller's own task. Since each user owns a distinct chat record even when
  sharing a `session_id`, this fix benefits all channels.

## Impact
- No API/signature break: the new parameter is optional; the console stop
  fallback path is unaffected.
- Group chats keep working (each member has their own chat/task).

**Related Issue:** Fixes #5835 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
