### PR TITLE
Reset stop gates on conversation reset

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -206,6 +206,21 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Write the rolling compaction summary."""
         self._state.summary = value or ""
 
+    def _reset_stop_gates(self) -> None:
+        """Clear loop-gate state for commands that reset conversation state."""
+        workspace = getattr(self._prompt_context, "workspace", None)
+        handler = getattr(workspace, "_stop_handler", None)
+        reset = getattr(handler, "reset", None)
+        if callable(reset):
+            reset()
+
+        agent = self._agent or getattr(self._prompt_context, "agent", None)
+        if agent is not None:
+            if hasattr(agent, "_gate_pending_stop"):
+                agent._gate_pending_stop = None
+            if hasattr(agent, "_gate_pending_continue"):
+                agent._gate_pending_continue = None
+
     def is_command(self, query: str | None) -> bool:
         """Check if the query is a system command (alias for mixin)."""
         return self.is_conversation_command(query)
@@ -457,6 +472,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Process /new command."""
         if not messages:
             self._set_summary("")
+            self._reset_stop_gates()
             return await self._make_system_msg(
                 "**No messages to summarize.**\n\n"
                 "- Current memory is empty\n"
@@ -476,6 +492,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         self._set_summary("")
 
         await self._persist_and_clear()
+        self._reset_stop_gates()
         return await self._make_system_msg(
             "**New Conversation Started!**\n\n"
             "- Summary task started in background\n"
@@ -492,6 +509,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Process /clear command."""
         await self._persist_and_clear()
         self._set_summary("")
+        self._reset_stop_gates()
         return await self._make_system_msg(
             "**History Cleared!**\n\n"
             "- Compressed summary reset\n"

--- a/src/qwenpaw/loop/gates/handler.py
+++ b/src/qwenpaw/loop/gates/handler.py
@@ -55,6 +55,20 @@ class StopHandler:
         """Read-only view of registered gates."""
         return list(self._gates)
 
+    def reset(self) -> None:
+        """Reset stateful gates without unregistering them."""
+        for gate in self._gates:
+            reset = getattr(gate, "reset", None)
+            if callable(reset):
+                try:
+                    reset()
+                except Exception:
+                    logger.warning(
+                        "StopGate '%s' reset raised",
+                        gate.name,
+                        exc_info=True,
+                    )
+
     async def __call__(
         self,
         ctx: Any,

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -38,6 +38,29 @@ async def test_process_clear_returns_clear_history_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_clear_resets_stop_gates_and_pending_gate_state() -> None:
+    agent = _make_agent()
+    agent._gate_pending_stop = object()
+    agent._gate_pending_continue = "continue"
+    stop_handler = MagicMock()
+    ctx = SimpleNamespace(
+        workspace=SimpleNamespace(_stop_handler=stop_handler),
+        agent=agent,
+    )
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        agent=agent,
+        prompt_context=ctx,
+    )
+
+    await handler.handle_command("/clear")
+
+    stop_handler.reset.assert_called_once_with()
+    assert agent._gate_pending_stop is None
+    assert agent._gate_pending_continue is None
+
+
+@pytest.mark.asyncio
 async def test_system_prompt_command_returns_current_prompt() -> None:
     agent = _make_agent()
 


### PR DESCRIPTION
## Summary

- Add `StopHandler.reset()` to reset stateful gates without unregistering them.
- Reset stop gates and pending gate state when `/new` or `/clear` resets conversation context.
- Add a regression test for clearing stop gate state from the command handler.

Closes #5884

## Tests / Verification

- `uv run --extra test pytest tests/unit/agents/test_command_handler.py -q`
- `python3 -m compileall -q src/qwenpaw/agents/command_handler.py src/qwenpaw/loop/gates/handler.py tests/unit/agents/test_command_handler.py`

## Risks / Rollback

Low risk. The change only calls `reset()` on gates that explicitly expose it and leaves registered gates in place. Rollback by reverting this commit.
