### PR TITLE
Pass session id to command memory tasks

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -206,6 +206,23 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Write the rolling compaction summary."""
         self._state.summary = value or ""
 
+    def _current_session_id(self) -> str:
+        """Best-effort session id for command-triggered background tasks."""
+        state = self._state_direct
+        if state is None and self._agent is not None:
+            state = getattr(self._agent, "state", None)
+
+        candidates = [
+            getattr(state, "session_id", "") if state is not None else "",
+            self._session_id,
+            getattr(self._prompt_context, "session_id", None),
+        ]
+        for candidate in candidates:
+            session_id = str(candidate or "").strip()
+            if session_id:
+                return session_id
+        return ""
+
     def is_command(self, query: str | None) -> bool:
         """Check if the query is a system command (alias for mixin)."""
         return self.is_conversation_command(query)
@@ -345,7 +362,10 @@ class CommandHandler(ConversationCommandHandlerMixin):
         evicted = max(0, before - after)
         reme_cfg = agent_config.running.reme_light_memory_config
         if self._has_memory_manager() and reme_cfg.summarize_when_compact:
-            self.memory_manager.add_summarize_task(messages=messages)
+            self.memory_manager.add_summarize_task(
+                messages=messages,
+                session_id=self._current_session_id(),
+            )
 
         summary = self._get_summary()
         folded = int(compress_stats.get("folded", 0) or 0)
@@ -497,7 +517,10 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 "- Enable memory manager to use this feature",
             )
 
-        self.memory_manager.add_summarize_task(messages=messages)
+        self.memory_manager.add_summarize_task(
+            messages=messages,
+            session_id=self._current_session_id(),
+        )
         self._set_summary("")
 
         await self._persist_and_clear()
@@ -757,7 +780,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         try:
             await self.memory_manager.auto_memory(
                 memory_messages,
-                session_id=str(getattr(self._state, "session_id", "") or ""),
+                session_id=self._current_session_id(),
                 reply_id=reply_ids[-1],
                 reply_ids=reply_ids,
             )

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -376,12 +376,21 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         """Persist conversation messages through ReMe auto-memory."""
         if not messages:
             return ""
+        session_id = str(kwargs.get("session_id") or "")
+        if not session_id:
+            logger.warning(
+                "ReMe summarize skipped; session_id is empty: "
+                "agent_id=%s messages=%s",
+                self.agent_id,
+                len(messages),
+            )
+            return ""
 
         response = await self._run_reme_job(
             "auto_memory",
             needs_llm=True,
             messages=[msg.model_dump(mode="json") for msg in messages],
-            session_id=str(kwargs.get("session_id") or ""),
+            session_id=session_id,
             memory_hint=str(kwargs.get("memory_hint") or ""),
         )
         if response is None:

--- a/tests/unit/agents/memory/test_reme_light_memory_manager.py
+++ b/tests/unit/agents/memory/test_reme_light_memory_manager.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import AsyncMock
+
+import pytest
+from agentscope.message import Msg, TextBlock
+
+from qwenpaw.agents.memory.reme_light_memory_manager import (
+    ReMeLightMemoryManager,
+)
+
+
+def _msg(role: str, text: str) -> Msg:
+    return Msg(
+        name="user" if role == "user" else "QwenPaw",
+        role=role,
+        content=[TextBlock(type="text", text=text)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_summarize_skips_reme_job_without_session_id(tmp_path) -> None:
+    manager = ReMeLightMemoryManager(
+        working_dir=str(tmp_path),
+        agent_id="default",
+    )
+    manager._run_reme_job = AsyncMock()
+
+    result = await manager.summarize([_msg("user", "hello")])
+
+    assert result == ""
+    manager._run_reme_job.assert_not_awaited()

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -38,6 +38,29 @@ async def test_process_clear_returns_clear_history_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_new_passes_session_id_to_summarize_task() -> None:
+    state = SimpleNamespace(
+        context=[_msg("user", "hi")],
+        summary="",
+        session_id="",
+    )
+    memory_manager = MagicMock()
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        state=state,
+        memory_manager=memory_manager,
+        session_id="qq:session-1",
+    )
+
+    await handler.handle_command("/new")
+
+    memory_manager.add_summarize_task.assert_called_once()
+    _, kwargs = memory_manager.add_summarize_task.call_args
+    assert kwargs["messages"][0].get_text_content() == "hi"
+    assert kwargs["session_id"] == "qq:session-1"
+
+
+@pytest.mark.asyncio
 async def test_system_prompt_command_returns_current_prompt() -> None:
     agent = _make_agent()
 
@@ -274,6 +297,41 @@ class _FakeCtxConfig(SimpleNamespace):
             **update,
         }
         return _FakeCtxConfig(**merged)
+
+
+@pytest.mark.asyncio
+async def test_compact_passes_session_id_to_summarize_task() -> None:
+    async def _compress_context(context_config=None):
+        del context_config
+
+    agent = _make_agent()
+    agent.state = SimpleNamespace(
+        context=[_msg("user", "hi")],
+        summary="",
+        session_id="",
+    )
+    agent.context_config = _FakeCtxConfig(trigger_ratio=0.8, reserve_ratio=0.2)
+    agent.compress_context = _compress_context
+    memory_manager = MagicMock()
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        agent=agent,
+        memory_manager=memory_manager,
+        session_id="qq:session-1",
+    )
+    # pylint: disable=protected-access
+    handler._get_agent_config = lambda: _make_config(
+        reserve_ratio=0.2,
+        strategy="native",
+        summarize_when_compact=True,
+    )
+
+    await handler.handle_command("/compact")
+
+    memory_manager.add_summarize_task.assert_called_once()
+    _, kwargs = memory_manager.add_summarize_task.call_args
+    assert kwargs["messages"][0].get_text_content() == "hi"
+    assert kwargs["session_id"] == "qq:session-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Resolve the active session id in `CommandHandler` for command-triggered memory work.
- Pass that session id to `/new`, `/compact`, and manual `/memorize` memory calls.
- Skip ReMe summarize defensively when no session id is available instead of calling `auto_memory` with an empty id.
- Add regression tests for command-triggered summarize session ids and ReMe's empty-session guard.

Closes #5887

## Tests / Verification

- `uv run --extra test pytest tests/unit/agents/test_command_handler.py tests/unit/agents/memory/test_reme_light_memory_manager.py -q`
- `python3 -m compileall -q src/qwenpaw/agents/command_handler.py src/qwenpaw/agents/memory/reme_light_memory_manager.py tests/unit/agents/test_command_handler.py tests/unit/agents/memory/test_reme_light_memory_manager.py`
- `git diff --check`

## Risks / Rollback

Low risk. The change only adds session-id propagation for existing background memory calls and prevents ReMe from running an invalid auto-memory job when no session id can be resolved. Roll back by reverting this commit.
