### PR TITLE
fix(tui): improve approvals and warmup sessions

### DIFF
--- a/src/qwenpaw/agents/acp/meta.py
+++ b/src/qwenpaw/agents/acp/meta.py
@@ -6,5 +6,6 @@ without importing the ACP server implementation.
 """
 
 ACP_CODING_PROJECT_META_KEY = "qwenpaw.coding_project_dir"
+ACP_EPHEMERAL_META_KEY = "qwenpaw.ephemeral"
 
-__all__ = ["ACP_CODING_PROJECT_META_KEY"]
+__all__ = ["ACP_CODING_PROJECT_META_KEY", "ACP_EPHEMERAL_META_KEY"]

--- a/src/qwenpaw/agents/acp/meta.py
+++ b/src/qwenpaw/agents/acp/meta.py
@@ -7,5 +7,10 @@ without importing the ACP server implementation.
 
 ACP_CODING_PROJECT_META_KEY = "qwenpaw.coding_project_dir"
 ACP_EPHEMERAL_META_KEY = "qwenpaw.ephemeral"
+ACP_APPROVAL_EXPIRES_AT_META_KEY = "qwenpaw.approval_expires_at"
 
-__all__ = ["ACP_CODING_PROJECT_META_KEY", "ACP_EPHEMERAL_META_KEY"]
+__all__ = [
+    "ACP_APPROVAL_EXPIRES_AT_META_KEY",
+    "ACP_CODING_PROJECT_META_KEY",
+    "ACP_EPHEMERAL_META_KEY",
+]

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -77,7 +77,7 @@ from ...config.config import ModelSlotConfig
 from ...exceptions import AppBaseException
 from ...providers.provider_manager import ProviderManager
 from ...agents.command_handler import SYSTEM_COMMAND_DESCRIPTIONS
-from .meta import ACP_CODING_PROJECT_META_KEY
+from .meta import ACP_CODING_PROJECT_META_KEY, ACP_EPHEMERAL_META_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -319,6 +319,8 @@ class QwenPawACPAgent(Agent):
             project_dir = project_dir.strip()
             if project_dir:
                 info[ACP_CODING_PROJECT_META_KEY] = project_dir
+        if meta.get(ACP_EPHEMERAL_META_KEY) is True:
+            info[ACP_EPHEMERAL_META_KEY] = True
         return info
 
     async def _ensure_app_services(self) -> Any:
@@ -613,6 +615,8 @@ class QwenPawACPAgent(Agent):
             project_dir = project_dir.strip()
             if project_dir:
                 request_context[ACP_CODING_PROJECT_META_KEY] = project_dir
+        if session_info.get(ACP_EPHEMERAL_META_KEY) is True:
+            request_context[ACP_EPHEMERAL_META_KEY] = True
 
         request = AgentRequest(
             input=[
@@ -892,12 +896,12 @@ class QwenPawACPAgent(Agent):
             return [
                 PermissionOption(
                     option_id="allow_once",
-                    name="Just Once",
+                    name="Just Once Exact",
                     kind="allow_once",
                 ),
                 PermissionOption(
                     option_id="allow_always",
-                    name="Always Allow",
+                    name="Always Allow Pattern",
                     kind="allow_always",
                 ),
                 PermissionOption(
@@ -909,7 +913,7 @@ class QwenPawACPAgent(Agent):
         return [
             PermissionOption(
                 option_id="allow_once",
-                name="Approve",
+                name="Approve Exact",
                 kind="allow_once",
             ),
             PermissionOption(

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -896,12 +896,12 @@ class QwenPawACPAgent(Agent):
             return [
                 PermissionOption(
                     option_id="allow_once",
-                    name="Just Once Exact",
+                    name="Allow Exact This Session",
                     kind="allow_once",
                 ),
                 PermissionOption(
                     option_id="allow_always",
-                    name="Always Allow Pattern",
+                    name="Allow Pattern This Session",
                     kind="allow_always",
                 ),
                 PermissionOption(
@@ -913,7 +913,7 @@ class QwenPawACPAgent(Agent):
         return [
             PermissionOption(
                 option_id="allow_once",
-                name="Approve Exact",
+                name="Allow Exact This Session",
                 kind="allow_once",
             ),
             PermissionOption(

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -848,19 +848,41 @@ class QwenPawACPAgent(Agent):
 
         svc = get_approval_service()
         try:
-            response = await self._conn.request_permission(
-                session_id=session_id,
-                tool_call=ToolCallUpdate(
-                    tool_call_id=pending.request_id,
-                    title=(
-                        f"{pending.tool_name} requires approval "
-                        f"({pending.severity})"
+            permission_task = asyncio.create_task(
+                self._conn.request_permission(
+                    session_id=session_id,
+                    tool_call=ToolCallUpdate(
+                        tool_call_id=pending.request_id,
+                        title=(
+                            f"{pending.tool_name} requires approval "
+                            f"({pending.severity})"
+                        ),
+                        kind=self._approval_tool_kind(pending.tool_name),
+                        raw_input=self._approval_tool_input(pending),
                     ),
-                    kind=self._approval_tool_kind(pending.tool_name),
-                    raw_input=self._approval_tool_input(pending),
+                    options=self._approval_options(pending),
                 ),
-                options=self._approval_options(pending),
             )
+            pending_future = getattr(pending, "future", None)
+            if isinstance(pending_future, asyncio.Future):
+                done, _pending_tasks = await asyncio.wait(
+                    {permission_task, pending_future},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if pending_future in done and not permission_task.done():
+                    logger.info(
+                        "ACP approval request expired before client "
+                        "response: request=%s",
+                        pending.request_id[:8],
+                    )
+                    permission_task.cancel()
+                    try:
+                        await permission_task
+                    except asyncio.CancelledError:
+                        pass
+                    return
+
+            response = await permission_task
         except Exception:
             logger.exception(
                 "ACP approval bridge failed for request=%s",

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -77,7 +77,11 @@ from ...config.config import ModelSlotConfig
 from ...exceptions import AppBaseException
 from ...providers.provider_manager import ProviderManager
 from ...agents.command_handler import SYSTEM_COMMAND_DESCRIPTIONS
-from .meta import ACP_CODING_PROJECT_META_KEY, ACP_EPHEMERAL_META_KEY
+from .meta import (
+    ACP_APPROVAL_EXPIRES_AT_META_KEY,
+    ACP_CODING_PROJECT_META_KEY,
+    ACP_EPHEMERAL_META_KEY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -852,6 +856,7 @@ class QwenPawACPAgent(Agent):
                 self._conn.request_permission(
                     session_id=session_id,
                     tool_call=ToolCallUpdate(
+                        _meta=self._approval_tool_meta(pending),
                         tool_call_id=pending.request_id,
                         title=(
                             f"{pending.tool_name} requires approval "
@@ -944,6 +949,19 @@ class QwenPawACPAgent(Agent):
                 kind="reject_once",
             ),
         ]
+
+    @staticmethod
+    def _approval_tool_meta(pending: Any) -> dict[str, Any]:
+        """Return ACP metadata for approval prompt rendering."""
+        created_at = getattr(pending, "created_at", None)
+        timeout_seconds = getattr(pending, "timeout_seconds", None)
+        if not isinstance(created_at, (int, float)):
+            return {}
+        if not isinstance(timeout_seconds, (int, float)):
+            return {}
+        return {
+            ACP_APPROVAL_EXPIRES_AT_META_KEY: created_at + timeout_seconds,
+        }
 
     @staticmethod
     def _approval_tool_input(pending: Any) -> dict[str, Any] | None:

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -611,7 +611,7 @@ class QwenPawACPAgent(Agent):
         )
 
         session_mode = session_info.get("mode", self.MODE_DEFAULT)
-        request_context: dict[str, str] = {}
+        request_context: dict[str, Any] = {}
         if session_mode == self.MODE_BYPASS:
             request_context["_headless_tool_guard"] = "false"
         project_dir = session_info.get(ACP_CODING_PROJECT_META_KEY)
@@ -875,12 +875,9 @@ class QwenPawACPAgent(Agent):
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if pending_future in done and not permission_task.done():
-                    cancel_reason = "resolved"
-                    try:
-                        if pending_future.result() == ApprovalDecision.TIMEOUT:
-                            cancel_reason = "timeout"
-                    except Exception:  # noqa: BLE001 - best-effort UX hint
-                        pass
+                    cancel_reason = self._pending_cancel_reason(
+                        pending_future,
+                    )
                     logger.info(
                         "ACP approval request %s before client response: "
                         "request=%s",
@@ -917,6 +914,27 @@ class QwenPawACPAgent(Agent):
             decision = ApprovalDecision.DENIED
             scope = None
         await svc.resolve_request(pending.request_id, decision, scope=scope)
+
+    @staticmethod
+    def _pending_cancel_reason(pending_future: asyncio.Future) -> str:
+        """Why a pending approval resolved before the client answered.
+
+        ``wait_for_approval`` times out via ``asyncio.wait_for``, which
+        cancels the shared future instead of setting a TIMEOUT result —
+        check ``cancelled()`` before ``result()``, which would raise
+        CancelledError (a BaseException that would escape the bridge and
+        kill the polling loop in ``_bridge_approval_requests``).
+        """
+        from ...security.tool_guard.approval import ApprovalDecision
+
+        if pending_future.cancelled():
+            return "timeout"
+        try:
+            if pending_future.result() == ApprovalDecision.TIMEOUT:
+                return "timeout"
+        except Exception:  # noqa: BLE001 - best-effort UX hint
+            pass
+        return "resolved"
 
     @staticmethod
     def _approval_options(pending: Any) -> list[PermissionOption]:

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -837,7 +837,10 @@ class QwenPawACPAgent(Agent):
     ) -> None:
         """Ask the ACP client to approve/deny a QwenPaw pending approval."""
         from ...app.approvals import get_approval_service
-        from ...security.tool_guard.approval import ApprovalDecision
+        from ...security.tool_guard.approval import (
+            ApprovalDecision,
+            ApprovalScope,
+        )
 
         svc = get_approval_service()
         try:
@@ -852,18 +855,7 @@ class QwenPawACPAgent(Agent):
                     kind=self._approval_tool_kind(pending.tool_name),
                     raw_input=self._approval_tool_input(pending),
                 ),
-                options=[
-                    PermissionOption(
-                        option_id="approve",
-                        name="Approve",
-                        kind="allow_once",
-                    ),
-                    PermissionOption(
-                        option_id="deny",
-                        name="Deny",
-                        kind="reject_once",
-                    ),
-                ],
+                options=self._approval_options(pending),
             )
         except Exception:
             logger.exception(
@@ -876,12 +868,56 @@ class QwenPawACPAgent(Agent):
             )
             return
 
-        decision = (
-            ApprovalDecision.APPROVED
-            if self._permission_option_id(response) == "approve"
-            else ApprovalDecision.DENIED
-        )
-        await svc.resolve_request(pending.request_id, decision)
+        option_id = self._permission_option_id(response)
+        if option_id == "allow_once":
+            decision = ApprovalDecision.APPROVED
+            scope = ApprovalScope.EXACT
+        elif option_id == "allow_always":
+            decision = ApprovalDecision.APPROVED
+            scope = ApprovalScope.SIMILAR
+        else:
+            decision = ApprovalDecision.DENIED
+            scope = None
+        await svc.resolve_request(pending.request_id, decision, scope=scope)
+
+    @staticmethod
+    def _approval_options(pending: Any) -> list[PermissionOption]:
+        """Build ACP permission options for a pending QwenPaw approval."""
+        display = QwenPawACPAgent._approval_display(pending)
+        if (
+            display.get("is_generalized")
+            and display.get("similar_target")
+            and display.get("similar_target") != display.get("exact_target")
+        ):
+            return [
+                PermissionOption(
+                    option_id="allow_once",
+                    name="Just Once",
+                    kind="allow_once",
+                ),
+                PermissionOption(
+                    option_id="allow_always",
+                    name="Always Allow",
+                    kind="allow_always",
+                ),
+                PermissionOption(
+                    option_id="deny",
+                    name="Deny",
+                    kind="reject_once",
+                ),
+            ]
+        return [
+            PermissionOption(
+                option_id="allow_once",
+                name="Approve",
+                kind="allow_once",
+            ),
+            PermissionOption(
+                option_id="deny",
+                name="Deny",
+                kind="reject_once",
+            ),
+        ]
 
     @staticmethod
     def _approval_tool_input(pending: Any) -> dict[str, Any] | None:
@@ -893,7 +929,29 @@ class QwenPawACPAgent(Agent):
         if not isinstance(tool_call, dict):
             return None
         raw_input = tool_call.get("input")
-        return raw_input if isinstance(raw_input, dict) else None
+        if not isinstance(raw_input, dict):
+            return None
+        result = dict(raw_input)
+        display = QwenPawACPAgent._approval_display(pending)
+        if display.get("is_generalized") and (
+            display.get("exact_target") or display.get("similar_target")
+        ):
+            result.setdefault("approve_exact_target", display["exact_target"])
+            result.setdefault(
+                "approve_pattern_target",
+                display["similar_target"],
+            )
+        return result
+
+    @staticmethod
+    def _approval_display(pending: Any) -> dict[str, Any]:
+        try:
+            from ...app.approvals.display import approval_display_fields
+
+            return approval_display_fields(pending)
+        except Exception:
+            logger.debug("failed to read approval display metadata")
+            return {}
 
     @staticmethod
     def _permission_option_id(response: Any) -> str | None:

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -875,12 +875,19 @@ class QwenPawACPAgent(Agent):
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if pending_future in done and not permission_task.done():
+                    cancel_reason = "resolved"
+                    try:
+                        if pending_future.result() == ApprovalDecision.TIMEOUT:
+                            cancel_reason = "timeout"
+                    except Exception:  # noqa: BLE001 - best-effort UX hint
+                        pass
                     logger.info(
-                        "ACP approval request expired before client "
-                        "response: request=%s",
+                        "ACP approval request %s before client response: "
+                        "request=%s",
+                        cancel_reason,
                         pending.request_id[:8],
                     )
-                    permission_task.cancel()
+                    permission_task.cancel(cancel_reason)
                     try:
                         await permission_task
                     except asyncio.CancelledError:

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -16,11 +16,11 @@ from pathlib import Path
 from urllib.parse import unquote, urlparse
 from uuid import uuid4
 
-from textual import work
+from textual import events, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
-from textual.widgets import TextArea
+from textual.widgets import OptionList, TextArea
 
 from .events import (
     AvailableCommands,
@@ -311,6 +311,16 @@ class PawApp(App):
             self._transcript().follow_future_content()
         self._consume()
 
+    async def on_key(self, event: events.Key) -> None:
+        """Keep active permission prompts keyboard-driven after focus moves."""
+        if not self._permission_active():
+            return
+        if event.key not in ("down", "up", "enter", "tab", "escape"):
+            return
+        event.prevent_default()
+        event.stop()
+        await self._handle_permission_key(event.key)
+
     # -- helpers -------------------------------------------------------------
     def _status(self) -> StatusBar:
         return self.query_one(StatusBar)
@@ -486,8 +496,7 @@ class PawApp(App):
         request = self._permission.request
         if request is None:
             return
-        self._permission.clear_request()
-        self.query_one("#prompt", PromptInput).focus()
+        self._clear_permission()
         self.run_worker(
             self._transport.resolve_permission(
                 request.request_id,
@@ -1057,7 +1066,7 @@ class PawApp(App):
         elif isinstance(event, TurnEnded):
             self._busy = False
             self._awaiting_backend_update = False
-            self._permission.clear_request()
+            self._clear_permission()
             if self._thought is not None:
                 self._thought.done()
             if self._activity is not None:
@@ -1123,7 +1132,22 @@ class PawApp(App):
         self._mark_backend_update()
         self._menu.display = False
         self._permission.show_request(event)
-        self.query_one("#prompt", PromptInput).focus()
+        self._permission.focus()
+
+    def _clear_permission(self) -> None:
+        was_active = self._permission_active()
+        self._permission.clear_request()
+        if was_active:
+            self.query_one("#prompt", PromptInput).focus()
+
+    def on_option_list_option_selected(
+        self,
+        event: OptionList.OptionSelected,
+    ) -> None:
+        if event.option_list is not self._permission:
+            return
+        event.stop()
+        self._resolve_permission(event.option_id)
 
     async def on_unmount(self) -> None:
         await self._transport.close()

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -27,6 +27,7 @@ from .events import (
     BackendWarmed,
     Connected,
     PermissionRequest,
+    PermissionExpired,
     PlanUpdate,
     PushMessage,
     SessionSummary,
@@ -1046,6 +1047,9 @@ class PawApp(App):
         elif isinstance(event, PermissionRequest):
             self._on_permission(event)
 
+        elif isinstance(event, PermissionExpired):
+            await self._on_permission_expired(event)
+
         elif isinstance(event, TransportError):
             self._awaiting_backend_update = False
             self._turn_saw_error = True
@@ -1133,6 +1137,13 @@ class PawApp(App):
         self._menu.display = False
         self._permission.show_request(event)
         self._permission.focus()
+
+    async def _on_permission_expired(self, event: PermissionExpired) -> None:
+        current = self._permission.request
+        if current is not None and current.request_id == event.request_id:
+            self._clear_permission()
+        self._turn_saw_output = True
+        await self._mount(InfoMessage(event.message, level="warn"))
 
     def _clear_permission(self) -> None:
         was_active = self._permission_active()

--- a/src/qwenpaw/cli/tui/app.py
+++ b/src/qwenpaw/cli/tui/app.py
@@ -318,6 +318,12 @@ class PawApp(App):
             return
         if event.key not in ("down", "up", "enter", "tab", "escape"):
             return
+        if self.focused is self._permission and event.key in (
+            "down",
+            "up",
+            "enter",
+        ):
+            return
         event.prevent_default()
         event.stop()
         await self._handle_permission_key(event.key)

--- a/src/qwenpaw/cli/tui/events.py
+++ b/src/qwenpaw/cli/tui/events.py
@@ -138,6 +138,7 @@ class PermissionRequest:
     options: list[PermissionOption] = field(default_factory=list)
     tool_kind: str | None = None
     params: str | None = None
+    expires_at: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/qwenpaw/cli/tui/events.py
+++ b/src/qwenpaw/cli/tui/events.py
@@ -141,6 +141,14 @@ class PermissionRequest:
 
 
 @dataclass(frozen=True)
+class PermissionExpired:
+    """A previously shown permission prompt is no longer actionable."""
+
+    request_id: str
+    message: str
+
+
+@dataclass(frozen=True)
 class SlashCommand:
     """One agent slash command, used to drive input auto-suggestions."""
 
@@ -209,6 +217,7 @@ TuiEvent = (
     | Usage
     | TokenUsage
     | PermissionRequest
+    | PermissionExpired
     | AvailableCommands
     | PushMessage
     | UserTurn

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -35,7 +35,10 @@ from acp.schema import (
     RequestPermissionResponse,
 )
 
-from ....agents.acp.meta import ACP_CODING_PROJECT_META_KEY
+from ....agents.acp.meta import (
+    ACP_CODING_PROJECT_META_KEY,
+    ACP_EPHEMERAL_META_KEY,
+)
 from ..__version__ import __version__
 from ..events import (
     BackendWarmed,
@@ -69,8 +72,8 @@ _WARMUP_PROMPT = (
 # ``_meta`` flag marking the warmup session ephemeral so the QwenPaw ACP server
 # never registers a console chat or persists state for it. Passed as an extra
 # kwarg on ``new_session``/``prompt`` (the ACP client folds extra kwargs into
-# the request's ``_meta``). Mirrors the server's ``ACP_EPHEMERAL_META_KEY``.
-_EPHEMERAL_META_KEY = "qwenpaw.ephemeral"
+# the request's ``_meta``).
+_EPHEMERAL_META_KEY = ACP_EPHEMERAL_META_KEY
 
 
 def _open_agent_stderr_log() -> tuple[int | None, str | None]:

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -36,6 +36,7 @@ from acp.schema import (
 )
 
 from ....agents.acp.meta import (
+    ACP_APPROVAL_EXPIRES_AT_META_KEY,
     ACP_CODING_PROJECT_META_KEY,
     ACP_EPHEMERAL_META_KEY,
 )
@@ -138,6 +139,29 @@ def _permission_params(tool_call: Any) -> str | None:
     return tool_input_text(_tool_call_raw_input(tool_call)) or None
 
 
+def _permission_expires_at(tool_call: Any) -> float | None:
+    meta = _tool_call_meta(tool_call)
+    value = meta.get(ACP_APPROVAL_EXPIRES_AT_META_KEY)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _tool_call_meta(tool_call: Any) -> dict[str, Any]:
+    if isinstance(tool_call, dict):
+        meta = tool_call.get("_meta") or tool_call.get("field_meta")
+    else:
+        meta = getattr(tool_call, "field_meta", None)
+        if meta is None:
+            meta = getattr(tool_call, "_meta", None)
+    return meta if isinstance(meta, dict) else {}
+
+
 def _tool_call_raw_input(tool_call: Any) -> Any:
     if isinstance(tool_call, dict):
         return tool_call.get("rawInput", tool_call.get("raw_input"))
@@ -212,6 +236,7 @@ class _TuiClient:
                 title=str(title),
                 tool_kind=getattr(tool_call, "kind", None),
                 params=_permission_params(tool_call),
+                expires_at=_permission_expires_at(tool_call),
                 options=[
                     PermissionOption(
                         option_id=getattr(o, "option_id", ""),

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import os
 import sys
+import time
 import uuid
 from contextlib import AsyncExitStack
 from typing import Any, AsyncIterator, cast
@@ -152,16 +153,25 @@ def _permission_expires_at(tool_call: Any) -> float | None:
     return None
 
 
+_PERMISSION_TIMEOUT_MESSAGE = (
+    "Approval request timed out. The tool call was blocked; "
+    "start a new request to try again."
+)
+
+# Extra slack past the advertised deadline before the TUI expires a prompt
+# locally, so the server (which shares the same clock and blocks the tool at
+# exactly the deadline) always times out first and a last-second approval is
+# never dropped on the client side.
+_PERMISSION_EXPIRY_GRACE_SECONDS = 1.0
+
+
 def _permission_expired_message(exc: asyncio.CancelledError) -> str:
     reason = str(exc.args[0]) if exc.args else ""
     if reason == "timeout":
-        return (
-            "Approval request timed out. The tool call was blocked; "
-            "start a new request to try again."
-        )
+        return _PERMISSION_TIMEOUT_MESSAGE
     return (
-        "Approval request is no longer pending. The tool call was blocked; "
-        "start a new request to try again."
+        "Approval request is no longer pending; it was resolved or "
+        "cancelled elsewhere."
     )
 
 
@@ -243,13 +253,14 @@ class _TuiClient:
             or getattr(tool_call, "tool_call_id", None)
             or "Permission required"
         )
+        expires_at = _permission_expires_at(tool_call)
         await self._queue.put(
             PermissionRequest(
                 request_id=request_id,
                 title=str(title),
                 tool_kind=getattr(tool_call, "kind", None),
                 params=_permission_params(tool_call),
-                expires_at=_permission_expires_at(tool_call),
+                expires_at=expires_at,
                 options=[
                     PermissionOption(
                         option_id=getattr(o, "option_id", ""),
@@ -262,8 +273,28 @@ class _TuiClient:
             ),
         )
 
+        # ACP has no agent→client request cancellation, so a server-side
+        # timeout never reaches this handler — enforce the advertised
+        # deadline locally (with grace, so the server always expires first).
+        timeout = None
+        if expires_at is not None:
+            timeout = (
+                max(expires_at - time.time(), 0.0)
+                + _PERMISSION_EXPIRY_GRACE_SECONDS
+            )
+
         try:
-            option_id = await future
+            option_id = await asyncio.wait_for(future, timeout)
+        except asyncio.TimeoutError:
+            await self._queue.put(
+                PermissionExpired(
+                    request_id=request_id,
+                    message=_PERMISSION_TIMEOUT_MESSAGE,
+                ),
+            )
+            return RequestPermissionResponse(
+                outcome=DeniedOutcome(outcome="cancelled"),
+            )
         except asyncio.CancelledError as exc:
             if not future.done():
                 future.cancel()

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -152,6 +152,19 @@ def _permission_expires_at(tool_call: Any) -> float | None:
     return None
 
 
+def _permission_expired_message(exc: asyncio.CancelledError) -> str:
+    reason = str(exc.args[0]) if exc.args else ""
+    if reason == "timeout":
+        return (
+            "Approval request timed out. The tool call was blocked; "
+            "start a new request to try again."
+        )
+    return (
+        "Approval request is no longer pending. The tool call was blocked; "
+        "start a new request to try again."
+    )
+
+
 def _tool_call_meta(tool_call: Any) -> dict[str, Any]:
     if isinstance(tool_call, dict):
         meta = tool_call.get("_meta") or tool_call.get("field_meta")
@@ -251,17 +264,13 @@ class _TuiClient:
 
         try:
             option_id = await future
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
             if not future.done():
                 future.cancel()
             await self._queue.put(
                 PermissionExpired(
                     request_id=request_id,
-                    message=(
-                        "Approval request is no longer pending. "
-                        "The tool call was blocked; start a new request "
-                        "to try again."
-                    ),
+                    message=_permission_expired_message(exc),
                 ),
             )
             raise

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -44,6 +44,7 @@ from ..events import (
     BackendWarmed,
     Connected,
     PermissionOption,
+    PermissionExpired,
     PermissionRequest,
     PushMessage,
     SessionSummary,
@@ -225,6 +226,20 @@ class _TuiClient:
 
         try:
             option_id = await future
+        except asyncio.CancelledError:
+            if not future.done():
+                future.cancel()
+            await self._queue.put(
+                PermissionExpired(
+                    request_id=request_id,
+                    message=(
+                        "Approval request is no longer pending. "
+                        "The tool call was blocked; start a new request "
+                        "to try again."
+                    ),
+                ),
+            )
+            raise
         finally:
             self._pending.pop(request_id, None)
 

--- a/src/qwenpaw/cli/tui/transport/acp.py
+++ b/src/qwenpaw/cli/tui/transport/acp.py
@@ -278,9 +278,9 @@ class _TuiClient:
         # deadline locally (with grace, so the server always expires first).
         timeout = None
         if expires_at is not None:
-            timeout = (
-                max(expires_at - time.time(), 0.0)
-                + _PERMISSION_EXPIRY_GRACE_SECONDS
+            timeout = max(
+                expires_at + _PERMISSION_EXPIRY_GRACE_SECONDS - time.time(),
+                0.0,
             )
 
         try:

--- a/src/qwenpaw/cli/tui/widgets/permission_overlay.py
+++ b/src/qwenpaw/cli/tui/widgets/permission_overlay.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import math
+import time
+
 from rich.text import Text
 from textual.widgets import OptionList
 from textual.widgets.option_list import Option
@@ -11,6 +14,7 @@ from ..events import PermissionRequest
 
 _MAX_PARAM_LINES = 6
 _MAX_PARAM_COLUMNS = 120
+_TITLE_OPTION_ID = "__permission_title"
 
 
 class PermissionOverlay(OptionList):
@@ -24,7 +28,7 @@ class PermissionOverlay(OptionList):
         dock: bottom;
         height: auto;
         max-height: 12;
-        margin: 0 2 4 2;
+        margin: 0 0 4 0;
         border: round #ffcf6d;
         background: #101827 96%;
         display: none;
@@ -41,6 +45,8 @@ class PermissionOverlay(OptionList):
         super().__init__(id="permission-overlay")
         self._request: PermissionRequest | None = None
         self._option_ids: set[str] = set()
+        self._last_countdown: str | None = None
+        self._countdown_timer = None
 
     @property
     def request(self) -> PermissionRequest | None:
@@ -67,9 +73,14 @@ class PermissionOverlay(OptionList):
         self._option_ids = {option.option_id for option in request.options}
         self.clear_options()
 
-        title = Text("Approval required: ", style="bold #ffcf6d")
-        title.append(request.title, style="bold")
-        self.add_option(Option(title, disabled=True))
+        self._last_countdown = None
+        self.add_option(
+            Option(
+                self._title_text(request),
+                id=_TITLE_OPTION_ID,
+                disabled=True,
+            ),
+        )
         if request.tool_kind:
             self.add_option(
                 Option(
@@ -98,12 +109,28 @@ class PermissionOverlay(OptionList):
 
         self.display = True
         self.highlighted = self._first_action_index()
+        self._start_countdown_timer()
 
     def clear_request(self) -> None:
+        self._stop_countdown_timer()
         self._request = None
         self._option_ids.clear()
+        self._last_countdown = None
         self.clear_options()
         self.display = False
+
+    def refresh_countdown(self) -> None:
+        request = self._request
+        if request is None or request.expires_at is None or not self.display:
+            return
+        countdown = self._countdown_text(request.expires_at)
+        if countdown == self._last_countdown:
+            return
+        self._last_countdown = countdown
+        self.replace_option_prompt(
+            _TITLE_OPTION_ID,
+            self._title_text(request),
+        )
 
     def cursor_up(self) -> None:
         self.action_cursor_up()
@@ -116,6 +143,43 @@ class PermissionOverlay(OptionList):
             if self.get_option_at_index(index).id in self._option_ids:
                 return index
         return None
+
+    def _title_text(self, request: PermissionRequest) -> Text:
+        title = Text("Approval required", style="bold #ffcf6d")
+        if request.expires_at is not None:
+            countdown = self._countdown_text(request.expires_at)
+            self._last_countdown = countdown
+            style = "#ffcf6d" if countdown != "expired" else "bold #ff6d6d"
+            title.append(" (", style="#8a8a8a")
+            title.append(countdown, style=style)
+            title.append(")", style="#8a8a8a")
+        title.append(": ", style="bold #ffcf6d")
+        title.append(request.title, style="bold")
+        return title
+
+    @staticmethod
+    def _countdown_text(expires_at: float) -> str:
+        remaining = math.ceil(expires_at - time.time())
+        if remaining <= 0:
+            return "expired"
+        minutes, seconds = divmod(remaining, 60)
+        if minutes:
+            return f"expires in {minutes}m{seconds:02d}s"
+        return f"expires in {seconds}s"
+
+    def _start_countdown_timer(self) -> None:
+        self._stop_countdown_timer()
+        if self._request is None or self._request.expires_at is None:
+            return
+        self._countdown_timer = self.set_interval(
+            1.0,
+            self.refresh_countdown,
+        )
+
+    def _stop_countdown_timer(self) -> None:
+        if self._countdown_timer is not None:
+            self._countdown_timer.stop()
+            self._countdown_timer = None
 
 
 def _param_lines(params: str) -> list[str]:

--- a/src/qwenpaw/cli/tui/widgets/permission_overlay.py
+++ b/src/qwenpaw/cli/tui/widgets/permission_overlay.py
@@ -16,7 +16,7 @@ _MAX_PARAM_COLUMNS = 120
 class PermissionOverlay(OptionList):
     """Selectable approval prompt shown above the chat input."""
 
-    can_focus = False
+    can_focus = True
 
     DEFAULT_CSS = """
     PermissionOverlay {

--- a/src/qwenpaw/cli/tui/widgets/permission_overlay.py
+++ b/src/qwenpaw/cli/tui/widgets/permission_overlay.py
@@ -151,6 +151,8 @@ class PermissionOverlay(OptionList):
             _TITLE_OPTION_ID,
             self._title_text(request),
         )
+        if countdown == "expired":
+            self._stop_countdown_timer()
 
     def cursor_up(self) -> None:
         self.action_cursor_up()

--- a/src/qwenpaw/cli/tui/widgets/permission_overlay.py
+++ b/src/qwenpaw/cli/tui/widgets/permission_overlay.py
@@ -15,6 +15,13 @@ from ..events import PermissionRequest
 _MAX_PARAM_LINES = 6
 _MAX_PARAM_COLUMNS = 120
 _TITLE_OPTION_ID = "__permission_title"
+_IMPORTANT_PARAM_LABELS = {
+    "command": "Command",
+    "approve_exact_target": "Exact Target",
+    "approve_pattern_target": "Pattern Target",
+    "path": "Path",
+    "file_path": "Path",
+}
 
 
 class PermissionOverlay(OptionList):
@@ -84,18 +91,31 @@ class PermissionOverlay(OptionList):
         if request.tool_kind:
             self.add_option(
                 Option(
-                    Text(f"kind: {request.tool_kind}", style="#8a8a8a"),
+                    _labeled_text("Action", request.tool_kind),
                     disabled=True,
                 ),
             )
         if request.params:
             self.add_option(
-                Option(Text("parameters", style="#8a8a8a"), disabled=True),
+                Option(
+                    Text("Review target", style="bold #8fd3ff"),
+                    disabled=True,
+                ),
             )
             for line in _param_lines(request.params):
                 self.add_option(
-                    Option(Text(line, style="#d8dee9"), disabled=True),
+                    Option(_param_text(line), disabled=True),
                 )
+        if request.options:
+            self.add_option(
+                Option(
+                    Text(
+                        "Choose a session-scoped action",
+                        style="#9ca3af",
+                    ),
+                    disabled=True,
+                ),
+            )
 
         for option in request.options:
             label = Text(option.name or option.option_id)
@@ -197,3 +217,42 @@ def _truncate_line(line: str) -> str:
     if len(line) <= _MAX_PARAM_COLUMNS:
         return line
     return line[: _MAX_PARAM_COLUMNS - 3] + "..."
+
+
+def _labeled_text(label: str, value: str) -> Text:
+    text = Text()
+    text.append(f"{label}: ", style="bold #8fd3ff")
+    text.append(_truncate_line(value), style="bold #d8dee9")
+    return text
+
+
+def _param_text(line: str) -> Text:
+    if line.startswith("..."):
+        return Text(line, style="#9ca3af")
+    key, separator, value = line.partition(":")
+    if not separator:
+        return Text(_truncate_line(line), style="#d8dee9")
+
+    normalized = key.strip()
+    label = _IMPORTANT_PARAM_LABELS.get(
+        normalized,
+        normalized.replace("_", " ").title(),
+    )
+    value = value.strip()
+
+    label_style = "bold #8fd3ff"
+    value_style = "#d8dee9"
+    if normalized == "command":
+        label_style = "bold #ffcf6d"
+        value_style = "bold #f8f8f2"
+    elif normalized == "approve_pattern_target":
+        label_style = "bold #b48cff"
+        value_style = "bold #d8dee9"
+    elif normalized == "approve_exact_target":
+        label_style = "bold #8fd3ff"
+        value_style = "bold #d8dee9"
+
+    text = Text()
+    text.append(f"{label}: ", style=label_style)
+    text.append(_truncate_line(value), style=value_style)
+    return text

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -562,6 +562,11 @@ class GovernancePolicy:
     shell_evasion_checks: dict[str, bool] = field(default_factory=dict)
     detection_rules: List[DetectionRuleConfig] = field(default_factory=list)
 
+    # Default-rule migrations already applied to this policy (rule match
+    # strings). Once a migration is recorded here, the corresponding default
+    # user rule is never re-added on load — so deleting it stays deleted.
+    applied_migrations: List[str] = field(default_factory=list)
+
     # Internal reference to registry (defaults to module-level
     # DEFAULT_REGISTRY)
     _registry: ToolRegistry = field(
@@ -1021,6 +1026,9 @@ def load_governance_policy(
     if not isinstance(env_blacklist, list):
         env_blacklist = []
 
+    # ── Applied default-rule migrations (absent in pre-migration files) ──
+    applied_migrations = _parse_applied_migrations(data)
+
     # ── Cold start / migration: fill in missing default rules ──
     if not user_rules:
         user_rules = copy.deepcopy(DEFAULT_USER_RULES)
@@ -1029,7 +1037,13 @@ def load_governance_policy(
             user_rules,
             workspace_dir,
             coding_project_dir,
+            applied_migrations=applied_migrations,
         )
+    # Record all known migrations as applied so the next save makes any
+    # user deletion of a migrated rule stick.
+    applied_migrations = sorted(
+        set(applied_migrations) | _MIGRATED_DEFAULT_USER_RULE_MATCHES,
+    )
     if not env_blacklist:
         env_blacklist = list(DEFAULT_ENV_BLACKLIST)
 
@@ -1071,6 +1085,7 @@ def load_governance_policy(
         sensitive_paths=sensitive_paths,
         shell_evasion_checks=shell_evasion_checks,
         detection_rules=detection_rules,
+        applied_migrations=applied_migrations,
     )
 
 
@@ -1112,6 +1127,8 @@ def save_governance_policy(
     }
 
     # v2.0 fields (only write when non-empty to keep YAML clean)
+    if policy.applied_migrations:
+        data["applied_migrations"] = list(policy.applied_migrations)
     if policy.sensitive_paths:
         data["sensitive_paths"] = list(policy.sensitive_paths)
     if policy.shell_evasion_checks:
@@ -1183,18 +1200,36 @@ def _create_default_policy(
         execution_level="smart",
         sensitive_paths=list(_DEFAULT_SENSITIVE_PATHS),
         shell_evasion_checks=dict(_DEFAULT_SHELL_EVASION_CHECKS),
+        applied_migrations=sorted(_MIGRATED_DEFAULT_USER_RULE_MATCHES),
     )
+
+
+def _parse_applied_migrations(data: dict[str, Any]) -> List[str]:
+    """Read the applied default-rule migration markers from policy YAML."""
+    applied = data.get("applied_migrations", [])
+    if not isinstance(applied, list):
+        return []
+    return [m for m in applied if isinstance(m, str)]
 
 
 def _merge_missing_default_user_rules(
     user_rules: List[GovernanceRule],
     workspace_dir: str = "",
     coding_project_dir: str = "",
+    applied_migrations: List[str] | None = None,
 ) -> List[GovernanceRule]:
-    """Append migrated default user rules missing from a persisted policy."""
+    """Append migrated default user rules missing from a persisted policy.
+
+    A rule whose match is recorded in ``applied_migrations`` is never
+    re-added: the migration already ran once, so a missing rule means the
+    user deleted it on purpose.
+    """
+    applied = set(applied_migrations or [])
     merged = list(user_rules)
     for default_rule in DEFAULT_USER_RULES:
         if default_rule.match not in _MIGRATED_DEFAULT_USER_RULE_MATCHES:
+            continue
+        if default_rule.match in applied:
             continue
         if _has_equivalent_rule(
             merged,

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -507,6 +507,13 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
     ),
 ]
 
+# Default user rules added after policy.yaml existed in the wild. Existing
+# persisted policies keep their user_rules, so migrate only these known safe
+# defaults instead of replacing user customizations wholesale.
+_MIGRATED_DEFAULT_USER_RULE_MATCHES = {
+    "*(CODING_PROJECT_DIR/**)",
+}
+
 
 # ---------------------------------------------------------------------------
 # GovernancePolicy
@@ -1014,9 +1021,15 @@ def load_governance_policy(
     if not isinstance(env_blacklist, list):
         env_blacklist = []
 
-    # ── Cold start: fill in missing default rules ──
+    # ── Cold start / migration: fill in missing default rules ──
     if not user_rules:
         user_rules = copy.deepcopy(DEFAULT_USER_RULES)
+    else:
+        user_rules = _merge_missing_default_user_rules(
+            user_rules,
+            workspace_dir,
+            coding_project_dir,
+        )
     if not env_blacklist:
         env_blacklist = list(DEFAULT_ENV_BLACKLIST)
 
@@ -1171,6 +1184,43 @@ def _create_default_policy(
         sensitive_paths=list(_DEFAULT_SENSITIVE_PATHS),
         shell_evasion_checks=dict(_DEFAULT_SHELL_EVASION_CHECKS),
     )
+
+
+def _merge_missing_default_user_rules(
+    user_rules: List[GovernanceRule],
+    workspace_dir: str = "",
+    coding_project_dir: str = "",
+) -> List[GovernanceRule]:
+    """Append migrated default user rules missing from a persisted policy."""
+    merged = list(user_rules)
+    for default_rule in DEFAULT_USER_RULES:
+        if default_rule.match not in _MIGRATED_DEFAULT_USER_RULE_MATCHES:
+            continue
+        if _has_equivalent_rule(
+            merged,
+            default_rule,
+            workspace_dir,
+            coding_project_dir,
+        ):
+            continue
+        merged.append(copy.deepcopy(default_rule))
+    return merged
+
+
+def _has_equivalent_rule(
+    rules: List[GovernanceRule],
+    default_rule: GovernanceRule,
+    workspace_dir: str = "",
+    coding_project_dir: str = "",
+) -> bool:
+    """Return True when a persisted policy already has this default rule."""
+    candidates = {default_rule.match}
+    if workspace_dir:
+        resolved = copy.deepcopy(default_rule)
+        cpd = coding_project_dir or workspace_dir
+        _resolve_placeholders([resolved], workspace_dir, cpd)
+        candidates.add(resolved.match)
+    return any(rule.match in candidates for rule in rules)
 
 
 def _resolve_placeholders(

--- a/src/qwenpaw/hooks/session/session_hook.py
+++ b/src/qwenpaw/hooks/session/session_hook.py
@@ -11,11 +11,24 @@ from __future__ import annotations
 import logging
 
 from ..base import LifecycleHook
+from ...agents.acp.meta import ACP_EPHEMERAL_META_KEY
 from ...runtime._state_utils import StateProxy
 from ...runtime.hooks import HookContext, HookResult
 from ...runtime.phases import Phase
 
 logger = logging.getLogger(__name__)
+
+
+def _is_ephemeral_request(ctx: HookContext) -> bool:
+    request = ctx.request
+    request_context = getattr(request, "request_context", None)
+    if isinstance(request_context, dict):
+        value = request_context.get(ACP_EPHEMERAL_META_KEY)
+        if value is True:
+            return True
+        if isinstance(value, str) and value.lower() in {"1", "true", "yes"}:
+            return True
+    return False
 
 
 class SessionLoadHook(LifecycleHook):
@@ -26,6 +39,8 @@ class SessionLoadHook(LifecycleHook):
     priority = 10
 
     async def run(self, ctx: HookContext) -> HookResult:
+        if _is_ephemeral_request(ctx):
+            return HookResult()
         if ctx.workspace is None:
             return HookResult()
         session = getattr(ctx.workspace, "session", None)
@@ -63,6 +78,8 @@ class SessionSaveHook(LifecycleHook):
     priority = 90
 
     async def run(self, ctx: HookContext) -> HookResult:
+        if _is_ephemeral_request(ctx):
+            return HookResult()
         if ctx.workspace is None or ctx.agent is None:
             return HookResult()
         session = getattr(ctx.workspace, "session", None)

--- a/tests/unit/agents/hooks/test_session_hook.py
+++ b/tests/unit/agents/hooks/test_session_hook.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Session hook persistence behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.agents.acp.meta import ACP_EPHEMERAL_META_KEY
+from qwenpaw.hooks.session.session_hook import (
+    SessionLoadHook,
+    SessionSaveHook,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.p1]
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.loaded = False
+        self.saved = False
+
+    async def load_session_state(self, *args, **kwargs) -> None:
+        del args, kwargs
+        self.loaded = True
+
+    async def save_session_state(self, *args, **kwargs) -> None:
+        del args, kwargs
+        self.saved = True
+
+
+def _ctx(session: _FakeSession, *, ephemeral: bool):
+    return SimpleNamespace(
+        request=SimpleNamespace(
+            request_context={ACP_EPHEMERAL_META_KEY: ephemeral},
+            user_id="acp_warmup",
+            channel="",
+        ),
+        workspace=SimpleNamespace(session=session),
+        agent=SimpleNamespace(state_dict=lambda: {"context": []}),
+        session_id="warmup-session",
+    )
+
+
+async def test_ephemeral_request_skips_session_load_and_save():
+    session = _FakeSession()
+    ctx = _ctx(session, ephemeral=True)
+
+    await SessionLoadHook().run(ctx)
+    await SessionSaveHook().run(ctx)
+
+    assert session.loaded is False
+    assert session.saved is False
+
+
+async def test_normal_request_loads_and_saves_session_state():
+    session = _FakeSession()
+    ctx = _ctx(session, ephemeral=False)
+
+    await SessionLoadHook().run(ctx)
+    await SessionSaveHook().run(ctx)
+
+    assert session.loaded is True
+    assert session.saved is True

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -13,6 +13,7 @@ import asyncio
 
 from acp.schema import AllowedOutcome, RequestPermissionResponse
 
+from qwenpaw.agents.acp.meta import ACP_APPROVAL_EXPIRES_AT_META_KEY
 from qwenpaw.agents.acp.server import (
     _ACP_REDUNDANT_COMMANDS,
     _EnvelopeTracker,
@@ -328,6 +329,11 @@ async def test_approval_bridge_resolves_pending_approval(monkeypatch):
     )
     assert tool_call.kind == "execute"
     assert tool_call.raw_input == {"command": "ls"}
+    assert tool_call.field_meta == {
+        ACP_APPROVAL_EXPIRES_AT_META_KEY: (
+            pending.created_at + pending.timeout_seconds
+        ),
+    }
     assert {option.option_id for option in request["options"]} == {
         "allow_once",
         "deny",

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -301,6 +301,8 @@ async def test_approval_bridge_resolves_pending_approval(monkeypatch):
         "allow_once",
         "deny",
     }
+    names = {option.option_id: option.name for option in request["options"]}
+    assert names["allow_once"] == "Approve Exact"
     assert pending.scope is ApprovalScope.EXACT
 
 
@@ -381,6 +383,9 @@ async def test_approval_bridge_resolves_pattern_scope(monkeypatch):
     kinds = {option.option_id: option.kind for option in request["options"]}
     assert kinds["allow_once"] == "allow_once"
     assert kinds["allow_always"] == "allow_always"
+    names = {option.option_id: option.name for option in request["options"]}
+    assert names["allow_once"] == "Just Once Exact"
+    assert names["allow_always"] == "Always Allow Pattern"
     assert request["tool_call"].raw_input == {
         "command": "git status",
         "approve_exact_target": "git status",

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -501,6 +501,84 @@ async def test_approval_bridge_expires_when_pending_times_out(monkeypatch):
     assert pending.status == ApprovalDecision.TIMEOUT.value
 
 
+async def test_approval_bridge_survives_wait_for_timeout(monkeypatch):
+    """The real timeout path (``wait_for_approval`` → ``asyncio.wait_for``)
+    cancels the shared pending future instead of setting a TIMEOUT result.
+    The bridge must not let that CancelledError escape (it would kill the
+    per-turn approval polling loop) and must still cancel the client prompt.
+    """
+    from qwenpaw.app.approvals.service import ApprovalService
+    from qwenpaw.security.tool_guard.approval import ApprovalDecision
+    from qwenpaw.security.tool_guard.models import (
+        GuardFinding,
+        GuardSeverity,
+        GuardThreatCategory,
+        ToolGuardResult,
+    )
+
+    approval_svc = ApprovalService()
+    monkeypatch.setattr(
+        "qwenpaw.app.approvals.service._approval_service",
+        approval_svc,
+    )
+
+    agent = QwenPawACPAgent(agent_id="default")
+    conn = _HangingApprovalConn()
+    agent.on_connect(conn)
+
+    result = ToolGuardResult(
+        tool_name="execute_shell_command",
+        params={"command": "rm -rf /tmp/nope"},
+        findings=[
+            GuardFinding(
+                id="finding-1",
+                rule_id="test",
+                category=GuardThreatCategory.RESOURCE_ABUSE,
+                severity=GuardSeverity.MEDIUM,
+                title="Approval required",
+                description="Shell command requires approval.",
+                tool_name="execute_shell_command",
+            ),
+        ],
+    )
+    pending = await approval_svc.create_pending(
+        session_id="sess-approval",
+        root_session_id="sess-approval",
+        owner_agent_id="default",
+        user_id="acp_user",
+        channel="console",
+        agent_id="default",
+        tool_name="execute_shell_command",
+        result=result,
+        extra={
+            "tool_call": {
+                "id": "tool-1",
+                "name": "execute_shell_command",
+                "input": {"command": "rm -rf /tmp/nope"},
+            },
+        },
+    )
+
+    bridge = asyncio.create_task(
+        agent._request_approval_decision("sess-approval", pending),
+    )
+    await asyncio.wait_for(conn.started.wait(), timeout=1.0)
+
+    waiter = asyncio.create_task(
+        approval_svc.wait_for_approval(pending.request_id, 0.05),
+    )
+    decision = await asyncio.wait_for(waiter, timeout=1.0)
+    assert decision == ApprovalDecision.TIMEOUT
+
+    # The bridge coroutine must finish normally, not die cancelled.
+    await asyncio.wait_for(asyncio.shield(bridge), timeout=1.0)
+    assert not bridge.cancelled()
+
+    assert conn.cancelled is True
+    assert conn.cancel_reason == "timeout"
+    assert pending.status == ApprovalDecision.TIMEOUT.value
+
+
 def test_acp_bootstrap_includes_runtime_slash_commands():
     from qwenpaw.app.app_services import AppServiceManager
 

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -35,8 +35,9 @@ class _FakeConn:
 class _ApprovalConn(_FakeConn):
     """Records ACP permission requests and approves them."""
 
-    def __init__(self) -> None:
+    def __init__(self, option_id: str = "allow_once") -> None:
         super().__init__()
+        self.option_id = option_id
         self.permission_requests: list[dict[str, object]] = []
 
     async def request_permission(
@@ -56,7 +57,7 @@ class _ApprovalConn(_FakeConn):
         return RequestPermissionResponse(
             outcome=AllowedOutcome(
                 outcome="selected",
-                option_id="approve",
+                option_id=self.option_id,
             ),
         )
 
@@ -221,7 +222,10 @@ async def test_report_prompt_error_shows_details_for_local_diagnostics():
 
 async def test_approval_bridge_resolves_pending_approval(monkeypatch):
     from qwenpaw.app.approvals.service import ApprovalService
-    from qwenpaw.security.tool_guard.approval import ApprovalDecision
+    from qwenpaw.security.tool_guard.approval import (
+        ApprovalDecision,
+        ApprovalScope,
+    )
     from qwenpaw.security.tool_guard.models import (
         GuardFinding,
         GuardSeverity,
@@ -293,6 +297,95 @@ async def test_approval_bridge_resolves_pending_approval(monkeypatch):
     )
     assert tool_call.kind == "execute"
     assert tool_call.raw_input == {"command": "ls"}
+    assert {option.option_id for option in request["options"]} == {
+        "allow_once",
+        "deny",
+    }
+    assert pending.scope is ApprovalScope.EXACT
+
+
+async def test_approval_bridge_resolves_pattern_scope(monkeypatch):
+    from qwenpaw.app.approvals.service import ApprovalService
+    from qwenpaw.security.tool_guard.approval import (
+        ApprovalDecision,
+        ApprovalScope,
+    )
+    from qwenpaw.security.tool_guard.models import (
+        GuardFinding,
+        GuardSeverity,
+        GuardThreatCategory,
+        ToolGuardResult,
+    )
+
+    approval_svc = ApprovalService()
+    monkeypatch.setattr(
+        "qwenpaw.app.approvals.service._approval_service",
+        approval_svc,
+    )
+
+    agent = QwenPawACPAgent(agent_id="default")
+    conn = _ApprovalConn(option_id="allow_always")
+    agent.on_connect(conn)
+
+    result = ToolGuardResult(
+        tool_name="execute_shell_command",
+        params={"command": "git status"},
+        findings=[
+            GuardFinding(
+                id="finding-1",
+                rule_id="test",
+                category=GuardThreatCategory.RESOURCE_ABUSE,
+                severity=GuardSeverity.MEDIUM,
+                title="Approval required",
+                description="Shell command requires approval.",
+                tool_name="execute_shell_command",
+            ),
+        ],
+    )
+    pending = await approval_svc.create_pending(
+        session_id="sess-approval",
+        root_session_id="sess-approval",
+        owner_agent_id="default",
+        user_id="acp_user",
+        channel="console",
+        agent_id="default",
+        tool_name="execute_shell_command",
+        result=result,
+        extra={
+            "tool_call": {
+                "id": "tool-1",
+                "name": "execute_shell_command",
+                "input": {"command": "git status"},
+            },
+            "display": {
+                "tool_name": "execute_shell_command",
+                "tool_source": "No rule hit",
+                "exact_target": "git status",
+                "similar_target": "git *",
+                "is_generalized": True,
+            },
+        },
+    )
+
+    await agent._request_approval_decision("sess-approval", pending)
+    decision = await asyncio.wait_for(pending.future, timeout=1.0)
+
+    assert decision == ApprovalDecision.APPROVED
+    assert pending.scope is ApprovalScope.SIMILAR
+    request = conn.permission_requests[0]
+    assert {option.option_id for option in request["options"]} == {
+        "allow_once",
+        "allow_always",
+        "deny",
+    }
+    kinds = {option.option_id: option.kind for option in request["options"]}
+    assert kinds["allow_once"] == "allow_once"
+    assert kinds["allow_always"] == "allow_always"
+    assert request["tool_call"].raw_input == {
+        "command": "git status",
+        "approve_exact_target": "git status",
+        "approve_pattern_target": "git *",
+    }
 
 
 def test_acp_bootstrap_includes_runtime_slash_commands():

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -62,6 +62,37 @@ class _ApprovalConn(_FakeConn):
         )
 
 
+class _HangingApprovalConn(_FakeConn):
+    """Records ACP permission requests and waits until cancelled."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.cancelled = False
+        self.permission_requests: list[dict[str, object]] = []
+
+    async def request_permission(
+        self,
+        *,
+        session_id: str,
+        tool_call: object,
+        options: list[object],
+    ) -> RequestPermissionResponse:
+        self.permission_requests.append(
+            {
+                "session_id": session_id,
+                "tool_call": tool_call,
+                "options": options,
+            },
+        )
+        self.started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
 async def _drain() -> None:
     """Let the fire-and-forget advertise task run to completion."""
     for _ in range(5):
@@ -391,6 +422,74 @@ async def test_approval_bridge_resolves_pattern_scope(monkeypatch):
         "approve_exact_target": "git status",
         "approve_pattern_target": "git *",
     }
+
+
+async def test_approval_bridge_expires_when_pending_times_out(monkeypatch):
+    from qwenpaw.app.approvals.service import ApprovalService
+    from qwenpaw.security.tool_guard.approval import ApprovalDecision
+    from qwenpaw.security.tool_guard.models import (
+        GuardFinding,
+        GuardSeverity,
+        GuardThreatCategory,
+        ToolGuardResult,
+    )
+
+    approval_svc = ApprovalService()
+    monkeypatch.setattr(
+        "qwenpaw.app.approvals.service._approval_service",
+        approval_svc,
+    )
+
+    agent = QwenPawACPAgent(agent_id="default")
+    conn = _HangingApprovalConn()
+    agent.on_connect(conn)
+
+    result = ToolGuardResult(
+        tool_name="execute_shell_command",
+        params={"command": "rm -rf /tmp/nope"},
+        findings=[
+            GuardFinding(
+                id="finding-1",
+                rule_id="test",
+                category=GuardThreatCategory.RESOURCE_ABUSE,
+                severity=GuardSeverity.MEDIUM,
+                title="Approval required",
+                description="Shell command requires approval.",
+                tool_name="execute_shell_command",
+            ),
+        ],
+    )
+    pending = await approval_svc.create_pending(
+        session_id="sess-approval",
+        root_session_id="sess-approval",
+        owner_agent_id="default",
+        user_id="acp_user",
+        channel="console",
+        agent_id="default",
+        tool_name="execute_shell_command",
+        result=result,
+        extra={
+            "tool_call": {
+                "id": "tool-1",
+                "name": "execute_shell_command",
+                "input": {"command": "rm -rf /tmp/nope"},
+            },
+        },
+    )
+
+    task = asyncio.create_task(
+        agent._request_approval_decision("sess-approval", pending),
+    )
+    await asyncio.wait_for(conn.started.wait(), timeout=1.0)
+
+    await approval_svc.resolve_request(
+        pending.request_id,
+        ApprovalDecision.TIMEOUT,
+    )
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert conn.cancelled is True
+    assert pending.status == ApprovalDecision.TIMEOUT.value
 
 
 def test_acp_bootstrap_includes_runtime_slash_commands():

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -302,7 +302,7 @@ async def test_approval_bridge_resolves_pending_approval(monkeypatch):
         "deny",
     }
     names = {option.option_id: option.name for option in request["options"]}
-    assert names["allow_once"] == "Approve Exact"
+    assert names["allow_once"] == "Allow Exact This Session"
     assert pending.scope is ApprovalScope.EXACT
 
 
@@ -384,8 +384,8 @@ async def test_approval_bridge_resolves_pattern_scope(monkeypatch):
     assert kinds["allow_once"] == "allow_once"
     assert kinds["allow_always"] == "allow_always"
     names = {option.option_id: option.name for option in request["options"]}
-    assert names["allow_once"] == "Just Once Exact"
-    assert names["allow_always"] == "Always Allow Pattern"
+    assert names["allow_once"] == "Allow Exact This Session"
+    assert names["allow_always"] == "Allow Pattern This Session"
     assert request["tool_call"].raw_input == {
         "command": "git status",
         "approve_exact_target": "git status",

--- a/tests/unit/agents/test_acp_available_commands.py
+++ b/tests/unit/agents/test_acp_available_commands.py
@@ -70,6 +70,7 @@ class _HangingApprovalConn(_FakeConn):
         super().__init__()
         self.started = asyncio.Event()
         self.cancelled = False
+        self.cancel_reason = ""
         self.permission_requests: list[dict[str, object]] = []
 
     async def request_permission(
@@ -89,8 +90,9 @@ class _HangingApprovalConn(_FakeConn):
         self.started.set()
         try:
             await asyncio.Future()
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
             self.cancelled = True
+            self.cancel_reason = str(exc.args[0]) if exc.args else ""
             raise
 
 
@@ -495,6 +497,7 @@ async def test_approval_bridge_expires_when_pending_times_out(monkeypatch):
     await asyncio.wait_for(task, timeout=1.0)
 
     assert conn.cancelled is True
+    assert conn.cancel_reason == "timeout"
     assert pending.status == ApprovalDecision.TIMEOUT.value
 
 

--- a/tests/unit/agents/test_acp_coding_project.py
+++ b/tests/unit/agents/test_acp_coding_project.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from acp import text_block
 
-from qwenpaw.agents.acp.meta import ACP_CODING_PROJECT_META_KEY
+from qwenpaw.agents.acp.meta import (
+    ACP_CODING_PROJECT_META_KEY,
+    ACP_EPHEMERAL_META_KEY,
+)
 from qwenpaw.agents.acp.server import QwenPawACPAgent
 
 
@@ -100,4 +103,26 @@ async def test_acp_resume_project_metadata_is_stripped(tmp_path):
     assert (
         workspace.requests[0].request_context[ACP_CODING_PROJECT_META_KEY]
         == project_dir
+    )
+
+
+async def test_acp_ephemeral_metadata_flows_to_request_context(tmp_path):
+    project_dir = str(tmp_path)
+    workspace = _FakeWorkspace()
+    agent = _TestACPAgent(workspace)
+    agent.on_connect(_FakeConn())
+
+    response = await agent.new_session(
+        cwd=project_dir,
+        **{ACP_EPHEMERAL_META_KEY: True},
+    )
+
+    await agent.prompt(
+        prompt=[text_block("warmup")],
+        session_id=response.session_id,
+    )
+
+    assert workspace.requests
+    assert (
+        workspace.requests[0].request_context[ACP_EPHEMERAL_META_KEY] is True
     )

--- a/tests/unit/cli/tui/test_acp_transport.py
+++ b/tests/unit/cli/tui/test_acp_transport.py
@@ -164,6 +164,36 @@ async def test_permission_cancellation_emits_expired_event():
 
 
 @pytest.mark.asyncio
+async def test_permission_timeout_cancellation_emits_timeout_message():
+    queue = asyncio.Queue()
+    client = _TuiClient(queue)
+    task = asyncio.create_task(
+        client.request_permission(
+            options=[],
+            session_id="sess-1",
+            tool_call=SimpleNamespace(
+                title="dangerous_tool",
+                kind="execute",
+                raw_input={"command": "rm -rf /tmp/nope"},
+            ),
+        ),
+    )
+
+    request = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(request, PermissionRequest)
+
+    task.cancel("timeout")
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    expired = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(expired, PermissionExpired)
+    assert expired.request_id == request.request_id
+    assert "timed out" in expired.message
+    assert "blocked" in expired.message
+
+
+@pytest.mark.asyncio
 async def test_permission_request_carries_expiry_metadata():
     queue = asyncio.Queue()
     client = _TuiClient(queue)

--- a/tests/unit/cli/tui/test_acp_transport.py
+++ b/tests/unit/cli/tui/test_acp_transport.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -16,6 +17,7 @@ from qwenpaw.agents.acp.meta import ACP_CODING_PROJECT_META_KEY
 from qwenpaw.cli.tui.events import (
     BackendWarmed,
     Connected,
+    PermissionExpired,
     PermissionRequest,
     TextDelta,
     ThoughtDelta,
@@ -24,7 +26,7 @@ from qwenpaw.cli.tui.events import (
     TurnEnded,
     UserTurn,
 )
-from qwenpaw.cli.tui.transport.acp import AcpTransport
+from qwenpaw.cli.tui.transport.acp import AcpTransport, _TuiClient
 
 pytestmark = [pytest.mark.unit, pytest.mark.p1]
 
@@ -127,6 +129,35 @@ async def test_permission_allow():
 
     text = "".join(e.text for e in events if isinstance(e, TextDelta))
     assert "[perm:allow]" in text
+
+
+@pytest.mark.asyncio
+async def test_permission_cancellation_emits_expired_event():
+    queue = asyncio.Queue()
+    client = _TuiClient(queue)
+    task = asyncio.create_task(
+        client.request_permission(
+            options=[],
+            session_id="sess-1",
+            tool_call=SimpleNamespace(
+                title="dangerous_tool",
+                kind="execute",
+                raw_input={"command": "rm -rf /tmp/nope"},
+            ),
+        ),
+    )
+
+    request = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(request, PermissionRequest)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    expired = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(expired, PermissionExpired)
+    assert expired.request_id == request.request_id
+    assert "no longer pending" in expired.message
 
 
 @pytest.mark.asyncio
@@ -238,8 +269,6 @@ async def test_load_session_replays_history():
 
 
 def test_session_agent_reads_meta():
-    from types import SimpleNamespace
-
     from qwenpaw.cli.tui.transport.acp import _session_agent
 
     # Agent id reported via the session response _meta.

--- a/tests/unit/cli/tui/test_acp_transport.py
+++ b/tests/unit/cli/tui/test_acp_transport.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -197,7 +198,7 @@ async def test_permission_timeout_cancellation_emits_timeout_message():
 async def test_permission_request_carries_expiry_metadata():
     queue = asyncio.Queue()
     client = _TuiClient(queue)
-    expires_at = 1234567890.0
+    expires_at = time.time() + 300.0
     task = asyncio.create_task(
         client.request_permission(
             options=[],
@@ -220,6 +221,48 @@ async def test_permission_request_carries_expiry_metadata():
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_permission_expires_locally_at_deadline(monkeypatch):
+    """ACP has no agent→client cancel, so the client enforces the deadline
+    itself: past the advertised expiry the handler answers "cancelled" and
+    emits PermissionExpired so the overlay clears with an explanation.
+    """
+    monkeypatch.setattr(
+        "qwenpaw.cli.tui.transport.acp._PERMISSION_EXPIRY_GRACE_SECONDS",
+        0.05,
+    )
+    queue = asyncio.Queue()
+    client = _TuiClient(queue)
+    task = asyncio.create_task(
+        client.request_permission(
+            options=[],
+            session_id="sess-1",
+            tool_call=SimpleNamespace(
+                title="dangerous_tool",
+                kind="execute",
+                raw_input={"command": "rm -rf /tmp/nope"},
+                field_meta={
+                    ACP_APPROVAL_EXPIRES_AT_META_KEY: time.time() - 1.0,
+                },
+            ),
+        ),
+    )
+
+    request = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(request, PermissionRequest)
+
+    response = await asyncio.wait_for(task, timeout=1.0)
+    assert response.outcome.outcome == "cancelled"
+
+    expired = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(expired, PermissionExpired)
+    assert expired.request_id == request.request_id
+    assert "timed out" in expired.message
+
+    # A late resolve after expiry must be a harmless no-op.
+    client.resolve(request.request_id, "allow_once")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/tui/test_acp_transport.py
+++ b/tests/unit/cli/tui/test_acp_transport.py
@@ -231,7 +231,7 @@ async def test_permission_expires_locally_at_deadline(monkeypatch):
     """
     monkeypatch.setattr(
         "qwenpaw.cli.tui.transport.acp._PERMISSION_EXPIRY_GRACE_SECONDS",
-        0.05,
+        10.0,
     )
     queue = asyncio.Queue()
     client = _TuiClient(queue)
@@ -244,7 +244,7 @@ async def test_permission_expires_locally_at_deadline(monkeypatch):
                 kind="execute",
                 raw_input={"command": "rm -rf /tmp/nope"},
                 field_meta={
-                    ACP_APPROVAL_EXPIRES_AT_META_KEY: time.time() - 1.0,
+                    ACP_APPROVAL_EXPIRES_AT_META_KEY: time.time() - 20.0,
                 },
             ),
         ),
@@ -253,7 +253,7 @@ async def test_permission_expires_locally_at_deadline(monkeypatch):
     request = await asyncio.wait_for(queue.get(), timeout=1.0)
     assert isinstance(request, PermissionRequest)
 
-    response = await asyncio.wait_for(task, timeout=1.0)
+    response = await asyncio.wait_for(task, timeout=0.5)
     assert response.outcome.outcome == "cancelled"
 
     expired = await asyncio.wait_for(queue.get(), timeout=1.0)

--- a/tests/unit/cli/tui/test_acp_transport.py
+++ b/tests/unit/cli/tui/test_acp_transport.py
@@ -13,7 +13,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from qwenpaw.agents.acp.meta import ACP_CODING_PROJECT_META_KEY
+from qwenpaw.agents.acp.meta import (
+    ACP_APPROVAL_EXPIRES_AT_META_KEY,
+    ACP_CODING_PROJECT_META_KEY,
+)
 from qwenpaw.cli.tui.events import (
     BackendWarmed,
     Connected,
@@ -158,6 +161,35 @@ async def test_permission_cancellation_emits_expired_event():
     assert isinstance(expired, PermissionExpired)
     assert expired.request_id == request.request_id
     assert "no longer pending" in expired.message
+
+
+@pytest.mark.asyncio
+async def test_permission_request_carries_expiry_metadata():
+    queue = asyncio.Queue()
+    client = _TuiClient(queue)
+    expires_at = 1234567890.0
+    task = asyncio.create_task(
+        client.request_permission(
+            options=[],
+            session_id="sess-1",
+            tool_call=SimpleNamespace(
+                title="dangerous_tool",
+                kind="execute",
+                raw_input={"command": "rm -rf /tmp/nope"},
+                field_meta={
+                    ACP_APPROVAL_EXPIRES_AT_META_KEY: expires_at,
+                },
+            ),
+        ),
+    )
+
+    request = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert isinstance(request, PermissionRequest)
+    assert request.expires_at == expires_at
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/tui/test_app.py
+++ b/tests/unit/cli/tui/test_app.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 # pylint: disable=use-implicit-booleaness-not-comparison
 
 import asyncio
+import time
 
 import pytest
 
@@ -835,6 +836,32 @@ async def test_permission_overlay_expires_with_message():
         assert not overlay.display
         infos = [i.content.plain for i in app.query(InfoMessage)]
         assert any("Approval request is no longer pending" in i for i in infos)
+
+
+@pytest.mark.asyncio
+async def test_permission_overlay_shows_expiry_countdown():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(
+            PermissionRequest(
+                request_id="r-countdown",
+                title="dangerous_tool",
+                expires_at=time.time() + 65,
+                options=[
+                    PermissionOption("allow", "Allow", "allow_once"),
+                    PermissionOption("deny", "Deny", "reject_once"),
+                ],
+            ),
+        )
+        await pilot.pause()
+
+        overlay = app.query_one(PermissionOverlay)
+        title = overlay.get_option_at_index(0).prompt
+        assert "Approval required" in title.plain
+        assert "expires in" in title.plain
+        assert "dangerous_tool" in title.plain
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/tui/test_app.py
+++ b/tests/unit/cli/tui/test_app.py
@@ -93,6 +93,7 @@ class FakeTransport:
                 PermissionRequest(
                     request_id="r1",
                     title="dangerous_tool",
+                    tool_kind="execute",
                     params="command: rm -rf /tmp/nope",
                     options=[
                         PermissionOption("allow", "Allow", "allow_once"),
@@ -758,7 +759,12 @@ async def test_permission_overlay_resolves_with_keyboard_selection():
             getattr(overlay.get_option_at_index(index).prompt, "plain", "")
             for index in range(len(overlay.options))
         )
-        assert "command: rm -rf /tmp/nope" in option_text
+        assert "Action: execute" in option_text
+        assert "Review target" in option_text
+        assert "Command: rm -rf /tmp/nope" in option_text
+        assert "Choose a session-scoped action" in option_text
+        assert "kind:" not in option_text
+        assert "parameters" not in option_text
 
         # Down selects Deny, then Enter resolves the highlighted option.
         await pilot.press("down")
@@ -828,14 +834,62 @@ async def test_permission_overlay_expires_with_message():
         await app._dispatch(
             PermissionExpired(
                 request_id="r-expired",
-                message="Approval request is no longer pending.",
+                message=(
+                    "Approval request timed out. The tool call was blocked; "
+                    "start a new request to try again."
+                ),
             ),
         )
         await pilot.pause()
 
         assert not overlay.display
         infos = [i.content.plain for i in app.query(InfoMessage)]
-        assert any("Approval request is no longer pending" in i for i in infos)
+        assert any("Approval request timed out" in i for i in infos)
+
+
+@pytest.mark.asyncio
+async def test_permission_overlay_formats_approval_targets():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(
+            PermissionRequest(
+                request_id="r-targets",
+                title="execute_shell_command requires approval (MEDIUM)",
+                tool_kind="execute",
+                params=(
+                    "command: git status\n"
+                    "approve_exact_target: git status\n"
+                    "approve_pattern_target: git *"
+                ),
+                options=[
+                    PermissionOption(
+                        "allow_once",
+                        "Allow Exact This Session",
+                        "allow_once",
+                    ),
+                    PermissionOption(
+                        "allow_always",
+                        "Allow Pattern This Session",
+                        "allow_always",
+                    ),
+                    PermissionOption("deny", "Deny", "reject_once"),
+                ],
+            ),
+        )
+        await pilot.pause()
+
+        overlay = app.query_one(PermissionOverlay)
+        option_text = "\n".join(
+            getattr(overlay.get_option_at_index(index).prompt, "plain", "")
+            for index in range(len(overlay.options))
+        )
+        assert "Command: git status" in option_text
+        assert "Exact Target: git status" in option_text
+        assert "Pattern Target: git *" in option_text
+        assert "approve_exact_target" not in option_text
+        assert "approve_pattern_target" not in option_text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/tui/test_app.py
+++ b/tests/unit/cli/tui/test_app.py
@@ -766,6 +766,13 @@ async def test_permission_overlay_resolves_with_keyboard_selection():
         assert "kind:" not in option_text
         assert "parameters" not in option_text
 
+        handled_by_app: list[str] = []
+
+        async def _record_app_level_permission_key(key: str) -> None:
+            handled_by_app.append(key)
+
+        app._handle_permission_key = _record_app_level_permission_key
+
         # Down selects Deny, then Enter resolves the highlighted option.
         await pilot.press("down")
         await pilot.pause()
@@ -777,6 +784,7 @@ async def test_permission_overlay_resolves_with_keyboard_selection():
                 break
 
         assert transport.resolved == [("r1", "deny")]
+        assert handled_by_app == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/tui/test_app.py
+++ b/tests/unit/cli/tui/test_app.py
@@ -751,6 +751,7 @@ async def test_permission_overlay_resolves_with_keyboard_selection():
             if overlay.display:
                 break
         assert overlay.display
+        assert app.focused is overlay
         option_text = "\n".join(
             getattr(overlay.get_option_at_index(index).prompt, "plain", "")
             for index in range(len(overlay.options))
@@ -761,6 +762,37 @@ async def test_permission_overlay_resolves_with_keyboard_selection():
         await pilot.press("down")
         await pilot.pause()
         assert overlay.selected == "deny"
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+            if transport.resolved:
+                break
+
+        assert transport.resolved == [("r1", "deny")]
+
+
+@pytest.mark.asyncio
+async def test_permission_overlay_resolves_after_prompt_loses_focus():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        prompt = app.query_one("#prompt")
+        prompt.value = "do permission thing"
+        await pilot.press("enter")
+
+        overlay = app.query_one(PermissionOverlay)
+        for _ in range(10):
+            await pilot.pause()
+            if overlay.display:
+                break
+        assert overlay.display
+
+        overlay.cursor_down()
+        assert overlay.selected == "deny"
+        app.set_focus(None)
+        assert app.focused is None
+
         await pilot.press("enter")
         for _ in range(10):
             await pilot.pause()

--- a/tests/unit/cli/tui/test_app.py
+++ b/tests/unit/cli/tui/test_app.py
@@ -21,6 +21,7 @@ from qwenpaw.cli.tui.events import (
     Connected,
     FileLink,
     PermissionOption,
+    PermissionExpired,
     PermissionRequest,
     SessionSummary,
     SessionTitle,
@@ -800,6 +801,40 @@ async def test_permission_overlay_resolves_after_prompt_loses_focus():
                 break
 
         assert transport.resolved == [("r1", "deny")]
+
+
+@pytest.mark.asyncio
+async def test_permission_overlay_expires_with_message():
+    transport = FakeTransport()
+    app = PawApp(transport)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app._dispatch(
+            PermissionRequest(
+                request_id="r-expired",
+                title="dangerous_tool",
+                options=[
+                    PermissionOption("allow", "Allow", "allow_once"),
+                    PermissionOption("deny", "Deny", "reject_once"),
+                ],
+            ),
+        )
+        await pilot.pause()
+
+        overlay = app.query_one(PermissionOverlay)
+        assert overlay.display
+
+        await app._dispatch(
+            PermissionExpired(
+                request_id="r-expired",
+                message="Approval request is no longer pending.",
+            ),
+        )
+        await pilot.pause()
+
+        assert not overlay.display
+        infos = [i.content.plain for i in app.query(InfoMessage)]
+        assert any("Approval request is no longer pending" in i for i in infos)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -165,10 +165,13 @@ class TestDefaultPolicyLoad:
             for rule in policy.user_rules
             if rule.reason != "Coding project dir"
         ]
+        # Pre-migration files carry no applied_migrations marker.
+        policy.applied_migrations = []
         save_governance_policy(policy, str(policy_dir), ws, cpd)
 
         yaml_text = (policy_dir / "policy.yaml").read_text(encoding="utf-8")
         assert "CODING_PROJECT_DIR" not in yaml_text
+        assert "applied_migrations" not in yaml_text
 
         reloaded = load_governance_policy(str(policy_dir), ws, cpd)
         assert (
@@ -182,6 +185,53 @@ class TestDefaultPolicyLoad:
         assert reloaded.evaluate(_tc("Write", f"{cpd}/script.py")).action is (
             GovernanceAction.ALLOW
         )
+
+    def test_deleted_coding_project_dir_rule_stays_deleted(self, tmp_path):
+        """Once the migration marker is persisted, a user who deletes the
+        coding-dir ALLOW rule keeps it deleted across reloads (writes fall
+        through to the ASK fallback instead of being silently re-allowed).
+        """
+        ws = "/home/user/workspace"
+        cpd = "/home/user/coding"
+        policy_dir = tmp_path / "policy"
+        policy_dir.mkdir()
+        policy = _create_default_policy(
+            workspace_dir=ws,
+            coding_project_dir=cpd,
+        )
+        # User deletes the rule from a policy saved by current code (which
+        # records the migration as applied).
+        policy.user_rules = [
+            rule
+            for rule in policy.user_rules
+            if rule.reason != "Coding project dir"
+        ]
+        save_governance_policy(policy, str(policy_dir), ws, cpd)
+
+        yaml_text = (policy_dir / "policy.yaml").read_text(encoding="utf-8")
+        assert "applied_migrations" in yaml_text
+
+        reloaded = load_governance_policy(str(policy_dir), ws, cpd)
+        assert not [
+            rule
+            for rule in reloaded.user_rules
+            if rule.reason == "Coding project dir"
+        ]
+        assert (
+            reloaded.evaluate(
+                _tc("Write", f"{cpd}/script.py"),
+            ).action
+            is not GovernanceAction.ALLOW
+        )
+
+        # The marker round-trips, so it stays deleted on the next cycle too.
+        save_governance_policy(reloaded, str(policy_dir), ws, cpd)
+        again = load_governance_policy(str(policy_dir), ws, cpd)
+        assert not [
+            rule
+            for rule in again.user_rules
+            if rule.reason == "Coding project dir"
+        ]
 
     def test_coding_project_dir_roundtrip_portable(self, tmp_path):
         """save→reload keeps the CODING_PROJECT_DIR placeholder in YAML

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -148,6 +148,41 @@ class TestDefaultPolicyLoad:
             GovernanceAction.ALLOW
         )
 
+    def test_existing_policy_migrates_coding_project_dir_rule(self, tmp_path):
+        """Existing policy.yaml files from before the coding-dir default
+        should gain that rule on load instead of prompting for project writes.
+        """
+        ws = "/home/user/workspace"
+        cpd = "/home/user/coding"
+        policy_dir = tmp_path / "policy"
+        policy_dir.mkdir()
+        policy = _create_default_policy(
+            workspace_dir=ws,
+            coding_project_dir=cpd,
+        )
+        policy.user_rules = [
+            rule
+            for rule in policy.user_rules
+            if rule.reason != "Coding project dir"
+        ]
+        save_governance_policy(policy, str(policy_dir), ws, cpd)
+
+        yaml_text = (policy_dir / "policy.yaml").read_text(encoding="utf-8")
+        assert "CODING_PROJECT_DIR" not in yaml_text
+
+        reloaded = load_governance_policy(str(policy_dir), ws, cpd)
+        assert (
+            sum(
+                1
+                for rule in reloaded.user_rules
+                if rule.reason == "Coding project dir"
+            )
+            == 1
+        )
+        assert reloaded.evaluate(_tc("Write", f"{cpd}/script.py")).action is (
+            GovernanceAction.ALLOW
+        )
+
     def test_coding_project_dir_roundtrip_portable(self, tmp_path):
         """save→reload keeps the CODING_PROJECT_DIR placeholder in YAML
         (distinct coding dir), so the policy stays portable across


### PR DESCRIPTION
## Description

This PR updates the TUI/ACP approval flow and related session handling:

- Supports the current scoped approval flow for ACP/TUI by carrying coding project metadata into requests and resolving exact vs pattern approvals through the selected option.
- Clarifies ACP approval option labels so the TUI shows the actual rule scope:
  - `Allow Exact This Session`
  - `Allow Pattern This Session`
- Keeps ephemeral TUI warmup sessions out of persisted session load/save state.
- Makes the TUI permission overlay own focus while active and still routes approval keys if focus is lost.
- Expires stale TUI approval prompts when the backend pending approval has already resolved.
- Propagates approval timeout cancellation from the ACP server to the TUI, clears the overlay, and shows a transcript warning that the request timed out and the tool call was blocked.
- Aligns the approval overlay border with the input box and shows a live countdown to approval expiry.
- Formats the approval overlay with friendlier labels and emphasis for the action, command, exact target, and pattern target instead of showing raw field names.
- Lets the focused approval overlay handle its own up/down/enter keys, while app-level routing remains a fallback when focus moves elsewhere.
- Enforces stale approval expiry relative to `expires_at + grace`, so prompts whose advertised deadline is already past the grace window expire immediately.
- Adds a one-shot governance policy migration marker so users can delete the default coding project dir rule without it being recreated on every load.

Root cause: the TUI-side ACP bridge had not fully caught up with scoped/pattern approval metadata, and the permission overlay relied on prompt-local key handling even though approval is an app-level modal interaction. Warmup ACP sessions also shared the normal persistence path. In the timeout path, the backend pending approval could resolve before the client-side ACP permission prompt returned, leaving the TUI with a stale actionable prompt and no clear user-facing timeout message.

The follow-up review fixes also avoid intercepting `OptionList` navigation while the overlay itself has focus, and make local timeout enforcement respect already-stale `expires_at` metadata.

The exact and pattern approval options both create session-scoped governance rules. The TUI can choose exact vs pattern, but rule duration remains fixed to the current session in the backend policy layer.

**Related Issue:** Relates to #5645 and #5796

**Security Considerations:** Approval scope remains explicit and tied to the selected ACP option. The labels now avoid implying permanent approval. No credential, auth, or config handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `uv run pytest tests/unit/agents/test_acp_available_commands.py tests/unit/agents/test_acp_coding_project.py tests/unit/agents/hooks/test_session_hook.py tests/unit/cli/tui/test_app.py tests/unit/cli/tui/test_acp_transport.py -q`
- `uv run pytest tests/unit/agents/test_acp_available_commands.py tests/unit/agents/test_acp_coding_project.py tests/unit/agents/hooks/test_session_hook.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py tests/unit/governance/test_policy.py -q`
- `uv run pytest tests/unit/agents/test_acp_available_commands.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py -q`
- `uv run pytest tests/unit/agents/test_acp_available_commands.py::test_approval_bridge_expires_when_pending_times_out tests/unit/cli/tui/test_acp_transport.py::test_permission_cancellation_emits_expired_event tests/unit/cli/tui/test_acp_transport.py::test_permission_timeout_cancellation_emits_timeout_message tests/unit/cli/tui/test_app.py::test_permission_overlay_resolves_with_keyboard_selection tests/unit/cli/tui/test_app.py::test_permission_overlay_expires_with_message tests/unit/cli/tui/test_app.py::test_permission_overlay_formats_approval_targets -q`
- `uv run pytest tests/unit/cli/tui/test_app.py::test_permission_overlay_resolves_with_keyboard_selection tests/unit/cli/tui/test_app.py::test_permission_overlay_resolves_after_prompt_loses_focus tests/unit/cli/tui/test_acp_transport.py::test_permission_expires_locally_at_deadline -q`
- `uv run pre-commit run --all-files`
- `uv run pre-commit run --files src/qwenpaw/agents/acp/server.py src/qwenpaw/cli/tui/transport/acp.py src/qwenpaw/cli/tui/widgets/permission_overlay.py tests/unit/agents/test_acp_available_commands.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py`
- `uv run pre-commit run --files src/qwenpaw/cli/tui/app.py src/qwenpaw/cli/tui/transport/acp.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py`

## Local Verification Evidence

```bash
uv run pytest tests/unit/agents/test_acp_available_commands.py::test_approval_bridge_expires_when_pending_times_out tests/unit/cli/tui/test_acp_transport.py::test_permission_cancellation_emits_expired_event tests/unit/cli/tui/test_acp_transport.py::test_permission_timeout_cancellation_emits_timeout_message tests/unit/cli/tui/test_app.py::test_permission_overlay_resolves_with_keyboard_selection tests/unit/cli/tui/test_app.py::test_permission_overlay_expires_with_message tests/unit/cli/tui/test_app.py::test_permission_overlay_formats_approval_targets -q
# 6 passed, 1 warning in 1.17s

uv run pytest tests/unit/agents/test_acp_available_commands.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py -q
# 92 passed, 1 warning in 14.64s

uv run pytest tests/unit/agents/test_acp_available_commands.py tests/unit/agents/test_acp_coding_project.py tests/unit/agents/hooks/test_session_hook.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py tests/unit/governance/test_policy.py -q
# 168 passed, 1 warning in 15.09s

uv run pytest tests/unit/cli/tui/test_app.py::test_permission_overlay_resolves_with_keyboard_selection tests/unit/cli/tui/test_app.py::test_permission_overlay_resolves_after_prompt_loses_focus tests/unit/cli/tui/test_acp_transport.py::test_permission_expires_locally_at_deadline -q
# 3 passed, 1 warning in 1.10s

uv run pre-commit run --files src/qwenpaw/agents/acp/server.py src/qwenpaw/cli/tui/transport/acp.py src/qwenpaw/cli/tui/widgets/permission_overlay.py tests/unit/agents/test_acp_available_commands.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py
# Passed

uv run pre-commit run --files src/qwenpaw/cli/tui/app.py src/qwenpaw/cli/tui/transport/acp.py tests/unit/cli/tui/test_acp_transport.py tests/unit/cli/tui/test_app.py
# Passed

uv run pre-commit run --all-files
# Passed
```

## Additional Notes

Opened from `ekzhu:fix-tui-approval` into `agentscope-ai/QwenPaw:main`.
