### PR TITLE
fix: fix provider-aware context threshold display

### DIFF
--- a/console/src/pages/Agent/Config/index.tsx
+++ b/console/src/pages/Agent/Config/index.tsx
@@ -54,13 +54,18 @@ function AgentConfigPage() {
       .then((info) => {
         if (info.active_llm) {
           return api.listProviders().then((providers) => {
-            for (const p of providers) {
-              const all = [...(p.models ?? []), ...(p.extra_models ?? [])];
-              const m = all.find((m) => m.id === info.active_llm?.model);
-              if (m?.max_input_length) {
-                setMaxInputLength(m.max_input_length);
-                return;
-              }
+            const provider = providers.find(
+              (p) => p.id === info.active_llm?.provider_id,
+            );
+            const all = [
+              ...(provider?.models ?? []),
+              ...(provider?.extra_models ?? []),
+            ];
+            const model = all.find(
+              (item) => item.id === info.active_llm?.model,
+            );
+            if (model?.max_input_length != null) {
+              setMaxInputLength(model.max_input_length);
             }
           });
         }


### PR DESCRIPTION
## Description

This change intentionally removes cross-provider fallback when resolving the frontend display value, because that fallback could select an unrelated provider’s model and diverge from backend runtime behavior.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
