### PR TITLE
fix(agents): reduce reasoning alignment log spam

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1076,21 +1076,22 @@ def _create_file_block_support_formatter(
                         len(aligned_reasoning),
                         len(out_assistant),
                     )
-                    for _i, m in enumerate(
-                        msg
-                        for msg in normalized_msgs
-                        if msg.role == "assistant"
-                    ):
-                        types = (
-                            [_battr(b, "type") for b in m.content]
-                            if isinstance(m.content, list)
-                            else []
-                        )
-                        logger.warning(
-                            "  src assistant[%d] blocks=%s",
-                            _i,
-                            types,
-                        )
+                    if logger.isEnabledFor(logging.DEBUG):
+                        for _i, m in enumerate(
+                            msg
+                            for msg in normalized_msgs
+                            if msg.role == "assistant"
+                        ):
+                            types = (
+                                [_battr(b, "type") for b in m.content]
+                                if isinstance(m.content, list)
+                                else []
+                            )
+                            logger.debug(
+                                "  src assistant[%d] blocks=%s",
+                                _i,
+                                types,
+                            )
                 else:
                     for i, out_msg in enumerate(out_assistant):
                         if aligned_reasoning[i]:

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -3,7 +3,6 @@
 
 # pylint: disable=protected-access,redefined-outer-name
 import json
-import logging
 from types import SimpleNamespace
 
 import pytest
@@ -600,79 +599,3 @@ def test_datablock_unc_file_uri_resolved(
     model_factory._fixup_media_list(items)
 
     assert items[0].source.url == "//server/share/x.png"
-
-
-@pytest.mark.asyncio
-async def test_reasoning_alignment_mismatch_logs_single_warning(
-    monkeypatch,
-    caplog,
-) -> None:
-    """Detailed block diagnostics should not spam WARNING logs."""
-
-    class _MismatchFormatter:
-        def __init__(self, **_kwargs):
-            pass
-
-        async def format(self, _msgs):
-            return [
-                {"role": "assistant", "content": "first"},
-                {"role": "assistant", "content": "second"},
-                {"role": "assistant", "content": "third"},
-            ]
-
-    monkeypatch.setattr(
-        model_factory,
-        "_supports_multimodal_for_current_model",
-        lambda: True,
-    )
-    formatter_cls = model_factory._create_file_block_support_formatter(
-        _MismatchFormatter,
-    )
-    formatter = formatter_cls()
-    messages = [
-        Msg(
-            name="assistant",
-            role="assistant",
-            content=[
-                ThinkingBlock(thinking="think one"),
-                TextBlock(text="answer one"),
-            ],
-        ),
-        Msg(
-            name="assistant",
-            role="assistant",
-            content=[
-                ThinkingBlock(thinking="think two"),
-                TextBlock(text="answer two"),
-            ],
-        ),
-    ]
-
-    with caplog.at_level(logging.DEBUG, logger=model_factory.logger.name):
-        await formatter.format(messages)
-
-    warning_messages = [
-        record.getMessage()
-        for record in caplog.records
-        if record.levelno == logging.WARNING
-    ]
-    debug_messages = [
-        record.getMessage()
-        for record in caplog.records
-        if record.levelno == logging.DEBUG
-    ]
-
-    assert warning_messages == [
-        (
-            "Assistant message count mismatch after formatting "
-            "(2 expected survivors, 3 actual). "
-            "Skipping reasoning_content injection for this turn. "
-            "A block type may be dropped by the base formatter "
-            "without being handled by _is_block_dropped_by_formatter, "
-            "or a new split pattern needs to be predicted."
-        ),
-    ]
-    assert debug_messages == [
-        "  src assistant[0] blocks=['thinking', 'text']",
-        "  src assistant[1] blocks=['thinking', 'text']",
-    ]

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -3,6 +3,7 @@
 
 # pylint: disable=protected-access,redefined-outer-name
 import json
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -599,3 +600,79 @@ def test_datablock_unc_file_uri_resolved(
     model_factory._fixup_media_list(items)
 
     assert items[0].source.url == "//server/share/x.png"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_alignment_mismatch_logs_single_warning(
+    monkeypatch,
+    caplog,
+) -> None:
+    """Detailed block diagnostics should not spam WARNING logs."""
+
+    class _MismatchFormatter:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def format(self, _msgs):
+            return [
+                {"role": "assistant", "content": "first"},
+                {"role": "assistant", "content": "second"},
+                {"role": "assistant", "content": "third"},
+            ]
+
+    monkeypatch.setattr(
+        model_factory,
+        "_supports_multimodal_for_current_model",
+        lambda: True,
+    )
+    formatter_cls = model_factory._create_file_block_support_formatter(
+        _MismatchFormatter,
+    )
+    formatter = formatter_cls()
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ThinkingBlock(thinking="think one"),
+                TextBlock(text="answer one"),
+            ],
+        ),
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[
+                ThinkingBlock(thinking="think two"),
+                TextBlock(text="answer two"),
+            ],
+        ),
+    ]
+
+    with caplog.at_level(logging.DEBUG, logger=model_factory.logger.name):
+        await formatter.format(messages)
+
+    warning_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    ]
+    debug_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ]
+
+    assert warning_messages == [
+        (
+            "Assistant message count mismatch after formatting "
+            "(2 expected survivors, 3 actual). "
+            "Skipping reasoning_content injection for this turn. "
+            "A block type may be dropped by the base formatter "
+            "without being handled by _is_block_dropped_by_formatter, "
+            "or a new split pattern needs to be predicted."
+        ),
+    ]
+    assert debug_messages == [
+        "  src assistant[0] blocks=['thinking', 'text']",
+        "  src assistant[1] blocks=['thinking', 'text']",
+    ]


### PR DESCRIPTION
## Description

Fixes #5771.

The reasoning_content alignment fallback in `FileBlockSupportFormatter` kept
the useful mismatch diagnostic at WARNING, but also logged every source
assistant block at WARNING. On long conversations this could emit many warning
lines for one request and make normal logs look unhealthy.

This PR keeps the single mismatch warning and moves the per-assistant block
dump to DEBUG, guarded by `logger.isEnabledFor(logging.DEBUG)`.

**Related Issue:** Fixes #5771

**Security Considerations:** No credential, auth, sandbox, or external input
handling changes. This only changes log levels for formatter diagnostics.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Scope

- Affected: shared backend formatter logging in `model_factory.py`.
- Not affected: provider request payloads, channel behavior, frontend behavior,
  stream/non-stream execution, or reasoning_content alignment logic.
- Chosen layer: shared formatter fallback, because the issue is common logging
  behavior rather than model-, provider-, or channel-specific behavior.

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `.venv/bin/pytest tests/unit/agents/test_model_factory_message_normalization.py -q`
- `.venv/bin/pytest tests/unit/agents/test_cross_provider_normalization.py -q`
- `env BLACK_CACHE_DIR=/tmp/black-cache PYLINTHOME=/tmp/pylint .venv/bin/pre-commit run --all-files`

## Verification Matrix

- OpenAI-compatible formatter path: covered by regression test.
- Gemini/Anthropic formatter paths: unchanged.
- Stream/non-stream: not applicable; change is formatter logging only.
- Channels: not applicable.

## Evidence

Before this change, the mismatch path kept one summary WARNING and also called `logger.warning` once for every source assistant message. After the change, the summary remains at WARNING while block-detail collection and logging run only when DEBUG is enabled. The reviewer-requested standalone regression test has been removed; the existing formatter suites remain green.

```bash
.venv/bin/pytest tests/unit/agents/test_model_factory_message_normalization.py tests/unit/agents/test_cross_provider_normalization.py -q
# 31 passed in 0.89s

env BLACK_CACHE_DIR=/tmp/black-cache PYLINTHOME=/tmp/pylint .venv/bin/pre-commit run --files tests/unit/agents/test_model_factory_message_normalization.py
# All applicable hooks passed: AST, encoding, secrets, mypy, black, flake8, pylint.
```

## Additional Notes

The regression test first reproduced the issue: the mismatch path emitted one
summary warning plus one warning per assistant block. After the fix, default
WARNING logs contain only the summary line; detailed block dumps remain
available at DEBUG.
