### PR TITLE
fix(envelope): passthrough tool result error state to frontend

### DIFF
--- a/console/src/components/Chat/ToolCards/adapters/v1Adapter.tsx
+++ b/console/src/components/Chat/ToolCards/adapters/v1Adapter.tsx
@@ -23,19 +23,26 @@ import GenericToolCard from "../cards/GenericToolCard";
 // ---------------------------------------------------------------------------
 
 const ERROR_STATUSES = new Set(["failed", "rejected", "canceled"]);
+const TOOL_ERROR_STATES = new Set(["error", "interrupted", "denied"]);
 
 /**
  * Derive the tool execution status from V1 message data.
  *
- * No result item (content[1]) → tool hasn't produced output yet → "calling".
- * Message-level status on tool_call messages reflects *delivery*, not execution,
- * so we only consult it when a result item exists.
+ * Checks the tool-execution-layer `state` (nested inside resultItem.data)
+ * first — it reflects the real outcome of the tool call. Falls back to
+ * message-level `status` for delivery state.
  */
 function deriveToolStatus(
   resultItem: Record<string, unknown> | undefined,
   data: Record<string, unknown>,
 ): ToolCallStatus {
   if (!resultItem) return "calling";
+
+  const resultData = (resultItem?.data ?? {}) as Record<string, unknown>;
+  const toolState = resultData.state as string;
+  if (toolState && TOOL_ERROR_STATES.has(toolState)) {
+    return "error";
+  }
 
   const rawStatus =
     (data.status as string) || (resultItem.status as string) || "";

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -591,6 +591,12 @@ def agentscope_msg_to_message(
                     output=output,
                 ).model_dump(exclude_none=True)
 
+                tool_state = block.get("state")
+                if hasattr(tool_state, "value"):
+                    tool_state = tool_state.value
+                if tool_state is not None:
+                    output_data["state"] = tool_state
+
                 data_content = DataContent(
                     delta=False,
                     index=None,

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -19,8 +19,6 @@ from .message_convert import _media_type_to_block_type
 
 logger = logging.getLogger(__name__)
 
-_TOOL_ERROR_STATES = frozenset({"error", "interrupted", "denied"})
-
 
 def _gen_msg_id() -> str:
     return "msg_" + uuid.uuid4().hex
@@ -510,18 +508,10 @@ class Envelope:
                 out_message.name = "assistant"
                 out_message.object = "message"
 
-            msg_status = (
-                RunStatus.Failed
-                if tool_state in _TOOL_ERROR_STATES
-                else RunStatus.Completed
-            )
-
             out_message.add_content(new_content=final_content)
-            final_content.status = msg_status
-            yield self._tag_seq(final_content)
+            yield self._tag_seq(final_content.completed())
             self._response.output.append(out_message)
-            out_message.status = msg_status
-            yield self._tag_seq(out_message)
+            yield self._tag_seq(out_message.completed())
 
         # === DATA BLOCK ===
         elif evt_type == EventType.DATA_BLOCK_START.value:

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -19,6 +19,8 @@ from .message_convert import _media_type_to_block_type
 
 logger = logging.getLogger(__name__)
 
+_TOOL_ERROR_STATES = frozenset({"error", "interrupted", "denied"})
+
 
 def _gen_msg_id() -> str:
     return "msg_" + uuid.uuid4().hex
@@ -508,10 +510,18 @@ class Envelope:
                 out_message.name = "assistant"
                 out_message.object = "message"
 
+            msg_status = (
+                RunStatus.Failed
+                if tool_state in _TOOL_ERROR_STATES
+                else RunStatus.Completed
+            )
+
             out_message.add_content(new_content=final_content)
-            yield self._tag_seq(final_content.completed())
+            final_content.status = msg_status
+            yield self._tag_seq(final_content)
             self._response.output.append(out_message)
-            yield self._tag_seq(out_message.completed())
+            out_message.status = msg_status
+            yield self._tag_seq(out_message)
 
         # === DATA BLOCK ===
         elif evt_type == EventType.DATA_BLOCK_START.value:


### PR DESCRIPTION
## Description

Tool result events (e.g. from `execute_shell_command`, MCP tools) carry a `state` field (`success`/`error`/`interrupted`/`denied`) indicating the real execution outcome. However, this state was not surfaced to the frontend — both the SSE streaming path (`envelope.py`) and the HTTP history path (`utils.py`) always marked tool result messages as `completed`, causing the frontend to render all tool calls with a green success icon regardless of actual outcome.

This PR fixes the issue by:
1. **History path (`utils.py`)**: Passing through `block.get("state")` into `output_data["state"]` (with defensive enum-to-string conversion), so reloaded chat history also carries the tool execution state.
2. **Frontend (`v1Adapter.tsx`)**: Making `deriveToolStatus` check `resultData.state` (tool-execution-layer truth) before falling back to message-level `status`, so error/interrupted/denied tools correctly render with an error indicator.

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

1. Trigger a tool call that results in an error (e.g. run a dangerous shell command that gets denied, or a tool that raises an exception).
2. Verify the frontend tool card shows a red error icon instead of a green success icon.
3. Refresh the page (reload chat history) and verify the error state persists (tool card still shows error).
4. Trigger a successful tool call and verify it still shows the green success icon as before.

## Additional Notes

- A new module-level constant `_TOOL_ERROR_STATES = frozenset({"error", "interrupted", "denied"})` is added in `envelope.py`, with a corresponding `TOOL_ERROR_STATES` Set in the frontend `v1Adapter.tsx`. Both derive from `agentscope.message.ToolResultState` and should be updated if the upstream enum changes.
- The `utils.py` change includes defensive enum-to-string conversion (`hasattr(tool_state, "value")`) consistent with `envelope.py`'s existing pattern, guarding against Pydantic v2 `model_dump()` retaining enum instances.