### PR TITLE
fix(agents): preserve Responses API function_call names

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1116,14 +1116,17 @@ def _create_file_block_support_formatter(
 def _strip_top_level_message_name(
     messages: list[dict],
 ) -> list[dict]:
-    """Strip top-level `name` from OpenAI chat messages.
+    """Strip top-level `name` from OpenAI chat-style messages.
 
     Some strict OpenAI-compatible backends reject `messages[*].name`
     (especially for assistant/tool roles) and may return 500/400 on
-    follow-up turns. Keep function/tool names unchanged.
+    follow-up turns. Responses API also uses top-level non-message items
+    such as ``{"type": "function_call", "name": ...}``, where ``name`` is
+    required; those must be left unchanged.
     """
     for message in messages:
-        message.pop("name", None)
+        if "role" in message:
+            message.pop("name", None)
     return messages
 
 


### PR DESCRIPTION
## Summary

Fixes #5910.

When QwenPaw formats history for OpenAI-compatible providers, `_strip_top_level_message_name()` removes top-level `name` fields to avoid strict Chat Completions backends rejecting `messages[*].name`. The same post-processing path is also used for OpenAI Responses API formatter output. Responses API represents tool-call history as top-level input items, for example:

```json
{
  "type": "function_call",
  "call_id": "...",
  "name": "memory_search",
  "arguments": "..."
}
```

For those items, `name` is the required function/tool name, not a chat message name. The previous unconditional `message.pop("name", None)` removed it, producing malformed Responses API input when Auto Memory Search injected a synthetic `memory_search` tool call.

## Changes

- Restrict `_strip_top_level_message_name()` to chat-style message dictionaries that contain `role`.
- Preserve top-level `name` on non-message Responses API items such as `type == "function_call"`.
- Update the helper docstring to document why Responses API items must be left untouched.

## Why this approach

Checking for `role` keeps the original compatibility behavior for Chat Completions messages while avoiding schema-specific blacklisting. It also protects future Responses API top-level items that may legitimately use fields overlapping with chat message fields.

## Validation

- `pytest tests/unit/agents/test_model_factory_message_normalization.py -q`
- `pytest tests/unit/agents/memory/test_base_memory_manager.py tests/unit/agents/memory/test_adbpg_memory_manager.py tests/unit/agents/test_message_request_normalizer.py -q`
