### PR TITLE
fix(loop): reset gate state on new user turn and peer-reset on continuation

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -477,7 +477,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
             return
 
         # Model produced text (wants to stop).
-        if stop_result.action == StopAction.CONTINUE:
+        if stop_result.action == StopAction.INTERRUPT_AND_CONTINUE:
             logger.info(
                 "Stop handler BLOCKED exit: %s",
                 stop_result.reason,

--- a/src/qwenpaw/loop/gates/base.py
+++ b/src/qwenpaw/loop/gates/base.py
@@ -112,6 +112,14 @@ class StopGate(ABC):
         """
         return ""
 
+    def reset(self) -> None:
+        """Reset gate state for a new user turn.
+
+        Stateful gates override this to clear internal
+        counters/history. Default implementation is a no-op
+        for stateless gates.
+        """
+
 
 __all__ = [
     "StopAction",

--- a/src/qwenpaw/loop/gates/base.py
+++ b/src/qwenpaw/loop/gates/base.py
@@ -13,28 +13,32 @@ from typing import Any, Optional
 
 
 class StopAction(str, Enum):
-    """Whether the agent should stop or continue."""
+    """Gate decisions for the agent loop.
 
-    STOP = "stop"
-    CONTINUE = "continue"
+    BYPASS: gate has no opinion, skip.
+    INTERRUPT_AND_CONTINUE: interrupt current pattern,
+        inject a prompt, then keep the loop going.
+    TERMINATE: end the agent loop immediately.
+    """
 
-    # Backward-compatible aliases
-    ALLOW = "stop"
-    BLOCK = "continue"
+    BYPASS = "bypass"
+    INTERRUPT_AND_CONTINUE = "interrupt_and_continue"
+    TERMINATE = "terminate"
 
 
 @dataclass
 class StopHandlerResult:
     """Return value from a stop handler / gate.
 
-    When ``action`` is CONTINUE, ``continuation_message``
-    is injected as the next user turn to keep the
-    agent running.
+    When ``action`` is INTERRUPT_AND_CONTINUE,
+    ``continuation_message`` is injected as the next
+    user turn to keep the agent running.
     """
 
-    action: StopAction = StopAction.STOP
+    action: StopAction = StopAction.TERMINATE
     continuation_message: str = ""
     reason: str = ""
+    reset_peers: bool = False
 
 
 @dataclass
@@ -57,12 +61,13 @@ class StopHandlerRegistration:
 class StopGate(ABC):
     """Abstract base class for all stop condition gates.
 
-    Lifecycle per evaluation:
-    1. check(ctx) is called
-    2. If returns StopHandlerResult(STOP) -> stop
-    3. If returns None -> call continuation_prompt()
-       to collect additional context for the
-       continuation message
+    Lifecycle per evaluation (driven by StopHandler):
+    1. check(ctx) returns action + reason + reset_peers
+    2. TERMINATE -> stop immediately
+    3. INTERRUPT_AND_CONTINUE -> handler calls
+       build_continuation() to get the message,
+       then injects it as a new user turn
+    4. BYPASS / None -> gate idle, no action
 
     Subclasses MUST implement:
     - name (property): unique gate identifier
@@ -70,8 +75,8 @@ class StopGate(ABC):
 
     Subclasses MAY override:
     - priority (property): evaluation order, default 100
-    - continuation_prompt(): additional text to inject
-      into continuation when not stopping
+    - build_continuation(): text to inject when
+      INTERRUPT_AND_CONTINUE is triggered
     """
 
     @property
@@ -92,17 +97,18 @@ class StopGate(ABC):
         """Evaluate one stop condition.
 
         Returns:
-            StopHandlerResult(STOP) -> agent stops.
-            StopHandlerResult(CONTINUE) -> loop active.
-            None -> gate idle / no opinion.
+            TERMINATE -> agent stops.
+            INTERRUPT_AND_CONTINUE -> handler calls
+                build_continuation() for the message.
+            BYPASS or None -> gate idle / no opinion.
         """
 
-    def continuation_prompt(self) -> str:
-        """Additional context for the continuation msg.
+    def build_continuation(self) -> str:
+        """Return the text to inject as a user turn.
 
-        Called only after check() returns None.
-        StopHandler collects all non-empty results
-        and prepends them to the base continuation.
+        Called by StopHandler when check() returns
+        INTERRUPT_AND_CONTINUE. Subclasses override
+        to provide gate-specific continuation prompts.
         """
         return ""
 

--- a/src/qwenpaw/loop/gates/budget.py
+++ b/src/qwenpaw/loop/gates/budget.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """BudgetGate — universal token budget limiter.
 
-Tracks per-session token usage. Returns STOP when
+Tracks per-session token usage. Returns TERMINATE when
 ``max_tokens`` is exceeded.
 """
 from __future__ import annotations
@@ -61,19 +61,22 @@ class BudgetGate(LoopGate):
     async def check(
         self,
         ctx: Any,  # pylint: disable=unused-argument
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Check token budget."""
+        _bypass = StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
         state: Optional[_BudgetState] = self._state()
         if state is None:
-            return None
+            return _bypass
 
         if state.tokens_used >= state.max_tokens:
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason="Token budget exceeded",
             )
-        return None
+        return _bypass
 
 
 __all__ = ["BudgetGate"]

--- a/src/qwenpaw/loop/gates/doom_loop.py
+++ b/src/qwenpaw/loop/gates/doom_loop.py
@@ -214,18 +214,7 @@ class DoomLoopGate(LoopGate):
                     if isinstance(block, dict)
                     else getattr(block, "input", "")
                 )
-                if isinstance(raw_input, str):
-                    args_hash = hashlib.md5(
-                        raw_input.encode(),
-                    ).hexdigest()[:8]
-                else:
-                    args_hash = hashlib.md5(
-                        json.dumps(
-                            raw_input,
-                            sort_keys=True,
-                            default=str,
-                        ).encode(),
-                    ).hexdigest()[:8]
+                args_hash = self._hash_args(raw_input)
                 state.history.append(
                     _ToolCallRecord(
                         tool_name=name,
@@ -233,6 +222,25 @@ class DoomLoopGate(LoopGate):
                     ),
                 )
                 return
+
+    @staticmethod
+    def _hash_args(raw_input: Any) -> str:
+        """Hash tool call args with truncation for large inputs.
+
+        Only the first 2048 bytes are hashed — enough
+        for repetition detection without serializing
+        potentially large file contents.
+        """
+        _MAX_HASH_INPUT = 2048
+        if isinstance(raw_input, str):
+            data = raw_input[:_MAX_HASH_INPUT].encode()
+        else:
+            data = json.dumps(
+                raw_input,
+                sort_keys=True,
+                default=str,
+            ).encode()[:_MAX_HASH_INPUT]
+        return hashlib.md5(data).hexdigest()[:8]
 
     def _detect_repetition(
         self,

--- a/src/qwenpaw/loop/gates/doom_loop.py
+++ b/src/qwenpaw/loop/gates/doom_loop.py
@@ -11,7 +11,7 @@ import json
 import logging
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from .base import (
     StopAction,
@@ -46,9 +46,9 @@ class DoomLoopGate(LoopGate):
     Sliding-window repetition detection that escalates
     through configured stages.
 
-    - action="modify_prompt": inject warning via
-      continuation_prompt(), don't stop.
-    - action="stop": return STOP immediately.
+    - action="modify_prompt": INTERRUPT_AND_CONTINUE,
+      inject warning via build_continuation().
+    - action="stop": return TERMINATE immediately.
     """
 
     @property
@@ -101,18 +101,26 @@ class DoomLoopGate(LoopGate):
         )
 
     def reset(self) -> None:
-        """Clear history and state for session."""
-        self.deactivate()
+        """Clear history and counters for current session."""
+        state = self._state()
+        if state is not None:
+            state.history.clear()
+            state.consecutive_hits = 0
+            state.prompt = ""
+            state.last_recorded_iter = -1
 
     async def check(
         self,
         ctx: Any,
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Evaluate doom loop state.
 
         Auto-records tool calls from agent context when
         available (no explicit record() needed).
         """
+        _bypass = StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
         state = self._ensure_state()
         self._auto_record_from_ctx(ctx, state)
 
@@ -121,7 +129,7 @@ class DoomLoopGate(LoopGate):
         if not is_looping:
             state.consecutive_hits = 0
             state.prompt = ""
-            return None
+            return _bypass
 
         if state.consecutive_hits == 0:
             state.consecutive_hits = self._window_size
@@ -135,7 +143,7 @@ class DoomLoopGate(LoopGate):
                 break
 
         if active_stage is None:
-            return None
+            return _bypass
 
         if active_stage.action == "stop":
             logger.info(
@@ -143,7 +151,7 @@ class DoomLoopGate(LoopGate):
                 state.consecutive_hits,
             )
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=active_stage.prompt,
             )
 
@@ -153,12 +161,11 @@ class DoomLoopGate(LoopGate):
             state.consecutive_hits,
         )
         return StopHandlerResult(
-            action=StopAction.CONTINUE,
-            continuation_message=active_stage.prompt,
+            action=StopAction.INTERRUPT_AND_CONTINUE,
             reason="doom_loop repetition warning",
         )
 
-    def continuation_prompt(self) -> str:
+    def build_continuation(self) -> str:
         """Return current doom loop warning."""
         state = self._state()
         if state is None:

--- a/src/qwenpaw/loop/gates/file_loop_gate.py
+++ b/src/qwenpaw/loop/gates/file_loop_gate.py
@@ -13,7 +13,7 @@ Hierarchy:
 Subclasses implement:
     - ``name`` (property)
     - ``_is_complete(state_dir)`` -> bool
-    - ``continuation_prompt()`` -> str
+    - ``build_continuation()`` -> str
 """
 from __future__ import annotations
 
@@ -67,18 +67,20 @@ class FileLoopGate(LoopGate):
     async def check(
         self,
         ctx: Any,  # pylint: disable=unused-argument
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Session-aware check with iteration limit."""
         state: Optional[_FileLoopState] = self._state()
         if state is None or not state.active:
-            return None
+            return StopHandlerResult(
+                action=StopAction.BYPASS,
+            )
 
         state.iteration += 1
 
         if state.iteration > self._MAX_ITERATIONS:
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=(
                     f"{self.name} max iterations " f"({self._MAX_ITERATIONS})"
                 ),
@@ -91,13 +93,12 @@ class FileLoopGate(LoopGate):
         if self._is_complete(state_dir):
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=f"{self.name} completed",
             )
 
         return StopHandlerResult(
-            action=StopAction.CONTINUE,
-            continuation_message=(self.continuation_prompt()),
+            action=StopAction.INTERRUPT_AND_CONTINUE,
             reason=(
                 f"{self.name} iteration "
                 f"{state.iteration}"

--- a/src/qwenpaw/loop/gates/handler.py
+++ b/src/qwenpaw/loop/gates/handler.py
@@ -138,13 +138,7 @@ class StopHandler:
             return
         for gate in self._gates:
             if gate is not continue_gate:
-                reset_fn = getattr(
-                    gate,
-                    "reset",
-                    None,
-                )
-                if callable(reset_fn):
-                    reset_fn()
+                gate.reset()
 
 
 __all__ = ["StopHandler"]

--- a/src/qwenpaw/loop/gates/handler.py
+++ b/src/qwenpaw/loop/gates/handler.py
@@ -4,14 +4,16 @@
 Architecture:
     StopHandler holds an ordered list of StopGate.
     Gates are checked in priority order (lower first).
-    Any gate returning STOP -> agent stops immediately.
-    Any gate returning CONTINUE -> loop keeps going.
-    No gates registered OR all None -> STOP.
+    TERMINATE -> agent stops immediately.
+    INTERRUPT_AND_CONTINUE -> call gate.build_continuation()
+        to get the message, then inject it.
+    BYPASS / None -> skip.
+    No gates or all BYPASS -> TERMINATE.
 """
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Optional
+from typing import Any
 
 from .base import (
     StopAction,
@@ -25,14 +27,15 @@ logger = logging.getLogger(__name__)
 class StopHandler:
     """Universal stop handler with composable gates.
 
-    Any gate returning STOP -> agent stops immediately.
-    Any gate returning CONTINUE -> loop keeps going.
-    No gates registered OR all None -> STOP.
+    TERMINATE -> agent stops immediately.
+    INTERRUPT_AND_CONTINUE -> inject prompt via
+        gate.build_continuation(), keep going.
+    BYPASS / None -> skip.
+    No gates or all BYPASS -> TERMINATE.
     """
 
     def __init__(self) -> None:
         self._gates: list[StopGate] = []
-        self._continuation_fn: (Optional[Callable[..., str]]) = None
 
     def register(self, gate: StopGate) -> None:
         """Register a gate and re-sort by priority."""
@@ -42,13 +45,6 @@ class StopHandler:
     def unregister(self, name: str) -> None:
         """Remove all gates matching *name*."""
         self._gates = [g for g in self._gates if g.name != name]
-
-    def set_continuation(
-        self,
-        fn: Callable[..., str],
-    ) -> None:
-        """Set callback that builds continuation msg."""
-        self._continuation_fn = fn
 
     @property
     def gates(self) -> list[StopGate]:
@@ -61,18 +57,19 @@ class StopHandler:
     ) -> StopHandlerResult:
         """Run all gates in priority order.
 
-        Any STOP  -> stop immediately.
-        Any CONTINUE -> loop keeps going.
-        All None / no gates -> STOP (no active loop).
+        TERMINATE -> stop immediately.
+        INTERRUPT_AND_CONTINUE -> inject prompt, keep going.
+        BYPASS / None -> gate idle, skip.
+        No gates or all BYPASS -> TERMINATE.
         """
         if not self._gates:
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
             )
 
-        prompts: list[str] = []
         has_continue = False
         continue_result: StopHandlerResult | None = None
+        continue_gate: StopGate | None = None
 
         for gate in self._gates:
             try:
@@ -85,44 +82,34 @@ class StopHandler:
                 )
                 continue
 
-            if result is not None:
-                logger.debug(
-                    "StopGate '%s' fired: %s",
-                    gate.name,
-                    result.action.value,
-                )
-                if result.action == StopAction.STOP:
-                    return result
-                has_continue = True
-                if continue_result is None:
-                    continue_result = result
+            if result is None or (result.action == StopAction.BYPASS):
+                continue
 
-            prompt = gate.continuation_prompt()
-            if prompt:
-                prompts.append(prompt)
+            logger.debug(
+                "StopGate '%s' fired: %s",
+                gate.name,
+                result.action.value,
+            )
+            if result.action == StopAction.TERMINATE:
+                return result
+            has_continue = True
+            if continue_result is None:
+                continue_result = result
+                continue_gate = gate
 
         if not has_continue:
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
             )
 
-        msg = continue_result.continuation_message if continue_result else ""
-        if self._continuation_fn:
-            try:
-                fn_msg = self._continuation_fn(ctx)
-            except Exception:
-                logger.warning(
-                    "continuation_fn raised",
-                    exc_info=True,
-                )
-                fn_msg = ""
-            if fn_msg:
-                msg = f"{msg}\n\n{fn_msg}" if msg else fn_msg
-        if prompts:
-            prefix = "\n\n".join(prompts)
-            msg = f"{prefix}\n\n{msg}" if msg else prefix
+        self._maybe_reset_peers(
+            continue_result,
+            continue_gate,
+        )
+
+        msg = continue_gate.build_continuation() if continue_gate else ""
         return StopHandlerResult(
-            action=StopAction.CONTINUE,
+            action=StopAction.INTERRUPT_AND_CONTINUE,
             continuation_message=msg,
             reason=(
                 continue_result.reason
@@ -130,6 +117,34 @@ class StopHandler:
                 else "Active gate continues"
             ),
         )
+
+    def _maybe_reset_peers(
+        self,
+        continue_result: StopHandlerResult | None,
+        continue_gate: StopGate | None,
+    ) -> None:
+        """Reset peer gates on sub-turn continuation.
+
+        IMPORTANT: When a gate triggers
+        INTERRUPT_AND_CONTINUE with reset_peers=True (e.g. rubric gate starting
+        a new sub-turn), reset all OTHER gates so they
+        begin the sub-turn with fresh state (iteration
+        counter, doom loop history, etc.).
+        Gates that merely inject warnings (e.g. doom
+        loop modify_prompt) keep reset_peers=False and
+        do NOT trigger peer resets.
+        """
+        if continue_result is None or not continue_result.reset_peers:
+            return
+        for gate in self._gates:
+            if gate is not continue_gate:
+                reset_fn = getattr(
+                    gate,
+                    "reset",
+                    None,
+                )
+                if callable(reset_fn):
+                    reset_fn()
 
 
 __all__ = ["StopHandler"]

--- a/src/qwenpaw/loop/gates/iteration.py
+++ b/src/qwenpaw/loop/gates/iteration.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """IterationGate — universal iteration limiter.
 
-Tracks per-session iteration count.  Returns STOP when
+Tracks per-session iteration count.  Returns TERMINATE when
 ``max_iterations`` is reached.
 """
 from __future__ import annotations
@@ -55,11 +55,13 @@ class IterationGate(LoopGate):
     async def check(
         self,
         ctx: Any,  # pylint: disable=unused-argument
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Check iteration limit."""
         state: Optional[_IterState] = self._state()
         if state is None:
-            return None
+            return StopHandlerResult(
+                action=StopAction.BYPASS,
+            )
 
         state.iteration += 1
         logger.debug(
@@ -71,12 +73,20 @@ class IterationGate(LoopGate):
         if state.iteration >= state.max_iterations:
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=(
                     f"Max iterations " f"({state.max_iterations}) reached"
                 ),
             )
-        return None
+        return StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
+
+    def reset(self) -> None:
+        """Reset iteration counter for current session."""
+        state = self._state()
+        if state is not None:
+            state.iteration = 0
 
 
 __all__ = ["IterationGate"]

--- a/src/qwenpaw/loop/gates/rubric.py
+++ b/src/qwenpaw/loop/gates/rubric.py
@@ -180,20 +180,23 @@ class StandaloneRubricGate(StopGate):
     async def check(
         self,
         ctx: Any,
-    ) -> Optional[StopHandlerResult]:
-        """Return CONTINUE up to max_interventions.
+    ) -> StopHandlerResult:
+        """Intervene up to max_interventions.
 
         Only triggers on text-only responses
         (no tool calls).
         """
+        _bypass = StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
         if isinstance(ctx, dict) and ctx.get(
             "has_tool_calls",
         ):
-            return None
+            return _bypass
 
         if self._count >= self._max:
             self._count = 0
-            return None
+            return _bypass
 
         self._count += 1
         logger.debug(
@@ -202,10 +205,18 @@ class StandaloneRubricGate(StopGate):
             self._max,
         )
         return StopHandlerResult(
-            action=StopAction.CONTINUE,
-            continuation_message=self._prompt,
+            action=StopAction.INTERRUPT_AND_CONTINUE,
             reason="text-only response re-prompt",
+            reset_peers=True,
         )
+
+    def build_continuation(self) -> str:
+        """Return the re-prompt text."""
+        return self._prompt
+
+    def reset(self) -> None:
+        """Reset intervention counter for new turn."""
+        self._count = 0
 
 
 __all__ = [

--- a/src/qwenpaw/loop/gates/runner.py
+++ b/src/qwenpaw/loop/gates/runner.py
@@ -79,10 +79,11 @@ async def run_stop_handlers(
         iteration: Current iteration number.
 
     Returns:
-        StopHandlerResult with STOP or CONTINUE.
+        StopHandlerResult with TERMINATE or
+        INTERRUPT_AND_CONTINUE.
     """
     if not handlers:
-        return StopHandlerResult(action=StopAction.STOP)
+        return StopHandlerResult(action=StopAction.TERMINATE)
 
     handlers = _filter_by_scope(handlers)
     handlers = sorted(handlers, key=lambda h: h.priority)
@@ -107,20 +108,20 @@ async def run_stop_handlers(
 
         if isinstance(result, StopHandlerResult):
             if result.action in (
-                StopAction.STOP,
-                StopAction.CONTINUE,
+                StopAction.TERMINATE,
+                StopAction.INTERRUPT_AND_CONTINUE,
             ):
                 return result
         elif isinstance(result, dict):
             action = result.get("action", "stop")
             if action == "stop":
                 return StopHandlerResult(
-                    action=StopAction.STOP,
+                    action=StopAction.TERMINATE,
                     reason=result.get("reason", ""),
                 )
             if action in ("continue", "block"):
                 return StopHandlerResult(
-                    action=StopAction.CONTINUE,
+                    action=StopAction.INTERRUPT_AND_CONTINUE,
                     continuation_message=result.get(
                         "message",
                         "",
@@ -128,7 +129,7 @@ async def run_stop_handlers(
                     reason=result.get("reason", ""),
                 )
 
-    return StopHandlerResult(action=StopAction.STOP)
+    return StopHandlerResult(action=StopAction.TERMINATE)
 
 
 def apply_stop_result(  # pylint: disable=protected-access
@@ -140,15 +141,25 @@ def apply_stop_result(  # pylint: disable=protected-access
     """Process stop_result and set pending state on agent.
 
     Called after _run_stop_handlers in a tool-call iteration.
-    Defers both STOP and CONTINUE actions to next iteration.
+    Defers both TERMINATE and INTERRUPT_AND_CONTINUE
+    actions to next iteration.
     """
     if is_tool_call:
-        if stop_result.action == StopAction.STOP and stop_result.reason:
+        if stop_result.action == StopAction.TERMINATE and stop_result.reason:
             logger.info(
                 "Gate wants stop (deferred): %s",
                 stop_result.reason,
             )
             agent._gate_pending_stop = stop_result
+        elif (
+            stop_result.action == StopAction.INTERRUPT_AND_CONTINUE
+            and stop_result.continuation_message
+        ):
+            logger.info(
+                "Gate wants continue (deferred): %s",
+                stop_result.reason,
+            )
+            agent._gate_pending_continue = stop_result.continuation_message
 
 
 def check_pending_gates(  # pylint: disable=protected-access
@@ -157,7 +168,7 @@ def check_pending_gates(  # pylint: disable=protected-access
     """Check and consume pending gate state.
 
     Returns:
-        StopHandlerResult if a pending STOP should be applied,
+        StopHandlerResult if pending TERMINATE applies,
         None otherwise (also injects pending continue into ctx).
     """
     pending = getattr(agent, "_gate_pending_stop", None)

--- a/src/qwenpaw/loop/react_gates.py
+++ b/src/qwenpaw/loop/react_gates.py
@@ -81,7 +81,10 @@ def register_react_gates(
         return handler
 
     loop_cfg = running_config.loop
-    handler = get_or_create_stop_handler(workspace)
+    handler = get_or_create_stop_handler(
+        workspace,
+        scope="default",
+    )
 
     # 1. Iteration Gate
     if loop_cfg.iteration.enabled:

--- a/src/qwenpaw/loop/react_gates.py
+++ b/src/qwenpaw/loop/react_gates.py
@@ -41,6 +41,16 @@ def resolve_max_iterations(
     return running_config.max_iters
 
 
+def _reset_gates_for_new_turn(
+    handler: StopHandler,
+) -> None:
+    """Reset all gates for a new user turn."""
+    for gate in handler.gates:
+        reset_fn = getattr(gate, "reset", None)
+        if callable(reset_fn):
+            reset_fn()
+
+
 def register_react_gates(
     workspace: Any,
     running_config: "AgentsRunningConfig",
@@ -48,6 +58,8 @@ def register_react_gates(
     """Register default ReAct StopHandler with configured gates.
 
     Idempotent: skips if already registered for this workspace.
+    Resets all gates on re-entry so each user turn starts
+    with fresh state.
 
     Args:
         workspace: The workspace/agent-workspace object
@@ -62,7 +74,11 @@ def register_react_gates(
         "_react_gates_registered",
         False,
     ):
-        return get_or_create_stop_handler(workspace)
+        handler = get_or_create_stop_handler(
+            workspace,
+        )
+        _reset_gates_for_new_turn(handler)
+        return handler
 
     loop_cfg = running_config.loop
     handler = get_or_create_stop_handler(workspace)

--- a/src/qwenpaw/loop/react_gates.py
+++ b/src/qwenpaw/loop/react_gates.py
@@ -46,9 +46,7 @@ def _reset_gates_for_new_turn(
 ) -> None:
     """Reset all gates for a new user turn."""
     for gate in handler.gates:
-        reset_fn = getattr(gate, "reset", None)
-        if callable(reset_fn):
-            reset_fn()
+        gate.reset()
 
 
 def register_react_gates(

--- a/src/qwenpaw/modes/goal/gates.py
+++ b/src/qwenpaw/modes/goal/gates.py
@@ -10,7 +10,7 @@ per-request ReAct iterations (inner loop).
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from ...loop.gates.base import (
     StopAction,
@@ -71,8 +71,8 @@ class GoalTurnGate(LoopGate):
     per-request ReAct iterations (inner loop).
 
     Returns:
-        CONTINUE — session active, under limit.
-        STOP — session deactivated (update_goal
+        INTERRUPT_AND_CONTINUE — active, under limit.
+        TERMINATE — session deactivated (update_goal
             called) or iteration limit reached.
         None — no active session (not in goal mode).
     """
@@ -97,15 +97,17 @@ class GoalTurnGate(LoopGate):
     async def check(
         self,
         ctx: Any,
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Check turn limit via GoalSession."""
         session = self._mode.session_by_ctx_var()
         if session is None:
-            return None
+            return StopHandlerResult(
+                action=StopAction.BYPASS,
+            )
 
         if not session.active:
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=(f"Goal completed: " f"{session.last_verdict}"),
             )
 
@@ -122,18 +124,38 @@ class GoalTurnGate(LoopGate):
         if session.iteration >= self._max_iterations:
             session.active = False
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason="Max iterations reached",
             )
         return StopHandlerResult(
-            action=StopAction.CONTINUE,
+            action=StopAction.INTERRUPT_AND_CONTINUE,
+        )
+
+    def build_continuation(self) -> str:
+        """Build goal continuation prompt."""
+        from .prompts import CONTINUATION_PROMPT
+
+        session = self._mode.session_by_ctx_var()
+        if session is None:
+            return ""
+        remaining = max(
+            0,
+            session.max_tokens - session.tokens_used,
+        )
+        return CONTINUATION_PROMPT.format(
+            objective=session.goal,
+            iteration=session.iteration,
+            max_iterations=session.max_iterations,
+            tokens_used=session.tokens_used,
+            token_budget=session.max_tokens,
+            remaining_tokens=remaining,
         )
 
 
 class GoalBudgetGate(LoopGate):
     """Goal-mode token budget gate.
 
-    Returns STOP when token budget is exceeded.
+    Returns TERMINATE when token budget is exceeded.
     """
 
     def __init__(
@@ -154,16 +176,19 @@ class GoalBudgetGate(LoopGate):
     async def check(
         self,
         ctx: Any,  # pylint: disable=unused-argument
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
+        _bypass = StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
         session = self._mode.session_by_ctx_var()
         if session is None or not session.active:
-            return None
+            return _bypass
         if session.tokens_used < session.max_tokens:
-            return None
+            return _bypass
 
         session.active = False
         return StopHandlerResult(
-            action=StopAction.STOP,
+            action=StopAction.TERMINATE,
             reason="Token budget exceeded",
         )
 
@@ -171,8 +196,8 @@ class GoalBudgetGate(LoopGate):
 class RubricGate(LoopGate):
     """Rubric evaluation gate (session-safe).
 
-    SATISFIED (goal completed) -> STOP.
-    Otherwise -> None (no objection, continue).
+    SATISFIED (goal completed) -> TERMINATE.
+    Otherwise -> BYPASS (no objection).
     """
 
     @property
@@ -195,11 +220,13 @@ class RubricGate(LoopGate):
     async def check(
         self,
         ctx: Any,  # pylint: disable=unused-argument
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Evaluate rubric for goal completion."""
         session = self._mode.session_by_ctx_var()
         if session is None:
-            return None
+            return StopHandlerResult(
+                action=StopAction.BYPASS,
+            )
 
         evaluation = await self._rubric.evaluate(
             goal=session.goal,
@@ -220,10 +247,12 @@ class RubricGate(LoopGate):
                 session.iteration,
             )
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=evaluation.explanation,
             )
-        return None
+        return StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
 
 
 __all__ = [

--- a/src/qwenpaw/modes/goal/goal_mode.py
+++ b/src/qwenpaw/modes/goal/goal_mode.py
@@ -202,9 +202,6 @@ class GoalMode(AgentMode):
         handler.register(GoalTurnGate(self))
         handler.register(GoalBudgetGate(self))
         handler.register(RubricGate(self, rubric))
-        handler.set_continuation(
-            self._build_continuation,
-        )
 
         completion_gate = create_completion_gate(
             workspace,
@@ -261,27 +258,6 @@ class GoalMode(AgentMode):
 
         rewrite_user_msg(ctx, goal_text)
         return None
-
-    def _build_continuation(
-        self,
-        ctx: Any,  # pylint: disable=unused-argument
-    ) -> str:
-        """Build continuation message."""
-        session = self._first_active_session()
-        if session is None:
-            return ""
-        remaining = max(
-            0,
-            session.max_tokens - session.tokens_used,
-        )
-        return CONTINUATION_PROMPT.format(
-            objective=session.goal,
-            iteration=session.iteration,
-            max_iterations=(session.max_iterations),
-            tokens_used=session.tokens_used,
-            token_budget=session.max_tokens,
-            remaining_tokens=remaining,
-        )
 
     # ---- prompt / session helpers ----
 

--- a/src/qwenpaw/modes/mission/__init__.py
+++ b/src/qwenpaw/modes/mission/__init__.py
@@ -130,7 +130,6 @@ class MissionMode(AgentMode):
             format_help,
             format_list,
             format_status,
-            is_meta_question,
             parse_mission_args,
             start_mission,
         )
@@ -160,17 +159,6 @@ class MissionMode(AgentMode):
         # --- help / empty ---
         if not task_text or len(task_text.strip()) < 5:
             return _info_msg(format_help())
-
-        # --- meta questions ---
-        if is_meta_question(task_text):
-            return _info_msg(
-                "**Mission Mode**\n\n"
-                "Describe a task to start a mission:\n"
-                "- `/mission \u5b9e\u73b0\u7528\u6237\u8ba4\u8bc1`\n"
-                "- `/mission Add notifications`\n\n"
-                "Info: `/mission status` or "
-                "`/mission list`",
-            )
 
         # --- start new mission ---
         workspace_dir = getattr(ctx, "workspace_dir")

--- a/src/qwenpaw/modes/mission/gates.py
+++ b/src/qwenpaw/modes/mission/gates.py
@@ -7,6 +7,7 @@ with a StopHandler-compatible gate that checks
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -81,7 +82,10 @@ class MissionGate(LoopGate):
             read_prd,
         )
 
-        cfg = read_loop_config(state.loop_dir)
+        cfg = await asyncio.to_thread(
+            read_loop_config,
+            state.loop_dir,
+        )
         phase = cfg.get("current_phase", "")
         state.phase = phase
 
@@ -95,10 +99,11 @@ class MissionGate(LoopGate):
         if phase not in _EXEC_PHASES:
             return _bypass
 
-        return self._eval_prd(
-            read_prd(state.loop_dir),
-            cfg,
+        prd = await asyncio.to_thread(
+            read_prd,
+            state.loop_dir,
         )
+        return self._eval_prd(prd, cfg)
 
     def _eval_prd(
         self,

--- a/src/qwenpaw/modes/mission/gates.py
+++ b/src/qwenpaw/modes/mission/gates.py
@@ -35,6 +35,8 @@ class _MissionState:
     loop_dir: Path
     active: bool = True
     phase: str = "prd_generation"
+    last_prd: dict | None = None
+    last_cfg: dict | None = None
 
 
 class MissionGate(LoopGate):
@@ -43,8 +45,8 @@ class MissionGate(LoopGate):
     Activated when ``loop_config.json`` phase transitions
     to ``execution_confirmed`` or ``execution``.
     Each ``check()`` reads prd.json and returns:
-    - STOP if all stories passed or phase is terminal
-    - CONTINUE with remaining summary otherwise
+    - TERMINATE if all stories passed or terminal phase
+    - INTERRUPT_AND_CONTINUE with remaining summary
     """
 
     @property
@@ -58,13 +60,16 @@ class MissionGate(LoopGate):
     async def check(  # pylint: disable=too-many-return-statements
         self,
         ctx: Any,  # pylint: disable=unused-argument
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Evaluate mission completion."""
+        _bypass = StopHandlerResult(
+            action=StopAction.BYPASS,
+        )
         state: Optional[_MissionState] = self._state()
         if state is None:
             state = self._try_restore(ctx)
         if state is None or not state.active:
-            return None
+            return _bypass
 
         from .state import (
             read_loop_config,
@@ -78,12 +83,12 @@ class MissionGate(LoopGate):
         if phase in _TERMINAL_PHASES:
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason=f"Mission {phase}",
             )
 
         if phase not in _EXEC_PHASES:
-            return None
+            return _bypass
 
         return self._eval_prd(
             read_prd(state.loop_dir),
@@ -94,39 +99,51 @@ class MissionGate(LoopGate):
         self,
         prd: dict,
         cfg: dict,
-    ) -> Optional[StopHandlerResult]:
+    ) -> StopHandlerResult:
         """Evaluate PRD completion status."""
         from .state import (
             get_all_passed,
         )
 
         if not prd:
-            return None
+            return StopHandlerResult(
+                action=StopAction.BYPASS,
+            )
 
         stories = prd.get("userStories", [])
         if not stories:
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason="No user stories in prd.json",
             )
 
         if get_all_passed(prd):
             self.deactivate()
             return StopHandlerResult(
-                action=StopAction.STOP,
+                action=StopAction.TERMINATE,
                 reason="All stories passed",
             )
 
+        state: Optional[_MissionState] = self._state()
+        if state is not None:
+            state.last_prd = prd
+            state.last_cfg = cfg
+
         return StopHandlerResult(
-            action=StopAction.CONTINUE,
-            continuation_message=(self._remaining_summary(prd, cfg)),
+            action=StopAction.INTERRUPT_AND_CONTINUE,
             reason="Mission in progress",
         )
 
-    def continuation_prompt(self) -> str:
-        """Fallback prompt when check() returns None."""
-        return ""
+    def build_continuation(self) -> str:
+        """Build remaining-story summary for injection."""
+        state: Optional[_MissionState] = self._state()
+        if state is None or state.last_prd is None or state.last_cfg is None:
+            return ""
+        return self._remaining_summary(
+            state.last_prd,
+            state.last_cfg,
+        )
 
     def activate_for_mission(
         self,

--- a/src/qwenpaw/modes/mission/gates.py
+++ b/src/qwenpaw/modes/mission/gates.py
@@ -59,12 +59,17 @@ class MissionGate(LoopGate):
 
     async def check(  # pylint: disable=too-many-return-statements
         self,
-        ctx: Any,  # pylint: disable=unused-argument
+        ctx: Any,
     ) -> StopHandlerResult:
         """Evaluate mission completion."""
         _bypass = StopHandlerResult(
             action=StopAction.BYPASS,
         )
+        if isinstance(ctx, dict) and ctx.get(
+            "has_tool_calls",
+        ):
+            return _bypass
+
         state: Optional[_MissionState] = self._state()
         if state is None:
             state = self._try_restore(ctx)

--- a/src/qwenpaw/modes/mission/prompts.py
+++ b/src/qwenpaw/modes/mission/prompts.py
@@ -23,14 +23,16 @@ You are the **orchestrator**, not the executor. Your ONLY job is:
 - Phase 2 (after user confirms): Dispatch workers, monitor them, verify results
 
 **What you MUST NOT do:**
+- Execute the task yourself — ALL work (including research,
+  search, writing, analysis) MUST be delegated to workers
 - Run implementation commands (npm, pip, cargo, make, python, node, etc.)
 - Create/edit project source files (*.py, *.ts, *.js, *.jsx, *.tsx, etc.)
 - Install dependencies
 - Run tests/linters yourself (workers do this)
-- Do ANY actual coding work
+- Do ANY actual coding or research work
 
-**If you catch yourself about to do implementation work — STOP immediately
-and dispatch a worker instead.**
+**If you catch yourself about to do the task directly — STOP
+immediately and dispatch a worker instead.**
 
 **Language rule**: Always communicate with the user in the same language as
 the original task description below.  Worker prompts should also be in that
@@ -273,10 +275,13 @@ independently.
 
 ### 0h. Non-software tasks
 
-For research, writing, analysis, etc.: stories can be research steps,
-draft sections, analysis phases.  `branchName` may be "".  Criteria
-should still be verifiable ("Section has ≥500 words", "All sources
-cited").
+For research, writing, analysis, information search, planning,
+etc.: stories can be research steps, draft sections, analysis
+phases.  `branchName` may be "".  Criteria should still be
+verifiable ("Section has ≥500 words", "All sources cited",
+"Covers at least 3 sources").  The controller MUST NOT execute
+these tasks directly — delegate to workers just like software
+tasks.
 
 ### 0i. Checklist before saving prd.json
 

--- a/tests/unit/loop/test_doom_loop_gate.py
+++ b/tests/unit/loop/test_doom_loop_gate.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access
+"""Tests for DoomLoopGate reset behaviour."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.loop.gates.base import StopAction
+from qwenpaw.loop.gates.doom_loop import DoomLoopGate
+
+
+def _stage(after, action="stop", prompt="stop"):
+    return SimpleNamespace(
+        after=after,
+        action=action,
+        prompt=prompt,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _force_session_id():
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="test-session",
+    ):
+        yield
+
+
+@pytest.fixture()
+def gate():
+    g = DoomLoopGate(
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[
+            _stage(3, "modify_prompt", "warning"),
+            _stage(6, "stop", "doom stop"),
+        ],
+    )
+    g.activate(None)
+    g._ensure_state()
+    return g
+
+
+def test_reset_clears_history(gate):
+    """reset() empties the history deque."""
+    gate.record("tool_a", "hash1")
+    gate.record("tool_a", "hash1")
+    assert len(gate._ensure_state().history) == 2
+    gate.reset()
+    assert len(gate._ensure_state().history) == 0
+
+
+def test_reset_clears_counters(gate):
+    """reset() zeroes consecutive_hits and prompt."""
+    state = gate._ensure_state()
+    state.consecutive_hits = 5
+    state.prompt = "some warning"
+    state.last_recorded_iter = 10
+    gate.reset()
+    state = gate._ensure_state()
+    assert state.consecutive_hits == 0
+    assert state.prompt == ""
+    assert state.last_recorded_iter == -1
+
+
+def test_reset_keeps_gate_active(gate):
+    """reset() does NOT deactivate the gate."""
+    gate.reset()
+    assert gate._state() is not None
+
+
+@pytest.mark.asyncio
+async def test_no_false_positive_after_reset(gate):
+    """After reset, fresh calls don't trigger doom loop."""
+    for _ in range(3):
+        gate.record("tool_a", "hash1")
+    gate.reset()
+    gate.record("tool_b", "hash2")
+    result = await gate.check({"iteration": 0})
+    assert result.action == StopAction.BYPASS
+
+
+@pytest.mark.asyncio
+async def test_cross_request_no_bleed(gate):
+    """Simulates two user requests: reset prevents bleed."""
+    for _ in range(3):
+        gate.record("search", "abc")
+
+    result = await gate.check({"iteration": 3})
+    assert result is not None
+
+    gate.reset()
+    gate.record("search", "abc")
+    result = await gate.check({"iteration": 1})
+    assert result.action == StopAction.BYPASS
+
+
+def test_reset_when_no_state():
+    """reset() is a no-op when gate has no state."""
+    g = DoomLoopGate(
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[],
+    )
+    g.reset()
+
+
+@pytest.mark.asyncio
+async def test_session_isolation():
+    """reset() only affects current session."""
+    g = DoomLoopGate(
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[
+            _stage(3, "stop", "doom"),
+        ],
+    )
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="s1",
+    ):
+        g._ensure_state()
+        g.record("t", "h")
+        g.record("t", "h")
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="s2",
+    ):
+        g._ensure_state()
+        g.record("t", "h")
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="s1",
+    ):
+        g.reset()
+        assert len(g._state().history) == 0
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="s2",
+    ):
+        assert len(g._state().history) == 1

--- a/tests/unit/loop/test_handler_continuation_reset.py
+++ b/tests/unit/loop/test_handler_continuation_reset.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""Tests for StopHandler peer-gate reset on continuation."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from qwenpaw.loop.gates.base import (
+    StopAction,
+    StopGate,
+    StopHandlerResult,
+)
+from qwenpaw.loop.gates.handler import StopHandler
+
+
+class _AlwaysContinueGate(StopGate):
+    """Returns INTERRUPT_AND_CONTINUE with reset_peers."""
+
+    def __init__(
+        self,
+        *,
+        reset_peers: bool = False,
+    ):
+        self._reset_peers = reset_peers
+
+    @property
+    def name(self) -> str:
+        return "always-continue"
+
+    async def check(
+        self,
+        ctx: Any,
+    ) -> Optional[StopHandlerResult]:
+        return StopHandlerResult(
+            action=StopAction.INTERRUPT_AND_CONTINUE,
+            reason="test",
+            reset_peers=self._reset_peers,
+        )
+
+    def build_continuation(self) -> str:
+        return "keep going"
+
+
+class _ResettableGate(StopGate):
+    """Gate that tracks reset() calls."""
+
+    def __init__(self, gate_name: str = "resettable"):
+        self._name = gate_name
+        self.reset_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def check(
+        self,
+        ctx: Any,
+    ) -> Optional[StopHandlerResult]:
+        return None
+
+    def reset(self) -> None:
+        self.reset_count += 1
+
+
+@pytest.mark.asyncio
+async def test_reset_peers_true_resets_others():
+    """CONTINUE with reset_peers=True resets other gates."""
+    handler = StopHandler()
+    trigger = _AlwaysContinueGate(reset_peers=True)
+    peer = _ResettableGate("peer")
+    handler.register(trigger)
+    handler.register(peer)
+
+    await handler({})
+    assert peer.reset_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_peers_true_skips_trigger():
+    """The triggering gate itself is NOT reset."""
+    handler = StopHandler()
+
+    class _ContinueResettable(StopGate):
+        def __init__(self):
+            self.reset_count = 0
+
+        @property
+        def name(self):
+            return "trigger"
+
+        @property
+        def priority(self):
+            return 1
+
+        async def check(self, ctx):
+            return StopHandlerResult(
+                action=StopAction.INTERRUPT_AND_CONTINUE,
+                reason="test",
+                reset_peers=True,
+            )
+
+        def build_continuation(self):
+            return "go"
+
+        def reset(self):
+            self.reset_count += 1
+
+    trigger = _ContinueResettable()
+    handler.register(trigger)
+
+    await handler({})
+    assert trigger.reset_count == 0
+
+
+@pytest.mark.asyncio
+async def test_reset_peers_false_no_reset():
+    """CONTINUE with reset_peers=False does NOT reset."""
+    handler = StopHandler()
+    trigger = _AlwaysContinueGate(reset_peers=False)
+    peer = _ResettableGate("peer")
+    handler.register(trigger)
+    handler.register(peer)
+
+    await handler({})
+    assert peer.reset_count == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_peers_all_reset():
+    """All peers (except trigger) are reset."""
+    handler = StopHandler()
+    trigger = _AlwaysContinueGate(reset_peers=True)
+    p1 = _ResettableGate("p1")
+    p2 = _ResettableGate("p2")
+    handler.register(trigger)
+    handler.register(p1)
+    handler.register(p2)
+
+    await handler({})
+    assert p1.reset_count == 1
+    assert p2.reset_count == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_without_reset_method_skipped():
+    """Gates without reset() are silently skipped."""
+    handler = StopHandler()
+    trigger = _AlwaysContinueGate(reset_peers=True)
+
+    class _NoResetGate(StopGate):
+        @property
+        def name(self):
+            return "no-reset"
+
+        async def check(self, ctx):
+            return None
+
+    handler.register(trigger)
+    handler.register(_NoResetGate())
+
+    result = await handler({})
+    assert result.action == StopAction.INTERRUPT_AND_CONTINUE

--- a/tests/unit/loop/test_iteration_gate.py
+++ b/tests/unit/loop/test_iteration_gate.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access
+"""Tests for IterationGate reset behaviour."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.loop.gates.base import StopAction
+from qwenpaw.loop.gates.iteration import IterationGate
+
+
+@pytest.fixture(autouse=True)
+def _force_session_id():
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="test-session",
+    ):
+        yield
+
+
+@pytest.fixture()
+def gate():
+    g = IterationGate(max_iterations=5)
+    g.activate()
+    return g
+
+
+@pytest.mark.asyncio
+async def test_check_increments(gate):
+    """check() increments the counter each call."""
+    for _ in range(4):
+        result = await gate.check({})
+        assert result.action == StopAction.BYPASS
+    result = await gate.check({})
+    assert result.action == StopAction.TERMINATE
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_counter(gate):
+    """reset() sets iteration back to 0."""
+    for _ in range(3):
+        await gate.check({})
+    gate.reset()
+    state = gate._state()
+    assert state is not None
+    assert state.iteration == 0
+
+
+@pytest.mark.asyncio
+async def test_reset_preserves_max(gate):
+    """reset() keeps max_iterations unchanged."""
+    gate.reset()
+    state = gate._state()
+    assert state.max_iterations == 5
+
+
+@pytest.mark.asyncio
+async def test_reset_allows_full_budget(gate):
+    """After reset the full iteration budget is available."""
+    for _ in range(3):
+        await gate.check({})
+    gate.reset()
+    for _ in range(4):
+        result = await gate.check({})
+        assert result.action == StopAction.BYPASS
+    result = await gate.check({})
+    assert result.action == StopAction.TERMINATE
+
+
+def test_reset_when_inactive():
+    """reset() is a no-op when no session state."""
+    g = IterationGate(max_iterations=5)
+    g.reset()
+
+
+@pytest.fixture()
+def gate_pair():
+    """Instance with state in two sessions."""
+    g = IterationGate(max_iterations=5)
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="session-a",
+    ):
+        g.activate()
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="session-b",
+    ):
+        g.activate()
+    return g
+
+
+@pytest.mark.asyncio
+async def test_reset_session_isolation(gate_pair):
+    """reset() only affects the current session."""
+    g = gate_pair
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="session-a",
+    ):
+        for _ in range(3):
+            await g.check({})
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="session-b",
+    ):
+        for _ in range(2):
+            await g.check({})
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="session-a",
+    ):
+        g.reset()
+        assert g._state().iteration == 0
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="session-b",
+    ):
+        assert g._state().iteration == 2

--- a/tests/unit/loop/test_react_gates_reset.py
+++ b/tests/unit/loop/test_react_gates_reset.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Tests for register_react_gates new-turn reset."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.loop.gates.handler import StopHandler
+from qwenpaw.loop.react_gates import (
+    _reset_gates_for_new_turn,
+    register_react_gates,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_session_id():
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="test-session",
+    ):
+        yield
+
+
+def _running_config(
+    max_iters=100,
+    doom_enabled=True,
+    rubric_enabled=True,
+):
+    doom_stage = SimpleNamespace(
+        after=3,
+        action="stop",
+        prompt="doom",
+    )
+    doom = SimpleNamespace(
+        enabled=doom_enabled,
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[doom_stage],
+    )
+    iteration = SimpleNamespace(
+        enabled=True,
+        max_iterations=max_iters,
+    )
+    rubric = SimpleNamespace(
+        enabled=rubric_enabled,
+        prompt="continue working",
+        max_interventions=1,
+    )
+    loop = SimpleNamespace(
+        iteration=iteration,
+        doom_loop=doom,
+        rubric=rubric,
+    )
+    return SimpleNamespace(
+        max_iters=max_iters,
+        loop=loop,
+    )
+
+
+def _workspace():
+    plugins = SimpleNamespace(stop_handlers=[])
+    return SimpleNamespace(plugins=plugins)
+
+
+def test_first_call_registers_gates():
+    """First call registers gates on workspace."""
+    ws = _workspace()
+    cfg = _running_config()
+    handler = register_react_gates(ws, cfg)
+    assert isinstance(handler, StopHandler)
+    assert len(handler.gates) >= 2
+    assert ws._react_gates_registered is True
+
+
+@pytest.mark.asyncio
+async def test_second_call_resets_iteration():
+    """Second call resets IterationGate counter."""
+    ws = _workspace()
+    cfg = _running_config(max_iters=10)
+    handler = register_react_gates(ws, cfg)
+
+    from qwenpaw.loop.gates.iteration import (
+        IterationGate,
+    )
+
+    iter_gate = None
+    for g in handler.gates:
+        if isinstance(g, IterationGate):
+            iter_gate = g
+            break
+    assert iter_gate is not None
+
+    for _ in range(5):
+        await iter_gate.check({})
+    assert iter_gate._state().iteration == 5
+
+    register_react_gates(ws, cfg)
+    assert iter_gate._state().iteration == 0
+
+
+@pytest.mark.asyncio
+async def test_second_call_resets_doom_loop():
+    """Second call resets DoomLoopGate history."""
+    ws = _workspace()
+    cfg = _running_config()
+    handler = register_react_gates(ws, cfg)
+
+    from qwenpaw.loop.gates.doom_loop import (
+        DoomLoopGate,
+    )
+
+    doom_gate = None
+    for g in handler.gates:
+        if isinstance(g, DoomLoopGate):
+            doom_gate = g
+            break
+    assert doom_gate is not None
+
+    doom_gate.record("tool_a", "h1")
+    doom_gate.record("tool_a", "h1")
+    assert len(doom_gate._ensure_state().history) == 2
+
+    register_react_gates(ws, cfg)
+    assert len(doom_gate._ensure_state().history) == 0
+
+
+def test_reset_gates_for_new_turn_helper():
+    """_reset_gates_for_new_turn calls reset on all."""
+    from qwenpaw.loop.gates.base import StopGate
+
+    class _Tracked(StopGate):
+        def __init__(self):
+            self.was_reset = False
+
+        @property
+        def name(self):
+            return "tracked"
+
+        async def check(self, ctx):
+            return None
+
+        def reset(self):
+            self.was_reset = True
+
+    handler = StopHandler()
+    g1 = _Tracked()
+    g2 = _Tracked()
+    handler.register(g1)
+    handler.register(g2)
+
+    _reset_gates_for_new_turn(handler)
+    assert g1.was_reset
+    assert g2.was_reset


### PR DESCRIPTION
## Description

Fix gate state accumulation across user requests and refactor the StopAction enum + continuation message architecture for semantic clarity.

**Root cause:** `IterationGate` and `DoomLoopGate` never reset their internal counters/history when a new user query arrived, causing false stops and phantom doom-loop detections. Additionally, `StandaloneRubricGate` lacked a reset mechanism, and the `StopAction` enum names were semantically confusing.

**Key changes:**

1. **Gate reset on new user turn** — Add `reset()` to `IterationGate`, `DoomLoopGate`, and `StandaloneRubricGate`. Call all resets from `register_react_gates()` on every new turn via `_reset_gates_for_new_turn()`.

2. **Peer-gate reset on continuation** — Introduce `reset_peers: bool` on `StopHandlerResult`. When a gate (e.g. rubric) triggers `INTERRUPT_AND_CONTINUE` with `reset_peers=True`, all OTHER gates are reset. Doom-loop warnings keep `reset_peers=False`.

3. **Fix deferred INTERRUPT_AND_CONTINUE** — `apply_stop_result()` now handles `INTERRUPT_AND_CONTINUE` during tool-call iterations by setting `_gate_pending_continue`, preventing doom-loop warnings from being silently dropped.

4. **Rename StopAction enum:**
   - `STOP` → `TERMINATE` (end the loop)
   - `CONTINUE` → `INTERRUPT_AND_CONTINUE` (inject prompt, keep going)
   - New `BYPASS` value (gate has no opinion; `None` still accepted for backward compat)

5. **Unify continuation message flow:**
   - Gates provide messages via `build_continuation()` on `StopGate` base class
   - Handler calls `gate.build_continuation()` after `INTERRUPT_AND_CONTINUE`
   - Remove `_continuation_fn` / `set_continuation()` callback mechanism
   - Move `GoalMode._build_continuation()` into `GoalTurnGate.build_continuation()`
   - Gates no longer set `continuation_message` in their `check()` results

**Related Issue:** Fixes #5906, Fixes #5896

**Security Considerations:** None

## Type of Change

- [x] Bug fix
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

```bash
# Run gate-specific unit tests
pytest tests/unit/loop/ -v

# All 22 tests cover:
# - IterationGate reset + session isolation
# - DoomLoopGate reset + cross-request bleed prevention
# - StopHandler peer-gate reset (reset_peers=True/False)
# - react_gates new-turn reset flow
```

## Local Verification Evidence

```bash
pre-commit run --all-files
# All checks passed (ast, black, flake8, pylint, mypy)

pytest tests/unit/loop/ -v
# 22 passed in 0.13s
```

## Additional Notes

- `StopHandlerResult.continuation_message` field is retained for handler→agent output, but individual gates no longer populate it in `check()`.
- External dict-based handlers in `runner.py` still accept string actions (`"stop"`, `"continue"`, `"block"`) for backward compatibility.
- `FileLoopGate` has no subclasses in the current codebase; `build_continuation()` returns `""` by default, ready for future plugins.