### PR TITLE
test(inbox): make append_event cap test O(1), not O(n²)

### DIFF
--- a/tests/unit/app/inbox/test_inbox_store.py
+++ b/tests/unit/app/inbox/test_inbox_store.py
@@ -7,6 +7,7 @@ Covers: append_event, list_events filters/pagination, mark_read,
 mark_all_read, delete_event (incl. run_id reference tracking), and the
 5000-event cap.
 """
+
 from __future__ import annotations
 
 import json
@@ -352,20 +353,42 @@ async def test_delete_event_run_id_not_referenced_after_last(inbox_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_append_event_caps_at_5000(inbox_path: Path):
-    # Append more than _MAX_EVENTS to confirm the tail is trimmed.
-    for _ in range(inbox_store._MAX_EVENTS + 50):
+async def test_append_event_caps_at_max(
+    inbox_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The event list is trimmed to _MAX_EVENTS, keeping the newest.
+
+    append_event does ``events.insert(0, event); del events[_MAX_EVENTS:]``
+    on every call, and _save_events re-serializes the whole list — so a
+    test that appends ``_MAX_EVENTS + 50`` (5050) times is O(n^2) and
+    takes ~160s, which tips over CI's --timeout=300 under parallel load.
+
+    monkeypatch a small cap so the trim is exercised in O(1): append one
+    past the cap and confirm the list is capped and the oldest is dropped.
+    """
+    small_cap = 5
+    monkeypatch.setattr(inbox_store, "_MAX_EVENTS", small_cap)
+
+    for i in range(small_cap + 2):
         await inbox_store.append_event(
             agent_id="a",
             source_type="t",
-            source_id="1",
+            source_id=str(i),
             event_type="e",
             status="ok",
             title="t",
             body="b",
         )
-    events = await inbox_store.list_events(limit=inbox_store._MAX_EVENTS + 100)
-    assert len(events) == inbox_store._MAX_EVENTS
+
+    events = await inbox_store.list_events(limit=small_cap + 100)
+    assert len(events) == small_cap
+    # newest-first: the last two appended (indices small_cap+1, small_cap)
+    # survived; the oldest two (0, 1) were trimmed off the tail.
+    assert events[0]["source_id"] == str(small_cap + 1)
+    assert events[-1]["source_id"] == str(2)
+    assert str(0) not in {e["source_id"] for e in events}
+    assert str(1) not in {e["source_id"] for e in events}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Rewrite `test_append_event_caps_at_5000` → `test_append_event_caps_at_max` so the inbox event-cap trim logic is tested in **O(1) (~0.03s)** instead of **O(n²) (~160s)**. No production-code change.

`append_event` does `events.insert(0, event); del events[_MAX_EVENTS:]; _save_events(events)`, and `_save_events` re-serializes the **entire** list with `json.dumps(indent=2, sort_keys=True)` on every call. The old test looped `_MAX_EVENTS + 50` = 5050 times → ~12.5M event serializations → ~160s wall-clock. CI runs `pytest -n auto --dist=loadscope --timeout=300`; under parallel load this test tipped past 300s and **failed the whole Unit Tests job**. That is the root cause of #5813 being red — #5813 inherited the test from #5809 on main and doesn't touch inbox itself.

Fix: `monkeypatch.setattr(inbox_store, "_MAX_EVENTS", 5)` and append 7 events. The trim contract is fully covered, and the assertion is now **stronger** (verifies newest-two retained + oldest-two dropped via `source_id`, not just the count).

**Related Issue:** Relates to #5813 (unblocks it once merged + #5813's temp skip reverted). Root test introduced by #5809.

**Security Considerations:** None — test-only change, no auth/config/path logic touched.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — N/A
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

- `pytest tests/unit/app/inbox/test_inbox_store.py -q` → 23 passed in 0.57s
- `pytest tests/unit/app/inbox/test_inbox_store.py::test_append_event_caps_at_max -q` → 1 passed in 0.03s (was ~160s as `test_append_event_caps_at_5000`)
- `pre-commit run --files tests/unit/app/inbox/test_inbox_store.py` → all hooks Passed (black, add-trailing-comma, mypy, flake8, pylint, etc.)

## Evidence

Local terminal transcripts (Python 3.11, project venv):

```bash
# Full inbox test file — all green
$ pytest tests/unit/app/inbox/test_inbox_store.py -q --no-header
.......................                                                  [100%]
23 passed in 0.57s

# The rewritten case — was ~160s, now 0.03s
$ pytest tests/unit/app/inbox/test_inbox_store.py::test_append_event_caps_at_max --no-header -q
.                                                                        [100%]
1 passed in 0.03s

# pre-commit over the changed file — every hook Passed
$ pre-commit run --files tests/unit/app/inbox/test_inbox_store.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint.....................................................................Passed
```

Before/after wall-clock for the cap test: **~160s → 0.03s** (the O(n²) re-serialization is eliminated by testing the trim against a small monkeypatched `_MAX_EVENTS`, not by changing production code).

CI behavior proof: on #5813 the `Tests` workflow failed solely because this test exceeded `--timeout=300` under parallel load (`pytest -n auto --dist=loadscope`). #5813's own added tests pass in <3s. This PR removes the flaky O(n²) source so the `Tests` job no longer tips over.

## Additional Notes

- A TEMP `@pytest.mark.skip` was pushed to #5813 (`81669519`) to get its CI green in the meantime. Once this PR merges, that skip should be reverted on #5813 — the test is now properly covered here.
- The O(n²) write path lives in `qwenpaw/app/inbox_store.py` (`_save_events` re-dumps everything). Out of scope for this PR; worth a separate proposal if inbox write volume matters in production.
- Lesson for the team's test skill: avoid "loop N times, each iteration re-processes the whole collection" patterns — they're silent O(n²) time bombs that only surface under CI parallelism.