### PR TITLE
fix(providers): OpenAI Responses API formatting and reasoning_content compatibility

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -63,6 +63,7 @@ function ModelConfigEditor({
   thinkingParamStyle,
   reasoningEffortOptions,
   thinkingBudgetRange = [1, 81920],
+  chatModel,
 }: {
   providerId: string;
   model: ModelInfo;
@@ -73,6 +74,7 @@ function ModelConfigEditor({
   thinkingParamStyle?: "budget" | "effort" | null;
   reasoningEffortOptions?: string[];
   thinkingBudgetRange?: [number, number];
+  chatModel?: string;
 }) {
   const { t } = useTranslation();
   const { message } = useAppMessage();
@@ -391,42 +393,47 @@ function ModelConfigEditor({
           )}
         </>
       )}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: 8,
-          padding: "6px 0",
-        }}
-      >
-        <div>
-          <span
-            style={{
-              fontSize: 13,
-              color: isDark ? "rgba(255,255,255,0.85)" : "#333",
-            }}
-          >
-            {t("models.relayReasoningLabel")}
-          </span>
-          <div
-            style={{
-              fontSize: 11,
-              color: isDark ? "rgba(255,255,255,0.35)" : "#999",
-              marginTop: 2,
-            }}
-          >
-            {t("models.relayReasoningHint")}
-          </div>
-        </div>
-        <Switch
-          checked={relayReasoning}
-          onChange={(checked) => {
-            setRelayReasoning(checked);
-            setDirty(true);
+      {/* Responses API models handle reasoning via native reasoning items
+         that the API requires to be echoed back; relay_reasoning has no
+         effect, so hide the toggle to avoid confusion. */}
+      {chatModel !== "OpenAIResponseModel" && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: 8,
+            padding: "6px 0",
           }}
-        />
-      </div>
+        >
+          <div>
+            <span
+              style={{
+                fontSize: 13,
+                color: isDark ? "rgba(255,255,255,0.85)" : "#333",
+              }}
+            >
+              {t("models.relayReasoningLabel")}
+            </span>
+            <div
+              style={{
+                fontSize: 11,
+                color: isDark ? "rgba(255,255,255,0.35)" : "#999",
+                marginTop: 2,
+              }}
+            >
+              {t("models.relayReasoningHint")}
+            </div>
+          </div>
+          <Switch
+            checked={relayReasoning}
+            onChange={(checked) => {
+              setRelayReasoning(checked);
+              setDirty(true);
+            }}
+          />
+        </div>
+      )}
 
       <div
         style={{
@@ -1075,6 +1082,7 @@ export function RemoteModelManageModal({
                         onProviderUpdated={onProviderUpdated}
                         onClose={() => setConfigOpenModelId(null)}
                         isDark={isDark}
+                        chatModel={provider.chat_model}
                         thinkingParamStyle={
                           extraModelIds.has(m.id)
                             ? undefined

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -30,10 +30,7 @@ try:
 except ImportError:
     GeminiChatFormatter = None
 
-try:
-    from agentscope.formatter import OpenAIResponseFormatter
-except ImportError:
-    OpenAIResponseFormatter = None
+from agentscope.formatter import OpenAIResponseFormatter
 
 from .utils.message_request_normalizer import (
     normalize_messages_for_model_request,
@@ -100,11 +97,12 @@ def _normalize_messages_for_formatter(
     msgs: list,
     base_formatter_class: Type[FormatterBase],
     formatter_instance: FormatterBase | None = None,
-) -> tuple[list, bool, bool]:
+) -> tuple[list, bool, bool, bool]:
     """Return normalized messages and formatter-family flags.
 
     The returned booleans are
-    ``(is_anthropic_formatter, is_gemini_formatter)``.
+    ``(is_anthropic_formatter, is_gemini_formatter,
+    is_response_formatter)``.
     All formatters receive a copied, normalized message list so
     request-time repair does not mutate stored history.
     """
@@ -113,6 +111,10 @@ def _normalize_messages_for_formatter(
     )
     is_gemini_formatter = GeminiChatFormatter is not None and (
         issubclass(base_formatter_class, GeminiChatFormatter)
+    )
+    is_response_formatter = issubclass(
+        base_formatter_class,
+        OpenAIResponseFormatter,
     )
     supports_multimodal = _supports_multimodal_for_current_model()
     if getattr(formatter_instance, "_qwenpaw_force_strip_media", False):
@@ -131,7 +133,12 @@ def _normalize_messages_for_formatter(
         target_family=target_family,
     )
 
-    return normalized_msgs, is_anthropic_formatter, is_gemini_formatter
+    return (
+        normalized_msgs,
+        is_anthropic_formatter,
+        is_gemini_formatter,
+        is_response_formatter,
+    )
 
 
 def _anthropic_media_dedup_key(source: Any) -> str | None:
@@ -585,20 +592,34 @@ def _fix_image_mime_types(messages: list[dict]) -> None:
     (e.g. ``.jpg`` → ``image/jpg``), but ``image/jpg`` is not a
     valid IANA MIME type — the correct form is ``image/jpeg``.
     Some APIs (Bedrock via litellm) reject the non-standard form.
+
+    Handles both Chat Completions format (``image_url`` is a dict
+    with a ``url`` key) and Responses API format (``image_url`` is
+    a plain string URL).
     """
     for msg in messages:
         content = msg.get("content")
         if not isinstance(content, list):
             continue
         for block in content:
-            url = (block.get("image_url") or {}).get("url", "")
+            if not isinstance(block, dict):
+                continue
+            raw = block.get("image_url")
+            if raw is None:
+                continue
+            if isinstance(raw, dict):
+                url = raw.get("url", "")
+            elif isinstance(raw, str):
+                url = raw
+            else:
+                continue
             for wrong, right in _MIME_FIXES.items():
                 if url.startswith(f"data:{wrong};"):
-                    block["image_url"]["url"] = url.replace(
-                        f"data:{wrong};",
-                        f"data:{right};",
-                        1,
-                    )
+                    fixed = url.replace(f"data:{wrong};", f"data:{right};", 1)
+                    if isinstance(raw, dict):
+                        raw["url"] = fixed
+                    else:
+                        block["image_url"] = fixed
 
 
 _MEDIA_BLOCK_TYPES = ("image", "audio", "video")
@@ -886,6 +907,7 @@ def _create_file_block_support_formatter(
                 normalized_msgs,
                 is_anthropic_formatter,
                 _is_gemini_formatter,
+                _is_response_formatter,
             ) = _normalize_messages_for_formatter(
                 msgs,
                 base_formatter_class,
@@ -959,6 +981,7 @@ def _create_file_block_support_formatter(
             if (
                 reasoning_contents
                 and not is_anthropic_formatter
+                and not _is_response_formatter
                 and getattr(
                     self,
                     "relay_reasoning_content",
@@ -1286,9 +1309,11 @@ def _create_formatter_instance(
     # results — promote them into a follow-up user message instead.
     # Anthropic format keeps images in tool_result natively, so no
     # promotion needed.
-    _promote_types = (OpenAIChatFormatter, GeminiChatFormatter)
-    if OpenAIResponseFormatter is not None:
-        _promote_types = (*_promote_types, OpenAIResponseFormatter)
+    _promote_types = (
+        OpenAIChatFormatter,
+        GeminiChatFormatter,
+        OpenAIResponseFormatter,
+    )
     if isinstance(base_formatter, _promote_types):
         kwargs["promote_tool_result_images"] = True
     return formatter_class(**kwargs)

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -43,6 +43,8 @@ from agentscope.formatter import (
     GeminiChatFormatter,
     OpenAIChatFormatter,
 )
+
+from agentscope.formatter import OpenAIResponseFormatter
 from agentscope.message import Base64Source, URLSource
 from pydantic import Field
 
@@ -223,5 +225,30 @@ class _CappingDashScopeFormatter(
         if capped is not None:
             return capped
         return super()._format_audio_source(
+            self._local_source_to_base64(source),
+        )
+
+
+class _CappingOpenAIResponseFormatter(
+    OpenAIResponseFormatter,
+    CappingFormatterMixin,
+):
+    """OpenAI Responses API formatter that caps oversized local media."""
+
+    def _placeholder(self, kind: str, size: int) -> dict[str, Any]:
+        # Responses API uses ``input_text`` / ``output_text`` — not the
+        # generic ``text`` type used by Chat Completions.  Capped media
+        # almost always comes from user messages, so ``input_text`` is
+        # the correct type here.
+        return {
+            "type": "input_text",
+            "text": self._placeholder_text(kind, size),
+        }
+
+    def _format_image_source(self, source: Any) -> dict[str, Any]:
+        capped = self._maybe_cap(source, "image")
+        if capped is not None:
+            return capped
+        return super()._format_image_source(
             self._local_source_to_base64(source),
         )

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from agentscope.model import ChatModelBase, OpenAIResponseModel
 
-from qwenpaw.providers.openai_provider import OpenAIProvider
+from .capping_formatter import _CappingOpenAIResponseFormatter
+from .openai_provider import OpenAIProvider
 
 logger = logging.getLogger(__name__)
 
@@ -137,4 +138,7 @@ class OpenAIResponseProvider(OpenAIProvider):
             context_size=self._get_context_size(model_id),
             client_kwargs=client_kwargs,
             extra_generate_kwargs=gen_kwargs or None,
+            formatter=_CappingOpenAIResponseFormatter(
+                max_bytes=self.max_inline_media_bytes,
+            ),
         )

--- a/tests/unit/agents/test_cross_provider_normalization.py
+++ b/tests/unit/agents/test_cross_provider_normalization.py
@@ -105,6 +105,7 @@ def test_gemini_history_to_openai(monkeypatch) -> None:
         normalized,
         is_anthropic,
         is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         history,
         OpenAIChatFormatter,
@@ -142,6 +143,7 @@ def test_gemini_history_to_anthropic(monkeypatch) -> None:
         _,
         is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         history,
         AnthropicChatFormatter,
@@ -172,6 +174,7 @@ def test_gemini_history_stays_gemini(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         history,
         GeminiChatFormatter,
@@ -204,6 +207,7 @@ def test_openai_history_to_gemini(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         history,
         GeminiChatFormatter,
@@ -264,6 +268,7 @@ def test_gemini_multi_toolcall_to_openai(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,
         OpenAIChatFormatter,
@@ -313,6 +318,7 @@ def test_thinking_blocks_preserved_for_openai(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         _history_with_thinking(),
         OpenAIChatFormatter,
@@ -341,6 +347,7 @@ def test_unsigned_thinking_blocks_dropped_for_anthropic(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         _history_with_thinking(),
         AnthropicChatFormatter,
@@ -389,6 +396,7 @@ def test_signed_thinking_blocks_preserved_for_anthropic(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         history,
         AnthropicChatFormatter,
@@ -417,6 +425,7 @@ def test_thinking_blocks_preserved_for_gemini(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         _history_with_thinking(),
         GeminiChatFormatter,
@@ -473,6 +482,7 @@ def test_raw_input_repair_works_before_cross_provider_clean(
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         history,
         OpenAIChatFormatter,

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -80,6 +80,7 @@ def _assert_request_time_stripped(formatter_class) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         original,
         formatter_class,
@@ -137,6 +138,7 @@ def test_multimodal_support_preserves_media(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         original,
         OpenAIChatFormatter,
@@ -163,6 +165,7 @@ def test_force_strip_media_flag_overrides_multimodal_support(
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         original,
         OpenAIChatFormatter,
@@ -182,6 +185,7 @@ def test_formatter_flags_returned_correctly() -> None:
         _normalized,
         is_anthropic,
         is_gemini,
+        is_response,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,
         OpenAIChatFormatter,
@@ -190,6 +194,7 @@ def test_formatter_flags_returned_correctly() -> None:
 
     assert is_anthropic is False
     assert is_gemini is False
+    assert is_response is False
 
 
 def test_anthropic_flag_detected(monkeypatch) -> None:
@@ -210,6 +215,7 @@ def test_anthropic_flag_detected(monkeypatch) -> None:
         _normalized,
         is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,
         AnthropicChatFormatter,
@@ -237,6 +243,7 @@ def test_gemini_flag_detected(monkeypatch) -> None:
         _normalized,
         _is_anthropic,
         is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,
         GeminiChatFormatter,
@@ -261,6 +268,7 @@ def test_original_messages_not_modified_by_formatter_prep() -> None:
         _normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         [original],
         OpenAIChatFormatter,
@@ -311,6 +319,7 @@ def test_openai_formatter_strips_extra_content(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         _messages_with_extra_content(),
         OpenAIChatFormatter,
@@ -339,6 +348,7 @@ def test_anthropic_formatter_strips_extra_content(monkeypatch) -> None:
         normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         _messages_with_extra_content(),
         AnthropicChatFormatter,
@@ -368,6 +378,7 @@ def test_gemini_formatter_preserves_extra_content(monkeypatch) -> None:
         _normalized,
         _is_anthropic,
         _is_gemini,
+        _is_response,
     ) = model_factory._normalize_messages_for_formatter(
         msgs,
         GeminiChatFormatter,


### PR DESCRIPTION

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
