### PR TITLE
docs(console): add Whisper installation notes

### DIFF
--- a/website/public/docs/console.en.md
+++ b/website/public/docs/console.en.md
@@ -489,10 +489,28 @@ model (same settings apply to voice input in chat and channel voice messages).
 - **Audio mode** — **Auto**: transcribe per settings below, then send text
   (works for most models). **Native**: send audio as an attachment (only for
   models that support audio).
-- **Transcription backend** — **Off**; **Whisper API** (OpenAI-compatible
-  `audio/transcriptions`; configure keys under [Models](#models) and select the
-  provider here); **Local Whisper** (requires `ffmpeg` and
-  `pip install 'qwenpaw[whisper]'`).
+- **Transcription backend** — **Off**; **Whisper API**; **Local Whisper**.
+
+**Whisper API setup:**
+
+1. Add an OpenAI-compatible provider under [Models](#models).
+2. Make sure the provider supports `audio/transcriptions` and has a valid API
+   key.
+3. Return here and select that provider as the Whisper API backend.
+
+**Local Whisper setup:**
+
+1. Install `ffmpeg` with your system package manager.
+2. Install the optional Python dependency in the environment that runs QwenPaw:
+   `pip install "qwenpaw[whisper]"`.
+3. Restart QwenPaw, then select **Local Whisper** here.
+
+Verify the local installation with:
+
+```bash
+ffmpeg -version
+python -c "import whisper; print('openai-whisper installed')"
+```
 
 **Save** applies to newly received audio. Follow on-page help for details.
 

--- a/website/public/docs/console.zh.md
+++ b/website/public/docs/console.zh.md
@@ -450,7 +450,26 @@ Console 页面左上角的 **当前智能体** 用于切换当前操作对象；
 配置**各频道发来的语音/音频**在进入模型前的处理方式（与聊天里的语音输入、频道语音消息共用这套设置）。
 
 - **音频模式**：**自动** — 先按下方转写设置转成文字再交给模型（多数模型适用）；**原生** — 直接把音频当附件交给模型（仅部分支持音频的模型可用）。
-- **转写后端**：**关闭**；**Whisper API** — 使用兼容 OpenAI `audio/transcriptions` 的提供商，需在 [模型](#模型) 中配置好对应密钥并在此选中提供商；**本地 Whisper** — 本机运行，需安装 `ffmpeg` 与 `pip install 'qwenpaw[whisper]'`。
+- **转写后端**：**关闭**；**Whisper API**；**本地 Whisper**。
+
+**Whisper API 安装配置：**
+
+1. 在 [模型](#模型) 中添加兼容 OpenAI 的提供商。
+2. 确认该提供商支持 `audio/transcriptions`，并已配置有效 API Key。
+3. 回到本页，将该提供商选为 Whisper API 后端。
+
+**本地 Whisper 安装配置：**
+
+1. 使用系统包管理器安装 `ffmpeg`。
+2. 在运行 QwenPaw 的 Python 环境中安装可选依赖：`pip install "qwenpaw[whisper]"`。
+3. 重启 QwenPaw，然后在本页选择 **本地 Whisper**。
+
+可用以下命令验证本地安装：
+
+```bash
+ffmpeg -version
+python -c "import whisper; print('openai-whisper installed')"
+```
 
 保存后对新收到的语音生效。详情以页面内说明为准。
 


### PR DESCRIPTION
## Description
Adds explicit Whisper setup instructions to the Console voice transcription docs:

- documents Whisper API provider setup for OpenAI-compatible audio transcription providers
- documents local Whisper installation with ffmpeg and the qwenpaw[whisper] optional dependency
- keeps English and Chinese docs aligned

Addresses #2069

## Type of Change
Documentation

## Component(s) Affected
Documentation, Console

## Checklist
- [x] Documentation updated
- [x] Relevant formatting checks passed
- [x] Relevant type checks passed
- [ ] pre-commit run --all-files (not run; docs-only change, local pnpm script was blocked by pnpm 11 build-script approval prompts before project scripts ran)
- [ ] pytest (not run; no Python behavior changed)

## Testing
- Verified Markdown formatting for the changed docs files
- Verified website TypeScript project still type-checks

## Local Verification Evidence
```bash
./node_modules/.bin/prettier --check public/docs/console.en.md public/docs/console.zh.md
# Checking formatting...
# All matched files use Prettier code style!

./node_modules/.bin/tsc -b --noEmit
# passed
```

## Notes
`pnpm run format:check` was attempted locally, but pnpm 11 stopped during dependency status checks with ignored-build approval prompts for esbuild/msw before running the project script. The equivalent local binaries were run directly.