### PR TITLE
fix(console): cover plugin market compatibility labels

### DIFF
--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
@@ -38,7 +38,10 @@ vi.mock("../hooks/useMarketPlugins", () => ({
   }),
 }));
 
-function makePlugin(detailsUrl: string): MarketPluginEntry {
+function makePlugin(
+  detailsUrl: string,
+  qwenpawCompatLabels?: string[],
+): MarketPluginEntry {
   return {
     id: "@agentscope/demo",
     display_name: "Demo plugin",
@@ -49,6 +52,7 @@ function makePlugin(detailsUrl: string): MarketPluginEntry {
     downloads: 10,
     view_count: 20,
     details_url: detailsUrl,
+    qwenpaw_compat_labels: qwenpawCompatLabels,
     locales: {
       en: {
         description: "Demo description",
@@ -96,5 +100,18 @@ describe("MarketPluginList", () => {
 
     expect(windowOpen).not.toHaveBeenCalled();
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("shows the QwenPaw compatibility versions returned by the market", () => {
+    hoisted.plugins.push(
+      makePlugin("https://platform.agentscope.io/plugins/agentscope/demo", [
+        "1.x",
+        "2.x",
+      ]),
+    );
+
+    render(<MarketPluginList onInstalled={vi.fn()} />);
+
+    expect(screen.getByText("QwenPaw 1.x, 2.x")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

- Add test coverage for QwenPaw compatibility labels.
- Verify multiple supported versions render correctly.

<img width="2302" height="1288" alt="image" src="https://github.com/user-attachments/assets/4daae7bb-18d7-47f0-875e-03bb1e907596" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
