### PR TITLE
fix: add errors='replace' to _run_command for GBK compatibility

### DIFF
--- a/src/qwenpaw/agents/context/scroll/eviction_index.py
+++ b/src/qwenpaw/agents/context/scroll/eviction_index.py
@@ -311,7 +311,7 @@ class EvictionIndex:
 
     def describe(self) -> str:
         """The tier/span map without the ``render`` preamble — for the
-        user-facing ``/compact`` reply. Empty string if nothing is indexed."""
+        user-facing ``/compact`` reply. Empty string if nothing is indexed.""" ""
         return "\n".join(self._tier_lines())
 
     def _tier_lines(self) -> list[str]:

--- a/src/qwenpaw/utils/system_info.py
+++ b/src/qwenpaw/utils/system_info.py
@@ -151,6 +151,7 @@ def _run_command(args: list[str], timeout: int = 5) -> str | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            errors='replace',
             timeout=timeout,
             check=False,
         )

--- a/src/qwenpaw/utils/system_info.py
+++ b/src/qwenpaw/utils/system_info.py
@@ -151,7 +151,7 @@ def _run_command(args: list[str], timeout: int = 5) -> str | None:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            errors='replace',
+            errors="replace",
             timeout=timeout,
             check=False,
         )

--- a/tests/unit/agents/context/test_agent_resume.py
+++ b/tests/unit/agents/context/test_agent_resume.py
@@ -95,7 +95,7 @@ def test_state_dict_carries_the_scroll_bookkeeping(store):
 def test_resume_after_crash_does_not_reappend(store):
     """Full cycle: persist → snapshot → JSON round-trip (the "crash") →
     rebuild a fresh agent+manager → the restored window is recognized as
-    already durable, so the next write-through appends nothing."""
+    already durable, so the next write-through appends nothing."""."""
     agent1, mgr1 = _seed_session(store)
     assert store.count("s1") == 3
     snapshot = json.loads(json.dumps(QwenPawAgent.state_dict(agent1)))

--- a/tests/unit/agents/context/test_eviction_index.py
+++ b/tests/unit/agents/context/test_eviction_index.py
@@ -55,7 +55,7 @@ def test_render_closes_with_live_turn_banner():
 
 def test_describe_omits_the_model_facing_banner():
     """``describe()`` feeds the user-facing /compact reply — it should show the
-    tier/span map only, not the model-only 'answer THIS' banner."""
+    tier/span map only, not the model-only 'answer THIS' banner.""" ""
     idx = EvictionIndex(session_id="s")
     _add(idx, 5, "old headline")
     described = idx.describe()

--- a/tests/unit/agents/context/test_memoryspace.py
+++ b/tests/unit/agents/context/test_memoryspace.py
@@ -428,7 +428,7 @@ def test_like_fallback_emits_degradation_notice(ms: MemorySpace):
 
 def test_no_notice_when_fts_available(ms: MemorySpace):
     """The notice is FTS-unavailable-only — a normal FTS build never sees it,
-    even when a query degrades to LIKE for lack of word tokens."""
+    even when a query degrades to LIKE for lack of word tokens.""" ""
     # All-punctuation query falls back to LIKE, but FTS5 *is* available here.
     rows = ms.search("!!!")
     assert all(r["kind"] != "_notice" for r in rows)

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -709,7 +709,7 @@ async def test_unheadlined_span_tiled_into_multiple_headlines(
 async def test_skipped_section_keeps_extractive_fallback(store: HistoryStore):
     """A section the model omits is still labelled — the harness fills it with
     an extractive fallback drawn from that section's own text, never
-    ``(no milestone)`` for a section that had content."""
+    ``(no milestone)`` for a section that had content.""" ""
     ctx = [
         user("distinctive-billing-question"),
         assistant("answered billing"),  # NO headline
@@ -772,7 +772,7 @@ async def test_unheadlined_span_falls_back_when_summary_fails(
     store: HistoryStore,
 ):
     """A model/timeout error must never abort eviction — the span keeps the
-    ``(no milestone)`` marker and the evicted count is unaffected."""
+    ``(no milestone)`` marker and the evicted count is unaffected.""" ""
     ctx = [
         user("old thing"),
         assistant("did old thing"),  # NO headline

--- a/tests/unit/app/approvals/test_driver_gate.py
+++ b/tests/unit/app/approvals/test_driver_gate.py
@@ -138,7 +138,7 @@ async def test_request_approval_missing_session_id_raises_approval_required(
     svc: ApprovalService,
 ):
     """Without a session_id the gate cannot route the pending — it must
-    fail fast with ApprovalRequiredError and never touch the service."""
+    fail fast with ApprovalRequiredError and never touch the service.""" ""
     gate = QwenPawDriverApprovalGate()
     ctx = _ctx(session_id="")
     with pytest.raises(ApprovalRequiredError):

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -126,7 +126,7 @@ def test_clean_display_text_strips_both_skill_and_headline():
 
 def test_msg_to_message_hides_headline_in_history_path():
     """Regression: the GET /chats/{id} path now strips the ⟦…⟧ headline, so it
-    no longer reappears after navigating away from the chat and back."""
+    no longer reappears after navigating away from the chat and back."""ck."""
     msg = Msg(
         name="assistant",
         role="assistant",

--- a/tests/unit/app/inbox/test_inbox_store.py
+++ b/tests/unit/app/inbox/test_inbox_store.py
@@ -220,7 +220,7 @@ async def test_list_events_handles_malformed_json(
 ):
     """Genuinely malformed JSON → caught by the except branch, returns [],
     and logs a warning (so permission/disk errors aren't silently
-    swallowed). Regression for the #5809 review feedback."""
+    swallowed). Regression for the #5809 review feedback.""" ""
     inbox_path.write_text("{bad", encoding="utf-8")
     with caplog.at_level("WARNING"):
         events = await inbox_store.list_events()

--- a/tests/unit/app/test_approval_scope.py
+++ b/tests/unit/app/test_approval_scope.py
@@ -79,7 +79,7 @@ class TestResolveRequestStashesScope:
 
     async def test_none_scope_defaults_to_exact_downstream(self):
         """No scope passed (IM channels / CLI) → scope stays None; the
-        consumer treats None as EXACT. Pending is still resolved."""
+        consumer treats None as EXACT. Pending is still resolved.""" ""
         svc = ApprovalService()
         pending = _make_pending()
         svc._pending[pending.request_id] = pending

--- a/tests/unit/governance/test_generalize_rule_match.py
+++ b/tests/unit/governance/test_generalize_rule_match.py
@@ -667,7 +667,7 @@ class TestDisableThinkingForwarding:
 
 def _compat_instance(cls):
     """Construct a compat instance bypassing ``__init__`` — the translation
-    methods don't touch instance state beyond what they're given."""
+    methods don't touch instance state beyond what they're given.""" ""
     return object.__new__(cls)
 
 

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -236,7 +236,7 @@ class TestDefaultPolicyLoad:
     def test_coding_project_dir_roundtrip_portable(self, tmp_path):
         """save→reload keeps the CODING_PROJECT_DIR placeholder in YAML
         (distinct coding dir), so the policy stays portable across
-        machines and the coding dir remains ALLOWed after reload."""
+        machines and the coding dir remains ALLOWed after reload.""" ""
         ws = "/home/user/workspace"
         cpd = "/home/user/coding"
         policy_dir = tmp_path / "policy"
@@ -641,7 +641,7 @@ class TestAssertPolicySandboxEscalation:
 
 class TestBuiltinRulePriority:
     """Builtin rules have higher priority than user_rules — even an explicit
-    DENY rule in user_rules cannot override a builtin ASK."""
+    DENY rule in user_rules cannot override a builtin ASK.""" ""
 
     @pytest.fixture()
     def governor_with_deny(self, tmp_path):
@@ -1024,7 +1024,7 @@ class TestAddApprovedRuleGeneralization:
 
     async def test_missing_generalized_target_raises(self, governor):
         """The keyword arg is required — calling without it is a TypeError,
-        not a silent skip. This guards the tool_adapter call site."""
+        not a silent skip. This guards the tool_adapter call site.""" ""
         with pytest.raises(TypeError):
             await governor.add_approved_rule(_tc("Bash", "git status"))
 


### PR DESCRIPTION
On Chinese Windows (cp936/GBK), nvidia-smi output contains non-text bytes
that cause UnicodeDecodeError when subprocess.run is called with
text=True. Adding errors='replace' safely substitutes bad bytes.