### PR TITLE
feat(chat): handle error state in ToolCardShell component

### DIFF
--- a/console/src/components/Chat/ToolCards/cards/AppendFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/AppendFileCard.tsx
@@ -22,6 +22,17 @@ const AppendFileCard: React.FC<AppendFileCardProps> = ({
     ? t("tool.appendFile", { file })
     : t("tool.appendFileDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<FileAddOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const appendedContent = (params.content as string) || "";
   const lineCount = countLines(appendedContent);
 

--- a/console/src/components/Chat/ToolCards/cards/BrowserUseCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/BrowserUseCard.tsx
@@ -258,6 +258,18 @@ const BrowserUseCard: React.FC<BrowserUseCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const title = getBrowserTitle(content.name, content.params || {}, t);
+
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<ChromeOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const resultText = formatBrowserResult(content.result);
 
   return (

--- a/console/src/components/Chat/ToolCards/cards/EditFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/EditFileCard.tsx
@@ -20,6 +20,17 @@ const EditFileCard: React.FC<EditFileCardProps> = ({
   const file = shortFileName((params.file_path || params.path || "") as string);
   const title = file ? t("tool.editFile", { file }) : t("tool.editFileDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<EditOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const oldText = (params.old_text as string) || "";
   const newText = (params.new_text as string) || "";
   const isLoading = content.status === "calling" && isStreaming;

--- a/console/src/components/Chat/ToolCards/cards/GlobSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GlobSearchCard.tsx
@@ -22,6 +22,17 @@ const GlobSearchCard: React.FC<GlobSearchCardProps> = ({
     ? t("tool.globSearch", { pattern })
     : t("tool.globSearchDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<FolderOpenOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const resultText = stringifyResult(content.result);
   const lineCount = countLines(resultText);
 

--- a/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GrepSearchCard.tsx
@@ -22,6 +22,17 @@ const GrepSearchCard: React.FC<GrepSearchCardProps> = ({
     ? t("tool.grepSearch", { pattern })
     : t("tool.grepSearchDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<SearchOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const resultText = stringifyResult(content.result);
   const lineCount = countLines(resultText);
 

--- a/console/src/components/Chat/ToolCards/cards/MemorySearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/MemorySearchCard.tsx
@@ -33,8 +33,17 @@ const MemorySearchCard: React.FC<MemorySearchCardProps> = ({
     : t("tool.memorySearchDefault");
   const title = meta ? `${baseTitle} · ${meta}` : baseTitle;
 
-  // Use the raw result string for formatMemorySearch — it expects JSON to parse.
-  // Fall back to stringifyResult if result is not a string.
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<BulbOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const rawResult =
     typeof content.result === "string"
       ? content.result

--- a/console/src/components/Chat/ToolCards/cards/ReadFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/ReadFileCard.tsx
@@ -20,6 +20,17 @@ const ReadFileCard: React.FC<ReadFileCardProps> = ({
   const file = shortFileName((params.file_path || params.path || "") as string);
   const title = file ? t("tool.readFile", { file }) : t("tool.readFileDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<FileTextOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const resultText = stringifyResult(content.result);
   const lineCount = countLines(resultText);
 

--- a/console/src/components/Chat/ToolCards/cards/SendFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/SendFileCard.tsx
@@ -25,6 +25,17 @@ const SendFileCard: React.FC<SendFileCardProps> = ({
   const file = shortFileName(filePath);
   const title = file ? t("tool.sendFile", { file }) : t("tool.sendFileDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<SendOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const media = getMediaInfo(content);
 
   return (

--- a/console/src/components/Chat/ToolCards/cards/ShellCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/ShellCard.tsx
@@ -22,12 +22,25 @@ const ShellCard: React.FC<ShellCardProps> = ({ content, isStreaming }) => {
     (content.params?.command as string) ||
     (content.params?.cmd as string) ||
     "";
+  const title = command ? t("tool.shell", { command }) : t("tool.shellDefault");
+
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<CodeOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const resultText = stringifyResult(content.result);
 
   return (
     <ToolCardShell
       icon={<CodeOutlined />}
-      title={command ? t("tool.shell", { command }) : t("tool.shellDefault")}
+      title={title}
       content={content}
       isStreaming={isStreaming}
     >

--- a/console/src/components/Chat/ToolCards/cards/WriteFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/WriteFileCard.tsx
@@ -22,6 +22,17 @@ const WriteFileCard: React.FC<WriteFileCardProps> = ({
     ? t("tool.writeFile", { file })
     : t("tool.writeFileDefault");
 
+  if (content.status === "error") {
+    return (
+      <ToolCardShell
+        content={content}
+        isStreaming={isStreaming}
+        icon={<FileAddOutlined />}
+        title={title}
+      />
+    );
+  }
+
   const writtenContent = (params.content as string) || "";
   const lineCount = countLines(writtenContent);
 

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -72,7 +72,16 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
         )}
       </summary>
       {isError ? (
-        <DefaultBlock title="Error" content={stringifyResult(content.result)} />
+        <>
+          <DefaultBlock
+            title="Input"
+            content={JSON.stringify(content.params, null, 2)}
+          />
+          <DefaultBlock
+            title="Error"
+            content={stringifyResult(content.result)}
+          />
+        </>
       ) : (
         children
       )}

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -8,6 +8,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolCallContent } from "./types";
+import DefaultBlock from "./DefaultBlock";
+import { stringifyResult } from "./utils";
 import styles from "./toolCards.module.less";
 
 export interface ToolCardShellProps {
@@ -62,14 +64,18 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
           {title}
           {isLoading && ` ${t("tool.loading")}`}
         </span>
-        {!isLoading && badges}
+        {!isLoading && !isError && badges}
         {inlineResult && (
           <span className={styles.toolCallInlineResult} title={inlineResult}>
             {inlineResult}
           </span>
         )}
       </summary>
-      {children}
+      {isError ? (
+        <DefaultBlock title="Error" content={stringifyResult(content.result)} />
+      ) : (
+        children
+      )}
     </details>
   );
 };


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

<img width="1598" height="450" alt="image" src="https://github.com/user-attachments/assets/58a8b543-8e25-4bc0-81b7-a865249f66b7" />


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

Fixes #5401

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
