### PR TITLE
fix(memory): propagate session_id into ReMe summarize tasks

### DIFF
--- a/src/qwenpaw/__version__.py
+++ b/src/qwenpaw/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "2.0.0b6"
+__version__ = "2.0.0b7"

--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -239,12 +239,20 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Resolve the active session id on a best-effort basis.
 
         Prefers the explicitly-injected ``session_id`` (standalone slash
-        command mode) and falls back to ``state.session_id``. Command-triggered
-        memory archival relies on this so ReMe ``auto_memory`` never runs with
-        an empty ``session_id``.
+        command mode), falls back to ``state.session_id``, and finally to the
+        request-scoped ``get_current_session_id()`` ContextVar (seeded by the
+        contextvars setup hook). The last fallback covers reconstructed-state
+        paths where ``state.session_id`` is absent but the dispatching request
+        carried one. Command-triggered memory archival relies on this so ReMe
+        ``auto_memory`` never runs with an empty ``session_id``.
         """
+        from ..app.agent_context import get_current_session_id
+
         return str(
-            self._session_id or getattr(self._state, "session_id", "") or "",
+            self._session_id
+            or getattr(self._state, "session_id", "")
+            or get_current_session_id()
+            or "",
         )
 
     def _forced_context_config(self, agent: "Agent"):

--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -235,6 +235,18 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Check if memory manager is available."""
         return self.memory_manager is not None
 
+    def _current_session_id(self) -> str:
+        """Resolve the active session id on a best-effort basis.
+
+        Prefers the explicitly-injected ``session_id`` (standalone slash
+        command mode) and falls back to ``state.session_id``. Command-triggered
+        memory archival relies on this so ReMe ``auto_memory`` never runs with
+        an empty ``session_id``.
+        """
+        return str(
+            self._session_id or getattr(self._state, "session_id", "") or "",
+        )
+
     def _forced_context_config(self, agent: "Agent"):
         """Clone the agent's ContextConfig for a manual ``/compact``.
 
@@ -345,7 +357,10 @@ class CommandHandler(ConversationCommandHandlerMixin):
         evicted = max(0, before - after)
         reme_cfg = agent_config.running.reme_light_memory_config
         if self._has_memory_manager() and reme_cfg.summarize_when_compact:
-            self.memory_manager.add_summarize_task(messages=messages)
+            self.memory_manager.add_summarize_task(
+                messages=messages,
+                session_id=self._current_session_id(),
+            )
 
         summary = self._get_summary()
         folded = int(compress_stats.get("folded", 0) or 0)
@@ -497,7 +512,10 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 "- Enable memory manager to use this feature",
             )
 
-        self.memory_manager.add_summarize_task(messages=messages)
+        self.memory_manager.add_summarize_task(
+            messages=messages,
+            session_id=self._current_session_id(),
+        )
         self._set_summary("")
 
         await self._persist_and_clear()
@@ -757,7 +775,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         try:
             await self.memory_manager.auto_memory(
                 memory_messages,
-                session_id=str(getattr(self._state, "session_id", "") or ""),
+                session_id=self._current_session_id(),
                 reply_id=reply_ids[-1],
                 reply_ids=reply_ids,
             )

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -377,11 +377,21 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if not messages:
             return ""
 
+        session_id = str(kwargs.get("session_id") or "")
+        if not session_id:
+            logger.warning(
+                "ReMe summarize skipped; session_id is empty: "
+                "agent_id=%s messages=%s",
+                self.agent_id,
+                len(messages),
+            )
+            return ""
+
         response = await self._run_reme_job(
             "auto_memory",
             needs_llm=True,
             messages=[msg.model_dump(mode="json") for msg in messages],
-            session_id=str(kwargs.get("session_id") or ""),
+            session_id=session_id,
             memory_hint=str(kwargs.get("memory_hint") or ""),
         )
         if response is None:


### PR DESCRIPTION
## Summary

Command-triggered memory archival was invoking `add_summarize_task` **without** a `session_id`. As a result, ReMe's `auto_memory` job ran with an empty `session_id` on `/compact` and clear-style flows, so summarized memories could not be correctly attributed to their originating session.

This PR threads the active session id through those call sites and hardens the summarize job against empty ids.

## Changes

### `command_handler.py`
- Add `_current_session_id()` helper that resolves the active session id on a best-effort basis: it prefers the explicitly-injected `session_id` (standalone slash-command mode) and falls back to `state.session_id`.
- Pass `session_id=self._current_session_id()` when calling `add_summarize_task` from both the `/compact` path and the manual clear/summarize path.
- Reuse the same helper in `auto_memory` for consistency (replacing the inline `getattr(self._state, "session_id", "")` expression).

### `reme_light_memory_manager.py`
- Resolve `session_id` once at the top of the summarize handler.
- If `session_id` is empty, log a warning (with `agent_id` and message count) and skip the ReMe job instead of running it with an empty id.

## Why

Without a valid `session_id`, ReMe `auto_memory` cannot associate summarized memories with the correct session, degrading later recall. Centralizing session-id resolution in one helper removes the divergence between the summarize and auto-memory paths and prevents silent misattribution.