### PR TITLE
feat(website): Update homepage copy and visuals for QwenPaw 2.0

### DIFF
--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -15,8 +15,8 @@
     "titleleft": "Your Personal",
     "titleright": "AI assistant",
     "slogan": "Works for you, grows with you",
-    "sub": "{{version}}: QwenPaw custom LLMs, safety architecture, multi-agent collaboration,",
-    "sub1": "and memory management — all upgraded, all yours.",
+    "sub": "{{version}}: QwenPaw custom Agent OS, Loop Engineering, Scroll Context, ReMe v0.4,",
+    "sub1": "and TUI — all upgraded, all yours.",
     "releaseNote": "QwenPaw {{version}} is released",
     "cta": "Read the docs",
     "quickStart": "Quick Start"
@@ -51,26 +51,21 @@
     "sub": "Memory and personalization under your control.",
     "learnMore": "Learn more",
     "cards": {
-      "skills": {
-        "title": "Security Architecture",
-        "desc": "QwenPaw 1.0 adopts a three-layer defense architecture—Tool Guard, File Guard, and Skill Scanner—to protect against runtime threats, unauthorized file access, and risky skill installations across all agent operations."
+      "agentOs": {
+        "title": "Agent OS",
+        "desc": "QwenPaw 2.0 introduces Agent OS Foundation, an open intelligence layer powered by an OS-like Harness that connects models and applications. More QwenPaw-powered mini apps and lightweight applications are on the way."
       },
-      "control": {
-        "title": "Multi-agent Workspaces",
-        "desc": "QwenPaw 1.0 enables multiple isolated agent workspaces to run concurrently within a single instance, each with independent configurations and memory, supporting asynchronous collaboration for complex multi-role tasks."
+      "tui": {
+        "title": "Terminal UI",
+        "desc": "A full-screen terminal chat experience built with Textual, featuring streaming responses, rendered tool calls, and session management—with sessions and memory shared across the console and channels."
       },
-      "apps": {
-        "title": "QwenPaw Custom Models",
-        "desc": "QwenPaw 1.0 introduces the QwenPaw-Flash series—purpose-built small models for local deployment that require no cloud dependency, offer one-click setup, and are specifically optimized for high-frequency tasks such as document processing, memory update, and information retrieval.",
-        "learnMoreHref": "https://huggingface.co/agentscope-ai"
+      "scrollContext": {
+        "title": "Scroll Context",
+        "desc": "Every conversation turn is persisted to SQLite in real time. When the context window fills, indexed entries are evicted instead of summarized, while the original content remains available for on-demand recall."
       },
-      "memory": {
-        "title": "Memory",
-        "desc": "Compress context and tool output; turn experience into reusable memory—personalization stays under your control."
-      },
-      "toolkit": {
-        "title": "Tools, Skills & MCP",
-        "desc": "20+ built-in tools and skills with hot reload; plug in MCP and add skills anytime—your toolkit grows with QwenPaw."
+      "loopEngineering": {
+        "title": "Loop Engineering",
+        "desc": "Agent execution moves from hard-coded logic to composable orchestration. Workflows can already be assembled through plugin interfaces, with more loop-control patterns coming as official “Oh-My-Paw” plugins."
       }
     }
   },

--- a/website/src/i18n/locales/zh.json
+++ b/website/src/i18n/locales/zh.json
@@ -15,8 +15,8 @@
     "titleleft": "欢迎使用你的",
     "titleright": "专业AI助手",
     "slogan": "懂你所需，伴你左右",
-    "sub": "{{version}} 四大方面能力升级：",
-    "sub1": "为 QwenPaw 量身定制的小模型、安全机制、多智能体协同、以及记忆管理",
+    "sub": "{{version}} 五大方面能力升级：",
+    "sub1": "为 QwenPaw 量身定制的 Agent OS, TUI, 循环工程, 滚动上下文, 新版 ReMe",
     "releaseNote": "QwenPaw {{version}}版本全新发布",
     "cta": "查看文档",
     "quickStart": "快速开始"
@@ -51,26 +51,21 @@
     "sub": "记忆与个性化由你掌控。",
     "learnMore": "了解更多",
     "cards": {
-      "skills": {
-        "title": "安全机制",
-        "desc": "QwenPaw 1.0 构建了工具守卫、文件防护与技能扫描器三层防御体系，覆盖运行时拦截、访问控制与安装审计，全方位守护智能体的操作安全边界。"
+      "agentOs": {
+        "title": "Agent OS",
+        "desc": "QwenPaw 2.0 以类操作系统的 Harness 架构连接模型与应用，将 Agent 从独立应用升级为开放的智能基座。未来还将持续推出面向不同场景的 QwenPaw 小程序与轻量应用。"
       },
-      "control": {
-        "title": "多智能体",
-        "desc": " QwenPaw 1.0 支持在同一实例内并发运行多个隔离的智能体工作区，各自独立配置与记忆，并可通过异步协作机制共同完成复杂的多角色任务。"
+      "tui": {
+        "title": "终端交互",
+        "desc": "基于 Textual 打造全屏终端聊天体验，支持流式输出、工具调用渲染与会话管理，并与控制台及各频道共享会话和记忆。"
       },
-      "apps": {
-        "title": "QwenPaw 定制模型",
-        "desc": "QwenPaw 1.0 推出专为本地场景定制的 QwenPaw-Flash 系列小模型，支持一键部署、数据不出设备，针对文档处理、记忆更新、信息检索等高频任务进行了专项优化。",
-        "learnMoreHref": "https://www.modelscope.cn/organization/AgentScope"
+      "scrollContext": {
+        "title": "滚动上下文",
+        "desc": "每轮对话实时写入 SQLite。窗口满时通过索引驱逐腾出空间，不摘要、不丢弃原文；历史内容可随时按需回溯，确保上下文信息完整保留。"
       },
-      "memory": {
-        "title": "记忆",
-        "desc": "上下文与工具结果可压缩；经验与偏好可沉淀复用，记忆与个性化由你掌控。"
-      },
-      "toolkit": {
-        "title": "工具体系",
-        "desc": "十余内置工具与技能，支持热加载；自由接入 MCP、扩展自定义技能，能力随需加长。"
+      "loopEngineering": {
+        "title": "循环工程",
+        "desc": "Agent 执行逻辑从硬编码走向可编排：当前可通过插件接口灵活组合流程，未来还将以 “Oh-My-Paw” 官方插件持续提供更多循环控制方案，让同一个 Agent 按场景切换行为模式。"
       }
     }
   },

--- a/website/src/pages/Home/components/Hero.tsx
+++ b/website/src/pages/Home/components/Hero.tsx
@@ -174,9 +174,9 @@ export function Hero() {
               }}
             >
               <img
-                src="https://img.alicdn.com/imgextra/i1/O1CN01BLYCfm1Qyf5WcMDDf_!!6000000002045-2-tps-1924-1202.png"
+                src="https://img.alicdn.com/imgextra/i3/O1CN01C57zol1ud4um3nSMH_!!6000000006059-2-tps-1930-1202.png"
                 alt="QwenPaw console preview"
-                className="block h-auto max-h-full w-full rounded-t-[8px] object-top shadow-[0px_6px_56px_0px_rgba(38,33,29,0.24)] md:h-full md:object-cover"
+                className="block h-auto max-h-full w-full object-top md:h-full md:object-cover"
                 loading="lazy"
               />
             </motion.div>

--- a/website/src/pages/Home/components/WhatYouCanDo.tsx
+++ b/website/src/pages/Home/components/WhatYouCanDo.tsx
@@ -15,28 +15,28 @@ const CATEGORY_CONFIG: Array<{
     background:
       "https://img.alicdn.com/imgextra/i4/O1CN01tdSfuK1X2DrN462ga_!!6000000002865-2-tps-1578-946.png",
     preview:
-      "https://img.alicdn.com/imgextra/i1/O1CN013g8G931yNk65n8mZX_!!6000000006567-2-tps-1362-852.png",
+      "https://img.alicdn.com/imgextra/i2/O1CN01Be9DH21wKQ0fqNLSo_!!6000000006289-2-tps-1362-894.png",
   },
   {
     key: "creative",
     background:
       "https://img.alicdn.com/imgextra/i3/O1CN010T7jhC1LptQKwxNGm_!!6000000001349-2-tps-2114-1180.png",
     preview:
-      "https://img.alicdn.com/imgextra/i4/O1CN01XDvtE31elkXhE59ID_!!6000000003912-2-tps-1362-852.png",
+      "https://img.alicdn.com/imgextra/i3/O1CN013OF19c1j2vsqbmynl_!!6000000004491-2-tps-1362-894.png",
   },
   {
     key: "productivity",
     background:
       "https://img.alicdn.com/imgextra/i3/O1CN01SVXYZd1a2Af7uEY94_!!6000000003271-2-tps-1874-1046.png",
     preview:
-      "https://img.alicdn.com/imgextra/i3/O1CN01iuV2s61WutWawD5l9_!!6000000002849-2-tps-1362-852.png",
+      "https://img.alicdn.com/imgextra/i3/O1CN01Q0dF3W1FqudE7Rcop_!!6000000000539-2-tps-1362-894.png",
   },
   {
     key: "research",
     background:
       "https://img.alicdn.com/imgextra/i3/O1CN01oybwPf1vKaWII7bmm_!!6000000006154-2-tps-1962-1096.png",
     preview:
-      "https://img.alicdn.com/imgextra/i2/O1CN01fOt59G233eo5KBepG_!!6000000007200-2-tps-1362-852.png",
+      "https://img.alicdn.com/imgextra/i2/O1CN01GNAC861QnfbKZIFK2_!!6000000002021-2-tps-1362-894.png",
   },
 ];
 

--- a/website/src/pages/Home/components/WorksForYou.tsx
+++ b/website/src/pages/Home/components/WorksForYou.tsx
@@ -26,19 +26,24 @@ const item = {
 
 const cards = [
   {
-    key: "apps",
-    icon: "https://img.alicdn.com/imgextra/i4/O1CN01f3kIzy1qpCv6YMPnc_!!6000000005544-55-tps-95-95.svg",
-    href: "",
+    key: "agentOs",
+    icon: "https://img.alicdn.com/imgextra/i1/O1CN01b9Y72C1bJrbBiUsMl_!!6000000003445-2-tps-330-330.png",
+    href: "/docs/architecture",
   },
   {
-    key: "skills",
-    icon: "https://img.alicdn.com/imgextra/i1/O1CN01FZjjpn1c0uoErRfQI_!!6000000003539-55-tps-95-95.svg",
-    href: "/docs/security",
+    key: "tui",
+    icon: "https://img.alicdn.com/imgextra/i4/O1CN018nPL7R2AEpnnWjaI1_!!6000000008172-2-tps-330-330.png",
+    href: "/docs/tui",
   },
   {
-    key: "control",
-    icon: "https://img.alicdn.com/imgextra/i3/O1CN01zYweFi25bD3LD3QcW_!!6000000007544-55-tps-95-95.svg",
-    href: "/docs/multi-agent",
+    key: "scrollContext",
+    icon: "https://img.alicdn.com/imgextra/i1/O1CN01mlnREC1Moo7dQ3tgE_!!6000000001482-2-tps-330-330.png",
+    href: "/docs/context",
+  },
+  {
+    key: "loopEngineering",
+    icon: "https://img.alicdn.com/imgextra/i1/O1CN01aDM9r51VQpvzgywwx_!!6000000002648-2-tps-330-330.png",
+    href: "/docs/loop-engineering",
   },
 ] as const;
 
@@ -78,48 +83,37 @@ export function WorksForYou() {
               }}
             />
             <motion.div
-              className="grid gap-0 divide-y divide-[#f1e5dc] md:grid-cols-3 md:gap-x-10 md:gap-y-12 md:divide-y-0"
+              className="grid gap-0 divide-y divide-[#f1e5dc] md:grid-cols-4 md:gap-x-6 md:divide-y-0 lg:gap-x-10"
               variants={item}
             >
-              {cards.map((card) => {
-                const href =
-                  card.key === "apps"
-                    ? t("worksForYou.cards.apps.learnMoreHref")
-                    : card.href;
-                return (
-                  <article
-                    key={card.key}
-                    className="flex h-full flex-col py-6 first:pt-0 last:pb-0 md:py-0"
+              {cards.map((card) => (
+                <article
+                  key={card.key}
+                  className="flex h-full flex-col py-6 first:pt-0 last:pb-0 md:py-0"
+                >
+                  <img
+                    src={card.icon}
+                    alt=""
+                    aria-hidden
+                    className="h-20 w-20 object-contain opacity-80 md:h-23 md:w-23"
+                  />
+                  <h3 className="font-newsreader mt-3 text-[1.65rem] leading-[1.1] text-(--color-text) sm:text-[1.8rem] md:mt-6 md:text-[1.8rem]">
+                    {t(`worksForYou.cards.${card.key}.title`)}
+                  </h3>
+                  <p className="font-inter mt-2 text-[13px] leading-[1.65] text-(--color-text-secondary) md:text-base">
+                    {t(`worksForYou.cards.${card.key}.desc`)}
+                  </p>
+                  <a
+                    href={card.href}
+                    className="font-inter mt-auto inline-flex w-fit items-center gap-2 pt-4 text-[0.95rem] text-(--color-text) transition hover:text-orange-400! md:pt-5 md:text-base"
+                    target="_blank"
+                    rel="noopener noreferrer"
                   >
-                    <img
-                      src={card.icon}
-                      alt=""
-                      aria-hidden
-                      className="h-20 w-20 object-contain opacity-80 md:h-23 md:w-23"
-                    />
-                    <h3 className="font-newsreader mt-3 text-[1.65rem] leading-[1.1] text-(--color-text) sm:text-[1.8rem] md:mt-6 md:text-[1.8rem]">
-                      {t(`worksForYou.cards.${card.key}.title`)}
-                    </h3>
-                    <p className="font-inter mt-2 text-[13px] leading-[1.65] text-(--color-text-secondary) md:text-base">
-                      {t(`worksForYou.cards.${card.key}.desc`)}
-                    </p>
-                    <a
-                      href={href}
-                      className="font-inter mt-auto inline-flex w-fit items-center gap-2 pt-4 text-[0.95rem] text-(--color-text) transition hover:text-orange-400! md:pt-5 md:text-base"
-                      {...(href.startsWith("http://") ||
-                      href.startsWith("https://")
-                        ? {
-                            target: "_blank",
-                            rel: "noopener noreferrer",
-                          }
-                        : {})}
-                    >
-                      {t("worksForYou.learnMore")}
-                      <span aria-hidden>→</span>
-                    </a>
-                  </article>
-                );
-              })}
+                    {t("worksForYou.learnMore")}
+                    <span aria-hidden>→</span>
+                  </a>
+                </article>
+              ))}
             </motion.div>
             <div
               className="pointer-events-none absolute bottom-0 left-1/2 h-px w-screen -translate-x-1/2 animate-[qwenpaw-dash-move-left_1s_linear_infinite]"


### PR DESCRIPTION
## Summary

Refresh the homepage from QwenPaw 1.0 to QwenPaw 2.0, highlighting four core capabilities: Agent OS, Terminal UI, Scroll Context, and Loop Engineering.

- **Hero**: Update EN/ZH subtitle copy for v2.0’s five major upgrades (Agent OS, Loop Engineering, Scroll Context, ReMe v0.4, TUI); replace the console preview image
- **WorksForYou**: Expand from 3 cards to 4 in a single-row desktop layout; update icons, EN/ZH copy, and doc links (`/docs/architecture`, `/docs/tui`, `/docs/context`, `/docs/loop-engineering`); remove unused `memory` and `toolkit` i18n entries
- **WhatYouCanDo**: Update scenario preview images
- **i18n**: Sync `zh.json` and `en.json`; localize Chinese card titles (终端交互, 滚动上下文, 循环工程)

## Test plan

- [ ] Open the homepage and verify Hero subtitle copy in EN and ZH
- [ ] Switch languages and confirm WorksForYou card titles and descriptions render correctly
- [ ] Confirm four cards display in one row on desktop and stack vertically on mobile
- [ ] Click “Learn more” on each card and verify links to the correct docs pages
- [ ] Confirm Hero console preview and WhatYouCanDo scenario images load correctly