### PR TITLE
fix(mcp): apply access policy updates immediately

### DIFF
--- a/src/qwenpaw/app/driver_config_service.py
+++ b/src/qwenpaw/app/driver_config_service.py
@@ -115,6 +115,14 @@ class DriverConfigService:
             await self.reload_driver_best_effort(card.name)
         return path
 
+    async def save_policy(self, card: DriverCard) -> Path:
+        """Persist policy changes and update the active Driver immediately."""
+        path = await self.card_store.save(card)
+        manager = getattr(self._workspace, "driver_manager", None)
+        if manager is not None:
+            await manager.sync_driver_policy(card)
+        return path
+
     async def reload_driver_best_effort(self, name: str) -> None:
         manager = getattr(self._workspace, "driver_manager", None)
         if manager is None:

--- a/src/qwenpaw/app/driver_config_service.py
+++ b/src/qwenpaw/app/driver_config_service.py
@@ -117,11 +117,12 @@ class DriverConfigService:
 
     async def save_policy(self, card: DriverCard) -> Path:
         """Persist policy changes and update the active Driver immediately."""
-        path = await self.card_store.save(card)
         manager = getattr(self._workspace, "driver_manager", None)
         if manager is not None:
             await manager.sync_driver_policy(card)
-        return path
+        else:
+            await self.card_store.save(card)
+        return self.card_path(card.name, protocol=card.protocol)
 
     async def reload_driver_best_effort(self, name: str) -> None:
         manager = getattr(self._workspace, "driver_manager", None)

--- a/src/qwenpaw/app/driver_config_watcher.py
+++ b/src/qwenpaw/app/driver_config_watcher.py
@@ -2,8 +2,8 @@
 """Watch DriverCard files and hot-reload active Drivers.
 
 This is the protocol-neutral successor to the old MCP-only config watcher.
-Console/API saves already trigger reloads directly; this watcher preserves the
-manual-edit path for ``drivers/<protocol>/<name>.yaml`` files.
+Console/API saves already apply runtime updates directly. This watcher
+preserves the manual-edit path for ``drivers/<protocol>/<name>.yaml`` files.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ DEFAULT_POLL_INTERVAL = 2.0
 
 
 class DriverConfigWatcher:
-    """Poll DriverCard storage and reload changed external capabilities."""
+    """Poll DriverCard storage and refresh changed external capabilities."""
 
     def __init__(
         self,
@@ -114,17 +114,17 @@ class DriverConfigWatcher:
 
         for name in sorted(changed_names):
             try:
-                await self._driver_manager.reload_driver(name)
-                logger.info("Driver '%s' reloaded after card change", name)
+                await self._driver_manager.refresh_driver(name)
+                logger.info("Driver '%s' refreshed after card change", name)
             except Exception:
                 logger.warning(
-                    "Failed to reload Driver '%s' after card change",
+                    "Failed to refresh Driver '%s' after card change",
                     name,
                     exc_info=True,
                 )
 
         # Use the snapshot that triggered this pass as the baseline. If a
-        # manual edit lands while reload_driver() is running, the next poll
-        # will compare against this observed state and reload it instead of
+        # manual edit lands while refresh_driver() is running, the next poll
+        # will compare against this observed state and apply it instead of
         # accidentally swallowing the newer write.
         self._last_snapshot = current

--- a/src/qwenpaw/app/mcp/config_service.py
+++ b/src/qwenpaw/app/mcp/config_service.py
@@ -252,7 +252,7 @@ class MCPConfigService:
             card.policy,
             access,
         )
-        await self._driver_config.save_card(card)
+        await self._driver_config.save_policy(card)
         return mcp_access_policy_from_card(card)
 
     async def create_client(

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -173,6 +173,19 @@ class DriverManager:
             await self._shutdown_handler(old)
         return self._runtime_info_from_card(card)
 
+    async def sync_driver_policy(self, card: DriverCard) -> None:
+        """Apply a persisted policy to an active Driver without reconnecting.
+
+        This is a no-op when the Driver is not active; the persisted policy
+        will be loaded the next time the Driver starts.
+        """
+        card = self._validate_card_for_registered_protocol(card)
+        async with self._lock:
+            handler = self._handlers.get(card.name)
+            if handler is None or handler.card.protocol != card.protocol:
+                return
+            handler.set_policy(card.policy)
+
     async def delete_driver(self, name: str) -> None:
         """Delete persisted card and shutdown a published handler."""
         await self._card_store.delete(name)

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -173,18 +173,48 @@ class DriverManager:
             await self._shutdown_handler(old)
         return self._runtime_info_from_card(card)
 
-    async def sync_driver_policy(self, card: DriverCard) -> None:
-        """Apply a persisted policy to an active Driver without reconnecting.
+    async def refresh_driver(self, name: str) -> DriverRuntimeInfo | None:
+        """Apply an on-disk card change with the lightest safe action."""
+        path = await self._card_store.stored_path(name)
+        if path is None:
+            raise DriverNotFoundError(name)
+        card = await self._card_store.load_path(path)
+        card = self._validate_card_for_registered_protocol(card)
 
-        This is a no-op when the Driver is not active; the persisted policy
+        async with self._lock:
+            handler = self._handlers.get(name)
+            if handler is not None and not self._requires_reconnect(
+                handler.card,
+                card,
+            ):
+                handler.sync_runtime_metadata(card)
+                return self._runtime_info_from_card(card)
+
+        return await self.reload_driver(name)
+
+    async def sync_driver_policy(self, card: DriverCard) -> None:
+        """Persist and apply a Driver policy without reconnecting.
+
+        When the Driver is not active, only persistence is needed; the policy
         will be loaded the next time the Driver starts.
         """
         card = self._validate_card_for_registered_protocol(card)
         async with self._lock:
+            await self._card_store.save(card)
             handler = self._handlers.get(card.name)
             if handler is None or handler.card.protocol != card.protocol:
                 return
             handler.set_policy(card.policy)
+
+    @staticmethod
+    def _requires_reconnect(old: DriverCard, new: DriverCard) -> bool:
+        return (
+            old.name != new.name
+            or old.protocol != new.protocol
+            or old.endpoint != new.endpoint
+            or old.credentials != new.credentials
+            or old.enabled != new.enabled
+        )
 
     async def delete_driver(self, name: str) -> None:
         """Delete persisted card and shutdown a published handler."""

--- a/tests/integration/test_driver_mcp_approval_level_policy.py
+++ b/tests/integration/test_driver_mcp_approval_level_policy.py
@@ -313,6 +313,44 @@ async def test_manual_policy_edit_applies_without_transport_reload(
 
 
 @pytest.mark.asyncio
+async def test_manual_endpoint_edit_reloads_transport(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    manager = await _registry_with_policy(
+        tmp_path,
+        [PolicyRule(subject="*", effect="allow")],
+    )
+    original_client = FakeStdIOClient.instances[0]
+    watcher = DriverConfigWatcher(manager, tmp_path / "drivers")
+    baseline = await manager.card_store.snapshot()
+    watcher._last_snapshot = {  # pylint: disable=protected-access
+        path_id: (name, modified_at - 1.0)
+        for path_id, (name, modified_at) in baseline.items()
+    }
+
+    stored_path = card_path(
+        tmp_path / "drivers",
+        "policy_echo",
+        protocol="mcp",
+    )
+    edited_card = load_card(stored_path)
+    edited_card.endpoint = {
+        **edited_card.endpoint,
+        "command": "python-updated",
+    }
+    dump_card(edited_card, stored_path)
+
+    await watcher._check_once()  # pylint: disable=protected-access
+
+    assert len(FakeStdIOClient.instances) == 2
+    assert original_client.is_connected is False
+    assert FakeStdIOClient.instances[1].is_connected is True
+    assert FakeStdIOClient.instances[1].kwargs["command"] == "python-updated"
+
+
+@pytest.mark.asyncio
 async def test_driver_mcp_policy_ask_approve_resumes_client_call(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_driver_mcp_approval_level_policy.py
+++ b/tests/integration/test_driver_mcp_approval_level_policy.py
@@ -7,6 +7,12 @@ import pytest
 
 from qwenpaw.app.approvals.driver_gate import QwenPawDriverApprovalGate
 from qwenpaw.app.approvals.service import ApprovalService
+from qwenpaw.app.mcp.config_service import MCPConfigService
+from qwenpaw.app.mcp.schemas import (
+    MCPAccessPolicy,
+    MCPAccessRule,
+    MCPToolDefaultPolicy,
+)
 from qwenpaw.drivers.capabilities import DriverInvocation
 from qwenpaw.drivers.contracts import DriverCard, PolicyRule
 from qwenpaw.drivers.credentials.store import AsyncCredentialStore
@@ -87,6 +93,87 @@ async def test_driver_mcp_policy_deny_blocks_client_call(
 
     assert result.error_type == "driver_policy_denied"
     assert FakeStdIOClient.instances[0].calls == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_policy_update_applies_without_transport_reload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    manager = await _registry_with_policy(
+        tmp_path,
+        [PolicyRule(subject="*", effect="allow")],
+    )
+    capabilities = {
+        item.name: item
+        for item in await manager.list_capabilities(kind="tool")
+    }
+    service = MCPConfigService(
+        SimpleNamespace(
+            workspace_dir=tmp_path,
+            driver_manager=manager,
+        ),
+    )
+
+    reload_attempts = 0
+
+    async def fail_transport_reload(_name: str) -> None:
+        nonlocal reload_attempts
+        reload_attempts += 1
+        raise RuntimeError("transport reconnect failed")
+
+    monkeypatch.setattr(manager, "reload_driver", fail_transport_reload)
+
+    updated_policy = MCPAccessPolicy(
+        default_effect="deny",
+        client_overrides=[
+            MCPAccessRule(
+                source_value="console",
+                subject_type="all",
+                effect="allow",
+            ),
+        ],
+        tool_defaults=[
+            MCPToolDefaultPolicy(tool_name="echo", effect="deny"),
+        ],
+    )
+    returned_policy = await service.update_policy(
+        "policy_echo",
+        updated_policy,
+    )
+    # Let the previous fire-and-forget reload path run, if it was scheduled.
+    await asyncio.sleep(0)
+
+    request_context = {
+        "session_id": "s1",
+        "channel": "console",
+        "approval_level": "AUTO",
+    }
+    allowed_result = await manager.invoke_capability(
+        DriverInvocation(
+            capabilities["get_secret_status"].capability_id,
+            {},
+            request_context,
+        ),
+    )
+    denied_result = await manager.invoke_capability(
+        DriverInvocation(
+            capabilities["echo"].capability_id,
+            {"text": "blocked after update"},
+            request_context,
+        ),
+    )
+
+    assert allowed_result.ok is True
+    assert denied_result.error_type == "driver_policy_denied"
+    assert FakeStdIOClient.instances[0].calls == [
+        ("get_secret_status", {}),
+    ]
+    assert returned_policy == updated_policy
+    assert await service.get_policy("policy_echo") == updated_policy
+    assert reload_attempts == 0
+    assert len(FakeStdIOClient.instances) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_driver_mcp_approval_level_policy.py
+++ b/tests/integration/test_driver_mcp_approval_level_policy.py
@@ -7,6 +7,7 @@ import pytest
 
 from qwenpaw.app.approvals.driver_gate import QwenPawDriverApprovalGate
 from qwenpaw.app.approvals.service import ApprovalService
+from qwenpaw.app.driver_config_watcher import DriverConfigWatcher
 from qwenpaw.app.mcp.config_service import MCPConfigService
 from qwenpaw.app.mcp.schemas import (
     MCPAccessPolicy,
@@ -14,7 +15,11 @@ from qwenpaw.app.mcp.schemas import (
     MCPToolDefaultPolicy,
 )
 from qwenpaw.drivers.capabilities import DriverInvocation
-from qwenpaw.drivers.contracts import DriverCard, PolicyRule
+from qwenpaw.drivers.contracts import (
+    DriverCard,
+    PolicyRule,
+    coerce_driver_policy,
+)
 from qwenpaw.drivers.credentials.store import AsyncCredentialStore
 from qwenpaw.drivers.handlers.mcp import MCPDriverHandler
 from qwenpaw.drivers.manager import DriverManager
@@ -172,6 +177,137 @@ async def test_mcp_policy_update_applies_without_transport_reload(
     ]
     assert returned_policy == updated_policy
     assert await service.get_policy("policy_echo") == updated_policy
+    assert reload_attempts == 0
+    assert len(FakeStdIOClient.instances) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_policy_updates_serialize_persistence_and_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    manager = await _registry_with_policy(
+        tmp_path,
+        [PolicyRule(subject="*", effect="allow")],
+    )
+    capability = next(
+        item
+        for item in await manager.list_capabilities(kind="tool")
+        if item.name == "echo"
+    )
+    stored_path = card_path(
+        tmp_path / "drivers",
+        "policy_echo",
+        protocol="mcp",
+    )
+    first_card = load_card(stored_path)
+    first_card.policy = coerce_driver_policy(
+        [PolicyRule(subject="*", effect="allow")],
+    )
+    second_card = load_card(stored_path)
+    second_card.policy = coerce_driver_policy(
+        [PolicyRule(subject="*", effect="deny")],
+    )
+
+    original_save = manager.card_store.save
+    first_save_started = asyncio.Event()
+    release_first_save = asyncio.Event()
+    saved_effects: list[str] = []
+
+    async def controlled_save(card: DriverCard) -> Path:
+        saved_effects.append(card.policy.rules[0].effect)
+        if len(saved_effects) == 1:
+            first_save_started.set()
+            await release_first_save.wait()
+        return await original_save(card)
+
+    monkeypatch.setattr(manager.card_store, "save", controlled_save)
+
+    first_update = asyncio.create_task(manager.sync_driver_policy(first_card))
+    await asyncio.sleep(0)
+    first_save_was_started = first_save_started.is_set()
+    if not first_save_was_started:
+        await first_update
+    assert first_save_was_started
+
+    second_update = asyncio.create_task(
+        manager.sync_driver_policy(second_card),
+    )
+    await asyncio.sleep(0)
+    updates_were_serialized = saved_effects == ["allow"]
+
+    release_first_save.set()
+    await asyncio.gather(first_update, second_update)
+    assert updates_were_serialized
+
+    stored_card = load_card(stored_path)
+    denied_result = await manager.invoke_capability(
+        DriverInvocation(
+            capability.capability_id,
+            {"text": "blocked after concurrent updates"},
+            {"session_id": "s1"},
+        ),
+    )
+
+    assert [rule.effect for rule in stored_card.policy.rules] == ["deny"]
+    assert denied_result.error_type == "driver_policy_denied"
+    assert saved_effects == ["allow", "deny"]
+
+
+@pytest.mark.asyncio
+async def test_manual_policy_edit_applies_without_transport_reload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    manager = await _registry_with_policy(
+        tmp_path,
+        [PolicyRule(subject="*", effect="allow")],
+    )
+    capability = next(
+        item
+        for item in await manager.list_capabilities(kind="tool")
+        if item.name == "echo"
+    )
+    watcher = DriverConfigWatcher(manager, tmp_path / "drivers")
+    baseline = await manager.card_store.snapshot()
+    # Ensure the test is independent of filesystem timestamp resolution.
+    watcher._last_snapshot = {  # pylint: disable=protected-access
+        path_id: (name, modified_at - 1.0)
+        for path_id, (name, modified_at) in baseline.items()
+    }
+
+    stored_path = card_path(
+        tmp_path / "drivers",
+        "policy_echo",
+        protocol="mcp",
+    )
+    edited_card = load_card(stored_path)
+    edited_card.policy = coerce_driver_policy(
+        [PolicyRule(subject="*", effect="deny")],
+    )
+    dump_card(edited_card, stored_path)
+
+    reload_attempts = 0
+
+    async def fail_transport_reload(_name: str) -> None:
+        nonlocal reload_attempts
+        reload_attempts += 1
+        raise RuntimeError("transport reconnect failed")
+
+    monkeypatch.setattr(manager, "reload_driver", fail_transport_reload)
+
+    await watcher._check_once()  # pylint: disable=protected-access
+    denied_result = await manager.invoke_capability(
+        DriverInvocation(
+            capability.capability_id,
+            {"text": "blocked after manual edit"},
+            {"session_id": "s1"},
+        ),
+    )
+
+    assert denied_result.error_type == "driver_policy_denied"
     assert reload_attempts == 0
     assert len(FakeStdIOClient.instances) == 1
 


### PR DESCRIPTION
## Description

Fixes #5947.

MCP access-policy updates were persisted and then applied through a
fire-and-forget Driver reload. Until that reload completed, the active handler
continued evaluating the previous policy; if reconnecting failed, the stale
policy could remain active indefinitely.

This change adds a reconnect-independent policy path:

- `DriverManager.sync_driver_policy()` serializes DriverCard persistence and
  the live handler update under the manager lock.
- `DriverConfigWatcher` uses `refresh_driver()` for on-disk changes. Policy and
  config-only edits update the active handler in place, while name, protocol,
  endpoint, credential, and enabled-state changes retain the full reload path.

**Related Issue:** Fixes #5947

**Security Considerations:** Policy enforcement still occurs before credential
resolution and tool execution. After a successful API update, subsequent
invocations use the new policy. Manual policy edits take effect on the next
watcher poll without depending on transport reconnection.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; documented immediate-effect behavior is restored)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable. This change is in the shared Driver policy lifecycle and does
not modify channel contracts.

## Testing

Regression coverage verifies:

- Console/API policy updates immediately affect the active MCP handler without
  attempting a transport reload.
- Concurrent policy updates serialize persistence and runtime mutation, leaving
  the on-disk and active policies consistent.
- A policy-only manual YAML edit is applied by the watcher without reconnecting
  or creating a second MCP client.
- A manual endpoint edit still closes the old client and establishes a new
  transport connection.
- Existing MCP stdio, HTTP, and OAuth Driver flows remain green.

## Evidence

The focused Driver/MCP suite and every repository pre-commit hook pass locally.

```bash
.venv/bin/pytest tests/integration/test_driver_mcp_*.py --no-cov -q
# 16 passed

.venv/bin/pre-commit run --all-files
# all hooks passed
```

## Additional Notes

**Chosen layer:** shared Driver lifecycle synchronization, rather than a
Console-, channel-, transport-, or individual-tool workaround.

**Verification matrix:**

- MCP stdio: covered by regression and flow tests
- MCP HTTP/OAuth: existing flow tests pass
- Console/API policy updates: covered
- Manual DriverCard policy edits: covered
- Concurrent policy writes: covered
- Endpoint changes: covered; retain full reload behavior
- Credential/enabled changes: retain full reload behavior
- Channels and stream modes: not applicable
