### PR TITLE
fix(console): improve dark mode text contrast for loop templates and chat history

### DIFF
--- a/console/src/layouts/sidebarSessionList.module.less
+++ b/console/src/layouts/sidebarSessionList.module.less
@@ -117,6 +117,14 @@
     color: rgba(255, 255, 255, 0.35);
   }
 
+  .historyHeader {
+    color: var(--text-secondary);
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.85);
+    }
+  }
+
   .searchInput {
     background: rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.1);

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -279,6 +279,18 @@
     color: rgba(255, 255, 255, 0.95);
   }
 
+  .groupLabel {
+    color: var(--text-quaternary);
+
+    &:hover {
+      color: var(--text-secondary);
+    }
+  }
+
+  .emptyState {
+    color: var(--text-quaternary);
+  }
+
   .createButton {
     background: #c75c00;
   }

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -11,8 +11,16 @@ body {
   background: #f9f8f4;
 }
 
+/* ─── Shared CSS custom properties (light mode defaults) ───────────────────── */
+:root {
+  --text-secondary: rgba(0, 0, 0, 0.45);
+  --text-quaternary: rgba(0, 0, 0, 0.25);
+}
+
 /* ─── Dark mode global token overrides ─────────────────────────────────────── */
 html.dark-mode {
+  --text-secondary: rgba(255, 255, 255, 0.55);
+  --text-quaternary: rgba(255, 255, 255, 0.35);
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary
Fix dark mode text contrast issues where text became nearly invisible on dark backgrounds.

Closes #5969

## Changes
- `console/src/styles/layout.css`: Define `--text-secondary` and `--text-quaternary` CSS variables in dark mode, so all components using `var(--text-secondary, rgba(0,0,0,...))` get proper light text colors
- `console/src/pages/Chat/components/ChatSessionDrawer/index.module.less`: Add dark mode overrides for `.groupLabel` and `.emptyState`
- `console/src/layouts/sidebarSessionList.module.less`: Add dark mode override for `.historyHeader`

## Testing
- [x] Verified color values match existing dark mode text patterns (e.g., `rgba(255,255,255,0.5)` used by `SessionItem` time labels)
- [x] All affected components use CSS `var()` fallback pattern -- the global variable definition in `layout.css` is the single source of truth