### PR TITLE
fix(console): improve dark mode text contrast for loop templates and chat history

### DIFF
--- a/console/src/layouts/sidebarSessionList.module.less
+++ b/console/src/layouts/sidebarSessionList.module.less
@@ -117,6 +117,14 @@
     color: rgba(255, 255, 255, 0.35);
   }
 
+  .historyHeader {
+    color: var(--text-secondary, rgba(255, 255, 255, 0.45));
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.85);
+    }
+  }
+
   .searchInput {
     background: rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.1);

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -234,7 +234,7 @@ function DoomLoopSection() {
                   >
                     <span
                       style={{
-                        color: "var(--text-secondary)",
+                        color: "var(--text-secondary, rgba(0,0,0,0.45))",
                         whiteSpace: "nowrap",
                       }}
                     >

--- a/console/src/pages/Chat/ModelSelector/OAuthConfirmModal.tsx
+++ b/console/src/pages/Chat/ModelSelector/OAuthConfirmModal.tsx
@@ -97,7 +97,7 @@ export function OAuthConfirmModal({
           <h3 style={{ margin: "0 0 8px", fontSize: 16, fontWeight: 600 }}>
             {t("modelSelector.oauthTitle", { provider: providerName })}
           </h3>
-          <p style={{ color: "var(--text-secondary)", margin: "0 0 24px" }}>
+          <p style={{ color: "var(--text-secondary, rgba(0,0,0,0.45))", margin: "0 0 24px" }}>
             {t("modelSelector.oauthDescription", { provider: providerName })}
           </p>
           <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
@@ -116,7 +116,7 @@ export function OAuthConfirmModal({
           <h3 style={{ margin: "16px 0 8px", fontSize: 16, fontWeight: 600 }}>
             {t("modelSelector.oauthWaiting")}
           </h3>
-          <p style={{ color: "var(--text-secondary)", margin: "0 0 24px" }}>
+          <p style={{ color: "var(--text-secondary, rgba(0,0,0,0.45))", margin: "0 0 24px" }}>
             {t("modelSelector.oauthWaitingDescription")}
           </p>
           <Button onClick={onCancel}>{t("common.cancel")}</Button>

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -279,6 +279,18 @@
     color: rgba(255, 255, 255, 0.95);
   }
 
+  .groupLabel {
+    color: var(--text-quaternary, rgba(255, 255, 255, 0.35));
+
+    &:hover {
+      color: var(--text-secondary, rgba(255, 255, 255, 0.55));
+    }
+  }
+
+  .emptyState {
+    color: var(--text-quaternary, rgba(255, 255, 255, 0.35));
+  }
+
   .createButton {
     background: #c75c00;
   }

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -13,6 +13,8 @@ body {
 
 /* ─── Dark mode global token overrides ─────────────────────────────────────── */
 html.dark-mode {
+  --text-secondary: rgba(255, 255, 255, 0.55);
+  --text-quaternary: rgba(255, 255, 255, 0.35);
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary

Improve dark mode text contrast for the console by introducing theme-aware CSS variables and ensuring all call sites have proper fallbacks.

Closes #5969

## Changes

- **layout.css**: Define `--text-secondary` and `--text-quaternary` under `html.dark-mode` only (not `:root`), so light mode continues using per-call-site fallbacks.
- **AgentLoopCard.tsx**: Add `rgba(0,0,0,0.45)` fallback to `var(--text-secondary)` at line 237
- **OAuthConfirmModal.tsx**: Add same fallback at lines 100 and 119
- **ChatSessionDrawer**: Use `var(--text-quaternary)` / `var(--text-secondary)` with dark-mode fallbacks
- **SidebarSessionList**: Use `var(--text-secondary)` with dark-mode fallback

## Testing

- [x] All `var(--text-secondary)` and `var(--text-quaternary)` usages have fallback values (verified with `git grep`)
- [x] Dark mode: variables resolve to intended rgba values
- [x] Light mode: all fallbacks kick in correctly, no regression