### PR TITLE
fix(console): improve dark mode text contrast for loop templates and chat history

### DIFF
--- a/console/src/layouts/sidebarSessionList.module.less
+++ b/console/src/layouts/sidebarSessionList.module.less
@@ -117,6 +117,14 @@
     color: rgba(255, 255, 255, 0.35);
   }
 
+  .historyHeader {
+    color: var(--text-secondary, rgba(255, 255, 255, 0.45));
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.85);
+    }
+  }
+
   .searchInput {
     background: rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.1);

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -234,7 +234,7 @@ function DoomLoopSection() {
                   >
                     <span
                       style={{
-                        color: "var(--text-secondary)",
+                        color: "var(--text-secondary, rgba(0,0,0,0.45))",
                         whiteSpace: "nowrap",
                       }}
                     >

--- a/console/src/pages/Chat/ModelSelector/OAuthConfirmModal.tsx
+++ b/console/src/pages/Chat/ModelSelector/OAuthConfirmModal.tsx
@@ -97,7 +97,12 @@ export function OAuthConfirmModal({
           <h3 style={{ margin: "0 0 8px", fontSize: 16, fontWeight: 600 }}>
             {t("modelSelector.oauthTitle", { provider: providerName })}
           </h3>
-          <p style={{ color: "var(--text-secondary, rgba(0,0,0,0.45))", margin: "0 0 24px" }}>
+          <p
+            style={{
+              color: "var(--text-secondary, rgba(0,0,0,0.45))",
+              margin: "0 0 24px",
+            }}
+          >
             {t("modelSelector.oauthDescription", { provider: providerName })}
           </p>
           <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
@@ -116,7 +121,12 @@ export function OAuthConfirmModal({
           <h3 style={{ margin: "16px 0 8px", fontSize: 16, fontWeight: 600 }}>
             {t("modelSelector.oauthWaiting")}
           </h3>
-          <p style={{ color: "var(--text-secondary, rgba(0,0,0,0.45))", margin: "0 0 24px" }}>
+          <p
+            style={{
+              color: "var(--text-secondary, rgba(0,0,0,0.45))",
+              margin: "0 0 24px",
+            }}
+          >
             {t("modelSelector.oauthWaitingDescription")}
           </p>
           <Button onClick={onCancel}>{t("common.cancel")}</Button>

--- a/console/src/pages/Chat/ModelSelector/OAuthConfirmModal.tsx
+++ b/console/src/pages/Chat/ModelSelector/OAuthConfirmModal.tsx
@@ -97,7 +97,7 @@ export function OAuthConfirmModal({
           <h3 style={{ margin: "0 0 8px", fontSize: 16, fontWeight: 600 }}>
             {t("modelSelector.oauthTitle", { provider: providerName })}
           </h3>
-          <p style={{ color: "var(--text-secondary)", margin: "0 0 24px" }}>
+          <p style={{ color: "var(--text-secondary, rgba(0,0,0,0.45))", margin: "0 0 24px" }}>
             {t("modelSelector.oauthDescription", { provider: providerName })}
           </p>
           <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
@@ -116,7 +116,7 @@ export function OAuthConfirmModal({
           <h3 style={{ margin: "16px 0 8px", fontSize: 16, fontWeight: 600 }}>
             {t("modelSelector.oauthWaiting")}
           </h3>
-          <p style={{ color: "var(--text-secondary)", margin: "0 0 24px" }}>
+          <p style={{ color: "var(--text-secondary, rgba(0,0,0,0.45))", margin: "0 0 24px" }}>
             {t("modelSelector.oauthWaitingDescription")}
           </p>
           <Button onClick={onCancel}>{t("common.cancel")}</Button>

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.module.less
@@ -279,6 +279,18 @@
     color: rgba(255, 255, 255, 0.95);
   }
 
+  .groupLabel {
+    color: var(--text-quaternary, rgba(255, 255, 255, 0.35));
+
+    &:hover {
+      color: var(--text-secondary, rgba(255, 255, 255, 0.55));
+    }
+  }
+
+  .emptyState {
+    color: var(--text-quaternary, rgba(255, 255, 255, 0.35));
+  }
+
   .createButton {
     background: #c75c00;
   }

--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -13,6 +13,8 @@ body {
 
 /* ─── Dark mode global token overrides ─────────────────────────────────────── */
 html.dark-mode {
+  --text-secondary: rgba(255, 255, 255, 0.55);
+  --text-quaternary: rgba(255, 255, 255, 0.35);
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Description

Improve dark mode text contrast for the console by introducing theme-aware CSS variables and ensuring all call sites have proper fallbacks. Previously, several UI elements in dark mode used hardcoded low-contrast rgba values that were barely readable.

**Related Issue:** Fixes #5969

**Security Considerations:** None — CSS-only changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Switch between light/dark mode in the console
2. Verify AgentLoopCard template text is readable in dark mode
3. Verify ChatSessionDrawer group labels and empty state are readable
4. Verify Sidebar history header is readable
5. Verify OAuth confirm modal description text is readable
6. Confirm all light-mode text remains unchanged (no regression)
7. Run `git grep` to verify no missing fallbacks

## Additional Notes

All `var(--text-secondary)` and `var(--text-quaternary)` usages now have fallback values. Variables are defined only under `html.dark-mode` to avoid overriding per-call-site fallbacks in light mode.