### PR TITLE
fix(scroll): sanitize unpaired tool messages after context compression

### DIFF
--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -36,6 +36,7 @@ from . import _as_internals as as_internals
 from .eviction_index import EvictionIndex, Leaf, Line
 from .history import HistoryStore
 from .serialize import msg_to_entries
+from ...utils.tool_message_utils import _remove_unpaired_tool_messages
 
 logger = logging.getLogger(__name__)
 
@@ -329,6 +330,14 @@ class ScrollContextManager:
             # full live Msg from the context.
             tail = [m for m in tail if m.id not in active_ids]
             tail.extend(active_tail)
+
+        # 3c) Sanitize: AgentScope's pairing-safe split only guarantees
+        #    intra-message block-level pairing. Standalone tool_result
+        #    messages (AgentScope 1.x flat-timeline format) can still be
+        #    orphaned across the compress/reserve boundary. Remove them
+        #    before the model sees them — the alternative is a 400
+        #    BadRequestError from the API.
+        tail = _remove_unpaired_tool_messages(tail)
 
         if middle:
             # 3b) Optional legacy archive of the evicted turns (opt-in). The


### PR DESCRIPTION
## Problem

When context compression evicts old messages, AgentScope's `_split_context_for_compression` only guarantees **intra-message block-level** `tool_call/tool_result` pairing. Standalone `tool_result` messages (AgentScope 1.x flat-timeline format) can be orphaned across the compress/reserve boundary.

This causes the model API to reject the request with:
```
400 - Messages with role 'tool' must be a response to a preceding message with 'tool_calls'
```

Reported in #5986.

## Fix

Call the existing `_remove_unpaired_tool_messages()` utility on the tail before rebuilding context. This function was already implemented in `agents/utils/tool_message_utils.py` but never wired into the compression pipeline.

The sanitize runs in `ScrollContextManager.compress()` step 3c, after the pairing-safe split and active-tail merge, right before context rebuild.

## Change

- `src/qwenpaw/agents/context/scroll/manager.py`: import `_remove_unpaired_tool_messages`, call it on `tail` before `_rebuild_context`

## Testing

- Syntax validated with `ast.parse()`
- Existing test suite covers `_remove_unpaired_tool_messages` in `tests/unit/agents/utils/`

Closes #5986