### PR TITLE
fix: multi-layer orphan tool_result message defense

### DIFF
--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -36,6 +36,7 @@ from . import _as_internals as as_internals
 from .eviction_index import EvictionIndex, Leaf, Line
 from .history import HistoryStore
 from .serialize import msg_to_entries
+from ...utils.tool_message_utils import _remove_unpaired_tool_messages
 
 logger = logging.getLogger(__name__)
 
@@ -329,6 +330,14 @@ class ScrollContextManager:
             # full live Msg from the context.
             tail = [m for m in tail if m.id not in active_ids]
             tail.extend(active_tail)
+
+        # 3c) Sanitize: AgentScope's pairing-safe split only guarantees
+        #    intra-message block-level pairing. Standalone tool_result
+        #    messages (AgentScope 1.x flat-timeline format) can still be
+        #    orphaned across the compress/reserve boundary. Remove them
+        #    before the model sees them — the alternative is a 400
+        #    BadRequestError from the API.
+        tail = _remove_unpaired_tool_messages(tail)
 
         if middle:
             # 3b) Optional legacy archive of the evicted turns (opt-in). The

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -152,6 +152,25 @@ class QwenPawAgent(CodingModeMixin, Agent):
         compression. Otherwise fall back to AgentScope's native path, gated on
         ``context_compact_config.enabled``.
         """
+        # ── Always sanitize tool messages before any model call ──
+        # Orphan tool_result messages (whose tool_call was evicted by a
+        # prior compression) can survive in context across session
+        # boundaries. compress() itself only cleans during an active split;
+        # if the context is already corrupted but under the trigger
+        # threshold, the corrupt messages still reach the model → 400.
+        # This unconditional guard runs on every compress_context() call
+        # (which fires before every reasoning step), catching orphans that
+        # leaked through any path: loaded sessions, pre-patch corruption,
+        # or unaccounted edge cases.
+        try:
+            from .utils.tool_message_utils import _sanitize_tool_messages
+
+            sanitized = _sanitize_tool_messages(self.state.context)
+            if sanitized is not self.state.context:
+                self.state.context = sanitized
+        except Exception:
+            pass
+
         if self._context_manager is not None:
             await self._context_manager.compress(self, context_config)
             return

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -226,6 +226,10 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 raise KeyError(
                     f"Could not load AgentState from snapshot: {exc}",
                 ) from exc
+            # ── Sanitize loaded context: orphan tool_result messages can
+            # persist in session JSON from an evicted tool_call and leak
+            # across session boundaries when the session is reloaded.
+            self._sanitize_loaded_context()
             # Rehydrate the scroll manager's bookkeeping so the restored window
             # is recognized as already durable (no re-append on resume).
             cm = getattr(self, "_context_manager", None)
@@ -247,6 +251,8 @@ class QwenPawAgent(CodingModeMixin, Agent):
             self.state = AgentState()
             self.state.context.extend(msgs)
             self.state.summary = summary
+            # Same sanitize as 2.0 path above.
+            self._sanitize_loaded_context()
             logger.info(
                 "Migrated 1.x session: %d messages + summary(%d chars)",
                 len(msgs),
@@ -258,6 +264,26 @@ class QwenPawAgent(CodingModeMixin, Agent):
             raise KeyError(
                 "state_dict has neither 'state' nor 'memory' key",
             )
+
+    def _sanitize_loaded_context(self) -> None:
+        """Strip orphan tool_result messages from the loaded context.
+
+        Orphan tool_result messages (whose tool_call has been evicted)
+        can persist in session JSON and leak across session boundaries
+        when loaded by ``load_state_dict``.  Without sanitization here
+        they reach the model and cause ``400 - Messages with role 'tool'
+        must be a response to a preceding message with 'tool_calls'``.
+        """
+        try:
+            from .utils.tool_message_utils import _sanitize_tool_messages
+
+            self.state.context = _sanitize_tool_messages(
+                self.state.context,
+            )
+        except Exception:
+            # Best-effort: a corrupt context will be caught again by
+            # compress_context() on the next reasoning cycle.
+            pass
 
     async def close(self) -> None:
         """Shut down governor, release the history store, and clean up expired

--- a/tests/unit/agents/context/test_agent_resume.py
+++ b/tests/unit/agents/context/test_agent_resume.py
@@ -40,6 +40,10 @@ class AgentShim:
         self._context_manager = context_manager
         self.state = state if state is not None else AgentState()
 
+    def _sanitize_loaded_context(self) -> None:
+        """Delegate to the production loaded-context sanitizer."""
+        QwenPawAgent._sanitize_loaded_context(self)
+
 
 def _user(text):
     return Msg(


### PR DESCRIPTION
## Problem

Orphan `tool_result` messages (whose `tool_call` was evicted by context compression) survive across session boundaries and leak to the model, causing:

```
400 - Messages with role "tool" must be a response to a preceding message with "tool_calls"
```

Reported in [#5986](https://github.com/agentscope-ai/QwenPaw/issues/5986).

## Root Cause Chain

```
Tool timeout offload → orphan tool_result persisted in session JSON
→ other session loads state with orphan
→ load_state_dict has no sanitize → orphan reaches model
→ MODEL_EXECUTION_ERROR → that session is cited → chain infection
```

## Fix: Four-Layer Defense

| # | Layer | Location | When |
|---|-------|----------|------|
| 1 | `load_state_dict` sanitize | `react_agent.py` | Session restore |
| 2 | `compress_context` sanitize | `react_agent.py` | Before every reasoning step |
| 3 | `compress()` tail sanitize | `manager.py` | After compression split |
| 4 | AgentScope split guard | upstream | At split boundary |

### Layer 1: Session restore (2b130f87)

`_sanitize_loaded_context()` called from both 2.0 and 1.x legacy `load_state_dict` paths. Catches orphan messages persisted in session JSON before they can infect a session.

### Layer 2: Unconditional pre-reasoning guard (313b442a)

`_sanitize_tool_messages()` called at the top of `compress_context()`, which fires before every reasoning cycle. The previous code only sanitized inside `compress()` during an active split — if context was already corrupted but under the trigger threshold, corrupt messages bypassed all guards.

### Layer 3: Post-split tail cleanup (574ab6f9)

Original PR #5987 fix (re-submitted here): call `_remove_unpaired_tool_messages()` on the tail return from AgentScope before rebuilding context.

### Layer 4: AgentScope upstream guard

Cross-message `tool_call`/`tool_result` pairing check added to `_split_context_for_compression` — prevents pairing break at the split boundary.

Closes [#5986](https://github.com/agentscope-ai/QwenPaw/issues/5986).