### PR TITLE
fix(compat): handle legacy 'file' block type in _coerce_block

### DIFF
--- a/src/qwenpaw/_compat/message.py
+++ b/src/qwenpaw/_compat/message.py
@@ -97,7 +97,7 @@ def _coerce_block(block: Any) -> Any:
     if not isinstance(block, Mapping):
         return block
     btype = block.get("type")
-    if btype in ("image", "audio", "video"):
+    if btype in ("image", "audio", "video", "file"):
         source = block.get("source")
         if source is None:
             return block


### PR DESCRIPTION
## Description

The 1.x to 2.0 message deserializer in `_compat/message.py` only converted `image`, `audio`, and `video` blocks to `DataBlock`, but missed `file` blocks. When a legacy session contained a `tool_result` with `file`-type output, the raw dict passed through unchanged and failed `ToolResultBlock` Pydantic validation (18 validation errors).

This fix adds `'file'` to the handled legacy modality types, so `type: 'file'` blocks are correctly converted to `DataBlock`.

**Related Issue:** N/A

**Security Considerations:** None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

The fix is a one-line change in a legacy compat layer. It only affects deserialization of 1.x sessions that contain `type: 'file'` blocks in tool results — a specific edge case. Existing tests covering the compat layer should continue to pass.

## Local Verification Evidence

```
pre-commit run --all-files
# All checks passed
```

## Additional Notes

Error log：
```
ERROR G:\code\CoPaw_fork\src\qwenpaw\app\task_tracker.py:299 | 2026-07-12 20:06:47 | run error run_key=8812798d-3f5e-46d2-835b-e03174157836
Traceback (most recent call last):
  File "G:\code\CoPaw_fork\src\qwenpaw\app\task_tracker.py", line 288, in _producer
    async for sse in stream_fn(payload):
    ...<6 lines>...
                q.put_nowait(sse)
  File "G:\code\CoPaw_fork\src\qwenpaw\app\channels\base.py", line 901, in _stream_with_tracker
    async for event in process_iterator:
    ...<40 lines>...
            await self.on_event_response(request, event)
  File "G:\code\CoPaw_fork\src\qwenpaw\app\workspace\workspace.py", line 266, in stream_query
    async for item in rt.run(request):
        yield item
  File "G:\code\CoPaw_fork\src\qwenpaw\runtime\runtime.py", line 75, in run
    cmd_msg = await cmd_registry.dispatch(text or "", ctx)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\code\CoPaw_fork\src\qwenpaw\runtime\slash_command_registry.py", line 117, in dispatch
    return await spec.handler(ctx, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\code\CoPaw_fork\src\qwenpaw\runtime\builtin_commands.py", line 408, in _handler
    state, payload = await _load_agent_state(ctx)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\code\CoPaw_fork\src\qwenpaw\runtime\builtin_commands.py", line 322, in _load_agent_state
    msgs, summary = parse_legacy_memory_state(memory_raw)
                    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "G:\code\CoPaw_fork\src\qwenpaw\app\chats\utils.py", line 55, in parse_legacy_memory_state
    messages.append(Msg.from_dict(payload))
                    ~~~~~~~~~~~~~^^^^^^^^^
  File "G:\code\CoPaw_fork\src\qwenpaw\_compat\__init__.py", line 33, in _from_dict
    return msg_from_dict(data)
  File "G:\code\CoPaw_fork\src\qwenpaw\_compat\message.py", line 187, in msg_from_dict
    return Msg.model_validate(payload)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "C:\Users\xxxx\.conda\envs\copaw\Lib\site-packages\pydantic\main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        obj,
        ^^^^
    ...<5 lines>...
        by_name=by_name,
        ^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 18 validation errors for Msg
content.0.TextBlock.type
  Input should be 'text' [type=literal_error, input_value='tool_result', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.TextBlock.text
  Field required [type=missing, input_value={'type': 'tool_result', '...e sent successfully.'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.ThinkingBlock.type
  Input should be 'thinking' [type=literal_error, input_value='tool_result', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.ThinkingBlock.thinking
  Field required [type=missing, input_value={'type': 'tool_result', '...e sent successfully.'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.HintBlock.type
  Input should be 'hint' [type=literal_error, input_value='tool_result', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.HintBlock.hint
  Field required [type=missing, input_value={'type': 'tool_result', '...e sent successfully.'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.ToolCallBlock.type
  Input should be 'tool_call' [type=literal_error, input_value='tool_result', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.ToolCallBlock.input
  Field required [type=missing, input_value={'type': 'tool_result', '...e sent successfully.'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.ToolResultBlock.output.str
  Input should be a valid string [type=string_type, input_value=[{'type': 'file', 'source...le sent successfully.'}], input_type=list]
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.TextBlock.type
  Input should be 'text' [type=literal_error, input_value='file', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.TextBlock.text
  Field required [type=missing, input_value={'type': 'file', 'source'...sk_planning_survey.pdf'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.DataBlock.type
  Input should be 'data' [type=literal_error, input_value='file', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.DataBlock.source.Base64Source.type
  Input should be 'base64' [type=literal_error, input_value='url', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.DataBlock.source.Base64Source.data
  Field required [type=missing, input_value={'type': 'url', 'url': 'f...sk_planning_survey.pdf'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.DataBlock.source.Base64Source.media_type
  Field required [type=missing, input_value={'type': 'url', 'url': 'f...sk_planning_survey.pdf'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.ToolResultBlock.output.list[union[TextBlock,DataBlock]].0.DataBlock.source.URLSource.media_type
  Field required [type=missing, input_value={'type': 'url', 'url': 'f...sk_planning_survey.pdf'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
content.0.DataBlock.type
  Input should be 'data' [type=literal_error, input_value='tool_result', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/literal_error
content.0.DataBlock.source
  Field required [type=missing, input_value={'type': 'tool_result', '...e sent successfully.'}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing
```

Before Fix:
<img width="743" height="1524" alt="image" src="https://github.com/user-attachments/assets/9ef1d5a3-621b-4b33-b7a8-82dd8a6d17d4" />

After Fix:
<img width="750" height="690" alt="image" src="https://github.com/user-attachments/assets/ab942530-adf2-4411-b5e2-53c9e5c5e178" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)