### PR TITLE
fix(pack): include AgentScope Glob helper in desktop bundle

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -65,6 +65,11 @@ datas += collect_tree(CONSOLE_DIST, "qwenpaw/console")
 # Include reme package data files (configs, tool yamls, etc.)
 datas += collect_data_files("reme")
 datas += collect_data_files("whisper")
+# AgentScope's Glob tool passes this helper's source path to a subprocess.
+datas += collect_data_files(
+    "agentscope.tool._builtin._scripts",
+    include_py_files=True,
+)
 
 # Collect package metadata for packages that use importlib.metadata at runtime.
 # Keep this allowlist in sync when adding runtime dependencies that query
@@ -140,6 +145,8 @@ a = Analysis(
         "dotenv",
         *collect_submodules("acp"),
         "acp",
+        # Glob resolves this package dynamically through importlib.resources.
+        *collect_submodules("agentscope.tool._builtin._scripts"),
         "psutil",
         "multipart",
         "websockets",


### PR DESCRIPTION
## Description

AgentScope 2.0.4's `Glob` tool resolves
`agentscope.tool._builtin._scripts` dynamically with
`importlib.resources` and passes `_glob_helper.py` to a subprocess. The
Desktop PyInstaller spec did not collect that package, so ReMe jobs failed
while constructing their AgentScope toolkit.

This change fixes the shared Desktop packaging layer by:

- collecting the dynamically loaded `_scripts` package as hidden modules
- keeping the helper Python sources as on-disk package data

The second part is required because `Glob` needs a real helper file path, not
only a module stored in the PYZ archive.

**Related Issue:** Fixes #5952. Fixes #5965.

**Security Considerations:** Packaging-only change. It does not alter tool
permissions, credentials, network access, or runtime policy.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing API or configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Reproduced the issue with an unmodified minimal PyInstaller onedir build
  using `agentscope==2.0.4`: constructing `Glob()` failed with the reported
  `ModuleNotFoundError`.
- Rebuilt the minimal probe with the proposed hidden modules and source data:
  `Glob()` initialized successfully and its helper path existed.
- Built the repository's complete shared `qwenpaw.spec` successfully with
  AgentScope 2.0.4 and PyInstaller 6.16.0.
- Confirmed the full frozen executable archive contains both `_scripts`
  modules and the onedir contains `_scripts/__init__.py` plus
  `_scripts/_glob_helper.py`.

Verification matrix:

| Surface | Result |
| --- | --- |
| Full PyInstaller onedir build | Passed on Linux |
| Windows Desktop | Shared spec covered; platform CI pending |
| macOS Desktop | Shared spec covered; platform CI pending |
| Source / pip installs | Unchanged |
| ReMe and AgentScope runtime code | Unchanged |
| Channels and providers | Not applicable |

## Local Verification Evidence

```bash
pre-commit run --all-files
# All hooks passed.

python -m PyInstaller --noconfirm --clean \
  --distpath /tmp/qwenpaw-5952-full-dist \
  --workpath /tmp/qwenpaw-5952-full-build \
  scripts/pack-tauri/qwenpaw.spec
# Build complete.

python -m PyInstaller.utils.cliutils.archive_viewer -r -b \
  /tmp/qwenpaw-5952-full-dist/qwenpaw-backend/qwenpaw-backend
# agentscope.tool._builtin._scripts
# agentscope.tool._builtin._scripts._glob_helper

find /tmp/qwenpaw-5952-full-dist/qwenpaw-backend \
  -path '*agentscope/tool/_builtin/_scripts*'
# _internal/agentscope/tool/_builtin/_scripts/__init__.py
# _internal/agentscope/tool/_builtin/_scripts/_glob_helper.py
```

## Additional Notes

No runtime `sys.modules` compatibility stub is added. The shared packaging
spec is the common fix point for both Windows and macOS Desktop bundles.
