### PR TITLE
fix(runtime): pair offload hints with tool calls

### DIFF
--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -3,16 +3,23 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 
 def make_offload_hint_msg(entry: Any) -> Any:
     """Construct a hint Msg for a completed offloaded tool call.
 
-    The hint contains a system-notification TextBlock and a
-    ToolResultBlock with the finalized response content.
+    The hint contains a system-notification TextBlock and a paired tool
+    call/result sequence with the finalized response content.
     """
-    from agentscope.message import Msg, TextBlock, ToolResultBlock
+    from agentscope.message import (
+        Msg,
+        TextBlock,
+        ToolCallBlock,
+        ToolCallState,
+        ToolResultBlock,
+    )
 
     end = entry.end_state or "unknown"
     notification = TextBlock(
@@ -25,18 +32,27 @@ def make_offload_hint_msg(entry: Any) -> Any:
             "</system-notification>"
         ),
     )
+    hint_tool_call_id = uuid.uuid4().hex
+    tool_call = ToolCallBlock(
+        type="tool_call",
+        id=hint_tool_call_id,
+        name=entry.ctx.tool_name,
+        input="{}",
+        state=ToolCallState.FINISHED,
+    )
     tool_result = ToolResultBlock(
         type="tool_result",
-        id=entry.ctx.tool_call_id,
+        id=hint_tool_call_id,
         name=entry.ctx.tool_name,
         output=list(entry.final_response.content or []),
         state=entry.final_response.state,
     )
     # AgentScope 2.0 validates that system messages contain only text
-    # blocks.  This hint must carry a ToolResultBlock so provider formatters
-    # keep it on the tool-result path; use assistant role intentionally.
+    # blocks.  This hint must carry a paired tool call/result so provider
+    # formatters keep the result on their valid tool-result paths; use the
+    # assistant role intentionally.
     return Msg(
         name="system",
         role="assistant",
-        content=[notification, tool_result],
+        content=[notification, tool_call, tool_result],
     )

--- a/tests/unit/tool_calls/test_hint.py
+++ b/tests/unit/tool_calls/test_hint.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+"""Tests for completed background tool-call hint messages."""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from agentscope.formatter import (
+    AnthropicChatFormatter,
+    GeminiChatFormatter,
+    OpenAIChatFormatter,
+    OpenAIResponseFormatter,
+)
+from agentscope.message import (
+    TextBlock,
+    ToolCallBlock,
+    ToolCallState,
+    ToolResultState,
+)
+from agentscope.tool import ToolResponse
+
+from qwenpaw.tool_calls._hint import make_offload_hint_msg
+
+
+_NOTIFICATION = (
+    "<system-notification>\n"
+    "Background tool call `slow_tool` (id=call-bg) completed with "
+    "state=success. The full result follows in the next tool_result block.\n"
+    "</system-notification>"
+)
+
+
+@pytest.fixture(name="offload_hint")
+def _offload_hint():
+    """Build a representative completed background tool-call hint."""
+    response = ToolResponse(
+        content=[TextBlock(type="text", text="done")],
+        id="call-bg",
+        state=ToolResultState.SUCCESS,
+    )
+    entry = SimpleNamespace(
+        end_state="success",
+        ctx=SimpleNamespace(
+            tool_call_id="call-bg",
+            tool_name="slow_tool",
+        ),
+        final_response=response,
+    )
+    return make_offload_hint_msg(entry)
+
+
+def test_offload_hint_pairs_tool_call_and_result(offload_hint) -> None:
+    assert [block.type for block in offload_hint.content] == [
+        "text",
+        "tool_call",
+        "tool_result",
+    ]
+
+    tool_call = offload_hint.content[1]
+    assert isinstance(tool_call, ToolCallBlock)
+    assert tool_call.id != "call-bg"
+    assert len(tool_call.id) == 32
+    assert uuid.UUID(tool_call.id).hex == tool_call.id
+    assert tool_call.name == "slow_tool"
+    assert tool_call.input == "{}"
+    assert tool_call.state == ToolCallState.FINISHED
+    assert offload_hint.content[2].id == tool_call.id
+
+
+@pytest.mark.asyncio
+async def test_offload_hint_formats_for_openai(offload_hint) -> None:
+    formatted = await OpenAIChatFormatter().format([offload_hint])
+    hint_call_id = offload_hint.content[1].id
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "name": "system",
+            "content": [{"type": "text", "text": _NOTIFICATION}],
+            "tool_calls": [
+                {
+                    "id": hint_call_id,
+                    "type": "function",
+                    "function": {
+                        "name": "slow_tool",
+                        "arguments": "{}",
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": hint_call_id,
+            "content": "done",
+            "name": "slow_tool",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_offload_hint_formats_for_openai_responses(offload_hint) -> None:
+    formatted = await OpenAIResponseFormatter().format([offload_hint])
+    hint_call_id = offload_hint.content[1].id
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": _NOTIFICATION},
+            ],
+        },
+        {
+            "type": "function_call",
+            "call_id": hint_call_id,
+            "name": "slow_tool",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": hint_call_id,
+            "output": "done",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_offload_hint_formats_for_anthropic(offload_hint) -> None:
+    formatted = await AnthropicChatFormatter().format([offload_hint])
+    hint_call_id = offload_hint.content[1].id
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": _NOTIFICATION},
+                {
+                    "type": "tool_use",
+                    "id": hint_call_id,
+                    "name": "slow_tool",
+                    "input": {},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": hint_call_id,
+                    "content": [{"type": "text", "text": "done"}],
+                },
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_offload_hint_formats_for_gemini(offload_hint) -> None:
+    formatted = await GeminiChatFormatter().format([offload_hint])
+    hint_call_id = offload_hint.content[1].id
+
+    assert formatted == [
+        {
+            "role": "model",
+            "parts": [
+                {"text": _NOTIFICATION},
+                {
+                    "function_call": {
+                        "id": hint_call_id,
+                        "name": "slow_tool",
+                        "args": {},
+                    },
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "function_response": {
+                        "id": hint_call_id,
+                        "name": "slow_tool",
+                        "response": {"output": "done"},
+                    },
+                },
+            ],
+        },
+    ]


### PR DESCRIPTION
## Description

Fixes #5996.

Completed background tool calls were injected into conversation history as an
assistant `TextBlock` followed by a `ToolResultBlock`, without a matching
`ToolCallBlock`. AgentScope's OpenAI formatter consequently emitted an orphan
`role=tool` message, which OpenAI-compatible APIs reject.

This change adds a completed synthetic tool call before the finalized result in
the shared offload-hint builder. The synthetic call/result pair receives a new
ID so it does not collide with the original offloaded interaction, while the
notification continues to identify the original task ID.

**Security Considerations:** No authentication, authorization, secret, or
external-input handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration change)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (not applicable)
- [ ] Contract test exists (not applicable)
- [ ] Contract test implements `create_instance()` (not applicable)
- [ ] All contract verification points pass (not applicable)
- [ ] Optional channel unit tests (not applicable)

## Testing

The regression test constructs a completed background hint and asserts the full
wire-format output for each supported formatter family.

- OpenAI-compatible Chat: covered
- OpenAI Responses: covered
- Anthropic: covered
- Gemini: covered
- Stream/non-stream: shared stored-message formatting path covered
- Channels: not applicable

## Local Verification Evidence

```bash
.venv/bin/pytest tests/unit/tool_calls/ -q
# 22 passed

.venv/bin/pre-commit run --all-files
# all hooks passed
```

## Additional Notes

The fix is intentionally in `make_offload_hint_msg()` rather than a
provider-specific formatter or channel workaround.
