### PR TITLE
fix(Telegram): harden Telegram polling against 409 conflict loop

### DIFF
--- a/src/qwenpaw/app/channels/telegram/channel.py
+++ b/src/qwenpaw/app/channels/telegram/channel.py
@@ -60,7 +60,15 @@ _RECONNECT_FACTOR = 1.8
 _POLLING_STATUS_CHECK_INTERVAL_S = 15
 _POLLING_NETWORK_RETRY_BASE_S = 5.0
 _POLLING_NETWORK_RETRY_MAX_S = 60.0
-_POLLING_CONFLICT_RETRY_DELAY_S = 10.0
+# Worst-case client-side lifetime of an in-flight getUpdates request; the
+# conflict backoff cap must exceed it so a stale poll is surely gone.
+_GET_UPDATES_READ_TIMEOUT_S = 20
+# Conflict backoff: start small (most conflicts are transient self-overlaps),
+# escalate up to a cap above the worst-case old-connection lifetime.
+_POLLING_CONFLICT_RETRY_BASE_S = 5.0
+_POLLING_CONFLICT_RETRY_MAX_S = _GET_UPDATES_READ_TIMEOUT_S + 1.0
+# Grace period after shutdown for the HTTP session to fully close.
+_TEARDOWN_SETTLE_S = 0.5
 
 _MEDIA_ATTRS: list[tuple[str, type, Any, str]] = [
     ("document", FileContent, ContentType.FILE, "file_url"),
@@ -365,6 +373,9 @@ class TelegramChannel(BaseChannel):
         self._pending_reconnect_delay_s = _RECONNECT_INITIAL_S
         self._polling_network_error_count = 0
         self._polling_conflict_count = 0
+        # Set when a reconnect is requested so the polling watchdog exits
+        # immediately instead of waiting out its status-check interval.
+        self._reconnect_event = asyncio.Event()
 
         # Interactive card handler (tool-guard approval cards).
         from .cards.dispatcher import TelegramCardHandler
@@ -412,7 +423,7 @@ class TelegramChannel(BaseChannel):
         base_url, base_file_url = _telegram_base_urls(self._base_url)
         if base_url:
             builder = builder.base_url(base_url).base_file_url(base_file_url)
-        builder = builder.get_updates_read_timeout(20)
+        builder = builder.get_updates_read_timeout(_GET_UPDATES_READ_TIMEOUT_S)
         builder = builder.get_updates_connect_timeout(10)
         proxy = proxy_url()
         if proxy:
@@ -511,10 +522,13 @@ class TelegramChannel(BaseChannel):
         if reason == "conflict":
             self._polling_conflict_count += 1
             self._polling_network_error_count = 0
-            return (
-                self._polling_conflict_count,
-                _POLLING_CONFLICT_RETRY_DELAY_S,
+            attempt = self._polling_conflict_count
+            delay = min(
+                _POLLING_CONFLICT_RETRY_BASE_S
+                * (_RECONNECT_FACTOR ** (attempt - 1)),
+                _POLLING_CONFLICT_RETRY_MAX_S,
             )
+            return attempt, delay
 
         self._polling_network_error_count += 1
         self._polling_conflict_count = 0
@@ -562,6 +576,9 @@ class TelegramChannel(BaseChannel):
                     reason,
                     stop_err,
                 )
+        # Wake the polling watchdog so the cycle exits without waiting out
+        # its status-check interval.
+        self._reconnect_event.set()
 
     @classmethod
     def from_env(
@@ -1289,6 +1306,7 @@ class TelegramChannel(BaseChannel):
         self._pending_reconnect_attempt = 0
         self._pending_reconnect_delay_s = _RECONNECT_INITIAL_S
         self._polling_error_task = None
+        self._reconnect_event.clear()
 
         def _on_poll_error(exc) -> None:
             if (
@@ -1369,7 +1387,15 @@ class TelegramChannel(BaseChannel):
         logger.info("telegram: polling started (receiving updates)")
 
         while getattr(app.updater, "running", False):
-            await asyncio.sleep(_POLLING_STATUS_CHECK_INTERVAL_S)
+            try:
+                await asyncio.wait_for(
+                    self._reconnect_event.wait(),
+                    timeout=_POLLING_STATUS_CHECK_INTERVAL_S,
+                )
+            except asyncio.TimeoutError:
+                continue
+            else:
+                break
 
         if self._polling_error_task:
             try:
@@ -1407,7 +1433,12 @@ class TelegramChannel(BaseChannel):
             if getattr(app, "running", False):
                 await app.stop()
             await app.shutdown()
+            # Give the closed HTTP session and Telegram's server side a brief
+            # moment to release the old getUpdates connection.
+            await asyncio.sleep(_TEARDOWN_SETTLE_S)
         except Exception as exc:
+            # CancelledError is BaseException, so it propagates and is not
+            # swallowed here (keeps stop()'s cancellation working).
             logger.debug("telegram teardown: %s", exc)
 
     async def _run_polling(self) -> None:

--- a/tests/unit/channels/test_telegram.py
+++ b/tests/unit/channels/test_telegram.py
@@ -1839,3 +1839,137 @@ class TestTelegramProxyUrl:
 
             expected_proxy = "http://user:pass@proxy.example.com:8080"
             mock_builder.proxy.assert_called_once_with(expected_proxy)
+
+
+# =============================================================================
+# Polling reconnect / 409 conflict handling
+# =============================================================================
+
+
+class TestTelegramPollingReconnect:
+    """Cover conflict/network classification and reconnect backoff timing."""
+
+    def test_conflict_classification(self, telegram_channel):
+        """Conflict errors are detected by class name or message text."""
+        from qwenpaw.app.channels.telegram.channel import TelegramChannel
+
+        class Conflict(Exception):
+            pass
+
+        assert TelegramChannel._looks_like_polling_conflict(Conflict("x"))
+        assert TelegramChannel._looks_like_polling_conflict(
+            Exception(
+                "Conflict: terminated by other getUpdates request; "
+                "make sure that only one bot instance is running",
+            ),
+        )
+        assert not TelegramChannel._looks_like_polling_conflict(
+            Exception("some unrelated error"),
+        )
+
+    def test_network_classification(self, telegram_channel):
+        """Transport errors (OSError etc.) are treated as network errors."""
+        from qwenpaw.app.channels.telegram.channel import TelegramChannel
+
+        assert TelegramChannel._looks_like_network_error(OSError("boom"))
+        assert not TelegramChannel._looks_like_network_error(
+            Exception("logic error"),
+        )
+
+    def test_conflict_backoff_is_monotonic_and_capped(self, telegram_channel):
+        """Conflict delay escalates and never exceeds the safety cap."""
+        from qwenpaw.app.channels.telegram.channel import (
+            _POLLING_CONFLICT_RETRY_MAX_S,
+        )
+
+        delays = []
+        for expected_attempt in range(1, 8):
+            attempt, delay = telegram_channel._plan_polling_reconnect(
+                "conflict",
+            )
+            assert attempt == expected_attempt
+            assert delay <= _POLLING_CONFLICT_RETRY_MAX_S
+            delays.append(delay)
+
+        # Non-decreasing and eventually pinned to the cap.
+        assert delays == sorted(delays)
+        assert delays[0] < delays[-1]
+        assert delays[-1] == _POLLING_CONFLICT_RETRY_MAX_S
+
+    def test_conflict_cap_exceeds_read_timeout(self):
+        """Regression lock: worst-case wait must clear a lingering poll."""
+        from qwenpaw.app.channels.telegram.channel import (
+            _GET_UPDATES_READ_TIMEOUT_S,
+            _POLLING_CONFLICT_RETRY_MAX_S,
+        )
+
+        assert _POLLING_CONFLICT_RETRY_MAX_S >= _GET_UPDATES_READ_TIMEOUT_S + 1
+
+    def test_conflict_and_network_counters_are_mutually_reset(
+        self,
+        telegram_channel,
+    ):
+        """Switching reason resets the other counter (fresh backoff)."""
+        c_attempt1, _ = telegram_channel._plan_polling_reconnect("conflict")
+        assert c_attempt1 == 1
+        telegram_channel._plan_polling_reconnect("conflict")
+
+        n_attempt1, _ = telegram_channel._plan_polling_reconnect("network")
+        assert n_attempt1 == 1
+        assert telegram_channel._polling_conflict_count == 0
+
+        # Back to conflict: counter restarts from 1.
+        c_again, _ = telegram_channel._plan_polling_reconnect("conflict")
+        assert c_again == 1
+        assert telegram_channel._polling_network_error_count == 0
+
+    @pytest.mark.asyncio
+    async def test_request_reconnect_stops_updater_and_sets_event(
+        self,
+        telegram_channel,
+    ):
+        """Reconnect request stops the updater and wakes the watchdog."""
+        telegram_channel._pending_reconnect_reason = None
+        telegram_channel._reconnect_event.clear()
+
+        app = MagicMock()
+        app.updater = MagicMock()
+        app.updater.running = True
+        app.updater.stop = AsyncMock()
+
+        await telegram_channel._request_polling_reconnect(
+            app,
+            reason="conflict",
+            error=Exception("Conflict"),
+        )
+
+        app.updater.stop.assert_awaited_once()
+        assert telegram_channel._reconnect_event.is_set()
+        assert telegram_channel._pending_reconnect_reason == "conflict"
+
+    @pytest.mark.asyncio
+    async def test_teardown_swallows_errors_and_settles(
+        self,
+        telegram_channel,
+    ):
+        """Teardown shuts down the app and applies the settle delay."""
+        from qwenpaw.app.channels.telegram.channel import TelegramChannel
+
+        app = MagicMock()
+        app.updater = MagicMock()
+        app.updater.running = True
+        app.updater.stop = AsyncMock()
+        app.running = True
+        app.stop = AsyncMock()
+        app.shutdown = AsyncMock()
+
+        with patch(
+            "qwenpaw.app.channels.telegram.channel.asyncio.sleep",
+            new=AsyncMock(),
+        ) as mock_sleep:
+            await TelegramChannel._teardown_application(app)
+
+        app.updater.stop.assert_awaited_once()
+        app.stop.assert_awaited_once()
+        app.shutdown.assert_awaited_once()
+        mock_sleep.assert_awaited_once()


### PR DESCRIPTION
## Description

Telegram polling could fall into a self-perpetuating 409 "Conflict: terminated by
other getUpdates request" loop. The residual root cause was a timing gap: the
conflict reconnect delay (10s) was shorter than the worst-case in-flight
`getUpdates` read timeout (20s), and the two windows are not aligned, so a new
poll was fired while the old connection was still alive on Telegram's side —
immediately triggering another 409.

This PR reworks the conflict recovery to be timing-safe while keeping recovery
fast in the common case:

- **Graded (exponential) conflict backoff** instead of a fixed 10s delay:
  starts small (`5s`) and escalates (`×1.8`) up to a cap of
  `_GET_UPDATES_READ_TIMEOUT_S + 1s` (=21s), guaranteeing the stale poll is gone
  before reconnecting, without a large fixed window on transient conflicts.
- **Event-driven watchdog**: `_reconnect_event` wakes the polling cycle
  immediately on a reconnect request instead of waiting out the 15s status-check
  interval.
- **Teardown settle**: brief grace period after `Application.shutdown()` so the
  HTTP session fully closes and Telegram notices the disconnect before we
  reconnect.
- Derived the read-timeout constant (`_GET_UPDATES_READ_TIMEOUT_S`) and reused it
  both in the builder and the backoff cap so the invariant stays coupled.

**Related Issue:** Fixes #2024 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
