### PR TITLE
fix: fix legacy session loading for file content blocks

### DIFF
--- a/src/qwenpaw/_compat/message.py
+++ b/src/qwenpaw/_compat/message.py
@@ -84,15 +84,16 @@ def _coerce_source(
 # ---------------------------------------------------------------------------
 
 
-# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-return-statements, too-many-branches
 def _coerce_block(block: Any) -> Any:
     """Map a stored content block dict to a 2.0 block instance.
 
     Old per-modality blocks (``image`` / ``audio`` / ``video``) are
     rewritten to the unified ``DataBlock``; legacy ``tool_use`` blocks
     are rewritten to ``ToolCallBlock`` (with ``input`` JSON-encoded if
-    needed).  Anything else is returned as-is so the union discriminator
-    on ``Msg.content`` can handle it.
+    needed); legacy ``file`` blocks are downgraded to text placeholders.
+    Anything else is returned as-is so the union discriminator on
+    ``Msg.content`` can handle it.
     """
     if not isinstance(block, Mapping):
         return block
@@ -124,6 +125,28 @@ def _coerce_block(block: Any) -> Any:
             new_block["output"] = [_coerce_block(b) for b in output]
             return new_block
         return block
+    if btype == "file":
+        filename = block.get("filename") or block.get("name") or ""
+        source = block.get("source")
+        if isinstance(source, Mapping):
+            source_type = source.get("type")
+            if source_type == "url":
+                path = source.get("url") or ""
+            elif source_type == "base64":
+                path = ""
+            else:
+                path = ""
+        else:
+            path = str(source) if source else ""
+        filename = (
+            filename or (path.rsplit("/", 1)[-1] if path else "") or "file"
+        )
+        text = (
+            f"File '{filename}' is available at: {path}"
+            if path
+            else f"File '{filename}'"
+        )
+        return {"type": "text", "text": text}
     return block
 
 


### PR DESCRIPTION
## Description

This PR fixes a legacy session compatibility issue where persisted type: "file" content blocks could fail Pydantic validation during session restore after the AgentScope 2.x migration.

The fix downgrades legacy file blocks to text placeholders in the message compatibility layer, preserving the filename/path context while avoiding unsupported file block validation errors.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
