### PR TITLE
fix(models): prevent browser autofill on provider search input (#5981)

### DIFF
--- a/console/src/pages/Settings/Models/index.tsx
+++ b/console/src/pages/Settings/Models/index.tsx
@@ -39,6 +39,10 @@ function ModelsPage() {
   const { providers, activeModels, loading, error, fetchAll } = useProviders();
   const [addProviderOpen, setAddProviderOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  // Prevent browsers from autofilling the search input with saved credentials
+  // (e.g. the username from the login page). Browsers skip read-only inputs
+  // during autofill, so we make it editable only after the user focuses it.
+  const [searchReadOnly, setSearchReadOnly] = useState(true);
 
   // Shared Modal state — only one instance each instead of N per card
   const [configModalProvider, setConfigModalProvider] =
@@ -335,9 +339,11 @@ function ModelsPage() {
                       placeholder={t("models.searchPlaceholder")}
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
+                      onFocus={() => setSearchReadOnly(false)}
                       className={styles.searchInput}
                       prefix={<SearchOutlined />}
                       allowClear
+                      readOnly={searchReadOnly}
                       autoComplete="off"
                       name="models-provider-search-nofill"
                       data-form-type="other"


### PR DESCRIPTION
Adopt a "read-only start" strategy for the search box in `console/src/pages/Settings/Models/index.tsx`:
Set the search box to `readOnly` during the initial render.
Browsers do not auto-fill read-only input fields.
Immediately remove the `readOnly` attribute when the user focuses on the input, ensuring normal typing is unaffected.

Fixes #5981

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Local Verification Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
