### PR TITLE
fix(runtime): honor shell command timeouts

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -642,6 +642,15 @@ class QwenPawAgent(CodingModeMixin, Agent):
             self.name,
         )
         mgr.clear_agent_tool_timeouts(agent_id)
+
+        shell_timeout = self._agent_config.running.shell_command_timeout
+        if shell_timeout > 0:
+            mgr.set_agent_tool_timeout(
+                agent_id,
+                "execute_shell_command",
+                float(shell_timeout),
+            )
+
         builtin_tools = (
             getattr(
                 getattr(self._agent_config, "tools", None),

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -516,6 +516,10 @@ async def execute_shell_command(
         if configured is not None:
             timeout = configured
 
+    from ...tool_calls import reschedule_call_timeout
+
+    reschedule_call_timeout(timeout)
+
     # Use current workspace_dir from context, fallback to WORKING_DIR
     if cwd is not None:
         working_dir = cwd

--- a/src/qwenpaw/tool_calls/__init__.py
+++ b/src/qwenpaw/tool_calls/__init__.py
@@ -9,7 +9,11 @@ from ._hooks import ToolHookRegistry
 from ._middleware import ToolCoordinatorMiddleware
 from ._result_limiter import ToolResultLimiter
 from ._stream import ToolStream
-from ._timeout_helper import cancellable_wait, effective_timeout
+from ._timeout_helper import (
+    cancellable_wait,
+    effective_timeout,
+    reschedule_call_timeout,
+)
 
 __all__ = [
     "CancelReason",
@@ -25,6 +29,7 @@ __all__ = [
     "cancellable_wait",
     "effective_timeout",
     "get_call_context",
+    "reschedule_call_timeout",
     "reset_call_context",
     "set_call_context",
 ]

--- a/src/qwenpaw/tool_calls/_timeout_helper.py
+++ b/src/qwenpaw/tool_calls/_timeout_helper.py
@@ -4,11 +4,41 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from typing import Any
 
 from ._ctxvars import get_call_context
 
 logger = logging.getLogger(__name__)
+
+
+def reschedule_call_timeout(timeout_secs: float) -> bool:
+    """Reset the active tool call deadline from the current time.
+
+    Tools use this after resolving a configured default or per-call timeout.
+    The coordinator is notified so an in-progress wait immediately observes
+    the new deadline. Calls outside a managed tool context are unchanged.
+
+    Args:
+        timeout_secs: Effective timeout in seconds.
+
+    Returns:
+        Whether an active call deadline was updated.
+    """
+    ctx = get_call_context()
+    if ctx is None:
+        return False
+
+    try:
+        timeout = float(timeout_secs)
+    except (TypeError, ValueError):
+        return False
+    if not math.isfinite(timeout) or timeout <= 0:
+        return False
+
+    ctx.deadline = asyncio.get_running_loop().time() + timeout
+    ctx.deadline_changed_event.set()
+    return True
 
 
 async def cancellable_wait(

--- a/tests/unit/agents/test_react_agent_tool_timeouts.py
+++ b/tests/unit/agents/test_react_agent_tool_timeouts.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Tests for QwenPawAgent tool timeout registration."""
+
+# pylint: disable=protected-access
+
+from types import SimpleNamespace
+
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.tool_calls import ToolCoordinator
+
+
+def _register_agent_shell_timeout(
+    coordinator: ToolCoordinator,
+    *,
+    agent_id: str,
+    timeout: float,
+) -> None:
+    agent = SimpleNamespace(
+        name=agent_id,
+        _request_context={
+            "tool_coordinator": coordinator,
+            "agent_id": agent_id,
+        },
+        _agent_config=SimpleNamespace(
+            running=SimpleNamespace(shell_command_timeout=timeout),
+            tools=SimpleNamespace(builtin_tools={}),
+        ),
+        _get_tool_coordinator=lambda: coordinator,
+    )
+
+    QwenPawAgent._register_tool_call_hooks(agent)
+
+
+def test_shell_timeout_is_registered_per_agent() -> None:
+    coordinator = ToolCoordinator()
+
+    _register_agent_shell_timeout(
+        coordinator,
+        agent_id="agent-a",
+        timeout=120.0,
+    )
+    _register_agent_shell_timeout(
+        coordinator,
+        agent_id="agent-b",
+        timeout=300.0,
+    )
+
+    assert (
+        coordinator._resolve_timeout(
+            "agent-a",
+            "execute_shell_command",
+            None,
+        )
+        == 120.0
+    )
+    assert (
+        coordinator._resolve_timeout(
+            "agent-b",
+            "execute_shell_command",
+            None,
+        )
+        == 300.0
+    )

--- a/tests/unit/agents/tools/test_shell_timeout.py
+++ b/tests/unit/agents/tools/test_shell_timeout.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Tests for shell timeout propagation into Runtime 2.0 deadlines."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from qwenpaw.agents.tools.shell import execute_shell_command
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_timeout", "configured_timeout", "expected_timeout"),
+    [
+        (60.0, 240.0, 240.0),
+        (90.0, 240.0, 90.0),
+    ],
+)
+async def test_effective_timeout_reschedules_coordinator_deadline(
+    tmp_path,
+    requested_timeout: float,
+    configured_timeout: float,
+    expected_timeout: float,
+) -> None:
+    sandbox_result = SimpleNamespace(
+        sandbox_violation=None,
+        exit_code=0,
+        stdout="completed",
+        stderr="",
+    )
+
+    with patch(
+        "qwenpaw.agents.tools.shell.get_current_shell_command_timeout",
+        return_value=configured_timeout,
+    ), patch(
+        "qwenpaw.agents.tools.shell.get_current_shell_command_executable",
+        return_value=None,
+    ), patch(
+        "qwenpaw.agents.tools.shell.get_current_workspace_dir",
+        return_value=tmp_path,
+    ), patch(
+        "qwenpaw.agents.tools.shell._execute_in_sandbox",
+        AsyncMock(return_value=sandbox_result),
+    ) as execute_in_sandbox, patch(
+        "qwenpaw.tool_calls.reschedule_call_timeout",
+    ) as reschedule:
+        result = await execute_shell_command(
+            "echo completed",
+            timeout=requested_timeout,
+            sandbox_config=SimpleNamespace(),
+        )
+
+    reschedule.assert_called_once_with(expected_timeout)
+    assert execute_in_sandbox.await_args.args[2] == expected_timeout
+    assert result.content[0].text == "completed"

--- a/tests/unit/tool_calls/test_timeout_helper.py
+++ b/tests/unit/tool_calls/test_timeout_helper.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Tests for cooperative tool-call timeout helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, AsyncGenerator
+
+import pytest
+from agentscope.message import TextBlock
+from agentscope.tool import ToolResponse
+
+from qwenpaw.tool_calls import (
+    ToolCallContext,
+    ToolCoordinator,
+    reset_call_context,
+    reschedule_call_timeout,
+    set_call_context,
+)
+
+
+@dataclass
+class _ToolCall:
+    id: str = "call-1"
+    name: str = "execute_shell_command"
+    input: dict[str, Any] = field(default_factory=dict)
+
+
+@pytest.mark.asyncio
+async def test_reschedule_call_timeout_updates_active_context() -> None:
+    loop = asyncio.get_running_loop()
+    ctx = ToolCallContext(
+        tool_call_id="call-1",
+        tool_name="execute_shell_command",
+        session_id="session-1",
+        agent_id="agent-1",
+        root_session_id="root-1",
+        started_at=loop.time(),
+        deadline=loop.time() + 60.0,
+        cancel_event=asyncio.Event(),
+    )
+    token = set_call_context(ctx)
+
+    try:
+        before = loop.time()
+        assert reschedule_call_timeout(240.0) is True
+    finally:
+        reset_call_context(token)
+
+    assert ctx.deadline is not None
+    assert before + 240.0 <= ctx.deadline <= loop.time() + 240.0
+    assert ctx.deadline_changed_event.is_set()
+
+
+def test_reschedule_call_timeout_without_context_is_noop() -> None:
+    assert reschedule_call_timeout(240.0) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timeout",
+    [0.0, -1.0, float("inf"), float("nan"), "invalid", None],
+)
+async def test_invalid_timeout_does_not_change_context(timeout: Any) -> None:
+    loop = asyncio.get_running_loop()
+    original_deadline = loop.time() + 60.0
+    ctx = ToolCallContext(
+        tool_call_id="call-1",
+        tool_name="execute_shell_command",
+        session_id="session-1",
+        agent_id="agent-1",
+        root_session_id="root-1",
+        started_at=loop.time(),
+        deadline=original_deadline,
+        cancel_event=asyncio.Event(),
+    )
+    token = set_call_context(ctx)
+
+    try:
+        assert reschedule_call_timeout(timeout) is False
+    finally:
+        reset_call_context(token)
+
+    assert ctx.deadline == original_deadline
+    assert not ctx.deadline_changed_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_observes_rescheduled_timeout() -> None:
+    coordinator = ToolCoordinator(default_timeout_secs=0.01)
+    tool_call = _ToolCall()
+
+    async def next_handler(
+        tool_call: _ToolCall,
+    ) -> AsyncGenerator[ToolResponse, None]:
+        assert reschedule_call_timeout(0.2) is True
+        await asyncio.sleep(0.03)
+        yield ToolResponse(
+            content=[TextBlock(type="text", text="completed")],
+            id=tool_call.id,
+        )
+
+    events = [
+        item
+        async for item in coordinator.execute(
+            tool_call=tool_call,
+            next_handler=next_handler,
+            session_id="session-1",
+            agent_id="agent-1",
+            root_session_id="root-1",
+        )
+    ]
+
+    assert len(events[-1].content) == 1
+    assert events[-1].content[0].text == "completed"
+    assert events[-1].metadata.get("offloaded") is not True


### PR DESCRIPTION
## Description

Fixes #5963.

Runtime 2.0 created the `execute_shell_command` coordinator deadline from a
shared 60-second hook default before the shell tool resolved its effective
timeout. As a result, `running.shell_command_timeout` and an explicit per-call
`timeout` still reached the subprocess layer but could not extend the earlier
coordinator deadline, so long commands were prematurely cancelled/offloaded.

This change restores the existing timeout contract by:

- registering `running.shell_command_timeout` as a per-agent coordinator
  timeout, preserving different settings for agents sharing one coordinator;
- adding a managed-call helper that resets the active deadline and notifies the
  coordinator to recalculate its wait; and
- invoking that helper after the shell resolves its configured or explicit
  effective timeout, before entering sandbox, Windows, or Unix execution.

Calls made outside a managed Runtime context remain unchanged. Invalid,
non-positive, and non-finite timeout values cannot overwrite an active
deadline.

**Security Considerations:** No permission, sandbox policy, or command parsing
changes. The coordinator now enforces the same timeout already accepted by the
shell execution layer.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; this restores documented behavior)
- [ ] Ready for review

### For Channel Changes (DingTalk, Feishu, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (not applicable)
- [ ] Contract test exists (not applicable)
- [ ] Contract test implements `create_instance()` (not applicable)
- [ ] All contract verification points pass (not applicable)
- [ ] Optional channel unit tests (not applicable)

## Testing

- Per-agent configured shell deadlines: covered with two agents sharing one
  coordinator.
- Explicit per-call timeout precedence: covered.
- Coordinator deadline-change notification: covered through a real
  `ToolCoordinator` execution.
- Context-free direct calls: unchanged and covered.
- Invalid timeout values: covered.
- Sandbox/Windows/Unix shell paths: shared timeout resolution plus existing
  shell regression suite covered.
- Channels/providers/streaming: not applicable.

## Local Verification Evidence

```bash
.venv/bin/pytest tests/unit/tool_calls \
  tests/unit/agents/tools/test_shell.py \
  tests/unit/agents/tools/test_shell_timeout.py \
  tests/unit/agents/test_react_agent_tool_timeouts.py -q
# 93 passed

.venv/bin/pre-commit run --all-files
# all hooks passed
```

## Additional Notes

This PR fixes premature use of the hard-coded 60-second deadline. Once the
effective configured/per-call deadline is genuinely reached, Runtime 2.0 keeps
its existing timeout completion and offload behavior.
