### PR TITLE
fix(providers): use max_completion_tokens for reasoning models

### DIFF
--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -33,6 +33,24 @@ TOKEN_PLAN_BASE_URL = (
     "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
 )
 
+
+def _uses_max_completion_tokens(model_id: str) -> bool:
+    """Return whether an OpenAI model requires max_completion_tokens."""
+    model_name = model_id.strip().lower().rsplit("/", maxsplit=1)[-1]
+    return model_name.startswith("gpt-5") or (
+        len(model_name) > 1
+        and model_name[0] == "o"
+        and model_name[1].isdigit()
+    )
+
+
+def _token_limit_kwargs(model_id: str, limit: int) -> dict[str, int]:
+    """Build the model-specific output token limit argument."""
+    if _uses_max_completion_tokens(model_id):
+        return {"max_completion_tokens": limit}
+    return {"max_tokens": limit}
+
+
 if os.environ.get("LANGFUSE_SECRET_KEY") and importlib.util.find_spec(
     "langfuse",
 ):
@@ -156,8 +174,8 @@ class OpenAIProvider(Provider):
                     },
                 ],
                 timeout=timeout,
-                max_tokens=20,
                 stream=True,
+                **_token_limit_kwargs(model_id, 20),
             )
             # consume the stream to ensure the model is actually responsive
             async for _ in res:
@@ -200,8 +218,16 @@ class OpenAIProvider(Provider):
             merged_headers["X-DashScope-Cdpl"] = dashscope_meta
 
         gen_kwargs = self.get_effective_generate_kwargs(model_id)
+        max_tokens = gen_kwargs.pop("max_tokens", None)
+        if _uses_max_completion_tokens(model_id):
+            if max_tokens is not None:
+                gen_kwargs.setdefault(
+                    "max_completion_tokens",
+                    max_tokens,
+                )
+            max_tokens = None
         parameters = OpenAIChatModel.Parameters(
-            max_tokens=gen_kwargs.pop("max_tokens", None),
+            max_tokens=max_tokens,
             temperature=gen_kwargs.pop("temperature", None),
             top_p=gen_kwargs.pop("top_p", None),
         )
@@ -322,8 +348,8 @@ class OpenAIProvider(Provider):
                         ],
                     },
                 ],
-                max_tokens=200,
                 timeout=timeout,
+                **_token_limit_kwargs(model_id, 200),
             )
             answer = (res.choices[0].message.content or "").lower().strip()
             reasoning = ""
@@ -440,8 +466,8 @@ class OpenAIProvider(Provider):
                         ],
                     },
                 ],
-                max_tokens=200,
                 timeout=req_timeout,
+                **_token_limit_kwargs(model_id, 200),
             )
             return self._evaluate_video_response(
                 res,
@@ -655,8 +681,8 @@ class GitHubModelsProvider(OpenAIProvider):
                     },
                 ],
                 timeout=timeout,
-                max_tokens=5,
                 stream=True,
+                **_token_limit_kwargs(model_id, 5),
             )
             try:
                 async for _ in res:

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -126,6 +127,95 @@ async def test_check_model_connection_success(monkeypatch) -> None:
     assert captured[0]["timeout"] == 4
     assert captured[0]["max_tokens"] == 20
     assert captured[0]["stream"] is True
+
+
+async def test_check_gpt5_model_uses_max_completion_tokens(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    captured: list[dict] = []
+
+    class FakeStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.append(kwargs)
+            return FakeStream()
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+    monkeypatch.setattr(provider, "_client", lambda timeout=5: fake_client)
+
+    ok, msg = await provider.check_model_connection("gpt-5.2", timeout=4)
+
+    assert ok is True
+    assert msg == ""
+    assert captured[0]["max_completion_tokens"] == 20
+    assert "max_tokens" not in captured[0]
+
+
+def test_token_limit_kwargs_handles_reasoning_model_ids() -> None:
+    assert openai_provider_module._token_limit_kwargs(
+        "openai/gpt-5-mini",
+        200,
+    ) == {"max_completion_tokens": 200}
+    assert openai_provider_module._token_limit_kwargs(
+        "o3",
+        200,
+    ) == {"max_completion_tokens": 200}
+    assert openai_provider_module._token_limit_kwargs(
+        "openai/o4-mini",
+        200,
+    ) == {"max_completion_tokens": 200}
+    assert openai_provider_module._token_limit_kwargs(
+        "openai/gpt-4o-mini",
+        200,
+    ) == {"max_tokens": 200}
+
+
+def test_get_gpt5_model_maps_configured_max_tokens() -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {"max_tokens": 4096}
+
+    model = provider.get_chat_model_instance("gpt-5.2")
+
+    assert model.parameters.max_tokens is None
+    assert model._extra_generate_kwargs == {
+        "max_completion_tokens": 4096,
+    }
+
+
+def test_get_o_series_model_maps_configured_max_tokens() -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {"max_tokens": 4096}
+
+    model = provider.get_chat_model_instance("o3")
+
+    assert model.parameters.max_tokens is None
+    assert model._extra_generate_kwargs == {
+        "max_completion_tokens": 4096,
+    }
+
+
+def test_get_gpt5_model_preserves_explicit_max_completion_tokens() -> None:
+    provider = _make_provider()
+    provider.generate_kwargs = {
+        "max_tokens": 4096,
+        "max_completion_tokens": 2048,
+    }
+
+    model = provider.get_chat_model_instance("gpt-5-mini")
+
+    assert model.parameters.max_tokens is None
+    assert model._extra_generate_kwargs == {
+        "max_completion_tokens": 2048,
+    }
 
 
 async def test_check_model_connection_api_error_returns_false(


### PR DESCRIPTION
## Description

Use `max_completion_tokens` for GPT-5 and O-series Chat Completions requests while preserving `max_tokens` for other model families and OpenAI-compatible providers.

This change:

- applies the model-specific token parameter to connection, image, video, and GitHub Models probes
- maps existing GPT-5 and O-series `max_tokens` configuration to `max_completion_tokens` at runtime
- preserves an explicitly configured `max_completion_tokens` value
- recognizes direct and namespaced model IDs, such as `gpt-5.2`, `o3`, and `openai/o4-mini`

**Related Issue:** Relates to #2777 (addresses the GPT-5 token-parameter compatibility problem; the model-list behavior is intentionally unchanged)

**Security Considerations:** None. This only adapts generation parameter names.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (providers)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration change)
- [x] Ready for review

## Testing

Unit tests cover legacy-model probe behavior, GPT-5 and O-series behavior, namespaced model IDs, configured `max_tokens` migration, and explicit `max_completion_tokens` precedence.

## Evidence

The focused provider tests capture outgoing request kwargs and verify that GPT-5, `o3`, and namespaced `openai/o4-mini` requests include `max_completion_tokens` while omitting `max_tokens`. The legacy `gpt-4o-mini` case continues to send `max_tokens`. All 46 provider and provider-manager tests pass.

```bash
pre-commit run --all-files
# all hooks passed, including mypy, black, flake8, pylint, and prettier

python -m pytest \
  tests/unit/providers/test_openai_provider.py \
  tests/unit/providers/test_provider_manager.py -q
# 46 passed in 0.45s
```

## Additional Notes

The [OpenAI Chat Completions parameter reference](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create) documents `max_completion_tokens` as the replacement for the deprecated `max_tokens` parameter.
