### PR TITLE
perf(scroll): batch session history migration writes

### DIFF
--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -8,6 +8,7 @@ import logging
 import sqlite3
 import sys
 import threading
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -232,6 +233,31 @@ class HistoryStore:
 
     # --- write path ----------------------------------------------------
 
+    @staticmethod
+    def _insert_row(
+        session_id: str,
+        agent_id: str | None,
+        entry: LogEntry,
+        dedup_key: str | None,
+    ) -> tuple:
+        """Build the SQLite row shared by single and batched appends."""
+        return (
+            session_id,
+            agent_id,
+            entry.kind,
+            entry.role,
+            entry.name,
+            entry.content,
+            entry.tool_call_id,
+            _to_json(entry.tool_input),
+            entry.tool_state,
+            entry.headline,
+            _to_json(entry.blocks),
+            _to_json(entry.metadata or None),
+            entry.created_at or datetime.now(timezone.utc).isoformat(),
+            dedup_key,
+        )
+
     def append(
         self,
         *,
@@ -249,22 +275,7 @@ class HistoryStore:
         restored window can re-link bookkeeping without duplicating rows. A
         ``None`` key is never deduped.
         """
-        row = (
-            session_id,
-            agent_id,
-            entry.kind,
-            entry.role,
-            entry.name,
-            entry.content,
-            entry.tool_call_id,
-            _to_json(entry.tool_input),
-            entry.tool_state,
-            entry.headline,
-            _to_json(entry.blocks),
-            _to_json(entry.metadata or None),
-            entry.created_at or datetime.now(timezone.utc).isoformat(),
-            dedup_key,
-        )
+        row = self._insert_row(session_id, agent_id, entry, dedup_key)
         placeholders = ", ".join("?" for _ in _INSERT_COLUMNS)
         with self._lock, self._conn:
             cur = self._conn.execute(
@@ -291,6 +302,51 @@ class HistoryStore:
                     (seq, entry.content or ""),
                 )
             return seq
+
+    def append_many(
+        self,
+        *,
+        session_id: str,
+        entries: Sequence[tuple[LogEntry, str | None]],
+        agent_id: str | None = None,
+    ) -> int:
+        """Append a group of events in one transaction.
+
+        Returns the number of newly inserted rows. Duplicate keys remain
+        no-ops and only newly inserted rows are added to FTS, matching
+        :meth:`append`. This is intended for backfills where committing every
+        individual row would turn SQLite fsync latency into startup latency.
+        """
+        if not entries:
+            return 0
+
+        placeholders = ", ".join("?" for _ in _INSERT_COLUMNS)
+        sql = (
+            f"INSERT INTO conversation_history "
+            f"({', '.join(_INSERT_COLUMNS)}) VALUES ({placeholders}) "
+            f"ON CONFLICT(session_id, dedup_key) DO NOTHING"
+        )
+        inserted = 0
+        with self._lock, self._conn:
+            for entry, dedup_key in entries:
+                row = self._insert_row(
+                    session_id,
+                    agent_id,
+                    entry,
+                    dedup_key,
+                )
+                cur = self._conn.execute(sql, row)
+                if cur.rowcount == 0:
+                    continue
+                inserted += 1
+                seq = int(cur.lastrowid or 0)
+                if self._fts and entry.name not in _RECALL_TOOL_NAMES:
+                    self._conn.execute(
+                        "INSERT INTO conversation_history_fts(rowid, content) "
+                        "VALUES (?, ?)",
+                        (seq, entry.content or ""),
+                    )
+        return inserted
 
     def update_entry(
         self,

--- a/src/qwenpaw/agents/context/scroll/sync.py
+++ b/src/qwenpaw/agents/context/scroll/sync.py
@@ -264,7 +264,7 @@ def _sync_file(
     res.messages = len(messages)
     res.unparseable = unparseable
 
-    before = 0 if dry_run else history.count(session_id)
+    pending_entries = []
     for row_index, msg in enumerate(messages):
         # Skip messages older than the retention window so we don't import rows
         # the same-boot purge would immediately delete. NULL timestamps are
@@ -295,14 +295,17 @@ def _sync_file(
                 dedup_key = mid
             res.rows_processed += 1
             if not dry_run:
-                history.append(
-                    session_id=session_id,
-                    agent_id=agent_id,
-                    entry=entry,
-                    dedup_key=dedup_key,
-                )
+                pending_entries.append((entry, dedup_key))
 
-    res.rows_inserted = 0 if dry_run else history.count(session_id) - before
+    # One transaction per source file. The old per-row append path committed
+    # every event independently, making migration time proportional to disk
+    # fsync latency (tens of minutes for a large backlog).
+    if not dry_run:
+        res.rows_inserted = history.append_many(
+            session_id=session_id,
+            agent_id=agent_id,
+            entries=pending_entries,
+        )
     return res
 
 

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -52,6 +52,42 @@ def test_append_is_idempotent_on_session_dedup_key(store: HistoryStore):
     assert store.count("s") == 1  # no duplicate row
 
 
+def test_append_many_batches_and_deduplicates(store: HistoryStore):
+    inserted = store.append_many(
+        session_id="s",
+        entries=[
+            (_entry("one"), "m1"),
+            (_entry("two"), "m2"),
+            (_entry("duplicate"), "m1"),
+        ],
+    )
+    assert inserted == 2
+    assert store.count("s") == 2
+
+    assert (
+        store.append_many(
+            session_id="s",
+            entries=[(_entry("one again"), "m1")],
+        )
+        == 0
+    )
+    assert store.count("s") == 2
+
+
+def test_append_many_populates_fts(store: HistoryStore):
+    if not store._fts:
+        pytest.skip("SQLite build lacks FTS5")
+    store.append_many(
+        session_id="s",
+        entries=[(_entry("batch aardvark"), "m1")],
+    )
+    rows = store._conn.execute(
+        "SELECT rowid FROM conversation_history_fts WHERE "
+        "conversation_history_fts MATCH 'aardvark'",
+    ).fetchall()
+    assert len(rows) == 1
+
+
 def test_same_dedup_key_different_session_does_not_collide(
     store: HistoryStore,
 ):


### PR DESCRIPTION
## Summary

Speed up the one-time session history migration during startup.

Previously, every history row was committed in a separate SQLite transaction, which could make large migrations take several minutes. This PR batches all rows from each session file into one transaction.

The existing behavior is preserved:

- Messages older than the configured retention period are still skipped.
- Duplicate rows are still ignored.
- FTS indexing and migration manifests continue to work.

## Testing

- All context tests pass: `176 passed`
- Added tests for batch insertion, deduplication, and FTS indexing