### PR TITLE
refactor(governance): auto-sync DEFAULT_USER_RULES without manual whitelist

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -518,13 +518,6 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
     ),
 ]
 
-# Default user rules added after policy.yaml existed in the wild. Existing
-# persisted policies keep their user_rules, so migrate only these known safe
-# defaults instead of replacing user customizations wholesale.
-_MIGRATED_DEFAULT_USER_RULE_MATCHES = {
-    "*(CODING_PROJECT_DIR/**)",
-}
-
 
 # ---------------------------------------------------------------------------
 # GovernancePolicy
@@ -1050,10 +1043,10 @@ def load_governance_policy(
             coding_project_dir,
             applied_migrations=applied_migrations,
         )
-    # Record all known migrations as applied so the next save makes any
-    # user deletion of a migrated rule stick.
+    # Record all DEFAULT_USER_RULES as applied so the next save
+    # makes any user deletion of a default rule stick.
     applied_migrations = sorted(
-        set(applied_migrations) | _MIGRATED_DEFAULT_USER_RULE_MATCHES,
+        set(applied_migrations) | {r.match for r in DEFAULT_USER_RULES},
     )
     if not env_blacklist:
         env_blacklist = list(DEFAULT_ENV_BLACKLIST)
@@ -1211,7 +1204,7 @@ def _create_default_policy(
         execution_level="smart",
         sensitive_paths=list(_DEFAULT_SENSITIVE_PATHS),
         shell_evasion_checks=dict(_DEFAULT_SHELL_EVASION_CHECKS),
-        applied_migrations=sorted(_MIGRATED_DEFAULT_USER_RULE_MATCHES),
+        applied_migrations=sorted(r.match for r in DEFAULT_USER_RULES),
     )
 
 
@@ -1229,17 +1222,15 @@ def _merge_missing_default_user_rules(
     coding_project_dir: str = "",
     applied_migrations: List[str] | None = None,
 ) -> List[GovernanceRule]:
-    """Append migrated default user rules missing from a persisted policy.
+    """Append default user rules missing from a persisted policy.
 
     A rule whose match is recorded in ``applied_migrations`` is never
-    re-added: the migration already ran once, so a missing rule means the
-    user deleted it on purpose.
+    re-added: the migration already ran once, so a missing rule means
+    the user deleted it on purpose.
     """
     applied = set(applied_migrations or [])
     merged = list(user_rules)
     for default_rule in DEFAULT_USER_RULES:
-        if default_rule.match not in _MIGRATED_DEFAULT_USER_RULE_MATCHES:
-            continue
         if default_rule.match in applied:
             continue
         if _has_equivalent_rule(

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -270,6 +270,62 @@ class TestDefaultPolicyLoad:
         decision = reloaded.evaluate(_tc("Edit", f"{cpd}/app.py"))
         assert decision.action is GovernanceAction.ALLOW
 
+    def test_new_default_rule_auto_migrated(self, tmp_path):
+        """A newly added DEFAULT_USER_RULES entry is auto-merged
+        into an existing policy.yaml without a manual whitelist."""
+        from unittest.mock import patch
+
+        ws = "/home/user/workspace"
+        policy_dir = tmp_path / "policy"
+        policy_dir.mkdir()
+
+        policy = _create_default_policy(workspace_dir=ws)
+        save_governance_policy(policy, str(policy_dir), ws)
+
+        new_rule = GovernanceRule(
+            match="NewTool(*)",
+            action=GovernanceAction.ALLOW,
+            reason="New tool auto-test",
+        )
+        patched = list(DEFAULT_USER_RULES) + [new_rule]
+        with patch(
+            "qwenpaw.governance.policy.DEFAULT_USER_RULES",
+            patched,
+        ):
+            reloaded = load_governance_policy(str(policy_dir), ws)
+        assert any(r.match == "NewTool(*)" for r in reloaded.user_rules)
+
+    def test_deleted_new_default_rule_stays_deleted(self, tmp_path):
+        """Once a new default rule is migrated and then deleted by
+        the user, it must not be re-added on subsequent loads."""
+        from unittest.mock import patch
+
+        ws = "/home/user/workspace"
+        policy_dir = tmp_path / "policy"
+        policy_dir.mkdir()
+
+        new_rule = GovernanceRule(
+            match="NewTool(*)",
+            action=GovernanceAction.ALLOW,
+            reason="New tool auto-test",
+        )
+        patched = list(DEFAULT_USER_RULES) + [new_rule]
+
+        with patch(
+            "qwenpaw.governance.policy.DEFAULT_USER_RULES",
+            patched,
+        ):
+            p1 = load_governance_policy(str(policy_dir), ws)
+            assert any(r.match == "NewTool(*)" for r in p1.user_rules)
+            # User deletes the rule
+            p1.user_rules = [
+                r for r in p1.user_rules if r.match != "NewTool(*)"
+            ]
+            save_governance_policy(p1, str(policy_dir), ws)
+
+            p2 = load_governance_policy(str(policy_dir), ws)
+        assert not any(r.match == "NewTool(*)" for r in p2.user_rules)
+
     @pytest.mark.parametrize(
         "ws, cpd, label",
         [


### PR DESCRIPTION
## Description

Remove the `_MIGRATED_DEFAULT_USER_RULE_MATCHES` whitelist gate so that any newly added `DEFAULT_USER_RULES` entry is automatically merged into existing `policy.yaml` files on load. The `applied_migrations` mechanism still prevents user-deleted rules from being re-added.

This eliminates the need to manually update a whitelist every time a new tool is registered and given a default ALLOW rule.

**Related Issue:** N/A

**Security Considerations:** The `applied_migrations` field in `policy.yaml` ensures that once a default rule has been seen and subsequently deleted by the user, it will not be re-added on future loads. Builtin rules are completely unaffected.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Run governance policy tests:

```bash
pytest tests/unit/governance/test_policy.py -v
```

Two new test cases verify the change:
- `test_new_default_rule_auto_migrated`: A newly added `DEFAULT_USER_RULES` entry is auto-merged into an existing `policy.yaml` without needing a manual whitelist entry.
- `test_deleted_new_default_rule_stays_deleted`: Once a new default rule is migrated and then deleted by the user, it is not re-added on subsequent loads.

## Local Verification Evidence

```bash
pre-commit run --files src/qwenpaw/governance/policy.py tests/unit/governance/test_policy.py
# All passed

pytest tests/unit/governance/test_policy.py -v
# 70 passed in 1.26s
```

## Additional Notes

Changes are minimal and surgical:
1. Deleted `_MIGRATED_DEFAULT_USER_RULE_MATCHES` (the whitelist variable)
2. Removed the whitelist gate in `_merge_missing_default_user_rules`
3. Updated `applied_migrations` collection to use all `DEFAULT_USER_RULES` match strings instead of the deleted whitelist


Made with [Cursor](https://cursor.com)