### PR TITLE
fix(packaging): bundle AgentScope resource files

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -65,6 +65,15 @@ datas += collect_tree(CONSOLE_DIST, "qwenpaw/console")
 # Include reme package data files (configs, tool yamls, etc.)
 datas += collect_data_files("reme")
 datas += collect_data_files("whisper")
+datas += collect_data_files("agentscope")
+datas += collect_data_files(
+    "agentscope.tool._builtin._scripts",
+    include_py_files=True,
+)
+datas += collect_data_files(
+    "agentscope.workspace._mcp_gateway",
+    include_py_files=True,
+)
 
 # Collect package metadata for packages that use importlib.metadata at runtime.
 # Keep this allowlist in sync when adding runtime dependencies that query
@@ -146,6 +155,8 @@ a = Analysis(
         "modelscope",
         "modelscope.hub.api",
         "modelscope.hub.snapshot_download",
+        *collect_submodules("agentscope.tool._builtin._scripts"),
+        *collect_submodules("agentscope.workspace._mcp_gateway"),
         *collect_submodules("whisper"),
         *collect_submodules("chromadb"),
     ],


### PR DESCRIPTION
## Description

Bundle AgentScope runtime resources into the Tauri/PyInstaller backend so
packaged desktop builds can resolve the resource files AgentScope loads outside
normal Python imports.

This includes:

- `agentscope.tool._builtin._scripts` with `.py` files, so `Glob` can resolve
  and execute `_glob_helper.py` through `importlib.resources`.
- `agentscope.workspace._mcp_gateway` with `.py` files, matching the same
  resource-read pattern used by AgentScope sandbox workspaces.
- regular AgentScope package data, including Docker templates and
  model/embedding/TTS YAML cards.

The immediate reported failure is the missing `_scripts` subpackage. Any
agent/tool path that instantiates `Glob` could fail with
`ModuleNotFoundError: No module named 'agentscope.tool._builtin._scripts'`,
which also breaks ReMe background memory jobs when they walk an affected tool
set.

**Related Issue:** Fixes #5965, fixes #6012

**Security Considerations:** No auth, network, or secret handling changes. This
only includes existing AgentScope package resources in the desktop backend
bundle.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Targeted local checks:

```bash
.venv/Scripts/python.exe -c "import py_compile; py_compile.compile('scripts/pack-tauri/qwenpaw.spec', doraise=True)"
git diff --check HEAD^ HEAD
```

Hook collection check:

```text
collect_data_files("agentscope") -> 78 files
has Dockerfile.template -> True
has qwen-plus.yaml -> True
collect_data_files("agentscope.workspace._mcp_gateway", include_py_files=True) -> 3 files, includes _mcp_gateway_app.py
collect_data_files("agentscope.tool._builtin._scripts", include_py_files=True) -> 2 files, includes _glob_helper.py
collect_submodules("agentscope.workspace._mcp_gateway") -> 3 modules
```

Packaged Windows backend verification before this PR:

```text
- Runtime: qwenpaw-backend.exe
- agentscope-2.0.4 metadata present
- agentscope/tool/_builtin/_scripts/_glob_helper.py missing
- Probe result: ModuleNotFoundError: No module named
  'agentscope.tool._builtin._scripts'
```

Packaged Windows artifact verification after the initial fix:

```text
- agentscope/tool/_builtin/_scripts/__init__.py present
- agentscope/tool/_builtin/_scripts/_glob_helper.py present
- from agentscope.tool import Glob, Toolkit; Toolkit(tools=[Glob()]) succeeds
- /dream returns "Auto-dream Complete"
- /memorize 1 returns "Auto-memory Started"; summary task completes
- logs contain no ModuleNotFoundError / _scripts / Auto-memory Failed /
  auto-dream failed / Traceback for the verified paths
```

No verifier workflow changes are included in this commit.

## Additional Notes

`python-runtime` still does not contain AgentScope, but the running desktop
backend path is the PyInstaller `qwenpaw-backend` bundle. This PR fixes the
missing resources in that backend bundle, which is the direct cause of the
reported `_scripts` import error.
