### PR TITLE
ci: add CodeQL 2-shard security scan (dry-run) + Dependabot

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,20 @@
+name: "QwenPaw CodeQL Config"
+
+# Use security-extended for broader coverage than the default suite.
+# This adds rules for path traversal, SSRF, command injection,
+# hardcoded credentials, and unsafe deserialization.
+queries:
+  - uses: security-extended
+
+# Exclude test files — tests contain intentionally "unsafe" patterns
+# (mock subprocess, test injection vectors, etc.) that are not real
+# vulnerabilities.
+paths-ignore:
+  - tests/**
+  - e2e/**
+  - scripts/repro_*.py
+  - .claude/**
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+
+# Dependabot: automated dependency updates for Python + npm.
+# Checks weekly, opens PRs with changelogs and test results.
+# Only minor/patch updates by default — major versions need manual review.
+
+updates:
+  # Python backend dependencies (pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    allow:
+      - update-type: "version-update:semver-minor"
+      - update-type: "version-update:semver-patch"
+    commit-message:
+      prefix: "deps"
+      include: scope
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-dev-deps:
+        patterns:
+          - "pytest*"
+          - "black"
+          - "flake8"
+          - "pylint"
+          - "mypy"
+          - "pre-commit"
+          - "ruff"
+
+  # Console frontend dependencies (package.json)
+  - package-ecosystem: "npm"
+    directory: "/console"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    allow:
+      - update-type: "version-update:semver-minor"
+      - update-type: "version-update:semver-patch"
+    commit-message:
+      prefix: "deps"
+      include: scope
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,92 @@
+name: CodeQL
+
+# Security vulnerability scanning for QwenPaw.
+#
+# Phase 1 (current): dry-run mode — discoveries are reported as alerts
+# in the Security tab and as PR comments, but do NOT block merge.
+# Phase 2 (week 2): clean up findings, configure false-positive
+# suppression.
+# Phase 3 (week 3): remove continue-on-error to make CodeQL a required
+# check (maintainer must add it to branch protection).
+#
+# Two shards, one per language — each scans its own file set, so findings
+# are deduplicated across languages and no CI time is wasted on
+# re-scanning the same files:
+#   python      → all Python (src/qwenpaw/** + scripts/**), minus the
+#                  test/repro exclusions in codeql-config.yml
+#   typescript  → console/src/** (React/Vite frontend)
+# Tests are intentionally excluded (see codeql-config.yml paths-ignore):
+# they contain intentionally "unsafe" patterns that are not real
+# vulnerabilities.
+
+on:
+  pull_request:
+    branches: [main, master, dev, develop]
+    paths:
+      - 'src/**'
+      - 'console/src/**'
+      - 'scripts/**'
+      - 'tests/**'
+      - '.github/workflows/codeql.yml'
+      - '.github/codeql-config.yml'
+  push:
+    branches: [main]
+  schedule:
+    # Weekly full scan: Monday 03:17 UTC (off-peak)
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: python
+            languages: python
+            build-mode: none
+          - shard: typescript
+            languages: typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.languages }}
+          config-file: ./.github/codeql-config.yml
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        id: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: ${{ matrix.shard }}
+        # Phase 1: dry-run — don't fail the workflow on findings.
+        # Phase 3: remove this line to enable blocking.
+        continue-on-error: true
+
+      - name: Upload CodeQL results summary
+        if: always()
+        run: |
+          echo "### CodeQL Scan: ${{ matrix.shard }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Status:** ${{ steps.analyze.outcome }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Language:** ${{ matrix.languages }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Mode:** dry-run (non-blocking)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View findings in the [Security tab](https://github.com/${{ github.repository }}/security/code-scanning)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

Add CodeQL security scanning (2 shards, one per language, dry-run mode) and Dependabot automated dependency updates. QwenPaw currently has **zero security scanning** — no CodeQL, no Bandit, no SAST. This is the last piece of the CI quality stack.

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Evidence

QwenPaw manages API keys, IM credentials, shell execution, and file system access. The #5090 rm bypass was found by manual review — CodeQL's `py/command-line-injection` rule can catch this class of bug automatically in CI.

CI verification (head `062f8ef3`):
- ✅ Pre-commit Checks (incl. actionlint)
- ✅ CodeQL (python) · 1m46s
- ✅ CodeQL (typescript) · 1m17s
- ✅ Real behavior proof
- ✅ Console + website format checks
- ✅ PR Spam Gate

```bash
CodeQL (python)      pass  1m46s
CodeQL (typescript)  pass  1m17s
```

## Proposed Solution

### 1. CodeQL workflow (`.github/workflows/codeql.yml`)

Two shards, one per language — each scans a distinct file set, so findings are deduplicated across languages and no CI time is wasted re-scanning the same files:

| Shard | Language | Scope | Purpose |
|---|---|---|---|
| python | Python | `src/qwenpaw/**` + `scripts/**` (paths-ignore exempts tests) | Core source + scripts |
| typescript | TypeScript | `console/src/**` | React/Vite frontend |

- **Query suite**: `security-extended` (covers path traversal, SSRF, command injection, hardcoded credentials, unsafe deserialization)
- **Phase 1 (current)**: `continue-on-error: true` at step level — dry-run mode, findings reported but don't block merge
- **Phase 2 (week 2)**: clean up findings, suppress false-positives
- **Phase 3 (week 3)**: remove `continue-on-error` to enable blocking
- **Weekly schedule**: full reposcan every Monday 03:17 UTC

### 2. CodeQL config (`.github/codeql-config.yml`)

- `security-extended` query suite
- `paths-ignore` for `tests/**`, `e2e/**`, repro scripts, and frontend spec files (intentionally "unsafe" patterns that aren't real vulns)

### 3. Dependabot (`.github/dependabot.yml`)

Three ecosystems:
| Ecosystem | Directory | Schedule | Scope |
|---|---|---|---|
| pip | `/` | weekly Monday | minor + patch only |
| npm | `/console` | weekly Monday | minor + patch only |
| github-actions | `/` | weekly Monday | all updates |

- Major version updates excluded (require manual review)
- Python dev dependencies (pytest, black, flake8, pylint, mypy) grouped into one PR

## Review feedback addressed (@yutai78786)

1. **Original 4 shards scanned the same file set** — `codeql-config.yml` was shared with only `paths-ignore`, so the three Python shards scanned identical files (~3 duplicate findings + redundant CI). Collapsed to 1 python + 1 typescript shard.
2. **`python-tests` contradicted `paths-ignore: tests/**`** — the shard existed to scan `tests/` but the config excluded it, scanning almost nothing. Removed the shard; tests stay consistently excluded.
3. **Trailing newlines** — added to all three new files.

Also fixed an actionlint failure that blocked `Pre-commit Checks`: `${{ job.steps.analyze.outcome }}` → `${{ steps.analyze.outcome }}` + added `id: analyze` (the `job` context has no `steps` property; latent bug surfaced by a newer actionlint).

## Alternatives Considered

- **Bandit only** (Python SAST) — lighter but doesn't cover TypeScript/React frontend
- **Semgrep** — more flexible rules but requires external service setup
- **Manual security review only** — doesn't scale, #5090 proved it's insufficient

## Additional Context

This PR is part of the CI quality stack:
1. pre-commit (format/type) — already exists
2. pr-spam-gate — already exists (PR #5844 wired into tests.yml)
3. real-behavior-proof (PR body quality) — merged (#5844)
4. Unit/Contract/Integrated tests — already exist
5. **CodeQL (security)** — this PR, last piece

## Willing to Contribute

- [x] I am willing to open a PR for this feature (after discussion).
