### PR TITLE
feat(auth): implement trusted proxy verification and enhance client IP resolution

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -33,7 +33,11 @@ from ..utils.logging import (
     LOG_FILE_PATH,
 )
 from ..utils.system_info import summarize_python_environment
-from .auth import AuthMiddleware, auto_register_from_env
+from .auth import (
+    AuthMiddleware,
+    auto_register_from_env,
+    check_proxy_config_sanity,
+)
 from .routers import router as api_router, create_agent_scoped_router
 from .routers.agent_scoped import AgentContextMiddleware
 from .routers.approval import router as approval_router
@@ -179,6 +183,7 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
         raise RuntimeError(f"{message} Original error: {exc}") from exc
 
     auto_register_from_env()
+    check_proxy_config_sanity()
 
     try:
         from ..utils.telemetry import (

--- a/src/qwenpaw/app/auth.py
+++ b/src/qwenpaw/app/auth.py
@@ -573,7 +573,7 @@ _LOOPBACK = frozenset({"127.0.0.1", "::1"})
 _BRACKETED = re.compile(r"^\[([^\]]+)\](?::\d+)?$")
 _V4_PORT = re.compile(r"^(\d{1,3}(?:\.\d{1,3}){3}):\d+$")
 
-# Rate-limit the untrusted-proxy-header warning (once per IP)
+_MAX_WARN_IPS = 1024
 _warned_untrusted_ips: set[str] = set()
 
 
@@ -621,7 +621,7 @@ _auth_config_cache: tuple = (0, None, [])
 
 
 def _get_config_cached():
-    """Return config with mtime-based cache (~1µs stat vs ~1ms read)."""
+    """Return (config, trusted_networks) with mtime-based cache."""
     global _auth_config_cache  # noqa: PLW0603
     from ..config import load_config
     from ..config.utils import get_config_path
@@ -654,7 +654,11 @@ def _resolve_client_ip(request: Request) -> str:
         has_proxy_hdr = request.headers.get(
             "x-forwarded-for",
         ) or request.headers.get("x-real-ip")
-        if has_proxy_hdr and direct_ip not in _warned_untrusted_ips:
+        if (
+            has_proxy_hdr
+            and direct_ip not in _warned_untrusted_ips
+            and len(_warned_untrusted_ips) < _MAX_WARN_IPS
+        ):
             _warned_untrusted_ips.add(direct_ip)
             logger.warning(
                 "Ignoring proxy headers from untrusted source"
@@ -765,9 +769,11 @@ def check_proxy_config_sanity() -> None:
     except (OSError, ValueError):
         return
     sec = cfg.security
-    if sec.allow_no_auth_hosts and not sec.trusted_proxies:
+    has_non_loopback = any(h not in _LOOPBACK for h in sec.allow_no_auth_hosts)
+    if has_non_loopback and not sec.trusted_proxies:
         logger.warning(
-            "allow_no_auth_hosts is set but trusted_proxies is"
-            " empty. If behind a reverse proxy, add proxy IPs"
-            " to security.trusted_proxies.",
+            "allow_no_auth_hosts contains non-loopback entries"
+            " but trusted_proxies is empty. If behind a reverse"
+            " proxy, add proxy IPs to"
+            " security.trusted_proxies.",
         )

--- a/src/qwenpaw/app/auth.py
+++ b/src/qwenpaw/app/auth.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import os
+import re
 import secrets
 import time
 from typing import Optional
@@ -564,32 +566,62 @@ def revoke_all_tokens() -> bool:
 
 
 # ---------------------------------------------------------------------------
-# FastAPI middleware
+# FastAPI middleware — client IP resolution with trusted proxy verification
 # ---------------------------------------------------------------------------
 
+_LOOPBACK = frozenset({"127.0.0.1", "::1"})
+_BRACKETED = re.compile(r"^\[([^\]]+)\](?::\d+)?$")
+_V4_PORT = re.compile(r"^(\d{1,3}(?:\.\d{1,3}){3}):\d+$")
 
-def _resolve_client_ip(request: Request) -> str:
-    """Return the real client IP, respecting reverse-proxy headers."""
-    forwarded_for = request.headers.get("x-forwarded-for", "")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
-    real_ip = request.headers.get("x-real-ip", "")
-    if real_ip:
-        return real_ip.strip()
-    return request.client.host if request.client else ""
+# Rate-limit the untrusted-proxy-header warning (once per IP)
+_warned_untrusted_ips: set[str] = set()
 
 
-# Make this function available at module level so it can be
-# imported from routers
-resolve_client_ip = _resolve_client_ip
+def _normalize_ip(raw: str) -> str | None:
+    """Strip brackets, port, zone-id and validate. None on failure."""
+    if not raw:
+        return None
+    s = raw.strip()
+    m = _BRACKETED.match(s) or _V4_PORT.match(s)
+    if m:
+        s = m.group(1)
+    if "%" in s:
+        s = s.split("%", 1)[0]
+    try:
+        return str(ipaddress.ip_address(s))
+    except ValueError:
+        return None
+
+
+def _parse_networks(entries: list[str]) -> list:
+    """Parse CIDR/IP strings into network objects."""
+    nets = []
+    for entry in entries:
+        try:
+            nets.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            continue
+    return nets
+
+
+def _ip_in_networks(ip_str: str, networks: list) -> bool:
+    """Check if a normalized IP string falls within any network."""
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    for net in networks:
+        if addr.version == net.version and addr in net:
+            return True
+    return False
 
 
 # Cached config for hot-path auth checks (avoids disk read per request)
-_auth_config_cache: tuple = (0, None)  # (mtime_ns, config)
+_auth_config_cache: tuple = (0, None, [])
 
 
 def _get_config_cached():
-    """Return config with mtime-based cache (stat is ~1us vs read ~1ms)."""
+    """Return config with mtime-based cache (~1µs stat vs ~1ms read)."""
     global _auth_config_cache  # noqa: PLW0603
     from ..config import load_config
     from ..config.utils import get_config_path
@@ -600,26 +632,67 @@ def _get_config_cached():
     except OSError:
         mtime_ns = 0
     if mtime_ns != _auth_config_cache[0] or _auth_config_cache[1] is None:
-        _auth_config_cache = (mtime_ns, load_config())
-    return _auth_config_cache[1]
+        cfg = load_config()
+        nets = _parse_networks(cfg.security.trusted_proxies)
+        _auth_config_cache = (mtime_ns, cfg, nets)
+    return _auth_config_cache[1], _auth_config_cache[2]
+
+
+def _resolve_client_ip(request: Request) -> str:
+    """Return the real client IP.
+
+    Only trusts proxy headers when the direct TCP peer is in
+    trusted_proxies. XFF is parsed right-to-left, skipping
+    trusted IPs.
+    """
+    direct_raw = request.client.host if request.client else ""
+    direct_ip = _normalize_ip(direct_raw) or direct_raw
+
+    _cfg, networks = _get_config_cached()
+    if not networks or not _ip_in_networks(direct_ip, networks):
+        # Log once per untrusted source to avoid flooding
+        has_proxy_hdr = request.headers.get(
+            "x-forwarded-for",
+        ) or request.headers.get("x-real-ip")
+        if has_proxy_hdr and direct_ip not in _warned_untrusted_ips:
+            _warned_untrusted_ips.add(direct_ip)
+            logger.warning(
+                "Ignoring proxy headers from untrusted source"
+                " %s (add to security.trusted_proxies if"
+                " legitimate)",
+                direct_ip,
+            )
+        return direct_ip
+
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        for token in reversed(xff.split(",")):
+            norm = _normalize_ip(token)
+            if norm is None:
+                break
+            if not _ip_in_networks(norm, networks):
+                return norm
+
+    real_ip = _normalize_ip(
+        request.headers.get("x-real-ip", ""),
+    )
+    return real_ip or direct_ip
+
+
+resolve_client_ip = _resolve_client_ip
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
     """Middleware that checks Bearer token on protected routes."""
 
-    async def dispatch(
-        self,
-        request: Request,
-        call_next,
-    ) -> Response:
-        """Check Bearer token on protected API routes; skip public paths."""
+    async def dispatch(self, request: Request, call_next):
         if self._should_skip_auth(request):
             return await call_next(request)
 
         token = self._extract_token(request)
         if not token:
             return Response(
-                content=json.dumps({"detail": "Not authenticated"}),
+                content='{"detail":"Not authenticated"}',
                 status_code=401,
                 media_type="application/json",
             )
@@ -627,9 +700,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         user = verify_token(token)
         if user is None:
             return Response(
-                content=json.dumps(
-                    {"detail": "Invalid or expired token"},
-                ),
+                content='{"detail":"Invalid or expired token"}',
                 status_code=401,
                 media_type="application/json",
             )
@@ -638,41 +709,65 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
     @staticmethod
-    def _should_skip_auth(request: Request) -> bool:
-        """Return ``True`` when the request does not require auth."""
+    def _should_skip_auth(  # pylint: disable=too-many-return-statements
+        request: Request,
+    ) -> bool:
         if not is_auth_enabled() or not has_registered_users():
             return True
 
         path = request.url.path
-
-        if request.method == "OPTIONS":
-            return True
-
-        if path in _PUBLIC_PATHS or any(
-            path.startswith(p) for p in _PUBLIC_PREFIXES
+        if (
+            request.method == "OPTIONS"
+            or path in _PUBLIC_PATHS
+            or any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+            or not path.startswith("/api/")
         ):
             return True
 
-        # Only protect /api/ routes
-        if not path.startswith("/api/"):
-            return True
+        cfg, _ = _get_config_cached()
+        allowed = cfg.security.allow_no_auth_hosts
+        client_ip = resolve_client_ip(request)
+        norm = _normalize_ip(client_ip) or client_ip
+        if norm not in allowed:
+            return False
 
-        # Check if client host is in allow_no_auth_hosts whitelist
-        client_host = resolve_client_ip(request)
-        config = _get_config_cached()
-        allowed_hosts = config.security.allow_no_auth_hosts
-        return client_host in allowed_hosts
+        # Defense-in-depth: loopback whitelist requires
+        # direct TCP peer also be loopback.
+        if norm in _LOOPBACK:
+            peer = _normalize_ip(
+                request.client.host if request.client else "",
+            )
+            if peer not in _LOOPBACK:
+                logger.warning(
+                    "Auth skip blocked: client_ip=%s but"
+                    " direct peer %s is not loopback",
+                    norm,
+                    peer,
+                )
+                return False
+        return True
 
     @staticmethod
     def _extract_token(request: Request) -> Optional[str]:
-        """Extract Bearer token from header or WebSocket query param."""
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            return auth_header[7:]
-        if "upgrade" in request.headers.get("connection", "").lower():
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            return auth[7:]
+        conn = request.headers.get("connection", "")
+        if "upgrade" in conn.lower():
             return request.query_params.get("token")
+        return request.query_params.get("token") or None
 
-        token = request.query_params.get("token")
-        if token:
-            return token
-        return None
+
+def check_proxy_config_sanity() -> None:
+    """Log a warning at startup if proxy config looks suspect."""
+    try:
+        cfg, _ = _get_config_cached()
+    except (OSError, ValueError):
+        return
+    sec = cfg.security
+    if sec.allow_no_auth_hosts and not sec.trusted_proxies:
+        logger.warning(
+            "allow_no_auth_hosts is set but trusted_proxies is"
+            " empty. If behind a reverse proxy, add proxy IPs"
+            " to security.trusted_proxies.",
+        )

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2110,14 +2110,18 @@ class SecurityConfig(BaseModel):
         import ipaddress as _ipaddress
 
         _DENY = {"0.0.0.0/0", "::/0", "0.0.0.0", "::"}
+        cleaned = []
         for entry in v:
+            entry = entry.strip()
             if entry in _DENY:
                 raise ValueError(
-                    f"trusted_proxies must not contain '{entry}' "
-                    f"(equivalent to disabling the security fix)",
+                    f"trusted_proxies must not contain"
+                    f" '{entry}' (equivalent to disabling"
+                    f" the security fix)",
                 )
-            _ipaddress.ip_network(entry, strict=False)
-        return v
+            net = _ipaddress.ip_network(entry, strict=False)
+            cleaned.append(str(net))
+        return cleaned
 
 
 class Config(BaseModel):

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2094,6 +2094,30 @@ class SecurityConfig(BaseModel):
             "WARNING: Only add trusted IP addresses to this list."
         ),
     )
+    trusted_proxies: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Reverse proxy IP/CIDR list. X-Forwarded-For / X-Real-IP "
+            "headers are only trusted when the direct TCP peer matches "
+            "an entry in this list. Empty (default) = never trust proxy "
+            "headers. Example: ['127.0.0.1', '172.17.0.0/16']"
+        ),
+    )
+
+    @field_validator("trusted_proxies")
+    @classmethod
+    def _validate_trusted_proxies(cls, v: List[str]) -> List[str]:
+        import ipaddress as _ipaddress
+
+        _DENY = {"0.0.0.0/0", "::/0", "0.0.0.0", "::"}
+        for entry in v:
+            if entry in _DENY:
+                raise ValueError(
+                    f"trusted_proxies must not contain '{entry}' "
+                    f"(equivalent to disabling the security fix)",
+                )
+            _ipaddress.ip_network(entry, strict=False)
+        return v
 
 
 class Config(BaseModel):

--- a/tests/unit/app/auth/test_client_ip.py
+++ b/tests/unit/app/auth/test_client_ip.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the auth bypass fix (NVDB-TEMP-CAIVD-2026671557).
+
+Validates that _resolve_client_ip and _should_skip_auth correctly handle
+trusted proxy verification and XFF right-to-left parsing.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qwenpaw.app.auth import (
+    _ip_in_networks,
+    _normalize_ip,
+    _parse_networks,
+    _resolve_client_ip,
+    _warned_untrusted_ips,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_warn_state():
+    """Reset per-IP warning dedup between tests."""
+    _warned_untrusted_ips.clear()
+    yield
+    _warned_untrusted_ips.clear()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_ip
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeIp:
+    def test_plain_ipv4(self):
+        assert _normalize_ip("1.2.3.4") == "1.2.3.4"
+
+    def test_ipv4_with_port(self):
+        assert _normalize_ip("1.2.3.4:8080") == "1.2.3.4"
+
+    def test_plain_ipv6(self):
+        assert _normalize_ip("::1") == "::1"
+
+    def test_bracketed_ipv6_with_port(self):
+        assert _normalize_ip("[::1]:443") == "::1"
+
+    def test_ipv6_with_zone_id(self):
+        assert _normalize_ip("fe80::1%eth0") == "fe80::1"
+
+    def test_empty_string(self):
+        assert _normalize_ip("") is None
+
+    def test_garbage(self):
+        assert _normalize_ip("not-an-ip") is None
+
+
+# ---------------------------------------------------------------------------
+# _ip_in_networks
+# ---------------------------------------------------------------------------
+
+
+class TestIpInNetworks:
+    def test_exact_match(self):
+        nets = _parse_networks(["10.0.0.1"])
+        assert _ip_in_networks("10.0.0.1", nets) is True
+
+    def test_no_match(self):
+        nets = _parse_networks(["10.0.0.1"])
+        assert _ip_in_networks("1.2.3.4", nets) is False
+
+    def test_cidr_match(self):
+        nets = _parse_networks(["172.17.0.0/16"])
+        assert _ip_in_networks("172.17.0.5", nets) is True
+
+    def test_cidr_no_match(self):
+        nets = _parse_networks(["172.17.0.0/16"])
+        assert _ip_in_networks("192.168.1.1", nets) is False
+
+    def test_ipv6_cidr(self):
+        nets = _parse_networks(["fd00::/64"])
+        assert _ip_in_networks("fd00::5", nets) is True
+
+    def test_invalid_ip(self):
+        nets = _parse_networks(["10.0.0.0/8"])
+        assert _ip_in_networks("garbage", nets) is False
+
+    def test_empty_networks(self):
+        assert _ip_in_networks("10.0.0.1", []) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_client_ip
+# ---------------------------------------------------------------------------
+
+
+def _make_request(
+    client_host: str,
+    xff: str = "",
+    real_ip: str = "",
+) -> MagicMock:
+    """Create a mock Request with specified client and headers."""
+    request = MagicMock()
+    request.client = MagicMock()
+    request.client.host = client_host
+
+    headers = {}
+    if xff:
+        headers["x-forwarded-for"] = xff
+    if real_ip:
+        headers["x-real-ip"] = real_ip
+    request.headers = headers
+    return request
+
+
+def _make_config_return(trusted_proxies=None, allow_no_auth_hosts=None):
+    """Build the (config, networks) tuple that _get_config_cached returns."""
+    config = MagicMock()
+    config.security.trusted_proxies = trusted_proxies or []
+    config.security.allow_no_auth_hosts = allow_no_auth_hosts or [
+        "127.0.0.1",
+        "::1",
+    ]
+    networks = _parse_networks(config.security.trusted_proxies)
+    return (config, networks)
+
+
+class TestResolveClientIp:
+    """Core vulnerability regression tests."""
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_vuln_regression_xff_spoofed_no_trusted_proxies(self, mock_cfg):
+        """CVE scenario: attacker spoofs XFF, no trusted_proxies configured."""
+        mock_cfg.return_value = _make_config_return(trusted_proxies=[])
+        req = _make_request("1.2.3.4", xff="127.0.0.1")
+        assert _resolve_client_ip(req) == "1.2.3.4"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_vuln_regression_real_ip_spoofed_no_trusted_proxies(
+        self,
+        mock_cfg,
+    ):
+        """Attacker spoofs X-Real-IP, no trusted_proxies configured."""
+        mock_cfg.return_value = _make_config_return(trusted_proxies=[])
+        req = _make_request("1.2.3.4", real_ip="127.0.0.1")
+        assert _resolve_client_ip(req) == "1.2.3.4"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_single_trusted_proxy(self, mock_cfg):
+        """Legitimate single-tier proxy: returns real client IP from XFF."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1"],
+        )
+        req = _make_request("10.0.0.1", xff="8.8.8.8")
+        assert _resolve_client_ip(req) == "8.8.8.8"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_attacker_prepends_loopback_in_xff(self, mock_cfg):
+        """Attacker prepends 127.0.0.1 in XFF; right-to-left skips trusted."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1"],
+        )
+        req = _make_request("10.0.0.1", xff="127.0.0.1, 8.8.8.8")
+        assert _resolve_client_ip(req) == "8.8.8.8"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_all_xff_are_trusted_falls_back_to_direct(self, mock_cfg):
+        """When all XFF entries are trusted proxies, fall back to direct_ip."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1", "10.0.0.2"],
+        )
+        req = _make_request("10.0.0.1", xff="10.0.0.2")
+        # All XFF are trusted → falls through to X-Real-IP or direct_ip
+        assert _resolve_client_ip(req) == "10.0.0.1"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_cidr_trusted_proxy(self, mock_cfg):
+        """CIDR matching for trusted proxy (Docker/K8s scenarios)."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["172.17.0.0/16"],
+        )
+        req = _make_request("172.17.0.5", xff="8.8.8.8")
+        assert _resolve_client_ip(req) == "8.8.8.8"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_direct_not_trusted_ignores_xff(self, mock_cfg):
+        """Direct connection NOT in trusted_proxies: XFF is ignored."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1"],
+        )
+        req = _make_request("1.2.3.4", xff="127.0.0.1")
+        assert _resolve_client_ip(req) == "1.2.3.4"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_unparseable_xff_token_stops_parsing(self, mock_cfg):
+        """Junk tokens in XFF abort parsing to prevent injection."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1"],
+        )
+        req = _make_request(
+            "10.0.0.1",
+            xff="127.0.0.1, junk_token, 10.0.0.1",
+        )
+        # Reversed: 10.0.0.1 (trusted, skip) → junk_token (None → break)
+        # Falls through to X-Real-IP or direct_ip
+        assert _resolve_client_ip(req) == "10.0.0.1"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_x_real_ip_used_when_xff_empty(self, mock_cfg):
+        """X-Real-IP is used when no XFF and direct is trusted."""
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1"],
+        )
+        req = _make_request("10.0.0.1", real_ip="203.0.113.7")
+        assert _resolve_client_ip(req) == "203.0.113.7"
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    def test_localhost_direct_no_proxy_headers(self, mock_cfg):
+        """Local CLI: direct loopback, no proxy headers → returns 127.0.0.1."""
+        mock_cfg.return_value = _make_config_return(trusted_proxies=[])
+        req = _make_request("127.0.0.1")
+        assert _resolve_client_ip(req) == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# _should_skip_auth defense-in-depth
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSkipAuthDefenseInDepth:
+    """Verify loopback whitelist requires direct peer also be loopback."""
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    @patch("qwenpaw.app.auth.is_auth_enabled", return_value=True)
+    @patch("qwenpaw.app.auth.has_registered_users", return_value=True)
+    def test_loopback_direct_passes(self, _a, _b, mock_cfg):
+        from qwenpaw.app.auth import AuthMiddleware  # noqa: F811
+
+        mock_cfg.return_value = _make_config_return()
+        req = _make_request("127.0.0.1")
+        req.url = MagicMock()
+        req.url.path = "/api/protected"
+        req.method = "GET"
+        # pylint: disable=protected-access
+        assert AuthMiddleware._should_skip_auth(req) is True
+
+    @patch("qwenpaw.app.auth._get_config_cached")
+    @patch("qwenpaw.app.auth.is_auth_enabled", return_value=True)
+    @patch("qwenpaw.app.auth.has_registered_users", return_value=True)
+    def test_loopback_via_proxy_blocked(self, _a, _b, mock_cfg):
+        """test resolved IP=127.0.0.1 but direct peer is external."""
+        from qwenpaw.app.auth import AuthMiddleware  # noqa: F811
+
+        mock_cfg.return_value = _make_config_return(
+            trusted_proxies=["10.0.0.1"],
+            allow_no_auth_hosts=["127.0.0.1", "::1"],
+        )
+        # Simulate: trusted proxy forwards XFF=127.0.0.1
+        # _resolve_client_ip would return 127.0.0.1 from XFF
+        # But _should_skip_auth checks direct peer
+        req = _make_request("10.0.0.1", xff="127.0.0.1")
+        req.url = MagicMock()
+        req.url.path = "/api/protected"
+        req.method = "GET"
+        # pylint: disable=protected-access
+        assert AuthMiddleware._should_skip_auth(req) is False


### PR DESCRIPTION
…P resolution

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
