### PR TITLE
feat(governance): allow gh CLI commands

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -383,7 +383,6 @@ DEFAULT_SANDBOX_DENY_PATHS: List[str] = [
     # pip / PyPI API tokens
     "~/.pypirc",
     # Other common sensitive configs
-    "~/.config/gh",  # GitHub CLI
     "~/.config/nix",  # Nix config
     "~/.netrc",  # generic login credentials
 ]
@@ -515,6 +514,12 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         match="*(CODING_PROJECT_DIR/**)",
         action=GovernanceAction.ALLOW,
         reason="Coding project dir",
+    ),
+    # ── GitHub CLI ──
+    GovernanceRule(
+        match="Bash(gh *)",
+        action=GovernanceAction.ALLOW,
+        reason="GitHub CLI operations",
     ),
 ]
 

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -530,7 +530,8 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         action=GovernanceAction.DENY,
         reason="Destructive GitHub API calls prohibited",
     ),
-    # ALLOW all other gh operations (agent needs write access for PR/issue management)
+    # ALLOW all other gh operations
+    # (agent needs write access for PR/issue management)
     GovernanceRule(
         match="Bash(gh)",
         action=GovernanceAction.ALLOW,
@@ -697,8 +698,7 @@ class GovernancePolicy:
                 if action == GovernanceAction.ALLOW and is_strict:
                     return GovernanceDecision(
                         action=GovernanceAction.ASK,
-                        reason="STRICT mode: all tool calls "
-                        "require approval",
+                        reason="STRICT mode: all tool calls require approval",
                         findings=findings or None,
                         source="STRICT mode",
                     )
@@ -718,8 +718,7 @@ class GovernancePolicy:
                 if action == GovernanceAction.ALLOW and is_strict:
                     return GovernanceDecision(
                         action=GovernanceAction.ASK,
-                        reason="STRICT mode: all tool calls "
-                        "require approval",
+                        reason="STRICT mode: all tool calls require approval",
                         findings=findings or None,
                         source="STRICT mode",
                     )
@@ -736,7 +735,7 @@ class GovernancePolicy:
             if is_strict:
                 return GovernanceDecision(
                     action=GovernanceAction.ASK,
-                    reason="STRICT mode: all tool calls " "require approval",
+                    reason="STRICT mode: all tool calls require approval",
                     findings=findings or None,
                     source="STRICT mode",
                 )

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -517,6 +517,11 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
     ),
     # ── GitHub CLI ──
     GovernanceRule(
+        match="Bash(gh)",
+        action=GovernanceAction.ALLOW,
+        reason="GitHub CLI operations",
+    ),
+    GovernanceRule(
         match="Bash(gh *)",
         action=GovernanceAction.ALLOW,
         reason="GitHub CLI operations",

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -383,6 +383,9 @@ DEFAULT_SANDBOX_DENY_PATHS: List[str] = [
     # pip / PyPI API tokens
     "~/.pypirc",
     # Other common sensitive configs
+    # NOTE: ~/.config/gh intentionally excluded — gh CLI needs to read its
+    # auth config (hosts.yml) for operations. The gh ALLOW rule + DENY for
+    # destructive subcommands provides the safety boundary instead.
     "~/.config/nix",  # Nix config
     "~/.netrc",  # generic login credentials
 ]
@@ -516,6 +519,18 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         reason="Coding project dir",
     ),
     # ── GitHub CLI ──
+    # DENY destructive operations first (first-match-wins)
+    GovernanceRule(
+        match="Bash(gh repo delete *)",
+        action=GovernanceAction.DENY,
+        reason="Repository deletion prohibited",
+    ),
+    GovernanceRule(
+        match="Bash(gh api -X DELETE *)",
+        action=GovernanceAction.DENY,
+        reason="Destructive GitHub API calls prohibited",
+    ),
+    # ALLOW all other gh operations (agent needs write access for PR/issue management)
     GovernanceRule(
         match="Bash(gh)",
         action=GovernanceAction.ALLOW,


### PR DESCRIPTION
## Description

Add a default ALLOW rule for Bash(gh *) so that GitHub CLI operations (gh issue, gh pr, gh api, etc.) no longer trigger approval prompts.

Also remove ~/.config/gh from DEFAULT_SANDBOX_DENY_PATHS so that the gh CLI can read its own auth config (hosts.yml) when running inside the sandbox.

The new rule will be auto-synced into existing user policy.yaml files via the mechanism introduced in #6025.

Related Issue: #6023 (item 5)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
