### PR TITLE
fix: filter tool results with same id

### DIFF
--- a/src/qwenpaw/agents/utils/tool_message_utils.py
+++ b/src/qwenpaw/agents/utils/tool_message_utils.py
@@ -189,27 +189,48 @@ def _remove_unpaired_tool_messages(msgs: list) -> list:
 
 
 def _dedup_tool_blocks(msgs: list) -> list:
-    """Remove duplicate tool_use blocks (same ID) within a single message."""
+    """Remove duplicate tool_use/tool_result blocks sharing the same ID.
+
+    For both tool_call and tool_result blocks, if multiple blocks across
+    all messages share the same ID, only the first occurrence is kept.
+    Messages whose content becomes empty after dedup are dropped entirely.
+    """
     changed = False
     result: list = []
+    seen_call_ids: set[str] = set()
+    seen_result_ids: set[str] = set()
     for msg in msgs:
         if not isinstance(msg.content, list):
             result.append(msg)
             continue
-        seen_ids: set[str] = set()
         new_blocks: list = []
         deduped = False
         for block in msg.content:
-            if _is_tool_call(block) and _block_attr(block, "id"):
-                bid = _block_attr(block, "id")
-                if bid in seen_ids:
+            bid = _block_attr(block, "id")
+            if bid and _is_tool_call(block):
+                if bid in seen_call_ids:
+                    logger.debug(
+                        "Dropping duplicate tool_call block id=%s",
+                        bid,
+                    )
                     deduped = True
                     continue
-                seen_ids.add(bid)
+                seen_call_ids.add(bid)
+            elif bid and _is_tool_result(block):
+                if bid in seen_result_ids:
+                    logger.debug(
+                        "Dropping duplicate tool_result block id=%s",
+                        bid,
+                    )
+                    deduped = True
+                    continue
+                seen_result_ids.add(bid)
             new_blocks.append(block)
         if deduped:
-            msg.content = new_blocks
             changed = True
+            if not new_blocks:
+                continue
+            msg.content = new_blocks
         result.append(msg)
     return result if changed else msgs
 


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
