### PR TITLE
feat(website): add AgentScope Platform entry in nav and hero CTA

### DIFF
--- a/website/src/components/Icon/AgentScopePlatformIcon.tsx
+++ b/website/src/components/Icon/AgentScopePlatformIcon.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useId } from "react";
 import type { IconProps } from "./types";
 
 export const AgentScopePlatformIcon: React.FC<IconProps> = ({
   size = 18,
   className = "",
 }) => {
+  const uid = useId();
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -17,11 +18,11 @@ export const AgentScopePlatformIcon: React.FC<IconProps> = ({
       aria-hidden
     >
       <defs>
-        <linearGradient x1="0" y1="0" x2="1.006" y2="0.023" id="as_p_g0">
+        <linearGradient x1="0" y1="0" x2="1.006" y2="0.023" id={`${uid}-0`}>
           <stop offset="0%" stopColor="#FEAF30" />
           <stop offset="100%" stopColor="#F74B0E" />
         </linearGradient>
-        <linearGradient x1="0" y1="0.255" x2="0.888" y2="0.758" id="as_p_g1">
+        <linearGradient x1="0" y1="0.255" x2="0.888" y2="0.758" id={`${uid}-1`}>
           <stop offset="0%" stopColor="#F53807" />
           <stop offset="100%" stopColor="#FDAE2F" />
         </linearGradient>
@@ -30,7 +31,7 @@ export const AgentScopePlatformIcon: React.FC<IconProps> = ({
           y1="0.316"
           x2="0.433"
           y2="0.397"
-          id="as_p_g2"
+          id={`${uid}-2`}
         >
           <stop offset="0%" stopColor="#FA410C" />
           <stop offset="100%" stopColor="#FDB52D" />
@@ -40,7 +41,7 @@ export const AgentScopePlatformIcon: React.FC<IconProps> = ({
           y1="0.338"
           x2="-0.05"
           y2="1.58"
-          id="as_p_g3"
+          id={`${uid}-3`}
         >
           <stop offset="0%" stopColor="#FDAE2C" />
           <stop offset="100%" stopColor="#F8410E" />
@@ -48,7 +49,7 @@ export const AgentScopePlatformIcon: React.FC<IconProps> = ({
       </defs>
       <path
         d="M3.489,3.356L1.521,0L11.359,0C12.288,0.142,13.12,0.506,13.673,1.042L3.489,3.356Z"
-        fill="url(#as_p_g0)"
+        fill={`url(#${uid}-0)`}
       />
       <path
         d={
@@ -74,16 +75,16 @@ export const AgentScopePlatformIcon: React.FC<IconProps> = ({
           "Q11.114,3.344,11.042,3.344Q10.97,3.344,10.897,3.351Z"
         }
         fillRule="evenodd"
-        fill="url(#as_p_g1)"
+        fill={`url(#${uid}-1)`}
       />
       <path
         d="M7.365,4.072L10.854,14.149L14.731,14.149L11.219,4.072L7.365,4.072Z"
-        fill="url(#as_p_g2)"
+        fill={`url(#${uid}-2)`}
         transform="matrix(-1,0,0,1,14.73,0)"
       />
       <path
         d="M3.512,4.072L7.366,4.072L3.875,14.149L3.512,4.072Z"
-        fill="url(#as_p_g3)"
+        fill={`url(#${uid}-3)`}
       />
     </svg>
   );

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -5,7 +5,9 @@ import { QwenpawMascot } from "./QwenpawMascot";
 import { useTranslation } from "react-i18next";
 import { useSiteLanguage } from "@/i18n/SiteLanguageContext";
 import { useSiteConfig } from "@/config-context";
-import { GitHubIcon, BlogIcon, NoteIcon } from "./Icon";
+import { GitHubIcon, BlogIcon, NoteIcon, AgentScopePlatformIcon } from "./Icon";
+
+const AGENTSCOPE_PLATFORM_URL = "https://platform.agentscope.io/";
 
 const AGENTSCOPE_LOGO_SIZE = 22;
 
@@ -110,6 +112,17 @@ export function Nav() {
             <span>{t("nav.github")}</span>
           </a>
           <a
+            href={AGENTSCOPE_PLATFORM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={navLinkOrangeClass}
+            title={t("nav.platformTitle")}
+            aria-label={t("nav.platformTitle")}
+          >
+            <AgentScopePlatformIcon size={18} />
+            <span>{t("nav.platform")}</span>
+          </a>
+          <a
             href="https://agentscope.io/"
             target="_blank"
             rel="noopener noreferrer"
@@ -183,6 +196,18 @@ export function Nav() {
           title="QwenPaw on GitHub"
         >
           <GitHubIcon /> {t("nav.github")}
+        </a>
+        <a
+          href={AGENTSCOPE_PLATFORM_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={navLinkOrangeClass}
+          onClick={() => setOpen(false)}
+          title={t("nav.platformTitle")}
+          aria-label={t("nav.platformTitle")}
+        >
+          <AgentScopePlatformIcon size={18} />
+          <span>{t("nav.platform")}</span>
         </a>
         <a
           href="https://agentscope.io/"

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -9,6 +9,8 @@
     "github": "GitHub",
     "githubComingSoon": "Coming Soon",
     "lang": "中文",
+    "platform": "Platform",
+    "platformTitle": "AgentScope Platform",
     "agentscopeTeam": "AgentScope"
   },
   "hero": {
@@ -19,7 +21,8 @@
     "sub1": "and TUI — all upgraded, all yours.",
     "releaseNote": "QwenPaw {{version}} is released",
     "cta": "Read the docs",
-    "quickStart": "Quick Start"
+    "quickStart": "Quick Start",
+    "quickTry": "Try Now"
   },
   "follow": {
     "title": "Follow us",

--- a/website/src/i18n/locales/zh.json
+++ b/website/src/i18n/locales/zh.json
@@ -9,6 +9,8 @@
     "github": "GitHub",
     "githubComingSoon": "Coming Soon",
     "lang": "ENG",
+    "platform": "Platform",
+    "platformTitle": "AgentScope 体验平台",
     "agentscopeTeam": "AgentScope"
   },
   "hero": {
@@ -19,7 +21,8 @@
     "sub1": "为 QwenPaw 量身定制的 Agent OS, TUI, 循环工程, 滚动上下文, 新版 ReMe",
     "releaseNote": "QwenPaw {{version}}版本全新发布",
     "cta": "查看文档",
-    "quickStart": "快速开始"
+    "quickStart": "快速开始",
+    "quickTry": "快速体验"
   },
   "follow": {
     "title": "关注我们",

--- a/website/src/pages/Home/components/Hero.tsx
+++ b/website/src/pages/Home/components/Hero.tsx
@@ -1,9 +1,15 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
-import { DottedlinedownArrowIcon, PathIcon } from "@/components/Icon";
+import {
+  AgentScopePlatformIcon,
+  DottedlinedownArrowIcon,
+  PathIcon,
+} from "@/components/Icon";
 import ShinyText from "@/components/ShinyText";
 import { LATEST_RELEASE_VERSION } from "@/pages/releaseNotesData";
+
+const AGENTSCOPE_PLATFORM_URL = "https://platform.agentscope.io/";
 
 const container = {
   hidden: { opacity: 0, y: 14 },
@@ -146,6 +152,15 @@ export function Hero() {
               <DottedlinedownArrowIcon />
               <span>{t("hero.quickStart")}</span>
             </button>
+            <a
+              href={AGENTSCOPE_PLATFORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-11 w-full max-w-60 items-center justify-center gap-1.5 rounded-lg border border-[#F3F1F0] bg-(--color-secondary) px-4 text-[15px] font-normal text-(--color-text) transition hover:brightness-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--color-primary) sm:h-10 sm:w-auto sm:max-w-none"
+            >
+              <AgentScopePlatformIcon size={18} />
+              <span>{t("hero.quickTry")}</span>
+            </a>
           </div>
 
           <motion.div


### PR DESCRIPTION
## Description

Add AgentScope Platform entry points on the website so visitors can jump to `https://platform.agentscope.io/` more easily.

- Add a **Platform** link (with icon) in both desktop and mobile navigation
- Add a **Try Now** CTA button in the homepage Hero next to Quick Start
- Add EN/ZH i18n strings for the new nav/hero labels

**Related Issue:** Relates to website navigation / platform discovery

**Security Considerations:** N/A — external link only (`target="_blank"` + `rel="noopener noreferrer"`)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Documentation (website)
- [ ] Core / Backend
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open the website homepage
2. Confirm the nav shows a **Platform** link and opens `https://platform.agentscope.io/`
3. Confirm the Hero shows a **Try Now** button and opens the same URL
4. Resize to mobile and confirm the Platform link appears in the mobile menu
5. Switch language and confirm EN/ZH labels render correctly

## Evidence

Manually verified on the website homepage:

- Desktop nav: Platform link renders and opens AgentScope Platform in a new tab
- Mobile nav: Platform link renders in the expanded menu and opens AgentScope Platform
- Hero CTA: Try Now button appears next to Quick Start and opens `https://platform.agentscope.io/`
- i18n: EN uses "Platform" / "Try Now"; ZH uses "Platform" / "快速体验"

Changed files:
- `website/src/components/Nav.tsx`
- `website/src/pages/Home/components/Hero.tsx`
- `website/src/i18n/locales/en.json`
- `website/src/i18n/locales/zh.json`

## Additional Notes

Commit: `0d9ec4a4` — `fix: nav add platform`