### PR TITLE
fix(mcp): resolve ${VAR} env references in legacy driver migration

### DIFF
--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import re
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -231,6 +233,18 @@ def legacy_mcp_client_to_driver(
     return card, credential
 
 
+ENV_VAR_PATTERN = re.compile(r"\$\{(\w+)\}")
+
+
+def _resolve_env_var(value: str) -> str:
+    """Replace ${VAR_NAME} patterns with their environment variable values."""
+
+    def _replace(m: re.Match) -> str:
+        return os.environ.get(m.group(1), m.group(0))
+
+    return ENV_VAR_PATTERN.sub(_replace, value)
+
+
 def _build_legacy_credential(
     client_key: str,
     oauth: Any,
@@ -245,7 +259,7 @@ def _build_legacy_credential(
     ref = mcp_credential_ref(client_key)
 
     for key, value in env_secrets.items():
-        secrets[key] = value
+        secrets[key] = _resolve_env_var(value)
 
     headers = endpoint.get("headers") if isinstance(endpoint, dict) else None
     for header, value in header_secrets.items():
@@ -254,7 +268,7 @@ def _build_legacy_credential(
             spec = headers.get(header)
             if isinstance(spec, dict) and spec.get("source") == "credential":
                 secret_key = str(spec.get("field") or secret_key)
-        secrets[secret_key] = value
+        secrets[secret_key] = _resolve_env_var(value)
 
     if oauth is not None:
         kind = CREDENTIAL_KIND_OAUTH_AUTH_CODE
@@ -275,7 +289,7 @@ def _build_legacy_credential(
         for key in ("access_token", "refresh_token", "client_secret"):
             value = getattr(oauth, key, "")
             if value:
-                secrets[key] = value
+                secrets[key] = _resolve_env_var(value)
 
     if not secrets and not public:
         return None


### PR DESCRIPTION
详见 #6029

## What Problem This Solves (问题描述)

QwenPaw 2.0 引入 driver MCP 架构后，旧版 agent.json 中的 MCP 配置通过 _build_legacy_credential() 迁移到新 driver 存储。但 migration 过程中，headers 和 env 中的 ${VAR} 环境变量引用未被解析，而是原样存入 credential store，导致认证失败。例如 ${WIND_API_KEY} 字面量被存储而非其实际值，所有依赖 Wind MCP 的工具无法使用。

## Evidence (验证证据)

修复后在本机验证通过：

- Wind MCP 7 个 server 全部认证成功（stock_data / index_data / fund_data / macro_data / finance_data / industry_data / news）
- 调用贵州茅台最新价返回 ¥1,212.21
- 沪深300指数行情返回 4,695.32 (-1.79%)
- 科创ETF行情返回正常

## 修改文件

- src/qwenpaw/drivers/adapters/mcp_legacy_config.py (+17/-3)

## 修复说明

在 _build_legacy_credential() 中新增 _resolve_env_var() 函数，使用 re.sub 替换所有 ${VAR_NAME} 出现位置为 os.environ 中的实际值。覆盖 env secrets、header secrets、OAuth secrets 三处存储路径。

Fixes #6029