### PR TITLE
fix(loop): exempt read-only tools from doom loop detection (#5906)

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1104,6 +1104,25 @@ class DoomLoopConfig(BaseModel):
         default=False,
         description=("Also run during /goal and " "/mission loop modes"),
     )
+    exempt_tools: List[str] = Field(
+        default_factory=lambda: [
+            "recall_history",
+            "recall_history_python",
+            "read_file",
+        ],
+        description=(
+            "Tool names exempt from doom loop "
+            "detection. Read-only tools that are "
+            "legitimately called repeatedly "
+            "(e.g. memory recall, file reading) "
+            "should be listed here to avoid "
+            "false positives (#5906)."
+            " recall_history_python is the "
+            "sandboxed REPL used by default in "
+            "scroll context; recall_history is "
+            "the structured fallback."
+        ),
+    )
 
 
 class IterationGateConfig(BaseModel):

--- a/src/qwenpaw/loop/gates/doom_loop.py
+++ b/src/qwenpaw/loop/gates/doom_loop.py
@@ -65,6 +65,7 @@ class DoomLoopGate(LoopGate):
         window_size: int = 3,
         similarity_threshold: float = 1.0,
         stages: list | None = None,
+        exempt_tools: set[str] | None = None,
     ) -> None:
         super().__init__()
         self._window_size = max(2, window_size)
@@ -73,6 +74,14 @@ class DoomLoopGate(LoopGate):
             stages or [],
             key=lambda s: s.after,
         )
+        self._exempt_tools = set(exempt_tools) if exempt_tools else set()
+
+        # Trade-off (#5906): fully exempting read-only tools means a
+        # model stuck in an infinite read-only loop (e.g. same
+        # recall_history call forever) is invisible to this gate and
+        # will burn tokens unchecked.  This is an accepted hotfix cost
+        # — the alternative (higher tolerance instead of full exempt)
+        # is tracked as a follow-up.
 
     def _ensure_state(self) -> _DoomState:
         """Get or create per-session state."""
@@ -93,6 +102,8 @@ class DoomLoopGate(LoopGate):
     ) -> None:
         """Record a completed tool call."""
         state = self._ensure_state()
+        if tool_name in self._exempt_tools:
+            return
         state.history.append(
             _ToolCallRecord(
                 tool_name=tool_name,
@@ -177,7 +188,15 @@ class DoomLoopGate(LoopGate):
         ctx: Any,
         state: _DoomState,
     ) -> None:
-        """Extract latest tool call from agent context."""
+        """Extract latest tool call from agent context.
+
+        Skips exempt tools — if the last tool call in the context
+        is exempt, continues scanning backwards for the next
+        non-exempt one.  ``last_recorded_iter`` is only advanced
+        after a record is actually appended (or no tool call at
+        all is found), so an exempt tool never silently swallows
+        a non-exempt call in the same iteration.
+        """
         if not isinstance(ctx, dict):
             return
         agent = ctx.get("agent")
@@ -186,7 +205,6 @@ class DoomLoopGate(LoopGate):
         cur_iter = ctx.get("iteration", 0)
         if cur_iter <= state.last_recorded_iter:
             return
-        state.last_recorded_iter = cur_iter
 
         context = getattr(
             getattr(agent, "state", None),
@@ -194,10 +212,12 @@ class DoomLoopGate(LoopGate):
             [],
         )
         if not context:
+            state.last_recorded_iter = cur_iter
             return
         last_msg = context[-1]
         content = getattr(last_msg, "content", None)
         if not content or not isinstance(content, list):
+            state.last_recorded_iter = cur_iter
             return
         for block in reversed(content):
             btype = getattr(block, "type", None)
@@ -209,6 +229,8 @@ class DoomLoopGate(LoopGate):
                     if isinstance(block, dict)
                     else getattr(block, "name", "")
                 )
+                if name in self._exempt_tools:
+                    continue
                 raw_input = (
                     block.get("input", "")
                     if isinstance(block, dict)
@@ -221,7 +243,9 @@ class DoomLoopGate(LoopGate):
                         args_hash=args_hash,
                     ),
                 )
+                state.last_recorded_iter = cur_iter
                 return
+        state.last_recorded_iter = cur_iter
 
     @staticmethod
     def _hash_args(raw_input: Any) -> str:

--- a/src/qwenpaw/modes/default/mode.py
+++ b/src/qwenpaw/modes/default/mode.py
@@ -112,6 +112,13 @@ class DefaultMode(AgentMode):
                         loop_config.doom_loop.similarity_threshold
                     ),
                     stages=loop_config.doom_loop.stages,
+                    exempt_tools=set(
+                        getattr(
+                            loop_config.doom_loop,
+                            "exempt_tools",
+                            [],
+                        ),
+                    ),
                 ),
             )
         if loop_config.rubric.enabled:

--- a/src/qwenpaw/modes/goal/helpers.py
+++ b/src/qwenpaw/modes/goal/helpers.py
@@ -96,6 +96,7 @@ def create_doom_loop_gate(
             window_size=doom_cfg.window_size,
             similarity_threshold=(doom_cfg.similarity_threshold),
             stages=doom_cfg.stages,
+            exempt_tools=set(getattr(doom_cfg, "exempt_tools", [])),
         )
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/tests/unit/loop/test_doom_loop_gate.py
+++ b/tests/unit/loop/test_doom_loop_gate.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name,protected-access
-"""Tests for DoomLoopGate reset behaviour."""
+"""Tests for DoomLoopGate reset behaviour and exempt-tools (#5906)."""
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -38,6 +38,27 @@ def gate():
             _stage(3, "modify_prompt", "warning"),
             _stage(6, "stop", "doom stop"),
         ],
+    )
+    g.activate(None)
+    g._ensure_state()
+    return g
+
+
+@pytest.fixture()
+def gate_with_exemptions():
+    """Gate with read-only tools exempt from doom loop detection."""
+    g = DoomLoopGate(
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[
+            _stage(3, "modify_prompt", "warning"),
+            _stage(6, "stop", "doom stop"),
+        ],
+        exempt_tools={
+            "recall_history",
+            "recall_history_python",
+            "read_file",
+        },
     )
     g.activate(None)
     g._ensure_state()
@@ -145,3 +166,204 @@ async def test_session_isolation():
         return_value="s2",
     ):
         assert len(g._state().history) == 1
+
+
+# ---------------------------------------------------------------------------
+# #5906 — exempt read-only tools from doom loop detection
+# ---------------------------------------------------------------------------
+
+def test_exempt_tool_not_recorded(gate_with_exemptions):
+    """recall_history calls are not added to doom loop history."""
+    gate_with_exemptions.record("recall_history", "hash1")
+    gate_with_exemptions.record("recall_history", "hash1")
+    gate_with_exemptions.record("recall_history", "hash1")
+    assert len(gate_with_exemptions._ensure_state().history) == 0
+
+
+@pytest.mark.asyncio
+async def test_exempt_tool_does_not_trigger_warning(gate_with_exemptions):
+    """6 consecutive recall_history calls must NOT trigger doom loop."""
+    for _ in range(6):
+        gate_with_exemptions.record("recall_history", "same_args")
+    result = await gate_with_exemptions.check({"iteration": 6})
+    assert result.action == StopAction.BYPASS
+
+
+@pytest.mark.asyncio
+async def test_exempt_tool_does_not_trigger_terminate(gate_with_exemptions):
+    """Even past the stop threshold, exempt tools must not terminate."""
+    for _ in range(10):
+        gate_with_exemptions.record("read_file", "same_args")
+    result = await gate_with_exemptions.check({"iteration": 10})
+    assert result.action == StopAction.BYPASS
+
+
+@pytest.mark.asyncio
+async def test_non_exempt_tool_still_triggers(gate_with_exemptions):
+    """Non-exempt tools are still subject to doom loop detection."""
+    for _ in range(3):
+        gate_with_exemptions.record("search_web", "same_query")
+    result = await gate_with_exemptions.check({"iteration": 3})
+    assert result.action == StopAction.INTERRUPT_AND_CONTINUE
+
+
+def test_exempt_mixed_with_normal_only_counts_normal(gate_with_exemptions):
+    """Exempt calls interspersed with normal calls only count normal ones."""
+    gate_with_exemptions.record("recall_history", "h1")
+    gate_with_exemptions.record("search_web", "q1")
+    gate_with_exemptions.record("recall_history", "h2")
+    gate_with_exemptions.record("search_web", "q1")
+    gate_with_exemptions.record("recall_history", "h3")
+    # Only 2 search_web calls in history — below window_size=3
+    assert len(gate_with_exemptions._ensure_state().history) == 2
+
+
+def test_no_exempt_tools_by_default():
+    """Without exempt_tools, all tool calls are recorded (backward compat)."""
+    g = DoomLoopGate(
+        window_size=3,
+        similarity_threshold=1.0,
+        stages=[_stage(3, "stop", "doom")],
+    )
+    g.activate(None)
+    g._ensure_state()
+    g.record("recall_history", "h1")
+    g.record("recall_history", "h1")
+    assert len(g._ensure_state().history) == 2
+
+
+def test_exempt_tools_via_auto_record(gate_with_exemptions):
+    """_auto_record_from_ctx skips exempt tools when extracting from context."""
+    agent = SimpleNamespace(
+        state=SimpleNamespace(
+            context=[
+                SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            name="recall_history",
+                            input={"query": "test"},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    ctx = {"agent": agent, "iteration": 1}
+    state = gate_with_exemptions._ensure_state()
+    gate_with_exemptions._auto_record_from_ctx(ctx, state)
+    assert len(state.history) == 0
+
+
+def test_non_exempt_via_auto_record(gate_with_exemptions):
+    """_auto_record_from_ctx records non-exempt tools normally."""
+    agent = SimpleNamespace(
+        state=SimpleNamespace(
+            context=[
+                SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            name="search_web",
+                            input={"q": "test"},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    ctx = {"agent": agent, "iteration": 1}
+    state = gate_with_exemptions._ensure_state()
+    gate_with_exemptions._auto_record_from_ctx(ctx, state)
+    assert len(state.history) == 1
+
+
+def test_exempt_does_not_swallow_non_exempt_same_iter(gate_with_exemptions):
+    """P1: exempt tool after non-exempt in same context must not skip the
+    non-exempt call.  reversed(content) hits recall_history first (exempt),
+    but search_web before it must still be recorded.
+    """
+    agent = SimpleNamespace(
+        state=SimpleNamespace(
+            context=[
+                SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            name="search_web",
+                            input={"q": "dangerous"},
+                        ),
+                        SimpleNamespace(
+                            type="tool_use",
+                            name="recall_history",
+                            input={"query": "what did I do"},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    ctx = {"agent": agent, "iteration": 1}
+    state = gate_with_exemptions._ensure_state()
+    gate_with_exemptions._auto_record_from_ctx(ctx, state)
+    assert len(state.history) == 1
+    assert state.history[0].tool_name == "search_web"
+
+
+def test_all_exempt_in_iter_advances_recorded_iter(gate_with_exemptions):
+    """If all tool calls in an iteration are exempt, last_recorded_iter
+    advances so the iteration is not re-scanned."""
+    agent = SimpleNamespace(
+        state=SimpleNamespace(
+            context=[
+                SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            name="recall_history",
+                            input={},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    ctx = {"agent": agent, "iteration": 5}
+    state = gate_with_exemptions._ensure_state()
+    gate_with_exemptions._auto_record_from_ctx(ctx, state)
+    assert len(state.history) == 0
+    assert state.last_recorded_iter == 5
+
+
+@pytest.mark.asyncio
+async def test_recall_history_python_exempt(gate_with_exemptions):
+    """recall_history_python (sandboxed REPL, default scroll tool) is
+    exempt — repeated calls must not trigger doom loop (#5906 main path).
+    """
+    for _ in range(6):
+        gate_with_exemptions.record("recall_history_python", "same")
+    result = await gate_with_exemptions.check({"iteration": 6})
+    assert result.action == StopAction.BYPASS
+
+
+def test_recall_history_python_via_auto_record(gate_with_exemptions):
+    """_auto_record_from_ctx skips recall_history_python."""
+    agent = SimpleNamespace(
+        state=SimpleNamespace(
+            context=[
+                SimpleNamespace(
+                    content=[
+                        SimpleNamespace(
+                            type="tool_use",
+                            name="recall_history_python",
+                            input={"code": "df.head()"},
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+    ctx = {"agent": agent, "iteration": 1}
+    state = gate_with_exemptions._ensure_state()
+    gate_with_exemptions._auto_record_from_ctx(ctx, state)
+    assert len(state.history) == 0


### PR DESCRIPTION
## Problem

`DoomLoopGate` with `similarity_threshold=1.0` flags legitimate repeated read-only tool calls as doom loops. Users reading memory 3+ times get a warning; 6+ times gets terminated — making normal memory recall trigger doom loop false positives.

**Issue:** #5906

## Root Cause

`DoomLoopGate.record()` and `_auto_record_from_ctx()` count ALL tool calls equally, including read-only tools that are legitimately called repeatedly (e.g. recalling conversation history, reading files).

## Fix

Add `exempt_tools` config to `DoomLoopConfig` (default: `["recall_history", "recall_history_python", "read_file"]`). `DoomLoopGate` skips recording any tool in the exempt set, so repeated read-only calls never enter the sliding window.

Key insight: `recall_history_python` is the sandboxed REPL that is the **default** recall tool in scroll context. `recall_history` (structured) is only the fallback for environments without a sandbox (e.g. Windows without WSL2). Both must be exempt — omitting `recall_history_python` leaves the main code path unfixed.

## P1 Fix (control flow bug found during review)

`_auto_record_from_ctx` previously advanced `last_recorded_iter` before checking exempt — an exempt tool as the last call in context would swallow non-exempt calls earlier in the same iteration. Now: `last_recorded_iter` advances only after a record is appended or the iteration is fully scanned; exempt tools use `continue` (not `return`) so earlier non-exempt calls are still found.

## Trade-off

Fully exempting read-only tools means a model stuck in an infinite read-only loop is invisible to this gate and will burn tokens unchecked. This is an accepted hotfix cost — the alternative (higher tolerance instead of full exempt) is tracked as a follow-up.

## Changes

- `config.py`: Add `exempt_tools` field to `DoomLoopConfig` (includes `recall_history_python` for default scroll context path)
- `doom_loop.py`: Add `exempt_tools` param; skip in `record()` and `_auto_record_from_ctx()` (with `continue` + deferred iter advance); document trade-off in `__init__` comment
- `react_gates.py`: Pass `exempt_tools` from config to `DoomLoopGate`
- `goal/helpers.py`: Same wiring for `/goal` mode
- `test_doom_loop_gate.py`: 12 new tests covering exempt behavior, P1 swallow scenario, `recall_history_python` main path, and all-exempt iter advancement

## Test Results

All 34 tests in `tests/unit/loop/` pass (12 new + 22 existing), zero regression.