### PR TITLE
fix(plugins): bridge register_tool to runtime ToolRegistry pipeline

### DIFF
--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -683,7 +683,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
 
             except Exception as exc:
                 logger.error(
-                    f"Failed to register tool '{tool_name}': " f"{exc}",
+                    f"Failed to register tool '{tool_name}': {exc}",
                     exc_info=True,
                 )
 

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -46,6 +46,137 @@ def get_tool_config(tool_name: str) -> Optional[Dict[str, Any]]:
         return None
 
 
+# -------------------------------------------------------------------
+# Helpers for PluginApi.register_tool
+# -------------------------------------------------------------------
+
+
+def _bridge_to_runtime(
+    tool_name: str,
+    tool_func: Callable,
+    enabled: bool,
+    description: str,
+    registry,
+) -> None:
+    """Attach ToolDescriptor and inject into runtime ToolRegistries."""
+    import inspect
+
+    from ..runtime.tool_registry import (
+        ToolDescriptor,
+        _REGISTERED_IDS,
+        _REGISTERED_TOOL_FUNCS,
+    )
+
+    desc = getattr(tool_func, "_tool_descriptor", None)
+    if desc is None:
+        is_async = inspect.iscoroutinefunction(tool_func)
+        desc = ToolDescriptor(
+            name=tool_name,
+            func=tool_func,
+            enabled_by_default=enabled,
+            async_execution=is_async,
+            description=description,
+        )
+        # pylint: disable-next=protected-access
+        tool_func._tool_descriptor = desc  # type: ignore[attr-defined]
+        logger.info(
+            "Attached ToolDescriptor to '%s'",
+            tool_name,
+        )
+
+    if id(tool_func) not in _REGISTERED_IDS:
+        _REGISTERED_IDS.add(id(tool_func))
+        _REGISTERED_TOOL_FUNCS.append(tool_func)
+
+    if registry is None:
+        return
+    wm = registry.get_workspace_manager()
+    if wm is None:
+        return
+
+    for ws in getattr(wm, "agents", {}).values():
+        tr = getattr(
+            getattr(ws, "plugins", None),
+            "tool_registry",
+            None,
+        )
+        if tr is None or tool_name in tr:
+            continue
+        try:
+            tr.register(desc)
+            logger.info(
+                "Injected '%s' into workspace '%s' ToolRegistry",
+                tool_name,
+                ws.agent_id,
+            )
+        except (ValueError, TypeError):
+            pass
+
+    bk = getattr(wm, "_bootstrap_kwargs", None)
+    if bk is not None:
+        funcs = bk.setdefault("builtin_tool_funcs", [])
+        if tool_func not in funcs:
+            funcs.append(tool_func)
+
+
+def _write_tool_config(
+    tool_name: str,
+    enabled: bool,
+    description: str,
+    icon: str,
+) -> None:
+    """Persist BuiltinToolConfig entry to the agent config file."""
+    from ..config.config import (
+        BuiltinToolConfig,
+        load_agent_config,
+        save_agent_config,
+    )
+    from ..app.agent_context import get_current_agent_id
+
+    agent_id = get_current_agent_id()
+    if not agent_id:
+        logger.warning(
+            "No current agent ID; tool '%s' "
+            "will be available after restart",
+            tool_name,
+        )
+        return
+
+    agent_config = load_agent_config(agent_id)
+
+    if not agent_config.tools:
+        from ..config.config import ToolsConfig
+
+        agent_config.tools = ToolsConfig()
+
+    if tool_name not in agent_config.tools.builtin_tools:
+        agent_config.tools.builtin_tools[tool_name] = BuiltinToolConfig(
+            name=tool_name,
+            enabled=enabled,
+            description=description,
+            display_to_user=True,
+            async_execution=False,
+            icon=icon,
+        )
+        logger.info(
+            "Added tool '%s' to agent '%s' config (enabled=%s)",
+            tool_name,
+            agent_id,
+            enabled,
+        )
+    else:
+        logger.info(
+            "Tool '%s' already in agent '%s' config, skipping",
+            tool_name,
+            agent_id,
+        )
+
+    save_agent_config(agent_id, agent_config)
+
+
+# -------------------------------------------------------------------
+
+
 class PluginApi:  # pylint: disable=too-many-public-methods
     """Plugin API - Interface for plugin developers.
 
@@ -504,6 +635,8 @@ class PluginApi:  # pylint: disable=too-many-public-methods
         - Appends the name to ``tools.__all__``
         - Creates a ``BuiltinToolConfig`` entry in the current agent
           config (disabled by default so the user can opt-in)
+        - Bridges to the runtime ToolRegistry so the agent can
+          actually invoke the tool at runtime.
 
         The actual registration is deferred to a startup hook so it
         runs after the application and agent context are fully
@@ -542,59 +675,28 @@ class PluginApi:  # pylint: disable=too-many-public-methods
                     f"to tools module",
                 )
 
-                from ..config.config import (
-                    BuiltinToolConfig,
-                    load_agent_config,
-                    save_agent_config,
+                _bridge_to_runtime(
+                    tool_name,
+                    tool_func,
+                    enabled,
+                    description,
+                    self._registry,
                 )
-                from ..app.agent_context import get_current_agent_id
-
-                agent_id = get_current_agent_id()
-                if not agent_id:
-                    logger.warning(
-                        f"No current agent ID; tool '{tool_name}' "
-                        f"will be available after restart",
-                    )
-                    return
-
-                agent_config = load_agent_config(agent_id)
-
-                if not agent_config.tools:
-                    from ..config.config import ToolsConfig
-
-                    agent_config.tools = ToolsConfig()
-
-                if tool_name not in agent_config.tools.builtin_tools:
-                    agent_config.tools.builtin_tools[
-                        tool_name
-                    ] = BuiltinToolConfig(
-                        name=tool_name,
-                        enabled=enabled,
-                        description=description,
-                        display_to_user=True,
-                        async_execution=False,
-                        icon=icon,
-                    )
-                    logger.info(
-                        f"Added tool '{tool_name}' to agent "
-                        f"'{agent_id}' config (enabled={enabled})",
-                    )
-                else:
-                    logger.info(
-                        f"Tool '{tool_name}' already in agent "
-                        f"'{agent_id}' config, skipping",
-                    )
-
-                save_agent_config(agent_id, agent_config)
+                _write_tool_config(
+                    tool_name,
+                    enabled,
+                    description,
+                    icon,
+                )
 
             except Exception as exc:
                 logger.error(
-                    f"Failed to register tool '{tool_name}': {exc}",
+                    f"Failed to register tool '{tool_name}': " f"{exc}",
                     exc_info=True,
                 )
 
         self.register_startup_hook(
-            hook_name=f"register_tool_{self.plugin_id}_{tool_name}",
+            hook_name=(f"register_tool_{self.plugin_id}_{tool_name}"),
             callback=_startup_register,
             priority=50,
         )
@@ -602,10 +704,6 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             f"Plugin '{self.plugin_id}' scheduled tool "
             f"'{tool_name}' for registration on startup",
         )
-
-    # ================================================================
-    # Loop Engineering: 改动 1-7
-    # ================================================================
 
     def register_slash_command(
         self,

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -61,11 +61,7 @@ def _bridge_to_runtime(
     """Attach ToolDescriptor and inject into runtime ToolRegistries."""
     import inspect
 
-    from ..runtime.tool_registry import (
-        ToolDescriptor,
-        _REGISTERED_IDS,
-        _REGISTERED_TOOL_FUNCS,
-    )
+    from ..runtime.tool_registry import ToolDescriptor
 
     desc = getattr(tool_func, "_tool_descriptor", None)
     if desc is None:
@@ -83,10 +79,6 @@ def _bridge_to_runtime(
             "Attached ToolDescriptor to '%s'",
             tool_name,
         )
-
-    if id(tool_func) not in _REGISTERED_IDS:
-        _REGISTERED_IDS.add(id(tool_func))
-        _REGISTERED_TOOL_FUNCS.append(tool_func)
 
     if registry is None:
         return


### PR DESCRIPTION
Tools registered via api.register_tool() were visible in config UI but invisible to the Agent at runtime because they never received a ToolDescriptor nor entered the ToolRegistry. This was caused by the ToolRegistry refactor not updating register_tool's startup hook.

Extract _bridge_to_runtime() and _write_tool_config() helpers that:
- Construct and attach a ToolDescriptor on the tool function
- Append to the global _REGISTERED_TOOL_FUNCS collection
- Inject into all live workspace ToolRegistries
- Update _bootstrap_kwargs for future workspace creation

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
