### PR TITLE
fix(console): clear message queue when a session is deleted

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -282,6 +282,27 @@ describe("ChatSessionDrawer", () => {
     expect(mockDeleteChat).not.toHaveBeenCalled();
   });
 
+  it("delete clears the message queue for both local id and backend id", async () => {
+    const { useMessageQueueStore } = await import("@/stores/messageQueueStore");
+    useMessageQueueStore.getState().enqueue("s1", { text: "local" });
+    useMessageQueueStore.getState().enqueue("uuid-1", { text: "backend" });
+    expect(useMessageQueueStore.getState().getQueue("s1")).toHaveLength(1);
+    expect(useMessageQueueStore.getState().getQueue("uuid-1")).toHaveLength(1);
+
+    withSession({ realId: "uuid-1" });
+    const user = userEvent.setup();
+    renderWithProviders(<ChatSessionDrawer {...defaultProps} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("delete-btn")).toBeInTheDocument(),
+    );
+    await user.click(screen.getByTestId("delete-btn"));
+
+    await waitFor(() => {
+      expect(useMessageQueueStore.getState().getQueue("s1")).toEqual([]);
+      expect(useMessageQueueStore.getState().getQueue("uuid-1")).toEqual([]);
+    });
+  });
+
   it("edit start sets editing state and edit submit calls updateChat", async () => {
     withSession({ realId: "uuid-1" });
     const user = userEvent.setup();

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -32,6 +32,7 @@ import SessionItem from "../../../../components/SessionItem";
 import { getChannelLabel } from "../../../Control/Channels/components";
 import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
+import { useMessageQueueStore } from "../../../../stores/messageQueueStore";
 import {
   buildSessionPath,
   getSessionIdFromPath,
@@ -454,6 +455,15 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       }
 
       localStorage.removeItem(`approval_level-${sessionId}`);
+
+      // Clear the message queue for the deleted session so stale items don't
+      // linger in storage or get sent after deletion. The queue may be keyed
+      // by the local id or the resolved backend id, so clear both. Also notify
+      // the chat page (when mounted) to abort any in-flight background send.
+      const mq = useMessageQueueStore.getState();
+      mq.clear(sessionId);
+      if (backendId && backendId !== sessionId) mq.clear(backendId);
+      sessionApi.onSessionRemoved?.(backendId ?? sessionId);
 
       // Fetch the updated session list after deletion
       const freshList =

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
@@ -4,6 +4,7 @@ import type { IAgentScopeRuntimeWebUISession } from "@agentscope-ai/chat";
 import type { ChatStatus } from "../../../../api/types/chat";
 import { chatApi } from "../../../../api/modules/chat";
 import sessionApi from "../../sessionApi";
+import { useMessageQueueStore } from "../../../../stores/messageQueueStore";
 import {
   ContextMenu,
   useContextMenu,
@@ -251,6 +252,15 @@ export function useSessionListData(
       if (backendId) await chatApi.deleteChat(backendId);
 
       localStorage.removeItem(`approval_level-${sessionId}`);
+
+      // Clear the message queue for the deleted session so stale items don't
+      // linger in storage or get sent after deletion. The queue may be keyed
+      // by the local id or the resolved backend id, so clear both. Also notify
+      // the chat page (when mounted) to abort any in-flight background send.
+      const mq = useMessageQueueStore.getState();
+      mq.clear(sessionId);
+      if (backendId && backendId !== sessionId) mq.clear(backendId);
+      sessionApi.onSessionRemoved?.(backendId ?? sessionId);
 
       // Fetch fresh session list after deletion
       const freshList =

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2037,24 +2037,18 @@ export default function ChatPage() {
     };
 
     sessionApi.onSessionRemoved = (removedId) => {
-      if (!isChatActiveRef.current) return;
-      // Clean up the queue for the removed session so stale items don't
-      // linger in storage or get sent after the conversation is deleted.
+      // Clean up the queue and abort any in-flight background send for the
+      // removed session so stale items don't linger in storage or get sent
+      // after the conversation is deleted. Navigation to a fresh chat is
+      // owned by the delete handlers (via the "qwenpaw:sidebar-new-chat"
+      // event), so this callback stays focused on resource cleanup and can
+      // run regardless of which session is currently active.
       try {
         useMessageQueueStore.getState().clear(removedId);
       } catch {
         // ignore
       }
-      // Clear URL when current session is removed
-      // Check if removed session matches current session (by realId or sessionId)
-      const currentRealId = sessionApi.getRealIdForSession(
-        chatIdRef.current || "",
-      );
-      if (chatIdRef.current === removedId || currentRealId === removedId) {
-        lastSessionIdRef.current = null;
-        stopBackgroundQueue(removedId);
-        navigateRef.current(buildCurrentBasePath(), { replace: true });
-      }
+      stopBackgroundQueue(removedId);
     };
 
     sessionApi.onSessionSelected = (


### PR DESCRIPTION
The queue-cleanup logic added in #6040 lived inside sessionApi.onSessionRemoved, but that callback is only triggered by sessionApi.removeSession(), which is never called. The real delete paths (useSessionListData.handleDelete and ChatSessionDrawer.handleDelete) call chatApi.deleteChat() directly, so the message queue was never cleared on delete.

- Both delete handlers now clear the queue for the deleted session (both the local id and the resolved backend id, since the queue may be keyed by either) and notify onSessionRemoved to abort any in-flight background send.
- Simplify onSessionRemoved to focus on resource cleanup (clear queue + stop background send); navigation to a fresh chat remains owned by the delete handlers via the qwenpaw:sidebar-new-chat event.
- Add a test verifying the queue is cleared on delete.

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
