### PR TITLE
fix(hint): flatten background tool hint message and yield result events on SSE stream

### DIFF
--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -587,21 +587,102 @@ class QwenPawAgent(CodingModeMixin, Agent):
         """Return the ToolCoordinator from request_context, or None."""
         return (self._request_context or {}).get("tool_coordinator")
 
-    async def _inject_pending_hints(self) -> None:
-        """Pop background-tool hints and append them to agent context."""
+    async def _inject_pending_hints_with_events(self) -> list[Any]:
+        """Pop background-tool hints, append to context, and build
+        tool-result events so the SSE stream renders them inline.
+
+        Returns a list of AgentEvents that the caller should yield
+        before proceeding with the normal reply flow.
+        """
+        from agentscope.event import (
+            ToolCallEndEvent,
+            ToolCallStartEvent,
+            ToolResultEndEvent,
+            ToolResultStartEvent,
+            ToolResultTextDeltaEvent,
+        )
+        from agentscope.message import ToolResultState
+
         mgr = self._get_tool_coordinator()
         if mgr is None:
-            return
+            return []
         session_id = (self._request_context or {}).get("session_id", "")
         if not session_id:
-            return
+            return []
+
         hints = await mgr.pop_pending_hints(session_id)
+        if not hints:
+            return []
+
+        events: list[Any] = []
         for hint in hints:
             self.state.context.append(hint)
 
+            meta = getattr(hint, "metadata", None) or {}
+            if meta.get("hint_type") != "tool_completed":
+                continue
+
+            tool_name = meta.get("tool_name", "unknown")
+            end_state = meta.get("end_state", "unknown")
+
+            hint_reply_id = uuid.uuid4().hex
+            new_call_id = f"bg-{uuid.uuid4().hex[:24]}"
+
+            result_text_parts: list[str] = []
+            for block in (hint.content or [])[1:]:
+                text = getattr(block, "text", None)
+                if text is not None:
+                    result_text_parts.append(text)
+                else:
+                    result_text_parts.append(str(block))
+            result_text = "\n".join(result_text_parts) or "(no output)"
+
+            state = (
+                ToolResultState.SUCCESS
+                if end_state == "success"
+                else ToolResultState.ERROR
+            )
+
+            events.extend(
+                [
+                    ToolCallStartEvent(
+                        reply_id=hint_reply_id,
+                        tool_call_id=new_call_id,
+                        tool_call_name=tool_name,
+                    ),
+                    ToolCallEndEvent(
+                        reply_id=hint_reply_id,
+                        tool_call_id=new_call_id,
+                    ),
+                    ToolResultStartEvent(
+                        reply_id=hint_reply_id,
+                        tool_call_id=new_call_id,
+                        tool_call_name=tool_name,
+                    ),
+                    ToolResultTextDeltaEvent(
+                        reply_id=hint_reply_id,
+                        tool_call_id=new_call_id,
+                        delta=result_text,
+                    ),
+                    ToolResultEndEvent(
+                        reply_id=hint_reply_id,
+                        tool_call_id=new_call_id,
+                        state=state,
+                    ),
+                ],
+            )
+
+        return events
+
     async def _reply(self, **kwargs: Any) -> Any:
-        """Override to inject pending background-tool hints before reply."""
-        await self._inject_pending_hints()
+        """Override to inject pending background-tool hints before reply.
+
+        Hint events use their own reply_id (generated per hint) so they
+        render as independent tool cards in the SSE stream, separate from
+        the main reply that follows.
+        """
+        for evt in await self._inject_pending_hints_with_events():
+            yield evt
         async for evt in super()._reply(**kwargs):
             yield evt
 

--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -33,4 +33,10 @@ def make_offload_hint_msg(entry: Any) -> Any:
         name="system",
         role="assistant",
         content=[notification] + result_blocks,
+        metadata={
+            "hint_type": "tool_completed",
+            "tool_call_id": entry.ctx.tool_call_id,
+            "tool_name": entry.ctx.tool_name,
+            "end_state": end,
+        },
     )

--- a/src/qwenpaw/tool_calls/_hint.py
+++ b/src/qwenpaw/tool_calls/_hint.py
@@ -9,10 +9,12 @@ from typing import Any
 def make_offload_hint_msg(entry: Any) -> Any:
     """Construct a hint Msg for a completed offloaded tool call.
 
-    The hint contains a system-notification TextBlock and a
-    ToolResultBlock with the finalized response content.
+    The hint flattens the finalized response content blocks (TextBlock,
+    ImageBlock, etc.) directly into the message so that provider formatters
+    treat it as an ordinary assistant message — no ToolResultBlock means no
+    orphan ``role=tool`` wire message and no tool-call pairing issues.
     """
-    from agentscope.message import Msg, TextBlock, ToolResultBlock
+    from agentscope.message import Msg, TextBlock
 
     end = entry.end_state or "unknown"
     notification = TextBlock(
@@ -20,23 +22,15 @@ def make_offload_hint_msg(entry: Any) -> Any:
         text=(
             "<system-notification>\n"
             f"Background tool call `{entry.ctx.tool_name}` "
-            f"(id={entry.ctx.tool_call_id}) completed with state={end}. "
-            "The full result follows in the next tool_result block.\n"
+            f"(id={entry.ctx.tool_call_id}) "
+            f"completed with state={end}. "
+            "Result below.\n"
             "</system-notification>"
         ),
     )
-    tool_result = ToolResultBlock(
-        type="tool_result",
-        id=entry.ctx.tool_call_id,
-        name=entry.ctx.tool_name,
-        output=list(entry.final_response.content or []),
-        state=entry.final_response.state,
-    )
-    # AgentScope 2.0 validates that system messages contain only text
-    # blocks.  This hint must carry a ToolResultBlock so provider formatters
-    # keep it on the tool-result path; use assistant role intentionally.
+    result_blocks = list(entry.final_response.content or [])
     return Msg(
         name="system",
         role="assistant",
-        content=[notification, tool_result],
+        content=[notification] + result_blocks,
     )

--- a/tests/unit/tool_calls/test_coordinator_result_finalizer.py
+++ b/tests/unit/tool_calls/test_coordinator_result_finalizer.py
@@ -243,15 +243,18 @@ async def test_background_completion_hint_uses_finalized_response(tmp_path):
         _wait_for_hint(coordinator, "session-bg"),
         timeout=1,
     )
-    tool_result = next(
-        block
-        for block in hint.content
-        if getattr(block, "type", None) == "tool_result"
-    )
 
     assert events[-1].metadata["offloaded"] is True
     assert hint.role == "assistant"
-    assert _tool_result_output_text_bytes(tool_result) <= 512
+    # After the flatten fix, result blocks are inlined directly into
+    # hint.content (no ToolResultBlock wrapper).  The first block is the
+    # notification TextBlock; the remaining blocks are the finalized result.
+    result_text_bytes = sum(
+        len(block.text.encode("utf-8"))
+        for block in hint.content[1:]
+        if getattr(block, "type", None) == "text"
+    )
+    assert result_text_bytes <= 512
     assert finalizer_calls == 1
 
 

--- a/tests/unit/tool_calls/test_hint.py
+++ b/tests/unit/tool_calls/test_hint.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Tests for completed background tool-call hint messages."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from agentscope.message import TextBlock, ToolCallBlock, ToolResultBlock
+from agentscope.tool import ToolResponse
+
+from qwenpaw.tool_calls._hint import make_offload_hint_msg
+
+
+def _make_entry(
+    *,
+    tool_call_id: str = "call-bg",
+    tool_name: str = "slow_tool",
+    end_state: str = "success",
+    content: list | None = None,
+):
+    if content is None:
+        content = [TextBlock(type="text", text="done")]
+    response = ToolResponse(
+        content=content,
+        id=tool_call_id,
+    )
+    return SimpleNamespace(
+        end_state=end_state,
+        ctx=SimpleNamespace(
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+        ),
+        final_response=response,
+    )
+
+
+class TestHintMessageStructure:
+    """Verify that the hint message contains only ordinary content blocks."""
+
+    def test_no_tool_blocks(self) -> None:
+        hint = make_offload_hint_msg(_make_entry())
+        for block in hint.content:
+            assert not isinstance(block, (ToolCallBlock, ToolResultBlock))
+
+    def test_role_is_assistant(self) -> None:
+        hint = make_offload_hint_msg(_make_entry())
+        assert hint.role == "assistant"
+
+    def test_notification_text_contains_tool_info(self) -> None:
+        hint = make_offload_hint_msg(
+            _make_entry(
+                tool_call_id="call-123",
+                tool_name="web_search",
+                end_state="success",
+            ),
+        )
+        notification = hint.content[0]
+        assert isinstance(notification, TextBlock)
+        assert "web_search" in notification.text
+        assert "call-123" in notification.text
+        assert "success" in notification.text
+
+    def test_result_blocks_are_flattened(self) -> None:
+        result_blocks = [
+            TextBlock(type="text", text="first"),
+            TextBlock(type="text", text="second"),
+        ]
+        hint = make_offload_hint_msg(_make_entry(content=result_blocks))
+        assert len(hint.content) == 3
+        assert hint.content[1].text == "first"
+        assert hint.content[2].text == "second"
+
+    def test_empty_result(self) -> None:
+        hint = make_offload_hint_msg(_make_entry(content=[]))
+        assert len(hint.content) == 1
+        assert isinstance(hint.content[0], TextBlock)
+
+    def test_none_result(self) -> None:
+        entry = _make_entry()
+        entry.final_response.content = None
+        hint = make_offload_hint_msg(entry)
+        assert len(hint.content) == 1
+
+
+class TestHintFormatterCompatibility:
+    """Verify that formatters produce ordinary assistant wire messages."""
+
+    @pytest.mark.asyncio
+    async def test_openai_format_no_tool_messages(self) -> None:
+        from agentscope.formatter import OpenAIChatFormatter
+
+        hint = make_offload_hint_msg(_make_entry())
+        formatted = await OpenAIChatFormatter().format([hint])
+        assert len(formatted) == 1
+        assert formatted[0]["role"] == "assistant"
+        assert "tool_calls" not in formatted[0]
+
+    @pytest.mark.asyncio
+    async def test_anthropic_format_no_tool_messages(self) -> None:
+        from agentscope.formatter import AnthropicChatFormatter
+
+        hint = make_offload_hint_msg(_make_entry())
+        formatted = await AnthropicChatFormatter().format([hint])
+        assert len(formatted) == 1
+        assert formatted[0]["role"] == "assistant"
+        for block in formatted[0].get("content", []):
+            assert block.get("type") != "tool_use"
+
+    @pytest.mark.asyncio
+    async def test_gemini_format_no_tool_messages(self) -> None:
+        from agentscope.formatter import GeminiChatFormatter
+
+        hint = make_offload_hint_msg(_make_entry())
+        formatted = await GeminiChatFormatter().format([hint])
+        assert len(formatted) == 1
+        assert formatted[0]["role"] == "model"
+        for part in formatted[0].get("parts", []):
+            assert "function_call" not in part


### PR DESCRIPTION
## Description

Background tool calls that complete after being offloaded produce a hint message
containing an orphan `ToolResultBlock` (no matching `ToolCallBlock`). When the
OpenAI formatter splits this block into a `role=tool` wire message, the API
rejects it with 400: "Messages with role 'tool' must be a response to a
preceding message with 'tool_calls'".

This PR fixes the issue in two parts:

1. **Flatten hint message** (`_hint.py`): Remove the `ToolResultBlock` wrapper
   from `make_offload_hint_msg()` and place the result content blocks directly
   into `message.content`, making the hint a plain assistant message that all
   formatters handle correctly.

2. **Yield tool events on SSE stream** (`react_agent.py`): When pending hints
   are injected at the start of `_reply()`, yield standard tool-result event
   sequences (`ToolCallStart → ToolCallEnd → ToolResultStart → ToolResultTextDelta
   → ToolResultEnd`) so the frontend renders background tool results as normal
   inline tool cards — zero frontend changes required.

**Related Issue:** Fixes #5996 Fixes #5985 Fixes #5962

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review
