### PR TITLE
fix(doctor): use readiness endpoint in doctor

### DIFF
--- a/src/qwenpaw/cli/doctor_cmd.py
+++ b/src/qwenpaw/cli/doctor_cmd.py
@@ -89,6 +89,63 @@ def _http_get(url: str, **kwargs) -> httpx.Response:
     return httpx.get(url, **kwargs)
 
 
+def _check_api_health(
+    base: str,
+    timeout: float,
+) -> tuple[bool, httpx.Response | None]:
+    """Probe the application readiness endpoint and report its status."""
+    health_url = f"{base.rstrip('/')}/api/healthz"
+    try:
+        response = _http_get(health_url, timeout=timeout)
+    except httpx.RequestError as exc:
+        click.echo(
+            click.style("FAIL", fg="red")
+            + f" — health not reachable ({health_url})\n{exc}",
+            err=True,
+        )
+        click.echo(
+            f"Hint: start the server with `qwenpaw app` (default {base}).",
+            err=True,
+        )
+        return False, None
+
+    if response.status_code == 200:
+        click.echo(
+            click.style("OK", fg="green")
+            + f" — health ({health_url}, HTTP 200)",
+        )
+        return True, response
+
+    if response.status_code == 503:
+        detail = "Background startup in progress"
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        if isinstance(body, dict):
+            response_detail = body.get("detail")
+            if isinstance(response_detail, str) and response_detail.strip():
+                detail = response_detail.strip()
+        click.echo(
+            click.style("FAIL", fg="red")
+            + f" — health not ready ({health_url}, HTTP 503)\n{detail}",
+            err=True,
+        )
+        click.echo(
+            "Hint: wait for background startup to complete, then rerun "
+            "`qwenpaw doctor`.",
+            err=True,
+        )
+        return False, response
+
+    click.echo(
+        click.style("FAIL", fg="red")
+        + f" — health HTTP {response.status_code} ({health_url})",
+        err=True,
+    )
+    return False, response
+
+
 def _fetch_running_server_python(
     base: str,
     timeout: float,
@@ -843,35 +900,11 @@ def run_doctor_checks(
             click.echo(click.style("Note:", fg="yellow") + f" {mismatch}")
 
     click.echo("\n=== API ===")
-    health_url = f"{base}/api/agent/health"
     version_url = f"{base}/api/version"
-    try:
-        health_resp = _http_get(health_url, timeout=timeout)
-    except httpx.RequestError as exc:
+    health_ok, health_resp = _check_api_health(base, timeout)
+    if not health_ok:
         failed = True
-        click.echo(
-            click.style("FAIL", fg="red")
-            + f" — health not reachable ({health_url})\n{exc}",
-            err=True,
-        )
-        click.echo(
-            f"Hint: start the server with `qwenpaw app` (default {base}).",
-            err=True,
-        )
-    else:
-        if health_resp.status_code == 200:
-            click.echo(
-                click.style("OK", fg="green")
-                + f" — health ({health_url}, HTTP 200)",
-            )
-        else:
-            failed = True
-            click.echo(
-                click.style("FAIL", fg="red")
-                + f" — health HTTP {health_resp.status_code} ({health_url})",
-                err=True,
-            )
-
+    if health_resp is not None:
         try:
             version_resp = _http_get(version_url, timeout=timeout)
         except httpx.RequestError as exc:
@@ -915,7 +948,7 @@ def run_doctor_checks(
                         ),
                     )
 
-        if health_resp.status_code == 200:
+        if health_ok:
             try:
                 root_resp = _http_get(
                     f"{base}/",

--- a/tests/unit/cli/test_doctor_health.py
+++ b/tests/unit/cli/test_doctor_health.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Tests for the API health probe used by ``qwenpaw doctor``."""
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from qwenpaw.cli import doctor_cmd
+
+
+class _Response:
+    def __init__(
+        self,
+        status_code: int,
+        json_data: dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def json(self) -> dict[str, Any]:
+        return self._json_data
+
+
+def test_api_health_uses_readiness_endpoint(monkeypatch, capsys) -> None:
+    response = _Response(200, {"status": "ok"})
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def _fake_get(url: str, **kwargs):
+        calls.append((url, kwargs))
+        return response
+
+    monkeypatch.setattr(doctor_cmd, "_http_get", _fake_get)
+
+    ok, actual = doctor_cmd._check_api_health(
+        "http://127.0.0.1:8088",
+        timeout=2.0,
+    )
+
+    assert ok is True
+    assert actual is response
+    assert calls == [
+        ("http://127.0.0.1:8088/api/healthz", {"timeout": 2.0}),
+    ]
+    captured = capsys.readouterr()
+    assert "OK" in captured.out
+    assert "/api/healthz, HTTP 200" in captured.out
+    assert captured.err == ""
+
+
+def test_api_health_reports_background_startup(monkeypatch, capsys) -> None:
+    response = _Response(
+        503,
+        {
+            "status": "starting",
+            "detail": "Background startup in progress",
+        },
+    )
+    monkeypatch.setattr(
+        doctor_cmd,
+        "_http_get",
+        lambda _url, **_kwargs: response,
+    )
+
+    ok, actual = doctor_cmd._check_api_health(
+        "http://127.0.0.1:8088",
+        timeout=2.0,
+    )
+
+    assert ok is False
+    assert actual is response
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "FAIL" in captured.err
+    assert "health not ready" in captured.err
+    assert "Background startup in progress" in captured.err
+    assert "rerun `qwenpaw doctor`" in captured.err
+
+
+def test_api_health_reports_connection_failure(monkeypatch, capsys) -> None:
+    def _raise_connection_error(_url: str, **_kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(
+        doctor_cmd,
+        "_http_get",
+        _raise_connection_error,
+    )
+
+    ok, response = doctor_cmd._check_api_health(
+        "http://127.0.0.1:8088",
+        timeout=2.0,
+    )
+
+    assert ok is False
+    assert response is None
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "health not reachable" in captured.err
+    assert "connection refused" in captured.err
+    assert "start the server with `qwenpaw app`" in captured.err


### PR DESCRIPTION
## Description

`qwenpaw doctor` still probes the removed `/api/agent/health` route, so a
healthy AgentScope 2.0 server is reported as an HTTP 404 failure. This PR moves
the shared CLI health probe to the `/api/healthz` readiness endpoint introduced
in #6028.

The new health check reports HTTP 200 as ready, presents HTTP 503 as an
actionable background-startup state, and preserves the existing `/api/version`
diagnostic. The Console root probe only runs after readiness succeeds. The fix
is intentionally placed in the shared doctor command rather than adding back a
legacy agent-scoped route.

**Related Issue:** Fixes #5983

**Security Considerations:** No authentication, authorization, credential, or
endpoint policy changes. The existing HTTP proxy policy remains in use.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; this PR does not change channel code or contracts.

## Testing

Run the health endpoint contract and doctor tests:

```bash
pytest tests/unit/app/routers/test_healthz.py \
  tests/unit/cli/test_doctor_health.py \
  tests/unit/cli/test_cli_doctor_proxy.py -q
```

Run the complete CLI unit suite:

```bash
pytest tests/unit/cli -q
```

## Evidence

- Cross-layer healthz and doctor regression tests: **9 passed**.
- Complete CLI unit suite: **233 passed**.
- `pre-commit run --all-files`: all hooks passed, including mypy, black,
  flake8, pylint, and prettier.
- Full repository run: **5238 passed, 8 skipped, 1 unrelated failure**. The
  failure is
  `tests/unit/channels/test_onebot_channel.py::TestWatchdog::test_watchdog_restarts_when_port_unreachable`;
  this branch has no OneBot diff, and the same failure reproduced in 3/3
  isolated reruns.

```text
$ pytest tests/unit/app/routers/test_healthz.py tests/unit/cli/test_doctor_health.py tests/unit/cli/test_cli_doctor_proxy.py -q
.........                                                                [100%]
9 passed, 1 warning in 2.52s

$ pytest tests/unit/cli -q
233 passed in 27.41s

$ pre-commit run --all-files
check python ast.........................................................Passed
check yaml...............................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

$ pytest -q
1 failed, 5238 passed, 8 skipped, 55 warnings in 1194.88s (0:19:54)
```

## Additional Notes

Verification matrix:

- Healthz HTTP 200: covered
- Healthz HTTP 503: covered with startup detail and retry hint
- Health connection failure: covered
- `/api/version`: unchanged
- Console root probe: gated on readiness
- Providers and channels: not applicable

No documentation currently references the removed doctor health URL, so no
documentation update is required.
