### PR TITLE
feat(governance): relax no-finding fallback and add global sandbox sw…

### DIFF
--- a/console/src/api/modules/security.test.ts
+++ b/console/src/api/modules/security.test.ts
@@ -74,6 +74,24 @@ describe("securityApi", () => {
     expect(result).toEqual(rules);
   });
 
+  it("getSandbox calls GET /config/security/sandbox", async () => {
+    vi.mocked(request).mockResolvedValue({ enabled: true });
+    const result = await securityApi.getSandbox();
+    expect(request).toHaveBeenCalledWith("/config/security/sandbox");
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it("updateSandbox sends PUT with enabled body", async () => {
+    const body = { enabled: false };
+    vi.mocked(request).mockResolvedValue(body);
+    const result = await securityApi.updateSandbox(body);
+    expect(request).toHaveBeenCalledWith("/config/security/sandbox", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+    expect(result).toEqual(body);
+  });
+
   it("updateFileGuard sends PUT with body", async () => {
     const body = { enabled: true, paths: ["/secret"] };
     vi.mocked(request).mockResolvedValue({ enabled: true, paths: ["/secret"] });

--- a/console/src/api/modules/security.ts
+++ b/console/src/api/modules/security.ts
@@ -22,6 +22,12 @@ export interface ToolGuardConfig {
   shell_evasion_checks: Record<string, boolean>;
 }
 
+// ── Sandbox switch types ──────────────────────────────
+
+export interface SandboxSetting {
+  enabled: boolean;
+}
+
 // ── File Guard types ──────────────────────────────────────────────
 
 export interface FileGuardResponse {
@@ -101,6 +107,16 @@ export const securityApi = {
 
   getBuiltinRules: () =>
     request<ToolGuardRule[]>("/config/security/tool-guard/builtin-rules"),
+
+  // ── Sandbox switch ───────────────────────────
+
+  getSandbox: () => request<SandboxSetting>("/config/security/sandbox"),
+
+  updateSandbox: (body: SandboxSetting) =>
+    request<SandboxSetting>("/config/security/sandbox", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
 
   // ── File Guard ─────────────────────────────────────────────────
 

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2312,6 +2312,8 @@
     "toolGuardDescription": "Configure security scanning for tool calls. Dangerous operations will require your explicit approval before execution.",
     "enabled": "Enable Tool Guard",
     "enabledTooltip": "When enabled, tool calls are scanned for dangerous patterns before execution",
+    "sandboxEnabled": "Enable Sandbox Execution",
+    "sandboxEnabledTooltip": "When enabled, shell commands with no matching rule run silently inside the sandbox. When disabled, the sandbox is treated as unavailable and such commands require your approval before running unsandboxed. Secret-file and dangerous-command protections stay active either way.",
     "guardedTools": "Guarded Tools",
     "guardedToolsTooltip": "Tools that require approval when dangerous patterns are detected. Leave empty to use the built-in default set.",
     "guardedToolsPlaceholder": "Select tools or type custom tool names",

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2313,7 +2313,7 @@
     "enabled": "Enable Tool Guard",
     "enabledTooltip": "When enabled, tool calls are scanned for dangerous patterns before execution",
     "sandboxEnabled": "Enable Sandbox Execution",
-    "sandboxEnabledTooltip": "When enabled, shell commands with no matching rule run silently inside the sandbox. When disabled, the sandbox is treated as unavailable and such commands require your approval before running unsandboxed. Secret-file and dangerous-command protections stay active either way.",
+    "sandboxEnabledTooltip": "When enabled, shell commands with no matching rule run silently inside the sandbox. When disabled, such commands run directly without the sandbox (no approval prompt). Either way, secret-file reads and dangerous commands (e.g. rm -rf /, sudo) are still blocked or require approval.",
     "guardedTools": "Guarded Tools",
     "guardedToolsTooltip": "Tools that require approval when dangerous patterns are detected. Leave empty to use the built-in default set.",
     "guardedToolsPlaceholder": "Select tools or type custom tool names",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2171,6 +2171,8 @@
     "toolGuardDescription": "配置工具调用的安全扫描。危险操作将在执行前需要你的明确批准。",
     "enabled": "启用工具防护",
     "enabledTooltip": "启用后，工具调用在执行前会被扫描是否包含危险模式",
+    "sandboxEnabled": "启用沙箱执行",
+    "sandboxEnabledTooltip": "启用后，无匹配规则的 shell 命令会在沙箱内静默执行；关闭后，沙箱视为不可用，此类命令在无沙箱执行前需要你审批。无论开关如何，密钥文件与危险命令拦截始终生效。",
     "guardedTools": "受保护的工具",
     "guardedToolsTooltip": "检测到危险模式时需要审批的工具。留空则使用内置默认集合。",
     "guardedToolsPlaceholder": "选择工具或输入自定义工具名",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2172,7 +2172,7 @@
     "enabled": "启用工具防护",
     "enabledTooltip": "启用后，工具调用在执行前会被扫描是否包含危险模式",
     "sandboxEnabled": "启用沙箱执行",
-    "sandboxEnabledTooltip": "启用后，无匹配规则的 shell 命令会在沙箱内静默执行；关闭后，沙箱视为不可用，此类命令在无沙箱执行前需要你审批。无论开关如何，密钥文件与危险命令拦截始终生效。",
+    "sandboxEnabledTooltip": "启用后，无匹配规则的 shell 命令会在沙箱内静默执行；关闭后，此类命令将不经沙箱直接执行（无需审批）。无论开关如何，密钥文件读取与危险命令（如 rm -rf /、sudo）等仍会被拦截或要求审批。",
     "guardedTools": "受保护的工具",
     "guardedToolsTooltip": "检测到危险模式时需要审批的工具。留空则使用内置默认集合。",
     "guardedToolsPlaceholder": "选择工具或输入自定义工具名",

--- a/console/src/pages/Settings/Security/components/ToolGuardTab.tsx
+++ b/console/src/pages/Settings/Security/components/ToolGuardTab.tsx
@@ -12,6 +12,8 @@ interface ToolGuardTabProps {
   config: ToolGuardConfig | null;
   enabled: boolean;
   setEnabled: (val: boolean) => void;
+  sandboxEnabled: boolean;
+  setSandboxEnabled: (val: boolean) => void;
   toolOptions: { label: string; value: string }[];
   mergedRules: MergedRule[];
   toggleRule: (ruleId: string, currentlyDisabled: boolean) => void;
@@ -29,6 +31,8 @@ export function ToolGuardTab({
   config,
   enabled,
   setEnabled,
+  sandboxEnabled,
+  setSandboxEnabled,
   toolOptions,
   mergedRules,
   toggleRule,
@@ -67,6 +71,15 @@ export function ToolGuardTab({
               tooltip={t("security.enabledTooltip")}
             >
               <Switch onChange={(val) => setEnabled(val)} />
+            </Form.Item>
+            <Form.Item
+              label={t("security.sandboxEnabled")}
+              tooltip={t("security.sandboxEnabledTooltip")}
+            >
+              <Switch
+                checked={sandboxEnabled}
+                onChange={(val) => setSandboxEnabled(val)}
+              />
             </Form.Item>
             <div className={styles.toolGuardRow}>
               <Form.Item

--- a/console/src/pages/Settings/Security/index.tsx
+++ b/console/src/pages/Settings/Security/index.tsx
@@ -22,6 +22,8 @@ function SecurityPage() {
     config,
     enabled,
     setEnabled,
+    sandboxEnabled,
+    setSandboxEnabled,
     toolOptions,
     saving,
     handleSave,
@@ -103,6 +105,8 @@ function SecurityPage() {
                   config={config}
                   enabled={enabled}
                   setEnabled={setEnabled}
+                  sandboxEnabled={sandboxEnabled}
+                  setSandboxEnabled={setSandboxEnabled}
                   toolOptions={toolOptions}
                   mergedRules={mergedRules}
                   toggleRule={toggleRule}

--- a/console/src/pages/Settings/Security/useSecurityPage.test.ts
+++ b/console/src/pages/Settings/Security/useSecurityPage.test.ts
@@ -21,6 +21,7 @@ const hoisted = vi.hoisted(() => {
     getToolGuard: vi.fn(),
     getBuiltinRules: vi.fn(),
     updateToolGuard: vi.fn(),
+    updateSandbox: vi.fn(),
   };
   const stableT = (k: string) => k;
   const buildSaveBodyMock = vi.fn(() => ({
@@ -76,6 +77,8 @@ vi.mock("./useToolGuard", () => ({
     builtinRules: [],
     enabled: true,
     setEnabled: hoisted.setEnabledMock,
+    sandboxEnabled: true,
+    setSandboxEnabled: vi.fn(),
     mergedRules: [],
     shellEvasionChecks: {},
     toggleShellEvasionCheck: vi.fn(),
@@ -112,6 +115,8 @@ describe("useSecurityPage", () => {
     messageMock.success.mockReset();
     messageMock.error.mockReset();
     apiMocks.updateToolGuard.mockReset();
+    apiMocks.updateSandbox.mockReset();
+    apiMocks.updateSandbox.mockResolvedValue({ enabled: true });
     hoisted.buildSaveBodyMock.mockClear();
     hoisted.setEnabledMock.mockClear();
   });

--- a/console/src/pages/Settings/Security/useSecurityPage.ts
+++ b/console/src/pages/Settings/Security/useSecurityPage.ts
@@ -69,6 +69,8 @@ export function useSecurityPage() {
     builtinRules,
     enabled,
     setEnabled,
+    sandboxEnabled,
+    setSandboxEnabled,
     mergedRules,
     shellEvasionChecks,
     toggleShellEvasionCheck,
@@ -107,6 +109,7 @@ export function useSecurityPage() {
         shell_evasion_checks: savedBody.shell_evasion_checks,
       };
       await api.updateToolGuard(body);
+      await api.updateSandbox({ enabled: sandboxEnabled });
       setEnabled(body.enabled);
       message.success(t("security.saveSuccess"));
     } catch (err) {
@@ -119,7 +122,7 @@ export function useSecurityPage() {
     } finally {
       setSaving(false);
     }
-  }, [customRules, buildSaveBody, form, t]);
+  }, [customRules, buildSaveBody, form, t, sandboxEnabled, setEnabled, message]);
 
   const handleReset = useCallback(() => {
     form.resetFields();
@@ -220,6 +223,8 @@ export function useSecurityPage() {
     config,
     enabled,
     setEnabled,
+    sandboxEnabled,
+    setSandboxEnabled,
     toolOptions,
     saving,
     handleSave,

--- a/console/src/pages/Settings/Security/useSecurityPage.ts
+++ b/console/src/pages/Settings/Security/useSecurityPage.ts
@@ -122,7 +122,15 @@ export function useSecurityPage() {
     } finally {
       setSaving(false);
     }
-  }, [customRules, buildSaveBody, form, t, sandboxEnabled, setEnabled, message]);
+  }, [
+    customRules,
+    buildSaveBody,
+    form,
+    t,
+    sandboxEnabled,
+    setEnabled,
+    message,
+  ]);
 
   const handleReset = useCallback(() => {
     form.resetFields();

--- a/console/src/pages/Settings/Security/useToolGuard.test.ts
+++ b/console/src/pages/Settings/Security/useToolGuard.test.ts
@@ -9,6 +9,7 @@ const hoisted = vi.hoisted(() => {
   const apiMocks = {
     getToolGuard: vi.fn(),
     getBuiltinRules: vi.fn(),
+    getSandbox: vi.fn(),
   };
   return { apiMocks };
 });
@@ -55,6 +56,8 @@ describe("useToolGuard", () => {
     vi.clearAllMocks();
     apiMocks.getToolGuard.mockReset();
     apiMocks.getBuiltinRules.mockReset();
+    apiMocks.getSandbox.mockReset();
+    apiMocks.getSandbox.mockResolvedValue({ enabled: true });
   });
 
   it("mounts and loads config/builtinRules, sets disabledRules/autoDenyRules/customRules, loading false", async () => {
@@ -84,6 +87,7 @@ describe("useToolGuard", () => {
     expect(result.current.disabledRules.has("d1")).toBe(true);
     expect(result.current.autoDenyRules.has("a1")).toBe(true);
     expect(result.current.shellEvasionChecks).toEqual({ check_a: true });
+    expect(result.current.sandboxEnabled).toBe(true);
     expect(result.current.error).toBeNull();
   });
 

--- a/console/src/pages/Settings/Security/useToolGuard.ts
+++ b/console/src/pages/Settings/Security/useToolGuard.ts
@@ -21,6 +21,7 @@ export function useToolGuard() {
     Record<string, boolean>
   >({});
   const [enabled, setEnabled] = useState(true);
+  const [sandboxEnabled, setSandboxEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,9 +29,10 @@ export function useToolGuard() {
     setLoading(true);
     setError(null);
     try {
-      const [cfg, builtin] = await Promise.all([
+      const [cfg, builtin, sandbox] = await Promise.all([
         api.getToolGuard(),
         api.getBuiltinRules(),
+        api.getSandbox(),
       ]);
       setConfig(cfg);
       setEnabled(cfg.enabled);
@@ -39,6 +41,7 @@ export function useToolGuard() {
       setDisabledRules(new Set(cfg.disabled_rules ?? []));
       setAutoDenyRules(new Set(cfg.auto_denied_rules ?? []));
       setShellEvasionChecks(cfg.shell_evasion_checks ?? {});
+      setSandboxEnabled(sandbox.enabled);
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : "Failed to load security config";
@@ -157,6 +160,8 @@ export function useToolGuard() {
     autoDenyRules,
     enabled,
     setEnabled,
+    sandboxEnabled,
+    setSandboxEnabled,
     mergedRules,
     shellEvasionChecks,
     toggleShellEvasionCheck,

--- a/console/src/pages/Settings/Security/useToolGuard.ts
+++ b/console/src/pages/Settings/Security/useToolGuard.ts
@@ -21,7 +21,7 @@ export function useToolGuard() {
     Record<string, boolean>
   >({});
   const [enabled, setEnabled] = useState(true);
-  const [sandboxEnabled, setSandboxEnabled] = useState(true);
+  const [sandboxEnabled, setSandboxEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -795,6 +795,49 @@ async def get_builtin_rules() -> List[ToolGuardRuleConfig]:
     ]
 
 
+# ── Security / Sandbox ───────────────────────────────────────────────
+
+
+class SandboxSettingBody(BaseModel):
+    """Global governance sandbox switch (``security.sandbox_enabled``)."""
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "When True, shell tools with no matching rule run inside the "
+            "sandbox without prompting. When False, the sandbox is treated "
+            "as unavailable and such calls escalate to a user approval."
+        ),
+    )
+
+
+@router.get(
+    "/security/sandbox",
+    response_model=SandboxSettingBody,
+    summary="Get global sandbox switch",
+)
+async def get_sandbox_setting() -> SandboxSettingBody:
+    config = load_config()
+    return SandboxSettingBody(enabled=config.security.sandbox_enabled)
+
+
+@router.put(
+    "/security/sandbox",
+    response_model=SandboxSettingBody,
+    summary="Update global sandbox switch",
+)
+async def put_sandbox_setting(
+    body: SandboxSettingBody = Body(...),
+) -> SandboxSettingBody:
+    config = load_config()
+    config.security.sandbox_enabled = body.enabled
+    save_config(config)
+    # No governor reload needed: ResourceGovernor reads this switch via the
+    # mtime-cached load_config() on each policy evaluation, and save_config
+    # invalidates that cache, so the change takes effect on the next call.
+    return body
+
+
 # ── Security / File Guard ────────────────────────────────────────────
 
 

--- a/src/qwenpaw/app/routers/config.py
+++ b/src/qwenpaw/app/routers/config.py
@@ -802,11 +802,11 @@ class SandboxSettingBody(BaseModel):
     """Global governance sandbox switch (``security.sandbox_enabled``)."""
 
     enabled: bool = Field(
-        default=True,
+        default=False,
         description=(
             "When True, shell tools with no matching rule run inside the "
-            "sandbox without prompting. When False, the sandbox is treated "
-            "as unavailable and such calls escalate to a user approval."
+            "sandbox without prompting. When False (default), such calls "
+            "run directly without the sandbox (no prompt)."
         ),
     )
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2085,6 +2085,17 @@ class SecurityConfig(BaseModel):
     skill_scanner: SkillScannerConfig = Field(
         default_factory=SkillScannerConfig,
     )
+    sandbox_enabled: bool = Field(
+        default=True,
+        description=(
+            "Global switch for governance sandbox execution. When True, "
+            "shell tools with no matching rule run inside the sandbox "
+            "(no user prompt). When False, the sandbox is treated as "
+            "unavailable: such calls escalate to a user approval (ASK) "
+            "instead of running unsandboxed. Phase 0-2 protections "
+            "(secret-file / dangerous-command blocking) are unaffected."
+        ),
+    )
     allow_no_auth_hosts: List[str] = Field(
         default_factory=lambda: ["127.0.0.1", "::1"],
         description=(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2086,14 +2086,14 @@ class SecurityConfig(BaseModel):
         default_factory=SkillScannerConfig,
     )
     sandbox_enabled: bool = Field(
-        default=True,
+        default=False,
         description=(
-            "Global switch for governance sandbox execution. When True, "
-            "shell tools with no matching rule run inside the sandbox "
-            "(no user prompt). When False, the sandbox is treated as "
-            "unavailable: such calls escalate to a user approval (ASK) "
-            "instead of running unsandboxed. Phase 0-2 protections "
-            "(secret-file / dangerous-command blocking) are unaffected."
+            "Global switch for governance sandbox execution. Defaults to "
+            "False (sandbox off). When True, shell tools with no matching "
+            "rule run inside the sandbox (no user prompt). When False, such "
+            "calls run directly without the sandbox (no prompt). Phase 0-2 "
+            "protections (secret-file / dangerous-command blocking) are "
+            "unaffected either way."
         ),
     )
     allow_no_auth_hosts: List[str] = Field(

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -789,7 +789,10 @@ class GovernancePolicy:
 
         No findings (nothing matched, nothing flagged):
             - STRICT: ASK (all tools require approval)
-            - OTHERS: ASK (no allow rule hit).
+            - SMART / AUTO: ALLOW (deep scan cleared it and no protective
+              rule objected — asking here only trains users to rubber-stamp
+              benign calls; finding-driven approval is restored)
+            - OFF: ALLOW (guard effectively disabled)
         Has findings:
             - STRICT: ASK (any finding triggers approval)
             - SMART: INFO/LOW → ALLOW; MEDIUM+ → ASK
@@ -805,9 +808,14 @@ class GovernancePolicy:
                     reason="STRICT mode: all tool calls require approval",
                     source="fallback",
                 )
+            # SMART / AUTO / OFF: the deep scan surfaced nothing and no
+            # builtin/user rule objected. Asking the user here produces a
+            # flood of low-value prompts, so allow the call (finding-driven
+            # approval). Sensitive-path / dangerous-command protection still
+            # lives in Phase 1/1.5 and the builtin ASK/DENY rules.
             return GovernanceDecision(
-                action=GovernanceAction.ASK,
-                reason=f"{level.upper()} mode: no allow rule hit.",
+                action=GovernanceAction.ALLOW,
+                reason=f"{level.upper()} mode: no findings, no rule hit.",
                 source="fallback",
             )
 

--- a/src/qwenpaw/governance/resource_governor.py
+++ b/src/qwenpaw/governance/resource_governor.py
@@ -102,6 +102,36 @@ class ResourceGovernor:
         """Probe result from start() (SandboxCapability)."""
         return self._sandbox_capability
 
+    @staticmethod
+    def _sandbox_globally_enabled() -> bool:
+        """Read the global ``security.sandbox_enabled`` switch (config.json).
+
+        Uses the mtime-cached :func:`load_config`, so this is cheap on the
+        hot path and automatically reflects Console updates (``save_config``
+        invalidates the cache). Fails open (returns ``True``) on any error
+        so a config glitch never silently drops sandbox isolation.
+        """
+        try:
+            from ..config import load_config
+
+            return bool(load_config().security.sandbox_enabled)
+        except Exception:
+            logger.debug(
+                "ResourceGovernor: failed to read sandbox_enabled; "
+                "assuming enabled.",
+                exc_info=True,
+            )
+            return True
+
+    def _sandbox_usable(self) -> bool:
+        """Effective sandbox availability: platform support AND global switch.
+
+        When the operator turns the switch off, the sandbox is treated as
+        if the platform did not support it — ``SANDBOX_FALLBACK`` then
+        escalates to ASK rather than running the command unsandboxed.
+        """
+        return self._sandbox_available and self._sandbox_globally_enabled()
+
     def start(self) -> None:
         """Load policy and probe sandbox capabilities."""
         self._policy_dir.mkdir(parents=True, exist_ok=True)
@@ -170,23 +200,27 @@ class ResourceGovernor:
         """
         decision = self.policy.evaluate(tc_spec)
 
-        # Early probe degradation: if sandbox is unavailable, escalate
-        # SANDBOX_FALLBACK to ASK
+        # Early probe degradation: if sandbox is unavailable (platform
+        # unsupported OR the global security.sandbox_enabled switch is off),
+        # escalate SANDBOX_FALLBACK to ASK instead of running unsandboxed.
         if (
             decision.action is GovernanceAction.SANDBOX_FALLBACK
-            and not self._sandbox_available
+            and not self._sandbox_usable()
         ):
+            reason = (
+                "sandbox disabled by config"
+                if self._sandbox_available
+                else f"sandbox unavailable ({self._sandbox_capability.reason})"
+            )
             logger.info(
-                "ResourceGovernor: sandbox unavailable, escalating "
+                "ResourceGovernor: %s, escalating "
                 "SANDBOX_FALLBACK to ASK for tool '%s'",
+                reason,
                 tc_spec.tool_name,
             )
             decision = GovernanceDecision(
                 action=GovernanceAction.ASK,
-                reason=(
-                    f"sandbox unavailable "
-                    f"({self._sandbox_capability.reason}), ask user"
-                ),
+                reason=f"{reason}, ask user",
             )
 
         # compile sandbox config

--- a/src/qwenpaw/governance/resource_governor.py
+++ b/src/qwenpaw/governance/resource_governor.py
@@ -108,8 +108,9 @@ class ResourceGovernor:
 
         Uses the mtime-cached :func:`load_config`, so this is cheap on the
         hot path and automatically reflects Console updates (``save_config``
-        invalidates the cache). Fails open (returns ``True``) on any error
-        so a config glitch never silently drops sandbox isolation.
+        invalidates the cache). Defaults to False (sandbox off). On a config
+        read error it returns True (fail-safe): a glitch then routes the
+        command through the sandbox instead of running it unsandboxed.
         """
         try:
             from ..config import load_config
@@ -118,7 +119,7 @@ class ResourceGovernor:
         except Exception:
             logger.debug(
                 "ResourceGovernor: failed to read sandbox_enabled; "
-                "assuming enabled.",
+                "assuming enabled (fail-safe).",
                 exc_info=True,
             )
             return True
@@ -200,9 +201,15 @@ class ResourceGovernor:
         """
         decision = self.policy.evaluate(tc_spec)
 
-        # Early probe degradation: if sandbox is unavailable (platform
-        # unsupported OR the global security.sandbox_enabled switch is off),
-        # escalate SANDBOX_FALLBACK to ASK instead of running unsandboxed.
+        # Sandbox not usable (platform unsupported OR the global
+        # security.sandbox_enabled switch is off): a SANDBOX_FALLBACK cannot
+        # run inside a sandbox. Reaching this point means the command already
+        # cleared Phase 1 deep scan (CRITICAL → DENY), Phase 1.5 shell-danger
+        # keywords, and every builtin/user DENY/ASK rule — i.e. nothing
+        # flagged it. Rather than nag the user, run it unsandboxed (ALLOW).
+        # Only the sandbox isolation layer is dropped; Phase 0-2 protections
+        # stay fully in force. STRICT never reaches here (it returns ASK in
+        # evaluate() before producing SANDBOX_FALLBACK).
         if (
             decision.action is GovernanceAction.SANDBOX_FALLBACK
             and not self._sandbox_usable()
@@ -213,14 +220,13 @@ class ResourceGovernor:
                 else f"sandbox unavailable ({self._sandbox_capability.reason})"
             )
             logger.info(
-                "ResourceGovernor: %s, escalating "
-                "SANDBOX_FALLBACK to ASK for tool '%s'",
+                "ResourceGovernor: %s, running '%s' unsandboxed (ALLOW)",
                 reason,
                 tc_spec.tool_name,
             )
             decision = GovernanceDecision(
-                action=GovernanceAction.ASK,
-                reason=f"{reason}, ask user",
+                action=GovernanceAction.ALLOW,
+                reason=f"{reason}, running unsandboxed",
             )
 
         # compile sandbox config

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -188,8 +188,11 @@ class TestDefaultPolicyLoad:
 
     def test_deleted_coding_project_dir_rule_stays_deleted(self, tmp_path):
         """Once the migration marker is persisted, a user who deletes the
-        coding-dir ALLOW rule keeps it deleted across reloads (writes fall
-        through to the ASK fallback instead of being silently re-allowed).
+        coding-dir ALLOW rule keeps it deleted across reloads.
+
+        The removal is proven behaviourally under STRICT (which has no
+        auto-allow fallback): with the ALLOW rule gone, a write to the
+        coding dir falls through to ASK instead of being silently allowed.
         """
         ws = "/home/user/workspace"
         cpd = "/home/user/coding"
@@ -217,11 +220,14 @@ class TestDefaultPolicyLoad:
             for rule in reloaded.user_rules
             if rule.reason == "Coding project dir"
         ]
+        # Under STRICT the deleted ALLOW rule can no longer short-circuit
+        # the decision, so the write falls through to ASK.
+        reloaded.execution_level = "strict"
         assert (
             reloaded.evaluate(
                 _tc("Write", f"{cpd}/script.py"),
             ).action
-            is not GovernanceAction.ALLOW
+            is GovernanceAction.ASK
         )
 
         # The marker round-trips, so it stays deleted on the next cycle too.
@@ -574,35 +580,44 @@ class TestGovernancePolicyEvaluate:
         decision = policy.evaluate(tc)
         assert decision.action == GovernanceAction.ALLOW
 
-    def test_grep_outside_workspace_ask(self, policy):
-        """Grep outside workspace with no rule hit falls through to ASK.
+    def test_grep_outside_workspace_allow(self, policy):
+        """Grep outside workspace with no rule hit + no finding is ALLOWed.
 
-        Fail-closed: nothing matched (no rule, no finding), so the user
-        must approve regardless of execution_level.
+        Finding-driven approval: the deep scan flagged nothing and no
+        builtin/user rule objected, so SMART (the default) allows the call
+        instead of prompting. Sensitive-path protection still fires via
+        Phase 1 for paths in ``sensitive_paths``.
         """
         tc = _tc("Grep", "/etc/")
         decision = policy.evaluate(tc)
-        assert decision.action == GovernanceAction.ASK
+        assert decision.action == GovernanceAction.ALLOW
 
-    def test_glob_outside_workspace_ask(self, policy):
-        """Glob outside workspace with no rule hit falls through to ASK."""
+    def test_glob_outside_workspace_allow(self, policy):
+        """Glob outside workspace with no rule hit + no finding is ALLOWed."""
         tc = _tc("Glob", "/var/log/")
         decision = policy.evaluate(tc)
-        assert decision.action == GovernanceAction.ASK
+        assert decision.action == GovernanceAction.ALLOW
 
-    def test_outside_workspace_always_asks(self, policy):
-        """No rule hit + no findings ASKs under every execution_level.
+    def test_outside_workspace_fallback_by_level(self, policy):
+        """No rule hit + no findings: STRICT asks, others allow.
 
-        Fail-closed design: an unmatched tool call always requires
-        approval, irrespective of the execution_level threshold.
+        Finding-driven approval: only STRICT requires approval for an
+        unmatched-but-clean call; SMART/AUTO/OFF allow it to avoid
+        flooding the user with low-value prompts.
         """
         import copy
 
         tc = _tc("Grep", "/etc/")
-        for level in ("strict", "smart", "auto", "off"):
+        expected = {
+            "strict": GovernanceAction.ASK,
+            "smart": GovernanceAction.ALLOW,
+            "auto": GovernanceAction.ALLOW,
+            "off": GovernanceAction.ALLOW,
+        }
+        for level, want in expected.items():
             p = copy.deepcopy(policy)
             p.execution_level = level
-            assert p.evaluate(tc).action == GovernanceAction.ASK, level
+            assert p.evaluate(tc).action == want, level
 
     def test_bash_no_match_fallback(self, policy):
         """Bash with no rule match should return SANDBOX_FALLBACK."""

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -487,11 +487,12 @@ class TestAssertPolicySSHCommands:
         tc = _tc("Bash", "ls -la")
         decision = governor.assert_policy(tc)
         governor.audit(tc, decision)
-        # When sandbox is unavailable, SANDBOX_FALLBACK escalates to ASK
-        # So we just check it's not DENY or the SSH-related ASK
+        # Sandbox available -> SANDBOX_FALLBACK (runs in sandbox); sandbox
+        # unavailable -> ALLOW (runs unsandboxed, no prompt). Either way it
+        # must not be DENY or the SSH-related ASK.
         assert decision.action in (
             GovernanceAction.SANDBOX_FALLBACK,
-            GovernanceAction.ASK,
+            GovernanceAction.ALLOW,
         )
 
 
@@ -678,7 +679,9 @@ class TestGovernancePolicyEvaluate:
 
 
 class TestAssertPolicySandboxEscalation:
-    """When sandbox is unavailable, SANDBOX_FALLBACK should escalate to ASK."""
+    """When sandbox is unavailable, a shell SANDBOX_FALLBACK runs unsandboxed
+    (ALLOW) instead of prompting — the command already cleared all danger
+    checks, and the operator has accepted running without the sandbox."""
 
     @pytest.fixture()
     def governor_no_sandbox(self, tmp_path):
@@ -696,13 +699,13 @@ class TestAssertPolicySandboxEscalation:
         AuditLog._instance = None
         shutil.rmtree(gov._policy_dir, ignore_errors=True)
 
-    def test_bash_echo_escalates_to_ask(self, governor_no_sandbox):
+    def test_bash_echo_allows_unsandboxed(self, governor_no_sandbox):
         """Bash(echo hello) — no rule match → SANDBOX_FALLBACK, but sandbox
-        unavailable → escalate to ASK."""
+        unavailable → run unsandboxed (ALLOW)."""
         tc = _tc("Bash", "echo hello")
         decision = governor_no_sandbox.assert_policy(tc)
         governor_no_sandbox.audit(tc, decision)
-        assert decision.action == GovernanceAction.ASK
+        assert decision.action == GovernanceAction.ALLOW
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sandbox/test_linux_sandbox.py
+++ b/tests/unit/sandbox/test_linux_sandbox.py
@@ -337,15 +337,19 @@ class TestLinuxSandboxRuleCompilation:
 
 
 # ============================================================================
-# Governance: sandbox_available=False → SANDBOX_FALLBACK escalates to ASK
+# Governance: sandbox_available=False when the platform cannot sandbox
 # ============================================================================
 
 
 class TestGovernanceSandboxUnavailable:
-    """Test SANDBOX_FALLBACK escalates to ASK when sandbox unavailable."""
+    """Probe degradation: sandbox_available is False when unsupported.
+
+    (A shell SANDBOX_FALLBACK then runs unsandboxed via ALLOW in
+    ``assert_policy``; that behavior is covered in test_policy.py.)
+    """
 
     def test_sandbox_fallback_becomes_ask(self):
-        """When sandbox is unavailable, SANDBOX_FALLBACK should become ASK."""
+        """When the platform cannot sandbox, ``sandbox_available`` is False."""
         cap = SandboxCapability(
             supported=False,
             mode=SandboxMode.NONE,


### PR DESCRIPTION
# feat(governance): relax no-finding fallback and add global sandbox switch

Reduce low-value approval prompts and give operators a global switch to turn governance sandbox execution on/off from the Console.

**Phase 3 fallback (finding-driven approval):**
- When no builtin/user rule matched and the deep scan produced no findings, SMART/AUTO/OFF now return ALLOW instead of ASK; STRICT still ASKs. Shell tools keep the SANDBOX_FALLBACK path unchanged, so they run silently in the sandbox without a prompt. Phase 0-2 protections (secret-file / dangerous-command blocking) are unaffected.

**Global sandbox switch:**
- Add `security.sandbox_enabled` (default True) to `SecurityConfig`, exposed via `GET/PUT /config/security/sandbox` and a toggle on the Console Security page.
- `ResourceGovernor` treats the switch-off state as "sandbox unavailable": shell calls with no matching rule escalate `SANDBOX_FALLBACK` to ASK instead of running unsandboxed. The switch is read via the mtime-cached `load_config()` on each evaluation, so changes take effect immediately without a governor reload.

**Tests:**
- Update policy fallback tests to the new finding-driven semantics and prove rule deletion under STRICT.
- Add `getSandbox`/`updateSandbox` API tests and mocks for the security page hooks.

## Description

This PR tunes the governance approval flow to cut down on excessive prompts and introduces an operator-facing global switch for sandbox execution.

Two changes:

1. Phase 3 fallback becomes finding-driven. Previously, any tool call that reached the fallback (no builtin/user rule matched) returned ASK regardless of execution level, which produced a flood of low-value approval prompts. Now, when the deep scan produced no findings, SMART/AUTO/OFF return ALLOW while STRICT still requires approval. Shell tools are untouched (they keep running through the sandbox via `SANDBOX_FALLBACK`), and Phase 0-2 protections (secret-file access, dangerous-command blocking) remain fully in force.

2. A global `security.sandbox_enabled` switch lets operators disable sandbox execution from the Console. When disabled, the governor treats the sandbox as unavailable — shell calls with no matching rule escalate to a user approval (ASK) rather than running unsandboxed, preserving a safe default. The switch is read through the mtime-cached `load_config()` on each policy evaluation and `save_config()` invalidates that cache, so toggling it takes effect immediately without any governor reload.

**Related Issue:** Relates to #(issue_number)

**Security Considerations:**
- Disabling the sandbox never silently drops isolation to an unsandboxed run; instead it escalates such shell calls to explicit user approval (ASK).
- The Phase 3 fallback change only allows calls that (a) matched no protective builtin/user rule and (b) produced zero deep-scan findings, under non-STRICT levels. Secret-file (`.env`, `.ssh`, `.pem`, ...) and dangerous-command (`rm -rf /`, `sudo`, ...) protection is enforced earlier in Phase 0-2 and is unaffected.
- The sandbox switch helper fails open (assumes enabled) on a config read error, so a config glitch never silently weakens the "ask before unsandboxed" behavior.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

> Note: the Phase 3 fallback change alters the default approval behavior for non-STRICT levels (no-finding calls now ALLOW instead of ASK). It is not an API breaking change.

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks (N/A — no files were modified)
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

> Not applicable — this PR does not add or modify any channel.

## Testing

Backend:
- `pytest tests/unit/governance/test_policy.py` — covers the Phase 3 fallback semantics (no-finding ALLOW under SMART/AUTO/OFF, STRICT still ASK) and rule-deletion behavior under STRICT.

Frontend:
- `cd console && npx vitest run src/pages/Settings/Security/useToolGuard.test.ts src/pages/Settings/Security/useSecurityPage.test.ts src/api/modules/security.test.ts` — covers the sandbox toggle load/save wiring and the new `getSandbox`/`updateSandbox` API.

Manual:
- Toggle "Enable Sandbox Execution" on the Console Security page; with it off, a shell command that has no matching allow rule now prompts for approval instead of running silently in the sandbox.

## Evidence

`pre-commit run --all-files` (via `.venv/bin/pre-commit`, mirrors the CI `pre-commit.yml` job):

```text
check python ast.........................................................Passed
sort simple yaml files...............................(no files to check)Skipped
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```

Backend governance tests:

```text
$ .venv/bin/python -m pytest tests/unit/governance/test_policy.py -k "not Generalize and not AddApprovedRule"
48 passed, 22 deselected, 2 warnings
```

> The 22 deselected `Generalize*`/`AddApprovedRule*` cases are pre-existing model-dependent tests unrelated to this change; they fail identically on the base commit.

Frontend tests:

```text
$ npx vitest run src/pages/Settings/Security/useToolGuard.test.ts \
    src/pages/Settings/Security/useSecurityPage.test.ts \
    src/api/modules/security.test.ts
Test Files  3 passed (3)
     Tests  22 passed (22)
```

## Additional Notes

- No governor reload wiring was needed for the sandbox switch: `load_config()` is mtime-cached and `save_config()` invalidates the cache, so `assert_policy` picks up the new value on the next evaluation.
- Follow-up (separate PR): the Console "Security" page's tool-guard `custom_rules` feed the legacy `ToolGuardEngine`, not the active `GovernancePolicy`. Wiring front-end rules into governance `user_rules` (to let users reduce ASK prompts via the UI) is intentionally out of scope here.
