### PR TITLE
perf(skills): skip redundant manifest reconciliation to prevent FD exhaustion

### DIFF
--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -1203,7 +1203,33 @@ def resolve_effective_skills(
 
 def ensure_skills_initialized(workspace_dir: Path) -> None:
     """Ensure workspace manifests exist before runtime use."""
-    reconcile_workspace_manifest(workspace_dir)
+    manifest_path = get_workspace_skill_manifest_path(workspace_dir)
+    if not manifest_path.exists():
+        reconcile_workspace_manifest(workspace_dir)
+        return
+
+    # Skip full-reconcile if disk skills match manifest keys.
+    try:
+        skills_dir = get_workspace_skills_dir(workspace_dir)
+        if not skills_dir.exists():
+            reconcile_workspace_manifest(workspace_dir)
+            return
+
+        manifest = read_skill_manifest(workspace_dir)
+        manifest_skills = set(manifest.get("skills", {}).keys())
+
+        disk_skills = {
+            path.name
+            for path in skills_dir.iterdir()
+            if not is_ignored_skill_entry(path.name)
+            and path.is_dir()
+            and (path / "SKILL.md").exists()
+        }
+
+        if disk_skills != manifest_skills:
+            reconcile_workspace_manifest(workspace_dir)
+    except Exception:
+        reconcile_workspace_manifest(workspace_dir)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What Problem This Solves

During runtime initialization, the runner calls \ensure_skills_initialized\. Previously, this unconditionally called \econcile_workspace_manifest\, which performed a full disk scan and wrote to the manifest file on every single request.

This PR optimizes \ensure_skills_initialized\ to perform a fast directory listing to check if the on-disk skill folders match the manifest keys. If they are already in sync, it avoids the expensive directory scanning, frontmatter parsing, and file-locked writes, preventing potential file descriptor exhaustion (\OSError: [Errno 24] Too many open files\).

## Evidence

Validation was performed via local tests ensuring that:
1. Reconciliation is run if the manifest does not exist or if on-disk skill directories don't match the manifest keys.
2. Reconciliation is skipped when they are already in sync.

The changes in \egistry.py\ also pass all \pre-commit\ checks (mypy, black, flake8, pylint).