### PR TITLE
fix(governance): bridge frontend tool-guard rules into policy deep scan

### DIFF
--- a/src/qwenpaw/governance/detectors.py
+++ b/src/qwenpaw/governance/detectors.py
@@ -61,6 +61,7 @@ def run_deep_scan(
     sensitive_paths: List[str],
     detection_rules: list[Any],
     shell_evasion_checks: dict[str, bool],
+    raw_params: dict[str, Any] | None = None,
 ) -> list[GuardFinding]:
     """Run all deep security detectors for one tool call.
 
@@ -73,6 +74,7 @@ def run_deep_scan(
         sensitive_paths: List of sensitive path prefixes from policy.yaml
         detection_rules: List of DetectionRuleConfig from policy.yaml
         shell_evasion_checks: Per-check enablement map from policy.yaml
+        raw_params: Full tool call parameters dict (for param-value scanning)
 
     Returns:
         Accumulated list of GuardFinding objects.
@@ -97,6 +99,7 @@ def run_deep_scan(
                 tool_name=tool_name,
                 target=target,
                 detection_rules=detection_rules,
+                raw_params=raw_params,
             ),
         )
 
@@ -348,12 +351,12 @@ def detect_dangerous_patterns(
     tool_name: str,
     target: str,
     detection_rules: list[Any],
+    raw_params: dict[str, Any] | None = None,
 ) -> list[GuardFinding]:
-    """Match tool target against regex detection rules.
+    """Match tool parameter values against regex detection rules.
 
-    Each rule specifies which tools and params it applies to.
-    Since GovernancePolicy passes `target` (the primary argument),
-    we match against that string.
+    Scans both the primary `target` and all string values in `raw_params`
+    to match the frontend Security page behavior ("匹配工具参数值").
     """
     findings: list[GuardFinding] = []
 
@@ -367,48 +370,63 @@ def detect_dangerous_patterns(
     }
     guard_tool_name = tool_aliases.get(tool_name, tool_name)
 
+    # Collect all scannable values: target + raw_params string values
+    scan_entries: list[tuple[str, str]] = [("target", target)]
+    if raw_params:
+        for param_name, param_value in raw_params.items():
+            if isinstance(param_value, str) and param_value:
+                # Avoid re-scanning target if it's already in params
+                if param_value != target:
+                    scan_entries.append((param_name, param_value))
+
     for rule in detection_rules:
         # Check if rule applies to this tool
         if rule.tools and guard_tool_name not in rule.tools:
             continue
 
         compiled_patterns, compiled_exclude = _get_compiled_patterns(rule)
+        matched = False
 
-        # Check exclude patterns first
-        if any(ep.search(target) for ep in compiled_exclude):
-            continue
+        for param_name, value in scan_entries:
+            if matched:
+                break
 
-        # Check match patterns
-        for pattern in compiled_patterns:
-            m = pattern.search(target)
-            if m:
-                # Context snippet around match
-                start = max(0, m.start() - 40)
-                end = min(len(target), m.end() + 40)
-                snippet = target[start:end]
+            # Check exclude patterns (against this value)
+            if any(ep.search(value) for ep in compiled_exclude):
+                continue
 
-                findings.append(
-                    GuardFinding(
-                        id=f"GUARD-{uuid.uuid4().hex[:12]}",
-                        rule_id=rule.id,
-                        category=rule.category,
-                        severity=rule.severity,
-                        title=f"[{rule.severity}] {rule.description}",
-                        description=(
-                            rule.description
-                            or f"Rule {rule.id} matched tool "
-                            f"'{tool_name}' target."
+            # Check match patterns
+            for pattern in compiled_patterns:
+                m = pattern.search(value)
+                if m:
+                    # Context snippet around match
+                    start = max(0, m.start() - 40)
+                    end = min(len(value), m.end() + 40)
+                    snippet = value[start:end]
+
+                    findings.append(
+                        GuardFinding(
+                            id=f"GUARD-{uuid.uuid4().hex[:12]}",
+                            rule_id=rule.id,
+                            category=rule.category,
+                            severity=rule.severity,
+                            title=f"[{rule.severity}] {rule.description}",
+                            description=(
+                                rule.description
+                                or f"Rule {rule.id} matched parameter "
+                                f"'{param_name}' of tool '{tool_name}'."
+                            ),
+                            tool_name=tool_name,
+                            param_name=param_name,
+                            matched_value=m.group(0),
+                            matched_pattern=pattern.pattern,
+                            snippet=snippet,
+                            remediation=rule.remediation,
+                            detector="pattern_detector",
                         ),
-                        tool_name=tool_name,
-                        param_name="target",
-                        matched_value=m.group(0),
-                        matched_pattern=pattern.pattern,
-                        snippet=snippet,
-                        remediation=rule.remediation,
-                        detector="pattern_detector",
-                    ),
-                )
-                break  # One match per rule is sufficient
+                    )
+                    matched = True
+                    break  # One match per rule is sufficient
 
     return findings
 

--- a/src/qwenpaw/governance/detectors.py
+++ b/src/qwenpaw/governance/detectors.py
@@ -93,7 +93,7 @@ def run_deep_scan(
         )
 
     # Detector 2: Pattern-based dangerous command detection
-    if detection_rules and target:
+    if detection_rules and (target or raw_params):
         findings.extend(
             detect_dangerous_patterns(
                 tool_name=tool_name,
@@ -346,7 +346,7 @@ def _get_compiled_patterns(
     return compiled, compiled_exclude
 
 
-def detect_dangerous_patterns(
+def detect_dangerous_patterns(  # noqa: E501  pylint: disable=too-many-locals,too-many-branches
     *,
     tool_name: str,
     target: str,
@@ -355,13 +355,14 @@ def detect_dangerous_patterns(
 ) -> list[GuardFinding]:
     """Match tool parameter values against regex detection rules.
 
-    Scans both the primary `target` and all string values in `raw_params`
-    to match the frontend Security page behavior ("匹配工具参数值").
+    Scans the primary `target` and string values in `raw_params`, honoring
+    each rule's `params` scope (empty = match all params). Aligns with the
+    frontend Security page semantics ("match tool parameter values").
     """
     findings: list[GuardFinding] = []
 
-    # Map governance tool names to tool_guard tool names for rule matching
-    # Policy uses "Bash", rules use "execute_shell_command"
+    # Map governance tool names to tool_guard tool names for rule matching.
+    # Policy uses "Bash"; rules use "execute_shell_command".
     tool_aliases = {
         "Bash": "execute_shell_command",
         "Read": "read_file",
@@ -370,19 +371,39 @@ def detect_dangerous_patterns(
     }
     guard_tool_name = tool_aliases.get(tool_name, tool_name)
 
-    # Collect all scannable values: target + raw_params string values
-    scan_entries: list[tuple[str, str]] = [("target", target)]
+    # Resolve the registry's primary param name for `target` so that
+    # rule.params filtering and finding.param_name use real names
+    # (e.g. "command" for Bash, "file_path" for Write).
+    from .tool_registry import (
+        DEFAULT_REGISTRY,
+    )  # pylint: disable=import-outside-toplevel
+
+    target_param_name = (
+        DEFAULT_REGISTRY.get_target_param(tool_name) or "target"
+    )
+
+    # Collect all scannable (param_name, value) pairs from raw_params.
+    # The target value is represented under its real param name.
+    scan_entries: list[tuple[str, str]] = []
     if raw_params:
         for param_name, param_value in raw_params.items():
             if isinstance(param_value, str) and param_value:
-                # Avoid re-scanning target if it's already in params
-                if param_value != target:
-                    scan_entries.append((param_name, param_value))
+                scan_entries.append((param_name, param_value))
+    # If target is non-empty and not already covered by raw_params, add it
+    # under the registry param name (fallback for callers without raw_params).
+    if target and not any(v == target for _, v in scan_entries):
+        scan_entries.insert(0, (target_param_name, target))
+
+    if not scan_entries:
+        return findings
 
     for rule in detection_rules:
         # Check if rule applies to this tool
         if rule.tools and guard_tool_name not in rule.tools:
             continue
+
+        # rule.params scoping: when non-empty, only scan listed params
+        rule_params = getattr(rule, "params", None) or []
 
         compiled_patterns, compiled_exclude = _get_compiled_patterns(rule)
         matched = False
@@ -390,6 +411,10 @@ def detect_dangerous_patterns(
         for param_name, value in scan_entries:
             if matched:
                 break
+
+            # Honor rule.params scope (H1 fix)
+            if rule_params and param_name not in rule_params:
+                continue
 
             # Check exclude patterns (against this value)
             if any(ep.search(value) for ep in compiled_exclude):
@@ -399,7 +424,6 @@ def detect_dangerous_patterns(
             for pattern in compiled_patterns:
                 m = pattern.search(value)
                 if m:
-                    # Context snippet around match
                     start = max(0, m.start() - 40)
                     end = min(len(value), m.end() + 40)
                     snippet = value[start:end]

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -617,8 +617,8 @@ class GovernancePolicy:
             Phase 2: Policy rules first-match-wins
                      (builtin_rules + user_rules)
             Phase 3: Fallback + execution_level threshold
-                     shell: findings honored (MEDIUM+ -> ASK), else
-                     SANDBOX_FALLBACK; other tools -> ASK
+                     shell: findings honored (MEDIUM+ -> ASK in SMART),
+                     else SANDBOX_FALLBACK; other tools -> fallback
 
         Returns: GovernanceDecision (with optional findings attached)
         """
@@ -802,7 +802,12 @@ class GovernancePolicy:
             from ..config import load_config
 
             cfg = load_config().security.tool_guard
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "_merge_config_rules: config load failed: %s; "
+                "using policy.yaml rules only",
+                exc,
+            )
             return list(self.detection_rules), dict(self.shell_evasion_checks)
 
         disabled_ids = set(cfg.disabled_rules or [])
@@ -817,11 +822,11 @@ class GovernancePolicy:
             if cr.id not in disabled_ids:
                 merged_rules.append(cr)
 
-        # OR-merge shell evasion checks
+        # Merge shell evasion checks: config values override policy.yaml
+        # defaults on overlapping keys (so the UI can turn checks OFF).
         merged_evasion = dict(self.shell_evasion_checks)
         for check_name, enabled in (cfg.shell_evasion_checks or {}).items():
-            if enabled:
-                merged_evasion[check_name] = True
+            merged_evasion[check_name] = enabled
 
         return merged_rules, merged_evasion
 

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -617,7 +617,8 @@ class GovernancePolicy:
             Phase 2: Policy rules first-match-wins
                      (builtin_rules + user_rules)
             Phase 3: Fallback + execution_level threshold
-                     shell → SANDBOX_FALLBACK, others → ASK
+                     shell: findings honored (MEDIUM+ -> ASK), else
+                     SANDBOX_FALLBACK; other tools -> ASK
 
         Returns: GovernanceDecision (with optional findings attached)
         """
@@ -720,6 +721,19 @@ class GovernancePolicy:
                     findings=findings or None,
                     source="STRICT mode",
                 )
+            # Finding-driven approval for shell: when the deep scan surfaced
+            # findings (e.g. a frontend custom rule matched the command),
+            # honor the execution-level severity threshold. MEDIUM+ findings
+            # in SMART, or any finding in AUTO/OFF, escalate to ASK so the
+            # user's own detection rules take effect for shell tools too.
+            # INFO/LOW findings (fallback returns ALLOW) fall through to the
+            # sandbox path below, where sandbox isolation is the safety net.
+            if findings:
+                fb = self._apply_execution_level_fallback(tc_spec, findings)
+                if fb.action is not GovernanceAction.ALLOW:
+                    return fb
+            # No findings (or only INFO/LOW): route to sandbox. When the
+            # sandbox is unusable, ResourceGovernor downgrades this to ALLOW.
             return GovernanceDecision(
                 action=GovernanceAction.SANDBOX_FALLBACK,
                 reason="sandbox fallback",
@@ -735,19 +749,31 @@ class GovernancePolicy:
     ) -> list[Any]:
         """Run deep security detectors (Phase 1).
 
+        Merges policy.yaml detection_rules/shell_evasion_checks with the
+        frontend Security page configuration (config.json →
+        security.tool_guard). Uses the mtime-cached load_config() so there
+        is negligible overhead on the hot path.  On config read failure the
+        scan falls back to policy.yaml-only rules (graceful degradation).
+
         Delegates to governance.detectors module.
         Returns a list of GuardFinding objects.
         """
         try:
             from .detectors import run_deep_scan
 
+            # Merge config.json custom_rules + shell_evasion_checks into
+            # the policy.yaml-sourced rules so frontend settings take
+            # effect in governance evaluation.
+            detection_rules, shell_evasion_checks = self._merge_config_rules()
+
             return run_deep_scan(
                 tool_name=tc_spec.tool_name,
                 target=tc_spec.target,
                 tool_type=tool_type,
                 sensitive_paths=self.sensitive_paths,
-                detection_rules=self.detection_rules,
-                shell_evasion_checks=self.shell_evasion_checks,
+                detection_rules=detection_rules,
+                shell_evasion_checks=shell_evasion_checks,
+                raw_params=tc_spec.raw_params,
             )
         except Exception as exc:
             logger.warning(
@@ -755,6 +781,49 @@ class GovernancePolicy:
                 exc,
             )
             return []
+
+    def _merge_config_rules(
+        self,
+    ) -> tuple[list[Any], dict[str, bool]]:
+        """Merge policy.yaml rules with config.json security.tool_guard.
+
+        Returns:
+            (merged_detection_rules, merged_shell_evasion_checks)
+
+        - custom_rules from config are appended to policy detection_rules.
+        - disabled_rules from config filter out rules by ID from both
+          policy.yaml and config custom_rules.
+        - shell_evasion_checks are OR-merged: enabled in either source
+          means enabled.
+        - On any config read error, returns the unmodified policy.yaml
+          values (graceful degradation).
+        """
+        try:
+            from ..config import load_config
+
+            cfg = load_config().security.tool_guard
+        except Exception:
+            return list(self.detection_rules), dict(self.shell_evasion_checks)
+
+        disabled_ids = set(cfg.disabled_rules or [])
+
+        # Start with policy.yaml detection_rules, filtering disabled
+        merged_rules: list[Any] = [
+            r for r in self.detection_rules if r.id not in disabled_ids
+        ]
+
+        # Append config.json custom_rules (excluding disabled)
+        for cr in cfg.custom_rules or []:
+            if cr.id not in disabled_ids:
+                merged_rules.append(cr)
+
+        # OR-merge shell evasion checks
+        merged_evasion = dict(self.shell_evasion_checks)
+        for check_name, enabled in (cfg.shell_evasion_checks or {}).items():
+            if enabled:
+                merged_evasion[check_name] = True
+
+        return merged_rules, merged_evasion
 
     def _apply_execution_level_fallback(
         self,

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -1468,3 +1468,132 @@ class TestShellFindingDrivenApproval:
         tc = _tc("Bash", "echo harmless")
         decision = policy.evaluate(tc)
         assert decision.action is GovernanceAction.SANDBOX_FALLBACK
+
+
+# ===========================================================================
+# TestRawParamsScanning — H4: verify detection against non-target params
+# (e.g. Write content) and empty-target scenarios.
+# ===========================================================================
+
+
+class TestRawParamsScanning:
+    """Verify detect_dangerous_patterns scans raw_params, respects
+    rule.params, and works even when target is empty."""
+
+    def test_write_content_match(self):
+        """Pattern in Write content field triggers a finding."""
+        from qwenpaw.governance.detectors import detect_dangerous_patterns
+        from unittest.mock import MagicMock
+
+        rule = MagicMock()
+        rule.id = "CONTENT_RULE"
+        rule.tools = ["write_file"]
+        rule.params = ["content"]  # scoped to content only
+        rule.category = "data_exfiltration"
+        rule.severity = "HIGH"
+        rule.patterns = [r"\bsecret_token\b"]
+        rule.exclude_patterns = []
+        rule.description = "Detects secret token in content"
+        rule.remediation = "Remove secret"
+
+        findings = detect_dangerous_patterns(
+            tool_name="Write",
+            target="/tmp/out.txt",
+            detection_rules=[rule],
+            raw_params={
+                "file_path": "/tmp/out.txt",
+                "content": "this has secret_token inside",
+            },
+        )
+        assert len(findings) == 1
+        assert findings[0].rule_id == "CONTENT_RULE"
+        assert findings[0].param_name == "content"
+
+    def test_rule_params_scoping_excludes_unrelated(self):
+        """Rule with params=["content"] must NOT match the file_path param."""
+        from qwenpaw.governance.detectors import detect_dangerous_patterns
+        from unittest.mock import MagicMock
+
+        rule = MagicMock()
+        rule.id = "SCOPED_RULE"
+        rule.tools = ["write_file"]
+        rule.params = ["content"]  # only content
+        rule.category = "command_injection"
+        rule.severity = "HIGH"
+        rule.patterns = [r"secret"]  # matches in path too if unchecked
+        rule.exclude_patterns = []
+        rule.description = "scoped"
+        rule.remediation = ""
+
+        findings = detect_dangerous_patterns(
+            tool_name="Write",
+            target="/tmp/secret_dir/file.txt",
+            detection_rules=[rule],
+            raw_params={
+                "file_path": "/tmp/secret_dir/file.txt",
+                "content": "harmless text",
+            },
+        )
+        # "secret" is in file_path but rule only scopes to content
+        assert len(findings) == 0
+
+    def test_empty_target_raw_params_still_detected(self):
+        """When target is empty, raw_params values are still scanned."""
+        from qwenpaw.governance.detectors import detect_dangerous_patterns
+        from unittest.mock import MagicMock
+
+        rule = MagicMock()
+        rule.id = "EMPTY_TARGET_RULE"
+        rule.tools = []
+        rule.params = []
+        rule.category = "command_injection"
+        rule.severity = "MEDIUM"
+        rule.patterns = [r"\bdanger\b"]
+        rule.exclude_patterns = []
+        rule.description = "danger detected"
+        rule.remediation = ""
+
+        findings = detect_dangerous_patterns(
+            tool_name="Write",
+            target="",
+            detection_rules=[rule],
+            raw_params={
+                "file_path": "/tmp/a.txt",
+                "content": "this is danger content",
+            },
+        )
+        assert len(findings) == 1
+        assert findings[0].rule_id == "EMPTY_TARGET_RULE"
+        assert findings[0].param_name == "content"
+
+    def test_shell_evasion_config_can_disable(self):
+        """Config setting a check to False overrides policy.yaml True."""
+        from unittest.mock import MagicMock
+
+        policy = _create_default_policy(workspace_dir="/tmp/test-workspace")
+        policy.execution_level = "smart"
+        # Policy has command_substitution enabled
+        policy.shell_evasion_checks = {
+            "command_substitution": True,
+        }
+
+        # Config DISABLES it
+        mock_cfg = MagicMock()
+        mock_cfg.security.tool_guard.custom_rules = []
+        mock_cfg.security.tool_guard.disabled_rules = []
+        mock_cfg.security.tool_guard.shell_evasion_checks = {
+            "command_substitution": False,
+        }
+
+        import qwenpaw.config
+
+        original = qwenpaw.config.load_config
+        qwenpaw.config.load_config = lambda: mock_cfg
+        try:
+            tc = _tc("Bash", "echo $(whoami)")
+            findings = policy._deep_security_scan(tc, "shell")
+            # Should NOT detect command substitution (config disabled it)
+            rule_ids = [f.rule_id for f in findings]
+            assert "SHELL_EVASION_COMMAND_SUBSTITUTION" not in rule_ids
+        finally:
+            qwenpaw.config.load_config = original

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -1237,3 +1237,234 @@ class TestGeneralizeTargetForApproval:
             "sandbox",
         )
         assert result == "echo $(date)"
+
+
+# ===========================================================================
+# TestDeepScanConfigMerge — verify _merge_config_rules bridges frontend
+# Security page rules into governance Phase 1.
+# ===========================================================================
+
+
+class TestDeepScanConfigMerge:
+    """Tests for GovernancePolicy._merge_config_rules().
+
+    Verifies that config.json security.tool_guard custom_rules,
+    disabled_rules, and shell_evasion_checks are merged into the
+    governance deep scan pipeline.
+    """
+
+    def _make_policy(self, tmp_path):
+        """Create a default policy for testing."""
+        policy = _create_default_policy(
+            str(tmp_path),
+            str(tmp_path),
+        )
+        policy.execution_level = "smart"
+        return policy
+
+    def test_deep_scan_merges_config_custom_rules(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A custom_rule from config.json should produce a finding in
+        governance Phase 1 deep scan."""
+        from unittest.mock import MagicMock
+
+        policy = self._make_policy(tmp_path)
+
+        # Mock load_config to return a config with a custom rule
+        mock_cfg = MagicMock()
+        mock_rule = MagicMock()
+        mock_rule.id = "CUSTOM_TEST_RULE"
+        mock_rule.tools = ["execute_shell_command"]
+        mock_rule.params = []
+        mock_rule.category = "command_injection"
+        mock_rule.severity = "HIGH"
+        mock_rule.patterns = [r"\btest_governance_bridge\b"]
+        mock_rule.exclude_patterns = []
+        mock_rule.description = "Test custom rule"
+        mock_rule.remediation = "Do not use test_governance_bridge"
+
+        mock_cfg.security.tool_guard.custom_rules = [mock_rule]
+        mock_cfg.security.tool_guard.disabled_rules = []
+        mock_cfg.security.tool_guard.shell_evasion_checks = {}
+
+        monkeypatch.setattr(
+            "qwenpaw.config.load_config",
+            lambda: mock_cfg,
+        )
+
+        tc = _tc("Bash", "echo test_governance_bridge")
+        findings = policy._deep_security_scan(tc, "shell")
+
+        # Should find at least one finding from our custom rule
+        rule_ids = [f.rule_id for f in findings]
+        assert "CUSTOM_TEST_RULE" in rule_ids
+
+    def test_deep_scan_disabled_rules_filter(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Rules listed in disabled_rules should not participate in
+        detection — neither policy.yaml rules nor config custom_rules."""
+        from unittest.mock import MagicMock
+        from qwenpaw.governance.policy import DetectionRuleConfig
+
+        policy = self._make_policy(tmp_path)
+
+        # Add a policy.yaml detection rule
+        yaml_rule = DetectionRuleConfig(
+            id="YAML_RULE_1",
+            tools=["execute_shell_command"],
+            patterns=[r"\byaml_pattern\b"],
+            severity="HIGH",
+            description="YAML rule",
+        )
+        policy.detection_rules = [yaml_rule]
+
+        # Mock config with disabled_rules that disables YAML_RULE_1
+        mock_cfg = MagicMock()
+        mock_cfg.security.tool_guard.custom_rules = []
+        mock_cfg.security.tool_guard.disabled_rules = ["YAML_RULE_1"]
+        mock_cfg.security.tool_guard.shell_evasion_checks = {}
+
+        monkeypatch.setattr(
+            "qwenpaw.config.load_config",
+            lambda: mock_cfg,
+        )
+
+        tc = _tc("Bash", "echo yaml_pattern")
+        findings = policy._deep_security_scan(tc, "shell")
+
+        # YAML_RULE_1 should be filtered out
+        rule_ids = [f.rule_id for f in findings]
+        assert "YAML_RULE_1" not in rule_ids
+
+    def test_deep_scan_config_shell_evasion_merge(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Shell evasion checks enabled in config.json should activate
+        in governance deep scan even if policy.yaml has them off."""
+        from unittest.mock import MagicMock
+
+        policy = self._make_policy(tmp_path)
+        # Policy has all evasion checks disabled
+        policy.shell_evasion_checks = {
+            "command_substitution": False,
+        }
+
+        # Config enables command_substitution
+        mock_cfg = MagicMock()
+        mock_cfg.security.tool_guard.custom_rules = []
+        mock_cfg.security.tool_guard.disabled_rules = []
+        mock_cfg.security.tool_guard.shell_evasion_checks = {
+            "command_substitution": True,
+        }
+
+        monkeypatch.setattr(
+            "qwenpaw.config.load_config",
+            lambda: mock_cfg,
+        )
+
+        # Command with $() substitution
+        tc = _tc("Bash", "echo $(whoami)")
+        findings = policy._deep_security_scan(tc, "shell")
+
+        # Should detect the command substitution
+        rule_ids = [f.rule_id for f in findings]
+        assert "SHELL_EVASION_COMMAND_SUBSTITUTION" in rule_ids
+
+    def test_deep_scan_config_load_failure_graceful(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """If load_config() raises, deep scan should still work using
+        policy.yaml rules only (graceful degradation)."""
+        from qwenpaw.governance.policy import DetectionRuleConfig
+
+        policy = self._make_policy(tmp_path)
+
+        # Add a policy.yaml rule that should still work
+        yaml_rule = DetectionRuleConfig(
+            id="YAML_FALLBACK_RULE",
+            tools=["execute_shell_command"],
+            patterns=[r"\bfallback_test\b"],
+            severity="MEDIUM",
+            description="Fallback rule",
+        )
+        policy.detection_rules = [yaml_rule]
+
+        # Make load_config raise
+        def _raise_config():
+            raise RuntimeError("config broken")
+
+        monkeypatch.setattr(
+            "qwenpaw.config.load_config",
+            _raise_config,
+        )
+
+        tc = _tc("Bash", "echo fallback_test")
+        findings = policy._deep_security_scan(tc, "shell")
+
+        # Should still detect via policy.yaml rule
+        rule_ids = [f.rule_id for f in findings]
+        assert "YAML_FALLBACK_RULE" in rule_ids
+
+
+# ===========================================================================
+# TestShellFindingDrivenApproval — shell commands with deep-scan findings
+# honor the execution-level severity threshold (Phase 3 fix).
+# ===========================================================================
+
+
+class TestShellFindingDrivenApproval:
+    """Phase 3 shell path: findings drive ASK instead of always falling to
+    SANDBOX_FALLBACK.
+
+    - HIGH/MEDIUM finding + SMART -> ASK
+    - INFO/LOW finding + SMART   -> SANDBOX_FALLBACK (sandbox is safety net)
+    - no finding + SMART         -> SANDBOX_FALLBACK
+    """
+
+    def _policy_with_shell_rule(self, severity: str):
+        """Build a SMART policy with one shell detection rule of *severity*."""
+        from qwenpaw.governance.policy import DetectionRuleConfig
+
+        policy = _create_default_policy(workspace_dir="/tmp/test-workspace")
+        policy.execution_level = "smart"
+        policy.detection_rules = [
+            DetectionRuleConfig(
+                id="SHELL_CUSTOM",
+                tools=["execute_shell_command"],
+                patterns=[r"\bmarker_token\b"],
+                severity=severity,
+                description="custom shell rule",
+            ),
+        ]
+        return policy
+
+    def test_high_finding_shell_smart_asks(self):
+        """HIGH finding on a shell command in SMART mode -> ASK."""
+        policy = self._policy_with_shell_rule("HIGH")
+        tc = _tc("Bash", "echo marker_token")
+        decision = policy.evaluate(tc)
+        assert decision.action is GovernanceAction.ASK
+
+    def test_low_finding_shell_smart_sandbox_fallback(self):
+        """INFO/LOW finding falls through to SANDBOX_FALLBACK."""
+        policy = self._policy_with_shell_rule("LOW")
+        tc = _tc("Bash", "echo marker_token")
+        decision = policy.evaluate(tc)
+        assert decision.action is GovernanceAction.SANDBOX_FALLBACK
+
+    def test_no_finding_shell_smart_sandbox_fallback(self):
+        """No finding -> SANDBOX_FALLBACK (unchanged behavior)."""
+        policy = self._policy_with_shell_rule("HIGH")
+        tc = _tc("Bash", "echo harmless")
+        decision = policy.evaluate(tc)
+        assert decision.action is GovernanceAction.SANDBOX_FALLBACK


### PR DESCRIPTION
# fix(governance): bridge frontend tool-guard rules into policy deep scan

- merge config.json security.tool_guard custom_rules/disabled_rules/
  shell_evasion_checks into GovernancePolicy Phase 1 deep scan via
  mtime-cached load_config (hot-reload, no restart needed)
- detect_dangerous_patterns now scans all raw_params string values,
  not just target, matching the frontend 'match tool parameter values'
  semantics (e.g. Write content field)
- Phase 3 shell path honors deep-scan findings: MEDIUM+ severity
  escalates to ASK instead of always routing to SANDBOX_FALLBACK, so
  user-defined detection rules take effect for shell tools too
- add unit tests: config rule merge (4) + shell finding-driven approval (3)

## Description

The Security page in the Web Console lets users configure custom detection
rules, disabled rules, and shell-evasion checks under
`config.json -> security.tool_guard`. However, these settings were consumed
only by the legacy `ToolGuardEngine` and never reached the active
`GovernancePolicy`, whose Phase 1 deep scan read rules exclusively from
`policy.yaml`. As a result, rules configured in the frontend had **no effect**
on the actual approval decisions.

This PR bridges the two systems so frontend Security settings flow end-to-end
into governance evaluation:

1. **Config merge** — `GovernancePolicy._deep_security_scan()` now merges the
   frontend `custom_rules` / `disabled_rules` / `shell_evasion_checks` (read via
   the mtime-cached `load_config()`) with the `policy.yaml`-sourced rules before
   running the detectors. Changes take effect on the next tool call — no service
   restart or new session required. On a config read error it degrades
   gracefully to `policy.yaml`-only rules.

2. **Param-value scanning** — `detect_dangerous_patterns()` previously matched
   only against the primary `target` (e.g. a file path). It now scans all string
   values in `raw_params` as well, matching the frontend tooltip's promise of
   "match tool parameter values". This closes the gap where, for example, a
   `Write` call's `content` field was never inspected.

3. **Shell finding-driven approval** — the Phase 3 shell branch used to route
   every non-STRICT shell command to `SANDBOX_FALLBACK` regardless of findings.
   When the sandbox is disabled this silently downgraded to ALLOW, so a HIGH
   finding from a user rule was effectively ignored for shell tools. Now shell
   commands with deep-scan findings honor the execution-level severity
   threshold (SMART: MEDIUM+ -> ASK); only no-finding (or INFO/LOW) commands
   fall through to `SANDBOX_FALLBACK`, where the sandbox remains the safety net.

**Related Issue:** Relates to the frontend/governance rule-bridging gap.

**Security Considerations:** This change strengthens enforcement — user-defined
detection rules now actually gate tool execution. Built-in CRITICAL -> DENY,
sensitive-path, and shell-danger-keyword protections remain unchanged. The
finding-driven shell path only escalates (toward ASK); it never weakens an
existing DENY/ASK decision. First-match-wins `user_rules` (approval memory)
still take precedence over detection findings by design.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. In the Console, open Settings -> Security -> Tool Guard and add a custom rule
   (e.g. pattern `\btest_governance_bridge\b`, severity HIGH, tools empty =
   all tools). Save.
2. With approval level SMART and the sandbox switch OFF, ask the agent to run a
   shell command containing the token, e.g. `echo test_governance_bridge`.
3. Expect an approval prompt (ASK) driven by `source=detection_rules`.
4. Verify a benign command (`echo harmless`) still runs without a prompt.
5. Confirm hot-reload: change the rule and re-run without restarting the server.

## Evidence

Unit tests (config rule merge + shell finding-driven approval + detectors):

```bash
pytest tests/unit/governance/test_policy.py::TestDeepScanConfigMerge \
       tests/unit/governance/test_policy.py::TestShellFindingDrivenApproval \
       tests/unit/governance/test_detectors.py -q
# 28 passed, 2 warnings in 0.18s
```

End-to-end log from the running service (SMART mode, sandbox OFF), showing a
shell command's HIGH custom-rule finding now escalates to ASK, then the
approved rule is remembered:

```text
governance decision: tool=Bash target='echo test_governance_bridge' \
  action=ask source=detection_rules sandbox=- \
  reason=E2E test: config rules bridge to governance
governance decision: tool=Bash target='echo test_governance_bridge' \
  action=allow source=user_rules sandbox=- reason=user approved
```

pre-commit (auto-triggered via git hook on commit):

```text
Running git hook   hook=pre-commit
Running git hook   hook=commit-msg
[feat/policy-fix 339a9271] fix(governance): bridge frontend tool-guard rules into policy deep scan
 3 files changed, 351 insertions(+), 40 deletions(-)
```

## Additional Notes

- Two parallel guard systems remain by design: the active `GovernancePolicy`
  (this PR) and the legacy `ToolGuardEngine`. This PR wires the frontend config
  into the governance path; it does not remove the legacy engine.
- `user_rules` (approval memory) intentionally override detection findings via
  Phase 2 first-match-wins. If a path/command was approved before, it stays
  ALLOW even if a later detection rule would match.
