### PR TITLE
fix(cli): prevent TUI crash when clicking streaming output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,10 @@ dependencies = [
     # (v4+ adds the streaming Markdown widget). 8.2.8 fixes parsing of
     # multi-codepoint Kitty "associated text" so input methods (Chinese,
     # Japanese, accents, ...) no longer leak escape sequences into the prompt
-    # (Textualize/textual#6592).
-    "textual>=8.2.8",
+    # (Textualize/textual#6592). Keep the temporary upper bound in sync with
+    # the TUI compatibility shim for Textualize/textual#6643; remove both
+    # after Textual ships and QwenPaw verifies the upstream fix.
+    "textual>=8.2.8,<8.2.9",
     "psutil>=6.0.0",
     "openai>=2.0.0,<=2.33.0",
     # anyio 4.13.0: _deliver_cancellation busy-loop / getpid storm (QwenPaw#2632)

--- a/src/qwenpaw/cli/tui/compat.py
+++ b/src/qwenpaw/cli/tui/compat.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Compatibility fixes for Textual releases supported by the TUI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.screen import Screen
+
+
+_ORIGINAL_GET_WIDGET_AND_OFFSET_AT = Screen.get_widget_and_offset_at
+_COMPAT_APPLIED = False
+
+
+def _safe_get_widget_and_offset_at(
+    self: Screen,
+    x: int,
+    y: int,
+) -> tuple[Any, Any]:
+    """Ignore widgets detached after the compositor's latest reflow."""
+    widget, offset = _ORIGINAL_GET_WIDGET_AND_OFFSET_AT(self, x, y)
+    if (
+        widget is not None
+        and not isinstance(widget, Screen)
+        and widget.parent is None
+    ):
+        return None, None
+    return widget, offset
+
+
+def apply_textual_compat() -> None:
+    """Apply process-wide Textual compatibility fixes exactly once."""
+    global _COMPAT_APPLIED  # pylint: disable=global-statement
+    if _COMPAT_APPLIED:
+        return
+
+    # Textualize/textual#6643: Markdown.update() may detach a widget before
+    # the compositor reflows. Textual 8.2.8 can return that stale widget from
+    # hit testing, then crash while beginning a selection. Remove this shim
+    # after QwenPaw requires the first Textual release containing the fix.
+    Screen.get_widget_and_offset_at = _safe_get_widget_and_offset_at
+    _COMPAT_APPLIED = True

--- a/src/qwenpaw/cli/tui/launch.py
+++ b/src/qwenpaw/cli/tui/launch.py
@@ -172,6 +172,9 @@ def run_tui(
     project: str | None = None,
 ) -> None:
     """Build the transport and run the Textual app (blocking)."""
+    from .compat import apply_textual_compat
+
+    apply_textual_compat()
     transport, description = _build_transport(
         agent=agent,
         resume=resume,

--- a/tests/unit/cli/tui/test_compat.py
+++ b/tests/unit/cli/tui/test_compat.py
@@ -22,7 +22,10 @@ def test_hit_testing_ignores_detached_widget(monkeypatch):
         lambda _screen, _x, _y: (detached, Offset(0, 0)),
     )
 
-    assert compat._safe_get_widget_and_offset_at(Screen(), 1, 1) == (None, None)
+    assert compat._safe_get_widget_and_offset_at(Screen(), 1, 1) == (
+        None,
+        None,
+    )
 
 
 def test_hit_testing_preserves_attached_widget(monkeypatch):
@@ -52,4 +55,7 @@ def test_apply_textual_compat_is_idempotent(monkeypatch):
     compat.apply_textual_compat()
     compat.apply_textual_compat()
 
-    assert Screen.get_widget_and_offset_at is compat._safe_get_widget_and_offset_at
+    assert (
+        Screen.get_widget_and_offset_at
+        is compat._safe_get_widget_and_offset_at
+    )

--- a/tests/unit/cli/tui/test_compat.py
+++ b/tests/unit/cli/tui/test_compat.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for Textual compatibility fixes."""
+
+from __future__ import annotations
+
+# Tests exercise the private wrapper and its one-time installation state.
+# pylint: disable=protected-access
+
+from textual.geometry import Offset
+from textual.screen import Screen
+from textual.widget import Widget
+
+from qwenpaw.cli.tui import compat
+
+
+def test_hit_testing_ignores_detached_widget(monkeypatch):
+    """A stale compositor hit must not reach Textual's selection path."""
+    detached = Widget()
+    monkeypatch.setattr(
+        compat,
+        "_ORIGINAL_GET_WIDGET_AND_OFFSET_AT",
+        lambda _screen, _x, _y: (detached, Offset(0, 0)),
+    )
+
+    assert compat._safe_get_widget_and_offset_at(Screen(), 1, 1) == (None, None)
+
+
+def test_hit_testing_preserves_attached_widget(monkeypatch):
+    """Normal text selection keeps the original hit-testing result."""
+    screen = Screen()
+    attached = Widget()
+    attached._parent = screen  # pylint: disable=protected-access
+    expected = (attached, Offset(2, 3))
+    monkeypatch.setattr(
+        compat,
+        "_ORIGINAL_GET_WIDGET_AND_OFFSET_AT",
+        lambda _screen, _x, _y: expected,
+    )
+
+    assert compat._safe_get_widget_and_offset_at(screen, 1, 1) == expected
+
+
+def test_apply_textual_compat_is_idempotent(monkeypatch):
+    """Repeated setup leaves the same wrapper installed."""
+    monkeypatch.setattr(compat, "_COMPAT_APPLIED", False)
+    monkeypatch.setattr(
+        Screen,
+        "get_widget_and_offset_at",
+        compat._ORIGINAL_GET_WIDGET_AND_OFFSET_AT,
+    )
+
+    compat.apply_textual_compat()
+    compat.apply_textual_compat()
+
+    assert Screen.get_widget_and_offset_at is compat._safe_get_widget_and_offset_at

--- a/tests/unit/cli/tui/test_launch.py
+++ b/tests/unit/cli/tui/test_launch.py
@@ -196,6 +196,37 @@ def test_run_tui_prints_resume_hint(monkeypatch, capsys, tmp_path):
     )
 
 
+def test_run_tui_applies_textual_compat_before_app_runs(monkeypatch):
+    """The hit-test guard is active before Textual handles any events."""
+    calls = []
+
+    class FakeTransport:
+        session_id = None
+        _project_dir = None
+
+    class FakeApp:
+        def __init__(self, *_args, **_kwargs):
+            calls.append("app-created")
+
+        def run(self):
+            calls.append("app-ran")
+
+    monkeypatch.setattr(
+        "qwenpaw.cli.tui.compat.apply_textual_compat",
+        lambda: calls.append("compat"),
+    )
+    monkeypatch.setattr(
+        launch,
+        "_build_transport",
+        lambda **_: (FakeTransport(), "fake transport"),
+    )
+    monkeypatch.setattr("qwenpaw.cli.tui.app.PawApp", FakeApp)
+
+    launch.run_tui()
+
+    assert calls == ["compat", "app-created", "app-ran"]
+
+
 def test_tui_help():
     result = CliRunner().invoke(tui_cmd, ["--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Description

Prevent the TUI from crashing when a user clicks or begins selecting assistant output while a response is streaming.

Textual 8.2.8 can briefly return a detached Markdown widget from its stale compositor map while `Markdown.update()` replaces streaming blocks. Textual's selection path then dereferences the widget's missing parent. This change adds a small compatibility shim that treats detached-widget hits as empty space and installs it before the TUI begins handling events. Hits on attached widgets remain unchanged, preserving normal text selection.

**Related Issue:** Fixes #6008

**Security Considerations:** None. This change only affects local TUI mouse hit testing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; this is an internal compatibility fix)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the focused compatibility lint checks and the complete TUI unit test suite:

```bash
uv run pylint src/qwenpaw/cli/tui/compat.py tests/unit/cli/tui/test_compat.py
uv run pytest -q tests/unit/cli/tui
uv lock --check
```

The regression tests verify that detached widgets are ignored, attached widgets still support selection, the shim is installed only once, and startup applies it before the app runs.

## Evidence

```text
check python ast.........................................................Passed
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed

------------------------------------
Your code has been rated at 10.00/10

........................................................................ [ 48%]
........................................................................ [ 97%]
...                                                                      [100%]
147 passed, 1 warning in 14.36s
```

## Additional Notes

This is an application-side workaround for Textualize/textual#6643. Textual is temporarily constrained to `>=8.2.8,<8.2.9` so an unverified release cannot silently invalidate the monkeypatch. Remove the upper bound and shim together after QwenPaw verifies the upstream fix.
