### PR TITLE
fix: ASK user for permissionfor sudo

### DIFF
--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -236,6 +236,9 @@ _BUILTIN_ASK_SPECS: List[tuple[str, str]] = [
     # ── Windows (PowerShell profile + history may hold keys) ──
     ("*(**/Microsoft.PowerShell_profile.ps1)", "PS profile may setx API keys"),
     ("*(**/ConsoleHost_history.txt)", "PowerShell may contain typed secrets"),
+    ("Bash(sudo *)", "Privilege escalation, ASK"),
+    ("Bash(gh repo delete *)", "Repository deletion, ASK"),
+    ("Bash(gh api -X DELETE *)", "Destructive GitHub API calls, ASK"),
 ]
 
 # (match, reason) pairs for builtin DENY rules — hard walls, never allowed.
@@ -245,9 +248,6 @@ _BUILTIN_ASK_SPECS: List[tuple[str, str]] = [
 # command variants that fnmatch cannot match.
 _BUILTIN_DENY_SPECS: List[tuple[str, str]] = [
     ("Bash(rm * -rf *//*)", "Root filesystem deletion"),
-    ("Bash(sudo *)", "Privilege escalation prohibited"),
-    ("Bash(gh repo delete *)", "Repository deletion prohibited"),
-    ("Bash(gh api -X DELETE *)", "Destructive GitHub API calls prohibited"),
 ]
 
 DEFAULT_BUILTIN_RULES: List[GovernanceRule] = [
@@ -271,17 +271,6 @@ _SHELL_DANGER_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             r"\brm\b(?=[^;|&]*\s+-[a-zA-Z]*[rR])[^;|&]*\s+/(?:\s|$|\*)",
         ),
         "Recursive deletion targeting root filesystem",
-    ),
-    # sudo in any position: start of command, after pipe/semicolon,
-    # subshell, absolute path, env prefix, xargs, etc.
-    (
-        re.compile(
-            r"(?:^|[;&|`]|\$\()\s*(?:/usr/s?bin/|/bin/)?sudo\b"
-            r"|\bxargs\s+.*\bsudo\b"
-            r"|\bcommand\s+sudo\b"
-            r"|\benv\s+.*\bsudo\b",
-        ),
-        "Privilege escalation (sudo)",
     ),
     # Fork bomb patterns
     (

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -590,11 +590,14 @@ class TestGovernancePolicyEvaluate:
         decision = policy.evaluate(tc)
         assert decision.action == GovernanceAction.ASK
 
-    def test_sudo_deny(self, policy):
-        """Bash(sudo ...) should be DENY from builtin rules."""
+    def test_sudo_ask(self, policy):
+        """Bash(sudo ...) is ASK from builtin rules (privilege escalation
+        gated on user approval). Note ``sudo rm -rf /`` is still DENY —
+        that is caught earlier by the Phase 1.5 rm-root regex, not this
+        builtin rule."""
         tc = _tc("Bash", "sudo apt-get install something")
         decision = policy.evaluate(tc)
-        assert decision.action == GovernanceAction.DENY
+        assert decision.action == GovernanceAction.ASK
 
     def test_internal_tool_allow(self, policy):
         """Internal tools should be ALLOW from user_rules."""


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
