### PR TITLE
fix(sandbox): preserve venv PATH in shell execution

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -11,6 +11,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Optional
 
@@ -368,13 +369,28 @@ async def _execute_in_sandbox(
     sandbox_config: Any,
     timeout: float,
     cwd: str,
+    env: dict[str, str],
 ) -> ExecutionResult:
     """Execute a shell command inside the sandbox and return raw result."""
     from ...sandbox import create_sandbox
 
-    sandbox_config.timeout_seconds = int(timeout)
+    # Sandbox backends rebuild their environment from os.environ. Carry over
+    # the PATH adjusted by the shell entrypoint unless policy set one itself.
+    sandbox_env = dict(sandbox_config.env_vars)
+    if not any(key.upper() == "PATH" for key in sandbox_env):
+        path_key = next(
+            (key for key in env if key.upper() == "PATH"),
+            "PATH",
+        )
+        sandbox_env[path_key] = env[path_key]
 
-    async with create_sandbox(sandbox_config) as sandbox:
+    effective_config = replace(
+        sandbox_config,
+        timeout_seconds=int(timeout),
+        env_vars=sandbox_env,
+    )
+
+    async with create_sandbox(effective_config) as sandbox:
         result = await sandbox.execute(cmd, cwd=cwd)
 
     return result
@@ -543,6 +559,7 @@ async def execute_shell_command(
             sandbox_config,
             timeout,
             str(working_dir),
+            env,
         )
         # Sandbox violation: command tried to access something not permitted
         if result.sandbox_violation:

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -14,6 +14,11 @@ Covers:
 """
 # pylint: disable=protected-access,unused-argument
 
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +26,7 @@ import pytest
 from qwenpaw.agents.tools.shell import (
     _collapse_embedded_newlines,
     _collapse_newlines_outside_quotes,
+    _execute_in_sandbox,
     _extract_powershell_command,
     _is_cmd,
     _is_dangerous_self_kill,
@@ -29,6 +35,12 @@ from qwenpaw.agents.tools.shell import (
     _sanitize_win_cmd,
     _shell_basename,
     smart_decode,
+)
+from qwenpaw.sandbox import (
+    ExecutionResult,
+    MountSpec,
+    SandboxConfig,
+    SandboxMode,
 )
 
 
@@ -307,13 +319,9 @@ class TestIsDangerousSelfKill:
         assert _is_dangerous_self_kill("taskkill /F /IM python")
 
     def test_taskkill_by_pid_self(self):
-        import os
-
         assert _is_dangerous_self_kill(f"taskkill /F /PID {os.getpid()}")
 
     def test_taskkill_by_pid_parent(self):
-        import os
-
         if hasattr(os, "getppid"):
             assert _is_dangerous_self_kill(
                 f"taskkill /F /PID {os.getppid()}",
@@ -323,8 +331,6 @@ class TestIsDangerousSelfKill:
         assert not _is_dangerous_self_kill("taskkill /F /PID 99999")
 
     def test_kill_unix_pid_self(self):
-        import os
-
         assert _is_dangerous_self_kill(f"kill -9 {os.getpid()}")
 
     def test_kill_unix_pid_other_is_safe(self):
@@ -560,3 +566,86 @@ class TestExecuteShellCommand:
                 timeout="invalid",
             )
             assert result.content is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="NoneSandbox currently requires a POSIX shell",
+    )
+    async def test_sandbox_path_starts_with_running_python_bin(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        from qwenpaw.agents.tools.shell import execute_shell_command
+
+        system_bin = tmp_path / "system-bin"
+        system_bin.mkdir()
+        monkeypatch.setenv("PATH", str(system_bin))
+        if sys.platform != "win32":
+            monkeypatch.setenv("SHELL", "/bin/sh")
+
+        script = "import os; print(os.environ.get('PATH', ''))"
+        args = [sys.executable, "-c", script]
+        command = (
+            subprocess.list2cmdline(args)
+            if sys.platform == "win32"
+            else shlex.join(args)
+        )
+        config = SandboxConfig(
+            mode=SandboxMode.NONE,
+            workspace_dir=str(tmp_path),
+            mounts=[MountSpec(path=str(tmp_path), writable=True)],
+        )
+
+        result = await execute_shell_command(
+            command,
+            cwd=tmp_path,
+            sandbox_config=config,
+        )
+
+        path_entries = result.content[0].text.strip().split(os.pathsep)
+        assert Path(path_entries[0]) == Path(sys.executable).parent
+        assert config.env_vars == {}
+        assert config.timeout_seconds == 30
+
+    @pytest.mark.asyncio
+    async def test_sandbox_uses_explicit_path_without_mutating_config(
+        self,
+        tmp_path,
+    ):
+        configured_path = os.pathsep.join(["custom", "bin"])
+        config = SandboxConfig(
+            mode=SandboxMode.NONE,
+            workspace_dir=str(tmp_path),
+            env_vars={"PATH": configured_path, "MASKED_SECRET": ""},
+        )
+        sandbox = AsyncMock()
+        sandbox.execute.return_value = ExecutionResult(0, "ok", "")
+        context_manager = MagicMock()
+        context_manager.__aenter__ = AsyncMock(return_value=sandbox)
+        context_manager.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "qwenpaw.sandbox.create_sandbox",
+            return_value=context_manager,
+        ) as create_sandbox:
+            await _execute_in_sandbox(
+                "echo ok",
+                config,
+                12.9,
+                str(tmp_path),
+                {"PATH": os.pathsep.join(["venv", "system"])},
+            )
+
+        effective_config = create_sandbox.call_args.args[0]
+        assert effective_config.env_vars == {
+            "PATH": configured_path,
+            "MASKED_SECRET": "",
+        }
+        assert effective_config.timeout_seconds == 12
+        assert config.env_vars == {
+            "PATH": configured_path,
+            "MASKED_SECRET": "",
+        }
+        assert config.timeout_seconds == 30


### PR DESCRIPTION
## Description

Sandboxed shell execution rebuilt its environment from `os.environ` and ignored the PATH prepared by the shell tool entrypoint. As a result, `python`, `python3`, and `pip` could resolve to system executables even when QwenPaw was launched from its virtual environment.

This change passes the prepared environment into the sandbox boundary and copies its PATH into the effective sandbox configuration. An explicit sandbox PATH remains authoritative, masked environment values remain unchanged, and the caller's `SandboxConfig` is no longer mutated while applying the per-command timeout.

**Related Issue:** Fixes #6042

**Security Considerations:** The change only propagates PATH that QwenPaw already constructs for direct shell execution. Explicit sandbox environment policy still takes precedence; no additional variables or secrets are exposed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed: no user-facing contract changed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Unit suite: 4,647 passed, 7 skipped.
- Contract suite: 262 passed, 3 skipped.
- PR integration gate (`integration and p0`): 122 passed, 267 deselected.
- Real macOS Seatbelt execution with a system-only parent PATH: bare `python`, `python3`, and `pip` all resolved from QwenPaw's virtual environment.
- End-to-end HTTP flow: started QwenPaw with a mock OpenAI-compatible provider, enabled sandboxing, submitted a chat task that invoked the shell tool, and verified the tool result used the running virtual environment's Python.

The unfiltered suite completed with 5,250 passed, 10 skipped, and one failure in `test_offload_while_running`. The same failure was reproduced on a clean `origin/main` worktree. It covers the currently disabled offload mechanism and does not enter the sandbox code changed here.

Not locally exercised: native Linux Bubblewrap/Landlock and Windows sandbox implementations. The shared sandbox configuration boundary is covered by the regression tests and macOS runtime validation.

## Evidence

Before this change, launching from a virtual environment while the parent PATH contained only system directories produced system Python from both NoneSandbox and Seatbelt. After the change:

```text
direct python  -> $REPO/.venv/bin/python
NoneSandbox    -> $REPO/.venv/bin/python
Seatbelt       -> $REPO/.venv/bin/python
HTTP E2E task  -> completed; shell result was $REPO/.venv/bin/python
```

```text
$ uv run pytest tests/unit -q
4647 passed, 7 skipped, 57 warnings

$ uv run pytest tests/contract -q
262 passed, 3 skipped, 1 warning

$ uv run pytest tests/integration -m 'integration and p0' -q
122 passed, 267 deselected

$ uv run pre-commit run --all-files
check python ast.........................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
```

## Additional Notes

The skipped tests and existing warning output are reported above rather than filtered. The full-suite baseline failure is intentionally left visible because marking the blanket pytest checklist as passed would be inaccurate.
