### PR TITLE
feat(toolcards): inline media preview in GenericToolCard and dedupe r…

### DIFF
--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -99,6 +99,19 @@ export const chatApi = {
     }),
 };
 
+/**
+ * Convert a backend content URL (path, file:// URL, or full URL) into a
+ * displayable URL. Keeps http/https/data URLs as-is, strips file:// prefix,
+ * and routes relative paths through chatApi.filePreviewUrl.
+ */
+export function toDisplayUrl(url: string | undefined): string {
+  if (!url) return "";
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  if (url.startsWith("data:")) return url;
+  if (url.startsWith("file://")) url = url.replace("file://", "");
+  return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
+}
+
 export const sessionApi = {
   listSessions: (params?: { user_id?: string; channel?: string }) => {
     const searchParams = new URLSearchParams();

--- a/console/src/components/Chat/ToolCards/cards/BrowserUseCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/BrowserUseCard.tsx
@@ -266,6 +266,7 @@ const BrowserUseCard: React.FC<BrowserUseCardProps> = ({
         isStreaming={isStreaming}
         icon={<ChromeOutlined />}
         title={title}
+        disableAutoMedia
       />
     );
   }
@@ -278,6 +279,7 @@ const BrowserUseCard: React.FC<BrowserUseCardProps> = ({
       isStreaming={isStreaming}
       icon={<ChromeOutlined />}
       title={title}
+      disableAutoMedia
     >
       {resultText && <DefaultBlock title="Output" content={resultText} />}
     </ToolCardShell>

--- a/console/src/components/Chat/ToolCards/cards/DesktopScreenshotCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/DesktopScreenshotCard.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { DesktopOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
-import { ToolCardShell, MediaPreview } from "../shared";
-import { getMediaInfo } from "../shared/utils";
+import { ToolCardShell } from "../shared";
 
 export interface DesktopScreenshotCardProps {
   content: ToolCallContent;
@@ -16,7 +15,6 @@ const DesktopScreenshotCard: React.FC<DesktopScreenshotCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const title = t("tool.desktopScreenshot");
-  const media = getMediaInfo(content);
 
   return (
     <ToolCardShell
@@ -24,9 +22,7 @@ const DesktopScreenshotCard: React.FC<DesktopScreenshotCardProps> = ({
       isStreaming={isStreaming}
       icon={<DesktopOutlined />}
       title={title}
-    >
-      {media && <MediaPreview media={media} />}
-    </ToolCardShell>
+    />
   );
 };
 

--- a/console/src/components/Chat/ToolCards/cards/GenericToolCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GenericToolCard.tsx
@@ -39,15 +39,21 @@ const GenericToolCard: React.FC<GenericToolCardProps> = ({
       isStreaming={isStreaming}
       disableAutoMedia
     >
-      {hasOutput && (
-        <DefaultBlock
-          title="Output"
-          content={resultText}
-          renderContent={() => (
-            <InlineMediaText text={resultText} media={mediaList} />
-          )}
-        />
-      )}
+      {(isOpen) =>
+        hasOutput && (
+          <DefaultBlock
+            title="Output"
+            content={resultText}
+            renderContent={
+              isOpen && mediaList.length > 0
+                ? () => (
+                    <InlineMediaText text={resultText} media={mediaList} />
+                  )
+                : undefined
+            }
+          />
+        )
+      }
     </ToolCardShell>
   );
 };

--- a/console/src/components/Chat/ToolCards/cards/GenericToolCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GenericToolCard.tsx
@@ -46,9 +46,7 @@ const GenericToolCard: React.FC<GenericToolCardProps> = ({
             content={resultText}
             renderContent={
               isOpen && mediaList.length > 0
-                ? () => (
-                    <InlineMediaText text={resultText} media={mediaList} />
-                  )
+                ? () => <InlineMediaText text={resultText} media={mediaList} />
                 : undefined
             }
           />

--- a/console/src/components/Chat/ToolCards/cards/GenericToolCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/GenericToolCard.tsx
@@ -11,7 +11,8 @@ import { ToolOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
 import { ToolCardShell } from "../shared";
 import { DefaultBlock } from "../shared";
-import { stringifyResult } from "../shared/utils";
+import InlineMediaText from "../shared/InlineMediaText";
+import { extractAllMediaFromResult, stringifyResult } from "../shared/utils";
 
 export interface GenericToolCardProps {
   content: ToolCallContent;
@@ -27,6 +28,8 @@ const GenericToolCard: React.FC<GenericToolCardProps> = ({
     ? `${content.serverLabel} / ${content.name}`
     : content.name;
   const resultText = stringifyResult(content.result);
+  const mediaList = extractAllMediaFromResult(content);
+  const hasOutput = resultText || mediaList.length > 0;
 
   return (
     <ToolCardShell
@@ -34,8 +37,17 @@ const GenericToolCard: React.FC<GenericToolCardProps> = ({
       title={t("tool.execute", { tool: toolLabel })}
       content={content}
       isStreaming={isStreaming}
+      disableAutoMedia
     >
-      {resultText && <DefaultBlock title="Output" content={resultText} />}
+      {hasOutput && (
+        <DefaultBlock
+          title="Output"
+          content={resultText}
+          renderContent={() => (
+            <InlineMediaText text={resultText} media={mediaList} />
+          )}
+        />
+      )}
     </ToolCardShell>
   );
 };

--- a/console/src/components/Chat/ToolCards/cards/MemorySearchCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/MemorySearchCard.tsx
@@ -40,6 +40,7 @@ const MemorySearchCard: React.FC<MemorySearchCardProps> = ({
         isStreaming={isStreaming}
         icon={<BulbOutlined />}
         title={title}
+        disableAutoMedia
       />
     );
   }
@@ -58,6 +59,7 @@ const MemorySearchCard: React.FC<MemorySearchCardProps> = ({
       isStreaming={isStreaming}
       icon={<BulbOutlined />}
       title={title}
+      disableAutoMedia
     >
       {formattedResult && (
         <DefaultBlock title="Output" content={formattedResult} />

--- a/console/src/components/Chat/ToolCards/cards/SendFileCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/SendFileCard.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { SendOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
-import { ToolCardShell, MediaPreview } from "../shared";
-import { shortFileName, getMediaInfo } from "../shared/utils";
+import { ToolCardShell } from "../shared";
+import { shortFileName } from "../shared/utils";
 
 export interface SendFileCardProps {
   content: ToolCallContent;
@@ -36,17 +36,13 @@ const SendFileCard: React.FC<SendFileCardProps> = ({
     );
   }
 
-  const media = getMediaInfo(content);
-
   return (
     <ToolCardShell
       content={content}
       isStreaming={isStreaming}
       icon={<SendOutlined />}
       title={title}
-    >
-      {media && <MediaPreview media={media} />}
-    </ToolCardShell>
+    />
   );
 };
 

--- a/console/src/components/Chat/ToolCards/cards/ViewImageCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/ViewImageCard.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { PictureOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
-import { ToolCardShell, MediaPreview } from "../shared";
-import { shortFileName, getMediaInfo } from "../shared/utils";
+import { ToolCardShell } from "../shared";
+import { shortFileName } from "../shared/utils";
 
 export interface ViewImageCardProps {
   content: ToolCallContent;
@@ -22,17 +22,13 @@ const ViewImageCard: React.FC<ViewImageCardProps> = ({
     ? t("tool.viewImage", { file })
     : t("tool.viewImageDefault");
 
-  const media = getMediaInfo(content);
-
   return (
     <ToolCardShell
       content={content}
       isStreaming={isStreaming}
       icon={<PictureOutlined />}
       title={title}
-    >
-      {media && <MediaPreview media={media} />}
-    </ToolCardShell>
+    />
   );
 };
 

--- a/console/src/components/Chat/ToolCards/cards/ViewVideoCard.tsx
+++ b/console/src/components/Chat/ToolCards/cards/ViewVideoCard.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { VideoCameraOutlined } from "@ant-design/icons";
 import type { ToolCallContent } from "../shared/types";
-import { ToolCardShell, MediaPreview } from "../shared";
-import { shortFileName, getMediaInfo } from "../shared/utils";
+import { ToolCardShell } from "../shared";
+import { shortFileName } from "../shared/utils";
 
 export interface ViewVideoCardProps {
   content: ToolCallContent;
@@ -22,17 +22,13 @@ const ViewVideoCard: React.FC<ViewVideoCardProps> = ({
     ? t("tool.viewVideo", { file })
     : t("tool.viewVideoDefault");
 
-  const media = getMediaInfo(content);
-
   return (
     <ToolCardShell
       content={content}
       isStreaming={isStreaming}
       icon={<VideoCameraOutlined />}
       title={title}
-    >
-      {media && <MediaPreview media={media} />}
-    </ToolCardShell>
+    />
   );
 };
 

--- a/console/src/components/Chat/ToolCards/shared/DefaultBlock.tsx
+++ b/console/src/components/Chat/ToolCards/shared/DefaultBlock.tsx
@@ -20,6 +20,8 @@ export interface DefaultBlockProps {
   title: string;
   content: string;
   copyTitle?: string;
+  /** Optional custom renderer for the content body. */
+  renderContent?: (content: string) => React.ReactNode;
 }
 
 /** Try to parse JSON. Returns parsed object or null. */
@@ -52,6 +54,7 @@ const DefaultBlock: React.FC<DefaultBlockProps> = ({
   title,
   content,
   copyTitle,
+  renderContent,
 }) => {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -72,7 +75,10 @@ const DefaultBlock: React.FC<DefaultBlockProps> = ({
       .catch(() => {});
   }, [content]);
 
-  const renderContent = () => {
+  const renderBody = () => {
+    if (renderContent) {
+      return renderContent(content);
+    }
     if (isMarkdown) {
       return (
         <div className={styles.defaultBlockContentMd}>
@@ -116,7 +122,7 @@ const DefaultBlock: React.FC<DefaultBlockProps> = ({
           {copied ? <CheckOutlined /> : <CopyOutlined />}
         </button>
       </div>
-      {renderContent()}
+      {renderBody()}
     </div>
   );
 };

--- a/console/src/components/Chat/ToolCards/shared/InlineMediaText.tsx
+++ b/console/src/components/Chat/ToolCards/shared/InlineMediaText.tsx
@@ -1,0 +1,132 @@
+/**
+ * InlineMediaText — replace file references inside a plain-text tool result
+ * with inline media previews.
+ *
+ * Used by GenericToolCard (scheme A): instead of appending previews below the
+ * text, the matching link/path text is "cut out" and replaced by the preview
+ * component. Any media that cannot be matched to a text span is still appended
+ * at the end so that image-only MCP blocks are not lost.
+ */
+
+import React, { useMemo } from "react";
+import type { MediaInfo } from "./utils";
+import MediaPreview from "./MediaPreview";
+import styles from "./toolCards.module.less";
+
+export interface InlineMediaTextProps {
+  text: string;
+  media: MediaInfo[];
+}
+
+type Token =
+  | { type: "text"; value: string }
+  | { type: "media"; media: MediaInfo };
+
+/** Build candidate literal strings that may appear in the result text. */
+function buildMatchCandidates(
+  rawUrl: string | undefined,
+  name: string,
+): string[] {
+  const candidates = new Set<string>();
+  if (rawUrl) {
+    candidates.add(rawUrl);
+    if (rawUrl.startsWith("file://")) {
+      candidates.add(rawUrl.replace("file://", ""));
+    }
+    const rawBase = rawUrl.split("/").pop();
+    if (rawBase) candidates.add(rawBase);
+  }
+  if (name) {
+    candidates.add(name);
+  }
+  return Array.from(candidates).filter(Boolean);
+}
+
+/** Find the left-most, longest candidate match in the remaining text. */
+function findBestMatch(
+  text: string,
+  mediaList: MediaInfo[],
+  matched: Set<MediaInfo>,
+): { index: number; length: number; media: MediaInfo } | null {
+  let best: { index: number; length: number; media: MediaInfo } | null = null;
+
+  for (const media of mediaList) {
+    if (matched.has(media)) continue;
+    const candidates = buildMatchCandidates(media.rawUrl, media.name);
+    for (const candidate of candidates) {
+      const idx = text.indexOf(candidate);
+      if (idx === -1) continue;
+      if (
+        !best ||
+        idx < best.index ||
+        (idx === best.index && candidate.length > best.length)
+      ) {
+        best = { index: idx, length: candidate.length, media };
+      }
+    }
+  }
+
+  return best;
+}
+
+const InlineMediaText: React.FC<InlineMediaTextProps> = ({ text, media }) => {
+  const tokens = useMemo<Token[]>(() => {
+    const sortedMedia = [...media].sort(
+      (a, b) => (b.rawUrl?.length ?? 0) - (a.rawUrl?.length ?? 0),
+    );
+    const matched = new Set<MediaInfo>();
+    const result: Token[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+      const match = findBestMatch(remaining, sortedMedia, matched);
+      if (!match) {
+        result.push({ type: "text", value: remaining });
+        break;
+      }
+
+      if (match.index > 0) {
+        result.push({ type: "text", value: remaining.slice(0, match.index) });
+      }
+      result.push({ type: "media", media: match.media });
+      matched.add(match.media);
+      remaining = remaining.slice(match.index + match.length);
+    }
+
+    return result;
+  }, [text, media]);
+
+  const unmatched = useMemo(
+    () =>
+      media.filter(
+        (m) => !tokens.some((t) => t.type === "media" && t.media === m),
+      ),
+    [media, tokens],
+  );
+
+  return (
+    <div className={styles.inlineMediaText}>
+      {tokens.map((token, index) =>
+        token.type === "text" ? (
+          <span key={`text-${index}`} className={styles.inlineMediaTextPlain}>
+            {token.value}
+          </span>
+        ) : (
+          <MediaPreview
+            key={`media-${token.media.url}-${index}`}
+            media={token.media}
+          />
+        ),
+      )}
+      {unmatched.length > 0 && (
+        <div className={styles.inlineMediaTextUnmatched}>
+          {unmatched.map((m) => (
+            <MediaPreview key={`unmatched-${m.url}`} media={m} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InlineMediaText;

--- a/console/src/components/Chat/ToolCards/shared/ResultMediaPreviews.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ResultMediaPreviews.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ResultMediaPreviews from "./ResultMediaPreviews";
+import type { ToolCallContent } from "./types";
+
+vi.mock("./MediaPreview", () => ({
+  default: ({ media }: { media: { name: string } }) => (
+    <div data-testid="media-preview">{media.name}</div>
+  ),
+}));
+
+const makeContent = (result: unknown): ToolCallContent => ({
+  type: "tool_call",
+  id: "test-id",
+  name: "test_tool",
+  params: {},
+  result,
+  status: "done",
+});
+
+describe("ResultMediaPreviews", () => {
+  it("renders nothing when result has no media", () => {
+    const { container } = render(
+      <ResultMediaPreviews content={makeContent("no media here")} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a media preview when result has an image", () => {
+    render(
+      <ResultMediaPreviews
+        content={makeContent([
+          { type: "image", source: { type: "url", url: "/uploads/img.png" } },
+        ])}
+      />,
+    );
+    expect(screen.getByTestId("media-preview")).toHaveTextContent("img.png");
+  });
+
+  it("renders multiple media previews", () => {
+    render(
+      <ResultMediaPreviews
+        content={makeContent([
+          { type: "image", source: { type: "url", url: "/uploads/a.png" } },
+          { type: "video", source: { type: "url", url: "/uploads/b.mp4" } },
+        ])}
+      />,
+    );
+    expect(screen.getAllByTestId("media-preview")).toHaveLength(2);
+  });
+});

--- a/console/src/components/Chat/ToolCards/shared/ResultMediaPreviews.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ResultMediaPreviews.tsx
@@ -1,0 +1,30 @@
+import React, { useMemo } from "react";
+import type { ToolCallContent } from "./types";
+import MediaPreview from "./MediaPreview";
+import { extractAllMediaFromResult } from "./utils";
+import styles from "./toolCards.module.less";
+
+export interface ResultMediaPreviewsProps {
+  content: ToolCallContent;
+}
+
+const ResultMediaPreviews: React.FC<ResultMediaPreviewsProps> = ({
+  content,
+}) => {
+  const mediaList = useMemo(
+    () => extractAllMediaFromResult(content),
+    [content],
+  );
+
+  if (mediaList.length === 0) return null;
+
+  return (
+    <div className={styles.resultMediaPreviews}>
+      {mediaList.map((media) => (
+        <MediaPreview key={media.url} media={media} />
+      ))}
+    </div>
+  );
+};
+
+export default ResultMediaPreviews;

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
@@ -29,9 +29,7 @@ const imageContent = () =>
 
 describe("ToolCardShell lazy media preview", () => {
   it("does not render media preview while collapsed", () => {
-    render(
-      <ToolCardShell icon={null} title="tool" content={imageContent()} />,
-    );
+    render(<ToolCardShell icon={null} title="tool" content={imageContent()} />);
     expect(screen.queryByTestId("media-preview")).toBeNull();
   });
 
@@ -50,7 +48,9 @@ describe("ToolCardShell lazy media preview", () => {
   it("passes open state to a render-function child", () => {
     const { container } = render(
       <ToolCardShell icon={null} title="tool" content={makeContent("text")}>
-        {(isOpen) => <div data-testid="child">{isOpen ? "open" : "closed"}</div>}
+        {(isOpen) => (
+          <div data-testid="child">{isOpen ? "open" : "closed"}</div>
+        )}
       </ToolCardShell>,
     );
     expect(screen.getByTestId("child")).toHaveTextContent("closed");

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ToolCardShell from "./ToolCardShell";
+import type { ToolCallContent } from "./types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("./MediaPreview", () => ({
+  default: ({ media }: { media: { name: string } }) => (
+    <div data-testid="media-preview">{media.name}</div>
+  ),
+}));
+
+const makeContent = (result: unknown): ToolCallContent => ({
+  type: "tool_call",
+  id: "test-id",
+  name: "test_tool",
+  params: {},
+  result,
+  status: "done",
+});
+
+const imageContent = () =>
+  makeContent([
+    { type: "image", source: { type: "url", url: "/uploads/img.png" } },
+  ]);
+
+describe("ToolCardShell lazy media preview", () => {
+  it("does not render media preview while collapsed", () => {
+    render(
+      <ToolCardShell icon={null} title="tool" content={imageContent()} />,
+    );
+    expect(screen.queryByTestId("media-preview")).toBeNull();
+  });
+
+  it("renders media preview only after the card is expanded", () => {
+    const { container } = render(
+      <ToolCardShell icon={null} title="tool" content={imageContent()} />,
+    );
+    const details = container.querySelector("details") as HTMLDetailsElement;
+
+    details.open = true;
+    fireEvent(details, new Event("toggle", { bubbles: false }));
+
+    expect(screen.getByTestId("media-preview")).toHaveTextContent("img.png");
+  });
+
+  it("passes open state to a render-function child", () => {
+    const { container } = render(
+      <ToolCardShell icon={null} title="tool" content={makeContent("text")}>
+        {(isOpen) => <div data-testid="child">{isOpen ? "open" : "closed"}</div>}
+      </ToolCardShell>,
+    );
+    expect(screen.getByTestId("child")).toHaveTextContent("closed");
+
+    const details = container.querySelector("details") as HTMLDetailsElement;
+    details.open = true;
+    fireEvent(details, new Event("toggle", { bubbles: false }));
+
+    expect(screen.getByTestId("child")).toHaveTextContent("open");
+  });
+});

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolCallContent } from "./types";
 import DefaultBlock from "./DefaultBlock";
+import ResultMediaPreviews from "./ResultMediaPreviews";
 import { stringifyResult } from "./utils";
 import styles from "./toolCards.module.less";
 
@@ -27,6 +28,8 @@ export interface ToolCardShellProps {
   badges?: React.ReactNode;
   /** Expandable body content. */
   children?: React.ReactNode;
+  /** Disable automatic media preview extraction from result. */
+  disableAutoMedia?: boolean;
 }
 
 const ToolCardShell: React.FC<ToolCardShellProps> = ({
@@ -37,6 +40,7 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
   inlineResult,
   badges,
   children,
+  disableAutoMedia = false,
 }) => {
   const { t } = useTranslation();
   const isLoading = content.status === "calling" && isStreaming;
@@ -83,7 +87,10 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
           />
         </>
       ) : (
-        children
+        <>
+          {children}
+          {!disableAutoMedia && <ResultMediaPreviews content={content} />}
+        </>
       )}
     </details>
   );

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -5,7 +5,7 @@
  * blocks: icon + label on a single line, expandable body underneath.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolCallContent } from "./types";
 import DefaultBlock from "./DefaultBlock";
@@ -26,8 +26,12 @@ export interface ToolCardShellProps {
   inlineResult?: string | null;
   /** Optional badge elements (line counts, diff counts). */
   badges?: React.ReactNode;
-  /** Expandable body content. */
-  children?: React.ReactNode;
+  /**
+   * Expandable body content. May be a render function receiving the current
+   * open state so children can defer expensive work (e.g. media requests)
+   * until the card is expanded.
+   */
+  children?: React.ReactNode | ((isOpen: boolean) => React.ReactNode);
   /** Disable automatic media preview extraction from result. */
   disableAutoMedia?: boolean;
 }
@@ -43,6 +47,7 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
   disableAutoMedia = false,
 }) => {
   const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
   const isLoading = content.status === "calling" && isStreaming;
   const isError = content.status === "error";
 
@@ -51,6 +56,7 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
       className={`${styles.toolCallCompact} ${
         isLoading ? styles.toolCallCompactLoading : ""
       } ${isError ? styles.toolCallCompactError : ""}`}
+      onToggle={(e) => setIsOpen((e.currentTarget as HTMLDetailsElement).open)}
     >
       <summary className={styles.toolCallCompactSummary}>
         {isLoading ? (
@@ -88,8 +94,10 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
         </>
       ) : (
         <>
-          {children}
-          {!disableAutoMedia && <ResultMediaPreviews content={content} />}
+          {typeof children === "function" ? children(isOpen) : children}
+          {!disableAutoMedia && isOpen && (
+            <ResultMediaPreviews content={content} />
+          )}
         </>
       )}
     </details>

--- a/console/src/components/Chat/ToolCards/shared/index.ts
+++ b/console/src/components/Chat/ToolCards/shared/index.ts
@@ -7,8 +7,8 @@ export type { MediaPreviewProps } from "./MediaPreview";
 export { default as ResultMediaPreviews } from "./ResultMediaPreviews";
 export type { ResultMediaPreviewsProps } from "./ResultMediaPreviews";
 export { extractAllMediaFromResult } from "./utils";
+export { toDisplayUrl } from "@/api/modules/chat";
 export {
-  toDisplayUrl,
   shortFileName,
   countLines,
   getFileLanguage,

--- a/console/src/components/Chat/ToolCards/shared/index.ts
+++ b/console/src/components/Chat/ToolCards/shared/index.ts
@@ -4,6 +4,9 @@ export { default as DefaultBlock } from "./DefaultBlock";
 export type { DefaultBlockProps } from "./DefaultBlock";
 export { default as MediaPreview } from "./MediaPreview";
 export type { MediaPreviewProps } from "./MediaPreview";
+export { default as ResultMediaPreviews } from "./ResultMediaPreviews";
+export type { ResultMediaPreviewsProps } from "./ResultMediaPreviews";
+export { extractAllMediaFromResult } from "./utils";
 export {
   toDisplayUrl,
   shortFileName,

--- a/console/src/components/Chat/ToolCards/shared/toolCards.module.less
+++ b/console/src/components/Chat/ToolCards/shared/toolCards.module.less
@@ -390,3 +390,428 @@
     font-weight: 500;
   }
 }
+
+.resultMediaPreviews {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+// Inline media text — replaces file links inside tool result text with previews.
+.inlineMediaText {
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.6;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 300px;
+  overflow-y: auto;
+  color: var(--ant-color-text, #000) !important;
+}
+
+.inlineMediaTextPlain {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.inlineMediaTextUnmatched {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+// Tool card styles — self-contained within the plugin system.
+// Extracted from ChatV2 MessageList.module.less so plugin cards
+// have zero dependencies on files outside ToolCards/.
+
+// Tool call — compact single-line (click to expand)
+.toolCallCompact {
+  margin: 2px 0;
+  display: block;
+  width: 100%;
+
+  &.toolCallCompactLoading {
+    .toolCallLabel {
+      color: var(--ant-color-primary, #1677ff);
+    }
+  }
+
+  &.toolCallCompactError {
+    .toolCallLabel {
+      color: #ff4d4f;
+    }
+  }
+}
+
+.toolCallCompactSummary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  padding: 2px 0;
+  max-width: 100%;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::marker {
+    content: none;
+  }
+}
+
+.toolCallIcon {
+  font-size: 13px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.toolCallIconSuccess {
+  color: var(--ant-color-text-secondary, #8c8c8c);
+}
+
+.toolCallIconError {
+  color: #ff4d4f;
+}
+
+.toolCallSpinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--ant-color-border, rgba(0, 0, 0, 0.1));
+  border-top-color: var(--ant-color-primary, #1677ff);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: toolSpin 0.8s linear infinite;
+}
+
+@keyframes toolSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.toolCallLabel {
+  color: var(--ant-color-text, rgba(0, 0, 0, 0.88));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 0 1 auto;
+
+  &:hover {
+    color: var(--ant-color-primary, #1677ff);
+    text-decoration: underline;
+  }
+}
+
+// Badges — use explicit colors that work on both light and dark backgrounds.
+// The chat-anywhere dark-mode stylesheet applies a blanket
+// `color: rgba(255,255,255,0.85) !important` to all descendant spans
+// with high specificity. We double the class selector to win the
+// specificity battle while keeping !important.
+.diffAddBadge.diffAddBadge {
+  font-size: 12px;
+  color: #52c41a !important;
+  font-weight: 500;
+}
+
+.diffDelBadge.diffDelBadge {
+  font-size: 12px;
+  color: #ff4d4f !important;
+  font-weight: 500;
+}
+
+.lineReadBadge.lineReadBadge {
+  font-size: 12px;
+  color: #4096ff !important;
+  font-weight: 500;
+}
+
+.lineSearchBadge.lineSearchBadge {
+  font-size: 12px;
+  color: #faad14 !important;
+  font-weight: 500;
+}
+
+// Diff block
+.toolCallDiff {
+  margin: 4px 0 2px 18px;
+  font-size: 12px;
+  line-height: 1.6;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  overflow-x: auto;
+  max-height: 360px;
+  overflow-y: auto;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px var(--ant-color-border, rgba(0, 0, 0, 0.08));
+}
+
+.diffLineDel {
+  background: rgba(255, 77, 79, 0.08);
+  color: #ff4d4f !important;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0 6px;
+}
+
+.diffLineAdd {
+  background: rgba(82, 196, 26, 0.08);
+  color: #52c41a !important;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0 6px;
+}
+
+// Media preview
+.toolCallMediaPreview {
+  margin: 6px 0 4px 18px;
+}
+
+.toolCallImage {
+  max-width: 256px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.06));
+}
+
+// Bubble media (reused by MediaPreview)
+.bubbleVideo {
+  width: 256px;
+  height: 144px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.bubbleAudio {
+  background-color: var(--ant-color-bg-base, #fff);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  padding-right: 4px;
+  border-radius: 20px;
+  width: fit-content;
+  margin: 4px 0;
+
+  :global([class*="-media-progress-container"]) {
+    display: none;
+  }
+}
+
+:global(.dark-mode) {
+  .bubbleAudio {
+    background-color: #2a2a2a;
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+}
+
+.bubbleFile {
+  position: relative;
+  display: inline-block;
+}
+
+.bubbleFileDownload {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1;
+  opacity: 0;
+  font-size: 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #fff;
+  transition: opacity 0.2s;
+
+  .bubbleFile:hover & {
+    opacity: 1;
+  }
+}
+
+// Default block (input/output sections)
+.defaultBlock {
+  margin: 4px 0 4px 0;
+  border: 1px solid var(--ant-color-border-secondary, rgba(0, 0, 0, 0.06));
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px var(--ant-color-border-secondary, rgba(0, 0, 0, 0.06));
+  background: var(--ant-color-bg-container, #fff);
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.defaultBlockHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--ant-color-fill-quaternary, rgba(0, 0, 0, 0.02));
+  border-bottom: 1px solid
+    var(--ant-color-border-secondary, rgba(0, 0, 0, 0.06));
+}
+
+.defaultBlockTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: inherit !important;
+}
+
+.defaultBlockCopy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--ant-color-text-quaternary, #bbb);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+  transition: all 0.15s;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.06);
+    color: var(--ant-color-text-secondary, #666);
+  }
+}
+
+.defaultBlockContent {
+  margin: 0;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.6;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 300px;
+  overflow-y: auto;
+  color: var(--ant-color-text, #000) !important;
+}
+
+.defaultBlockContentMd {
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.6;
+  max-height: 360px;
+  overflow-y: auto;
+  color: var(--ant-color-text, #000) !important;
+
+  :global(p),
+  :global(ul),
+  :global(ol),
+  :global(pre) {
+    margin: 4px 0;
+  }
+  :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  :global(th),
+  :global(td) {
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    padding: 6px 10px;
+    text-align: left;
+  }
+  :global(th) {
+    background: rgba(0, 0, 0, 0.02);
+    font-weight: 500;
+  }
+}
+
+// Inline result (next to tool label)
+.toolCallInlineResult {
+  font-size: 12px;
+  color: var(--ant-color-text-tertiary, #999);
+  margin-left: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+// JSON syntax highlighting.
+// Double class selector + !important to beat the blanket
+// `color: rgba(255,255,255,0.85) !important` from chat-anywhere dark-mode.
+.jsonKey.jsonKey {
+  color: #cf1322 !important;
+}
+.jsonStr.jsonStr {
+  color: #389e0d !important;
+}
+.jsonNum.jsonNum {
+  color: #1677ff !important;
+}
+.jsonNull.jsonNull {
+  color: #d4880f !important;
+}
+
+:global(.dark-mode) {
+  .jsonKey.jsonKey {
+    color: #f5827a !important;
+  }
+  .jsonStr.jsonStr {
+    color: #7ec87e !important;
+  }
+  .jsonNum.jsonNum {
+    color: #6cb6ff !important;
+  }
+  .jsonNull.jsonNull {
+    color: #f0b95f !important;
+  }
+}
+
+// Markdown result block
+.toolCallResultMd {
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 4px 0 2px 18px;
+  padding: 8px 12px;
+  background: var(--ant-color-fill-quaternary, rgba(0, 0, 0, 0.03));
+  border-radius: 8px;
+  overflow-x: auto;
+  max-height: 360px;
+  color: var(--ant-color-text, #000) !important;
+  box-shadow: 0 1px 4px var(--ant-color-border, rgba(0, 0, 0, 0.08));
+
+  :global(p),
+  :global(ul),
+  :global(ol),
+  :global(pre) {
+    margin: 4px 0;
+  }
+  :global(pre) {
+    padding: 6px 10px;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+  :global(code) {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  }
+  :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    margin: 4px 0;
+  }
+  :global(th),
+  :global(td) {
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    padding: 6px 10px;
+    text-align: left;
+  }
+  :global(th) {
+    background: rgba(0, 0, 0, 0.02);
+    font-weight: 500;
+  }
+}

--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import type { TFunction } from "i18next";
 import { formatAgentList, formatMemorySearch } from "./utils";
 
-vi.mock("@/api/modules/chat", () => ({
-  chatApi: {
-    filePreviewUrl: vi.fn((p: string) => `http://localhost:8000${p}`),
-  },
-}));
+vi.mock("@/api/modules/chat", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/modules/chat")>();
+  return {
+    ...actual,
+    chatApi: {
+      ...actual.chatApi,
+      filePreviewUrl: vi.fn((p: string) => `http://localhost:8000${p}`),
+    },
+  };
+});
 
 const translate = ((key: string) => {
   const translations: Record<string, string> = {

--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { TFunction } from "i18next";
 import { formatAgentList, formatMemorySearch } from "./utils";
+
+vi.mock("@/api/modules/chat", () => ({
+  chatApi: {
+    filePreviewUrl: vi.fn((p: string) => `http://localhost:8000${p}`),
+  },
+}));
 
 const translate = ((key: string) => {
   const translations: Record<string, string> = {
@@ -108,5 +114,114 @@ describe("formatAgentList", () => {
       "| Coder | `agent-1` | Coding agent | ready |",
     );
     expect(formattedResult).not.toContain("|  | `` |  |  |");
+  });
+});
+
+import { extractAllMediaFromResult, type MediaInfo } from "./utils";
+import type { ToolCallContent } from "./types";
+
+const makeContent = (
+  result: unknown,
+  params?: Record<string, unknown>,
+): ToolCallContent => ({
+  type: "tool_call",
+  id: "test-id",
+  name: "test_tool",
+  params: params || {},
+  result,
+  status: "done",
+});
+
+describe("extractAllMediaFromResult", () => {
+  it("returns empty array when no media is found", () => {
+    expect(extractAllMediaFromResult(makeContent("plain text"))).toEqual([]);
+  });
+
+  it("extracts a single image from MCP content blocks", () => {
+    const content = makeContent([
+      { type: "image", source: { type: "url", url: "/uploads/img.png" } },
+      { type: "text", text: "Here is the image" },
+    ]);
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+    expect(media[0].type).toBe("image");
+    expect(media[0].name).toBe("img.png");
+  });
+
+  it("extracts multiple files from MCP content blocks", () => {
+    const content = makeContent([
+      { type: "image", source: { type: "url", url: "/uploads/a.png" } },
+      {
+        type: "file",
+        source: { type: "url", url: "/uploads/b.pdf" },
+        filename: "report.pdf",
+      },
+      { type: "video", source: { type: "url", url: "/uploads/c.mp4" } },
+    ]);
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(3);
+    expect(media.map((m: MediaInfo) => m.type)).toEqual([
+      "image",
+      "file",
+      "video",
+    ]);
+  });
+
+  it("parses JSON-string MCP blocks", () => {
+    const content = makeContent(
+      JSON.stringify([
+        { type: "audio", source: { type: "url", url: "/uploads/sound.mp3" } },
+      ]),
+    );
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+    expect(media[0].type).toBe("audio");
+  });
+
+  it("extracts path from plain text using saved-to pattern", () => {
+    const content = makeContent("Image saved to /tmp/output.png");
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+    expect(media[0].type).toBe("image");
+  });
+
+  it("falls back to params when result has no media", () => {
+    const content = makeContent("done", { image_path: "/tmp/params.png" });
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+    expect(media[0].type).toBe("image");
+  });
+
+  it("deduplicates by display URL", () => {
+    const content = makeContent([
+      { type: "image", source: { type: "url", url: "/uploads/img.png" } },
+      { type: "text", text: "see /uploads/img.png" },
+    ]);
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+  });
+
+  it("does not duplicate when params path differs from result block url", () => {
+    const content = makeContent(
+      JSON.stringify([
+        {
+          type: "image",
+          source: { type: "url", url: "file:///Users/zz/Desktop/尾巴帧.jpg" },
+        },
+        { type: "text", text: "Image loaded: 尾巴帧.jpg" },
+      ]),
+      { image_path: "尾巴帧.jpg" },
+    );
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+    expect(media[0].name).toBe("尾巴帧.jpg");
+    expect(media[0].rawUrl).toBe("file:///Users/zz/Desktop/尾巴帧.jpg");
+  });
+
+  it("preserves rawUrl on extracted media", () => {
+    const content = makeContent("Image saved to /tmp/output.png");
+    const media = extractAllMediaFromResult(content);
+    expect(media).toHaveLength(1);
+    expect(media[0].rawUrl).toBe("/tmp/output.png");
   });
 });

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -106,6 +106,8 @@ export type MediaType = "image" | "video" | "audio" | "file";
 
 export interface MediaInfo {
   url: string;
+  /** Original URL/path as it appeared in the tool result or params. */
+  rawUrl?: string;
   name: string;
   type: MediaType;
   size?: number;
@@ -218,6 +220,101 @@ export function getMediaInfo(tc: ToolCallContent): MediaInfo | null {
   const mediaType = classifyMediaType(ext);
 
   return { url: toDisplayUrl(rawUrl), name, type: mediaType };
+}
+
+/** Extract all media references from a tool result and params. */
+export function extractAllMediaFromResult(tc: ToolCallContent): MediaInfo[] {
+  const params = tc.params || {};
+  const paramPath = getPathFromParams(params);
+  const result = tc.result;
+  const seen = new Map<string, MediaInfo>();
+
+  const addMedia = (rawUrl: string, filename?: string) => {
+    if (!rawUrl) return;
+    const url = toDisplayUrl(rawUrl);
+    if (seen.has(url)) return;
+    const name =
+      filename ||
+      rawUrl.split("/").pop() ||
+      paramPath.split("/").pop() ||
+      "file";
+    const ext = getFileExtFromPath(name);
+    seen.set(url, {
+      url,
+      rawUrl,
+      name,
+      type: classifyMediaType(ext),
+    });
+  };
+
+  // Whether any media was found in the result itself (blocks or text).
+  // When the result already contains media, skip the params fallback to avoid
+  // duplicates when the same file is referenced with different paths.
+  let foundFromResult = false;
+
+  // 1) MCP content blocks (array or JSON string)
+  let blocks: unknown[] | null = null;
+  if (typeof result === "string") {
+    try {
+      const parsed = JSON.parse(result);
+      if (Array.isArray(parsed)) blocks = parsed;
+    } catch {
+      // not JSON, keep null
+    }
+  } else if (Array.isArray(result)) {
+    blocks = result;
+  }
+
+  if (blocks) {
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+
+      if (b.source && typeof b.source === "object") {
+        const src = b.source as Record<string, unknown>;
+        if (typeof src.url === "string" && src.url) {
+          addMedia(
+            src.url,
+            typeof b.filename === "string" ? b.filename : undefined,
+          );
+          foundFromResult = true;
+        }
+      }
+
+      if (typeof b.url === "string" && b.url) {
+        addMedia(
+          b.url,
+          typeof b.filename === "string" ? b.filename : undefined,
+        );
+        foundFromResult = true;
+      }
+
+      if (typeof b.path === "string" && b.path) {
+        addMedia(
+          b.path,
+          typeof b.filename === "string" ? b.filename : undefined,
+        );
+        foundFromResult = true;
+      }
+    }
+  }
+
+  // 2) Plain text regex fallback
+  if (!blocks && typeof result === "string") {
+    const textUrl = extractUrlFromText(result);
+    if (textUrl) {
+      addMedia(textUrl);
+      foundFromResult = true;
+    }
+  }
+
+  // 3) Param path fallback for tools that pass path in arguments.
+  // Only used when the result itself did not already contain a media reference.
+  if (paramPath && !foundFromResult) {
+    addMedia(paramPath);
+  }
+
+  return Array.from(seen.values());
 }
 
 /** Try to extract a file URL from a text result via regex patterns */

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -5,20 +5,11 @@
 
 import type { TFunction } from "i18next";
 import type { ToolCallContent } from "./types";
-import { chatApi } from "@/api/modules/chat";
+import { toDisplayUrl } from "@/api/modules/chat";
 
 // ---------------------------------------------------------------------------
 // URL helpers
 // ---------------------------------------------------------------------------
-
-/** Convert a backend file/image URL to a displayable URL */
-export function toDisplayUrl(url: string): string {
-  if (!url) return "";
-  if (url.startsWith("http://") || url.startsWith("https://")) return url;
-  if (url.startsWith("data:")) return url;
-  if (url.startsWith("file://")) url = url.replace("file://", "");
-  return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
-}
 
 // ---------------------------------------------------------------------------
 // File helpers

--- a/console/src/pages/Chat/utils.test.ts
+++ b/console/src/pages/Chat/utils.test.ts
@@ -9,11 +9,20 @@ import {
 } from "./utils";
 import type { CopyableResponse } from "./utils";
 
-// toDisplayUrl depends on chatApi.filePreviewUrl, needs to be mocked
-vi.mock("@/api/modules/chat", () => ({
-  chatApi: {
-    filePreviewUrl: vi.fn((p: string) => `http://localhost:8000${p}`),
-  },
+// toDisplayUrl depends on chatApi.filePreviewUrl, which depends on config
+vi.mock("@/api/modules/chat", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/modules/chat")>();
+  return {
+    ...actual,
+    chatApi: {
+      ...actual.chatApi,
+      filePreviewUrl: vi.fn((p: string) => `http://localhost:8000${p}`),
+    },
+  };
+});
+vi.mock("@/api/config", () => ({
+  getApiUrl: (path: string) => `/api${path}`,
+  getApiToken: vi.fn(() => ""),
 }));
 
 // ---------------------------------------------------------------------------
@@ -233,13 +242,13 @@ describe("toDisplayUrl", () => {
 
   it("calls chatApi.filePreviewUrl for relative paths", () => {
     expect(toDisplayUrl("/uploads/img.png")).toBe(
-      "http://localhost:8000/uploads/img.png",
+      "/api/files/preview/uploads/img.png",
     );
   });
 
   it("strips file:// prefix then resolves full URL", () => {
     expect(toDisplayUrl("file:///uploads/img.png")).toBe(
-      "http://localhost:8000/uploads/img.png",
+      "/api/files/preview/uploads/img.png",
     );
   });
 });

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -1,7 +1,6 @@
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-import { chatApi } from "../../api/modules/chat";
 export type CopyableContent = {
   type?: string;
   text?: string;
@@ -206,13 +205,7 @@ export function normalizeContentUrls(part: any): any {
   return p;
 }
 
-/** Turn a backend content URL (path or full URL) into a full URL for display. */
-export function toDisplayUrl(url: string | undefined): string {
-  if (!url) return "";
-  if (url.startsWith("http://") || url.startsWith("https://")) return url;
-  if (url.startsWith("file://")) url = url.replace("file://", "");
-  return chatApi.filePreviewUrl(url.startsWith("/") ? url : `/${url}`);
-}
+export { toDisplayUrl } from "@/api/modules/chat";
 
 // ---------------------------------------------------------------------------
 // DOM utilities


### PR DESCRIPTION
- Delay media preview rendering to tool card phase
- Add InlineMediaText to replace file links inside result text
- Fix extractAllMediaFromResult duplicate when result blocks and params reference same file
- Add disableAutoMedia to ToolCardShell and update dedicated cards

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
