### PR TITLE
fix(goal): clean up stale session after goal completion

### DIFF
--- a/src/qwenpaw/modes/goal/goal_mode.py
+++ b/src/qwenpaw/modes/goal/goal_mode.py
@@ -100,11 +100,22 @@ class GoalMode(AgentMode):
         """Default token budget for new goals."""
         return self._default_max_tokens
 
-    def first_active_session(
+    def active_session(
         self,
     ) -> GoalSession | None:
-        """Return first active GoalSession or None."""
-        return self._first_active_session()
+        """Return active session for current context.
+
+        Uses get_current_session_id() ContextVar to
+        look up session. Returns None if no session or
+        session is inactive.
+        """
+        key = get_current_session_id()
+        if key is None:
+            return None
+        s = self._sessions.get(key)
+        if s is not None and s.active:
+            return s
+        return None
 
     def session_by_ctx_var(
         self,
@@ -119,6 +130,16 @@ class GoalMode(AgentMode):
         if key is None:
             return None
         return self._sessions.get(key)
+
+    def deactivate(self) -> None:
+        """Remove current session from _sessions.
+
+        Called after goal completion to prevent stale
+        sessions from blocking subsequent messages.
+        """
+        key = get_current_session_id()
+        if key is not None:
+            self._sessions.pop(key, None)
 
     # ---- AgentMode interface ----
 
@@ -213,7 +234,7 @@ class GoalMode(AgentMode):
 
     def is_active(self, ctx: Any) -> bool:
         """Goal mode is active when session live."""
-        return self._first_active_session() is not None
+        return self.active_session() is not None
 
     # ---- slash command handlers ----
 
@@ -270,7 +291,7 @@ class GoalMode(AgentMode):
         First turn uses INITIAL_GOAL_PROMPT;
         subsequent turns use CONTINUATION_PROMPT.
         """
-        session = self._first_active_session()
+        session = self.active_session()
         if session is None:
             return ""
 
@@ -293,18 +314,6 @@ class GoalMode(AgentMode):
             token_budget=session.max_tokens,
             remaining_tokens=remaining,
         )
-
-    def _first_active_session(
-        self,
-    ) -> Optional[GoalSession]:
-        """Return active session via ContextVar."""
-        key = get_current_session_id()
-        if key is None:
-            return None
-        s = self._sessions.get(key)
-        if s is not None and s.active:
-            return s
-        return None
 
     @staticmethod
     def _current_session_key(

--- a/src/qwenpaw/modes/goal/tools.py
+++ b/src/qwenpaw/modes/goal/tools.py
@@ -23,7 +23,7 @@ def make_get_goal(owner: "GoalMode") -> Any:
 
     def get_goal() -> str:
         """Get the current goal status, budgets, and usage."""
-        session = owner.first_active_session()
+        session = owner.active_session()
         if session is None:
             return json.dumps(
                 {"status": "no_active_goal"},
@@ -68,13 +68,14 @@ def make_update_goal(owner: "GoalMode") -> Any:
                 f"Must be 'complete' or 'blocked'."
             )
 
-        session = owner.first_active_session()
+        session = owner.active_session()
         if session is None:
             return "No active goal to update."
 
         if status == "complete":
             session.active = False
             session.last_verdict = "satisfied"
+            owner.deactivate()
             logger.info(
                 "Goal marked complete by agent: %s",
                 session.goal[:80],
@@ -117,7 +118,7 @@ def make_create_goal(owner: "GoalMode") -> Any:
         if not objective or not objective.strip():
             return "Objective is required."
 
-        existing = owner.first_active_session()
+        existing = owner.active_session()
         if existing is not None:
             return "A goal is already active. " "Cancel it first with /cancel."
 


### PR DESCRIPTION
## Description

After `update_goal("complete")`, the `GoalSession` remained in `GoalMode._sessions` with `active=False`. On subsequent messages, `GoalTurnGate.check()` found the stale session via `session_by_ctx_var()` and returned `TERMINATE("Goal completed: satisfied")` on every message, permanently blocking normal chat.

This PR adds `GoalMode.deactivate()` to pop the session from `_sessions`, and calls it from `update_goal("complete")` so subsequent messages bypass the goal gate and chat normally.

**Related Issue:** Fixes #6082

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. `/goal write a hello world script`
2. Wait for agent to complete and call `update_goal(status="complete")`
3. Send a new message: `"hey"`
4. **Before fix:** Agent returns `TERMINATE("Goal completed: satisfied")` — repeats on every message
5. **After fix:** Agent responds normally

## Evidence

```bash
$ pytest tests/unit/loop/test_goal_stale_session.py -v

tests/unit/loop/test_goal_stale_session.py::TestDeactivate::test_deactivate_pops_session PASSED
tests/unit/loop/test_goal_stale_session.py::TestDeactivate::test_deactivate_idempotent PASSED
tests/unit/loop/test_goal_stale_session.py::TestUpdateGoalCleanup::test_complete_removes_session PASSED
tests/unit/loop/test_goal_stale_session.py::TestUpdateGoalCleanup::test_blocked_keeps_session PASSED
tests/unit/loop/test_goal_stale_session.py::TestGoalTurnGateAfterCompletion::test_bypass_after_deactivate PASSED
tests/unit/loop/test_goal_stale_session.py::TestGoalTurnGateAfterCompletion::test_terminate_before_deactivate PASSED
tests/unit/loop/test_goal_stale_session.py::TestGoalTurnGateAfterCompletion::test_no_stale_terminate_after_complete PASSED

7 passed in 0.29s

$ pre-commit run --files src/qwenpaw/modes/goal/goal_mode.py src/qwenpaw/modes/goal/tools.py
All checks passed
```

## Additional Notes

The fix mirrors `MissionGate`'s correct deactivation pattern — MissionGate calls `self.deactivate()` (which pops from `LoopGate._sessions`) on all terminal paths, while GoalMode previously never cleaned up its `_sessions` dict.

Only the `update_goal("complete")` path is cleaned up. Non-completion exits (max_iterations, budget_exceeded, blocked) intentionally retain the session.


Made with [Cursor](https://cursor.com)