### PR TITLE
fix(mcp): migrate ${VAR} headers to env credential refs during driver migration

### DIFF
--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -25,6 +25,7 @@ async def create_driver_service(ws: "Workspace", _service):
     # pylint: disable=protected-access
     from ...drivers.adapters.mcp_legacy_config import (
         migrate_legacy_mcp_if_needed,
+        upgrade_legacy_mcp_credentials,
     )
     from ...drivers.credentials.store import AsyncCredentialStore
     from ...drivers.handlers import MCPDriverHandler
@@ -49,6 +50,7 @@ async def create_driver_service(ws: "Workspace", _service):
     # endpoint validator and tests.  This PR intentionally keeps the concrete
     # runtime surface to MCP while leaving DriverManager protocol-neutral.
     await migrate_legacy_mcp_if_needed(ws, driver_manager)
+    await upgrade_legacy_mcp_credentials(driver_manager)
     await driver_manager.start()
     ws._service_manager.services["driver_manager"] = driver_manager
     logger.debug(

--- a/src/qwenpaw/drivers/adapters/env_ref.py
+++ b/src/qwenpaw/drivers/adapters/env_ref.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Parse ${VAR} environment references embedded in legacy MCP values.
+
+Legacy ``agent.json`` MCP clients may embed process-environment references in
+header/env values (e.g. ``Authorization: "Bearer ${API_KEY}"``). The Driver
+model represents such a reference structurally as an ``env:`` credential ref
+resolved at runtime, instead of persisting the literal ``${VAR}`` text. These
+helpers detect ``${VAR}`` references and describe how to rewrite one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ${VAR}: a standard environment variable name (letter/underscore first).
+# A bare "$" (e.g. "$PATH", "p@$$w0rd") never matches, so literal secrets
+# that merely contain "$" are left untouched.
+_ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+@dataclass(frozen=True)
+class EnvTemplate:
+    """A value that embeds one or more ${VAR} references.
+
+    ``format`` replaces every reference with the ``{value}`` placeholder that
+    the credential binding resolver understands; it is only meaningful when a
+    single reference is present (see :attr:`is_single`).
+    """
+
+    format: str
+    var_names: tuple[str, ...]
+
+    @property
+    def is_single(self) -> bool:
+        """True when exactly one ${VAR} reference was found."""
+        return len(self.var_names) == 1
+
+
+def parse_env_template(value: str) -> EnvTemplate | None:
+    """Return an EnvTemplate if ``value`` embeds ${VAR}, else ``None``."""
+    if "$" not in value:
+        return None
+    names = _ENV_REF_RE.findall(value)
+    if not names:
+        return None
+    fmt = _ENV_REF_RE.sub("{value}", value)
+    return EnvTemplate(format=fmt, var_names=tuple(names))
+
+
+def env_alias(var_name: str) -> str:
+    """Return the deterministic credential alias for an env-backed value."""
+    return f"env_{var_name.strip().lower()}"
+
+
+def env_ref(var_name: str) -> str:
+    """Return the ``env:`` credential store ref for a variable name."""
+    return f"env:{var_name.strip()}"

--- a/src/qwenpaw/drivers/adapters/mcp_binding.py
+++ b/src/qwenpaw/drivers/adapters/mcp_binding.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from typing import Any
 
+from .env_ref import env_alias, parse_env_template
 from ..credentials.types import CredentialRecord
 
 _SAFE_KEY_PATTERN = re.compile(r"[^a-z0-9_]+")
@@ -119,6 +121,50 @@ def source_binding_from_split(
             "field": str(secret_key),
         }
     return binding
+
+
+@dataclass
+class EnvRefPlan:
+    """Split of secret values into single ${VAR} bindings vs. the rest."""
+
+    env_bindings: dict[str, dict[str, str]] = field(default_factory=dict)
+    env_aliases: dict[str, str] = field(default_factory=dict)
+    plain_secrets: dict[str, str] = field(default_factory=dict)
+    multi_ref_keys: list[str] = field(default_factory=list)
+
+
+def plan_env_ref_bindings(secrets: dict[str, str]) -> EnvRefPlan:
+    """Route each secret value: single ${VAR} -> env: binding, else plain.
+
+    A value holding exactly one ${VAR} reference becomes a credential
+    binding against an ``env:``-backed alias, resolved from os.environ at
+    runtime so the real value is never persisted.  Plain values and values
+    with multiple references are returned untouched for the caller's
+    existing static-secret path; multi-reference keys are recorded so the
+    migration can warn about them.
+    """
+    plan = EnvRefPlan()
+    for raw_key, raw_value in dict(secrets or {}).items():
+        key = str(raw_key)
+        value = str(raw_value)
+        template = parse_env_template(value)
+        if template is not None and template.is_single:
+            var = template.var_names[0]
+            alias = env_alias(var)
+            plan.env_aliases[alias] = var
+            spec: dict[str, str] = {
+                "source": "credential",
+                "credential": alias,
+                "field": "value",
+            }
+            if template.format != "{value}":
+                spec["format"] = template.format
+            plan.env_bindings[key] = spec
+            continue
+        plan.plain_secrets[key] = value
+        if template is not None:
+            plan.multi_ref_keys.append(key)
+    return plan
 
 
 def binding_to_response(

--- a/src/qwenpaw/drivers/adapters/mcp_console.py
+++ b/src/qwenpaw/drivers/adapters/mcp_console.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 from .mcp_binding import (
+    EnvRefPlan,
     binding_plain_keys,
     binding_to_response,
     classify_mcp_binding,
     mask_mcp_secret_value,
     normalize_secret_key,
+    plan_env_ref_bindings,
     restore_masked_value,
     source_binding_from_split,
     split_mcp_binding,
@@ -27,6 +29,7 @@ from .mcp_card_builder import (
 )
 
 __all__ = [
+    "EnvRefPlan",
     "OAUTH_CREDENTIAL_ALIAS",
     "STATIC_CREDENTIAL_ALIAS",
     "attach_mcp_oauth_credential",
@@ -41,6 +44,7 @@ __all__ = [
     "mcp_credential_ref",
     "mcp_oauth_credential_ref",
     "normalize_secret_key",
+    "plan_env_ref_bindings",
     "restore_masked_value",
     "source_binding_from_split",
     "split_mcp_binding",

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -39,6 +39,7 @@ from ..contracts import (
 )
 from ..credentials.types import CredentialRecord
 from ..manager import DriverManager
+from ..storage import load_card
 
 
 @dataclass
@@ -68,6 +69,19 @@ class LegacyMCPMigrationReport:
         default_factory=list,
     )
     warnings: list[LegacyMCPMigrationWarning] = field(default_factory=list)
+
+
+@dataclass
+class LegacyMCPUpgradedBinding:
+    card_name: str
+    container: str
+    key: str
+    var: str
+
+
+@dataclass
+class LegacyMCPUpgradeReport:
+    upgraded: list[LegacyMCPUpgradedBinding] = field(default_factory=list)
 
 
 async def migrate_legacy_mcp_if_needed(
@@ -334,6 +348,194 @@ def _write_report(cards_dir: Path, report: LegacyMCPMigrationReport) -> None:
         return
     cards_dir.mkdir(parents=True, exist_ok=True)
     path = cards_dir / ".legacy_mcp_migration_report.yaml"
+    payload = asdict(report)
+    path.write_text(
+        yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+async def upgrade_legacy_mcp_credentials(
+    driver_manager: DriverManager,
+) -> LegacyMCPUpgradeReport:
+    """Self-heal MCP cards migrated before the #6029 fix.
+
+    Re-runs the ``env:`` conversion over already-migrated cards whose
+    credential secrets still hold a literal single ``${VAR}``.  Uses the
+    same ``plan_env_ref_bindings`` as fresh migration, so the decision
+    boundary is identical: real secrets (no ``${WORD}``) are untouched.
+    """
+    report = LegacyMCPUpgradeReport()
+    for path in await driver_manager.card_store.list_paths():
+        card = await asyncio.to_thread(load_card, path)
+        if card.protocol != PROTOCOL_MCP:
+            continue
+        await _upgrade_one_card(card, driver_manager, report)
+    await asyncio.to_thread(
+        _write_upgrade_report,
+        driver_manager.cards_dir,
+        report,
+    )
+    return report
+
+
+async def _upgrade_one_card(
+    card: DriverCard,
+    driver_manager: DriverManager,
+    report: LegacyMCPUpgradeReport,
+) -> None:
+    endpoint = card.endpoint
+    if not isinstance(endpoint, dict):
+        return
+    to_clear: dict[str, set[str]] = {}
+    changed = False
+    for container_name in ("headers", "env"):
+        container = endpoint.get(container_name)
+        if not isinstance(container, dict):
+            continue
+        for key, spec in list(container.items()):
+            planned = await _plan_binding_upgrade(
+                spec,
+                card,
+                driver_manager,
+            )
+            if planned is None:
+                continue
+            new_spec, alias, var, store_ref, field_name = planned
+            container[key] = new_spec
+            card.credentials[alias] = CredentialRef(
+                kind=CREDENTIAL_KIND_STATIC,
+                ref=env_ref(var),
+            )
+            to_clear.setdefault(store_ref, set()).add(field_name)
+            report.upgraded.append(
+                LegacyMCPUpgradedBinding(
+                    card_name=card.name,
+                    container=container_name,
+                    key=str(key),
+                    var=var,
+                ),
+            )
+            changed = True
+    if not changed:
+        return
+    await _clear_upgraded_secrets(driver_manager, card, to_clear)
+    await driver_manager.card_store.save(card)
+
+
+def _credential_source_ref(
+    spec: Any,
+    card: DriverCard,
+) -> tuple[str, str] | None:
+    """Return (store_ref, field) for an upgradable credential binding."""
+    if not isinstance(spec, dict) or spec.get("source") != "credential":
+        return None
+    alias = str(spec.get("credential") or "")
+    field_name = str(spec.get("field") or "")
+    if not alias or not field_name:
+        return None
+    cred_ref = card.credentials.get(alias)
+    store_ref = str(getattr(cred_ref, "ref", "") or "")
+    if not store_ref or store_ref.startswith("env:"):
+        return None
+    return store_ref, field_name
+
+
+async def _plan_binding_upgrade(
+    spec: Any,
+    card: DriverCard,
+    driver_manager: DriverManager,
+) -> tuple[dict[str, str], str, str, str, str] | None:
+    resolved = _credential_source_ref(spec, card)
+    if resolved is None:
+        return None
+    store_ref, field_name = resolved
+    try:
+        record = await driver_manager.credential_store.get(store_ref)
+    except Exception:
+        return None
+    literal = record.secrets.get(field_name)
+    if not isinstance(literal, str):
+        return None
+    plan = plan_env_ref_bindings({field_name: literal})
+    new_spec = plan.env_bindings.get(field_name)
+    if new_spec is None:
+        return None
+    new_alias, var = next(iter(plan.env_aliases.items()))
+    return new_spec, new_alias, var, store_ref, field_name
+
+
+async def _clear_upgraded_secrets(
+    driver_manager: DriverManager,
+    card: DriverCard,
+    to_clear: dict[str, set[str]],
+) -> None:
+    store = driver_manager.credential_store
+    for store_ref, fields in to_clear.items():
+        try:
+            record = await store.get(store_ref)
+        except Exception:
+            continue
+        remaining = {
+            key: value
+            for key, value in record.secrets.items()
+            if key not in fields
+        }
+        if remaining:
+            await store.put(
+                CredentialRecord(
+                    ref=record.ref,
+                    kind=record.kind,
+                    public=record.public,
+                    secrets=remaining,
+                    meta=record.meta,
+                ),
+            )
+            continue
+        await store.delete(store_ref)
+        _prune_orphan_credential_aliases(card, store_ref)
+
+
+def _prune_orphan_credential_aliases(
+    card: DriverCard,
+    store_ref: str,
+) -> None:
+    referenced = _referenced_aliases(card)
+    orphans = [
+        alias
+        for alias, cred in dict(card.credentials).items()
+        if str(getattr(cred, "ref", "") or "") == store_ref
+        and alias not in referenced
+    ]
+    for alias in orphans:
+        card.credentials.pop(alias, None)
+
+
+def _referenced_aliases(card: DriverCard) -> set[str]:
+    referenced: set[str] = set()
+    endpoint = card.endpoint
+    if not isinstance(endpoint, dict):
+        return referenced
+    for container_name in ("headers", "env"):
+        container = endpoint.get(container_name)
+        if not isinstance(container, dict):
+            continue
+        for spec in container.values():
+            if isinstance(spec, dict) and spec.get("source") == "credential":
+                alias = str(spec.get("credential") or "")
+                if alias:
+                    referenced.add(alias)
+    return referenced
+
+
+def _write_upgrade_report(
+    cards_dir: Path,
+    report: LegacyMCPUpgradeReport,
+) -> None:
+    if not report.upgraded:
+        return
+    cards_dir.mkdir(parents=True, exist_ok=True)
+    path = cards_dir / ".legacy_mcp_upgrade_report.yaml"
     payload = asdict(report)
     path.write_text(
         yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -11,10 +11,12 @@ from typing import Any
 
 import yaml
 
+from .env_ref import env_ref
 from .mcp_console import (
     mcp_credential_ref,
     mcp_oauth_credential_ref,
     normalize_secret_key,
+    plan_env_ref_bindings,
     source_binding_from_split,
     split_mcp_binding,
 )
@@ -164,18 +166,22 @@ def legacy_mcp_client_to_driver(
         "headers",
         dict(getattr(config, "headers", {}) or {}),
     )
+    env_plan = plan_env_ref_bindings(env_secrets)
+    header_plan = plan_env_ref_bindings(header_secrets)
 
     endpoint: dict[str, Any]
     if transport == "stdio":
+        env_binding = source_binding_from_split(
+            env_public,
+            {key: key for key in env_plan.plain_secrets},
+            credential_alias,
+        )
+        env_binding.update(env_plan.env_bindings)
         endpoint = {
             "transport": "stdio",
             "command": str(getattr(config, "command", "") or ""),
             "args": list(getattr(config, "args", []) or []),
-            "env": source_binding_from_split(
-                env_public,
-                {key: key for key in env_secrets},
-                credential_alias,
-            ),
+            "env": env_binding,
         }
         cwd = str(getattr(config, "cwd", "") or "")
         if cwd:
@@ -183,33 +189,44 @@ def legacy_mcp_client_to_driver(
     else:
         used: set[str] = set()
         header_secret_refs: dict[str, str] = {}
-        for header in header_secrets:
+        for header in header_plan.plain_secrets:
             secret_key = normalize_secret_key(header, used)
             used.add(secret_key)
             header_secret_refs[header] = secret_key
+        header_binding = source_binding_from_split(
+            header_public,
+            header_secret_refs,
+            credential_alias,
+        )
+        header_binding.update(header_plan.env_bindings)
         endpoint = {
             "transport": transport,
             "url": str(getattr(config, "url", "") or ""),
-            "headers": source_binding_from_split(
-                header_public,
-                header_secret_refs,
-                credential_alias,
-            ),
+            "headers": header_binding,
         }
 
     credential = _build_legacy_credential(
         client_key,
         oauth,
-        env_secrets,
-        header_secrets,
+        env_plan.plain_secrets,
+        header_plan.plain_secrets,
         endpoint,
         now,
     )
+    credentials = _legacy_credential_refs(credential)
+    for alias, var in {
+        **env_plan.env_aliases,
+        **header_plan.env_aliases,
+    }.items():
+        credentials[alias] = CredentialRef(
+            kind=CREDENTIAL_KIND_STATIC,
+            ref=env_ref(var),
+        )
     card = DriverCard(
         name=client_key,
         protocol=PROTOCOL_MCP,
         endpoint=endpoint,
-        credentials=_legacy_credential_refs(credential),
+        credentials=credentials,
         config={
             "display_name": str(getattr(config, "name", "") or client_key),
             "description": str(getattr(config, "description", "") or ""),

--- a/tests/integration/test_driver_mcp_env_ref_flow.py
+++ b/tests/integration/test_driver_mcp_env_ref_flow.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.drivers.capabilities import DriverInvocation
+from qwenpaw.drivers.contracts import CredentialRef, DriverCard, PolicyRule
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.handlers.mcp import MCPDriverHandler
+from qwenpaw.drivers.manager import DriverManager
+from qwenpaw.drivers.storage import card_path, dump_card
+from tests.integration.driver_mcp_fakes import patch_mcp_runtime_clients
+
+
+@pytest.mark.asyncio
+async def test_env_ref_header_resolves_from_environment_at_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_mcp_runtime_clients(monkeypatch)
+    monkeypatch.setenv("WIND_API_KEY", "ak_real_key_123")
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    dump_card(
+        DriverCard(
+            name="wind",
+            protocol="mcp",
+            endpoint={
+                "transport": "streamable_http",
+                "url": "http://127.0.0.1:18080/mcp",
+                "headers": {
+                    "Authorization": {
+                        "source": "credential",
+                        "credential": "env_wind_api_key",
+                        "field": "value",
+                        "format": "Bearer {value}",
+                    },
+                },
+            },
+            credentials={
+                "env_wind_api_key": CredentialRef(
+                    "static",
+                    "env:WIND_API_KEY",
+                ),
+            },
+            policy=[PolicyRule(subject="*", effect="allow")],
+        ),
+        card_path(tmp_path / "drivers", "wind", protocol="mcp"),
+    )
+    manager = DriverManager(tmp_path / "drivers", store)
+    manager.register_handler_type("mcp", MCPDriverHandler)
+
+    await manager.build_drivers()
+    capability = next(
+        item
+        for item in await manager.list_capabilities(kind="tool")
+        if item.name == "inspect_headers"
+    )
+    result = await manager.invoke_capability(
+        DriverInvocation(capability.capability_id, {}),
+    )
+
+    assert result.ok is True
+    assert result.value["headers"]["Authorization"] == "Bearer ak_real_key_123"
+    # A rotated env value is reflected without any persisted credential.
+    credentials_file = tmp_path / "credentials.yaml"
+    on_disk = (
+        credentials_file.read_text(encoding="utf-8")
+        if credentials_file.is_file()
+        else ""
+    )
+    assert "ak_real_key_123" not in on_disk

--- a/tests/unit/drivers/adapters/test_env_ref.py
+++ b/tests/unit/drivers/adapters/test_env_ref.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ${VAR} env-reference parsing in legacy MCP migration."""
+import pytest
+
+from qwenpaw.drivers.adapters.env_ref import (
+    EnvTemplate,
+    env_alias,
+    env_ref,
+    parse_env_template,
+)
+
+
+def test_single_reference_with_prefix_yields_format_placeholder() -> None:
+    tpl = parse_env_template("Bearer ${API_KEY}")
+    assert tpl == EnvTemplate(format="Bearer {value}", var_names=("API_KEY",))
+    assert tpl.is_single
+
+
+def test_pure_reference_uses_bare_placeholder() -> None:
+    tpl = parse_env_template("${API_KEY}")
+    assert tpl is not None
+    assert tpl.is_single
+    assert tpl.format == "{value}"
+    assert tpl.var_names == ("API_KEY",)
+
+
+def test_multiple_references_are_not_single() -> None:
+    tpl = parse_env_template("${CLIENT}:${SECRET}")
+    assert tpl is not None
+    assert not tpl.is_single
+    assert tpl.var_names == ("CLIENT", "SECRET")
+
+
+def test_plain_value_has_no_template() -> None:
+    assert parse_env_template("static-token") is None
+
+
+@pytest.mark.parametrize("value", ["$PATH", "p@$$w0rd", "cost is $100", "$"])
+def test_bare_dollar_is_not_a_reference(value: str) -> None:
+    assert parse_env_template(value) is None
+
+
+def test_hyphenated_name_is_not_matched() -> None:
+    assert parse_env_template("${API-KEY}") is None
+
+
+def test_leading_digit_name_is_not_matched() -> None:
+    assert parse_env_template("${1INVALID}") is None
+
+
+def test_env_alias_is_deterministic_and_lowercased() -> None:
+    assert env_alias("API_KEY") == "env_api_key"
+
+
+def test_env_ref_prefixes_store_env_scheme() -> None:
+    assert env_ref("API_KEY") == "env:API_KEY"

--- a/tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Migration tests: legacy ${VAR} header/env values -> env: credential refs."""
+from types import SimpleNamespace
+
+from qwenpaw.drivers.adapters.mcp_binding import (
+    EnvRefPlan,
+    plan_env_ref_bindings,
+)
+from qwenpaw.drivers.adapters.mcp_legacy_config import (
+    legacy_mcp_client_to_driver,
+)
+from qwenpaw.drivers.contracts import CredentialRef
+
+
+# --- plan_env_ref_bindings unit behavior ---
+
+
+def test_plan_links_single_env_ref_with_format() -> None:
+    plan = plan_env_ref_bindings({"Authorization": "Bearer ${API_KEY}"})
+    assert isinstance(plan, EnvRefPlan)
+    assert plan.env_bindings == {
+        "Authorization": {
+            "source": "credential",
+            "credential": "env_api_key",
+            "field": "value",
+            "format": "Bearer {value}",
+        },
+    }
+    assert plan.env_aliases == {"env_api_key": "API_KEY"}
+    assert not plan.plain_secrets
+    assert not plan.multi_ref_keys
+
+
+def test_plan_pure_ref_omits_format() -> None:
+    plan = plan_env_ref_bindings({"X-Api-Key": "${API_KEY}"})
+    assert plan.env_bindings["X-Api-Key"] == {
+        "source": "credential",
+        "credential": "env_api_key",
+        "field": "value",
+    }
+
+
+def test_plan_keeps_plain_secret_untouched() -> None:
+    plan = plan_env_ref_bindings({"Authorization": "Bearer static-token"})
+    assert plan.plain_secrets == {"Authorization": "Bearer static-token"}
+    assert not plan.env_bindings
+    assert not plan.env_aliases
+
+
+def test_plan_multi_ref_is_reported_and_kept_plain() -> None:
+    plan = plan_env_ref_bindings({"Authorization": "${USER}:${PASS}"})
+    assert plan.multi_ref_keys == ["Authorization"]
+    assert not plan.env_aliases
+    assert plan.plain_secrets == {"Authorization": "${USER}:${PASS}"}
+
+
+# --- end-to-end migration behavior ---
+
+
+def test_migration_links_header_env_ref_and_never_persists_key() -> None:
+    card, credential = legacy_mcp_client_to_driver(
+        "wind",
+        SimpleNamespace(
+            transport="streamable_http",
+            url="https://mcp.example.com/api/",
+            headers={"Authorization": "Bearer ${API_KEY}"},
+        ),
+    )
+    assert card.endpoint["headers"]["Authorization"] == {
+        "source": "credential",
+        "credential": "env_api_key",
+        "field": "value",
+        "format": "Bearer {value}",
+    }
+    assert card.credentials["env_api_key"] == CredentialRef(
+        "static",
+        "env:API_KEY",
+    )
+    assert credential is None or "authorization" not in credential.secrets
+
+
+def test_migration_mixed_static_and_env_ref_headers() -> None:
+    card, credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="streamable_http",
+            url="https://x/api/",
+            headers={
+                "Authorization": "Bearer ${API_KEY}",
+                "X-Api-Key": "literal-secret",
+            },
+        ),
+    )
+    assert card.credentials["env_api_key"] == CredentialRef(
+        "static",
+        "env:API_KEY",
+    )
+    assert credential is not None
+    assert credential.secrets.get("x_api_key") == "literal-secret"
+    assert "authorization" not in credential.secrets
+
+
+def test_migration_stdio_env_ref() -> None:
+    card, _credential = legacy_mcp_client_to_driver(
+        "svc",
+        SimpleNamespace(
+            transport="stdio",
+            command="run-server",
+            args=[],
+            env={"API_TOKEN": "${TOKEN}"},
+        ),
+    )
+    assert card.endpoint["env"]["API_TOKEN"] == {
+        "source": "credential",
+        "credential": "env_token",
+        "field": "value",
+    }
+    assert card.credentials["env_token"] == CredentialRef(
+        "static",
+        "env:TOKEN",
+    )

--- a/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
+++ b/tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""Tests for legacy MCP credential upgrade (self-heal of #6029 bad cards).
+
+Cards migrated *before* the #6029 fix stored ``${VAR}`` header values as
+literals in the credential store, so migration's "card already exists" gate
+never repairs them.  ``upgrade_legacy_mcp_credentials`` re-runs the same
+``env:`` conversion over already-migrated cards, and must:
+
+* rewrite only credential secret values that hold a single ``${WORD}``,
+* leave real secrets (no ``${WORD}``) byte-for-byte untouched,
+* be idempotent (skip credentials already resolved via ``env:``).
+"""
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.drivers.adapters.mcp_legacy_config import (
+    upgrade_legacy_mcp_credentials,
+)
+from qwenpaw.drivers.contracts import CredentialRef, DriverCard, PolicyRule
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.credentials.types import CredentialRecord
+from qwenpaw.drivers.manager import DriverManager
+from qwenpaw.drivers.storage import card_path, dump_card, load_card
+
+
+def _write_card(
+    cards_dir: Path,
+    *,
+    headers: dict,
+    credentials: dict,
+) -> None:
+    dump_card(
+        DriverCard(
+            name="wind",
+            protocol="mcp",
+            endpoint={
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com/api/",
+                "headers": headers,
+            },
+            credentials=credentials,
+            policy=[PolicyRule(subject="*", effect="allow")],
+        ),
+        card_path(cards_dir, "wind", protocol="mcp"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade_rewrites_single_env_ref_literal(
+    tmp_path: Path,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    await store.put(
+        CredentialRecord(
+            ref="mcp/wind",
+            kind="static",
+            secrets={"authorization": "Bearer ${API_KEY}"},
+        ),
+    )
+    cards_dir = tmp_path / "drivers"
+    _write_card(
+        cards_dir,
+        headers={
+            "Authorization": {
+                "source": "credential",
+                "credential": "static",
+                "field": "authorization",
+            },
+        },
+        credentials={"static": CredentialRef("static", "mcp/wind")},
+    )
+    manager = DriverManager(cards_dir, store)
+
+    report = await upgrade_legacy_mcp_credentials(manager)
+
+    card = load_card(card_path(cards_dir, "wind", protocol="mcp"))
+    assert card.endpoint["headers"]["Authorization"] == {
+        "source": "credential",
+        "credential": "env_api_key",
+        "field": "value",
+        "format": "Bearer {value}",
+    }
+    assert card.credentials["env_api_key"] == CredentialRef(
+        "static",
+        "env:API_KEY",
+    )
+    assert "mcp/wind" not in await store.list_refs()
+    assert len(report.upgraded) == 1
+
+
+@pytest.mark.asyncio
+async def test_upgrade_leaves_real_secret_untouched(
+    tmp_path: Path,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    await store.put(
+        CredentialRecord(
+            ref="mcp/wind",
+            kind="static",
+            secrets={"authorization": "Bearer sk-real-key-123"},
+        ),
+    )
+    cards_dir = tmp_path / "drivers"
+    _write_card(
+        cards_dir,
+        headers={
+            "Authorization": {
+                "source": "credential",
+                "credential": "static",
+                "field": "authorization",
+            },
+        },
+        credentials={"static": CredentialRef("static", "mcp/wind")},
+    )
+    manager = DriverManager(cards_dir, store)
+
+    report = await upgrade_legacy_mcp_credentials(manager)
+
+    card = load_card(card_path(cards_dir, "wind", protocol="mcp"))
+    assert card.endpoint["headers"]["Authorization"] == {
+        "source": "credential",
+        "credential": "static",
+        "field": "authorization",
+    }
+    assert card.credentials["static"] == CredentialRef("static", "mcp/wind")
+    record = await store.get("mcp/wind")
+    assert record.secrets["authorization"] == "Bearer sk-real-key-123"
+    assert report.upgraded == []
+
+
+@pytest.mark.asyncio
+async def test_upgrade_is_idempotent_for_env_refs(
+    tmp_path: Path,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    cards_dir = tmp_path / "drivers"
+    _write_card(
+        cards_dir,
+        headers={
+            "Authorization": {
+                "source": "credential",
+                "credential": "env_api_key",
+                "field": "value",
+                "format": "Bearer {value}",
+            },
+        },
+        credentials={"env_api_key": CredentialRef("static", "env:API_KEY")},
+    )
+    manager = DriverManager(cards_dir, store)
+
+    report = await upgrade_legacy_mcp_credentials(manager)
+
+    assert report.upgraded == []
+    card = load_card(card_path(cards_dir, "wind", protocol="mcp"))
+    assert card.credentials["env_api_key"] == CredentialRef(
+        "static",
+        "env:API_KEY",
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade_mixed_credential_preserves_real_secret(
+    tmp_path: Path,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    await store.put(
+        CredentialRecord(
+            ref="mcp/wind",
+            kind="static",
+            secrets={
+                "authorization": "Bearer ${API_KEY}",
+                "x_tenant": "acme-prod-1234",
+            },
+        ),
+    )
+    cards_dir = tmp_path / "drivers"
+    _write_card(
+        cards_dir,
+        headers={
+            "Authorization": {
+                "source": "credential",
+                "credential": "static",
+                "field": "authorization",
+            },
+            "X-Tenant": {
+                "source": "credential",
+                "credential": "static",
+                "field": "x_tenant",
+            },
+        },
+        credentials={"static": CredentialRef("static", "mcp/wind")},
+    )
+    manager = DriverManager(cards_dir, store)
+
+    report = await upgrade_legacy_mcp_credentials(manager)
+
+    card = load_card(card_path(cards_dir, "wind", protocol="mcp"))
+    assert card.endpoint["headers"]["Authorization"] == {
+        "source": "credential",
+        "credential": "env_api_key",
+        "field": "value",
+        "format": "Bearer {value}",
+    }
+    assert card.credentials["env_api_key"] == CredentialRef(
+        "static",
+        "env:API_KEY",
+    )
+    assert card.endpoint["headers"]["X-Tenant"] == {
+        "source": "credential",
+        "credential": "static",
+        "field": "x_tenant",
+    }
+    assert card.credentials["static"] == CredentialRef("static", "mcp/wind")
+    record = await store.get("mcp/wind")
+    assert record.secrets == {"x_tenant": "acme-prod-1234"}
+    assert len(report.upgraded) == 1


### PR DESCRIPTION
## Description

This PR fixes driver MCP migration silently copying `${VAR}` environment references into the credential store as literals (Issue #6029). As a result, the runtime sent `Authorization: Bearer ${VAR}` verbatim — every MCP tool call returned HTTP 401, and startup was blocked while the failing MCP servers retried until timeout.

The fix has two parts: **(1)** migration now converts single-`${VAR}` values into `env:` credential refs, and **(2)** a startup self-heal pass repairs cards that were already migrated — and corrupted — before this fix landed.

**Part 1 — Forward fix (migration):**

- Adds a new `env_ref` helper that parses `${VAR}` templates in legacy MCP secret values. It matches only `${WORD}`, so literals like `$PATH`, `p@$$w0rd`, and `$100` are left untouched.
- Introduces `plan_env_ref_bindings` in `mcp_binding.py`, which splits legacy secret values into single-`${VAR}` env bindings (`source: credential` + `format`) vs. plain secrets, and reports multi-var values.
- Updates the legacy migration (`mcp_legacy_config.py`) so a single `${VAR}` header/env value becomes a structured `env:` credential ref (`{kind: static, ref: env:VAR}`) plus a `format` binding, instead of storing the literal `${VAR}` string.
- Keeps the real secret off disk; it is resolved dynamically from the process environment at runtime, preserving `${VAR}` semantics.
- Leaves multi-var values (e.g. `${A}:${B}`) as plain secrets to avoid ambiguous splits — unchanged behavior, now surfaced via `multi_ref_keys`.
- Re-exports the new API through the `mcp_console` facade (backend module, not the web UI).

**Part 2 — Self-heal of pre-fix cards (`upgrade_legacy_mcp_credentials`):**

Migration only runs for clients that have not been migrated yet (`if card exists: skip`). Cards migrated *before* Part 1 already hold the literal `${VAR}` in the credential store, so that gate would never repair them — the reporter's own environment is in exactly this state. On driver-service startup (after migrate, before start), the new upgrade pass:

- Re-runs the **same** `plan_env_ref_bindings` conversion over already-migrated MCP cards, so the decision boundary is identical to a fresh migration — real secrets (no `${WORD}`) are never touched.
- Rewrites only credential secrets that hold a single `${WORD}` into an `env:` ref, clears the now-unused literal from the store, and prunes orphaned credential aliases.
- Is idempotent: cards already on `env:` refs are left unchanged (no rewrite, no report entry).
- Because the old migration stored the value verbatim, the stored literal *is* the user's original input, so the upgrade reconstructs exactly the binding a correct migration would have produced — no data is invented or lost.

Adds unit tests for `env_ref` parsing, migration planning, and the self-heal upgrade, plus an integration test proving end-to-end runtime resolution.

Related Issue: Closes #6029

This implements the issue's recommended **Option 1** (generate an `env:VAR` credential ref during migration). It is an alternative to the eager expansion in #6039: rather than expanding `${VAR}` to its value at migration time, it preserves the reference, so the secret stays dynamic and never lands on disk.

Security Considerations: The literal `${VAR}` is no longer written to the credential store, and the resolved secret is never persisted — it is read from the environment at resolve time. The self-heal pass additionally *removes* any literal already written by the old migration. This was verified end-to-end (the real key does not appear anywhere on disk after migration or self-heal). Only unambiguous single `${WORD}` values are converted; multi-var and non-`${...}` literals (including passwords containing `$`) are preserved verbatim. No change to credential store encryption or resolution mechanics — only the migration-produced binding structure changes.

## Scope & Known Limitations

Conversion is intentionally limited to a single `${WORD}` reference per value (optionally surrounded by literal text, e.g. `Bearer ${API_KEY}`), which covers the #6029 case and the mainstream MCP convention. The following are deliberately left as plain secrets (behavior unchanged from before this PR — no regression) rather than structurally migrated:

- **`${VAR:-default}` (default-value syntax)** — supported by some MCP hosts (e.g. Claude Code). Full support would need to encode the default into the credential ref and teach the `env:` resolver about defaults; that touches the credential contract and would persist the default value into the plaintext DriverCard, which is at odds with this PR's goal of keeping secrets off disk. Tracked as a separate follow-up.
- **Multiple references in one value** (e.g. `${A}:${B}`) — surfaced via `multi_ref_keys` and kept as a plain secret.
- **Bare `$VAR`, `%VAR%` (Windows), `$env:VAR` (PowerShell)** — not MCP config conventions. QwenPaw's own placeholder handling is brace-only for the same reason (see `run_tool_batch`), so these are left untouched to avoid ambiguity with a literal `$` in secret values.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran relevant local checks and tests
- [ ] Remote PR checks pass
- [x] Documentation updated (if needed) — N/A, internal migration logic only
- [x] Ready for review

## Testing

Local verification:

```
uv run python -m pytest \
  tests/unit/drivers/adapters/test_env_ref.py \
  tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py \
  tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py \
  tests/integration/test_driver_mcp_env_ref_flow.py -q
# 24 passed

uv run pre-commit run --files \
  src/qwenpaw/drivers/adapters/env_ref.py \
  src/qwenpaw/drivers/adapters/mcp_binding.py \
  src/qwenpaw/drivers/adapters/mcp_console.py \
  src/qwenpaw/drivers/adapters/mcp_legacy_config.py \
  src/qwenpaw/app/workspace/service_factories.py \
  tests/unit/drivers/adapters/test_env_ref.py \
  tests/unit/drivers/adapters/test_mcp_legacy_env_ref.py \
  tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py \
  tests/integration/test_driver_mcp_env_ref_flow.py
# black / flake8 / mypy / pylint all Passed
```

End-to-end verification (isolated cold-start of the real service, `QWENPAW_WORKING_DIR` override):

A legacy client with `"Authorization": "Bearer ${VERIFY_API_KEY}"` migrates to:

```
# drivers/mcp/wind_stock_data.yaml
headers:
  Authorization:
    source: credential
    credential: env_verify_api_key
    field: value
    format: Bearer {value}
credentials:
  env_verify_api_key:
    kind: static
    ref: env:VERIFY_API_KEY
```

`credentials.yaml` contains neither the literal `${VERIFY_API_KEY}` nor the resolved value. Runtime resolution:

| env state | resolved header |
| --- | --- |
| `VERIFY_API_KEY=verify-secret-xyz-123` | `Bearer verify-secret-xyz-123` |
| rotated to `ROTATED-999` (no disk change) | `Bearer ROTATED-999` |
| unset | `Bearer ` (empty; no `${VAR}` leak, no crash) |

Self-heal end-to-end (isolated cold-start; the bad card is injected with the *service's* master key, then a second boot heals it):

Before — a card migrated by the old code: credential store holds `authorization: "Bearer ${VERIFY_API_KEY}"` (literal) alongside a real `x_tenant: acme-prod-1234`; the card binds `Authorization` to `{source: credential, credential: static, field: authorization}`. After the next startup:

```
# drivers/mcp/wind_stock_data.yaml (healed)
headers:
  Authorization:
    source: credential
    credential: env_verify_api_key
    field: value
    format: Bearer {value}
  X-Tenant:                 # untouched real secret
    source: credential
    credential: static
    field: x_tenant
```

- `credentials.yaml`: the `authorization` literal is removed; the real `x_tenant` value is preserved.
- The upgrade report lists exactly `wind_stock_data / headers / Authorization / var VERIFY_API_KEY`.
- Runtime resolution of the healed card: `Bearer verify-secret-xyz-123` (present), `Bearer rotated-999` (rotated), `Bearer ` (unset); `X-Tenant` stays `acme-prod-1234` throughout.
- Zero decrypt failures; the empty-key `tavily_search` card is left untouched.

Manual scenarios covered by this fix:

1. Legacy `Authorization: Bearer ${API_KEY}` migrates to an `env:` credential ref; the literal string is not stored.
2. At runtime the header resolves to the real environment value, fixing the 401.
3. Rotating the env var takes effect without re-migration or disk writes (dynamic semantics preserved).
4. Missing env var degrades gracefully to `Bearer ` — no literal `${VAR}` sent, no startup block.
5. Multi-var values (`${A}:${B}`) and non-env literals (`$PATH`, `p@$$w0rd`, `$100`) are left untouched.
6. A card migrated *before* this fix (literal `${VAR}` already in the store) is self-healed to an `env:` ref on the next startup, with real sibling secrets preserved and the literal removed from disk.

