### PR TITLE
fix(goal): reset stop gates on /new and /clear commands

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -207,6 +207,32 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Write the rolling compaction summary."""
         self._state.summary = value or ""
 
+    def _reset_stop_gates(  # pylint: disable=protected-access
+        self,
+    ) -> None:
+        """Reset gate state on conversation reset."""
+        workspace = getattr(
+            self._prompt_context,
+            "workspace",
+            None,
+        )
+        handler = getattr(
+            workspace,
+            "_stop_handler",
+            None,
+        )
+        if handler is not None:
+            handler.reset()
+
+        agent = self._agent or getattr(
+            self._prompt_context,
+            "agent",
+            None,
+        )
+        if agent is not None:
+            agent._gate_pending_stop = None
+            agent._gate_pending_continue = None
+
     def is_command(self, query: str | None) -> bool:
         """Check if the query is a system command (alias for mixin)."""
         return self.is_conversation_command(query)
@@ -541,6 +567,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Process /new command."""
         if not messages:
             self._set_summary("")
+            self._reset_stop_gates()
             return await self._make_system_msg(
                 "**No messages to summarize.**\n\n"
                 "- Current memory is empty\n"
@@ -563,6 +590,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         self._set_summary("")
 
         await self._persist_and_clear()
+        self._reset_stop_gates()
         return await self._make_system_msg(
             "**New Conversation Started!**\n\n"
             "- Summary task started in background\n"
@@ -579,6 +607,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
         """Process /clear command."""
         await self._persist_and_clear()
         self._set_summary("")
+        self._reset_stop_gates()
         return await self._make_system_msg(
             "**History Cleared!**\n\n"
             "- Compressed summary reset\n"

--- a/src/qwenpaw/loop/gates/handler.py
+++ b/src/qwenpaw/loop/gates/handler.py
@@ -51,6 +51,18 @@ class StopHandler:
         """Read-only view of registered gates."""
         return list(self._gates)
 
+    def reset(self) -> None:
+        """Reset all stateful gates."""
+        for gate in self._gates:
+            try:
+                gate.reset()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "StopGate '%s' reset raised",
+                    gate.name,
+                    exc_info=True,
+                )
+
     async def __call__(
         self,
         ctx: Any,

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -35,6 +36,31 @@ async def test_process_clear_returns_clear_history_metadata() -> None:
     msg = await handler.handle_command("/clear")
 
     assert msg.metadata == {"clear_history": True, "clear_plan": True}
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_stop_gates() -> None:
+    agent = _make_agent()
+    agent._gate_pending_stop = object()
+    agent._gate_pending_continue = "cont"
+    stop_handler = MagicMock()
+    ctx = SimpleNamespace(
+        workspace=SimpleNamespace(
+            _stop_handler=stop_handler,
+        ),
+        agent=agent,
+    )
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        agent=agent,
+        prompt_context=ctx,
+    )
+
+    await handler.handle_command("/clear")
+
+    stop_handler.reset.assert_called_once()
+    assert agent._gate_pending_stop is None
+    assert agent._gate_pending_continue is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`/new` and `/clear` reset conversation history and summary but did not reset loop gate state (iteration counters, doom loop history, pending stop/continue). This caused stale gate state to bleed into new conversations — e.g. a completed goal's `TERMINATE` persisting after `/new`.

Add `StopHandler.reset()` to reset all registered gates, and call it from `CommandHandler._reset_stop_gates()` which also clears `agent._gate_pending_stop` / `_gate_pending_continue`. Invoked in all three exit paths of `_process_new` and `_process_clear`.

Based on the approach from PR #5885 by @FIELA.

**Related Issue:** Relates to #6082

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Start a `/goal` session and let it complete
2. Run `/new` or `/clear`
3. Send a new message
4. **Before fix:** stale gate state may cause unexpected `TERMINATE` or loop behavior
5. **After fix:** gate state is fully reset, new conversation starts clean

```bash
$ pytest tests/unit/agents/test_command_handler.py -v

14 passed in 0.32s
```

## Evidence

```bash
$ pre-commit run --files src/qwenpaw/agents/command_handler.py src/qwenpaw/loop/gates/handler.py tests/unit/agents/test_command_handler.py
All checks passed

$ pytest tests/unit/agents/test_command_handler.py -v
test_process_clear_returns_clear_history_metadata PASSED
test_clear_resets_stop_gates PASSED
test_system_prompt_command_returns_current_prompt PASSED
... (14 passed)
```

## Additional Notes

This is a clean reimplementation of the approach from PR #5885 by @FIELA, with pylint/flake8 compliance baked in from the start. The original author is credited via `Co-authored-by` in the commit.


Made with [Cursor](https://cursor.com)