### PR TITLE
feat(approval): use toolSource instead of executionLevel to control Always Allow button

### DIFF
--- a/console/src/components/ApprovalCard/ApprovalCard.tsx
+++ b/console/src/components/ApprovalCard/ApprovalCard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Button, Card, Tag, Typography, Space, Tooltip } from "antd";
 import { Shield, Check, X, Clock, Copy, Info, AlertCircle } from "lucide-react";
-import type { ToolExecutionLevel } from "../../utils/approval";
 import { useTranslation } from "react-i18next";
 import { useAgentStore } from "../../stores/agentStore";
 import { getAgentDisplayName } from "../../utils/agentDisplayName";
@@ -29,7 +28,6 @@ export interface ApprovalCardProps {
   isGeneralized?: boolean;
   exactTarget?: string;
   similarTarget?: string;
-  executionLevel?: ToolExecutionLevel;
   onApprove: (requestId: string, scope?: "exact" | "similar") => Promise<void>;
   onDeny: (requestId: string) => Promise<void>;
   onCancel?: () => void;
@@ -54,14 +52,13 @@ export function ApprovalCard({
   isGeneralized,
   exactTarget,
   similarTarget,
-  executionLevel,
   onApprove,
   onDeny,
   onCancel: _onCancel,
   onAcknowledge,
 }: ApprovalCardProps) {
   const { t } = useTranslation();
-  const isStrictMode = executionLevel === "STRICT";
+  const isAlwaysAllowDisabled = toolSource === "STRICT mode";
   const agents = useAgentStore((state) => state.agents);
   const agentsById = useMemo(
     () => new Map(agents.map((agent) => [agent.id, agent])),
@@ -274,11 +271,11 @@ export function ApprovalCard({
                   {t("approval.approvePattern", "Always Allow")}:
                 </Text>
                 <code className={styles.scopeCode}>{similarTarget}</code>
-                {isStrictMode && (
+                {isAlwaysAllowDisabled && (
                   <Tooltip
                     title={t(
-                      "approval.strictModeHint",
-                      "Always allow is unavailable in strict mode",
+                      "approval.alwaysAllowDisabledHint",
+                      "Always allow is unavailable for this approval source",
                     )}
                   >
                     <AlertCircle
@@ -379,10 +376,10 @@ export function ApprovalCard({
                 </Button>
                 <Tooltip
                   title={
-                    isStrictMode
+                    isAlwaysAllowDisabled
                       ? t(
-                          "approval.strictModeHint",
-                          "Always allow is unavailable in strict mode",
+                          "approval.alwaysAllowDisabledHint",
+                          "Always allow is unavailable for this approval source",
                         )
                       : undefined
                   }
@@ -392,7 +389,7 @@ export function ApprovalCard({
                     icon={<Check size={14} />}
                     onClick={() => handleApprove("similar")}
                     loading={loading === "approve-pattern"}
-                    disabled={isStrictMode || loading !== null}
+                    disabled={isAlwaysAllowDisabled || loading !== null}
                     className={styles.approveAlwaysButton}
                   >
                     {t("approval.approvePattern", "Always Allow")}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -64,6 +64,7 @@ interface ApprovalMessageData {
   rootSessionId?: string;
   agentId: string;
   toolName: string;
+  toolSource?: string;
   severity: string;
   findingsCount: number;
   findingsSummary: string;
@@ -1466,6 +1467,7 @@ export default function ChatPage() {
         rootSessionId: approval.root_session_id,
         agentId: approval.agent_id,
         toolName: approval.tool_name,
+        toolSource: approval.tool_source,
         severity: approval.severity,
         findingsCount: approval.findings_count,
         findingsSummary: approval.findings_summary,
@@ -3108,6 +3110,7 @@ export default function ChatPage() {
               requestId={request.requestId}
               agentId={request.agentId}
               toolName={request.toolName}
+              toolSource={request.toolSource}
               severity={request.severity}
               findingsCount={request.findingsCount}
               findingsSummary={request.findingsSummary}
@@ -3119,9 +3122,6 @@ export default function ChatPage() {
               isGeneralized={request.isGeneralized}
               exactTarget={request.exactTarget}
               similarTarget={request.similarTarget}
-              executionLevel={
-                sessionApprovalLevelRef.current ?? runningConfigApprovalLevel
-              }
               onApprove={(reqId, scope) => handleApprove(reqId, scope)}
               onDeny={handleDeny}
               onCancel={() => {

--- a/console/src/pages/Inbox/index.tsx
+++ b/console/src/pages/Inbox/index.tsx
@@ -31,7 +31,6 @@ import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { commandsApi } from "../../api/modules/commands";
 import { chatApi } from "../../api/modules/chat";
 import sessionApi from "../Chat/sessionApi";
-import { useAgentRunningConfigApprovalLevel } from "../../hooks/useAgentRunningConfigApprovalLevel";
 import { PushMessageCard } from "./components";
 import { useInboxData } from "./hooks/useInboxData";
 import { useTraceViewer } from "./hooks/useTraceViewer";
@@ -87,7 +86,6 @@ export default function InboxPage() {
   const [messagesPage, setMessagesPage] = useState(1);
   const [selectedMessageIds, setSelectedMessageIds] = useState<string[]>([]);
   const [batchMode, setBatchMode] = useState(false);
-  const runningConfigApprovalLevel = useAgentRunningConfigApprovalLevel();
   const agents = useAgentStore((state) => state.agents);
   const { approvals: pendingApprovals, setApprovals } = useApprovalContext();
   const {
@@ -466,7 +464,6 @@ export default function InboxPage() {
                   isGeneralized={approval.is_generalized}
                   exactTarget={approval.exact_target}
                   similarTarget={approval.similar_target}
-                  executionLevel={runningConfigApprovalLevel}
                   onApprove={(_reqId, scope) =>
                     handleApproveRequest(
                       approval.request_id,


### PR DESCRIPTION
…lways Allow button

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
