### PR TITLE
fix(desktop): prevent WKWebView from pinning stale console frontend

### DIFF
--- a/console/src/tauri/BackendReadyGate.tsx
+++ b/console/src/tauri/BackendReadyGate.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect } from "react";
 import BackendLoadingPage from "./BackendLoadingPage";
 import useBackendReadyPolling from "./useBackendReadyPolling";
-import { withDesktopMarker } from "./backendRuntime";
+import { withCacheBuster, withDesktopMarker } from "./backendRuntime";
 
 interface Props {
   children: ReactNode;
@@ -20,7 +20,7 @@ export default function BackendReadyGate({ children }: Props) {
 
   useEffect(() => {
     if (shouldGate && status === "ready" && readyUrl) {
-      window.location.replace(withDesktopMarker(readyUrl));
+      window.location.replace(withCacheBuster(withDesktopMarker(readyUrl)));
     }
   }, [readyUrl, shouldGate, status]);
 

--- a/console/src/tauri/backendRuntime.ts
+++ b/console/src/tauri/backendRuntime.ts
@@ -43,6 +43,19 @@ export function withDesktopMarker(url: string): string {
   return `${url}${sep}${DESKTOP_QUERY_KEY}=1`;
 }
 
+/**
+ * Append a per-launch cache-busting param so the WebView always fetches a fresh
+ * SPA entry (index.html) on each desktop startup. WKWebView caches the entry
+ * document by URL and does not reliably revalidate even with `Cache-Control:
+ * no-cache`, so a stable redirect URL keeps serving stale HTML that points at
+ * old asset hashes after a rebuild. The content-hashed JS/CSS it references are
+ * unaffected and still cache normally, so load stays fast.
+ */
+export function withCacheBuster(url: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}_=${Date.now()}`;
+}
+
 export function shouldUseTauriStartupGate(): boolean {
   return isTauriRuntime() && !isBackendHostedConsole();
 }

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -928,7 +928,8 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
     def _serve_console_index():
         if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
             return FileResponse(
-                _CONSOLE_INDEX, headers=_INDEX_NO_CACHE_HEADERS
+                _CONSOLE_INDEX,
+                headers=_INDEX_NO_CACHE_HEADERS,
             )
 
         raise HTTPException(status_code=404, detail="Not Found")

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -927,7 +927,9 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
 
     def _serve_console_index():
         if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-            return FileResponse(_CONSOLE_INDEX, headers=_INDEX_NO_CACHE_HEADERS)
+            return FileResponse(
+                _CONSOLE_INDEX, headers=_INDEX_NO_CACHE_HEADERS
+            )
 
         raise HTTPException(status_code=404, detail="Not Found")
 

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -850,11 +850,24 @@ _CONSOLE_INDEX = (
 )
 logger.info(f"STATIC_DIR: {_CONSOLE_STATIC_DIR}")
 
+# The SPA entry (index.html) must never be cached: it references content-hashed
+# JS/CSS bundles, so a stale cached index.html would keep pointing the WebView
+# at old asset hashes after a rebuild (see desktop dev cache issue). The hashed
+# assets under /assets remain safely cacheable because their name changes with
+# their content.
+_INDEX_NO_CACHE_HEADERS = {
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+    # Pragma/Expires cover legacy proxies and older WebView caches that do not
+    # honor Cache-Control on their own.
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+
 
 @app.get("/")
 def read_root():
     if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-        return FileResponse(_CONSOLE_INDEX)
+        return FileResponse(_CONSOLE_INDEX, headers=_INDEX_NO_CACHE_HEADERS)
     return {
         "message": (
             f"{PROJECT_NAME} web console is not available. "
@@ -914,7 +927,7 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
 
     def _serve_console_index():
         if _CONSOLE_INDEX and _CONSOLE_INDEX.exists():
-            return FileResponse(_CONSOLE_INDEX)
+            return FileResponse(_CONSOLE_INDEX, headers=_INDEX_NO_CACHE_HEADERS)
 
         raise HTTPException(status_code=404, detail="Not Found")
 


### PR DESCRIPTION
The desktop WebView redirects to a stable backend URL and the SPA entry (index.html) was served without cache headers, so WKWebView heuristically cached it and kept loading old asset hashes after a rebuild/app update — users stayed on pre-fix frontend code (e.g. broken message queue) until the cache was cleared, which uninstalling the app does not do.

- _app.py: serve index.html with no-cache/no-store/must-revalidate (+Pragma/ Expires for legacy proxies). Content-hashed /assets stay cacheable.
- backendRuntime.ts: add withCacheBuster() appending a per-launch _=<ts>.
- BackendReadyGate.tsx: apply cache-buster to the startup redirect so each launch fetches a fresh index.html and self-heals already-affected users.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
