### PR TITLE
fix(context): keep tool results paired with assistant calls during context compression

### DIFF
--- a/src/qwenpaw/agents/context/scroll/_as_internals.py
+++ b/src/qwenpaw/agents/context/scroll/_as_internals.py
@@ -32,4 +32,22 @@ async def split_for_compression(
     """Pairing-safe split of the live context into (to_compress, to_reserve),
     reserving roughly ``reserve`` tokens of the recent tail."""
     # pylint: disable-next=protected-access
-    return await agent._split_context_for_compression(reserve, tools)
+    to_compress, to_reserve = await agent._split_context_for_compression(
+        reserve,
+        tools,
+    )
+
+    # DeepSeek/OpenAI constraint: tool messages must be preceded by
+    # assistant message with tool_calls. Shift messages from to_compress
+    # to to_reserve to prevent orphaned tool messages at start of reserve.
+    while to_reserve and to_compress:
+        first_msg = to_reserve[0]
+        role = getattr(first_msg, "role", None) or (
+            first_msg.get("role") if isinstance(first_msg, dict) else None
+        )
+        if role == "tool":
+            to_reserve.insert(0, to_compress.pop())
+        else:
+            break
+
+    return to_compress, to_reserve

--- a/tests/unit/agents/context/test_as_internals_signatures.py
+++ b/tests/unit/agents/context/test_as_internals_signatures.py
@@ -62,3 +62,44 @@ async def test_adapter_forwards_to_the_wrapped_methods():
         ["t"],
     ) == (["compress"], ["reserve"])
     assert seen == {"prepare": True, "split": (0.1, ["t"])}
+
+
+async def test_split_for_compression_keeps_tool_messages_with_assistant():
+    class FakeAgent:
+        async def _split_context_for_compression(self, reserve, tools):
+            _ = (reserve, tools)
+            # Simulate a split that cuts right after the assistant message,
+            # leaving the tool responses in the reserved list.
+
+            class Msg:
+                def __init__(self, role, content):
+                    self.role = role
+                    self.content = content
+
+            to_compress = [
+                Msg("user", "hi"),
+                Msg("assistant", "call tool"),
+            ]
+            to_reserve = [
+                Msg("tool", "result A"),
+                Msg("tool", "result B"),
+                Msg("assistant", "final answer"),
+            ]
+            return (to_compress, to_reserve)
+
+    agent = FakeAgent()
+    to_compress, to_reserve = await _as_internals.split_for_compression(
+        agent,
+        0.1,
+        ["t"],
+    )
+
+    # Move assistant message to start of reserve list to pair with tool
+    assert len(to_compress) == 1
+    assert to_compress[0].role == "user"
+
+    assert len(to_reserve) == 4
+    assert to_reserve[0].role == "assistant"
+    assert to_reserve[1].role == "tool"
+    assert to_reserve[2].role == "tool"
+    assert to_reserve[3].role == "assistant"


### PR DESCRIPTION
## What Problem This Solves

When using DeepSeek V4 Pro or other OpenAI-compatible API backends in long conversations, triggering QwenPaw's context compression (inside the scroll manager) could lead to a permanent `400 Bad Request` error:
`Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

This occurs because `split_for_compression` splits the live context into `to_compress` and `to_reserve` purely based on token count, which can split right between the `assistant(tool_calls)` message and the following `tool` result messages. This leaves orphaned `tool` role messages at the beginning of the reserved context, breaking the strict format constraints of the DeepSeek API.

This PR fixes this by post-processing the split lists in `_as_internals.py`. If the reserved list starts with a `"tool"` message, it shifts messages from the end of `to_compress` to `to_reserve` until it starts with a non-tool message (the corresponding `assistant` message), maintaining the pairing integrity.

## Evidence

I added a new unit test in `test_as_internals_signatures.py` (`test_split_for_compression_keeps_tool_messages_with_assistant`) which mocks the split and asserts that the `assistant` message is correctly moved to keep the tool response paired.

All tests and pre-commit checks pass:
```bash
pytest tests/unit/agents/context/test_as_internals_signatures.py
pre-commit run --files src/qwenpaw/agents/context/scroll/_as_internals.py tests/unit/agents/context/test_as_internals_signatures.py
```

Output:
```
tests\unit\agents\context\test_as_internals_signatures.py ....           [100%]
======================== 4 passed in 0.62s =========================
```
