### PR TITLE
fix(governance): honor sandbox_enabled switch in OFF-mode sandbox path

### DIFF
--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -194,11 +194,19 @@ def _prepare_off_mode_sandbox(tool: Any, governor: Any) -> None:
     unsandboxed by design, and forcing a sandbox on them would silently narrow
     their filesystem access.
 
-    A no-op (leaving ``sandbox_config=None``) when the platform has no sandbox:
-    such a REPL is never registered in the first place, or it tolerates
-    unsandboxed execution via ``allow_unsandboxed``.
+    A no-op (leaving ``sandbox_config=None``) when the sandbox is not usable
+    -- either the platform has no sandbox, or the operator turned the global
+    ``security.sandbox_enabled`` switch off. In both cases such a REPL is
+    never registered in the first place, or it tolerates unsandboxed
+    execution via ``allow_unsandboxed``.
+
+    Uses ``governor.sandbox_usable`` (platform support AND the global switch)
+    rather than the platform-only ``sandbox_available`` probe, so that an
+    explicit ``sandbox_enabled=false`` is honoured on the OFF-mode path just
+    like it is on the normal policy path (see
+    :meth:`ResourceGovernor._sandbox_usable`).
     """
-    if governor is None or not getattr(governor, "sandbox_available", False):
+    if governor is None or not getattr(governor, "sandbox_usable", False):
         return
     policy_name = DEFAULT_REGISTRY.python_to_policy_name(
         getattr(tool, "name", "Unknown"),

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -734,6 +734,14 @@ class AgentBuilder:
         tool, which needs no sandbox. This is narrower than
         :meth:`_scroll_recall_runnable`, which gates whether scroll is wired at
         all; here scroll is already wired and structured recall is present.
+
+        Note: this is a build-time decision. Registration is evaluated once
+        when the agent is built; toggling ``security.sandbox_enabled`` at
+        runtime does NOT add or remove the REPL from an already-running
+        agent. The switch is still honoured on the execution path
+        (``_prepare_off_mode_sandbox`` / ``_sandbox_usable``) -- an already
+        registered REPL will simply skip sandbox provisioning once the switch
+        is off. Rebuild the agent to change which tools are offered.
         """
         if governor is not None:
             sandbox_usable = getattr(governor, "sandbox_usable", None)

--- a/tests/integration/test_security_config.py
+++ b/tests/integration/test_security_config.py
@@ -7,6 +7,76 @@ import pytest
 
 @pytest.mark.integration
 @pytest.mark.p0
+def test_global_sandbox_put_get_roundtrip(app_server) -> None:
+    """Test purpose:
+    - Verify the global sandbox switch supports update and readback, and that
+      the change is hot-reloaded (no restart) via the mtime-cached config.
+
+    Test flow:
+    1. GET current sandbox switch as baseline.
+    2. PUT toggled ``enabled`` value; assert echo matches.
+    3. GET sandbox switch and assert the new value is visible (hot-reload).
+    4. PUT the toggled value back to the original and re-read to confirm the
+       switch flips both ways without a restart.
+    5. Restore original value.
+
+    API endpoints:
+    - GET /api/config/security/sandbox
+    - PUT /api/config/security/sandbox
+    """
+    get_before = app_server.api_request(
+        "GET",
+        "/api/config/security/sandbox",
+    )
+    assert get_before.status_code == 200, app_server.logs_tail()
+    before = get_before.json()
+    assert isinstance(before, dict)
+    assert "enabled" in before
+
+    original_enabled = bool(before.get("enabled", False))
+    toggled_enabled = not original_enabled
+
+    try:
+        put_resp = app_server.api_request(
+            "PUT",
+            "/api/config/security/sandbox",
+            json={"enabled": toggled_enabled},
+        )
+        assert put_resp.status_code == 200, app_server.logs_tail()
+        assert bool(put_resp.json().get("enabled")) == toggled_enabled
+
+        get_after = app_server.api_request(
+            "GET",
+            "/api/config/security/sandbox",
+        )
+        assert get_after.status_code == 200, app_server.logs_tail()
+        assert bool(get_after.json().get("enabled")) == toggled_enabled
+
+        # Flip back to the original value and confirm the switch hot-reloads
+        # both directions (save_config invalidates the mtime cache).
+        put_back = app_server.api_request(
+            "PUT",
+            "/api/config/security/sandbox",
+            json={"enabled": original_enabled},
+        )
+        assert put_back.status_code == 200, app_server.logs_tail()
+        get_back = app_server.api_request(
+            "GET",
+            "/api/config/security/sandbox",
+        )
+        assert get_back.status_code == 200, app_server.logs_tail()
+        assert bool(get_back.json().get("enabled")) == original_enabled
+    finally:
+        restore = app_server.api_request(
+            "PUT",
+            "/api/config/security/sandbox",
+            json={"enabled": original_enabled},
+        )
+        assert restore.status_code == 200, app_server.logs_tail()
+
+
+@pytest.mark.integration
+@pytest.mark.p0
 def test_global_file_guard_put_get_roundtrip(app_server) -> None:
     """Test purpose:
     - Verify file-guard enabled flag supports update and readback.

--- a/tests/unit/governance/test_off_mode_sandbox.py
+++ b/tests/unit/governance/test_off_mode_sandbox.py
@@ -10,14 +10,27 @@ from __future__ import annotations
 
 # pylint: disable=protected-access
 
+from types import SimpleNamespace
+
 from qwenpaw.governance import tool_adapter
+from qwenpaw.governance.resource_governor import ResourceGovernor
 from qwenpaw.governance.tool_registry import DEFAULT_REGISTRY
 
 
 class _FakeGovernor:
-    def __init__(self, sandbox_available: bool = True) -> None:
+    def __init__(
+        self,
+        sandbox_available: bool = True,
+        sandbox_enabled: bool = True,
+    ) -> None:
         self.sandbox_available = sandbox_available
+        self._sandbox_enabled = sandbox_enabled
         self.compiled: list = []
+
+    @property
+    def sandbox_usable(self) -> bool:
+        """Mirror ResourceGovernor: platform support AND global switch."""
+        return self.sandbox_available and self._sandbox_enabled
 
     def compile_sandbox_config(self, tc_spec):  # noqa: ANN
         self.compiled.append(tc_spec)
@@ -81,6 +94,23 @@ class TestOffModeSandbox:
         assert not hasattr(tool, "_qp_sandbox_config")
         assert not gov.compiled
 
+    def test_sandbox_switch_off_is_noop(self):
+        """sandbox_enabled=false must skip OFF-mode provisioning too.
+
+        Even when the platform supports a sandbox, an explicit global
+        ``sandbox_enabled=false`` means the user opted out — the OFF-mode
+        path must honour that just like the normal policy path, leaving the
+        REPL unsandboxed rather than silently forcing a sandbox on it.
+        """
+        tool = _FakeTool("recall_history_python")
+        gov = _FakeGovernor(sandbox_available=True, sandbox_enabled=False)
+
+        tool_adapter._prepare_off_mode_sandbox(tool, gov)
+
+        assert not hasattr(tool, "_qp_sandbox_mode")
+        assert not hasattr(tool, "_qp_sandbox_config")
+        assert not gov.compiled
+
     def test_no_governor_is_noop(self):
         tool = _FakeTool("recall_history_python")
         tool_adapter._prepare_off_mode_sandbox(tool, None)
@@ -101,3 +131,77 @@ class TestOffModeSandbox:
         # sandbox_mode is only set AFTER a successful compile, so it stays
         # unset — the tool's own fail-closed guard then denies the call.
         assert not hasattr(tool, "_qp_sandbox_mode")
+
+
+class TestSandboxSwitchHotReload:
+    """The global ``sandbox_enabled`` switch must take effect without a
+    restart.
+
+    ``_prepare_off_mode_sandbox`` reads ``governor.sandbox_usable``, which
+    combines the one-time platform probe with the live config switch. Flipping
+    the switch on an already-started governor must change ``sandbox_usable`` on
+    the very next read — no ``governor.start()`` / process restart required
+    (the switch is read through the mtime-cached ``load_config``).
+    """
+
+    @staticmethod
+    def _governor_with_platform_sandbox(tmp_path) -> ResourceGovernor:
+        gov = ResourceGovernor(
+            workspace_dir=str(tmp_path),
+            governance_dir=str(tmp_path / "gov"),
+        )
+        # Simulate a successful platform probe from start().
+        gov._sandbox_available = True
+        return gov
+
+    @staticmethod
+    def _patch_switch(monkeypatch, state: dict) -> None:
+        import qwenpaw.config as config_mod
+
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda *a, **k: SimpleNamespace(
+                security=SimpleNamespace(
+                    sandbox_enabled=state["value"],
+                ),
+            ),
+        )
+
+    def test_sandbox_usable_follows_switch_without_restart(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        state = {"value": True}
+        self._patch_switch(monkeypatch, state)
+
+        gov = self._governor_with_platform_sandbox(tmp_path)
+        assert gov.sandbox_usable is True
+
+        # Operator flips the switch off (PUT /security/sandbox) — no restart.
+        state["value"] = False
+        assert gov.sandbox_usable is False
+
+        # ...and back on again, still the same governor instance.
+        state["value"] = True
+        assert gov.sandbox_usable is True
+
+    def test_off_mode_provisioning_skipped_when_switch_off(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """End-to-end with a real governor: OFF-mode provisioning is skipped
+        once the switch is off, even though the platform supports a sandbox.
+        """
+        state = {"value": False}
+        self._patch_switch(monkeypatch, state)
+
+        gov = self._governor_with_platform_sandbox(tmp_path)
+        tool = _FakeTool("recall_history_python")
+
+        tool_adapter._prepare_off_mode_sandbox(tool, gov)
+
+        assert not hasattr(tool, "_qp_sandbox_mode")
+        assert not hasattr(tool, "_qp_sandbox_config")


### PR DESCRIPTION
fix(governance): honor sandbox_enabled switch in OFF-mode sandbox path

`_prepare_off_mode_sandbox` only checked the platform probe (`sandbox_available`), ignoring the global `security.sandbox_enabled` switch. With `approval_level=OFF` + `sandbox_enabled=false` the REPL was still forced into a sandbox, silently overriding the user's opt-out.

Use `governor.sandbox_usable` (platform support AND global switch), matching the normal policy path (`_sandbox_usable`). Document that tool registration in `_scroll_repl_runnable` is a build-time decision (not hot-reloaded).

Tests: add OFF-mode switch-off no-op case, real-governor hot-reload cases, and the missing HTTP roundtrip for `PUT`/`GET /security/sandbox`.

## Description

The global `security.sandbox_enabled` switch is meant to globally control whether sandbox execution is active. On the **normal policy path**, `assert_policy` → `_sandbox_usable()` correctly degrades `SANDBOX_FALLBACK` to unsandboxed `ALLOW` when the switch is off.

However, the **OFF-mode path** (`_prepare_off_mode_sandbox` in `tool_adapter.py`) never consulted the switch — it only checked `governor.sandbox_available` (a one-time platform probe). As a result:

- User sets `approval_level=OFF` and `sandbox_enabled=false`
- The REPL tool still gets a `sandbox_config` injected and runs inside the sandbox
- The user's explicit "sandbox off" preference is silently ignored

This PR closes that inconsistency so both code paths evaluate sandbox eligibility the same way.

**Root cause**

```python
# tool_adapter.py (before)
def _prepare_off_mode_sandbox(tool, governor):
    if governor is None or not getattr(governor, "sandbox_available", False):
        return
    # ↑ platform capability only — never reads sandbox_enabled
```

vs. the normal policy path:

```python
# resource_governor.py
def _sandbox_usable(self) -> bool:
    return self._sandbox_available and self._sandbox_globally_enabled()
    # ↑ platform capability AND the user's sandbox_enabled switch
```

**Fix**

```python
# tool_adapter.py (after)
if governor is None or not getattr(governor, "sandbox_usable", False):
    return
```

`sandbox_usable` is the existing public property that combines the platform probe with the live, mtime-cached `sandbox_enabled` switch — so an explicit `sandbox_enabled=false` is now honored on the OFF-mode path too. Using the public property (rather than the private `_sandbox_usable()`) avoids reaching into private members while keeping the `getattr` fallback for duck-typed governors.

**Secondary items from the report**

1. *Tool registration is not hot-reloadable.* `_scroll_repl_runnable` in `builder.py` already reads `sandbox_usable`, but registration is a build-time decision — toggling `sandbox_enabled` at runtime does not add/remove the REPL from a running agent. This is now documented in the method docstring; the execution path still honors the switch.
2. *No hot-reload test.* Added coverage (see Testing).

**Related Issue:** Relates to the OFF-mode sandbox switch inconsistency report.

**Security Considerations:** This is a fail-safe direction change. Previously the REPL was *more* restrictive than requested (forced sandbox); the fix makes it respect the user's explicit opt-out. Fail-open shell tools (e.g. `Bash`) are deliberately left untouched — they already run unsandboxed by design in OFF mode. A compile failure still leaves `sandbox_config` unset, so the tool's own fail-closed guard denies rather than running unsandboxed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

> N/A — no channel code changed.

## Testing

Unit tests (`tests/unit/governance/test_off_mode_sandbox.py`):

- `test_sandbox_switch_off_is_noop` — `sandbox_available=True` + `sandbox_enabled=false` ⇒ OFF-mode provisioning is skipped (no `sandbox_config`).
- `TestSandboxSwitchHotReload::test_sandbox_usable_follows_switch_without_restart` — with a **real** `ResourceGovernor`, flipping the switch changes `sandbox_usable` on the next read, no `start()`/restart needed.
- `TestSandboxSwitchHotReload::test_off_mode_provisioning_skipped_when_switch_off` — end-to-end with a real governor: OFF-mode path skips provisioning once the switch is off.
- Existing cases (REPL gets sandbox, `Bash` untouched, no-platform no-op, no-governor no-op, compile-failure fails closed) still pass.

Integration test (`tests/integration/test_security_config.py`):

- `test_global_sandbox_put_get_roundtrip` — fills the previously missing HTTP roundtrip for `GET`/`PUT /api/config/security/sandbox`, asserting the switch flips both directions and is readback-consistent (hot-reload via the mtime-cached config).

How to run:

```bash
pytest tests/unit/governance/test_off_mode_sandbox.py -q
pytest tests/integration/test_security_config.py -q -k sandbox
```

## Evidence

Verified locally on macOS (Python 3.11) against branch `fix/off-mode-sandbox-enabled`:

- **pre-commit** on all four changed files: every hook (black, flake8, pylint, mypy, ast, trailing-comma, etc.) reports **Passed** — no auto-fixes required.
- **pytest** for `tests/unit/governance/test_off_mode_sandbox.py`: **11 passed**, including the new switch-off no-op case and the two real-`ResourceGovernor` hot-reload cases. The existing OFF-mode cases (REPL sandboxed, `Bash` untouched, no-platform no-op, compile-failure fails closed) remain green, confirming no regression.

The raw transcripts are below.

```bash
$ pre-commit run --files \
    src/qwenpaw/governance/tool_adapter.py \
    src/qwenpaw/runtime/builder.py \
    tests/unit/governance/test_off_mode_sandbox.py \
    tests/integration/test_security_config.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

```bash
$ pytest tests/unit/governance/test_off_mode_sandbox.py -q
11 passed, 2 warnings in 0.04s
```

## Additional Notes

Files changed (4 files, +195 / -5):

| File | Change |
|------|--------|
| `src/qwenpaw/governance/tool_adapter.py` | Core fix: `sandbox_available` → `sandbox_usable` compound check + docstring |
| `src/qwenpaw/runtime/builder.py` | Document that REPL registration is a build-time decision (not hot-reloaded) |
| `tests/unit/governance/test_off_mode_sandbox.py` | Switch-off no-op + real-governor hot-reload cases |
| `tests/integration/test_security_config.py` | Missing HTTP roundtrip for `PUT`/`GET /security/sandbox` |
