### PR TITLE
fix(acp): dedupe duplicated final response in delegate_external_agent

### DIFF
--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -684,6 +684,18 @@ async def _stream_action_responses(
         return
 
     event = final_text_event or final_fallback_event or run_result.get("event")
+    # Skip the final block if its text was already streamed as a snapshot.
+    rendered_final = render_event_text(event) if event else None
+    already_streamed = (
+        rendered_final is not None
+        and rendered_final.strip() in seen_stream_items
+    )
+    if already_streamed:
+        yield response_text(
+            f"runner: {runner_name} working directory: {execution_cwd}",
+            is_last=True,
+        )
+        return
     yield format_final_assistant_response(
         runner_name=runner_name,
         execution_cwd=execution_cwd,


### PR DESCRIPTION
## Description

`delegate_external_agent` returns the external agent's final answer **twice** in the tool result: once as the streamed snapshot and once again in the terminal block.

for example, when prompt QwenPaw like "和外部agent codex对话 ，问问他是谁",

we will get result like this:

```
[assistant]
你好，我是 Codex，一个基于 GPT-5 的编程协作助手。

我可以在你的工作区里阅读代码、修改文件、运行命令、调试问题、补测试、做代码审查，也可以帮你分析设计方案或解释已有代码。我的工作方式偏工程实践：先看现有项目结构和代码风格，再做尽量小而准确的改动，并在结束时说明改了什么、怎么验证的，以及还有哪些风险或后续事项[assistant]
你好，我是 Codex，一个基于 GPT-5 的编程协作助手。

我可以在你的工作区里阅读代码、修改文件、运行命令、调试问题、补测试、做代码审查，也可以帮你分析设计方案或解释已有代码。我的工作方式偏工程实践：先看现有项目结构和代码风格，再做尽量小而准确的改动，并在结束时说明改了什么、怎么验证的，以及还有哪些风险或后续事项。
```

Since the agentscope 2.0 / Runtime 2.0 migration, every `ToolChunk` a tool yields is accumulated into the persisted result via `append_chunk` (under agentscope 1.x streaming chunks were live-only). The final assistant text is flushed as a streaming snapshot and then emitted again by `format_final_assistant_response`, so both copies survive. Fix (only in `delegate_external_agent.py`): at finalization, if the text was already streamed (present in `seen_stream_items`), emit only the runner/cwd header as the terminal chunk; otherwise keep the existing path so the `completed` fallback is preserved.

**Related Issue:** N/A

**Security Considerations:** None. No change to channel auth, env, or config handling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

1. Configure an ACP runner (e.g. `codex`) and enable `delegate_external_agent`.
2. Run `delegate_external_agent(action="start", runner="codex", message=...)` with  a task that makes the agent produce a final text answer.
3. Before: the final answer appears twice in the tool result (streamed snapshot +  terminal block, separated by the `runner: ... working directory: ...` header).   After: it appears once, followed by the header-only terminal chunk.

```
[assistant]
你好，我是 Codex，一个基于 GPT-5 的编程协作助手。

我可以在你的本地工作区里帮你读代码、改代码、运行命令、排查错误、写测试、做代码审查，也可以协助处理文档、PDF、表格、演示文稿和前端页面验证等任务。当前我们共享的工作目录是：

`xxx`

我会尽量直接、务实地完成任务；如果涉及改文件或运行有影响的命令，我会先说明正在做什么，并在完成后告诉你改了哪些内容、如何验证。runner: codex working directory: xxx
```

Edge cases covered:
- No text output at all -> terminal block still shows `completed without text output`.
- Error terminal event -> already shown in stream, not duplicated.

## Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

Change is intentionally scoped to `delegate_external_agent.py`; the tool-call coordinator and `acp/tool_adapter.py` are untouched. Note this bug does not reproduce on the `v1.1.12.x` line, which pins `agentscope==1.0.20` (streaming
chunks were not accumulated into the persisted result there).
