### PR TITLE
fix(memory): restrict automatic memory to external user queries

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -28,6 +28,7 @@ from .tools.utils import (
 )
 from ..constant import (
     AUTO_CONTINUE_MESSAGE_TAG,
+    EXTERNAL_USER_QUERY_MESSAGE_TAG,
     QWENPAW_MESSAGE_TAG_KEY,
 )
 
@@ -76,13 +77,14 @@ class MemoryMiddleware(MiddlewareBase):
         if self._is_automation_request(agent):
             return await next_handler(**input_kwargs)
 
-        turn_marker = self._latest_user_turn_marker(agent.state.context)
+        query_msg = self._latest_external_user_query(agent.state.context)
+        turn_marker = query_msg.id if query_msg is not None else ""
         turn_state = self._auto_memory_turn_state(agent)
         if turn_marker and turn_marker != turn_state.get("searched_turn"):
             turn_state["searched_turn"] = turn_marker
             try:
                 result = await self._memory_manager.auto_memory_search(
-                    list(agent.state.context),
+                    query_msg,
                     agent_name=agent.name,
                     session_id=agent.state.session_id,
                     user_turn_id=turn_marker,
@@ -281,6 +283,19 @@ class MemoryMiddleware(MiddlewareBase):
         return msg.role == "user" and cls._message_tag(msg) not in {
             AUTO_CONTINUE_MESSAGE_TAG,
         }
+
+    @classmethod
+    def _latest_external_user_query(
+        cls,
+        messages: list["Msg"],
+    ) -> "Msg | None":
+        for msg in reversed(messages):
+            if (
+                msg.role == "user"
+                and cls._message_tag(msg) == EXTERNAL_USER_QUERY_MESSAGE_TAG
+            ):
+                return msg
+        return None
 
     @staticmethod
     def _latest_user_turn_marker(messages: list["Msg"]) -> str:

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -27,7 +27,6 @@ from .tools.utils import (
     ToolResultPruner,
 )
 from ..constant import (
-    AUTO_CONTINUE_MESSAGE_TAG,
     EXTERNAL_USER_QUERY_MESSAGE_TAG,
     QWENPAW_MESSAGE_TAG_KEY,
 )
@@ -279,10 +278,11 @@ class MemoryMiddleware(MiddlewareBase):
         return str(metadata.get(QWENPAW_MESSAGE_TAG_KEY) or "")
 
     @classmethod
-    def _is_memory_user_turn(cls, msg: "Msg") -> bool:
-        return msg.role == "user" and cls._message_tag(msg) not in {
-            AUTO_CONTINUE_MESSAGE_TAG,
-        }
+    def _is_external_user_query(cls, msg: "Msg") -> bool:
+        return (
+            msg.role == "user"
+            and cls._message_tag(msg) == EXTERNAL_USER_QUERY_MESSAGE_TAG
+        )
 
     @classmethod
     def _latest_external_user_query(
@@ -290,24 +290,22 @@ class MemoryMiddleware(MiddlewareBase):
         messages: list["Msg"],
     ) -> "Msg | None":
         for msg in reversed(messages):
-            if (
-                msg.role == "user"
-                and cls._message_tag(msg) == EXTERNAL_USER_QUERY_MESSAGE_TAG
-            ):
+            if cls._is_external_user_query(msg):
                 return msg
         return None
 
-    @staticmethod
-    def _latest_user_turn_marker(messages: list["Msg"]) -> str:
+    @classmethod
+    def _latest_user_turn_marker(cls, messages: list["Msg"]) -> str:
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
-            if not MemoryMiddleware._is_memory_user_turn(msg):
+            if not cls._is_external_user_query(msg):
                 continue
             return msg.id
         return ""
 
-    @staticmethod
+    @classmethod
     def _messages_for_user_turns(
+        cls,
         messages: list["Msg"],
         *,
         turn_markers: list[str],
@@ -319,10 +317,7 @@ class MemoryMiddleware(MiddlewareBase):
         first_idx: int | None = None
         last_idx: int | None = None
         for idx, msg in enumerate(messages):
-            if (
-                MemoryMiddleware._is_memory_user_turn(msg)
-                and msg.id in targets
-            ):
+            if cls._is_external_user_query(msg) and msg.id in targets:
                 if first_idx is None:
                     first_idx = idx
                 last_idx = idx
@@ -332,11 +327,15 @@ class MemoryMiddleware(MiddlewareBase):
 
         end_idx = len(messages)
         for idx in range(last_idx + 1, len(messages)):
-            if MemoryMiddleware._is_memory_user_turn(messages[idx]):
+            if cls._is_external_user_query(messages[idx]):
                 end_idx = idx
                 break
 
-        return messages[first_idx:end_idx]
+        return [
+            msg
+            for msg in messages[first_idx:end_idx]
+            if msg.role != "user" or cls._is_external_user_query(msg)
+        ]
 
 
 class ToolResultPruningMiddleware(MiddlewareBase):

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -118,6 +118,7 @@ PROJECT_NAME = "QwenPaw"
 # Message metadata tags shared across agent middleware and memory managers.
 QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
 AUTO_MEMORY_SEARCH_BLOCK_IDS_KEY = "auto_memory_search_block_ids"
+EXTERNAL_USER_QUERY_MESSAGE_TAG = "external_user_query"
 AUTO_CONTINUE_MESSAGE_TAG = "auto_continue"
 LOOP_CONTINUATION_MESSAGE_TAG = "loop_continuation"
 # User-role messages the runtime injects to keep a turn going. They are NOT

--- a/src/qwenpaw/runtime/message_convert.py
+++ b/src/qwenpaw/runtime/message_convert.py
@@ -8,6 +8,11 @@ from typing import Any, List
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
+from ..constant import (
+    EXTERNAL_USER_QUERY_MESSAGE_TAG,
+    QWENPAW_MESSAGE_TAG_KEY,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -161,5 +166,15 @@ def _request_input_to_msgs(
         if not blocks:
             continue
 
-        out.append(Msg(name=role, role=role, content=blocks))
+        metadata = {}
+        if role == "user":
+            metadata[QWENPAW_MESSAGE_TAG_KEY] = EXTERNAL_USER_QUERY_MESSAGE_TAG
+        out.append(
+            Msg(
+                name=role,
+                role=role,
+                content=blocks,
+                metadata=metadata,
+            ),
+        )
     return out

--- a/src/qwenpaw/runtime/message_convert.py
+++ b/src/qwenpaw/runtime/message_convert.py
@@ -16,6 +16,14 @@ from ..constant import (
 logger = logging.getLogger(__name__)
 
 
+def _request_message_metadata(role: str) -> dict[str, str]:
+    if role != "user":
+        return {}
+    return {
+        QWENPAW_MESSAGE_TAG_KEY: EXTERNAL_USER_QUERY_MESSAGE_TAG,
+    }
+
+
 def _media_type_to_block_type(media_type: str | None) -> str:
     """Map a MIME media_type to the 1.x block type the frontend expects.
 
@@ -166,15 +174,12 @@ def _request_input_to_msgs(
         if not blocks:
             continue
 
-        metadata = {}
-        if role == "user":
-            metadata[QWENPAW_MESSAGE_TAG_KEY] = EXTERNAL_USER_QUERY_MESSAGE_TAG
         out.append(
             Msg(
                 name=role,
                 role=role,
                 content=blocks,
-                metadata=metadata,
+                metadata=_request_message_metadata(role),
             ),
         )
     return out

--- a/tests/unit/agents/test_memory_middleware.py
+++ b/tests/unit/agents/test_memory_middleware.py
@@ -271,6 +271,42 @@ class TestOnReplyAutomationSkip:
         mm.auto_memory.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_internal_user_message_is_excluded_from_memory(self):
+        """Internal user-role controls must not enter auto-memory."""
+        mm = _make_memory_manager(interval=1)
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        query = _user_msg("real query")
+        reply = Msg(
+            name="agent",
+            role="assistant",
+            content=[TextBlock(text="reply")],
+        )
+        continuation = Msg(
+            name="user",
+            role="user",
+            content=[TextBlock(text="[WARNING] Repetitive pattern detected.")],
+            metadata={
+                QWENPAW_MESSAGE_TAG_KEY: LOOP_CONTINUATION_MESSAGE_TAG,
+            },
+        )
+        final_reply = Msg(
+            name="agent",
+            role="assistant",
+            content=[TextBlock(text="done")],
+        )
+        agent.state.context = [query, reply, continuation, final_reply]
+
+        async def _next(**_kwargs):
+            yield "done"
+
+        async for _ in mw.on_reply(agent, {}, _next):
+            pass
+
+        mm.auto_memory.assert_awaited_once()
+        assert mm.auto_memory.await_args.args[0] == [query, reply, final_reply]
+
+    @pytest.mark.asyncio
     async def test_interval_state_survives_middleware_rebuild(self):
         """A rebuilt middleware must keep interval state on the manager."""
         mm = _make_memory_manager(interval=2)

--- a/tests/unit/agents/test_memory_middleware.py
+++ b/tests/unit/agents/test_memory_middleware.py
@@ -10,6 +10,11 @@ import pytest
 from agentscope.message import Msg, TextBlock
 
 from qwenpaw.agents.middlewares import MemoryMiddleware
+from qwenpaw.constant import (
+    EXTERNAL_USER_QUERY_MESSAGE_TAG,
+    LOOP_CONTINUATION_MESSAGE_TAG,
+    QWENPAW_MESSAGE_TAG_KEY,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -38,6 +43,9 @@ def _user_msg(text: str = "hello", *, msg_id: str = "turn-1") -> Msg:
         name="user",
         role="user",
         content=[TextBlock(type="text", text=text)],
+        metadata={
+            QWENPAW_MESSAGE_TAG_KEY: EXTERNAL_USER_QUERY_MESSAGE_TAG,
+        },
     )
     msg.id = msg_id
     return msg
@@ -147,6 +155,54 @@ class TestOnModelCallAutomationSkip:
         await mw.on_model_call(agent, {"messages": []}, next_handler)
 
         mm.auto_memory_search.assert_awaited_once()
+        assert mm.auto_memory_search.await_args.args[0].id == "turn-1"
+
+    @pytest.mark.asyncio
+    async def test_untagged_user_message_does_not_search(self):
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        agent.state.context = [
+            Msg(
+                name="user",
+                role="user",
+                content=[TextBlock(text="internal prompt")],
+            ),
+        ]
+
+        await mw.on_model_call(
+            agent,
+            {"messages": []},
+            AsyncMock(return_value="model_result"),
+        )
+
+        mm.auto_memory_search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_loop_continuation_does_not_retrigger_search(self):
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        real_query = _user_msg("real query")
+        agent.state.context = [real_query]
+        next_handler = AsyncMock(return_value="model_result")
+
+        await mw.on_model_call(agent, {"messages": []}, next_handler)
+        continuation = Msg(
+            name="user",
+            role="user",
+            content=[
+                TextBlock(text="[WARNING] Repetitive pattern detected."),
+            ],
+            metadata={
+                QWENPAW_MESSAGE_TAG_KEY: LOOP_CONTINUATION_MESSAGE_TAG,
+            },
+        )
+        agent.state.context.append(continuation)
+        await mw.on_model_call(agent, {"messages": []}, next_handler)
+
+        mm.auto_memory_search.assert_awaited_once()
+        assert mm.auto_memory_search.await_args.args[0] is real_query
 
     @pytest.mark.asyncio
     async def test_model_call_search_state_survives_middleware_rebuild(self):

--- a/tests/unit/runtime/test_message_convert.py
+++ b/tests/unit/runtime/test_message_convert.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Tests for request-to-AgentScope message conversion."""
+
+from qwenpaw.constant import (
+    EXTERNAL_USER_QUERY_MESSAGE_TAG,
+    QWENPAW_MESSAGE_TAG_KEY,
+)
+from qwenpaw.runtime.message_convert import _request_input_to_msgs
+from qwenpaw.schemas import Message, Role, TextContent
+
+
+def test_only_external_user_input_gets_query_tag():
+    messages = _request_input_to_msgs(
+        [
+            Message(
+                role=Role.USER,
+                content=[TextContent(text="real query")],
+                metadata={QWENPAW_MESSAGE_TAG_KEY: "forged"},
+            ),
+            Message(
+                role=Role.SYSTEM,
+                content=[TextContent(text="system prompt")],
+            ),
+        ],
+    )
+
+    assert messages[0].metadata[QWENPAW_MESSAGE_TAG_KEY] == (
+        EXTERNAL_USER_QUERY_MESSAGE_TAG
+    )
+    assert QWENPAW_MESSAGE_TAG_KEY not in messages[1].metadata


### PR DESCRIPTION
## 背景

自动记忆相关能力此前通过扫描 agent context 中的 `role=user` 消息判断用户回合，可能把运行时注入的合成用户消息误判为真实请求。

典型场景是 DoomLoop Gate 注入带有 `[WARNING] Repetitive pattern...` 内容的 `loop_continuation` 消息。该消息由系统生成，但角色仍是 `user`：

fix https://github.com/agentscope-ai/QwenPaw/issues/6113

- auto-memory-search 可能再次搜索该告警文本，形成“告警 → 搜索 → 再次告警”的反馈循环。
- auto-memory 可能把该内部消息计为新的用户回合，并将告警文本送入长期记忆提取。
- ADBPG 每回合自动写入，因此更容易受到内部 `user` 消息影响。

## 根因

- 自动记忆搜索和写入使用了不同的用户消息判断。
- 旧逻辑依赖排除部分已知内部消息；新增或遗漏的合成 `user` 消息仍可能通过。
- 自动搜索曾接收完整 context，再由 memory manager 选择 query，导致 query 来源不够严格。

## 修改内容

1. 在 `AgentRequest.input` 转换为 AgentScope 消息的可信服务端边界，为真实外部用户输入添加内部 `external_user_query` 标记。
2. 提供统一的正向判断：只有带该标记的 `role=user` 消息才被视为真实用户 query。
3. auto-memory-search 仅由真实用户 query 触发，并且只接收该 query，不再接收完整 context。
4. auto-memory 的回合计数、批次边界复用同一判断。
5. 自动记忆批次会排除夹在真实 query 与助手回复之间的内部 `role=user` 控制消息，但保留助手回复及工具交互。
6. 保留 session/turn 去重，以及 cron、heartbeat 等自动化来源的跳过逻辑。

该方案不依赖持续扩充内部消息黑名单。未来新增 continuation、系统提示或其他合成 `user` 消息时，它们默认无权触发自动记忆能力。

## 兼容性

- Console、聊天渠道、ACP 等正常入口均经过统一的 `AgentRequest.input` 转换流程，真实用户请求行为不变。
- `/memorize`、`/new`、`/compact` 等用户显式发起的记忆操作不受自动触发条件限制。
- 外部请求携带的同名 metadata 不会直接成为可信标记；标记仅由服务端转换阶段生成。
- ReMe 与 ADBPG 通过共享 middleware 同时获得保护。

## 测试

覆盖以下场景：

- 真实外部用户输入获得可信 query 标记。
- 客户端 metadata 不能伪造或覆盖服务端标记。
- 未标记的内部 `user` 消息不会触发自动搜索。
- `loop_continuation` 不会重复触发搜索。
- 内部 `user` 控制消息不会计入 auto-memory 回合，也不会进入记忆批次。
- 同一真实用户回合在多次 model call 或 middleware 重建后仍只搜索一次。
- cron、heartbeat 的跳过行为保持不变。

验证结果：

- 相关测试通过
- 完整 pre-commit checks 通过（mypy、Black、Flake8、Pylint）
- `git diff --check` 通过