### PR TITLE
fix(governance): clear stale OFF-mode sandbox state

### DIFF
--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -206,12 +206,22 @@ def _prepare_off_mode_sandbox(tool: Any, governor: Any) -> None:
     like it is on the normal policy path (see
     :meth:`ResourceGovernor._sandbox_usable`).
     """
-    if governor is None or not getattr(governor, "sandbox_usable", False):
+    # These attributes live on a reusable FunctionTool wrapper, but describe
+    # one invocation only.  Clear any previous decision before consulting the
+    # current switch so a hot toggle (or a failed recompile) cannot reuse a
+    # stale sandbox config from an earlier call.
+    for attr in ("_qp_sandbox_mode", "_qp_sandbox_config"):
+        if hasattr(tool, attr):
+            delattr(tool, attr)
+
+    if governor is None:
         return
     policy_name = DEFAULT_REGISTRY.python_to_policy_name(
         getattr(tool, "name", "Unknown"),
     )
     if not DEFAULT_REGISTRY.requires_sandbox(policy_name):
+        return
+    if not getattr(governor, "sandbox_usable", False):
         return
     try:
         tc_spec = tool._build_tc_spec()

--- a/tests/unit/governance/test_off_mode_sandbox.py
+++ b/tests/unit/governance/test_off_mode_sandbox.py
@@ -111,6 +111,24 @@ class TestOffModeSandbox:
         assert not hasattr(tool, "_qp_sandbox_config")
         assert not gov.compiled
 
+    def test_sandbox_switch_off_clears_previous_config(self):
+        """A hot switch-off must not reuse per-call state from an earlier
+        sandboxed invocation on the same reusable tool wrapper.
+        """
+        tool = _FakeTool("recall_history_python")
+        gov = _FakeGovernor(sandbox_available=True, sandbox_enabled=True)
+
+        tool_adapter._prepare_off_mode_sandbox(tool, gov)
+        assert tool._qp_sandbox_mode is True
+        assert hasattr(tool, "_qp_sandbox_config")
+
+        gov._sandbox_enabled = False
+        tool_adapter._prepare_off_mode_sandbox(tool, gov)
+
+        assert not hasattr(tool, "_qp_sandbox_mode")
+        assert not hasattr(tool, "_qp_sandbox_config")
+        assert len(gov.compiled) == 1
+
     def test_no_governor_is_noop(self):
         tool = _FakeTool("recall_history_python")
         tool_adapter._prepare_off_mode_sandbox(tool, None)


### PR DESCRIPTION
## Description

Fix stale OFF-mode sandbox state being reused after the global sandbox switch is disabled.

`PolicyGuardedTool` instances are reusable, while `_qp_sandbox_mode` and
`_qp_sandbox_config` describe the sandbox decision for a single invocation.

After a successful OFF-mode sandboxed call, these attributes remained attached
to the tool instance. If `security.sandbox_enabled` was subsequently turned
off, `_prepare_off_mode_sandbox()` returned early because
`governor.sandbox_usable` was false, but it did not clear the sandbox state from
the previous invocation.

As a result, the next call could still receive and use the stale
`sandbox_config`, despite the global sandbox switch being disabled.

## Root Cause

Before this change, the flow was:

1. Call `recall_history_python` with the sandbox enabled.
2. `_prepare_off_mode_sandbox()` sets `_qp_sandbox_mode=True` and attaches a
   compiled `_qp_sandbox_config`.
3. Disable `security.sandbox_enabled` without rebuilding the agent.
4. Call the same reusable tool instance again.
5. `_prepare_off_mode_sandbox()` sees `sandbox_usable=False` and returns early.
6. The previous `_qp_sandbox_mode` and `_qp_sandbox_config` remain attached and
   may be reused.

This made the runtime hot switch incomplete even after #6109 taught the
OFF-mode path to consult `sandbox_usable`.

## Fix

- Clear `_qp_sandbox_mode` and `_qp_sandbox_config` at the start of every
  OFF-mode sandbox preparation.
- Recompute and attach sandbox state only when the current invocation requires
  a sandbox and `governor.sandbox_usable` is true.
- Check `requires_sandbox` before reading `sandbox_usable`, avoiding config
  reads for ordinary OFF-mode tools that never need sandbox provisioning.

The sandbox decision is now treated as per-invocation state instead of being
implicitly reused from an earlier call.

## Behavior After This Change

- Sandbox enabled: `recall_history_python` receives a newly compiled sandbox
  config.
- Sandbox disabled at runtime: stale sandbox state is removed and no sandbox
  config is injected.
- Sandbox compilation failure: a previous config cannot be reused; the REPL
  remains fail-closed.
- Tools that do not require a sandbox skip the global sandbox config lookup.

## Testing

Added a regression test that reuses the same `recall_history_python` tool
instance:

1. Prepare it while the sandbox switch is enabled.
2. Confirm sandbox mode and config are attached.
3. Disable the switch.
4. Prepare the same tool again.
5. Confirm the previous sandbox mode and config are removed and no new config
   is compiled.

Validation:

```bash
uv run pytest -q tests/unit/governance/test_off_mode_sandbox.py
# 12 passed

uv run pre-commit run --files \
  src/qwenpaw/governance/tool_adapter.py \
  tests/unit/governance/test_off_mode_sandbox.py
# All checks passed