### PR TITLE
fix(mcp): make legacy MCP migration one-shot via schema watermark (#6130)

### DIFF
--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -25,7 +25,6 @@ async def create_driver_service(ws: "Workspace", _service):
     # pylint: disable=protected-access
     from ...drivers.adapters.mcp_legacy_config import (
         migrate_legacy_mcp_if_needed,
-        upgrade_legacy_mcp_credentials,
     )
     from ...drivers.credentials.store import AsyncCredentialStore
     from ...drivers.handlers import MCPDriverHandler
@@ -50,7 +49,6 @@ async def create_driver_service(ws: "Workspace", _service):
     # endpoint validator and tests.  This PR intentionally keeps the concrete
     # runtime surface to MCP while leaving DriverManager protocol-neutral.
     await migrate_legacy_mcp_if_needed(ws, driver_manager)
-    await upgrade_legacy_mcp_credentials(driver_manager)
     await driver_manager.start()
     ws._service_manager.services["driver_manager"] = driver_manager
     logger.debug(

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1696,6 +1696,12 @@ class MCPConfig(BaseModel):
             ),
         },
     )
+    # One-shot migration watermark, persisted in agent.json.  Decoupled from
+    # DriverCard existence so that deleting a migrated client no longer lets
+    # startup migration resurrect it (#6130).  0 = not migrated; steps are
+    # defined by CURRENT_MCP_MIGRATION_VERSION in
+    # drivers.adapters.mcp_legacy_config.
+    migration_version: int = 0
 
 
 class BuiltinToolConfig(BaseModel):

--- a/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
+++ b/src/qwenpaw/drivers/adapters/mcp_legacy_config.py
@@ -41,6 +41,13 @@ from ..credentials.types import CredentialRecord
 from ..manager import DriverManager
 from ..storage import load_card
 
+# Schema version of the legacy-MCP -> DriverCard migration, persisted on
+# ``MCPConfig.migration_version`` (agent.json) as a one-shot watermark that
+# is independent of whether a DriverCard file happens to exist:
+#   v1: legacy agent.json ``mcp.clients`` -> DriverCard storage
+#   v2: single ``${VAR}`` literal -> ``env:`` credential ref (#6029 heal)
+CURRENT_MCP_MIGRATION_VERSION = 2
+
 
 @dataclass
 class LegacyMCPMigratedClient:
@@ -88,23 +95,57 @@ async def migrate_legacy_mcp_if_needed(
     ws: Any,
     driver_manager: DriverManager,
 ) -> LegacyMCPMigrationReport:
-    """Migrate legacy agent.json mcp.clients into Driver storage."""
+    """Run the one-shot, versioned migration of legacy MCP config.
+
+    The "already migrated?" judgement lives on the persisted
+    ``MCPConfig.migration_version`` watermark, not on whether a DriverCard
+    file exists.  Once a workspace reaches ``CURRENT_MCP_MIGRATION_VERSION``
+    the migration is skipped entirely, so deleting a migrated client no
+    longer makes the next start re-derive it from ``mcp.clients`` (#6130).
+    """
     report = LegacyMCPMigrationReport()
-    legacy_mcp = getattr(getattr(ws, "_config", None), "mcp", None)
-    clients = getattr(legacy_mcp, "clients", None)
-    if not clients:
+    mcp = getattr(getattr(ws, "_config", None), "mcp", None)
+    if mcp is None:
         return report
 
-    for client_key, config in dict(clients).items():
-        await _migrate_one_client(
-            str(client_key),
-            config,
-            driver_manager,
-            report,
-        )
+    current = int(getattr(mcp, "migration_version", 0) or 0)
+    if current >= CURRENT_MCP_MIGRATION_VERSION:
+        return report
+
+    if current < 1:
+        # v0 -> v1: move legacy mcp.clients into DriverCard storage.  The
+        # per-client "card exists" guard in _migrate_one_client is now only
+        # an in-run idempotency / crash-rerun guard, not the judgement.
+        clients = dict(getattr(mcp, "clients", None) or {})
+        for client_key, config in clients.items():
+            await _migrate_one_client(
+                str(client_key),
+                config,
+                driver_manager,
+                report,
+            )
+
+    if current < 2:
+        # v1 -> v2: fold the #6029 env: ref self-heal in as a one-shot step
+        # instead of re-scanning every card on every start.  Safe because
+        # bad literals are historical: post-fix migration never makes new.
+        await upgrade_legacy_mcp_credentials(driver_manager)
 
     await asyncio.to_thread(_write_report, driver_manager.cards_dir, report)
+
+    # Persist the watermark only after all steps succeed; on partial failure
+    # the version stays put and the next start re-runs (idempotent).
+    mcp.migration_version = CURRENT_MCP_MIGRATION_VERSION
+    await asyncio.to_thread(_persist_mcp_migration_version, ws)
     return report
+
+
+def _persist_mcp_migration_version(ws: Any) -> None:
+    """Persist the bumped MCPConfig.migration_version back to agent.json."""
+    from ...config.config import save_agent_config
+
+    # pylint: disable=protected-access
+    save_agent_config(ws.agent_id, ws._config)
 
 
 async def _migrate_one_client(

--- a/tests/unit/drivers/adapters/test_mcp_migration_version.py
+++ b/tests/unit/drivers/adapters/test_mcp_migration_version.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""Versioned, one-shot MCP migration watermark (#6130).
+
+Before this change the startup migration used "does the DriverCard file
+exist?" as its "already migrated?" judgement.  Deleting a migrated client
+(Console) removed the card but left the legacy ``agent.json -> mcp.clients``
+entry, so the next start re-derived the card — the deleted client reappeared.
+
+The fix moves the judgement onto an explicit, persisted schema watermark
+(``MCPConfig.migration_version``) that is decoupled from card existence:
+
+* once a workspace has reached ``CURRENT_MCP_MIGRATION_VERSION`` the migration
+  is skipped entirely, so a deleted card is never resurrected;
+* the ``env:`` self-heal upgrade (#6029) is folded in as a one-shot v1->v2
+  step instead of being re-scanned on every start.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import qwenpaw.config.config as cfg_config
+from qwenpaw.config.config import MCPConfig
+from qwenpaw.drivers.adapters.mcp_legacy_config import (
+    CURRENT_MCP_MIGRATION_VERSION,
+    migrate_legacy_mcp_if_needed,
+)
+from qwenpaw.drivers.contracts import CredentialRef, DriverCard, PolicyRule
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.credentials.types import CredentialRecord
+from qwenpaw.drivers.manager import DriverManager
+from qwenpaw.drivers.storage import (
+    card_path,
+    delete_card,
+    dump_card,
+    load_card,
+)
+
+
+def _client() -> SimpleNamespace:
+    """A minimal legacy MCP client config (read via getattr by migration)."""
+    return SimpleNamespace(
+        transport="streamable_http",
+        url="https://mcp.example.com/api/",
+        headers={},
+    )
+
+
+def _mcp(clients: dict, version: int) -> SimpleNamespace:
+    """Fake MCPConfig exposing .clients and a writable .migration_version."""
+    return SimpleNamespace(clients=dict(clients), migration_version=version)
+
+
+def _ws(mcp: SimpleNamespace, agent_id: str = "default") -> SimpleNamespace:
+    """Fake Workspace exposing ._config.mcp and .agent_id for migration."""
+    return SimpleNamespace(_config=SimpleNamespace(mcp=mcp), agent_id=agent_id)
+
+
+@pytest.fixture
+def captured_saves(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Capture save_agent_config calls without touching global config."""
+    saves: list = []
+    monkeypatch.setattr(
+        cfg_config,
+        "save_agent_config",
+        lambda agent_id, config: saves.append((agent_id, config)),
+    )
+    return saves
+
+
+def test_mcp_config_defaults_migration_version_zero() -> None:
+    assert MCPConfig().migration_version == 0
+    # Round-trips through model_dump so it persists in agent.json.
+    dumped = MCPConfig(migration_version=2).model_dump()
+    assert dumped["migration_version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_migration_skipped_when_already_at_current_version(
+    tmp_path: Path,
+    captured_saves: list,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    manager = DriverManager(tmp_path / "drivers", store)
+    mcp = _mcp({"wind": _client()}, version=CURRENT_MCP_MIGRATION_VERSION)
+
+    report = await migrate_legacy_mcp_if_needed(_ws(mcp), manager)
+
+    # A legacy client whose card does not exist is NOT re-created (#6130).
+    assert not card_path(
+        tmp_path / "drivers",
+        "wind",
+        protocol="mcp",
+    ).exists()
+    assert report.migrated == []
+    assert captured_saves == []  # nothing persisted on the skip path
+
+
+@pytest.mark.asyncio
+async def test_migration_runs_and_persists_watermark_when_unmigrated(
+    tmp_path: Path,
+    captured_saves: list,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    manager = DriverManager(tmp_path / "drivers", store)
+    mcp = _mcp({"wind": _client()}, version=0)
+
+    await migrate_legacy_mcp_if_needed(_ws(mcp), manager)
+
+    assert card_path(tmp_path / "drivers", "wind", protocol="mcp").exists()
+    assert mcp.migration_version == CURRENT_MCP_MIGRATION_VERSION
+    assert captured_saves and captured_saves[0][0] == "default"
+
+
+@pytest.mark.asyncio
+async def test_deleted_card_not_resurrected_after_watermark(
+    tmp_path: Path,
+    captured_saves: list,
+) -> None:
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    manager = DriverManager(tmp_path / "drivers", store)
+    mcp = _mcp({"wind": _client()}, version=0)
+    ws = _ws(mcp)
+
+    # First boot: migrate -> card created, watermark bumped once.
+    await migrate_legacy_mcp_if_needed(ws, manager)
+    target = card_path(tmp_path / "drivers", "wind", protocol="mcp")
+    assert target.exists()
+
+    # Console delete: card removed, legacy mcp.clients entry left intact.
+    delete_card(target)
+    assert not target.exists()
+    assert "wind" in mcp.clients
+
+    # Restart: migration sees the watermark and does NOT recreate the card,
+    # and performs no further persistence (steady state is write-free).
+    report = await migrate_legacy_mcp_if_needed(ws, manager)
+    assert not target.exists()
+    assert report.migrated == []
+    assert len(captured_saves) == 1
+
+
+@pytest.mark.asyncio
+async def test_migration_folds_env_ref_upgrade_step(
+    tmp_path: Path,
+    captured_saves: list,
+) -> None:
+    # A card already migrated (v1) but still holding a ${VAR} literal.
+    store = AsyncCredentialStore(tmp_path / "credentials.yaml")
+    await store.put(
+        CredentialRecord(
+            ref="mcp/wind",
+            kind="static",
+            secrets={"authorization": "Bearer ${API_KEY}"},
+        ),
+    )
+    cards_dir = tmp_path / "drivers"
+    dump_card(
+        DriverCard(
+            name="wind",
+            protocol="mcp",
+            endpoint={
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com/api/",
+                "headers": {
+                    "Authorization": {
+                        "source": "credential",
+                        "credential": "static",
+                        "field": "authorization",
+                    },
+                },
+            },
+            credentials={"static": CredentialRef("static", "mcp/wind")},
+            policy=[PolicyRule(subject="*", effect="allow")],
+        ),
+        card_path(cards_dir, "wind", protocol="mcp"),
+    )
+    manager = DriverManager(cards_dir, store)
+    # version=1 -> only the v1->v2 env: ref upgrade step should run.
+    mcp = _mcp({}, version=1)
+
+    await migrate_legacy_mcp_if_needed(_ws(mcp), manager)
+
+    card = load_card(card_path(cards_dir, "wind", protocol="mcp"))
+    assert card.endpoint["headers"]["Authorization"] == {
+        "source": "credential",
+        "credential": "env_api_key",
+        "field": "value",
+        "format": "Bearer {value}",
+    }
+    assert mcp.migration_version == CURRENT_MCP_MIGRATION_VERSION
+    assert len(captured_saves) == 1


### PR DESCRIPTION
## Summary

Deleting an MCP client from the Console removes its DriverCard and credentials but leaves the legacy `agent.json` `mcp.clients` entry untouched. On the next start, `migrate_legacy_mcp_if_needed` used **"does the DriverCard file exist?"** as its *already-migrated* test — so it re-derived a card from the still-present legacy entry and the **deleted client reappeared** (#6130).

That judgement conflated two different states — *never migrated* vs *migrated then deleted* — because DriverCard existence cannot distinguish them.

## Fix

Move the *already-migrated* judgement onto an explicit, persisted schema watermark, decoupled from card existence:

- **`MCPConfig.migration_version: int = 0`** — persisted in `agent.json`.
- **`migrate_legacy_mcp_if_needed` is now version-gated**: once a workspace reaches `CURRENT_MCP_MIGRATION_VERSION` (=2) the migration is **skipped entirely**, so a deleted card is never resurrected.
  - `v0 → v1`: migrate legacy `mcp.clients` into DriverCard storage. The per-client "card exists" check is now only an in-run idempotency / crash-rerun guard, **not** the migration judgement.
  - `v1 → v2`: fold the #6029 `env:` credential-ref self-heal in as a **one-shot** step, instead of re-scanning every card on every start. This is safe because bad `${VAR}` literals are historical — post-fix migration never produces new ones.
- The watermark is persisted (`save_agent_config`) only **after all steps succeed**; on partial failure the version stays put and the next start re-runs (idempotent).

`legacy mcp.clients` is intentionally **preserved** (rollback-safe; consistent with the explicit *"DO NOT clear … mcp"* contract in `app/migration.py`).

### Why a version field (and not a marker file, or clearing `mcp.clients`)

The migration-completed state cannot be derived from any surviving runtime artifact — deleting a card also deletes its credentials — so it must be persisted explicitly. That is exactly 1 bit of information, best modeled as a schema version on the config that already owns the data, requiring no new state file. It also lets the #6029 upgrade become a proper one-shot step instead of an every-boot scan.

## Changes

- `config/config.py`: add `MCPConfig.migration_version`.
- `drivers/adapters/mcp_legacy_config.py`: add `CURRENT_MCP_MIGRATION_VERSION`, version-gate `migrate_legacy_mcp_if_needed`, add `_persist_mcp_migration_version`.
- `app/workspace/service_factories.py`: drop the standalone `upgrade_legacy_mcp_credentials` call (now folded into the v1→v2 step).
- `tests/unit/drivers/adapters/test_mcp_migration_version.py`: new tests.

## Verification

**New unit tests (5), TDD** (watched them fail on the missing symbol first):
- skip entirely when already at current version;
- migrate + persist watermark when unmigrated;
- **deleted card is not resurrected after the watermark**;
- env-ref upgrade folded in at v1→v2;
- config default `migration_version == 0`.

**Hermetic cold-boot proof** (isolated `QWENPAW_WORKING_DIR`, a *separate process* per boot):
```
[SEED]   {"clients": ["tavily_search"], "migration_version": 0}
[BOOT#1] {"card_exists": true,  "migration_version": 2, "clients": ["tavily_search"]}
[DELETE] {"deleted": true, "card_exists_after": false}
[BOOT#2] {"card_exists": false, "migration_version": 2, "clients": ["tavily_search"]}
[GREEN] deleted MCP client stays deleted across restart
```

- No regressions: `tests/unit/drivers/ tests/unit/config/` + env-ref integration → **30 passed**.
- `pre-commit` (mypy / black / flake8 / pylint) clean.

## Steady-state note

The first start after this change performs one final reconciliation for any client deleted *before* the watermark existed (such a client may reappear once), then settles at `version=2` and never re-migrates. Once the watermark is established, steady-state boots perform no migration writes.

Closes #6130
