### PR TITLE
fix(loop): fine-tune doom loop limits and preserve spaces in thinking blocks

### DIFF
--- a/console/src/pages/Inbox/utils/traceUtils.test.ts
+++ b/console/src/pages/Inbox/utils/traceUtils.test.ts
@@ -123,7 +123,7 @@ describe("extractTraceText", () => {
       extractTraceText({
         content: [{ type: "thinking", thinking: "  hmm  " }],
       }),
-    ).toBe("hmm");
+    ).toBe("  hmm  ");
   });
 
   it("extracts text field from text block", () => {

--- a/console/src/pages/Inbox/utils/traceUtils.ts
+++ b/console/src/pages/Inbox/utils/traceUtils.ts
@@ -71,14 +71,14 @@ export const extractTraceText = (event: Record<string, unknown>): string => {
   const blockType = String(block.type || "").toLowerCase();
   if (blockType === "thinking") {
     const thinking = block.thinking;
-    if (typeof thinking === "string" && thinking.trim()) {
-      return thinking.trim();
+    if (typeof thinking === "string") {
+      return thinking;
     }
   }
   if (blockType === "text") {
     const text = block.text;
-    if (typeof text === "string" && text.trim()) {
-      return text.trim();
+    if (typeof text === "string") {
+      return text;
     }
   }
   if (blockType === "tool_result") {

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1037,7 +1037,7 @@ class DoomLoopConfig(BaseModel):
         description="Enable doom loop detection",
     )
     window_size: int = Field(
-        default=3,
+        default=2,
         ge=2,
         description=("Sliding window size for " "repetition detection"),
     )
@@ -1052,7 +1052,7 @@ class DoomLoopConfig(BaseModel):
     stages: List[DoomLoopStageConfig] = Field(
         default_factory=lambda: [
             DoomLoopStageConfig(
-                after=3,
+                after=2,
                 action="modify_prompt",
                 prompt=(
                     "[WARNING] Repetitive pattern "
@@ -1063,10 +1063,10 @@ class DoomLoopConfig(BaseModel):
                 ),
             ),
             DoomLoopStageConfig(
-                after=6,
+                after=4,
                 action="stop",
                 prompt=(
-                    "Doom loop: agent stuck after " "6 consecutive repetitions"
+                    "Doom loop: agent stuck after " "4 consecutive repetitions"
                 ),
             ),
         ],


### PR DESCRIPTION
## What Problem This Solves

This PR addresses two open issues:
1. **Model Loop Prevention Tuning (Doom Loop):** In alignment with maintainer guidance to avoid hard-coded execution intercepts inside `ToolCoordinatorMiddleware`, we address repetition loops by tuning the default configuration thresholds of the framework's native `DoomLoopGate`. By reducing `window_size` from `3` to `2`, we can detect matching consecutive tool calls sooner. We adjust the escalation stages to warn the agent at 2 repetitions (using `"modify_prompt"`) and stop execution at 4 repetitions, saving tokens and preventing runaway loops earlier.
2. **Thinking Block Whitespace Rendering (Issue #6129):** The console frontend previously truncated leading/trailing whitespace and line breaks from `thinking` (and `text`) content chunks by calling `.trim()` in `extractTraceText()`. This destroyed indented list styles and paragraph separations generated during the thinking phase. We remove the `.trim()` execution, preserving raw formatting for correct console and markdown layout rendering.

## Evidence

I verified the changes by running all relevant backend loop gate tests and frontend vitest suites. All checks and assertions pass successfully:

1. **Backend Tests:**
   ```bash
   pytest tests/unit/loop/
   ```
   Output: `22 passed in 0.45s`

2. **Frontend Tests:**
   ```bash
   npx vitest run src/pages/Inbox/utils/traceUtils.test.ts
   ```
   Output: `62 passed (62) in 2.95s`

All files pass pre-commit checks.
