### PR TITLE
fix(console): preserve spaces and newlines in thinking blocks rendering

### DIFF
--- a/console/src/pages/Inbox/utils/traceUtils.test.ts
+++ b/console/src/pages/Inbox/utils/traceUtils.test.ts
@@ -123,7 +123,7 @@ describe("extractTraceText", () => {
       extractTraceText({
         content: [{ type: "thinking", thinking: "  hmm  " }],
       }),
-    ).toBe("hmm");
+    ).toBe("  hmm  ");
   });
 
   it("extracts text field from text block", () => {

--- a/console/src/pages/Inbox/utils/traceUtils.ts
+++ b/console/src/pages/Inbox/utils/traceUtils.ts
@@ -71,14 +71,14 @@ export const extractTraceText = (event: Record<string, unknown>): string => {
   const blockType = String(block.type || "").toLowerCase();
   if (blockType === "thinking") {
     const thinking = block.thinking;
-    if (typeof thinking === "string" && thinking.trim()) {
-      return thinking.trim();
+    if (typeof thinking === "string") {
+      return thinking;
     }
   }
   if (blockType === "text") {
     const text = block.text;
-    if (typeof text === "string" && text.trim()) {
-      return text.trim();
+    if (typeof text === "string") {
+      return text;
     }
   }
   if (blockType === "tool_result") {


### PR DESCRIPTION
## What Problem This Solves

This PR addresses the formatting issue of missing spaces and line feeds in thinking reasoning blocks (Issue #6129).

Previously, the console frontend truncated leading/trailing whitespace and line breaks from `thinking` (and `text`) content chunks by calling `.trim()` in `extractTraceText()`. This destroyed indented list styles and paragraph separations generated during the thinking phase. We remove the `.trim()` execution, preserving raw formatting for correct console and markdown layout rendering.

## Evidence

I verified the changes by running the frontend vitest suite. All checks and assertions pass successfully:

1. **Frontend Tests:**
   ```bash
   npx vitest run src/pages/Inbox/utils/traceUtils.test.ts
   ```
   Output: `62 passed (62) in 2.95s`

All files pass pre-commit checks.
