### PR TITLE
feat(website): add blog view/like counts and switch GA to QwenPaw property

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -45,6 +45,8 @@ jobs:
         working-directory: website
         env:
           VITE_BASE_PATH: "/"
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: pnpm run build
 
       - name: Generate contributors_data.json

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -45,8 +45,6 @@ jobs:
         working-directory: website
         env:
           VITE_BASE_PATH: "/"
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: pnpm run build
 
       - name: Generate contributors_data.json

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
+    "@supabase/supabase-js": "^2.110.4",
     "@types/react-syntax-highlighter": "^15.5.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       "@fontsource-variable/geist":
         specifier: ^5.2.8
         version: 5.2.8
+      "@supabase/supabase-js":
+        specifier: ^2.110.4
+        version: 2.110.4
       "@types/react-syntax-highlighter":
         specifier: ^15.5.13
         version: 15.5.13
@@ -1955,6 +1958,54 @@ packages:
       }
     engines: { node: ">=18" }
 
+  "@supabase/auth-js@2.110.4":
+    resolution:
+      {
+        integrity: sha512-nD+gsHRX7/qCCKzpX8Lch/NUi0rmg4YereGTFzUT0BkPJ0ObDLkhCfjfiloRNLky1oHkb+QLA45Vx2zAsQ6iIQ==,
+      }
+    engines: { node: ">=22.0.0" }
+
+  "@supabase/functions-js@2.110.4":
+    resolution:
+      {
+        integrity: sha512-661Bg5VeEDv6twzQhXzoBpPV4xswuwGGDzmBkpa1wmpwu5/veHqT2lURNxCowCiUOWIkj8fJ9LLjq0sgwBIA4A==,
+      }
+    engines: { node: ">=22.0.0" }
+
+  "@supabase/phoenix@0.4.4":
+    resolution:
+      {
+        integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==,
+      }
+
+  "@supabase/postgrest-js@2.110.4":
+    resolution:
+      {
+        integrity: sha512-TVTPrB8Ee/0dqA6B1fieMnCS32TYi5IRgIFuW5jL5DWGtw/y9XIojVkgLROdm8mhfpkiwt51lEtKYb3jl5cx1w==,
+      }
+    engines: { node: ">=22.0.0" }
+
+  "@supabase/realtime-js@2.110.4":
+    resolution:
+      {
+        integrity: sha512-nPtV06SuJXA+iAMUFBRrhjReayDICIzM8qi0TbsOXlPhn3GK5sDchwidHDtw9VPVOgKeF3xyXlrjIxeA0YdpuA==,
+      }
+    engines: { node: ">=22.0.0" }
+
+  "@supabase/storage-js@2.110.4":
+    resolution:
+      {
+        integrity: sha512-s7e6KGY3KQQTLWz93xd8qJQpSZMqHQR8Yvigk4aqxdCc/XEzNhF/FiEEUO8bwZ2RrFxCe4rmPlHHd+/OyTATMw==,
+      }
+    engines: { node: ">=22.0.0" }
+
+  "@supabase/supabase-js@2.110.4":
+    resolution:
+      {
+        integrity: sha512-RErQw3rYFu/t23oli4q7Zb+PUiyAv2h2/aoGLJqaY35eBGugmo+Bb7ZByqxssoFcrxT6xVz3hQde53O/6/+HWA==,
+      }
+    engines: { node: ">=22.0.0" }
+
   "@tailwindcss/node@4.2.2":
     resolution:
       {
@@ -3847,6 +3898,13 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  iceberg-js@0.8.1:
+    resolution:
+      {
+        integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==,
+      }
+    engines: { node: ">=20.0.0" }
 
   iconv-lite@0.6.3:
     resolution:
@@ -7455,6 +7513,38 @@ snapshots:
 
   "@sindresorhus/merge-streams@4.0.0": {}
 
+  "@supabase/auth-js@2.110.4":
+    dependencies:
+      tslib: 2.8.1
+
+  "@supabase/functions-js@2.110.4":
+    dependencies:
+      tslib: 2.8.1
+
+  "@supabase/phoenix@0.4.4": {}
+
+  "@supabase/postgrest-js@2.110.4":
+    dependencies:
+      tslib: 2.8.1
+
+  "@supabase/realtime-js@2.110.4":
+    dependencies:
+      "@supabase/phoenix": 0.4.4
+      tslib: 2.8.1
+
+  "@supabase/storage-js@2.110.4":
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  "@supabase/supabase-js@2.110.4":
+    dependencies:
+      "@supabase/auth-js": 2.110.4
+      "@supabase/functions-js": 2.110.4
+      "@supabase/postgrest-js": 2.110.4
+      "@supabase/realtime-js": 2.110.4
+      "@supabase/storage-js": 2.110.4
+
   "@tailwindcss/node@4.2.2":
     dependencies:
       "@jridgewell/remapping": 2.3.5
@@ -8593,6 +8683,8 @@ snapshots:
       "@babel/runtime": 7.29.2
     optionalDependencies:
       typescript: 5.6.3
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
     dependencies:

--- a/website/src/components/BlogEngagement.tsx
+++ b/website/src/components/BlogEngagement.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Eye, Heart } from "lucide-react";
+import {
+  isBlogStatsConfigured,
+  recordBlogView,
+  toggleBlogLike,
+  type BlogStats,
+} from "@/lib/blogEngagement";
+
+function formatCount(n: number, locale: string): string {
+  try {
+    return new Intl.NumberFormat(locale, { notation: "compact" }).format(n);
+  } catch {
+    return String(n);
+  }
+}
+
+type BlogEngagementProps = {
+  slug: string;
+};
+
+/** Article-page views + like control. No-ops when Supabase env is missing. */
+export function BlogEngagement({ slug }: BlogEngagementProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage ?? "en";
+  const [stats, setStats] = useState<BlogStats | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!isBlogStatsConfigured()) return;
+    let canceled = false;
+    recordBlogView(slug).then((next) => {
+      if (!canceled && next) setStats(next);
+    });
+    return () => {
+      canceled = true;
+    };
+  }, [slug]);
+
+  if (!isBlogStatsConfigured() || !stats) return null;
+
+  const onToggleLike = async () => {
+    if (busy) return;
+    setBusy(true);
+    const next = await toggleBlogLike(slug);
+    if (next) setStats(next);
+    setBusy(false);
+  };
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-(--color-text-tertiary) sm:mt-4 sm:gap-4 sm:text-sm">
+      <span
+        className="inline-flex items-center gap-1.5"
+        title={t("blog.viewsLabel")}
+      >
+        <Eye size={15} strokeWidth={1.75} aria-hidden />
+        <span>
+          {t("blog.views", { count: formatCount(stats.views, locale) })}
+        </span>
+      </span>
+      <button
+        type="button"
+        onClick={onToggleLike}
+        disabled={busy}
+        className={`inline-flex cursor-pointer items-center gap-1.5 rounded-md border-0 bg-transparent p-0 transition-colors disabled:opacity-60 ${
+          stats.liked
+            ? "text-(--color-primary)"
+            : "text-(--color-text-tertiary) hover:text-(--color-primary)"
+        }`}
+        aria-pressed={stats.liked}
+        aria-label={stats.liked ? t("blog.unlike") : t("blog.like")}
+        title={stats.liked ? t("blog.unlike") : t("blog.like")}
+      >
+        <Heart
+          size={15}
+          strokeWidth={1.75}
+          fill={stats.liked ? "currentColor" : "none"}
+          aria-hidden
+        />
+        <span>
+          {t("blog.likes", { count: formatCount(stats.likes, locale) })}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -264,7 +264,12 @@
     "sessionCount": "{{count}} developer day sessions",
     "backToList": "Back to blog",
     "notFound": "Post not found",
-    "empty": "No blog posts yet"
+    "empty": "No blog posts yet",
+    "views": "{{count}} views",
+    "viewsLabel": "Views",
+    "likes": "{{count}}",
+    "like": "Like",
+    "unlike": "Unlike"
   },
   "docs": {
     "intro": "Introduction",

--- a/website/src/i18n/locales/zh.json
+++ b/website/src/i18n/locales/zh.json
@@ -264,7 +264,12 @@
     "sessionCount": "共 {{count}} 场开发者日会",
     "backToList": "返回博客列表",
     "notFound": "文章未找到",
-    "empty": "暂无博客文章"
+    "empty": "暂无博客文章",
+    "views": "{{count}} 次阅读",
+    "viewsLabel": "阅读量",
+    "likes": "{{count}}",
+    "like": "点赞",
+    "unlike": "取消点赞"
   },
   "docs": {
     "intro": "项目介绍",

--- a/website/src/lib/analytics.ts
+++ b/website/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-export const GA_ID = "G-BEX1XSB9KE";
+export const GA_ID = "G-EG8R8PT98F";
 
 declare global {
   interface Window {

--- a/website/src/lib/blogEngagement.ts
+++ b/website/src/lib/blogEngagement.ts
@@ -1,0 +1,156 @@
+import {
+  getSupabase,
+  isBlogStatsConfigured,
+  type BlogStatsRow,
+} from "./supabase";
+
+const VIEWED_PREFIX = "qwenpaw:blog:viewed:";
+const LIKED_PREFIX = "qwenpaw:blog:liked:";
+
+export type BlogStats = {
+  views: number;
+  likes: number;
+  liked: boolean;
+};
+
+function viewedKey(slug: string) {
+  return `${VIEWED_PREFIX}${slug}`;
+}
+
+function likedKey(slug: string) {
+  return `${LIKED_PREFIX}${slug}`;
+}
+
+export function hasLikedLocally(slug: string): boolean {
+  try {
+    return localStorage.getItem(likedKey(slug)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markLikedLocally(slug: string, liked: boolean) {
+  try {
+    if (liked) localStorage.setItem(likedKey(slug), "1");
+    else localStorage.removeItem(likedKey(slug));
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+function hasViewedThisSession(slug: string): boolean {
+  try {
+    return sessionStorage.getItem(viewedKey(slug)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markViewedThisSession(slug: string) {
+  try {
+    sessionStorage.setItem(viewedKey(slug), "1");
+  } catch {
+    /* ignore */
+  }
+}
+
+function rowToStats(row: BlogStatsRow | null, slug: string): BlogStats {
+  return {
+    views: row?.views ?? 0,
+    likes: row?.likes ?? 0,
+    liked: hasLikedLocally(slug),
+  };
+}
+
+/** Fetch stats for one post (no side effects). */
+export async function fetchBlogStats(slug: string): Promise<BlogStats | null> {
+  const sb = getSupabase();
+  if (!sb) return null;
+
+  const { data, error } = await sb
+    .from("blog_stats")
+    .select("slug, views, likes")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (error) {
+    console.warn("[blogStats] fetch failed", error.message);
+    return null;
+  }
+
+  return rowToStats(data as BlogStatsRow | null, slug);
+}
+
+/** Batch-fetch view counts for the blog list. */
+export async function fetchBlogViewCounts(
+  slugs: string[],
+): Promise<Record<string, number>> {
+  const sb = getSupabase();
+  if (!sb || slugs.length === 0) return {};
+
+  const { data, error } = await sb
+    .from("blog_stats")
+    .select("slug, views")
+    .in("slug", slugs);
+
+  if (error) {
+    console.warn("[blogStats] batch fetch failed", error.message);
+    return {};
+  }
+
+  const out: Record<string, number> = {};
+  for (const row of data ?? []) {
+    out[(row as { slug: string; views: number }).slug] =
+      (row as { slug: string; views: number }).views ?? 0;
+  }
+  return out;
+}
+
+/**
+ * Record one view per browser tab session, then return latest stats.
+ * Safe to call on every article mount.
+ */
+export async function recordBlogView(slug: string): Promise<BlogStats | null> {
+  const sb = getSupabase();
+  if (!sb) return null;
+
+  if (hasViewedThisSession(slug)) {
+    return fetchBlogStats(slug);
+  }
+
+  const { data, error } = await sb.rpc("increment_blog_view", {
+    p_slug: slug,
+  });
+
+  if (error) {
+    console.warn("[blogStats] view increment failed", error.message);
+    return fetchBlogStats(slug);
+  }
+
+  markViewedThisSession(slug);
+  return rowToStats(data as BlogStatsRow, slug);
+}
+
+/** Toggle like using localStorage ownership + RPC increment/decrement. */
+export async function toggleBlogLike(slug: string): Promise<BlogStats | null> {
+  const sb = getSupabase();
+  if (!sb) return null;
+
+  const currentlyLiked = hasLikedLocally(slug);
+  const rpc = currentlyLiked ? "decrement_blog_like" : "increment_blog_like";
+
+  // Optimistic local flag so rapid clicks stay consistent
+  markLikedLocally(slug, !currentlyLiked);
+
+  const { data, error } = await sb.rpc(rpc, { p_slug: slug });
+
+  if (error) {
+    markLikedLocally(slug, currentlyLiked);
+    console.warn("[blogStats] like toggle failed", error.message);
+    return fetchBlogStats(slug);
+  }
+
+  return rowToStats(data as BlogStatsRow, slug);
+}
+
+export { isBlogStatsConfigured };

--- a/website/src/lib/blogEngagement.ts
+++ b/website/src/lib/blogEngagement.ts
@@ -7,6 +7,8 @@ import {
 const VIEWED_PREFIX = "qwenpaw:blog:viewed:";
 const LIKED_PREFIX = "qwenpaw:blog:liked:";
 
+const pendingLikeToggles = new Set<string>();
+
 export type BlogStats = {
   views: number;
   likes: number;
@@ -136,21 +138,30 @@ export async function toggleBlogLike(slug: string): Promise<BlogStats | null> {
   const sb = getSupabase();
   if (!sb) return null;
 
-  const currentlyLiked = hasLikedLocally(slug);
-  const rpc = currentlyLiked ? "decrement_blog_like" : "increment_blog_like";
-
-  // Optimistic local flag so rapid clicks stay consistent
-  markLikedLocally(slug, !currentlyLiked);
-
-  const { data, error } = await sb.rpc(rpc, { p_slug: slug });
-
-  if (error) {
-    markLikedLocally(slug, currentlyLiked);
-    console.warn("[blogStats] like toggle failed", error.message);
+  if (pendingLikeToggles.has(slug)) {
     return fetchBlogStats(slug);
   }
+  pendingLikeToggles.add(slug);
 
-  return rowToStats(data as BlogStatsRow, slug);
+  try {
+    const currentlyLiked = hasLikedLocally(slug);
+    const rpc = currentlyLiked ? "decrement_blog_like" : "increment_blog_like";
+
+    // Optimistic local flag so rapid clicks stay consistent
+    markLikedLocally(slug, !currentlyLiked);
+
+    const { data, error } = await sb.rpc(rpc, { p_slug: slug });
+
+    if (error) {
+      markLikedLocally(slug, currentlyLiked);
+      console.warn("[blogStats] like toggle failed", error.message);
+      return fetchBlogStats(slug);
+    }
+
+    return rowToStats(data as BlogStatsRow, slug);
+  } finally {
+    pendingLikeToggles.delete(slug);
+  }
 }
 
 export { isBlogStatsConfigured };

--- a/website/src/lib/supabase.ts
+++ b/website/src/lib/supabase.ts
@@ -1,0 +1,29 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+export type BlogStatsRow = {
+  slug: string;
+  views: number;
+  likes: number;
+};
+
+let client: SupabaseClient | null = null;
+
+export function isBlogStatsConfigured(): boolean {
+  return Boolean(url && anonKey);
+}
+
+export function getSupabase(): SupabaseClient | null {
+  if (!isBlogStatsConfigured()) return null;
+  if (!client) {
+    client = createClient(url!, anonKey!, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
+  return client;
+}

--- a/website/src/pages/Blog/Post.tsx
+++ b/website/src/pages/Blog/Post.tsx
@@ -17,6 +17,7 @@ import {
 import { MermaidBlock } from "@/components/MermaidBlock";
 import { ImageZoom } from "@/components/ImageZoom";
 import { trackBlogPostView } from "@/lib/analytics";
+import { BlogEngagement } from "@/components/BlogEngagement";
 
 /** Turn plain "Meeting link: https://…" lines into markdown links for session lists. */
 function linkifySessionUrls(body: string): string {
@@ -240,6 +241,7 @@ export default function BlogPost() {
                 : t("blog.readTime", { minutes: readMinutes })}
             </span>
           </p>
+          {slug ? <BlogEngagement slug={slug} /> : null}
         </header>
 
         <div

--- a/website/src/pages/Blog/index.tsx
+++ b/website/src/pages/Blog/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Eye } from "lucide-react";
 import { BLOG_POSTS } from "./blogData";
 import {
   compareBlogPostsByDateDesc,
@@ -9,8 +9,20 @@ import {
   parseBlogMarkdown,
   type ParsedBlogPost,
 } from "@/lib/parseBlogMarkdown";
+import {
+  fetchBlogViewCounts,
+  isBlogStatsConfigured,
+} from "@/lib/blogEngagement";
 
 type BlogListItem = ParsedBlogPost & { slug: string; cover?: string };
+
+function formatViewCount(n: number, locale: string): string {
+  try {
+    return new Intl.NumberFormat(locale, { notation: "compact" }).format(n);
+  } catch {
+    return String(n);
+  }
+}
 
 const DEVELOPER_DAY_COLLECTION_SLUG = "qwenpaw-developer-day-collection";
 
@@ -57,6 +69,7 @@ export default function Blog() {
   const isZh = i18n.resolvedLanguage === "zh";
   const locale = i18n.resolvedLanguage ?? "en";
   const [posts, setPosts] = useState<BlogListItem[]>([]);
+  const [viewCounts, setViewCounts] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -73,7 +86,7 @@ export default function Blog() {
           ...parsed,
         };
       }),
-    ).then((results) => {
+    ).then(async (results) => {
       if (canceled) return;
       const valid: BlogListItem[] = [];
       for (const item of results) {
@@ -82,6 +95,11 @@ export default function Blog() {
       valid.sort(compareBlogPostsByDateDesc);
       setPosts(valid);
       setLoading(false);
+
+      if (isBlogStatsConfigured() && valid.length > 0) {
+        const counts = await fetchBlogViewCounts(valid.map((p) => p.slug));
+        if (!canceled) setViewCounts(counts);
+      }
     });
 
     return () => {
@@ -162,6 +180,20 @@ export default function Blog() {
                         {metaPrimary}
                         <span className="mx-1.5">·</span>
                         {metaSecondary}
+                        {isBlogStatsConfigured() && (
+                          <>
+                            <span className="mx-1.5">·</span>
+                            <span className="inline-flex items-center gap-1">
+                              <Eye size={12} strokeWidth={1.75} aria-hidden />
+                              {t("blog.views", {
+                                count: formatViewCount(
+                                  viewCounts[slug] ?? 0,
+                                  locale,
+                                ),
+                              })}
+                            </span>
+                          </>
+                        )}
                       </p>
                       <h2 className="font-newsreader mt-1 text-[15px] font-semibold leading-snug text-(--color-text) group-hover:text-(--color-primary) sm:mt-1.5 sm:text-base md:text-lg">
                         {frontmatter.title}

--- a/website/src/vite-env.d.ts
+++ b/website/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/website/supabase/blog_stats.sql
+++ b/website/supabase/blog_stats.sql
@@ -1,0 +1,105 @@
+-- QwenPaw blog views + likes
+-- Run once in Supabase Dashboard → SQL Editor → New query → Run
+
+create table if not exists public.blog_stats (
+  slug text primary key,
+  views bigint not null default 0 check (views >= 0),
+  likes bigint not null default 0 check (likes >= 0),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists blog_stats_views_idx on public.blog_stats (views desc);
+
+alter table public.blog_stats enable row level security;
+
+-- Public read for list + article pages
+drop policy if exists "blog_stats_select_public" on public.blog_stats;
+create policy "blog_stats_select_public"
+  on public.blog_stats
+  for select
+  to anon, authenticated
+  using (true);
+
+-- No direct insert/update/delete for anon — writes go through RPCs below
+
+create or replace function public.increment_blog_view(p_slug text)
+returns public.blog_stats
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  result public.blog_stats;
+begin
+  if p_slug is null or length(trim(p_slug)) = 0 then
+    raise exception 'slug required';
+  end if;
+
+  insert into public.blog_stats (slug, views, likes)
+  values (p_slug, 1, 0)
+  on conflict (slug) do update
+    set views = public.blog_stats.views + 1,
+        updated_at = now()
+  returning * into result;
+
+  return result;
+end;
+$$;
+
+create or replace function public.increment_blog_like(p_slug text)
+returns public.blog_stats
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  result public.blog_stats;
+begin
+  if p_slug is null or length(trim(p_slug)) = 0 then
+    raise exception 'slug required';
+  end if;
+
+  insert into public.blog_stats (slug, views, likes)
+  values (p_slug, 0, 1)
+  on conflict (slug) do update
+    set likes = public.blog_stats.likes + 1,
+        updated_at = now()
+  returning * into result;
+
+  return result;
+end;
+$$;
+
+create or replace function public.decrement_blog_like(p_slug text)
+returns public.blog_stats
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  result public.blog_stats;
+begin
+  if p_slug is null or length(trim(p_slug)) = 0 then
+    raise exception 'slug required';
+  end if;
+
+  insert into public.blog_stats (slug, views, likes)
+  values (p_slug, 0, 0)
+  on conflict (slug) do update
+    set likes = greatest(public.blog_stats.likes - 1, 0),
+        updated_at = now()
+  returning * into result;
+
+  return result;
+end;
+$$;
+
+revoke all on function public.increment_blog_view(text) from public;
+revoke all on function public.increment_blog_like(text) from public;
+revoke all on function public.decrement_blog_like(text) from public;
+
+grant execute on function public.increment_blog_view(text) to anon, authenticated;
+grant execute on function public.increment_blog_like(text) to anon, authenticated;
+grant execute on function public.decrement_blog_like(text) to anon, authenticated;
+
+grant select on table public.blog_stats to anon, authenticated;


### PR DESCRIPTION
## Description

Add public view and like counts on the website blog, backed by Supabase, and point Google Analytics at the QwenPaw measurement ID.

- Show view counts on the blog list and article pages
- Show a like button + count on article pages (per-browser like state in `localStorage`; one view increment per tab session)
- Store counts in Supabase (`blog_stats` table + RPC increments); UI hides gracefully when `VITE_SUPABASE_*` is unset
- Update GA measurement ID from `G-BEX1XSB9KE` (CoPaw) to `G-EG8R8PT98F` (qwenpaw-website)

**Related Issue:** Relates to website blog engagement / analytics

**Security Considerations:** Only the Supabase anon/publishable key is used in the frontend. Table writes go through SECURITY DEFINER RPCs with RLS (select-only for anon). Do not commit `.env` or `service_role` keys.

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Documentation (website)
- [ ] Core / Backend
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Create a Supabase project and run `website/supabase/blog_stats.sql`
2. Set local `website/.env`:
   - `VITE_SUPABASE_URL`
   - `VITE_SUPABASE_ANON_KEY`
3. `pnpm dev` in `website/`
4. Open `/blog` — view counts render when configured
5. Open an article (e.g. `/blog/paw-git`) — views increment once per session; like toggles and persists locally
6. Confirm a row appears in Supabase `blog_stats`
7. After deploy, confirm production loads `gtag/js?id=G-EG8R8PT98F` and GA Realtime receives hits

## Evidence

Manually verified locally with Supabase configured:

- Blog list shows view counts next to post meta
- Article page shows views + like control; like toggles fill state and updates count
- Session-deduped view increment writes to `blog_stats`
- Without env vars, engagement UI is hidden and the rest of the site works normally
- GA ID updated to `G-EG8R8PT98F` in `website/src/lib/analytics.ts`

## Additional Notes

Production blog stats require `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` at **build** time (Vite inlines `VITE_*`). Please add them as GitHub Actions secrets and pass them into the website deploy build step if not already configured.

SQL bootstrap script: `website/supabase/blog_stats.sql`
<img width="1862" height="498" alt="image" src="https://github.com/user-attachments/assets/4e8328f6-5aff-4fcb-9cd6-e71b5b66a1d6" />
<img width="2658" height="1198" alt="image" src="https://github.com/user-attachments/assets/03ff7c89-d23c-4931-a210-e5c9a0d251e2" />
