### PR TITLE
fix: images stripped for multimodal models when model info lookup fails or builtin annotation is wrong

### DIFF
--- a/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/RemoteModelManageModal.tsx
@@ -1014,20 +1014,18 @@ export function RemoteModelManageModal({
                           flexShrink: 0,
                         }}
                       />
-                      {m.probe_source !== "documentation" && (
-                        <Tooltip
-                          title={t("models.probeMultimodal", "测试多模态")}
-                        >
-                          <Button
-                            type="text"
-                            size="small"
-                            icon={<ExperimentOutlined />}
-                            onClick={() => handleProbeMultimodal(m.id)}
-                            loading={probingModelId === m.id}
-                            style={darkBtnStyle}
-                          />
-                        </Tooltip>
-                      )}
+                      <Tooltip
+                        title={t("models.probeMultimodal", "测试多模态")}
+                      >
+                        <Button
+                          type="text"
+                          size="small"
+                          icon={<ExperimentOutlined />}
+                          onClick={() => handleProbeMultimodal(m.id)}
+                          loading={probingModelId === m.id}
+                          style={darkBtnStyle}
+                        />
+                      </Tooltip>
                       <Tooltip title={t("models.testConnection")}>
                         <Button
                           type="text"

--- a/src/qwenpaw/agents/prompt.py
+++ b/src/qwenpaw/agents/prompt.py
@@ -429,10 +429,16 @@ def _get_active_model_info():
 
 
 def get_active_model_supports_multimodal() -> bool:
-    """Check if the current active model supports multimodal input."""
+    """Check if the current active model supports multimodal input.
+
+    Defaults to True when model info is unavailable so that
+    unknown models fail-open (sending an image to a text-only
+    model yields a recoverable API error, but stripping images
+    from a multimodal model silently breaks functionality).
+    """
     model_info, _ = _get_active_model_info()
     if model_info is None:
-        return False
+        return True
     return bool(model_info.supports_multimodal)
 
 

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -501,7 +501,7 @@ OPENCODE_MODELS: List[ModelInfo] = [
     ModelInfo(
         id="mimo-v2.5-free",
         name="Mimo V2.5",
-        supports_image=False,
+        supports_image=True,
         supports_video=False,
         probe_source="documentation",
         is_free=True,
@@ -2221,6 +2221,9 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                     "thinking_enabled",
                     "thinking_budget",
                     "reasoning_effort",
+                    "supports_multimodal",
+                    "supports_image",
+                    "supports_video",
                 )
                 for m in provider.models:
                     stored_model_config[m.id] = {
@@ -2256,6 +2259,14 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                                 model.reasoning_effort = cfg[
                                     "reasoning_effort"
                                 ]
+                            if cfg.get("supports_multimodal") is not None:
+                                model.supports_multimodal = cfg[
+                                    "supports_multimodal"
+                                ]
+                            if cfg.get("supports_image") is not None:
+                                model.supports_image = cfg["supports_image"]
+                            if cfg.get("supports_video") is not None:
+                                model.supports_video = cfg["supports_video"]
         # Load custom providers
         for provider_file in self.custom_path.glob("*.json"):
             provider = self.load_provider(provider_file.stem, is_builtin=False)


### PR DESCRIPTION
## Description

- Fix `mimo-v2.5-free` on OpenCode incorrectly annotated as text-only (`supports_image=False`) — it actually supports image input
- Add `supports_multimodal`, `supports_image`, `supports_video` to `_per_model_keys` so user overrides via disk config are persisted across restarts
- Change `get_active_model_supports_multimodal()` to default to `True` when model info is unavailable (fail-open), consistent with `view_media.py` and `model_factory.py` exception fallbacks
- Always show the multimodal probe button in the model management UI, even for builtin models with `probe_source="documentation"`, so users can override incorrect annotations


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
