### PR TITLE
feat(website): add Community Benefits nav and improve blog tags/meta cards

### DIFF
--- a/website/public/blog/introducing-qwenpaw-driver.en.md
+++ b/website/public/blog/introducing-qwenpaw-driver.en.md
@@ -2,7 +2,7 @@
 title: "QwenPaw Driver: A Unified Capability Access Layer"
 date: 2026-07-01
 author: QwenPaw Team
-tags: [architecture, driver, mcp, access-policy]
+tags: [CapabilityIntegration, ProtocolAdapters, AccessControl, MCP]
 excerpt: "Agent systems are evolving rapidly. Today's Agent no longer calls just a few built-in tools — it needs to interface with MCP Servers, remote Agents (A2A), ACP services, and potentially more protocols in the future."
 ---
 

--- a/website/public/blog/introducing-qwenpaw-driver.zh.md
+++ b/website/public/blog/introducing-qwenpaw-driver.zh.md
@@ -2,7 +2,7 @@
 title: "QwenPaw Driver：统一的外部能力接入层"
 date: 2026-07-01
 author: QwenPaw Team
-tags: [architecture, driver, mcp, access-policy]
+tags: [外部能力接入, 协议适配, 访问控制, MCP]
 excerpt: "Agent 系统正在快速演进。今天的 Agent 不再局限于调用几个内置工具——它需要对接 MCP Server、远程 Agent (A2A)、ACP 服务，以及未来更多的外部协议。"
 ---
 

--- a/website/public/blog/paw-git.en.md
+++ b/website/public/blog/paw-git.en.md
@@ -2,9 +2,14 @@
 title: "PawGit: Recoverable Agent Session State for QwenPaw"
 date: 2026-07-07
 author: QwenPaw Team
-tags: [pawgit, plugin, context-rot, agent-session]
+tags: [Plugin, SessionVersionControl, StateSnapshots, SessionRewind]
 cover: https://img.alicdn.com/imgextra/i2/O1CN01cdSRbU26gXIFiTRjL_!!6000000007691-2-tps-1254-1254.png
 excerpt: "In long sessions, Agents get dragged down by dirty context. PawGit adds checkpoints, timelines, and rewind for QwenPaw Agent session state—so you can return to a clean point without opening a new window and re-feeding your entire prompt."
+related:
+  heading: "Related Plugin: PawGit"
+  description: "Version control for QwenPaw sessions and memory, with state snapshots, DAG timelines, session rewind, and state reset."
+  linkText: "View and install PawGit →"
+  linkUrl: "https://platform.agentscope.io/plugins/pawgit"
 ---
 
 # PawGit: Recoverable Agent Session State for QwenPaw

--- a/website/public/blog/paw-git.zh.md
+++ b/website/public/blog/paw-git.zh.md
@@ -2,9 +2,14 @@
 title: "PawGit：为 QwenPaw Agent 会话状态提供可恢复性"
 date: 2026-07-07
 author: QwenPaw Team
-tags: [pawgit, plugin, context-rot, agent-session]
+tags: [插件, 会话版本控制, 状态快照, 会话回滚]
 cover: https://img.alicdn.com/imgextra/i2/O1CN01cdSRbU26gXIFiTRjL_!!6000000007691-2-tps-1254-1254.png
 excerpt: "长会话里 Agent 会被脏上下文拖住。PawGit 为 QwenPaw Agent 会话状态提供 checkpoint、timeline 与 rewind，让你在不必新开窗口重喂 prompt 的前提下，回到之前还干净的状态。"
+related:
+  heading: "相关插件：PawGit"
+  description: "QwenPaw 会话与记忆版本控制插件，支持状态快照、DAG 时间线、会话回滚与状态重置。"
+  linkText: "查看并安装 PawGit →"
+  linkUrl: "https://platform.agentscope.io/plugins/pawgit"
 ---
 
 # PawGit：为 QwenPaw Agent 会话状态提供可恢复性

--- a/website/public/blog/play-with-qwenpaw-pet.en.md
+++ b/website/public/blog/play-with-qwenpaw-pet.en.md
@@ -1,8 +1,19 @@
 ---
 title: "Play with QwenPaw-Pet"
 date: 2026-07-01
-tags: [pet, plugin, make-skill]
+tags: [Plugin, DesktopPet, PixelPets, SkillCreation]
 excerpt: "QwenPaw introduced the plugin system in version 1.1.3 and the pet system in version 1.1.8. I was not a big fan of the official pet templates, so I had never configured them. Personally, I prefer pixel-style pet designs."
+related:
+  heading: "Related Capabilities"
+  items:
+    - label: "Plugin"
+      name: "QwenPaw Pet"
+      href: "https://platform.agentscope.io/plugins/qwenpaw-pet"
+      description: "The official desktop pet plugin that forwards QwenPaw backend lifecycle events to QwenPaw Pet Desktop."
+    - label: "Built-in Skill"
+      name: "make-skill"
+      href: "https://qwenpaw.agentscope.io/docs/skills#Create-from-current-session-via-make-skill-Beta"
+      description: "Turns the workflow and experience from the current session into a reusable Skill. In this post, it is used to package the desktop-pet creation workflow as a reusable Skill."
 ---
 
 # Play with QwenPaw-Pet

--- a/website/public/blog/play-with-qwenpaw-pet.zh.md
+++ b/website/public/blog/play-with-qwenpaw-pet.zh.md
@@ -1,8 +1,19 @@
 ---
 title: "Play with QwenPaw-Pet"
 date: 2026-07-01
-tags: [pet, plugin, make-skill]
+tags: [插件, 桌宠, 像素宠物, 技能制作]
 excerpt: "QwenPaw在1.1.3版本引入了插件系统，并在1.1.8版本引入了宠物系统。但官方的宠物模板个人不太喜欢，就一直没有配置。个人一直比较喜欢像素风的宠物类型"
+related:
+  heading: "相关能力"
+  items:
+    - label: "插件"
+      name: "QwenPaw Pet"
+      href: "https://platform.agentscope.io/plugins/qwenpaw-pet"
+      description: "QwenPaw 官方桌宠插件，用于将后端生命周期事件同步至 QwenPaw Pet Desktop。"
+    - label: "内置技能"
+      name: "make-skill"
+      href: "https://qwenpaw.agentscope.io/docs/skills#通过-make-skill-从当前会话创建-Beta"
+      description: "将当前会话中的操作流程与经验沉淀为可复用 Skill。本文使用该能力将桌宠制作流程封装为可复用 Skill。"
 ---
 
 # Play with QwenPaw-Pet

--- a/website/public/blog/qwenpaw-developer-day-collection.en.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.en.md
@@ -2,7 +2,7 @@
 title: "QwenPaw Developer Day Collection"
 date: 2026-07-09
 author: QwenPaw Team
-tags: [QwenPaw, developer-day]
+tags: [DeveloperDay, MeetingNotes, SessionRecordings]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "Replay archive from QwenPaw developer day sessions — in-depth technical talks and practical insights for every QwenPaw developer and enthusiast."
 ---

--- a/website/public/blog/qwenpaw-developer-day-collection.en.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.en.md
@@ -1,15 +1,19 @@
 ---
 title: "QwenPaw Developer Day Collection"
-date: 2026-07-09
+date: 2026-07-14
 author: QwenPaw Team
 tags: [DeveloperDay, MeetingNotes, SessionRecordings]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "Replay archive from QwenPaw developer day sessions — in-depth technical talks and practical insights for every QwenPaw developer and enthusiast."
 ---
 
-Last updated July 9, 2026
+Last updated July 14, 2026
 
 ---
+
+**07-14 QwenPaw Developer Day: QwenPaw 2.0 WorkSpace & Sandbox Deep Dive**
+
+Meeting link: https://shanji.dingtalk.com/app/transcribes/76327569643336343833393033335f323034353035363233375f30
 
 **07-09 QwenPaw Developer Day: AgentScope 2.0 Latest Updates — Agent Team/Agent Service, Multi-Tenant RAG, Long-Term Memory, Real-Time Voice, Tool Middleware & WebUI**
 

--- a/website/public/blog/qwenpaw-developer-day-collection.zh.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.zh.md
@@ -2,7 +2,7 @@
 title: "QwenPaw 开发者日会合集"
 date: 2026-07-09
 author: QwenPaw Team
-tags: [QwenPaw, 日会合集]
+tags: [开发者日会, 会议纪要, 会议录屏]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "QwenPaw团队召开开发者日会，为每一位 QwenPaw 开发者与爱好者提供一份兼具理论深度与落地价值的完整技术交流档案。"
 ---

--- a/website/public/blog/qwenpaw-developer-day-collection.zh.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.zh.md
@@ -1,15 +1,19 @@
 ---
 title: "QwenPaw 开发者日会合集"
-date: 2026-07-09
+date: 2026-07-14
 author: QwenPaw Team
 tags: [开发者日会, 会议纪要, 会议录屏]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "QwenPaw团队召开开发者日会，为每一位 QwenPaw 开发者与爱好者提供一份兼具理论深度与落地价值的完整技术交流档案。"
 ---
 
-最近更新 2026 年 7 月 9 日
+最近更新 2026 年 7 月 14 日
 
 ---
+
+**07-14 QwenPaw 开发者日会：QwenPaw 2.0 WorkSpace & Sandbox 模块详解**
+
+会议链接：https://shanji.dingtalk.com/app/transcribes/76327569643336343833393033335f323034353035363233375f30
 
 **07-09 QwenPaw 开发者日会：AgentScope 2.0 最新更新详解（Agent Team/Agent Service、多租户RAG、长期记忆、实时语音、工具中间件和WebUI）**
 

--- a/website/public/blog/runtime-architecture-upgrade.en.md
+++ b/website/public/blog/runtime-architecture-upgrade.en.md
@@ -2,7 +2,7 @@
 title: "QwenPaw Runtime Architecture Upgrade: Design, Implementation & Extensibility"
 date: 2026-07-07
 author: QwenPaw Team
-tags: [architecture, runtime, hook, qwenpaw-2.0]
+tags: [ArchitectureUpgrade, EightPhaseOrchestration, HookSystem, QwenPaw2.0]
 cover: /blog/runtime-architecture-upgrade-cover.png
 excerpt: "QwenPaw Runtime was refactored from a 650-line god method into an 8-phase orchestration engine—enabling one-feature-one-directory extensibility with zero changes to Runtime core code."
 ---

--- a/website/public/blog/runtime-architecture-upgrade.zh.md
+++ b/website/public/blog/runtime-architecture-upgrade.zh.md
@@ -2,7 +2,7 @@
 title: "QwenPaw Runtime 架构升级解析：架构、实现与扩展"
 date: 2026-07-07
 author: QwenPaw Team
-tags: [architecture, runtime, hook, qwenpaw-2.0]
+tags: [架构升级, 八阶段编排, Hook机制, QwenPaw2.0]
 cover: /blog/runtime-architecture-upgrade-cover.png
 excerpt: "QwenPaw Runtime 从 650 行 god method 重构为 8 阶段编排引擎，通过 Hook、AgentMode 与声明式注册实现「一个功能一个目录、Runtime 零侵入扩展」。"
 ---

--- a/website/src/components/BlogRelatedCard.tsx
+++ b/website/src/components/BlogRelatedCard.tsx
@@ -1,0 +1,59 @@
+import type { BlogRelatedMeta } from "@/lib/parseBlogMarkdown";
+
+type BlogRelatedCardProps = {
+  related: BlogRelatedMeta;
+};
+
+/** Renders plugin/skill meta from blog frontmatter `related`. */
+export function BlogRelatedCard({ related }: BlogRelatedCardProps) {
+  const hasItems = (related.items?.length ?? 0) > 0;
+
+  return (
+    <aside className="blog-related-card mb-6" aria-label={related.heading}>
+      <p className="blog-related-card__heading">{related.heading}</p>
+      {related.description && (
+        <p className="blog-related-card__desc">{related.description}</p>
+      )}
+      {hasItems && (
+        <ul className="blog-related-card__list">
+          {related.items!.map((item) => (
+            <li key={`${item.label}-${item.name}`}>
+              <span className="blog-related-card__item-label">
+                {item.label}:{" "}
+              </span>
+              {item.href ? (
+                <a
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="blog-related-card__link"
+                >
+                  {item.name}
+                </a>
+              ) : (
+                <span className="blog-related-card__item-name">
+                  {item.name}
+                </span>
+              )}
+              {item.description && (
+                <p className="blog-related-card__desc">{item.description}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {related.linkUrl && related.linkText && (
+        <p className="blog-related-card__cta">
+          <a
+            href={related.linkUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="blog-related-card__link"
+          >
+            {related.linkText}
+          </a>
+        </p>
+      )}
+    </aside>
+  );
+}

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -1,11 +1,16 @@
 import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { Menu, X, BookOpen, Globe, Download } from "lucide-react";
+import { Menu, X, BookOpen, Globe, Download, Ellipsis } from "lucide-react";
 import { QwenpawMascot } from "./QwenpawMascot";
 import { useTranslation } from "react-i18next";
 import { useSiteLanguage } from "@/i18n/SiteLanguageContext";
 import { useSiteConfig } from "@/config-context";
 import { GitHubIcon, BlogIcon, NoteIcon, AgentScopePlatformIcon } from "./Icon";
+import {
+  CommunityBenefitsMobileList,
+  CommunityBenefitsPanel,
+  CommunityBenefitsTriggerLabel,
+} from "./NavCommunityBenefits";
 
 const AGENTSCOPE_PLATFORM_URL = "https://platform.agentscope.io/";
 
@@ -35,21 +40,18 @@ function AgentScopeLogo() {
 }
 
 const navLinkBaseClass =
-  "inline-flex items-center gap-2 rounded-md px-1 py-1.5 text-sm font-medium text-neutral-800 no-underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2";
+  "inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-md px-1 py-1.5 text-sm font-medium text-neutral-800 no-underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2";
 
 const navLinkOrangeClass = `${navLinkBaseClass} hover:!text-orange-400 focus-visible:outline-orange-400`;
 const navLinkBlueClass = `${navLinkBaseClass} hover:!text-[#0064FD] focus-visible:outline-[#0064FD]`;
 
-const navReleaseNotesClass = (isZh: boolean) =>
-  `${navLinkOrangeClass} w-[8rem] shrink-0 justify-center gap-1 ${
-    isZh ? "" : "!px-0"
-  }`;
 const navDownloadBtnClass = (isZh: boolean) =>
-  `inline-flex w-[6.5rem] shrink-0 items-center justify-center gap-1 rounded-md ${
+  `inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-md ${
     isZh ? "px-3" : "px-1.5"
   } py-1.5 text-sm font-medium text-neutral-800 no-underline transition-colors cursor-pointer border border-[#F3F1F0] bg-(--color-card-fill) hover:bg-(--color-secondary)`;
 
 const navIconStroke = 1.5;
+const moreMenuItemClass = `${navLinkOrangeClass} w-full justify-start px-3 py-2`;
 
 export function Nav() {
   const { projectName, docsPath } = useSiteConfig();
@@ -57,20 +59,51 @@ export function Nav() {
   const { t, i18n } = useTranslation();
   const isZh = i18n.resolvedLanguage === "zh";
   const [open, setOpen] = useState(false);
+  const [benefitsOpen, setBenefitsOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
+  const [moreBenefitsOpen, setMoreBenefitsOpen] = useState(false);
+  const [mobileBenefitsOpen, setMobileBenefitsOpen] = useState(false);
+  const benefitsRef = useRef<HTMLDivElement>(null);
   const moreRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const docsBase = docsPath.replace(/\/$/, "") || "/docs";
+
+  const clearCloseTimer = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  const openBenefits = () => {
+    clearCloseTimer();
+    setBenefitsOpen(true);
+  };
+
+  const scheduleCloseBenefits = () => {
+    clearCloseTimer();
+    closeTimerRef.current = setTimeout(() => {
+      setBenefitsOpen(false);
+      closeTimerRef.current = null;
+    }, 120);
+  };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (moreRef.current && !moreRef.current.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (benefitsRef.current && !benefitsRef.current.contains(target)) {
+        setBenefitsOpen(false);
+      }
+      if (moreRef.current && !moreRef.current.contains(target)) {
         setMoreOpen(false);
+        setMoreBenefitsOpen(false);
       }
     };
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && moreOpen) {
-        setMoreOpen(false);
-      }
+      if (event.key !== "Escape") return;
+      setBenefitsOpen(false);
+      setMoreOpen(false);
+      setMoreBenefitsOpen(false);
     };
     document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("keydown", handleEscape);
@@ -78,11 +111,79 @@ export function Nav() {
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEscape);
     };
-  }, [moreOpen]);
+  }, []);
+
+  useEffect(() => {
+    return () => clearCloseTimer();
+  }, []);
+
+  const platformLink = (
+    <a
+      href={AGENTSCOPE_PLATFORM_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={navLinkOrangeClass}
+      title={t("nav.platformTitle")}
+      aria-label={t("nav.platformTitle")}
+    >
+      <AgentScopePlatformIcon size={18} />
+      <span>{t("nav.platform")}</span>
+    </a>
+  );
+
+  const agentscopeLink = (
+    <a
+      href="https://agentscope.io/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`${navLinkBlueClass} whitespace-nowrap`}
+      title={isZh ? "基于 AgentScope 打造" : "Built on AgentScope"}
+      aria-label={t("nav.agentscopeTeam")}
+    >
+      <AgentScopeLogo />
+      <span>{t("nav.agentscopeTeam")}</span>
+    </a>
+  );
+
+  const releaseNotesLink = (className: string) => (
+    <Link to="/release-notes" className={className}>
+      <NoteIcon />
+      <span>{t("nav.releaseNotes")}</span>
+    </Link>
+  );
+
+  const desktopBenefits = (
+    <div
+      ref={benefitsRef}
+      className="relative hidden xl:block"
+      onMouseEnter={openBenefits}
+      onMouseLeave={scheduleCloseBenefits}
+    >
+      <button
+        type="button"
+        className={`${navLinkOrangeClass} cursor-pointer border-0 bg-transparent pt-2`}
+        aria-expanded={benefitsOpen}
+        aria-haspopup="true"
+        onClick={() => setBenefitsOpen((v) => !v)}
+      >
+        <CommunityBenefitsTriggerLabel open={benefitsOpen} />
+      </button>
+      {benefitsOpen && (
+        <div
+          className="absolute left-1/2 top-full z-100 mt-2 -translate-x-1/2 rounded-xl border border-neutral-100 bg-white shadow-[0_12px_40px_rgba(0,0,0,0.12)]"
+          role="menu"
+          onMouseEnter={openBenefits}
+          onMouseLeave={scheduleCloseBenefits}
+        >
+          <CommunityBenefitsPanel onNavigate={() => setBenefitsOpen(false)} />
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <header className="sticky top-0 z-99 border-b border-border bg-white">
-      <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-3 px-4 md:px-0">
+      <nav className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-2 px-4 md:px-0 lg:gap-3">
         <Link
           to="/"
           className="nav-brand-link flex shrink-0 items-center gap-2 text-lg font-semibold text-neutral-900 no-underline"
@@ -92,7 +193,7 @@ export function Nav() {
             <QwenpawMascot size={120} />
           </span>
         </Link>
-        <div className="nav-links hidden min-[641px]:flex min-[641px]:items-center min-[641px]:gap-6 lg:gap-8">
+        <div className="nav-links hidden min-[641px]:flex min-[641px]:min-w-0 min-[641px]:flex-1 min-[641px]:items-center min-[641px]:justify-end min-[641px]:gap-3 lg:gap-5 xl:gap-6">
           <Link to={docsBase} className={navLinkOrangeClass}>
             <BookOpen size={18} strokeWidth={navIconStroke} aria-hidden />
             <span>{t("nav.docs")}</span>
@@ -111,48 +212,101 @@ export function Nav() {
             <GitHubIcon />
             <span>{t("nav.github")}</span>
           </a>
-          <a
-            href={AGENTSCOPE_PLATFORM_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={navLinkOrangeClass}
-            title={t("nav.platformTitle")}
-            aria-label={t("nav.platformTitle")}
-          >
-            <AgentScopePlatformIcon size={18} />
-            <span>{t("nav.platform")}</span>
-          </a>
-          <a
-            href="https://agentscope.io/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`${navLinkBlueClass} whitespace-nowrap`}
-            title={isZh ? "基于 AgentScope 打造" : "Built on AgentScope"}
-            aria-label={t("nav.agentscopeTeam")}
-          >
-            <AgentScopeLogo />
-            <span>{t("nav.agentscopeTeam")}</span>
-          </a>
+
+          {/* lg+: show Platform / AgentScope inline; below lg they move into More */}
+          <span className="hidden lg:contents">
+            {platformLink}
+            {agentscopeLink}
+          </span>
+
+          {/* xl+: community benefits + release notes inline */}
+          {desktopBenefits}
+          <span className="hidden xl:contents">
+            {releaseNotesLink(navLinkOrangeClass)}
+          </span>
+
+          {/* Overflow More: tablet / iPad */}
+          <div ref={moreRef} className="relative xl:hidden">
+            <button
+              type="button"
+              className={`${navLinkOrangeClass} cursor-pointer border-0 bg-transparent`}
+              aria-expanded={moreOpen}
+              aria-haspopup="true"
+              aria-label={t("nav.more")}
+              onClick={() => {
+                setMoreOpen((v) => !v);
+                setMoreBenefitsOpen(false);
+              }}
+            >
+              <Ellipsis size={18} strokeWidth={navIconStroke} aria-hidden />
+              <span className="sr-only">{t("nav.more")}</span>
+            </button>
+            {moreOpen && (
+              <div
+                className="absolute right-0 top-full z-100 mt-2 min-w-56 rounded-xl border border-neutral-100 bg-white py-2 shadow-[0_12px_40px_rgba(0,0,0,0.12)]"
+                role="menu"
+              >
+                <div className="flex flex-col gap-0.5 px-1 lg:hidden">
+                  <a
+                    href={AGENTSCOPE_PLATFORM_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={moreMenuItemClass}
+                    onClick={() => setMoreOpen(false)}
+                  >
+                    <AgentScopePlatformIcon size={18} />
+                    <span>{t("nav.platform")}</span>
+                  </a>
+                  <a
+                    href="https://agentscope.io/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`${moreMenuItemClass} !text-[#0064FD]`}
+                    onClick={() => setMoreOpen(false)}
+                  >
+                    <AgentScopeLogo />
+                    <span>{t("nav.agentscopeTeam")}</span>
+                  </a>
+                </div>
+
+                <div className="px-1">
+                  <button
+                    type="button"
+                    className={`${moreMenuItemClass} cursor-pointer border-0 bg-transparent pt-2 text-left`}
+                    aria-expanded={moreBenefitsOpen}
+                    onClick={() => setMoreBenefitsOpen((v) => !v)}
+                  >
+                    <CommunityBenefitsTriggerLabel open={moreBenefitsOpen} />
+                  </button>
+                  {moreBenefitsOpen && (
+                    <CommunityBenefitsMobileList
+                      onNavigate={() => {
+                        setMoreBenefitsOpen(false);
+                        setMoreOpen(false);
+                      }}
+                    />
+                  )}
+                </div>
+
+                <div className="px-1 pt-0.5">
+                  {releaseNotesLink(moreMenuItemClass)}
+                </div>
+              </div>
+            )}
+          </div>
+
           <button
             type="button"
             onClick={toggleLang}
-            className={`${navLinkOrangeClass} w-[4.2rem] cursor-pointer border-0 bg-transparent`}
+            className={`${navLinkOrangeClass} cursor-pointer border-0 bg-transparent`}
             aria-label={t("nav.lang")}
           >
             <Globe size={18} strokeWidth={navIconStroke} aria-hidden />
             <span>{t("nav.lang")}</span>
           </button>
-          <Link
-            to="/release-notes"
-            role="menuitem"
-            className={navReleaseNotesClass(isZh)}
-          >
-            <NoteIcon />
-            <span className="truncate">{t("nav.releaseNotes")}</span>
-          </Link>
           <Link to="/downloads" className={navDownloadBtnClass(isZh)}>
             <Download size={18} strokeWidth={navIconStroke} aria-hidden />
-            <span className="truncate">{t("nav.download")}</span>
+            <span>{t("nav.download")}</span>
           </Link>
         </div>
 
@@ -221,6 +375,26 @@ export function Nav() {
           <AgentScopeLogo />
           <span>{t("nav.agentscopeTeam")}</span>
         </a>
+
+        <div>
+          <button
+            type="button"
+            className={`${navLinkOrangeClass} w-full cursor-pointer border-0 bg-transparent pt-2 text-left`}
+            aria-expanded={mobileBenefitsOpen}
+            onClick={() => setMobileBenefitsOpen((v) => !v)}
+          >
+            <CommunityBenefitsTriggerLabel open={mobileBenefitsOpen} />
+          </button>
+          {mobileBenefitsOpen && (
+            <CommunityBenefitsMobileList
+              onNavigate={() => {
+                setMobileBenefitsOpen(false);
+                setOpen(false);
+              }}
+            />
+          )}
+        </div>
+
         <button
           type="button"
           className={`${navLinkOrangeClass} w-full cursor-pointer border-0 bg-transparent text-left`}

--- a/website/src/components/NavCommunityBenefits.tsx
+++ b/website/src/components/NavCommunityBenefits.tsx
@@ -1,0 +1,152 @@
+import { ChevronDown } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export const COMMUNITY_BENEFITS_URL =
+  "https://opc.aliyun.com/qwenpaw?utm_content=g_1000415374";
+
+type BenefitItem = {
+  iconSrc: string;
+  titleKey: string;
+  descKey: string;
+};
+
+export const COMMUNITY_BENEFIT_ITEMS: BenefitItem[] = [
+  {
+    iconSrc:
+      "https://img.alicdn.com/imgextra/i4/O1CN01cyjRle1Rpn3G7SWPC_!!6000000002161-2-tps-96-96.png",
+    titleKey: "nav.benefit1Title",
+    descKey: "nav.benefit1Desc",
+  },
+  {
+    iconSrc:
+      "https://img.alicdn.com/imgextra/i3/O1CN010uwdvP27jZXKpjqty_!!6000000007833-2-tps-96-96.png",
+    titleKey: "nav.benefit2Title",
+    descKey: "nav.benefit2Desc",
+  },
+  {
+    iconSrc:
+      "https://img.alicdn.com/imgextra/i1/O1CN01yioNlX1QKMFpSOn3Z_!!6000000001957-2-tps-96-96.png",
+    titleKey: "nav.benefit3Title",
+    descKey: "nav.benefit3Desc",
+  },
+  {
+    iconSrc:
+      "https://img.alicdn.com/imgextra/i1/O1CN01Z8nE9K1X8B1xv3CtE_!!6000000002878-2-tps-96-96.png",
+    titleKey: "nav.benefit4Title",
+    descKey: "nav.benefit4Desc",
+  },
+];
+
+function BenefitIcon({ src }: { src: string }) {
+  return (
+    <img
+      src={src}
+      alt=""
+      width={36}
+      height={36}
+      className="size-9 shrink-0 object-contain"
+      aria-hidden
+    />
+  );
+}
+
+/** Desktop 2x2 megamenu panel. */
+export function CommunityBenefitsPanel({
+  onNavigate,
+}: {
+  onNavigate?: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="grid w-[min(36rem,calc(100vw-2rem))] grid-cols-2 gap-x-0 gap-y-1 p-3">
+      {COMMUNITY_BENEFIT_ITEMS.map((item) => (
+        <a
+          key={item.titleKey}
+          href={COMMUNITY_BENEFITS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onNavigate}
+          className="flex gap-3 rounded-lg px-3 py-3 no-underline transition-colors hover:bg-orange-50/70"
+        >
+          <BenefitIcon src={item.iconSrc} />
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold leading-snug text-neutral-900">
+              {t(item.titleKey)}
+            </span>
+            <span className="mt-0.5 block text-xs leading-snug text-neutral-500">
+              {t(item.descKey)}
+            </span>
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+/** Mobile accordion list of benefit links. */
+export function CommunityBenefitsMobileList({
+  onNavigate,
+}: {
+  onNavigate?: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mt-1 flex flex-col gap-1 rounded-xs bg-neutral-50 px-2 py-2">
+      {COMMUNITY_BENEFIT_ITEMS.map((item) => (
+        <a
+          key={item.titleKey}
+          href={COMMUNITY_BENEFITS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onNavigate}
+          className="flex gap-3 rounded-md px-2 py-2.5 no-underline transition-colors hover:bg-white"
+        >
+          <BenefitIcon src={item.iconSrc} />
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold leading-snug text-neutral-900">
+              {t(item.titleKey)}
+            </span>
+            <span className="mt-0.5 block text-xs leading-snug text-neutral-500">
+              {t(item.descKey)}
+            </span>
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export function CommunityBenefitsTriggerLabel({
+  open,
+  className = "",
+}: {
+  open?: boolean;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <span className={`inline-flex items-center whitespace-nowrap ${className}`}>
+      <span>{t("nav.communityBenefits")}</span>
+      <span className="relative inline-flex w-1 shrink-0 justify-center self-center">
+        <span
+          className="absolute bottom-full left-1/2 mb-3 -translate-x-1/2 whitespace-nowrap px-1 py-[3px] text-[9px] font-bold leading-none tracking-wide text-[#181818]"
+          style={{
+            borderRadius: "2.4px",
+            background: "linear-gradient(270deg, #f4e5c6 36%, #f6ded3 65%)",
+          }}
+        >
+          {t("nav.communityBenefitsNew")}
+        </span>
+      </span>
+      <ChevronDown
+        size={14}
+        strokeWidth={2}
+        aria-hidden
+        className={`transition-transform ${open ? "rotate-180" : ""}`}
+      />
+    </span>
+  );
+}

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -14,7 +14,7 @@
     "agentscopeTeam": "AgentScope",
     "communityBenefits": "Benefits",
     "communityBenefitsNew": "NEW",
-    "benefit1Title": "100M free tokens",
+    "benefit1Title": "ModelStudio: 100M free tokens",
     "benefit1Desc": "Check your free quota",
     "benefit2Title": "Token rebate",
     "benefit2Desc": "Up to ¥200 back",

--- a/website/src/i18n/locales/en.json
+++ b/website/src/i18n/locales/en.json
@@ -11,7 +11,17 @@
     "lang": "中文",
     "platform": "Platform",
     "platformTitle": "AgentScope Platform",
-    "agentscopeTeam": "AgentScope"
+    "agentscopeTeam": "AgentScope",
+    "communityBenefits": "Benefits",
+    "communityBenefitsNew": "NEW",
+    "benefit1Title": "100M free tokens",
+    "benefit1Desc": "Check your free quota",
+    "benefit2Title": "Token rebate",
+    "benefit2Desc": "Up to ¥200 back",
+    "benefit3Title": "Up to ¥1M tokens",
+    "benefit3Desc": "OPC innovation subsidy",
+    "benefit4Title": "Student subsidy",
+    "benefit4Desc": "¥50 credit · win iPhone 17"
   },
   "hero": {
     "titleleft": "Your Personal",

--- a/website/src/i18n/locales/zh.json
+++ b/website/src/i18n/locales/zh.json
@@ -11,7 +11,17 @@
     "lang": "ENG",
     "platform": "Platform",
     "platformTitle": "AgentScope 体验平台",
-    "agentscopeTeam": "AgentScope"
+    "agentscopeTeam": "AgentScope",
+    "communityBenefits": "社区福利",
+    "communityBenefitsNew": "NEW",
+    "benefit1Title": "百炼新客免费 1 亿 token",
+    "benefit1Desc": "点击查询我的免费额度",
+    "benefit2Title": "无门槛 Token 满返补贴",
+    "benefit2Desc": "个企同享新老同享，最高 200 元",
+    "benefit3Title": "最高 100 万元等额 Token",
+    "benefit3Desc": "OPC 创新助力，补贴权益升级",
+    "benefit4Title": "高校学生创新补贴",
+    "benefit4Desc": "50 元模型通兑，分享赢 iphone17"
   },
   "hero": {
     "titleleft": "欢迎使用你的",

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -275,6 +275,62 @@ button {
   line-height: 1.7;
 }
 
+.blog-related-card {
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.125rem;
+  border: 1px solid #dcc1b2;
+  border-radius: 0.75rem;
+  background: #fffaf6;
+}
+
+.blog-related-card__heading {
+  margin: 0 0 0.5rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text, #1a1a1a);
+}
+
+.blog-related-card__desc {
+  margin: 0.35rem 0 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--color-text-tertiary, #6b5e56);
+}
+
+.blog-related-card__list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.15rem;
+  list-style: disc;
+}
+
+.blog-related-card__list li {
+  margin: 0.4rem 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: var(--color-text-tertiary, #6b5e56);
+}
+
+.blog-related-card__item-label,
+.blog-related-card__item-name {
+  font-weight: 600;
+  color: var(--color-text, #1a1a1a);
+}
+
+.blog-related-card__link {
+  font-weight: 500;
+  color: var(--color-primary, #e36c2d);
+  text-decoration: none;
+}
+
+.blog-related-card__link:hover {
+  text-decoration: underline;
+}
+
+.blog-related-card__cta {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+}
+
 .blog-content hr {
   margin: 1rem 0 1.25rem;
   border: 0;

--- a/website/src/lib/parseBlogMarkdown.ts
+++ b/website/src/lib/parseBlogMarkdown.ts
@@ -1,5 +1,20 @@
 import yaml from "js-yaml";
 
+export interface BlogRelatedItem {
+  label: string;
+  name: string;
+  href?: string;
+  description?: string;
+}
+
+export interface BlogRelatedMeta {
+  heading: string;
+  description?: string;
+  linkText?: string;
+  linkUrl?: string;
+  items?: BlogRelatedItem[];
+}
+
 export interface BlogFrontmatter {
   title: string;
   date: string;
@@ -7,6 +22,7 @@ export interface BlogFrontmatter {
   tags: string[];
   cover?: string;
   excerpt?: string;
+  related?: BlogRelatedMeta;
 }
 
 export interface ParsedBlogPost {
@@ -62,6 +78,41 @@ function formatFrontmatterValue(value: unknown): string {
   return String(value);
 }
 
+function normalizeRelated(raw: unknown): BlogRelatedMeta | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const data = raw as Record<string, unknown>;
+  const heading = data.heading != null ? String(data.heading).trim() : "";
+  if (!heading) return undefined;
+
+  const itemsRaw = data.items;
+  const items: BlogRelatedItem[] = [];
+  if (Array.isArray(itemsRaw)) {
+    for (const entry of itemsRaw) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+      const item = entry as Record<string, unknown>;
+      const label = item.label != null ? String(item.label).trim() : "";
+      const name = item.name != null ? String(item.name).trim() : "";
+      if (!label || !name) continue;
+      items.push({
+        label,
+        name,
+        href: item.href != null ? String(item.href) : undefined,
+        description:
+          item.description != null ? String(item.description) : undefined,
+      });
+    }
+  }
+
+  return {
+    heading,
+    description:
+      data.description != null ? String(data.description) : undefined,
+    linkText: data.linkText != null ? String(data.linkText) : undefined,
+    linkUrl: data.linkUrl != null ? String(data.linkUrl) : undefined,
+    ...(items.length > 0 ? { items } : {}),
+  };
+}
+
 function normalizeFrontmatter(data: Record<string, unknown>): BlogFrontmatter {
   return {
     title: String(data.title ?? "Untitled"),
@@ -70,6 +121,7 @@ function normalizeFrontmatter(data: Record<string, unknown>): BlogFrontmatter {
     tags: normalizeTags(data.tags),
     cover: data.cover != null ? String(data.cover) : undefined,
     excerpt: data.excerpt != null ? String(data.excerpt) : undefined,
+    related: normalizeRelated(data.related),
   };
 }
 

--- a/website/src/pages/Blog/Post.tsx
+++ b/website/src/pages/Blog/Post.tsx
@@ -18,6 +18,7 @@ import { MermaidBlock } from "@/components/MermaidBlock";
 import { ImageZoom } from "@/components/ImageZoom";
 import { trackBlogPostView } from "@/lib/analytics";
 import { BlogEngagement } from "@/components/BlogEngagement";
+import { BlogRelatedCard } from "@/components/BlogRelatedCard";
 
 /** Turn plain "Meeting link: https://…" lines into markdown links for session lists. */
 function linkifySessionUrls(body: string): string {
@@ -243,6 +244,10 @@ export default function BlogPost() {
           </p>
           {slug ? <BlogEngagement slug={slug} /> : null}
         </header>
+
+        {frontmatter.related ? (
+          <BlogRelatedCard related={frontmatter.related} />
+        ) : null}
 
         <div
           className={`docs-content blog-content${


### PR DESCRIPTION
## Description

Improve the website navigation and blog experience:

- Add a **Community Benefits** nav entry with `NEW` badge, desktop hover/click megamenu, and mobile accordion
- Link all benefit items to `https://opc.aliyun.com/qwenpaw?utm_content=g_1000415374`
- Add tablet/iPad overflow via a `...` menu so nav items no longer wrap/overflow
- Update blog post tags (ZH/EN) per content guidelines
- Add frontmatter-driven **related plugin/skill** meta cards for PawGit and Play with QwenPaw-Pet (no HTML in markdown)

**Related Issue:** Relates to website nav / blog content updates

**Security Considerations:** N/A — external links only (`noopener noreferrer`)

## Type of Change

- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Documentation (website)
- [ ] Core / Backend
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

1. Open the website homepage and verify **Community Benefits / 社区福利** appears in nav
2. Desktop: hover/click opens the 2x2 panel; mouse leave / Esc / outside click closes it
3. Mobile: expand/collapse benefits list; links open the OPC page
4. Resize to iPad width (~768–1100px): overflow items appear under `...`
5. Switch EN/ZH and confirm shorter English labels + Chinese copy
6. Open `/blog` and confirm updated tags
7. Open PawGit and Play with QwenPaw-Pet posts and confirm related meta cards render from frontmatter

## Evidence

Manually verified:

- Community Benefits dropdown/accordion works on desktop and mobile
- iPad-width nav uses `...` overflow instead of wrapping “社区福利”
- Blog tags updated across ZH/EN markdown frontmatter
- Related cards for PawGit / QwenPaw-Pet render via `related` frontmatter + `BlogRelatedCard` (no `<div class="blog-related-card">` in markdown)

## Additional Notes

Commit: `5ff4d4ff` — `fix: blog opt, add benefits`
<img width="2850" height="1208" alt="image" src="https://github.com/user-attachments/assets/19a7ad03-46fc-4ab8-b227-6d9449854ac2" />
<img width="2398" height="1442" alt="image" src="https://github.com/user-attachments/assets/2795fddb-ff02-4369-bddd-652f9444ec46" />

