### PR TITLE
fix(chat): preserve whitespace in streaming thinking/text deltas

### DIFF
--- a/console/src/pages/Chat/headlineFilter.test.ts
+++ b/console/src/pages/Chat/headlineFilter.test.ts
@@ -81,4 +81,33 @@ describe("headline stream filter", () => {
     expect(payload.nested.delta).toContain("streamed headline remains");
     expect(payload.nested.content.text).toBe("visible");
   });
+
+  it("preserves boundary whitespace in streaming text deltas (issue #6129)", () => {
+    // A streaming reasoning/text delta chunk carries `delta: true`. Trimming
+    // each chunk would drop the spaces and line feeds that sit at chunk
+    // boundaries, so thinking blocks look glued together while streaming.
+    const payload = {
+      object: "content",
+      type: "text",
+      delta: true,
+      text: " think ",
+    };
+
+    stripScrollHeadlineTextBlocks(payload);
+
+    expect(payload.text).toBe(" think ");
+  });
+
+  it("preserves newline-only streaming deltas (issue #6129)", () => {
+    const payload = {
+      object: "content",
+      type: "text",
+      delta: true,
+      text: "\n\n",
+    };
+
+    stripScrollHeadlineTextBlocks(payload);
+
+    expect(payload.text).toBe("\n\n");
+  });
 });

--- a/console/src/pages/Chat/headlineFilter.ts
+++ b/console/src/pages/Chat/headlineFilter.ts
@@ -28,7 +28,16 @@ export function stripScrollHeadlineTextBlocks(node: unknown): void {
   }
 
   const record = node as Record<string, unknown>;
-  if (record.type === "text" && typeof record.text === "string") {
+  // Only mutate finalized text blocks. Streaming deltas (delta === true)
+  // must stay verbatim: trimming each chunk would drop the spaces and line
+  // feeds that sit at chunk boundaries, gluing thinking/text together while
+  // streaming (issue #6129). Their headline markers are handled by
+  // filterHeadlineDelta and re-stripped from the canonical completed block.
+  if (
+    record.type === "text" &&
+    typeof record.text === "string" &&
+    record.delta !== true
+  ) {
     record.text = stripScrollHeadlines(record.text);
   }
   Object.values(record).forEach(stripScrollHeadlineTextBlocks);


### PR DESCRIPTION
stripScrollHeadlineTextBlocks trimmed every text block including streaming delta chunks, dropping spaces and line feeds at chunk boundaries. This made thinking blocks appear glued together while streaming, though they rendered correctly once completed. Skip delta blocks (delta === true) so streaming chunks stay verbatim, matching the function's documented intent.

Fixes #6129
<img width="2558" height="1227" alt="image" src="https://github.com/user-attachments/assets/df795744-f955-4715-8961-54002094d65f" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
