### PR TITLE
fix(channels): bound unbounded state and track fire-and-forget tasks to prevent memory leaks

### DIFF
--- a/src/qwenpaw/app/channels/mattermost/channel.py
+++ b/src/qwenpaw/app/channels/mattermost/channel.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import uuid
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -35,6 +36,12 @@ MATTERMOST_POST_CHUNK_SIZE = 4000  # chars per post (hard limit ~16383)
 
 _DEFAULT_MEDIA_DIR = WORKING_DIR / "media" / "mattermost"
 _TYPING_TIMEOUT_S = 180
+
+# Hard cap on concurrently-tracked event handlers (flood protection).
+_EVENT_TASK_HARD_CAP = 500
+# Upper bounds for the lazy-context tracking maps (prevent unbounded growth).
+_SEEN_SESSIONS_MAX = 10000
+_PARTICIPATED_THREADS_MAX = 10000
 
 _IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
 _AUDIO_SUFFIXES = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".flac"}
@@ -157,8 +164,10 @@ class MattermostChannel(BaseChannel):
         self._bot_username: str = ""
         self._task: Optional[asyncio.Task] = None
         self._typing_tasks: dict[str, asyncio.Task] = {}
-        self._participated_threads: set[str] = set()
-        self._seen_sessions: set[str] = set()
+        self._participated_threads: "OrderedDict[str, None]" = OrderedDict()
+        self._seen_sessions: "OrderedDict[str, None]" = OrderedDict()
+        # Fire-and-forget event handlers, tracked so stop() can cancel them.
+        self._event_tasks: set[asyncio.Task] = set()
 
         # Reuse a single HTTP client (BaseChannel._http field)
         # Only Authorization header — Content-Type is set per-request by httpx
@@ -181,6 +190,36 @@ class MattermostChannel(BaseChannel):
     # ------------------------------------------------------------------
     # Construction helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _bounded_add(
+        store: "OrderedDict[str, None]",
+        key: str,
+        max_items: int,
+    ) -> None:
+        """Add *key* to an OrderedDict-backed set, evicting oldest over cap."""
+        store[key] = None
+        store.move_to_end(key)
+        while len(store) > max_items:
+            store.popitem(last=False)
+
+    def _spawn_event_task(self, coro) -> None:
+        """Schedule a tracked background event handler with a hard cap.
+
+        Under a message flood the cap prevents unbounded task accumulation;
+        excess events are dropped with a warning. Tracked tasks are cancelled
+        on stop().
+        """
+        if len(self._event_tasks) >= _EVENT_TASK_HARD_CAP:
+            logger.warning(
+                "mattermost: event task cap (%d) reached — dropping event",
+                _EVENT_TASK_HARD_CAP,
+            )
+            coro.close()
+            return
+        task = asyncio.create_task(coro)
+        self._event_tasks.add(task)
+        task.add_done_callback(self._event_tasks.discard)
 
     @classmethod
     def from_config(
@@ -312,6 +351,8 @@ class MattermostChannel(BaseChannel):
             return
         for cid in list(self._typing_tasks):
             self._stop_typing(cid)
+        # Stop the websocket loop first so it can no longer spawn new
+        # event handlers, then drain the in-flight ones.
         if self._task:
             self._task.cancel()
             try:
@@ -319,6 +360,11 @@ class MattermostChannel(BaseChannel):
             except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
                 pass
             self._task = None
+        for task in list(self._event_tasks):
+            task.cancel()
+        if self._event_tasks:
+            await asyncio.gather(*self._event_tasks, return_exceptions=True)
+        self._event_tasks.clear()
         try:
             await self._http.aclose()
         except Exception:
@@ -396,7 +442,9 @@ class MattermostChannel(BaseChannel):
                     async for raw in ws:
                         data = json.loads(raw)
                         if data.get("event") == "posted":
-                            asyncio.create_task(self._on_posted_event(data))
+                            self._spawn_event_task(
+                                self._on_posted_event(data),
+                            )
 
             except asyncio.CancelledError:
                 logger.debug("mattermost: websocket loop cancelled")
@@ -447,7 +495,11 @@ class MattermostChannel(BaseChannel):
         """Fetch history context if needed."""
         if is_dm:
             if session_id not in self._seen_sessions:
-                self._seen_sessions.add(session_id)
+                self._bounded_add(
+                    self._seen_sessions,
+                    session_id,
+                    _SEEN_SESSIONS_MAX,
+                )
                 logger.info(
                     "mattermost: first DM contact on %s — "
                     "fetching channel history",
@@ -462,7 +514,11 @@ class MattermostChannel(BaseChannel):
             )
         else:
             if session_id not in self._seen_sessions:
-                self._seen_sessions.add(session_id)
+                self._bounded_add(
+                    self._seen_sessions,
+                    session_id,
+                    _SEEN_SESSIONS_MAX,
+                )
                 logger.info(
                     "mattermost: new thread on %s — "
                     "fetching channel history as background",
@@ -607,7 +663,11 @@ class MattermostChannel(BaseChannel):
 
         # 10. Record thread participation
         if target_root_id:
-            self._participated_threads.add(target_root_id)
+            self._bounded_add(
+                self._participated_threads,
+                target_root_id,
+                _PARTICIPATED_THREADS_MAX,
+            )
 
     # ------------------------------------------------------------------
     # ------------------------------------------------------------------

--- a/src/qwenpaw/app/channels/onebot/channel.py
+++ b/src/qwenpaw/app/channels/onebot/channel.py
@@ -43,6 +43,9 @@ from ..utils import split_text
 
 logger = logging.getLogger(__name__)
 
+# Hard cap on concurrently-tracked event handlers (flood protection).
+_EVENT_TASK_HARD_CAP = 500
+
 
 class OneBotChannel(BaseChannel):
     """OneBot v11 channel via reverse WebSocket.
@@ -106,6 +109,9 @@ class OneBotChannel(BaseChannel):
 
         # Echo-based API call tracking
         self._pending_calls: Dict[str, asyncio.Future] = {}
+
+        # Fire-and-forget event handlers, tracked so stop() can cancel them.
+        self._event_tasks: Set[asyncio.Task] = set()
 
         # Bot self ID (populated on first meta_event/lifecycle)
         self._self_id: Optional[int] = None
@@ -247,6 +253,12 @@ class OneBotChannel(BaseChannel):
                 pass
             self._watchdog_task = None
         await self._stop_ws_server()
+        # Cancel any in-flight event handlers.
+        for task in list(self._event_tasks):
+            task.cancel()
+        if self._event_tasks:
+            await asyncio.gather(*self._event_tasks, return_exceptions=True)
+            self._event_tasks.clear()
 
     async def _start_ws_server(self) -> None:
         """Create and start the aiohttp WebSocket server.
@@ -422,7 +434,7 @@ class OneBotChannel(BaseChannel):
                         # Dispatch as background task so the WS read
                         # loop stays unblocked — handlers can freely
                         # await _call_api (e.g. resolve file URLs).
-                        asyncio.create_task(self._handle_event(data))
+                        self._spawn_event_task(self._handle_event(data))
                 elif msg.type in (
                     aiohttp.WSMsgType.ERROR,
                     aiohttp.WSMsgType.CLOSE,
@@ -439,6 +451,28 @@ class OneBotChannel(BaseChannel):
     # ------------------------------------------------------------------
     # Event dispatch
     # ------------------------------------------------------------------
+
+    def _spawn_event_task(self, coro) -> None:
+        """Schedule a tracked background event handler with a hard cap.
+
+        Under a message flood the cap prevents unbounded task accumulation;
+        excess events are dropped with a warning. Tracked tasks are cancelled
+        on stop().
+
+        Note: we must not block the WS read loop here — ``_call_api`` awaits
+        echo responses that arrive through the same loop, so a blocking
+        semaphore would deadlock. A drop-on-cap valve is used instead.
+        """
+        if len(self._event_tasks) >= _EVENT_TASK_HARD_CAP:
+            logger.warning(
+                "onebot: event task cap (%d) reached — dropping event",
+                _EVENT_TASK_HARD_CAP,
+            )
+            coro.close()
+            return
+        task = asyncio.create_task(coro)
+        self._event_tasks.add(task)
+        task.add_done_callback(self._event_tasks.discard)
 
     async def _handle_event(self, data: Dict[str, Any]) -> None:
         """Dispatch an OneBot v11 event."""

--- a/src/qwenpaw/app/channels/xiaoyi/channel.py
+++ b/src/qwenpaw/app/channels/xiaoyi/channel.py
@@ -14,6 +14,7 @@ import platform
 import re
 import time
 import uuid
+from collections import OrderedDict
 from pathlib import Path
 from typing import (
     Any,
@@ -57,6 +58,9 @@ from .constants import (
 from .utils import download_file
 
 logger = logging.getLogger(__name__)
+
+# Upper bound for per-session routing maps to prevent unbounded growth.
+_SESSION_MAP_MAX = 4096
 
 if TYPE_CHECKING:
     from ....schemas import AgentRequest
@@ -407,11 +411,13 @@ class XiaoYiChannel(BaseChannel):
         self._connected = False
         self._reconnect_attempts = 0
         self._stopping = False  # Flag to prevent reconnect during stop
+        # In-flight reconnect task, tracked so stop() can cancel it.
+        self._reconnect_task: Optional[asyncio.Task] = None
 
-        # Session routing: session_id -> server_name
-        self._session_server_map: Dict[str, str] = {}
-        # Session -> task_id mapping
-        self._session_task_map: Dict[str, str] = {}
+        # Session routing: session_id -> server_name (bounded)
+        self._session_server_map: "OrderedDict[str, str]" = OrderedDict()
+        # Session -> task_id mapping (bounded)
+        self._session_task_map: "OrderedDict[str, str]" = OrderedDict()
 
     @classmethod
     def from_env(
@@ -712,6 +718,19 @@ class XiaoYiChannel(BaseChannel):
                     f"agent_id={self.agent_id}",
                 )
 
+    @staticmethod
+    def _bounded_map_put(
+        store: "OrderedDict[str, str]",
+        key: str,
+        value: str,
+        max_items: int = _SESSION_MAP_MAX,
+    ) -> None:
+        """Set store[key]=value, evicting oldest entries beyond max_items."""
+        store[key] = value
+        store.move_to_end(key)
+        while len(store) > max_items:
+            store.popitem(last=False)
+
     # -----------------------------------------------------------------
     # Message routing (dual connection)
     # -----------------------------------------------------------------
@@ -745,7 +764,11 @@ class XiaoYiChannel(BaseChannel):
                 "sessionId",
             ) or message.get("sessionId")
             if session_id:
-                self._session_server_map[session_id] = server_name
+                self._bounded_map_put(
+                    self._session_server_map,
+                    session_id,
+                    server_name,
+                )
 
             # Handle clear context
             if (
@@ -830,7 +853,11 @@ class XiaoYiChannel(BaseChannel):
                 logger.warning("XiaoYi: No sessionId in message")
                 return
 
-            self._session_task_map[session_id] = task_id
+            self._bounded_map_put(
+                self._session_task_map,
+                session_id,
+                task_id or "",
+            )
 
             # Extract content parts
             text_parts: List[str] = []
@@ -1037,7 +1064,7 @@ class XiaoYiChannel(BaseChannel):
                 logger.error(f"XiaoYi: Reconnect failed: {e}")
                 self._schedule_reconnect()
 
-        asyncio.create_task(reconnect())
+        self._reconnect_task = asyncio.create_task(reconnect())
 
     async def stop(self) -> None:
         """Stop WebSocket connections."""
@@ -1045,6 +1072,15 @@ class XiaoYiChannel(BaseChannel):
 
         self._stopping = True  # Prevent reconnect during stop
         self._connected = False
+
+        # Cancel any in-flight reconnect task.
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except asyncio.CancelledError:
+                pass
+        self._reconnect_task = None
 
         # Disconnect both connections
         for conn in (self._conn_primary, self._conn_backup):

--- a/tests/unit/channels/test_mattermost.py
+++ b/tests/unit/channels/test_mattermost.py
@@ -344,10 +344,14 @@ class TestMattermostChannelInit:
 
         assert hasattr(channel, "_typing_tasks")
         assert isinstance(channel._typing_tasks, dict)
+        # Bounded OrderedDict-backed sets (FIFO eviction) prevent unbounded
+        # growth of the lazy-context tracking maps.
+        from collections import OrderedDict
+
         assert hasattr(channel, "_participated_threads")
-        assert isinstance(channel._participated_threads, set)
+        assert isinstance(channel._participated_threads, OrderedDict)
         assert hasattr(channel, "_seen_sessions")
-        assert isinstance(channel._seen_sessions, set)
+        assert isinstance(channel._seen_sessions, OrderedDict)
         assert channel._bot_id == ""
         assert channel._bot_username == ""
 
@@ -1372,7 +1376,7 @@ class TestMattermostIsTriggered:
         """Should trigger on thread participation."""
         mattermost_channel._bot_id = "bot_123"
         mattermost_channel._thread_follow = True
-        mattermost_channel._participated_threads.add("thread_abc")
+        mattermost_channel._participated_threads["thread_abc"] = None
 
         post = {
             "user_id": "user_abc",
@@ -1487,7 +1491,7 @@ class TestMattermostGetContextPrefix:
     @pytest.mark.asyncio
     async def test_get_context_prefix_cached_session(self, mattermost_channel):
         """Should return empty string for cached session."""
-        mattermost_channel._seen_sessions.add("mattermost_dm:dm_123")
+        mattermost_channel._seen_sessions["mattermost_dm:dm_123"] = None
 
         result = await mattermost_channel._get_context_prefix(
             session_id="mattermost_dm:dm_123",


### PR DESCRIPTION
## Description

Fixes several unbounded-growth / leaked-task issues in the Mattermost, OneBot,
and XiaoYi channels that could slowly accumulate memory or leave dangling
tasks on shutdown during long-running operation.

- **Mattermost**
  - `_seen_sessions` / `_participated_threads`: `set` → bounded `OrderedDict`
    (LRU, FIFO eviction, cap 10000) via a local `_bounded_add` helper.
  - `_on_posted_event`: the fire-and-forget `asyncio.create_task` is now tracked
    via `_spawn_event_task` (tracked set + hard cap 500 + cancel on `stop()`).
  - `stop()`: reordered to stop the WebSocket loop *before* draining in-flight
    event handlers, avoiding a shutdown race where a newly-spawned task could be
    dropped from tracking without being cancelled.

- **OneBot**
  - `_handle_event`: fire-and-forget task now tracked via `_spawn_event_task`
    (tracked set + hard cap 500 + cancel on `stop()`). A blocking semaphore is
    deliberately avoided because `_call_api` awaits echo responses on the same
    read loop and would deadlock; a drop-on-cap valve is used instead.

- **XiaoYi**
  - Reconnect task is now stored as `self._reconnect_task` and cancelled in
    `stop()` (previously untracked and uncancellable).
  - `_session_server_map` / `_session_task_map`: `dict` → bounded `OrderedDict`
    (LRU, cap 4096) via a local `_bounded_map_put` helper — these grew per
    session with no eviction on the normal path.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
