### PR TITLE
fix(browser): add MAX_WAITTIME for browser use

### DIFF
--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 _MAX_DIRECT_URL_DOWNLOAD_BYTES = 10 * 1024 * 1024
 _CDP_CONNECT_TIMEOUT_SECONDS = 30.0
 _BROWSER_CLEANUP_TIMEOUT_SECONDS = 5.0
-MAX_WAITTIME = 60.0
+_MAX_WAITTIME = 60.0
 _HEADLESS_VERIFICATION_WARNING = (
     "Headless browser launches are more likely to trigger verification. "
     "If verification appears, call browser_use with action='stop' to stop "
@@ -2290,7 +2290,14 @@ async def _action_click(  # pylint: disable=too-many-branches,too-many-return-st
         )
     try:
         if wait > 0:
-            await asyncio.sleep(min(wait / 1000.0, MAX_WAITTIME))
+            wait_secs = wait / 1000.0
+            if wait_secs > _MAX_WAITTIME:
+                logger.warning(
+                    "click wait %.1fs exceeds _MAX_WAITTIME %.1fs, capping",
+                    wait_secs,
+                    _MAX_WAITTIME,
+                )
+            await asyncio.sleep(min(wait_secs, _MAX_WAITTIME))
         mods = _parse_json_param(modifiers_json, [])
         if not isinstance(mods, list):
             mods = []
@@ -4147,12 +4154,12 @@ async def _action_wait_for(
         )
     try:
         if wait_time and wait_time > 0:
-            capped_wait = min(float(wait_time), MAX_WAITTIME)
+            capped_wait = min(float(wait_time), _MAX_WAITTIME)
             if capped_wait < wait_time:
                 logger.warning(
-                    "wait_for wait_time %.1fs exceeds MAX_WAITTIME %.1fs, capping",
+                    "wait_for wait_time %.1fs exceeds _MAX_WAITTIME %.1fs, capping",
                     wait_time,
-                    MAX_WAITTIME,
+                    _MAX_WAITTIME,
                 )
             await asyncio.sleep(capped_wait)
         text = (text or "").strip()
@@ -4569,7 +4576,13 @@ async def _action_batch(  # pylint: disable=too-many-nested-blocks
 
         # Post-action wait
         if sub_wait > 0:
-            await asyncio.sleep(min(float(sub_wait), MAX_WAITTIME))
+            if float(sub_wait) > _MAX_WAITTIME:
+                logger.warning(
+                    "batch wait %.1fs exceeds _MAX_WAITTIME %.1fs, capping",
+                    float(sub_wait),
+                    _MAX_WAITTIME,
+                )
+            await asyncio.sleep(min(float(sub_wait), _MAX_WAITTIME))
 
     completed = sum(1 for r in results if r.get("ok"))
     all_ok = completed == len(results)
@@ -5039,7 +5052,7 @@ async def browser_use(  # pylint: disable=R0911,R0912
             Seconds to wait. Used with action=wait_for and as the download
             event timeout for action=file_download. Defaults to 30 seconds for
             file_download when omitted. For action=wait_for it is capped at
-            60 seconds (MAX_WAITTIME) to avoid blocking the agent.
+            60 seconds (_MAX_WAITTIME) to avoid blocking the agent.
         text_gone (str):
             Wait until this text disappears from page. Used with
             action=wait_for.

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -50,6 +50,7 @@ logger = logging.getLogger(__name__)
 _MAX_DIRECT_URL_DOWNLOAD_BYTES = 10 * 1024 * 1024
 _CDP_CONNECT_TIMEOUT_SECONDS = 30.0
 _BROWSER_CLEANUP_TIMEOUT_SECONDS = 5.0
+MAX_WAITTIME = 60.0
 _HEADLESS_VERIFICATION_WARNING = (
     "Headless browser launches are more likely to trigger verification. "
     "If verification appears, call browser_use with action='stop' to stop "
@@ -2289,7 +2290,7 @@ async def _action_click(  # pylint: disable=too-many-branches,too-many-return-st
         )
     try:
         if wait > 0:
-            await asyncio.sleep(wait / 1000.0)
+            await asyncio.sleep(min(wait / 1000.0, MAX_WAITTIME))
         mods = _parse_json_param(modifiers_json, [])
         if not isinstance(mods, list):
             mods = []
@@ -4146,7 +4147,14 @@ async def _action_wait_for(
         )
     try:
         if wait_time and wait_time > 0:
-            await asyncio.sleep(wait_time)
+            capped_wait = min(float(wait_time), MAX_WAITTIME)
+            if capped_wait < wait_time:
+                logger.warning(
+                    "wait_for wait_time %.1fs exceeds MAX_WAITTIME %.1fs, capping",
+                    wait_time,
+                    MAX_WAITTIME,
+                )
+            await asyncio.sleep(capped_wait)
         text = (text or "").strip()
         text_gone = (text_gone or "").strip()
         if text:
@@ -4561,7 +4569,7 @@ async def _action_batch(  # pylint: disable=too-many-nested-blocks
 
         # Post-action wait
         if sub_wait > 0:
-            await asyncio.sleep(sub_wait)
+            await asyncio.sleep(min(float(sub_wait), MAX_WAITTIME))
 
     completed = sum(1 for r in results if r.get("ok"))
     all_ok = completed == len(results)
@@ -5030,7 +5038,8 @@ async def browser_use(  # pylint: disable=R0911,R0912
         wait_time (float):
             Seconds to wait. Used with action=wait_for and as the download
             event timeout for action=file_download. Defaults to 30 seconds for
-            file_download when omitted.
+            file_download when omitted. For action=wait_for it is capped at
+            60 seconds (MAX_WAITTIME) to avoid blocking the agent.
         text_gone (str):
             Wait until this text disappears from page. Used with
             action=wait_for.


### PR DESCRIPTION
## Description

The browser automation tool (`browser_control.py`) passed model-supplied wait durations directly into `asyncio.sleep()` with no upper bound. If the model misused `wait_time` (or the batch `wait` / pre-click `wait`) and passed a very large value, the agent would block for an arbitrarily long time.

This PR introduces a `MAX_WAITTIME = 60.0` (seconds) cap and clamps every blocking wait to it:

- `_action_wait_for` (`action=wait_for`) — clamps `wait_time`, and logs a warning when a value is capped.
- `_action_batch` — clamps the post-action `sub_wait`.
- `_action_click` — clamps the pre-click `wait` (milliseconds).

`file_download`'s `wait_time` is intentionally left unchanged: it is a genuine download-event timeout rather than a blocking sleep, so it should stay uncapped.

The docstring for `wait_time` was updated to document the 60-second cap for `action=wait_for`.

**Related Issue:** N/A

**Security Considerations:** None. Change only bounds a wait duration; no auth, env, or config handling is affected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

- Call `browser_use` with `action=wait_for` and a large `wait_time` (e.g.
  `100000`); confirm the wait is capped at 60s and a "capping" warning is
  logged.
- Verify normal values (e.g. `wait_time=5`) still wait the exact amount.
- Verify batch `wait` and pre-click `wait` values above 60s are clamped.
- Verify `file_download` still uses its full (uncapped) `wait_time` timeout.

## Evidence

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

`MAX_WAITTIME` is defined as a module-level constant next to the other browser
timeout constants so it can be reused/adjusted in one place.
