### PR TITLE
fix(agents): validate repaired tool inputs before execution

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -15,12 +15,16 @@ Currently provided:
 """
 
 import asyncio
+import json
 import logging
+import re
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Set
 
 from agentscope.middleware import MiddlewareBase
-from agentscope.message import Msg
+from agentscope.message import Msg, TextBlock, ToolResultState
 from agentscope.tool import ToolResponse
+from json_repair import repair_json
+import jsonschema
 
 from .tools.utils import (
     DEFAULT_MAX_BYTES,
@@ -37,6 +41,192 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 MAX_AUTO_MEMORY_TURN_MARKERS = 1000
 _AUTOMATION_MEMORY_SKIP_SOURCES = frozenset({"cron", "heartbeat"})
+
+_EXECUTABLE_ARGUMENT_KEYS = frozenset(
+    {"command", "script", "code", "content", "patch", "sql"},
+)
+_SHELL_ARGUMENT_KEYS = frozenset({"command", "shell_command"})
+_HEREDOC_START_RE = re.compile(
+    r"<<-?\s*(?P<quote>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)",
+)
+
+
+def _contains_executable_argument(value: Any) -> bool:
+    """Return whether repaired arguments contain executable/large payloads."""
+    if isinstance(value, dict):
+        return any(
+            str(key).lower() in _EXECUTABLE_ARGUMENT_KEYS
+            or _contains_executable_argument(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_executable_argument(item) for item in value)
+    return False
+
+
+def _incomplete_heredoc(  # pylint: disable=too-many-return-statements
+    value: Any,
+    inspect_string: bool = False,
+) -> str | None:
+    """Return a missing heredoc terminator found in nested arguments."""
+    if isinstance(value, dict):
+        for key, item in value.items():
+            missing = _incomplete_heredoc(
+                item,
+                str(key).lower() in _SHELL_ARGUMENT_KEYS,
+            )
+            if missing:
+                return missing
+        return None
+    if isinstance(value, list):
+        for item in value:
+            missing = _incomplete_heredoc(item, inspect_string)
+            if missing:
+                return missing
+        return None
+    if not inspect_string or not isinstance(value, str):
+        return None
+    for match in _HEREDOC_START_RE.finditer(value):
+        tag = match.group("tag")
+        remaining_lines = value[match.end() :].splitlines()
+        if not any(line.strip() == tag for line in remaining_lines):
+            return tag
+    return None
+
+
+def _repair_tool_call_input(
+    raw: str,
+    schema: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str]:
+    """Parse and safely repair tool input, returning an error when unsafe."""
+    decode_error: json.JSONDecodeError | None = None
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            return None, "tool arguments must decode to a JSON object"
+    except json.JSONDecodeError as exc:
+        decode_error = exc
+
+        try:
+            parsed = repair_json(
+                raw,
+                return_objects=True,
+                stream_stable=True,
+                schema=schema,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            parsed = None
+        if not isinstance(parsed, dict):
+            return None, (
+                f"{decode_error.msg} at character {decode_error.pos}; "
+                "automatic repair did not produce a JSON object"
+            )
+
+    # json_repair deliberately closes unterminated strings.  For commands,
+    # source code and file bodies that can turn a truncated stream into a
+    # different, executable payload.  Keep repair for ordinary syntax errors,
+    # but reject this one ambiguity instead of executing partial content.
+    if (
+        decode_error is not None
+        and "unterminated string" in decode_error.msg.lower()
+        and _contains_executable_argument(parsed)
+    ):
+        return None, (
+            f"{decode_error.msg} at character {decode_error.pos}; "
+            "an executable or file-content argument may be truncated"
+        )
+
+    missing_tag = _incomplete_heredoc(parsed)
+    if missing_tag:
+        return None, (
+            "repaired command contains an unterminated heredoc "
+            f"({missing_tag})"
+        )
+    return parsed, ""
+
+
+class ToolCallInputRepairMiddleware(MiddlewareBase):
+    """Repair model tool JSON before execution and persist canonical input."""
+
+    async def on_acting(
+        self,
+        agent: "Agent",
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        tool_call = input_kwargs.get("tool_call")
+        raw = getattr(tool_call, "input", None)
+        if not isinstance(raw, str):
+            async for event in next_handler(**input_kwargs):
+                yield event
+            return
+
+        schema = None
+        toolkit = getattr(agent, "toolkit", None)
+        if toolkit is not None:
+            activated_groups = getattr(
+                getattr(getattr(agent, "state", None), "tool_context", None),
+                "activated_groups",
+                None,
+            )
+            tool = await toolkit.check_tool_available(
+                getattr(tool_call, "name", ""),
+                activated_groups,
+            )
+            schema = tool.input_schema
+
+        parsed, error = _repair_tool_call_input(raw, schema)
+        if parsed is not None and schema:
+            try:
+                jsonschema.validate(parsed, schema)
+            except jsonschema.ValidationError as exc:
+                parsed = None
+                error = (
+                    "repaired arguments failed schema validation: "
+                    f"{exc.message}"
+                )
+        if parsed is None:
+            tool_name = str(getattr(tool_call, "name", "unknown"))
+            # Keep the rejected call/result pair valid for history formatters.
+            tool_call.input = "{}"
+            logger.warning(
+                "Rejected unsafe repaired tool input: tool=%r id=%r "
+                "input_length=%d reason=%s",
+                tool_name,
+                getattr(tool_call, "id", None),
+                len(raw),
+                error,
+            )
+            yield ToolResponse(
+                content=[
+                    TextBlock(
+                        type="text",
+                        text=(
+                            f"Tool call `{tool_name}` was not executed: "
+                            f"{error}. Retry with complete JSON arguments; "
+                            "split large payloads into smaller calls."
+                        ),
+                    ),
+                ],
+                state=ToolResultState.ERROR,
+                metadata={"tool_input_validation": "rejected"},
+            )
+            return
+
+        canonical = json.dumps(parsed, ensure_ascii=False)
+        if canonical != raw:
+            logger.info(
+                "Repaired tool-call JSON before execution: tool=%r id=%r "
+                "input_length=%d repaired_length=%d",
+                getattr(tool_call, "name", None),
+                getattr(tool_call, "id", None),
+                len(raw),
+                len(canonical),
+            )
+            tool_call.input = canonical
+
+        async for event in next_handler(**input_kwargs):
+            yield event
 
 
 class MemoryMiddleware(MiddlewareBase):

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -910,11 +910,14 @@ class AgentBuilder:
         """Build middleware list.
 
         Order (onion model, outermost first):
-        1. ToolResultPruningMiddleware — tiered tool result pruning
-        2. ToolCoordinatorMiddleware — tool call lifecycle management
-        3. Plugin-registered middlewares (sorted by priority)
+        1. ToolCallInputRepairMiddleware — validate/repair before execution
+        2. ToolResultPruningMiddleware — tiered tool result pruning
+        3. ToolCoordinatorMiddleware — tool call lifecycle management
+        4. Plugin-registered middlewares (sorted by priority)
         """
-        mws: list[Any] = []
+        from ..agents.middlewares import ToolCallInputRepairMiddleware
+
+        mws: list[Any] = [ToolCallInputRepairMiddleware()]
 
         pruning_middleware = None
         try:

--- a/tests/unit/agents/test_tool_call_input_repair_middleware.py
+++ b/tests/unit/agents/test_tool_call_input_repair_middleware.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Tests for execution-time tool-call JSON repair and validation."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from agentscope.message import ToolCallBlock, ToolResultState
+from agentscope.tool import ToolResponse
+
+from qwenpaw.agents.middlewares import ToolCallInputRepairMiddleware
+
+
+async def _run_middleware(raw: str, *, name: str = "write_file"):
+    middleware = ToolCallInputRepairMiddleware()
+    tool_call = ToolCallBlock(
+        id="call-1",
+        name=name,
+        input=raw,
+    )
+    observed = []
+
+    async def downstream(**kwargs):
+        observed.append(kwargs["tool_call"].input)
+        yield ToolResponse()
+
+    events = [
+        event
+        async for event in middleware.on_acting(
+            SimpleNamespace(),
+            {"tool_call": tool_call},
+            downstream,
+        )
+    ]
+    return tool_call, observed, events
+
+
+@pytest.mark.asyncio
+async def test_repairs_format_only_error_and_persists_canonical_input():
+    tool_call, observed, events = await _run_middleware(
+        "{'file_path': 'report.txt', 'content': 'complete',}",
+    )
+
+    assert json.loads(tool_call.input) == {
+        "file_path": "report.txt",
+        "content": "complete",
+    }
+    assert observed == [tool_call.input]
+    assert events[0].state == ToolResultState.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_repairs_large_complete_content():
+    content = "large payload\n" * 5000
+    raw = (
+        json.dumps(
+            {"file_path": "report.txt", "content": content},
+            ensure_ascii=False,
+        )[:-1]
+        + ",}"
+    )
+
+    tool_call, observed, _ = await _run_middleware(raw)
+
+    assert json.loads(tool_call.input)["content"] == content
+    assert observed == [tool_call.input]
+
+
+@pytest.mark.asyncio
+async def test_rejects_repair_that_closes_truncated_file_content():
+    raw = '{"file_path":"report.py","content":"print(123)'
+
+    tool_call, observed, events = await _run_middleware(raw)
+
+    assert tool_call.input == "{}"
+    assert observed == []
+    assert events[0].state == ToolResultState.ERROR
+    assert "may be truncated" in events[0].content[0].text
+
+
+@pytest.mark.asyncio
+async def test_rejects_command_with_unterminated_heredoc():
+    raw = json.dumps(
+        {"command": "cat > /tmp/output.py << 'PY'\nprint('partial')"},
+    )
+
+    tool_call, observed, events = await _run_middleware(
+        raw,
+        name="execute_shell_command",
+    )
+
+    assert tool_call.input == "{}"
+    assert observed == []
+    assert events[0].state == ToolResultState.ERROR
+    assert "unterminated heredoc" in events[0].content[0].text
+
+
+@pytest.mark.asyncio
+async def test_file_content_may_document_an_unterminated_heredoc_example():
+    raw = json.dumps(
+        {
+            "file_path": "notes.md",
+            "content": "Example syntax: cat << 'EOF'",
+        },
+    )
+
+    tool_call, observed, events = await _run_middleware(raw)
+
+    assert observed == [tool_call.input]
+    assert events[0].state == ToolResultState.SUCCESS

--- a/tests/unit/agents/test_tool_result_pruning_middleware.py
+++ b/tests/unit/agents/test_tool_result_pruning_middleware.py
@@ -21,6 +21,7 @@ html2text_stub.HTML2Text = type("HTML2Text", (), {})
 sys.modules.setdefault("html2text", html2text_stub)
 
 from qwenpaw.agents.middlewares import (  # noqa: E402
+    ToolCallInputRepairMiddleware,
     ToolResultPruningMiddleware,
 )
 from qwenpaw.agents.tools.utils import (  # noqa: E402
@@ -488,6 +489,7 @@ def test_builder_places_pruning_outside_tool_coordinator(tmp_path):
 
     middlewares = AgentBuilder._build_middlewares(ctx, agent_config)
 
+    assert isinstance(middlewares[0], ToolCallInputRepairMiddleware)
     pruning_index = next(
         idx
         for idx, middleware in enumerate(middlewares)


### PR DESCRIPTION
## Description

Follow-up to the closed #5717 and merged #5761.

#5761 fixes the repeated-call symptom in model history, but execution and
history normalization still use different representations of the arguments.
AgentScope repairs the malformed JSON for execution while the original
malformed string remains in `ToolCallBlock.input`.

### Current flow

Model emits malformed/truncated `ToolCallBlock.input`  
↓  
**AgentScope repairs it with `_json_loads_with_repair()`**  
↓  
The repaired arguments pass schema validation  
↓  
**The tool executes with the possibly incomplete repaired arguments**  
↓  
**The original malformed input remains in history**  
↓  
QwenPaw normalizes history for the next model request  
↓  
Strict JSON parsing of the original input fails  
↓  
**#5761 adds a synthetic "not executed" error after side effects may already
have occurred**

This creates two problems:

1. An incomplete repaired payload can still be executed. In the reproduction,
   a truncated shell heredoc was repaired and executed, creating an empty file.
2. History then incorrectly tells the model that the tool was not executed,
   although the repaired payload already produced side effects.

### Flow after this PR

Model emits `ToolCallBlock.input`  
↓  
**Execution-time middleware tries strict `json.loads()` and then
`json_repair` when needed**  
↓  
**Validate repaired arguments against the tool JSON Schema and run integrity
checks**  
↓

**Safe repair → write canonical JSON back to `ToolCallBlock.input` →
governance/approval → execute exactly those arguments → persist the same
valid JSON**

**Unsafe repair → replace input with safe `{}` → return a model-visible
tool error → do not call governance, approval, or the tool**

Complete large payloads remain supported. The middleware rejects only repairs
that indicate ambiguous executable/file-content truncation, fail schema
validation, or contain an unterminated shell heredoc. Ordinary format issues
such as quoting/trailing-comma damage are still repaired.

Related Issue: Relates to #5717 and #5761

Security Considerations: Unsafe repaired commands/content are rejected
before governance, approval, or execution. Raw tool arguments are not logged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] Contract test exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] Optional: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Tool-call repair middleware tests cover format-only repair, complete large
  payload repair, truncated content rejection, and unterminated heredoc
  rejection.
- Existing tool-message normalization and middleware tests remain green.

## Evidence

Local regression tests verify both accepted repairs and execution-blocking
rejections. All 114 targeted tests and every pre-commit hook passed on the PR branch.
case:
```
请生成一个较大的 Python 文件，使用 write_file 一次写入：
/tmp/qwenpaw-subagent-test/workspaces/default/tool_call_repair_test.py

文件至少包含 1000 个简单函数。写入后执行：
1. wc -l
2. python -m py_compile
3. 汇报验证结果
```
<img width="824" height="832" alt="20260716-154128" src="https://github.com/user-attachments/assets/0f572307-7d4a-4a78-9628-9d0706d3d2bc" />


## Additional Notes

This complements #5761: that PR protects the next model request; this PR
protects the execution path and keeps executed arguments consistent with
persisted history.
