### PR TITLE
fix(crons): preserve advanced fields in CLI updates

### DIFF
--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -234,7 +234,9 @@ def _build_spec_from_cli(
     silent: bool,
     save_result_to_inbox: Optional[bool] = None,
     share_session: bool = True,
+    max_concurrency: int = 1,
     timeout_seconds: int = 120,
+    misfire_grace_seconds: int = 600,
     tool_safety: bool = False,
 ) -> dict:
     """Build CronJobSpec JSON payload from CLI args (no id)."""
@@ -258,9 +260,9 @@ def _build_spec_from_cli(
     }
     runtime = {
         "share_session": share_session,
-        "max_concurrency": 1,
+        "max_concurrency": max_concurrency,
         "timeout_seconds": timeout_seconds,
-        "misfire_grace_seconds": 600,
+        "misfire_grace_seconds": misfire_grace_seconds,
         "tool_safety": tool_safety,
     }
     if task_type == "text":
@@ -695,10 +697,15 @@ def _resolve_update_spec(
         if share_session is not None
         else spec.get("runtime", {}).get("share_session", True)
     )
+    t_max_concurrency = spec.get("runtime", {}).get("max_concurrency", 1)
     t_timeout = (
         timeout_seconds
         if timeout_seconds is not None
         else spec.get("runtime", {}).get("timeout_seconds", 120)
+    )
+    t_misfire_grace = spec.get("runtime", {}).get(
+        "misfire_grace_seconds",
+        600,
     )
     t_tool_safety = (
         tool_safety
@@ -740,9 +747,22 @@ def _resolve_update_spec(
         silent=t_silent,
         save_result_to_inbox=t_save,
         share_session=t_share,
+        max_concurrency=t_max_concurrency,
         timeout_seconds=t_timeout,
+        misfire_grace_seconds=t_misfire_grace,
         tool_safety=t_tool_safety,
     )
+
+    # Agent requests may carry passthrough fields that have no dedicated CLI
+    # flag (for example request_context or a model override).  Rebuilding the
+    # request from --text used to drop them on unrelated updates.
+    if t_type == "agent" and spec.get("task_type") == "agent":
+        existing_request = spec.get("request")
+        if isinstance(existing_request, dict):
+            payload["request"] = {
+                **existing_request,
+                "input": payload["request"]["input"],
+            }
 
     # Preserve existing meta
     existing_meta = spec.get("meta")

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -3,7 +3,11 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from qwenpaw.cli.cron_cmd import _build_spec_from_cli, cron_group
+from qwenpaw.cli.cron_cmd import (
+    _build_spec_from_cli,
+    _resolve_update_spec,
+    cron_group,
+)
 
 
 def _agent_spec(**overrides):
@@ -30,6 +34,35 @@ def _agent_spec(**overrides):
     return _build_spec_from_cli(**values)
 
 
+def _resolve_agent_update(spec, **overrides):
+    values = {
+        "spec": spec,
+        "task_type": None,
+        "schedule_type": None,
+        "name": None,
+        "cron": None,
+        "run_at": None,
+        "repeat_every_days": None,
+        "repeat_end_type": None,
+        "repeat_until": None,
+        "repeat_count": None,
+        "channel": None,
+        "target_user": None,
+        "target_session": None,
+        "text": None,
+        "timezone": None,
+        "enabled": None,
+        "mode": None,
+        "silent": None,
+        "save_result_to_inbox": None,
+        "share_session": None,
+        "timeout_seconds": None,
+        "tool_safety": None,
+    }
+    values.update(overrides)
+    return _resolve_update_spec(**values)
+
+
 def test_build_agent_spec_includes_silent_delivery():
     payload = _agent_spec(silent=True)
 
@@ -46,3 +79,44 @@ def test_create_help_exposes_silent_delivery_flag():
 
     assert result.exit_code == 0
     assert "--silent / --no-silent" in result.output
+
+
+def test_update_preserves_advanced_runtime_and_request_fields():
+    existing = _agent_spec()
+    existing["runtime"].update(
+        {
+            "max_concurrency": 4,
+            "misfire_grace_seconds": 1800,
+        },
+    )
+    existing["request"].update(
+        {
+            "model": "custom-model",
+            "request_context": {"source_tag": "ops"},
+        },
+    )
+
+    updated = _resolve_agent_update(
+        existing,
+        name="Renamed refresh",
+    )
+
+    assert updated["name"] == "Renamed refresh"
+    assert updated["runtime"]["max_concurrency"] == 4
+    assert updated["runtime"]["misfire_grace_seconds"] == 1800
+    assert updated["request"]["model"] == "custom-model"
+    assert updated["request"]["request_context"] == {"source_tag": "ops"}
+
+
+def test_update_replaces_prompt_without_dropping_request_extensions():
+    existing = _agent_spec()
+    existing["request"]["request_context"] = {"source_tag": "ops"}
+
+    updated = _resolve_agent_update(
+        existing,
+        text="Refresh only changed documents",
+    )
+
+    content = updated["request"]["input"][0]["content"]
+    assert content[0]["text"] == "Refresh only changed documents"
+    assert updated["request"]["request_context"] == {"source_tag": "ops"}


### PR DESCRIPTION
## Description

`cron update` rebuilt runtime options and agent requests from CLI defaults, so changing a name or schedule could reset fields that the CLI does not expose. This carries forward `max_concurrency`, `misfire_grace_seconds`, and agent request extensions while applying only the requested CLI changes. An explicit prompt update replaces `request.input` and leaves fields such as `model` and `request_context` intact.

Fixes #6176.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] CLI
- [x] Tests

## Testing

- `uv run pytest tests/unit/cli/test_cron_cmd.py -q`
- pre-commit hooks on the changed files
- Full unit suite and an upstream baseline run

## Evidence

```text
tests/unit/cli/test_cron_cmd.py: 5 passed
changed-file pre-commit hooks: all passed
full unit suite: 2 failed, 4802 passed, 6 skipped
upstream/main malformed-tool-call baseline: 2 failed, 7 passed
```

The two full-suite failures are the same `test_runtime_malformed_tool_call.py` assertions reproduced on unmodified `upstream/main`.