### PR TITLE
fix(crons): honor final delivery mode

### DIFF
--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -14,6 +14,7 @@ from ..inbox_trace_store import (
 )
 from .models import CronJobSpec
 from ...security.tool_guard.execution_level import ToolExecutionLevel
+from ...schemas import RunStatus
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,8 @@ class CronExecutor:
         - task_type text: send fixed text to channel
         - task_type agent: ask agent with prompt, send reply to channel (
             stream_query + send_event)
+        - final delivery: consume the stream, then send only the last
+            completed message
         - silent agent task: consume the full agent stream without channel
             delivery, while preserving session and trace state
         """
@@ -166,9 +169,9 @@ class CronExecutor:
 
         async def _run() -> None:
             nonlocal delivery_error
-            async for event in self._workspace.stream_query(req):
-                if job.dispatch.silent:
-                    continue
+
+            async def _deliver(event: Any) -> None:
+                nonlocal delivery_error
                 try:
                     await self._channel_manager.send_event(
                         channel=target_channel,
@@ -187,6 +190,23 @@ class CronExecutor:
                             job.dispatch.channel,
                             delivery_error,
                         )
+
+            final_event: Any | None = None
+            async for event in self._workspace.stream_query(req):
+                if job.dispatch.silent:
+                    continue
+                if job.dispatch.mode == "final":
+                    if (
+                        getattr(event, "object", None) == "message"
+                        and getattr(event, "status", None)
+                        == RunStatus.Completed
+                    ):
+                        final_event = event
+                    continue
+                await _deliver(event)
+
+            if final_event is not None:
+                await _deliver(final_event)
 
         try:
             await asyncio.wait_for(

--- a/tests/unit/app/crons/test_executor.py
+++ b/tests/unit/app/crons/test_executor.py
@@ -7,31 +7,24 @@ import pytest
 
 from qwenpaw.app.crons.executor import CronExecutor
 from qwenpaw.app.crons.models import DispatchSpec, DispatchTarget
+from qwenpaw.schemas import Event, RunStatus
 from tests.unit.app.conftest import make_cron_job_spec
 
 
 class _Workspace:
     chat_manager = None
 
-    def __init__(self) -> None:
+    def __init__(self, events=None) -> None:
         self.events_consumed = 0
+        self.events = events if events is not None else ("first", "second")
 
     async def stream_query(self, _request):
-        for event in ("first", "second"):
+        for event in self.events:
             self.events_consumed += 1
             yield event
 
 
-@pytest.mark.asyncio
-async def test_silent_agent_job_runs_without_channel_delivery(monkeypatch):
-    workspace = _Workspace()
-    channel_manager = AsyncMock()
-    job = make_cron_job_spec(job_id="silent-job")
-    job.dispatch = DispatchSpec(
-        target=DispatchTarget(user_id="u1", session_id="console:u1"),
-        silent=True,
-    )
-
+def _patch_trace_storage(monkeypatch):
     monkeypatch.setattr(
         "qwenpaw.app.crons.executor.read_session_messages",
         AsyncMock(return_value=[]),
@@ -49,6 +42,20 @@ async def test_silent_agent_job_runs_without_channel_delivery(monkeypatch):
         "qwenpaw.app.crons.executor.finalize_trace",
         finalize_trace,
     )
+    return finalize_trace
+
+
+@pytest.mark.asyncio
+async def test_silent_agent_job_runs_without_channel_delivery(monkeypatch):
+    workspace = _Workspace()
+    channel_manager = AsyncMock()
+    job = make_cron_job_spec(job_id="silent-job")
+    job.dispatch = DispatchSpec(
+        target=DispatchTarget(user_id="u1", session_id="console:u1"),
+        silent=True,
+    )
+
+    finalize_trace = _patch_trace_storage(monkeypatch)
 
     result = await CronExecutor(
         workspace=workspace,
@@ -67,22 +74,7 @@ async def test_agent_job_still_delivers_by_default(monkeypatch):
     channel_manager = AsyncMock()
     job = make_cron_job_spec(job_id="normal-job")
 
-    monkeypatch.setattr(
-        "qwenpaw.app.crons.executor.read_session_messages",
-        AsyncMock(return_value=[]),
-    )
-    monkeypatch.setattr(
-        "qwenpaw.app.crons.executor.create_trace",
-        AsyncMock(),
-    )
-    monkeypatch.setattr(
-        "qwenpaw.app.crons.executor.append_trace_from_session_delta",
-        AsyncMock(),
-    )
-    monkeypatch.setattr(
-        "qwenpaw.app.crons.executor.finalize_trace",
-        AsyncMock(),
-    )
+    _patch_trace_storage(monkeypatch)
 
     result = await CronExecutor(
         workspace=workspace,
@@ -92,3 +84,61 @@ async def test_agent_job_still_delivers_by_default(monkeypatch):
     assert workspace.events_consumed == 2
     assert channel_manager.send_event.await_count == 2
     assert result["delivery_status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_final_mode_delivers_only_last_completed_message(monkeypatch):
+    first = Event(
+        object="message",
+        status=RunStatus.Completed,
+        data={"text": "first"},
+    )
+    progress = Event(object="message", status=RunStatus.InProgress)
+    final = Event(
+        object="message",
+        status=RunStatus.Completed,
+        data={"text": "final"},
+    )
+    workspace = _Workspace([first, progress, final])
+    channel_manager = AsyncMock()
+    job = make_cron_job_spec(job_id="final-job")
+    job.dispatch = DispatchSpec(
+        target=DispatchTarget(user_id="u1", session_id="console:u1"),
+        mode="final",
+    )
+
+    _patch_trace_storage(monkeypatch)
+
+    result = await CronExecutor(
+        workspace=workspace,
+        channel_manager=channel_manager,
+    ).execute(job)
+
+    assert workspace.events_consumed == 3
+    channel_manager.send_event.assert_awaited_once()
+    assert channel_manager.send_event.await_args.kwargs["event"] is final
+    assert result["delivery_status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_final_mode_reports_delivery_failure(monkeypatch):
+    final = Event(object="message", status=RunStatus.Completed)
+    workspace = _Workspace([final])
+    channel_manager = AsyncMock()
+    channel_manager.send_event.side_effect = RuntimeError("channel down")
+    job = make_cron_job_spec(job_id="final-failure-job")
+    job.dispatch = DispatchSpec(
+        target=DispatchTarget(user_id="u1", session_id="console:u1"),
+        mode="final",
+    )
+
+    _patch_trace_storage(monkeypatch)
+
+    result = await CronExecutor(
+        workspace=workspace,
+        channel_manager=channel_manager,
+    ).execute(job)
+
+    channel_manager.send_event.assert_awaited_once()
+    assert result["delivery_status"] == "failed"
+    assert "channel down" in result["delivery_error"]


### PR DESCRIPTION
## Description

The executor treated `final` like `stream` and forwarded every completed event. This consumes the full run, remembers the last completed message, and delivers it once after the stream ends. `stream` and `silent` keep their existing behavior, including delivery error handling.

Fixes #6177.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend
- [x] Tests

## Testing

- `pytest tests/unit/app/crons/test_executor.py -q`
- pre-commit hooks on the changed files
- Full unit suite and an upstream baseline run

## Evidence

```text
tests/unit/app/crons/test_executor.py: 4 passed
changed-file pre-commit hooks: all passed
full unit suite: 2 failed, 4802 passed, 6 skipped
upstream/main malformed-tool-call baseline: 2 failed, 7 passed
```

The two full-suite failures are the same `test_runtime_malformed_tool_call.py` assertions reproduced on unmodified `upstream/main`.