### PR TITLE
feat(logging): make rotation limits configurable

### DIFF
--- a/src/qwenpaw/utils/logging.py
+++ b/src/qwenpaw/utils/logging.py
@@ -5,6 +5,7 @@ import logging
 import logging.handlers
 import os
 import platform
+import re
 import sys
 from pathlib import Path
 
@@ -13,6 +14,8 @@ from ..constant import PROJECT_NAME, WORKING_DIR
 # Rotating file handler limits (idempotent add avoids duplicate handlers)
 _LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
 _LOG_BACKUP_COUNT = 3
+_LOG_MAX_SIZE_ENV = "QWENPAW_LOG_MAX_SIZE"
+_LOG_BACKUP_COUNT_ENV = "QWENPAW_LOG_MAX_BACKUPS"
 
 
 _LEVEL_MAP = {
@@ -29,6 +32,77 @@ LOG_NAMESPACE = PROJECT_NAME.lower()
 # Canonical log file name and path — import these instead of reconstructing.
 LOG_FILE_BASENAME = f"{LOG_NAMESPACE}.log"
 LOG_FILE_PATH = WORKING_DIR / LOG_FILE_BASENAME
+
+_LOG_SIZE_PATTERN = re.compile(r"^\s*(\d+)\s*([kmgt]?i?b?)?\s*$", re.I)
+_LOG_SIZE_FACTORS = {
+    "": 1,
+    "b": 1,
+    "k": 1024,
+    "kb": 1024,
+    "kib": 1024,
+    "m": 1024**2,
+    "mb": 1024**2,
+    "mib": 1024**2,
+    "g": 1024**3,
+    "gb": 1024**3,
+    "gib": 1024**3,
+    "t": 1024**4,
+    "tb": 1024**4,
+    "tib": 1024**4,
+}
+
+
+def _parse_log_size(value: str) -> int:
+    """Parse a positive byte count with an optional binary size suffix."""
+    match = _LOG_SIZE_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValueError("expected bytes or a K/KB/KiB-style size")
+    amount = int(match.group(1))
+    if amount <= 0:
+        raise ValueError("size must be greater than zero")
+    suffix = (match.group(2) or "").lower()
+    factor = _LOG_SIZE_FACTORS.get(suffix)
+    if factor is None:
+        raise ValueError(f"unsupported size suffix: {suffix}")
+    return amount * factor
+
+
+def _resolve_log_rotation_settings() -> tuple[int, int]:
+    """Resolve rotation settings from the environment with safe defaults."""
+    logger = logging.getLogger(LOG_NAMESPACE)
+    max_bytes = _LOG_MAX_BYTES
+    backup_count = _LOG_BACKUP_COUNT
+
+    raw_size = os.getenv(_LOG_MAX_SIZE_ENV)
+    if raw_size is not None:
+        try:
+            max_bytes = _parse_log_size(raw_size)
+        except ValueError as exc:
+            logger.warning(
+                "Ignoring invalid %s=%r (%s); using %s bytes",
+                _LOG_MAX_SIZE_ENV,
+                raw_size,
+                exc,
+                _LOG_MAX_BYTES,
+            )
+
+    raw_backups = os.getenv(_LOG_BACKUP_COUNT_ENV)
+    if raw_backups is not None:
+        try:
+            backup_count = int(raw_backups.strip())
+            if backup_count < 0:
+                raise ValueError("backup count must be non-negative")
+        except ValueError as exc:
+            backup_count = _LOG_BACKUP_COUNT
+            logger.warning(
+                "Ignoring invalid %s=%r (%s); using %s",
+                _LOG_BACKUP_COUNT_ENV,
+                raw_backups,
+                exc,
+                _LOG_BACKUP_COUNT,
+            )
+
+    return max_bytes, backup_count
 
 
 def _enable_windows_ansi() -> None:
@@ -217,8 +291,9 @@ def add_project_file_handler(log_path: Path) -> None:
     """Add a rotating file handler to the project logger for daemon logs.
 
     Uses _SafeRotatingFileHandler on all platforms with automatic log
-    rotation (max 5 MiB per file, 3 backups).  On Windows, rotation
-    errors caused by file locking are tolerated gracefully.
+    rotation. Defaults to 5 MiB per file and 3 backups; deployments can
+    override these with QWENPAW_LOG_MAX_SIZE and QWENPAW_LOG_MAX_BACKUPS.
+    On Windows, rotation errors caused by file locking are tolerated.
 
     Idempotent: if the logger already has a file handler for the same path,
     no new handler is added (avoids duplicate lines and leaked descriptors
@@ -240,11 +315,12 @@ def add_project_file_handler(log_path: Path) -> None:
             )
             return
 
+    max_bytes, backup_count = _resolve_log_rotation_settings()
     file_handler = _SafeRotatingFileHandler(
         log_path,
         encoding="utf-8",
-        maxBytes=_LOG_MAX_BYTES,
-        backupCount=_LOG_BACKUP_COUNT,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
     )
 
     file_handler.setLevel(logger.level or logging.INFO)

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -10,13 +10,19 @@ import logging
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from qwenpaw.utils.logging import (
     ColorFormatter,
     SuppressPathAccessLogFilter,
     add_project_file_handler,
     setup_logger,
     LOG_NAMESPACE,
+    _LOG_BACKUP_COUNT,
+    _LOG_MAX_BYTES,
     _LEVEL_MAP,
+    _parse_log_size,
+    _resolve_log_rotation_settings,
 )
 
 
@@ -229,6 +235,64 @@ class TestAddFileHandler:
             for handler in logger.handlers:
                 handler.close()
             logger.handlers = original_handlers
+
+    def test_uses_environment_rotation_limits(self, tmp_path, monkeypatch):
+        log_path = (tmp_path / "qwenpaw.log").resolve()
+        monkeypatch.setenv("QWENPAW_LOG_MAX_SIZE", "10MB")
+        monkeypatch.setenv("QWENPAW_LOG_MAX_BACKUPS", "5")
+        logger = logging.getLogger(LOG_NAMESPACE)
+        original_handlers = list(logger.handlers)
+        logger.handlers = []
+
+        try:
+            add_project_file_handler(log_path)
+            handler = next(
+                h
+                for h in logger.handlers
+                if getattr(h, "baseFilename", None) == str(log_path)
+            )
+            assert handler.maxBytes == 10 * 1024**2
+            assert handler.backupCount == 5
+        finally:
+            for handler in logger.handlers:
+                handler.close()
+            logger.handlers = original_handlers
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1024", 1024),
+        ("512K", 512 * 1024),
+        ("10MB", 10 * 1024**2),
+        ("1GiB", 1024**3),
+    ],
+)
+def test_parse_log_size(value, expected):
+    assert _parse_log_size(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "ten MB", "1PB"])
+def test_parse_log_size_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        _parse_log_size(value)
+
+
+def test_invalid_rotation_environment_uses_defaults(monkeypatch):
+    monkeypatch.setenv("QWENPAW_LOG_MAX_SIZE", "unbounded")
+    monkeypatch.setenv("QWENPAW_LOG_MAX_BACKUPS", "-2")
+
+    assert _resolve_log_rotation_settings() == (
+        _LOG_MAX_BYTES,
+        _LOG_BACKUP_COUNT,
+    )
+
+
+def test_zero_log_backups_is_supported(monkeypatch):
+    monkeypatch.delenv("QWENPAW_LOG_MAX_SIZE", raising=False)
+    monkeypatch.setenv("QWENPAW_LOG_MAX_BACKUPS", "0")
+
+    assert _resolve_log_rotation_settings() == (_LOG_MAX_BYTES, 0)
 
 
 class TestLogConstants:

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -103,6 +103,8 @@ You can customize paths and behavior via environment variables:
 | Variable                             | Default         | Description                                                                 |
 | ------------------------------------ | --------------- | --------------------------------------------------------------------------- |
 | `QWENPAW_LOG_LEVEL`                  | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)             |
+| `QWENPAW_LOG_MAX_SIZE`               | `5MiB`          | Maximum active log size; accepts bytes or suffixes such as `10MB` and `1GiB` |
+| `QWENPAW_LOG_MAX_BACKUPS`            | `3`             | Number of rotated log backups to retain; `0` disables backups                |
 | `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`        | Character threshold to trigger memory compaction                            |
 | `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`             | Number of recent messages to keep after compaction                          |
 | `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`           | Threshold ratio for triggering compaction (relative to context window size) |

--- a/website/public/docs/config.en.md
+++ b/website/public/docs/config.en.md
@@ -100,15 +100,15 @@ You can customize paths and behavior via environment variables:
 
 **Other configuration:**
 
-| Variable                             | Default         | Description                                                                 |
-| ------------------------------------ | --------------- | --------------------------------------------------------------------------- |
-| `QWENPAW_LOG_LEVEL`                  | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)             |
+| Variable                             | Default         | Description                                                                  |
+| ------------------------------------ | --------------- | ---------------------------------------------------------------------------- |
+| `QWENPAW_LOG_LEVEL`                  | `info`          | Log level (`debug` / `info` / `warning` / `error` / `critical`)              |
 | `QWENPAW_LOG_MAX_SIZE`               | `5MiB`          | Maximum active log size; accepts bytes or suffixes such as `10MB` and `1GiB` |
 | `QWENPAW_LOG_MAX_BACKUPS`            | `3`             | Number of rotated log backups to retain; `0` disables backups                |
-| `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`        | Character threshold to trigger memory compaction                            |
-| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`             | Number of recent messages to keep after compaction                          |
-| `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`           | Threshold ratio for triggering compaction (relative to context window size) |
-| `QWENPAW_CONSOLE_STATIC_DIR`         | _(auto-detect)_ | Console frontend static files path                                          |
+| `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`        | Character threshold to trigger memory compaction                             |
+| `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`             | Number of recent messages to keep after compaction                           |
+| `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`           | Threshold ratio for triggering compaction (relative to context window size)  |
+| `QWENPAW_CONSOLE_STATIC_DIR`         | _(auto-detect)_ | Console frontend static files path                                           |
 
 **Security & Authentication:**
 

--- a/website/public/docs/config.zh.md
+++ b/website/public/docs/config.zh.md
@@ -72,6 +72,8 @@ $QWENPAW_SECRET_DIR/                       # 默认 ~/.qwenpaw.secret
 | 变量                                 | 默认值         | 说明                                                            |
 | ------------------------------------ | -------------- | --------------------------------------------------------------- |
 | `QWENPAW_LOG_LEVEL`                  | `info`         | 日志级别（`debug` / `info` / `warning` / `error` / `critical`） |
+| `QWENPAW_LOG_MAX_SIZE`               | `5MiB`         | 当前日志文件大小上限，支持字节数及 `10MB`、`1GiB` 等后缀        |
+| `QWENPAW_LOG_MAX_BACKUPS`            | `3`            | 保留的轮转日志份数；设为 `0` 时不保留备份                       |
 | `QWENPAW_MEMORY_COMPACT_THRESHOLD`   | `100000`       | 触发记忆压缩的字符阈值                                          |
 | `QWENPAW_MEMORY_COMPACT_KEEP_RECENT` | `3`            | 压缩后保留的最近消息数                                          |
 | `QWENPAW_MEMORY_COMPACT_RATIO`       | `0.7`          | 触发压缩的阈值比例（相对于上下文窗口大小）                      |


### PR DESCRIPTION
## Description

File logging previously fixed rotation at 5 MiB with three backups. This adds `QWENPAW_LOG_MAX_SIZE` and `QWENPAW_LOG_MAX_BACKUPS`, keeps the existing defaults, and falls back safely with a warning when either value is invalid. Size values accept bytes or binary-style suffixes such as `512K`, `10MB`, and `1GiB`. The English and Chinese configuration references document both variables.

Fixes #6178.

## Type of Change

- [x] New feature
- [x] Documentation

## Component(s) Affected

- [x] Core / Backend
- [x] Documentation (website)
- [x] Tests

## Testing

- `pytest tests/unit/utils/test_logging.py -q`
- pre-commit hooks on the changed files
- Full unit suite and an upstream baseline run

## Evidence

```text
tests/unit/utils/test_logging.py: 33 passed
changed-file pre-commit hooks: all passed
full unit suite: 2 failed, 4812 passed, 6 skipped
upstream/main malformed-tool-call baseline: 2 failed, 7 passed
```

The two full-suite failures are the same `test_runtime_malformed_tool_call.py` assertions reproduced on unmodified `upstream/main`.