### PR TITLE
fix(loop): fine-tune doom loop thresholds, fix frontend after calc & align tests with #5761

### DIFF
--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -412,9 +412,7 @@ function DoomLoopSection() {
                           after:
                             stages.length === 0
                               ? 3
-                              : stages.length === 1
-                              ? 4
-                              : stages.length + 3,
+                              : (stages[stages.length - 1]?.after ?? 0) + 1,
                           action: "modify_prompt",
                           prompt: "",
                         })

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -413,8 +413,8 @@ function DoomLoopSection() {
                             stages.length === 0
                               ? 3
                               : stages.length === 1
-                                ? 4
-                                : stages.length + 3,
+                              ? 4
+                              : stages.length + 3,
                           action: "modify_prompt",
                           prompt: "",
                         })

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -409,7 +409,12 @@ function DoomLoopSection() {
                       type="dashed"
                       onClick={() =>
                         add({
-                          after: (stages.length + 1) * 3,
+                          after:
+                            stages.length === 0
+                              ? 3
+                              : stages.length === 1
+                                ? 4
+                                : stages.length + 3,
                           action: "modify_prompt",
                           prompt: "",
                         })

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1083,7 +1083,9 @@ class DoomLoopConfig(BaseModel):
                 after=4,
                 action="stop",
                 prompt=(
-                    "Doom loop: agent stuck after " "4 consecutive repetitions"
+                    "Doom loop: agent stuck "
+                    "after 4 consecutive "
+                    "repetitions"
                 ),
             ),
         ],

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1054,7 +1054,7 @@ class DoomLoopConfig(BaseModel):
         description="Enable doom loop detection",
     )
     window_size: int = Field(
-        default=2,
+        default=3,
         ge=2,
         description=("Sliding window size for " "repetition detection"),
     )
@@ -1069,7 +1069,7 @@ class DoomLoopConfig(BaseModel):
     stages: List[DoomLoopStageConfig] = Field(
         default_factory=lambda: [
             DoomLoopStageConfig(
-                after=2,
+                after=3,
                 action="modify_prompt",
                 prompt=(
                     "[WARNING] Repetitive pattern "

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1054,7 +1054,7 @@ class DoomLoopConfig(BaseModel):
         description="Enable doom loop detection",
     )
     window_size: int = Field(
-        default=3,
+        default=2,
         ge=2,
         description=("Sliding window size for " "repetition detection"),
     )
@@ -1069,7 +1069,7 @@ class DoomLoopConfig(BaseModel):
     stages: List[DoomLoopStageConfig] = Field(
         default_factory=lambda: [
             DoomLoopStageConfig(
-                after=3,
+                after=2,
                 action="modify_prompt",
                 prompt=(
                     "[WARNING] Repetitive pattern "
@@ -1080,10 +1080,10 @@ class DoomLoopConfig(BaseModel):
                 ),
             ),
             DoomLoopStageConfig(
-                after=6,
+                after=4,
                 action="stop",
                 prompt=(
-                    "Doom loop: agent stuck after " "6 consecutive repetitions"
+                    "Doom loop: agent stuck after " "4 consecutive repetitions"
                 ),
             ),
         ],


### PR DESCRIPTION
## Changes

### 1. Fine-tune doom loop thresholds (from #6138)
- Lower default stop threshold from `after=6` to `after=4`
- Align frontend default values

### 2. Fix frontend "Add Rule" after calculation bug
- Old: hardcoded conditional based on `stages.length`, ignoring existing stage values
- New: `(stages[stages.length - 1]?.after ?? 0) + 1` — always references the last stage's actual `after` value

### 3. Clean up config.py prompt string
- Fix implicit string concatenation formatting for 79-char line width

### 4. Align malformed tool_call tests with #5761
- PR #5761 changed `_coerce_tool_inputs_to_json` behavior: malformed blocks are now kept (marked failed + synthetic error result) instead of dropped
- Update `test_runtime_malformed_tool_call.py` assertions accordingly

Supersedes #6138

Made with [Cursor](https://cursor.com)