### PR TITLE
fix(governance): auto-register tools via @tool_descriptor and PluginApi (#6114)

### DIFF
--- a/plugins/tool/gpt-image2/gpt_image2.py
+++ b/plugins/tool/gpt-image2/gpt_image2.py
@@ -44,6 +44,7 @@ class GPTImage2ToolPlugin:
             tool_func=tool.generate_image_gpt,
             description=("Generate images using OpenAI GPT Image 2"),
             icon="🎨",
+            tool_type="network",
         )
 
         api.register_tool(
@@ -54,6 +55,7 @@ class GPTImage2ToolPlugin:
                 "with OpenAI GPT Image 2"
             ),
             icon="🖼️",
+            tool_type="network",
         )
 
         logger.info("GPT Image 2 tool plugin registered")

--- a/plugins/tool/qwen-image/qwen_image.py
+++ b/plugins/tool/qwen-image/qwen_image.py
@@ -46,6 +46,7 @@ class QwenImageToolPlugin:
                 "Generate images from text prompts " "using Qwen-Image"
             ),
             icon="🖼️",
+            tool_type="network",
         )
 
         api.register_tool(
@@ -53,6 +54,7 @@ class QwenImageToolPlugin:
             tool_func=tool.edit_image_qwen,
             description="Edit or fuse images using Qwen-Image",
             icon="✏️",
+            tool_type="network",
         )
 
         logger.info("Qwen-Image tool plugin registered")

--- a/plugins/tool/wan27/wan27.py
+++ b/plugins/tool/wan27/wan27.py
@@ -44,6 +44,7 @@ class Wan27ToolPlugin:
             tool_func=tool.text_to_video_wan,
             description=("Generate videos from text prompts " "using Wan 2.7"),
             icon="🎬",
+            tool_type="network",
         )
 
         api.register_tool(
@@ -51,6 +52,7 @@ class Wan27ToolPlugin:
             tool_func=tool.image_to_video_wan,
             description=("Generate videos from images using Wan 2.7"),
             icon="🎞️",
+            tool_type="network",
         )
 
         api.register_tool(
@@ -60,6 +62,7 @@ class Wan27ToolPlugin:
                 "Generate videos with character references " "using Wan 2.7"
             ),
             icon="🎭",
+            tool_type="network",
         )
 
         logger.info("Wan 2.7 tool plugin registered")

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -5,8 +5,10 @@ Every tool function decorated with ``@tool_descriptor`` is automatically
 collected into a global registry at import time.  Adding a new built-in
 tool requires only two things:
 
-1. Decorate the function with ``@tool_descriptor(...)`` in its module.
+1. Decorate the function with ``@tool_descriptor(...)`` (include
+   governance / UI / default_policy metadata as needed).
 2. Import the module here so that the decorator executes.
+   ``__all__`` is generated automatically from collected descriptors.
 
 :func:`discover_builtin_tool_funcs` returns all auto-collected built-in
 tools — no manual list maintenance or filesystem scanning required.
@@ -58,31 +60,13 @@ def discover_builtin_tool_funcs() -> list[Callable]:
     return get_builtin_tool_funcs()
 
 
-__all__ = [
-    "discover_builtin_tool_funcs",
-    "execute_shell_command",
-    "read_file",
-    "write_file",
-    "edit_file",
-    "append_file",
-    "grep_search",
-    "glob_search",
-    "send_file_to_user",
-    "desktop_screenshot",
-    "view_image",
-    "view_video",
-    "browser_use",
-    "web_search",
-    "web_fetch",
-    "get_current_time",
-    "set_user_timezone",
-    "get_token_usage",
-    "delegate_external_agent",
-    "list_agents",
-    "chat_with_agent",
-    "submit_to_agent",
-    "check_agent_task",
-    "spawn_subagent",
-    "materialize_skill",
-    "ast_search",
-]
+def _build_all() -> list[str]:
+    """Build ``__all__`` from auto-collected ``@tool_descriptor`` tools."""
+    from ...runtime.tool_registry import get_builtin_tool_funcs
+
+    return ["discover_builtin_tool_funcs"] + [
+        fn.__name__ for fn in get_builtin_tool_funcs()
+    ]
+
+
+__all__ = _build_all()

--- a/src/qwenpaw/agents/tools/__init__.py
+++ b/src/qwenpaw/agents/tools/__init__.py
@@ -69,4 +69,6 @@ def _build_all() -> list[str]:
     ]
 
 
+# Must stay below all side-effect imports above so every @tool_descriptor
+# has already appended to the global registry before __all__ is built.
 __all__ = _build_all()

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -430,7 +430,13 @@ def format_background_status_text(
     return "\n".join(parts)
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    policy_name="ListAgents",
+    ui_description="List configured agents from the local API",
+    ui_icon="🤖",
+)
 async def list_agents(
     base_url: Optional[str] = None,
 ) -> ToolChunk:
@@ -445,7 +451,17 @@ async def list_agents(
     return _tool_text_response(_json_text(result))
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    target_param="agent_id",
+    policy_name="ChatWithAgent",
+    ui_description=(
+        "Send a message to another configured agent and wait for "
+        "the response"
+    ),
+    ui_icon="💬",
+)
 async def chat_with_agent(
     to_agent: str,
     text: str,
@@ -529,7 +545,14 @@ async def chat_with_agent(
     )
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    target_param="agent_id",
+    policy_name="SubmitToAgent",
+    ui_description="Submit a background task to another configured agent",
+    ui_icon="📨",
+)
 async def submit_to_agent(
     to_agent: str,
     text: str,
@@ -613,7 +636,14 @@ async def submit_to_agent(
     )
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    target_param="task_id",
+    policy_name="CheckAgentTask",
+    ui_description="Check the status of a background agent task",
+    ui_icon="⏳",
+)
 async def check_agent_task(
     task_id: str,
 ) -> ToolChunk:
@@ -707,7 +737,13 @@ def _build_spawn_request_context(current_agent_id: str) -> dict[str, Any]:
     return context
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    policy_name="SpawnSubagent",
+    ui_description="Spawn an ephemeral sub-task within the current workspace",
+    ui_icon="🔀",
+)
 async def spawn_subagent(
     task: str,
     fork: bool = False,

--- a/src/qwenpaw/agents/tools/ast_tool.py
+++ b/src/qwenpaw/agents/tools/ast_tool.py
@@ -224,6 +224,15 @@ def _format_matches(
 @tool_descriptor(
     requires_modes=("coding",),
     requires_sandbox=("file_read",),
+    tool_type="file",
+    target_param="path",
+    pattern_param="pattern",
+    policy_name="AstSearch",
+    default_policy="allow",
+    policy_reason="AST search (global)",
+    ui_description="Search code by AST pattern (coding mode)",
+    ui_icon="🌳",
+    display_to_user=False,
 )
 async def ast_search(  # pylint: disable=too-many-return-statements
     pattern: str,

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -4870,7 +4870,16 @@ def _workspace_dir_key(workspace_dir: str | Path) -> str:
         return str(path.absolute())
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="network",
+    target_param="url",
+    policy_name="Browser",
+    default_policy="allow",
+    policy_reason="Allow all browser access",
+    ui_description="Browser automation and web interaction",
+    ui_icon="🌐",
+)
 async def browser_use(  # pylint: disable=R0911,R0912
     action: str,
     url: str = "",

--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -908,7 +908,14 @@ async def _run_streaming_agent_action(
         yield response_text(f"ACP execution error: {e}")
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    target_param="runner",
+    policy_name="DelegateExternalAgent",
+    ui_description="Delegate work to an external ACP agent runner",
+    ui_icon="📡",
+)
 async def delegate_external_agent(
     action: str,
     runner: str = "",

--- a/src/qwenpaw/agents/tools/delegate_external_agent.py
+++ b/src/qwenpaw/agents/tools/delegate_external_agent.py
@@ -910,6 +910,7 @@ async def _run_streaming_agent_action(
 
 @tool_descriptor(
     async_execution=True,
+    enabled_by_default=False,
     tool_type="internal",
     target_param="runner",
     policy_name="DelegateExternalAgent",

--- a/src/qwenpaw/agents/tools/desktop_screenshot.py
+++ b/src/qwenpaw/agents/tools/desktop_screenshot.py
@@ -123,7 +123,15 @@ async def _capture_macos_screencapture(
         return _tool_error(f"desktop_screenshot failed: {e!s}")
 
 
-@tool_descriptor(requires_sandbox=("file_write",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_write",),
+    async_execution=True,
+    tool_type="file",
+    target_param="path",
+    policy_name="DesktopScreenshot",
+    ui_description="Capture desktop screenshots",
+    ui_icon="📸",
+)
 async def desktop_screenshot(
     path: str = "",
     capture_window: bool = False,

--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -86,7 +86,17 @@ def _get_encoding_for_file(file_path: str) -> str:
     return "utf-8"
 
 
-@tool_descriptor(requires_sandbox=("file_read",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_read",),
+    async_execution=True,
+    tool_type="file",
+    target_param="file_path",
+    policy_name="Read",
+    default_policy="allow",
+    policy_reason="Read-only file access (global)",
+    ui_description="Read file contents",
+    ui_icon="📄",
+)
 async def read_file(  # pylint: disable=too-many-return-statements
     file_path: str,
     start_line: Optional[int] = None,
@@ -246,7 +256,15 @@ async def read_file(  # pylint: disable=too-many-return-statements
         )
 
 
-@tool_descriptor(requires_sandbox=("file_write",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_write",),
+    async_execution=True,
+    tool_type="file",
+    target_param="file_path",
+    policy_name="Write",
+    ui_description="Write content to file",
+    ui_icon="✍️",
+)
 async def write_file(
     file_path: str,
     content: str,
@@ -302,7 +320,15 @@ async def write_file(
 
 
 # pylint: disable=too-many-return-statements
-@tool_descriptor(requires_sandbox=("file_write",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_write",),
+    async_execution=True,
+    tool_type="file",
+    target_param="file_path",
+    policy_name="Edit",
+    ui_description="Edit file using find-and-replace",
+    ui_icon="🖊️",
+)
 async def edit_file(
     file_path: str,
     old_text: str,
@@ -411,6 +437,11 @@ async def edit_file(
     requires_sandbox=("file_write",),
     async_execution=True,
     enabled_by_default=False,
+    tool_type="file",
+    target_param="file_path",
+    policy_name="Append",
+    ui_description="Append content to a file",
+    ui_icon="📎",
 )
 async def append_file(
     file_path: str,

--- a/src/qwenpaw/agents/tools/file_search.py
+++ b/src/qwenpaw/agents/tools/file_search.py
@@ -593,7 +593,17 @@ def _walk_and_glob(
 # ---------------------------------------------------------------------------
 
 
-@tool_descriptor(requires_sandbox=("file_read",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_read",),
+    async_execution=True,
+    tool_type="file",
+    target_param="path",
+    policy_name="Grep",
+    default_policy="allow",
+    policy_reason="Content search (global)",
+    ui_description="Search file contents by pattern",
+    ui_icon="🔍",
+)
 async def grep_search(
     pattern: str,
     path: Optional[str] = None,
@@ -705,7 +715,18 @@ async def grep_search(
     return _make_response(result)
 
 
-@tool_descriptor(requires_sandbox=("file_read",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_read",),
+    async_execution=True,
+    tool_type="file",
+    target_param="path",
+    pattern_param="pattern",
+    policy_name="Glob",
+    default_policy="allow",
+    policy_reason="File listing (global)",
+    ui_description="Find files matching a glob pattern",
+    ui_icon="📁",
+)
 async def glob_search(
     pattern: str,
     path: Optional[str] = None,

--- a/src/qwenpaw/agents/tools/get_current_time.py
+++ b/src/qwenpaw/agents/tools/get_current_time.py
@@ -60,7 +60,9 @@ async def get_current_time() -> ToolChunk:
 
 @tool_descriptor(
     async_execution=True,
-    tool_type="file",
+    # Config/internal op — not a filesystem tool. Using tool_type="file"
+    # would make extract_target() join workspace_dir onto timezone names.
+    tool_type="internal",
     target_param="timezone_name",
     policy_name="SetUserTimezone",
     ui_description="Set user timezone",

--- a/src/qwenpaw/agents/tools/get_current_time.py
+++ b/src/qwenpaw/agents/tools/get_current_time.py
@@ -15,7 +15,13 @@ from ...runtime.tool_registry import tool_descriptor
 logger = logging.getLogger(__name__)
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    policy_name="GetCurrentTime",
+    ui_description="Get current date and time",
+    ui_icon="🕐",
+)
 async def get_current_time() -> ToolChunk:
     """Get the current time in format `%Y-%m-%d %H:%M:%S TZ (Day)`,
     e.g. "2026-02-13 19:30:45 Asia/Shanghai (Friday)".
@@ -52,7 +58,14 @@ async def get_current_time() -> ToolChunk:
     )
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="file",
+    target_param="timezone_name",
+    policy_name="SetUserTimezone",
+    ui_description="Set user timezone",
+    ui_icon="🌍",
+)
 async def set_user_timezone(timezone_name: str) -> ToolChunk:
     """Set the user timezone.
     Only call this tool when the user explicitly asks to change their timezone.

--- a/src/qwenpaw/agents/tools/get_token_usage.py
+++ b/src/qwenpaw/agents/tools/get_token_usage.py
@@ -11,7 +11,13 @@ from ...runtime.tool_registry import tool_descriptor
 from ...token_usage import get_token_usage_manager
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="internal",
+    policy_name="GetTokenUsage",
+    ui_description="Get llm token usage",
+    ui_icon="📊",
+)
 async def get_token_usage(
     days: int = 30,
     model_name: str | None = None,

--- a/src/qwenpaw/agents/tools/make_skill_tools.py
+++ b/src/qwenpaw/agents/tools/make_skill_tools.py
@@ -166,6 +166,10 @@ def _tool_text_response(text: str) -> ToolChunk:
     requires_skills=("make-skill",),
     requires_sandbox=("file_write",),
     async_execution=True,
+    tool_type="internal",
+    policy_name="MaterializeSkill",
+    ui_description="Materialize a skill definition into the workspace",
+    ui_icon="🧩",
 )
 async def materialize_skill(
     name: str,

--- a/src/qwenpaw/agents/tools/send_file.py
+++ b/src/qwenpaw/agents/tools/send_file.py
@@ -14,7 +14,17 @@ from ...runtime.tool_registry import tool_descriptor
 from .file_io import _resolve_file_path, _path_to_file_url
 
 
-@tool_descriptor(requires_sandbox=("file_read",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_read",),
+    async_execution=True,
+    tool_type="file",
+    target_param="file_path",
+    policy_name="SendFileToUser",
+    default_policy="allow",
+    policy_reason="File send to user (global)",
+    ui_description="Send files to user",
+    ui_icon="📤",
+)
 async def send_file_to_user(
     file_path: str,
 ) -> ToolChunk:

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -493,7 +493,15 @@ def _is_dangerous_self_kill(cmd: str) -> bool:
 
 
 # pylint: disable=too-many-branches, too-many-statements
-@tool_descriptor(requires_sandbox=("shell_exec",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("shell_exec",),
+    async_execution=True,
+    tool_type="shell",
+    target_param="command",
+    policy_name="Bash",
+    ui_description="Execute shell commands",
+    ui_icon="💻",
+)
 async def execute_shell_command(
     command: str,
     timeout: float = 60.0,

--- a/src/qwenpaw/agents/tools/view_media.py
+++ b/src/qwenpaw/agents/tools/view_media.py
@@ -321,7 +321,18 @@ def _get_multimodal_fallback_hint(media_type: str, path: str) -> str:
     )
 
 
-@tool_descriptor(requires_sandbox=("file_read",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_read",),
+    async_execution=True,
+    tool_type="file",
+    target_param="image_path",
+    policy_name="ViewImage",
+    default_policy="allow",
+    policy_reason="Image view (global)",
+    ui_description="Load an image into LLM context for visual analysis",
+    ui_icon="🖼️",
+    display_to_user=False,
+)
 async def view_image(image_path: str) -> ToolChunk:
     """Load an image file into the LLM context so the model can see it.
 
@@ -396,7 +407,18 @@ async def view_image(image_path: str) -> ToolChunk:
     )
 
 
-@tool_descriptor(requires_sandbox=("file_read",), async_execution=True)
+@tool_descriptor(
+    requires_sandbox=("file_read",),
+    async_execution=True,
+    tool_type="file",
+    target_param="video_path",
+    policy_name="ViewVideo",
+    default_policy="allow",
+    policy_reason="Video view (global)",
+    ui_description="Load a video into LLM context for visual analysis",
+    ui_icon="🎥",
+    display_to_user=False,
+)
 async def view_video(video_path: str) -> ToolChunk:
     """Load a video file into the LLM context so the model can see it.
 

--- a/src/qwenpaw/agents/tools/web_search.py
+++ b/src/qwenpaw/agents/tools/web_search.py
@@ -188,7 +188,16 @@ def _html_to_text(html_content: str) -> str:
     return body
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="network",
+    target_param="search_term",
+    policy_name="WebSearch",
+    default_policy="allow",
+    policy_reason="Allow web search",
+    ui_description="Search the web for real-time information",
+    ui_icon="🔎",
+)
 async def web_search(search_term: str) -> ToolChunk:
     """Search the web for real-time information about any topic. Returns summarized information from search results and relevant URLs.
 
@@ -254,7 +263,16 @@ async def web_search(search_term: str) -> ToolChunk:
     )
 
 
-@tool_descriptor(async_execution=True)
+@tool_descriptor(
+    async_execution=True,
+    tool_type="network",
+    target_param="url",
+    policy_name="WebFetch",
+    default_policy="allow",
+    policy_reason="Allow web fetch",
+    ui_description="Fetch and read content from a URL",
+    ui_icon="📥",
+)
 async def web_fetch(url: str) -> ToolChunk:
     """Fetch content from a specified URL and return its contents in a readable format. Use this tool when you need to retrieve and analyze webpage content.
 

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -230,6 +230,23 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             # pylint: disable-next=protected-access
             workspace_registry._bootstrap_kwargs[key] = value
 
+        # Warm descriptor-driven caches before serving requests so the
+        # first /tools or agent-config path does not pay full import cost
+        # on the event loop (macos integration tests use a 15s timeout).
+        try:
+            from ..config.config import _default_builtin_tools
+            from ..governance.policy import get_default_user_rules
+            from ..governance.tool_registry import DEFAULT_REGISTRY
+
+            DEFAULT_REGISTRY.get_all_tool_names()
+            _default_builtin_tools()
+            get_default_user_rules()
+        except Exception:
+            logger.debug(
+                "Descriptor cache warm-up skipped",
+                exc_info=True,
+            )
+
     except Exception:
         logger.debug(
             "Runtime infrastructure init skipped",

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -47,6 +47,55 @@ _current_approval_route: ContextVar[Optional[dict]] = ContextVar(
 )
 
 
+def resolve_agent_id_for_request(
+    request: Request,
+    agent_id: Optional[str] = None,
+    *,
+    require_enabled: bool = True,
+) -> str:
+    """Resolve the target agent id for a request without starting a workspace.
+
+    Priority matches :func:`get_agent_for_request`:
+    1. ``agent_id`` parameter (explicit override)
+    2. ``request.state.agent_id`` (from agent-scoped router)
+    3. ``X-Agent-Id`` header (from frontend)
+    4. Active agent from config
+
+    Raises:
+        HTTPException: If the agent is missing or disabled.
+    """
+    from fastapi import HTTPException
+
+    target_agent_id = agent_id
+
+    if not target_agent_id and hasattr(request.state, "agent_id"):
+        target_agent_id = request.state.agent_id
+
+    if not target_agent_id:
+        target_agent_id = request.headers.get("X-Agent-Id")
+
+    config = None
+    if not target_agent_id:
+        config = load_config()
+        target_agent_id = config.agents.active_agent or "default"
+
+    if config is None:
+        config = load_config()
+    if target_agent_id not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{target_agent_id}' not found",
+        )
+
+    agent_ref = config.agents.profiles[target_agent_id]
+    if require_enabled and not getattr(agent_ref, "enabled", True):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{target_agent_id}' is disabled",
+        )
+    return target_agent_id
+
+
 async def get_agent_for_request(
     request: Request,
     agent_id: Optional[str] = None,
@@ -71,39 +120,7 @@ async def get_agent_for_request(
     """
     from fastapi import HTTPException
 
-    # Determine which agent to use
-    target_agent_id = agent_id
-
-    # Check request.state.agent_id (set by agent-scoped router)
-    if not target_agent_id and hasattr(request.state, "agent_id"):
-        target_agent_id = request.state.agent_id
-
-    # Check X-Agent-Id header
-    if not target_agent_id:
-        target_agent_id = request.headers.get("X-Agent-Id")
-
-    # Load config once for fallback and validation
-    config = None
-    if not target_agent_id:
-        # Fallback to active agent from config
-        config = load_config()
-        target_agent_id = config.agents.active_agent or "default"
-
-    # Check if agent exists and is enabled
-    if config is None:
-        config = load_config()
-    if target_agent_id not in config.agents.profiles:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Agent '{target_agent_id}' not found",
-        )
-
-    agent_ref = config.agents.profiles[target_agent_id]
-    if not getattr(agent_ref, "enabled", True):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Agent '{target_agent_id}' is disabled",
-        )
+    target_agent_id = resolve_agent_id_for_request(request, agent_id)
 
     # Get MultiAgentManager
     if not hasattr(request.app.state, "multi_agent_manager"):

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -47,55 +47,6 @@ _current_approval_route: ContextVar[Optional[dict]] = ContextVar(
 )
 
 
-def resolve_agent_id_for_request(
-    request: Request,
-    agent_id: Optional[str] = None,
-    *,
-    require_enabled: bool = True,
-) -> str:
-    """Resolve the target agent id for a request without starting a workspace.
-
-    Priority matches :func:`get_agent_for_request`:
-    1. ``agent_id`` parameter (explicit override)
-    2. ``request.state.agent_id`` (from agent-scoped router)
-    3. ``X-Agent-Id`` header (from frontend)
-    4. Active agent from config
-
-    Raises:
-        HTTPException: If the agent is missing or disabled.
-    """
-    from fastapi import HTTPException
-
-    target_agent_id = agent_id
-
-    if not target_agent_id and hasattr(request.state, "agent_id"):
-        target_agent_id = request.state.agent_id
-
-    if not target_agent_id:
-        target_agent_id = request.headers.get("X-Agent-Id")
-
-    config = None
-    if not target_agent_id:
-        config = load_config()
-        target_agent_id = config.agents.active_agent or "default"
-
-    if config is None:
-        config = load_config()
-    if target_agent_id not in config.agents.profiles:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Agent '{target_agent_id}' not found",
-        )
-
-    agent_ref = config.agents.profiles[target_agent_id]
-    if require_enabled and not getattr(agent_ref, "enabled", True):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Agent '{target_agent_id}' is disabled",
-        )
-    return target_agent_id
-
-
 async def get_agent_for_request(
     request: Request,
     agent_id: Optional[str] = None,
@@ -120,7 +71,39 @@ async def get_agent_for_request(
     """
     from fastapi import HTTPException
 
-    target_agent_id = resolve_agent_id_for_request(request, agent_id)
+    # Determine which agent to use
+    target_agent_id = agent_id
+
+    # Check request.state.agent_id (set by agent-scoped router)
+    if not target_agent_id and hasattr(request.state, "agent_id"):
+        target_agent_id = request.state.agent_id
+
+    # Check X-Agent-Id header
+    if not target_agent_id:
+        target_agent_id = request.headers.get("X-Agent-Id")
+
+    # Load config once for fallback and validation
+    config = None
+    if not target_agent_id:
+        # Fallback to active agent from config
+        config = load_config()
+        target_agent_id = config.agents.active_agent or "default"
+
+    # Check if agent exists and is enabled
+    if config is None:
+        config = load_config()
+    if target_agent_id not in config.agents.profiles:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{target_agent_id}' not found",
+        )
+
+    agent_ref = config.agents.profiles[target_agent_id]
+    if not getattr(agent_ref, "enabled", True):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent '{target_agent_id}' is disabled",
+        )
 
     # Get MultiAgentManager
     if not hasattr(request.app.state, "multi_agent_manager"):

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -155,15 +155,20 @@ async def list_tools(
 ) -> List[ToolInfo]:
     """List all built-in tools and enabled status for active agent.
 
+    Resolves the agent id from the request and reads ``agent.json`` without
+    waiting for a full workspace startup. Listing tools is a config read and
+    must not block on channel/toolkit init (macos integration tests use a
+    15s HTTP timeout that races with ``schedule_agent_startup``).
+
     Returns:
         List of tool information
     """
-    from ..agent_context import get_agent_for_request
+    from ..agent_context import resolve_agent_id_for_request
     from ...config.config import load_agent_config
     from ...plugins.registry import PluginRegistry
 
-    workspace = await get_agent_for_request(request)
-    agent_config = load_agent_config(workspace.agent_id)
+    agent_id = resolve_agent_id_for_request(request)
+    agent_config = load_agent_config(agent_id)
 
     # Ensure tools config exists with defaults
     if not agent_config.tools or not agent_config.tools.builtin_tools:

--- a/src/qwenpaw/app/routers/tools.py
+++ b/src/qwenpaw/app/routers/tools.py
@@ -155,20 +155,15 @@ async def list_tools(
 ) -> List[ToolInfo]:
     """List all built-in tools and enabled status for active agent.
 
-    Resolves the agent id from the request and reads ``agent.json`` without
-    waiting for a full workspace startup. Listing tools is a config read and
-    must not block on channel/toolkit init (macos integration tests use a
-    15s HTTP timeout that races with ``schedule_agent_startup``).
-
     Returns:
         List of tool information
     """
-    from ..agent_context import resolve_agent_id_for_request
+    from ..agent_context import get_agent_for_request
     from ...config.config import load_agent_config
     from ...plugins.registry import PluginRegistry
 
-    agent_id = resolve_agent_id_for_request(request)
-    agent_config = load_agent_config(agent_id)
+    workspace = await get_agent_for_request(request)
+    agent_config = load_agent_config(workspace.agent_id)
 
     # Ensure tools config exists with defaults
     if not agent_config.tools or not agent_config.tools.builtin_tools:

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1761,163 +1761,48 @@ class BuiltinToolConfig(BaseModel):
 
 # pylint: disable=too-many-nested-blocks
 def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
-    """Return a fresh copy of the canonical built-in tool definitions.
+    """Return built-in tool definitions from ``@tool_descriptor`` UI metadata.
 
-    This includes both hardcoded tools and dynamically registered tools
-    from plugins.
+    Plugin tools from manifests are merged afterwards (disabled by default).
     """
-    tools = {
-        "execute_shell_command": BuiltinToolConfig(
-            name="execute_shell_command",
-            enabled=True,
-            description="Execute shell commands",
-            icon="💻",
-        ),
-        "read_file": BuiltinToolConfig(
-            name="read_file",
-            enabled=True,
-            description="Read file contents",
-            icon="📄",
-        ),
-        "write_file": BuiltinToolConfig(
-            name="write_file",
-            enabled=True,
-            description="Write content to file",
-            icon="✍️",
-        ),
-        "edit_file": BuiltinToolConfig(
-            name="edit_file",
-            enabled=True,
-            description="Edit file using find-and-replace",
-            icon="🖊️",
-        ),
-        "grep_search": BuiltinToolConfig(
-            name="grep_search",
-            enabled=True,
-            description="Search file contents by pattern",
-            icon="🔍",
-        ),
-        "glob_search": BuiltinToolConfig(
-            name="glob_search",
-            enabled=True,
-            description="Find files matching a glob pattern",
-            icon="📁",
-        ),
-        "browser_use": BuiltinToolConfig(
-            name="browser_use",
-            enabled=True,
-            description="Browser automation and web interaction",
-            icon="🌐",
-        ),
-        "web_search": BuiltinToolConfig(
-            name="web_search",
-            enabled=True,
-            description="Search the web for real-time information",
-            icon="🔎",
-        ),
-        "web_fetch": BuiltinToolConfig(
-            name="web_fetch",
-            enabled=True,
-            description="Fetch and read content from a URL",
-            icon="📥",
-        ),
-        "desktop_screenshot": BuiltinToolConfig(
-            name="desktop_screenshot",
-            enabled=True,
-            description="Capture desktop screenshots",
-            icon="📸",
-        ),
-        "view_image": BuiltinToolConfig(
-            name="view_image",
-            enabled=True,
-            description="Load an image into LLM context for visual analysis",
-            display_to_user=False,
-            icon="🖼️",
-        ),
-        "view_video": BuiltinToolConfig(
-            name="view_video",
-            enabled=True,
-            description="Load a video into LLM context for visual analysis",
-            display_to_user=False,
-            icon="🎥",
-        ),
-        "send_file_to_user": BuiltinToolConfig(
-            name="send_file_to_user",
-            enabled=True,
-            description="Send files to user",
-            icon="📤",
-        ),
-        "get_current_time": BuiltinToolConfig(
-            name="get_current_time",
-            enabled=True,
-            description="Get current date and time",
-            icon="🕐",
-        ),
-        "set_user_timezone": BuiltinToolConfig(
-            name="set_user_timezone",
-            enabled=True,
-            description="Set user timezone",
-            icon="🌍",
-        ),
-        "get_token_usage": BuiltinToolConfig(
-            name="get_token_usage",
-            enabled=True,
-            description="Get llm token usage",
-            icon="📊",
-        ),
-        "delegate_external_agent": BuiltinToolConfig(
-            name="delegate_external_agent",
-            enabled=False,
-            description="Delegate work to an external ACP agent runner",
-            icon="📡",
-        ),
-        "list_agents": BuiltinToolConfig(
-            name="list_agents",
-            enabled=True,
-            description="List configured agents from the local API",
-            icon="🤖",
-        ),
-        "chat_with_agent": BuiltinToolConfig(
-            name="chat_with_agent",
-            enabled=True,
-            description=(
-                "Send a message to another configured agent and wait for "
-                "the response"
-            ),
-            icon="💬",
-        ),
-        "submit_to_agent": BuiltinToolConfig(
-            name="submit_to_agent",
-            enabled=True,
-            description="Submit a background task to another configured agent",
-            icon="📨",
-        ),
-        "check_agent_task": BuiltinToolConfig(
-            name="check_agent_task",
-            enabled=True,
-            description="Check the status of a background agent task",
-            icon="⏳",
-        ),
-        "spawn_subagent": BuiltinToolConfig(
-            name="spawn_subagent",
-            enabled=True,
-            description=(
-                "Spawn an ephemeral sub-task within the current " "workspace"
-            ),
-            icon="🔀",
-        ),
-    }
+    tools: Dict[str, BuiltinToolConfig] = {}
+    try:
+        import qwenpaw.agents.tools as _agents_tools  # noqa: F401
+        from ..runtime.tool_registry import get_builtin_tool_funcs
+
+        _ = _agents_tools
+        for fn in get_builtin_tool_funcs():
+            desc = getattr(fn, "_tool_descriptor", None)
+            if desc is None:
+                continue
+            ui = getattr(desc, "ui", None)
+            tools[desc.name] = BuiltinToolConfig(
+                name=desc.name,
+                enabled=desc.enabled_by_default,
+                description=(
+                    (ui.description if ui and ui.description else "")
+                    or desc.description
+                    or ""
+                ),
+                display_to_user=(
+                    ui.display_to_user if ui is not None else True
+                ),
+                async_execution=desc.async_execution,
+                icon=(ui.icon if ui and ui.icon else None),
+            )
+    except Exception:
+        # Tools package unavailable during early import — empty set;
+        # callers typically re-invoke after agents.tools is loaded.
+        tools = {}
 
     # Merge dynamically registered tools from plugins
     try:
         from ..plugins.registry import PluginRegistry
 
         registry = PluginRegistry()
-        # Access manifests via public method
         all_manifests = registry.get_all_plugin_manifests()
         for plugin_id, manifest in all_manifests.items():
             meta = manifest.get("meta", {})
-            # Support old format: meta.tool_name
             if meta.get("tool_name"):
                 tool_name = meta["tool_name"]
                 if tool_name not in tools:
@@ -1932,7 +1817,6 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
                         async_execution=False,
                         icon=meta.get("tool_icon", "🔧"),
                     )
-            # Support new format: meta.tools array
             tools_list = meta.get("tools", [])
             if isinstance(tools_list, list):
                 for tool_info in tools_list:
@@ -1951,7 +1835,6 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
                                 icon=tool_info.get("icon", "🔧"),
                             )
     except Exception:
-        # Plugins not loaded yet, return hardcoded tools only
         pass
 
     return tools

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1790,9 +1790,14 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
                 async_execution=desc.async_execution,
                 icon=(ui.icon if ui and ui.icon else None),
             )
-    except Exception:
+    except Exception as exc:
         # Tools package unavailable during early import — empty set;
         # callers typically re-invoke after agents.tools is loaded.
+        logger.warning(
+            "Failed to build BuiltinToolConfig from tool descriptors: %s. "
+            "Built-in tools may be missing from the UI until reload.",
+            exc,
+        )
         tools = {}
 
     # Merge dynamically registered tools from plugins
@@ -1834,8 +1839,8 @@ def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
                                 async_execution=False,
                                 icon=tool_info.get("icon", "🔧"),
                             )
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Plugin tool merge skipped: %s", exc)
 
     return tools
 

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import re
+import threading
 from pathlib import Path
 from typing import Optional, Union, Dict, List, Literal, Any, Set
 
@@ -1759,90 +1761,119 @@ class BuiltinToolConfig(BaseModel):
     )
 
 
+_BUILTIN_TOOLS_CACHE: Dict[str, BuiltinToolConfig] | None = None
+_BUILTIN_TOOLS_LOCK = threading.Lock()
+
+
+def _reset_builtin_tools_cache_for_tests() -> None:
+    """Clear cached BuiltinToolConfig map (test helper only)."""
+    global _BUILTIN_TOOLS_CACHE
+    with _BUILTIN_TOOLS_LOCK:
+        _BUILTIN_TOOLS_CACHE = None
+
+
+def _copy_builtin_tools(
+    tools: Dict[str, BuiltinToolConfig],
+) -> Dict[str, BuiltinToolConfig]:
+    """Return a shallow dict of model copies so callers cannot mutate cache."""
+    return {name: cfg.model_copy() for name, cfg in tools.items()}
+
+
 # pylint: disable=too-many-nested-blocks
 def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
     """Return built-in tool definitions from ``@tool_descriptor`` UI metadata.
 
     Plugin tools from manifests are merged afterwards (disabled by default).
+    Successful builds are cached; descriptor import failure fails closed
+    (raises) unless a previous successful snapshot exists.
     """
-    tools: Dict[str, BuiltinToolConfig] = {}
-    try:
-        import qwenpaw.agents.tools as _agents_tools  # noqa: F401
-        from ..runtime.tool_registry import get_builtin_tool_funcs
+    global _BUILTIN_TOOLS_CACHE
+    with _BUILTIN_TOOLS_LOCK:
+        if _BUILTIN_TOOLS_CACHE is not None:
+            return _copy_builtin_tools(_BUILTIN_TOOLS_CACHE)
 
-        _ = _agents_tools
-        for fn in get_builtin_tool_funcs():
-            desc = getattr(fn, "_tool_descriptor", None)
-            if desc is None:
-                continue
-            ui = getattr(desc, "ui", None)
-            tools[desc.name] = BuiltinToolConfig(
-                name=desc.name,
-                enabled=desc.enabled_by_default,
-                description=(
-                    (ui.description if ui and ui.description else "")
-                    or desc.description
-                    or ""
-                ),
-                display_to_user=(
-                    ui.display_to_user if ui is not None else True
-                ),
-                async_execution=desc.async_execution,
-                icon=(ui.icon if ui and ui.icon else None),
+        tools: Dict[str, BuiltinToolConfig] = {}
+        try:
+            # Side-effect import via importlib (not `from ..agents import
+            # tools`) so mypy --follow-imports=skip does not form a static
+            # cycle with agents.tools → delegate_external_agent → config.
+            importlib.import_module("qwenpaw.agents.tools")
+            from ..runtime.tool_registry import get_builtin_tool_funcs
+
+            for fn in get_builtin_tool_funcs():
+                desc = getattr(fn, "_tool_descriptor", None)
+                if desc is None:
+                    continue
+                ui = getattr(desc, "ui", None)
+                tools[desc.name] = BuiltinToolConfig(
+                    name=desc.name,
+                    enabled=desc.enabled_by_default,
+                    description=(
+                        (ui.description if ui and ui.description else "")
+                        or desc.description
+                        or ""
+                    ),
+                    display_to_user=(
+                        ui.display_to_user if ui is not None else True
+                    ),
+                    async_execution=desc.async_execution,
+                    icon=(ui.icon if ui and ui.icon else None),
+                )
+        except Exception as exc:
+            logger.error(
+                "Failed to build BuiltinToolConfig from tool descriptors: %s",
+                exc,
+                exc_info=True,
             )
-    except Exception as exc:
-        # Tools package unavailable during early import — empty set;
-        # callers typically re-invoke after agents.tools is loaded.
-        logger.warning(
-            "Failed to build BuiltinToolConfig from tool descriptors: %s. "
-            "Built-in tools may be missing from the UI until reload.",
-            exc,
-        )
-        tools = {}
+            raise RuntimeError(
+                "Failed to build built-in tool config from descriptors; "
+                "refusing to persist an empty/incomplete ToolsConfig",
+            ) from exc
 
-    # Merge dynamically registered tools from plugins
-    try:
-        from ..plugins.registry import PluginRegistry
+        # Merge dynamically registered tools from plugins
+        try:
+            from ..plugins.registry import PluginRegistry
 
-        registry = PluginRegistry()
-        all_manifests = registry.get_all_plugin_manifests()
-        for plugin_id, manifest in all_manifests.items():
-            meta = manifest.get("meta", {})
-            if meta.get("tool_name"):
-                tool_name = meta["tool_name"]
-                if tool_name not in tools:
-                    tools[tool_name] = BuiltinToolConfig(
-                        name=tool_name,
-                        enabled=False,
-                        description=meta.get(
-                            "tool_description",
-                            f"Tool from plugin {plugin_id}",
-                        ),
-                        display_to_user=True,
-                        async_execution=False,
-                        icon=meta.get("tool_icon", "🔧"),
-                    )
-            tools_list = meta.get("tools", [])
-            if isinstance(tools_list, list):
-                for tool_info in tools_list:
-                    if isinstance(tool_info, dict) and "name" in tool_info:
-                        tool_name = tool_info["name"]
-                        if tool_name not in tools:
-                            tools[tool_name] = BuiltinToolConfig(
-                                name=tool_name,
-                                enabled=False,
-                                description=tool_info.get(
-                                    "description",
-                                    f"Tool from plugin {plugin_id}",
-                                ),
-                                display_to_user=True,
-                                async_execution=False,
-                                icon=tool_info.get("icon", "🔧"),
-                            )
-    except Exception as exc:
-        logger.debug("Plugin tool merge skipped: %s", exc)
+            registry = PluginRegistry()
+            all_manifests = registry.get_all_plugin_manifests()
+            for plugin_id, manifest in all_manifests.items():
+                meta = manifest.get("meta", {})
+                if meta.get("tool_name"):
+                    tool_name = meta["tool_name"]
+                    if tool_name not in tools:
+                        tools[tool_name] = BuiltinToolConfig(
+                            name=tool_name,
+                            enabled=False,
+                            description=meta.get(
+                                "tool_description",
+                                f"Tool from plugin {plugin_id}",
+                            ),
+                            display_to_user=True,
+                            async_execution=False,
+                            icon=meta.get("tool_icon", "🔧"),
+                        )
+                tools_list = meta.get("tools", [])
+                if isinstance(tools_list, list):
+                    for tool_info in tools_list:
+                        if isinstance(tool_info, dict) and "name" in tool_info:
+                            tool_name = tool_info["name"]
+                            if tool_name not in tools:
+                                tools[tool_name] = BuiltinToolConfig(
+                                    name=tool_name,
+                                    enabled=False,
+                                    description=tool_info.get(
+                                        "description",
+                                        f"Tool from plugin {plugin_id}",
+                                    ),
+                                    display_to_user=True,
+                                    async_execution=False,
+                                    icon=tool_info.get("icon", "🔧"),
+                                )
+        except Exception as exc:
+            logger.debug("Plugin tool merge skipped: %s", exc)
 
-    return tools
+        _BUILTIN_TOOLS_CACHE = tools
+        return _copy_builtin_tools(tools)
 
 
 class ToolsConfig(BaseModel):

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -380,47 +380,12 @@ FILE_WRITE_TOOLS: frozenset[str] = frozenset({"Write", "Edit", "Append"})
 # Default user_rules (for cold start)
 # ---------------------------------------------------------------------------
 
-DEFAULT_USER_RULES: List[GovernanceRule] = [
-    # NOTE: Internal tools (GetCurrentTime, GetTokenUsage, ListAgents,
-    # ChatWithAgent, SubmitToAgent, CheckAgentTask, DelegateExternalAgent)
-    # need no rule here — they are registered as "internal" type and
-    # short-circuited to ALLOW in Phase 0 of evaluate().
-    # ── Read-only file tools (global allow) ──
-    # Reads are safe to allow on any path: the builtin sensitive-path ASK
-    # rules (*.env / .ssh / .aws / …) are evaluated BEFORE user_rules
-    # (Phase 2 builtin-first), so reading secrets still prompts. Note '**'
-    # is required here, not '*': file tools match via wcmatch where '*'
-    # does not cross '/', so '*' would only match a single path segment.
-    GovernanceRule(
-        match="Read(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Read-only file access (global)",
-    ),
-    GovernanceRule(
-        match="Grep(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Content search (global)",
-    ),
-    GovernanceRule(
-        match="Glob(**)",
-        action=GovernanceAction.ALLOW,
-        reason="File listing (global)",
-    ),
-    GovernanceRule(
-        match="ViewImage(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Image view (global)",
-    ),
-    GovernanceRule(
-        match="ViewVideo(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Video view (global)",
-    ),
-    GovernanceRule(
-        match="SendFileToUser(**)",
-        action=GovernanceAction.ALLOW,
-        reason="File send to user (global)",
-    ),
+# Path-level / environment rules kept here manually (cannot be expressed
+# by ``@tool_descriptor``). Tool-level ``ToolName(**)`` ALLOW/ASK/DENY
+# rules are generated from descriptor ``default_policy`` fields via
+# :func:`get_default_user_rules`.
+_PATH_LEVEL_USER_RULES: List[GovernanceRule] = [
+    # NOTE: Internal tools need no rule — Phase 0 short-circuits them.
     # ── File tools (operations within WORKSPACE_DIR, always allowed) ──
     GovernanceRule(
         match="Read(WORKSPACE_DIR/**)",
@@ -472,25 +437,7 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         action=GovernanceAction.ALLOW,
         reason="File send within workspace",
     ),
-    # ── Browser (treat as always allowed for now) ──
-    GovernanceRule(
-        match="Browser(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Allow all browser access",
-    ),
-    # ── Web search & fetch (read-only network tools) ──
-    GovernanceRule(
-        match="WebSearch(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Allow web search",
-    ),
-    GovernanceRule(
-        match="WebFetch(**)",
-        action=GovernanceAction.ALLOW,
-        reason="Allow web fetch",
-    ),
     # ── /tmp ──
-    # Allow all tool access under /tmp without prompting.
     GovernanceRule(
         match="*(/tmp/**)",
         action=GovernanceAction.ALLOW,
@@ -503,7 +450,6 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         reason="Coding project dir",
     ),
     # ALLOW all other gh operations
-    # (agent needs write access for PR/issue management)
     GovernanceRule(
         match="Bash(gh)",
         action=GovernanceAction.ALLOW,
@@ -515,6 +461,89 @@ DEFAULT_USER_RULES: List[GovernanceRule] = [
         reason="GitHub CLI operations",
     ),
 ]
+
+
+def _auto_default_user_rules() -> List[GovernanceRule]:
+    """Build tool-level rules from ``@tool_descriptor(default_policy=...)``.
+
+    Import of ``agents.tools`` is deferred so this stays safe when
+    ``policy`` is imported before tool modules.
+    """
+    try:
+        import qwenpaw.agents.tools as _agents_tools  # noqa: F401
+        from ..runtime.tool_registry import get_builtin_tool_funcs
+        from .tool_registry import snake_to_pascal
+
+        _ = _agents_tools
+    except Exception:  # noqa: BLE001
+        return []
+
+    action_map = {
+        "allow": GovernanceAction.ALLOW,
+        "ask": GovernanceAction.ASK,
+        "deny": GovernanceAction.DENY,
+    }
+    rules: List[GovernanceRule] = []
+    for fn in get_builtin_tool_funcs():
+        desc = getattr(fn, "_tool_descriptor", None)
+        if desc is None:
+            continue
+        gov = getattr(desc, "governance", None)
+        if gov is None or not gov.default_policy:
+            continue
+        action = action_map.get(gov.default_policy.lower())
+        if action is None:
+            continue
+        pname = gov.policy_name or snake_to_pascal(desc.name)
+        rules.append(
+            GovernanceRule(
+                match=f"{pname}(**)",
+                action=action,
+                reason=gov.policy_reason or f"Auto-registered: {pname}",
+            ),
+        )
+    return rules
+
+
+def get_default_user_rules() -> List[GovernanceRule]:
+    """Path-level defaults + auto-generated tool-level descriptor rules.
+
+    If tests (or callers) replace module-level ``DEFAULT_USER_RULES`` with a
+    plain ``list``, that override is returned as-is so migration tests can
+    inject synthetic default rules.
+    """
+    # Late lookup avoids binding the proxy before it exists; a patched plain
+    # list (``type is list``) wins over the auto-built defaults.
+    override = globals().get("DEFAULT_USER_RULES")
+    if type(override) is list:
+        return list(override)
+    return list(_PATH_LEVEL_USER_RULES) + _auto_default_user_rules()
+
+
+# Backward-compatible name used by tests and callers. Resolved lazily so
+# descriptor imports are available when the list is first read.
+class _DefaultUserRulesProxy(list):
+    """List-like view over :func:`get_default_user_rules`."""
+
+    def _rules(self) -> List[GovernanceRule]:
+        return get_default_user_rules()
+
+    def __iter__(self):
+        return iter(self._rules())
+
+    def __len__(self) -> int:
+        return len(self._rules())
+
+    def __getitem__(self, index):
+        return self._rules()[index]
+
+    def __repr__(self) -> str:
+        return repr(self._rules())
+
+
+DEFAULT_USER_RULES: List[
+    GovernanceRule
+] = _DefaultUserRulesProxy()  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
@@ -1113,7 +1142,7 @@ def load_governance_policy(
 
     # ── Cold start / migration: fill in missing default rules ──
     if not user_rules:
-        user_rules = copy.deepcopy(DEFAULT_USER_RULES)
+        user_rules = copy.deepcopy(get_default_user_rules())
     else:
         user_rules = _merge_missing_default_user_rules(
             user_rules,
@@ -1124,7 +1153,7 @@ def load_governance_policy(
     # Record all DEFAULT_USER_RULES as applied so the next save
     # makes any user deletion of a default rule stick.
     applied_migrations = sorted(
-        set(applied_migrations) | {r.match for r in DEFAULT_USER_RULES},
+        set(applied_migrations) | {r.match for r in get_default_user_rules()},
     )
     if not env_blacklist:
         env_blacklist = list(DEFAULT_ENV_BLACKLIST)
@@ -1269,7 +1298,7 @@ def _create_default_policy(
 ) -> GovernancePolicy:
     """Create a policy with full default rules (cold start, v2.0)."""
     builtin_rules = copy.deepcopy(DEFAULT_BUILTIN_RULES)
-    user_rules = copy.deepcopy(DEFAULT_USER_RULES)
+    user_rules = copy.deepcopy(get_default_user_rules())
     if workspace_dir:
         cpd = coding_project_dir or workspace_dir
         _resolve_placeholders(builtin_rules, workspace_dir, cpd)
@@ -1282,7 +1311,7 @@ def _create_default_policy(
         execution_level="smart",
         sensitive_paths=list(_DEFAULT_SENSITIVE_PATHS),
         shell_evasion_checks=dict(_DEFAULT_SHELL_EVASION_CHECKS),
-        applied_migrations=sorted(r.match for r in DEFAULT_USER_RULES),
+        applied_migrations=sorted(r.match for r in get_default_user_rules()),
     )
 
 
@@ -1308,7 +1337,7 @@ def _merge_missing_default_user_rules(
     """
     applied = set(applied_migrations or [])
     merged = list(user_rules)
-    for default_rule in DEFAULT_USER_RULES:
+    for default_rule in get_default_user_rules():
         if default_rule.match in applied:
             continue
         if _has_equivalent_rule(

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import copy
 import logging
 import re
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from fnmatch import fnmatch
@@ -463,6 +464,10 @@ _PATH_LEVEL_USER_RULES: List[GovernanceRule] = [
 ]
 
 
+_AUTO_DEFAULT_USER_RULES_CACHE: List[GovernanceRule] | None = None
+_AUTO_DEFAULT_USER_RULES_LOCK = threading.Lock()
+
+
 def _auto_default_user_rules() -> List[GovernanceRule]:
     """Build tool-level rules from ``@tool_descriptor(default_policy=...)``.
 
@@ -474,45 +479,53 @@ def _auto_default_user_rules() -> List[GovernanceRule]:
     non-overlapping ``ToolName(**)`` ALLOW entries, so order does not
     change Phase 2 first-match outcomes; keep that invariant when adding
     ASK/DENY defaults.
+
+    Successful builds are cached so request paths do not rescan descriptors.
     """
-    try:
-        import qwenpaw.agents.tools as _agents_tools  # noqa: F401
-        from ..runtime.tool_registry import get_builtin_tool_funcs
-        from .tool_registry import snake_to_pascal
+    global _AUTO_DEFAULT_USER_RULES_CACHE
+    with _AUTO_DEFAULT_USER_RULES_LOCK:
+        if _AUTO_DEFAULT_USER_RULES_CACHE is not None:
+            return list(_AUTO_DEFAULT_USER_RULES_CACHE)
 
-        _ = _agents_tools
-    except Exception as exc:  # noqa: BLE001
-        logger.warning(
-            "Failed to build auto default user rules from descriptors: %s",
-            exc,
-        )
-        return []
+        try:
+            from ..agents import tools as _agents_tools  # noqa: F401
+            from ..runtime.tool_registry import get_builtin_tool_funcs
+            from .tool_registry import snake_to_pascal
 
-    action_map = {
-        "allow": GovernanceAction.ALLOW,
-        "ask": GovernanceAction.ASK,
-        "deny": GovernanceAction.DENY,
-    }
-    rules: List[GovernanceRule] = []
-    for fn in get_builtin_tool_funcs():
-        desc = getattr(fn, "_tool_descriptor", None)
-        if desc is None:
-            continue
-        gov = getattr(desc, "governance", None)
-        if gov is None or not gov.default_policy:
-            continue
-        action = action_map.get(gov.default_policy.lower())
-        if action is None:
-            continue
-        pname = gov.policy_name or snake_to_pascal(desc.name)
-        rules.append(
-            GovernanceRule(
-                match=f"{pname}(**)",
-                action=action,
-                reason=gov.policy_reason or f"Auto-registered: {pname}",
-            ),
-        )
-    return rules
+            _ = _agents_tools
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to build auto default user rules from descriptors: %s",
+                exc,
+            )
+            return []
+
+        action_map = {
+            "allow": GovernanceAction.ALLOW,
+            "ask": GovernanceAction.ASK,
+            "deny": GovernanceAction.DENY,
+        }
+        rules: List[GovernanceRule] = []
+        for fn in get_builtin_tool_funcs():
+            desc = getattr(fn, "_tool_descriptor", None)
+            if desc is None:
+                continue
+            gov = getattr(desc, "governance", None)
+            if gov is None or not gov.default_policy:
+                continue
+            action = action_map.get(gov.default_policy.lower())
+            if action is None:
+                continue
+            pname = gov.policy_name or snake_to_pascal(desc.name)
+            rules.append(
+                GovernanceRule(
+                    match=f"{pname}(**)",
+                    action=action,
+                    reason=gov.policy_reason or f"Auto-registered: {pname}",
+                ),
+            )
+        _AUTO_DEFAULT_USER_RULES_CACHE = rules
+        return list(rules)
 
 
 def get_default_user_rules() -> List[GovernanceRule]:

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -468,6 +468,12 @@ def _auto_default_user_rules() -> List[GovernanceRule]:
 
     Import of ``agents.tools`` is deferred so this stays safe when
     ``policy`` is imported before tool modules.
+
+    Rule order follows ``get_builtin_tool_funcs()`` collection order
+    (``agents/tools/__init__.py`` import order). Current auto rules are
+    non-overlapping ``ToolName(**)`` ALLOW entries, so order does not
+    change Phase 2 first-match outcomes; keep that invariant when adding
+    ASK/DENY defaults.
     """
     try:
         import qwenpaw.agents.tools as _agents_tools  # noqa: F401
@@ -475,7 +481,11 @@ def _auto_default_user_rules() -> List[GovernanceRule]:
         from .tool_registry import snake_to_pascal
 
         _ = _agents_tools
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to build auto default user rules from descriptors: %s",
+            exc,
+        )
         return []
 
     action_map = {
@@ -508,6 +518,17 @@ def _auto_default_user_rules() -> List[GovernanceRule]:
 def get_default_user_rules() -> List[GovernanceRule]:
     """Path-level defaults + auto-generated tool-level descriptor rules.
 
+    Concatenation order (matters for Phase 2 first-match on ``user_rules``):
+
+    1. ``_PATH_LEVEL_USER_RULES`` — workspace / tmp / coding-project / gh
+    2. ``_auto_default_user_rules()`` — ``ToolName(**)`` from descriptors
+
+    Today tool-level ALLOW rules are supersets of the path-level ALLOW rules
+    for the same tools, so reordering relative to the historical interleaved
+    list is semantically equivalent. Do **not** add tool-level DENY/ASK
+    defaults that would need to lose to a more specific path ALLOW without
+    revisiting this order.
+
     If tests (or callers) replace module-level ``DEFAULT_USER_RULES`` with a
     plain ``list``, that override is returned as-is so migration tests can
     inject synthetic default rules.
@@ -523,7 +544,14 @@ def get_default_user_rules() -> List[GovernanceRule]:
 # Backward-compatible name used by tests and callers. Resolved lazily so
 # descriptor imports are available when the list is first read.
 class _DefaultUserRulesProxy(list):
-    """List-like view over :func:`get_default_user_rules`."""
+    """Lazy list-like view over :func:`get_default_user_rules`.
+
+    Supported: iteration, ``len()``, integer index, ``repr``.
+
+    Unsupported / unsafe on the proxy itself: ``+``, ``==``, slice
+    assignment, in-place mutation. Prefer
+    ``list(DEFAULT_USER_RULES)`` / :func:`get_default_user_rules` first.
+    """
 
     def _rules(self) -> List[GovernanceRule]:
         return get_default_user_rules()

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+import threading
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,14 @@ class ToolRegistry:
         """
         return self._target_params.get(tool_name, "")
 
+    def get_pattern_param(self, tool_name: str) -> str:
+        """Return the optional pattern parameter name (e.g. Glob)."""
+        return self._pattern_params.get(tool_name, "")
+
+    def get_mapped_policy_name(self, python_name: str) -> Optional[str]:
+        """Return explicit python→policy mapping, or ``None`` if unset."""
+        return self._python_name_map.get(python_name)
+
     def requires_sandbox(self, tool_name: str) -> bool:
         """Whether the tool fails closed without a ``sandbox_config``.
 
@@ -148,6 +157,18 @@ class ToolRegistry:
         """Return all registered tool names."""
         return list(self._types.keys())
 
+    def get_identity(
+        self,
+        tool_name: str,
+    ) -> Tuple[str, str, str, bool]:
+        """Return (type, target, pattern, sandbox_required) for comparisons."""
+        return (
+            self.get_type(tool_name),
+            self.get_target_param(tool_name),
+            self.get_pattern_param(tool_name),
+            self.requires_sandbox(tool_name),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Shared registration helpers
@@ -159,6 +180,10 @@ def snake_to_pascal(name: str) -> str:
     return "".join(p.capitalize() for p in name.split("_"))
 
 
+class GovernanceRegistrationConflict(ValueError):
+    """Raised when a governance policy identity would be reused unsafely."""
+
+
 def register_tool_governance(
     registry: ToolRegistry,
     python_name: str,
@@ -168,7 +193,11 @@ def register_tool_governance(
     pattern_param: str = "",
     sandbox_required: bool = False,
 ) -> str:
-    """Register one tool into the governance registry (idempotent).
+    """Register one tool into the governance registry.
+
+    Idempotent only when the existing policy identity is owned by the same
+    ``python_name`` and metadata (type / target / pattern / sandbox) match.
+    Conflicting re-registration fails closed.
 
     Used by:
     - builtin ``@tool_descriptor`` scan (``_register_from_descriptors``)
@@ -176,10 +205,25 @@ def register_tool_governance(
     - goal-mode ``register_goal_tools_governance``
 
     Returns the policy-layer tool name that was registered
-    (or already present).
+    (or already present with identical metadata).
     """
     pname = policy_name or snake_to_pascal(python_name)
-    if registry.get_type(pname) == "unknown":
+    new_identity = (
+        tool_type,
+        target_param or "",
+        pattern_param or "",
+        bool(sandbox_required),
+    )
+    existing_type = registry.get_type(pname)
+    existing_map = registry.get_mapped_policy_name(python_name)
+
+    if existing_map is not None and existing_map != pname:
+        raise GovernanceRegistrationConflict(
+            f"Python tool {python_name!r} already maps to policy "
+            f"{existing_map!r}; cannot remap to {pname!r}",
+        )
+
+    if existing_type == "unknown":
         registry.register(
             pname,
             tool_type,
@@ -187,12 +231,26 @@ def register_tool_governance(
             pattern_param=pattern_param,
             sandbox_required=sandbox_required,
         )
-    else:
-        logger.debug(
-            "Tool %s already registered in governance, skipping type update",
-            pname,
+        registry.register_python_name(python_name, pname)
+        return pname
+
+    existing_identity = registry.get_identity(pname)
+    if existing_identity != new_identity:
+        raise GovernanceRegistrationConflict(
+            f"Governance policy identity conflict for {pname!r}: "
+            f"existing type/target/pattern/sandbox="
+            f"{existing_identity!r}, requested {new_identity!r}",
         )
-    registry.register_python_name(python_name, pname)
+
+    if existing_map is None:
+        # Another python name already owns this policy identity.
+        raise GovernanceRegistrationConflict(
+            f"Policy name {pname!r} is already registered; refusing to map "
+            f"additional python tool {python_name!r} onto it "
+            f"(name-fold / ownership collision)",
+        )
+
+    # Same python_name + identical metadata → idempotent.
     return pname
 
 
@@ -200,7 +258,7 @@ def _register_from_descriptors(registry: ToolRegistry) -> None:
     """Register builtins that declare governance.tool_type on descriptors."""
     try:
         # Side-effect import so @tool_descriptor registrations run.
-        import qwenpaw.agents.tools as _agents_tools  # noqa: F401
+        from ..agents import tools as _agents_tools  # noqa: F401
         from ..runtime.tool_registry import get_builtin_tool_funcs
 
         _ = _agents_tools
@@ -266,7 +324,13 @@ def _register_non_descriptor_tools(registry: ToolRegistry) -> None:
 
 
 def _collect_governance_gaps(registry: ToolRegistry) -> list[str]:
-    """Return policy names of descriptor tools missing from ``registry``."""
+    """Return names of collected builtins missing a governance identity.
+
+    Every function in the builtin runtime collection must declare a non-empty
+    ``governance.tool_type`` and be present in ``registry``. Empty tool_type
+    is itself a gap — tools must not appear in toolkit/UI without Phase 0
+    metadata.
+    """
     from ..runtime.tool_registry import get_builtin_tool_funcs
 
     gaps: list[str] = []
@@ -276,6 +340,12 @@ def _collect_governance_gaps(registry: ToolRegistry) -> list[str]:
             continue
         gov = getattr(desc, "governance", None)
         if gov is None or not gov.tool_type:
+            gaps.append(desc.name)
+            logger.error(
+                "Governance gap: tool %r is runtime-registered but has no "
+                "governance.tool_type (Phase 0 DENY / invisible to registry).",
+                desc.name,
+            )
             continue
         pname = gov.policy_name or snake_to_pascal(desc.name)
         if registry.get_type(pname) == "unknown":
@@ -290,10 +360,9 @@ def _collect_governance_gaps(registry: ToolRegistry) -> list[str]:
 
 
 def assert_no_governance_gaps() -> list[str]:
-    """Return policy names of descriptor tools missing from governance.
+    """Return names of collected builtins missing governance identity.
 
-    Tools with empty ``governance.tool_type`` are skipped (not yet migrated
-    or intentionally using another registration path).
+    Includes descriptors with empty ``governance.tool_type``.
     """
     return _collect_governance_gaps(DEFAULT_REGISTRY)
 
@@ -325,24 +394,40 @@ class _LazyDefaultRegistry:
     delaying construction until after ``agents.tools`` imports can run.
     """
 
-    __slots__ = ("_instance",)
+    __slots__ = ("_instance", "_lock")
 
     def __init__(self) -> None:
         object.__setattr__(self, "_instance", None)
+        object.__setattr__(self, "_lock", threading.Lock())
 
     def _get(self) -> ToolRegistry:
         inst = object.__getattribute__(self, "_instance")
-        if inst is None:
-            inst = _create_default_registry()
-            object.__setattr__(self, "_instance", inst)
-        return inst
+        if inst is not None:
+            return inst
+        lock = object.__getattribute__(self, "_lock")
+        with lock:
+            inst = object.__getattribute__(self, "_instance")
+            if inst is None:
+                inst = _create_default_registry()
+                object.__setattr__(self, "_instance", inst)
+            return inst
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._get(), name)
 
+    def __copy__(self) -> "_LazyDefaultRegistry":
+        # Singleton: copy must not duplicate the lock.
+        return self
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "_LazyDefaultRegistry":
+        memo[id(self)] = self
+        return self
+
     def _reset_for_tests(self) -> None:
         """Drop the cached instance (test helper only)."""
-        object.__setattr__(self, "_instance", None)
+        lock = object.__getattribute__(self, "_lock")
+        with lock:
+            object.__setattr__(self, "_instance", None)
 
 
 DEFAULT_REGISTRY: Any = _LazyDefaultRegistry()

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -187,6 +187,11 @@ def register_tool_governance(
             pattern_param=pattern_param,
             sandbox_required=sandbox_required,
         )
+    else:
+        logger.debug(
+            "Tool %s already registered in governance, skipping type update",
+            pname,
+        )
     registry.register_python_name(python_name, pname)
     return pname
 
@@ -200,9 +205,12 @@ def _register_from_descriptors(registry: ToolRegistry) -> None:
 
         _ = _agents_tools
     except Exception as exc:  # noqa: BLE001
-        logger.debug(
-            "Skipping descriptor governance registration: %s",
+        logger.error(
+            "Failed to import agents.tools for governance registration: %s. "
+            "Built-in tools will be missing from the governance whitelist "
+            "and denied at Phase 0 until import succeeds.",
             exc,
+            exc_info=True,
         )
         return
 
@@ -225,7 +233,12 @@ def _register_from_descriptors(registry: ToolRegistry) -> None:
 
 
 def _register_non_descriptor_tools(registry: ToolRegistry) -> None:
-    """Tools that intentionally skip ``@tool_descriptor`` auto-collection."""
+    """Register tools that intentionally skip ``@tool_descriptor`` collection.
+
+    Exception path for dynamic / mode-scoped tools that must not appear in
+    the global builtin set (scroll ``recall_history*``, memory manager
+    ``memory_search``). Keep this list documented when adding similar tools.
+    """
     # Scroll strategy tools — hand-built descriptors, not global builtins.
     register_tool_governance(
         registry,
@@ -252,16 +265,11 @@ def _register_non_descriptor_tools(registry: ToolRegistry) -> None:
     )
 
 
-def assert_no_governance_gaps() -> list[str]:
-    """Return policy names of descriptor tools missing from governance.
-
-    Tools with empty ``governance.tool_type`` are skipped (not yet migrated
-    or intentionally using another registration path).
-    """
+def _collect_governance_gaps(registry: ToolRegistry) -> list[str]:
+    """Return policy names of descriptor tools missing from ``registry``."""
     from ..runtime.tool_registry import get_builtin_tool_funcs
 
     gaps: list[str] = []
-    registry = DEFAULT_REGISTRY
     for fn in get_builtin_tool_funcs():
         desc = getattr(fn, "_tool_descriptor", None)
         if desc is None:
@@ -281,6 +289,15 @@ def assert_no_governance_gaps() -> list[str]:
     return gaps
 
 
+def assert_no_governance_gaps() -> list[str]:
+    """Return policy names of descriptor tools missing from governance.
+
+    Tools with empty ``governance.tool_type`` are skipped (not yet migrated
+    or intentionally using another registration path).
+    """
+    return _collect_governance_gaps(DEFAULT_REGISTRY)
+
+
 # ---------------------------------------------------------------------------
 # Default registry (lazy singleton)
 # ---------------------------------------------------------------------------
@@ -291,6 +308,13 @@ def _create_default_registry() -> ToolRegistry:
     registry = ToolRegistry()
     _register_from_descriptors(registry)
     _register_non_descriptor_tools(registry)
+    gaps = _collect_governance_gaps(registry)
+    if gaps:
+        logger.warning(
+            "Governance registry built with %d gap(s): %s",
+            len(gaps),
+            ", ".join(gaps),
+        )
     return registry
 
 

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -14,8 +14,12 @@ Relationship with policy.yaml:
 """
 
 from __future__ import annotations
+
+import logging
 import os
 from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
 
 
 class ToolRegistry:
@@ -146,97 +150,175 @@ class ToolRegistry:
 
 
 # ---------------------------------------------------------------------------
-# Default registry instance (21 tools)
+# Shared registration helpers
+# ---------------------------------------------------------------------------
+
+
+def snake_to_pascal(name: str) -> str:
+    """Convert ``snake_case`` to ``PascalCase``."""
+    return "".join(p.capitalize() for p in name.split("_"))
+
+
+def register_tool_governance(
+    registry: ToolRegistry,
+    python_name: str,
+    tool_type: str,
+    target_param: str = "",
+    policy_name: str = "",
+    pattern_param: str = "",
+    sandbox_required: bool = False,
+) -> str:
+    """Register one tool into the governance registry (idempotent).
+
+    Used by:
+    - builtin ``@tool_descriptor`` scan (``_register_from_descriptors``)
+    - ``PluginApi.register_tool`` (issue #6114)
+    - goal-mode ``register_goal_tools_governance``
+
+    Returns the policy-layer tool name that was registered
+    (or already present).
+    """
+    pname = policy_name or snake_to_pascal(python_name)
+    if registry.get_type(pname) == "unknown":
+        registry.register(
+            pname,
+            tool_type,
+            target_param,
+            pattern_param=pattern_param,
+            sandbox_required=sandbox_required,
+        )
+    registry.register_python_name(python_name, pname)
+    return pname
+
+
+def _register_from_descriptors(registry: ToolRegistry) -> None:
+    """Register builtins that declare governance.tool_type on descriptors."""
+    try:
+        # Side-effect import so @tool_descriptor registrations run.
+        import qwenpaw.agents.tools as _agents_tools  # noqa: F401
+        from ..runtime.tool_registry import get_builtin_tool_funcs
+
+        _ = _agents_tools
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "Skipping descriptor governance registration: %s",
+            exc,
+        )
+        return
+
+    for fn in get_builtin_tool_funcs():
+        desc = getattr(fn, "_tool_descriptor", None)
+        if desc is None:
+            continue
+        gov = getattr(desc, "governance", None)
+        if gov is None or not gov.tool_type:
+            continue
+        register_tool_governance(
+            registry,
+            python_name=desc.name,
+            tool_type=gov.tool_type,
+            target_param=gov.target_param,
+            policy_name=gov.policy_name,
+            pattern_param=gov.pattern_param,
+            sandbox_required=gov.fail_without_sandbox,
+        )
+
+
+def _register_non_descriptor_tools(registry: ToolRegistry) -> None:
+    """Tools that intentionally skip ``@tool_descriptor`` auto-collection."""
+    # Scroll strategy tools — hand-built descriptors, not global builtins.
+    register_tool_governance(
+        registry,
+        python_name="recall_history",
+        tool_type="internal",
+        target_param="op",
+        policy_name="RecallHistory",
+    )
+    register_tool_governance(
+        registry,
+        python_name="recall_history_python",
+        tool_type="shell",
+        target_param="source",
+        policy_name="RecallHistoryPython",
+        sandbox_required=True,
+    )
+    # Memory manager tool — registered dynamically outside agents.tools.
+    register_tool_governance(
+        registry,
+        python_name="memory_search",
+        tool_type="internal",
+        target_param="",
+        policy_name="MemorySearch",
+    )
+
+
+def assert_no_governance_gaps() -> list[str]:
+    """Return policy names of descriptor tools missing from governance.
+
+    Tools with empty ``governance.tool_type`` are skipped (not yet migrated
+    or intentionally using another registration path).
+    """
+    from ..runtime.tool_registry import get_builtin_tool_funcs
+
+    gaps: list[str] = []
+    registry = DEFAULT_REGISTRY
+    for fn in get_builtin_tool_funcs():
+        desc = getattr(fn, "_tool_descriptor", None)
+        if desc is None:
+            continue
+        gov = getattr(desc, "governance", None)
+        if gov is None or not gov.tool_type:
+            continue
+        pname = gov.policy_name or snake_to_pascal(desc.name)
+        if registry.get_type(pname) == "unknown":
+            gaps.append(pname)
+            logger.error(
+                "Governance gap: tool %r (policy %r) is runtime-registered "
+                "but missing from the governance registry (Phase 0 DENY).",
+                desc.name,
+                pname,
+            )
+    return gaps
+
+
+# ---------------------------------------------------------------------------
+# Default registry (lazy singleton)
 # ---------------------------------------------------------------------------
 
 
 def _create_default_registry() -> ToolRegistry:
     """Create and populate the default ToolRegistry."""
     registry = ToolRegistry()
-    _register_builtin_tools(registry)
-    _register_python_name_mappings(registry)
+    _register_from_descriptors(registry)
+    _register_non_descriptor_tools(registry)
     return registry
 
 
-def _register_builtin_tools(r: ToolRegistry) -> None:
-    """Register all built-in tool types."""
-    # ── File tools ──
-    for name, param in [
-        ("Read", "file_path"),
-        ("Write", "file_path"),
-        ("Edit", "file_path"),
-        ("Append", "file_path"),
-        ("Grep", "path"),
-        ("SendFileToUser", "file_path"),
-        ("ViewImage", "image_path"),
-        ("ViewVideo", "video_path"),
-        ("DesktopScreenshot", "path"),
-        ("SetUserTimezone", "timezone"),
-    ]:
-        r.register(name, "file", param)
-    r.register("Glob", "file", "path", pattern_param="pattern")
+class _LazyDefaultRegistry:
+    """Proxy that builds the real registry on first attribute access.
 
-    # ── Network / Shell ──
-    r.register("Browser", "network", "url")
-    r.register("WebSearch", "network", "search_term")
-    r.register("WebFetch", "network", "url")
-    r.register("Bash", "shell", "command")
-    # Fail-closed: the REPL runs model-authored Python and returns DENIED
-    # unless a sandbox_config is supplied (unlike Bash, which is fail-open).
-    r.register("RecallHistoryPython", "shell", "source", sandbox_required=True)
-    # Structured recall: bound-parameter read-only queries over history.db —
-    # the model supplies scalars, never code, so no sandbox/approval needed.
-    r.register("RecallHistory", "internal", "op")
+    Keeps the public name ``DEFAULT_REGISTRY`` stable for call sites while
+    delaying construction until after ``agents.tools`` imports can run.
+    """
 
-    # ── Internal tools ──
-    for name, param in [
-        ("GetCurrentTime", ""),
-        ("GetTokenUsage", ""),
-        ("ListAgents", ""),
-        ("MaterializeSkill", ""),
-        ("ChatWithAgent", "agent_id"),
-        ("SubmitToAgent", "agent_id"),
-        ("CheckAgentTask", "task_id"),
-        ("SpawnSubagent", ""),
-        ("DelegateExternalAgent", "runner"),
-        ("MemorySearch", ""),
-    ]:
-        r.register(name, "internal", param)
+    __slots__ = ("_instance",)
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_instance", None)
+
+    def _get(self) -> ToolRegistry:
+        inst = object.__getattribute__(self, "_instance")
+        if inst is None:
+            inst = _create_default_registry()
+            object.__setattr__(self, "_instance", inst)
+        return inst
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._get(), name)
+
+    def _reset_for_tests(self) -> None:
+        """Drop the cached instance (test helper only)."""
+        object.__setattr__(self, "_instance", None)
 
 
-def _register_python_name_mappings(
-    r: ToolRegistry,
-) -> None:
-    """Register python func name → policy name maps."""
-    mappings = {
-        "execute_shell_command": "Bash",
-        "read_file": "Read",
-        "write_file": "Write",
-        "edit_file": "Edit",
-        "memory_search": "MemorySearch",
-        "append_file": "Append",
-        "grep_search": "Grep",
-        "glob_search": "Glob",
-        "browser_use": "Browser",
-        "web_search": "WebSearch",
-        "web_fetch": "WebFetch",
-        "desktop_screenshot": "DesktopScreenshot",
-        "send_file_to_user": "SendFileToUser",
-        "view_image": "ViewImage",
-        "view_video": "ViewVideo",
-        "get_current_time": "GetCurrentTime",
-        "set_user_timezone": "SetUserTimezone",
-        "get_token_usage": "GetTokenUsage",
-        "delegate_external_agent": "DelegateExternalAgent",
-        "list_agents": "ListAgents",
-        "chat_with_agent": "ChatWithAgent",
-        "submit_to_agent": "SubmitToAgent",
-        "check_agent_task": "CheckAgentTask",
-        "spawn_subagent": "SpawnSubagent",
-        "materialize_skill": "MaterializeSkill",
-    }
-    for py_name, policy_name in mappings.items():
-        r.register_python_name(py_name, policy_name)
-
-
-DEFAULT_REGISTRY = _create_default_registry()
+DEFAULT_REGISTRY: Any = _LazyDefaultRegistry()

--- a/src/qwenpaw/modes/goal/helpers.py
+++ b/src/qwenpaw/modes/goal/helpers.py
@@ -31,27 +31,19 @@ def register_goal_tools_governance() -> None:
     try:
         from ...governance.tool_registry import (
             DEFAULT_REGISTRY,
+            register_tool_governance,
         )
 
-        for name in (
-            "GetGoal",
-            "CreateGoal",
-            "UpdateGoal",
-        ):
-            if DEFAULT_REGISTRY.get_type(name) == "unknown":
-                DEFAULT_REGISTRY.register(
-                    name,
-                    "internal",
-                    "",
-                )
         for py, policy in (
             ("get_goal", "GetGoal"),
             ("create_goal", "CreateGoal"),
             ("update_goal", "UpdateGoal"),
         ):
-            DEFAULT_REGISTRY.register_python_name(
-                py,
-                policy,
+            register_tool_governance(
+                DEFAULT_REGISTRY,
+                python_name=py,
+                tool_type="internal",
+                policy_name=policy,
             )
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -690,8 +690,24 @@ class PluginApi:  # pylint: disable=too-many-public-methods
         """
 
         def _startup_register():
+            # Governance first: fail closed before exposing the tool in
+            # toolkit/UI/runtime (avoids #6114-style visible-but-denied).
             try:
-                import qwenpaw.agents.tools as tools_module
+                _register_to_governance(
+                    tool_name,
+                    tool_type=tool_type,
+                    target_param=target_param,
+                )
+            except Exception as exc:
+                logger.error(
+                    f"Failed to register tool '{tool_name}' into "
+                    f"governance (not exposing tool): {exc}",
+                    exc_info=True,
+                )
+                return
+
+            try:
+                from ..agents import tools as tools_module
 
                 setattr(tools_module, tool_name, tool_func)
                 if tool_name not in tools_module.__all__:
@@ -714,15 +730,11 @@ class PluginApi:  # pylint: disable=too-many-public-methods
                     description,
                     icon,
                 )
-                _register_to_governance(
-                    tool_name,
-                    tool_type=tool_type,
-                    target_param=target_param,
-                )
 
             except Exception as exc:
                 logger.error(
-                    f"Failed to register tool '{tool_name}': {exc}",
+                    f"Failed to register tool '{tool_name}' after "
+                    f"governance sync: {exc}",
                     exc_info=True,
                 )
 

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -51,6 +51,29 @@ def get_tool_config(tool_name: str) -> Optional[Dict[str, Any]]:
 # -------------------------------------------------------------------
 
 
+def _register_to_governance(
+    tool_name: str,
+    tool_type: str = "network",
+    target_param: str = "",
+) -> None:
+    """Register a plugin tool into the governance whitelist.
+
+    Fixes issue #6114: tools visible to the agent were denied at Phase 0
+    because ``register_tool`` never synced the governance registry.
+    """
+    from ..governance.tool_registry import (
+        DEFAULT_REGISTRY,
+        register_tool_governance,
+    )
+
+    register_tool_governance(
+        DEFAULT_REGISTRY,
+        python_name=tool_name,
+        tool_type=tool_type,
+        target_param=target_param,
+    )
+
+
 def _bridge_to_runtime(
     tool_name: str,
     tool_func: Callable,
@@ -618,6 +641,8 @@ class PluginApi:  # pylint: disable=too-many-public-methods
         description: str = "",
         icon: str = "🔧",
         enabled: bool = False,
+        tool_type: str = "network",
+        target_param: str = "",
     ) -> None:
         """Register a tool function into the Agent's toolkit.
 
@@ -629,6 +654,8 @@ class PluginApi:  # pylint: disable=too-many-public-methods
           config (disabled by default so the user can opt-in)
         - Bridges to the runtime ToolRegistry so the agent can
           actually invoke the tool at runtime.
+        - Registers the tool into the governance whitelist so Phase 0
+          does not deny it as unregistered (issue #6114).
 
         The actual registration is deferred to a startup hook so it
         runs after the application and agent context are fully
@@ -643,6 +670,12 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             enabled: Whether the tool is enabled by default. The
                 recommended value is False so the user explicitly
                 enables the tool. Default: False.
+            tool_type: Governance tool type
+                (``"file"`` | ``"network"`` | ``"shell"`` | ``"internal"``).
+                Defaults to ``"network"`` to restore 1.0 pass-through
+                semantics for plugin tools while still running Phase 1
+                deep scans.
+            target_param: Optional governance target parameter name.
 
         Example:
             >>> from .tool import my_tool_func
@@ -652,6 +685,7 @@ class PluginApi:  # pylint: disable=too-many-public-methods
             ...         tool_func=my_tool_func,
             ...         description="Does something useful",
             ...         icon="🔧",
+            ...         tool_type="network",
             ...     )
         """
 
@@ -679,6 +713,11 @@ class PluginApi:  # pylint: disable=too-many-public-methods
                     enabled,
                     description,
                     icon,
+                )
+                _register_to_governance(
+                    tool_name,
+                    tool_type=tool_type,
+                    target_param=target_param,
                 )
 
             except Exception as exc:

--- a/src/qwenpaw/runtime/tool_registry.py
+++ b/src/qwenpaw/runtime/tool_registry.py
@@ -14,6 +14,35 @@ from typing import Any, Callable, Iterable
 
 
 @dataclass(frozen=True)
+class ToolGovernanceSpec:
+    """Governance identity for a tool (type, target param, policy name).
+
+    Empty ``tool_type`` means the descriptor does not auto-register into
+    the governance ToolRegistry (legacy / dynamic tools use other paths).
+
+    ``default_policy`` / ``policy_reason`` drive auto-generated
+    ``ToolName(**)`` entries in the default user rules list.
+    """
+
+    tool_type: str = ""
+    target_param: str = ""
+    pattern_param: str = ""
+    policy_name: str = ""
+    fail_without_sandbox: bool = False
+    default_policy: str = ""  # allow | ask | deny; empty = no auto rule
+    policy_reason: str = ""
+
+
+@dataclass(frozen=True)
+class ToolUISpec:
+    """UI / config presentation metadata for a tool."""
+
+    description: str = ""
+    icon: str = ""
+    display_to_user: bool = True
+
+
+@dataclass(frozen=True)
 class ToolDescriptor:
     """Declarative description of one tool function.
 
@@ -42,6 +71,10 @@ class ToolDescriptor:
     async_execution: bool = False
     description: str = ""
     metadata: dict[str, Any] = field(default_factory=dict)
+    governance: ToolGovernanceSpec = field(
+        default_factory=ToolGovernanceSpec,
+    )
+    ui: ToolUISpec = field(default_factory=ToolUISpec)
 
 
 class ToolRegistry:
@@ -177,6 +210,18 @@ def tool_descriptor(
     requires_sandbox: tuple[str, ...] = (),
     async_execution: bool | None = None,
     description: str = "",
+    # Governance (packed into ToolGovernanceSpec)
+    tool_type: str = "",
+    target_param: str = "",
+    pattern_param: str = "",
+    policy_name: str = "",
+    fail_without_sandbox: bool = False,
+    default_policy: str = "",
+    policy_reason: str = "",
+    # UI (packed into ToolUISpec)
+    ui_description: str = "",
+    ui_icon: str = "",
+    display_to_user: bool = True,
     **metadata: Any,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Attach a :class:`ToolDescriptor` to ``fn._tool_descriptor`` and
@@ -188,6 +233,10 @@ def tool_descriptor(
     Built-in tools (under ``qwenpaw.agents.tools``) are automatically
     discoverable via :func:`get_builtin_tool_funcs` — no manual list
     maintenance or filesystem scanning required.
+
+    Governance kwargs (``tool_type``, ``target_param``, …) are stored on
+    ``ToolDescriptor.governance`` and consumed at startup by
+    ``governance.tool_registry`` to build the policy whitelist.
     """
 
     def deco(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -215,6 +264,20 @@ def tool_descriptor(
                 else description
             ),
             metadata=dict(metadata),
+            governance=ToolGovernanceSpec(
+                tool_type=tool_type,
+                target_param=target_param,
+                pattern_param=pattern_param,
+                policy_name=policy_name,
+                fail_without_sandbox=fail_without_sandbox,
+                default_policy=default_policy,
+                policy_reason=policy_reason,
+            ),
+            ui=ToolUISpec(
+                description=ui_description,
+                icon=ui_icon,
+                display_to_user=display_to_user,
+            ),
         )
         # pylint: enable=protected-access
         if id(fn) not in _REGISTERED_IDS:
@@ -227,6 +290,8 @@ def tool_descriptor(
 
 __all__ = [
     "ToolDescriptor",
+    "ToolGovernanceSpec",
+    "ToolUISpec",
     "ToolRegistry",
     "get_builtin_tool_funcs",
     "tool_descriptor",

--- a/src/qwenpaw/runtime/tool_registry.py
+++ b/src/qwenpaw/runtime/tool_registry.py
@@ -22,6 +22,13 @@ class ToolGovernanceSpec:
 
     ``default_policy`` / ``policy_reason`` drive auto-generated
     ``ToolName(**)`` entries in the default user rules list.
+
+    Distinct from :attr:`ToolDescriptor.requires_sandbox`:
+    * ``requires_sandbox`` — runtime resource needs the sandbox honors
+      (``file_read``, ``file_write``, ``shell_exec``, …).
+    * ``fail_without_sandbox`` — governance fail-closed flag: when True,
+      the tool is denied unless a ``sandbox_config`` is supplied (e.g.
+      model-authored REPL).
     """
 
     tool_type: str = ""

--- a/src/qwenpaw/runtime/tool_registry.py
+++ b/src/qwenpaw/runtime/tool_registry.py
@@ -17,8 +17,10 @@ from typing import Any, Callable, Iterable
 class ToolGovernanceSpec:
     """Governance identity for a tool (type, target param, policy name).
 
-    Empty ``tool_type`` means the descriptor does not auto-register into
-    the governance ToolRegistry (legacy / dynamic tools use other paths).
+    Empty ``tool_type`` is invalid for collected builtins under
+    ``qwenpaw.agents.tools`` (treated as a governance gap). Dynamic tools
+    that intentionally skip the global builtin collection register via
+    ``register_tool_governance`` / other paths instead.
 
     ``default_policy`` / ``policy_reason`` drive auto-generated
     ``ToolName(**)`` entries in the default user rules list.

--- a/tests/integration/test_agent_scoped_misc.py
+++ b/tests/integration/test_agent_scoped_misc.py
@@ -16,7 +16,9 @@ from tests.integration.helpers import (
     scoped,
 )
 
-_HTTP_TIMEOUT = default_http_timeout(15.0)
+# Same floor as Windows CI (QWENPAW_INTEGRATION_HTTP_TIMEOUT=120): list tools
+# awaits workspace startup and can exceed the 15s default on slow runners.
+_HTTP_TIMEOUT = default_http_timeout(120.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_multi_agent_lifecycle.py
+++ b/tests/integration/test_multi_agent_lifecycle.py
@@ -21,7 +21,9 @@ from tests.integration.helpers import (
     toggle_agent,
 )
 
-_AGENT_HTTP_TIMEOUT = default_http_timeout(15.0)
+# Same floor as Windows CI (QWENPAW_INTEGRATION_HTTP_TIMEOUT=120): concurrent
+# agent create/reorder/delete can exceed the 15s default on slow runners.
+_AGENT_HTTP_TIMEOUT = default_http_timeout(120.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/unit/governance/test_unified_tool_registration.py
+++ b/tests/unit/governance/test_unified_tool_registration.py
@@ -3,10 +3,18 @@
 
 from __future__ import annotations
 
+from qwenpaw.agents.tools.delegate_external_agent import (
+    delegate_external_agent,
+)
+from qwenpaw.agents.tools.file_io import append_file
+from qwenpaw.config.config import _default_builtin_tools
 from qwenpaw.governance.policy import (
+    DEFAULT_USER_RULES,
     GovernanceAction,
     GovernancePolicy,
     ToolCallSpec,
+    _auto_default_user_rules,
+    get_default_user_rules,
 )
 from qwenpaw.governance.tool_registry import (
     DEFAULT_REGISTRY,
@@ -15,6 +23,7 @@ from qwenpaw.governance.tool_registry import (
     register_tool_governance,
     snake_to_pascal,
 )
+from qwenpaw.plugins.api import _register_to_governance
 
 
 def _tc(tool_name: str, target: str = "") -> ToolCallSpec:
@@ -86,6 +95,18 @@ class TestBuiltinDescriptorGovernance:
             DEFAULT_REGISTRY.python_to_policy_name("web_search") == "WebSearch"
         )
 
+    def test_set_user_timezone_target_param_matches_signature(self):
+        """extract_target must use the real function parameter name."""
+        assert (
+            DEFAULT_REGISTRY.get_target_param("SetUserTimezone")
+            == "timezone_name"
+        )
+        target = DEFAULT_REGISTRY.extract_target(
+            "SetUserTimezone",
+            {"timezone_name": "Asia/Shanghai"},
+        )
+        assert target == "Asia/Shanghai"
+
 
 class TestPluginGovernanceIssue6114:
     """Plugin tools must pass Phase 0 after register_tool_governance."""
@@ -117,8 +138,61 @@ class TestPluginGovernanceIssue6114:
             ), f"{pname} denied: {decision.reason}"
             assert "Unregistered tool" not in (decision.reason or "")
 
+    def test_register_to_governance_bridge(self):
+        """PluginApi helper must sync into the live DEFAULT_REGISTRY."""
+        _register_to_governance(
+            "__ut_bridge_plugin_tool__",
+            tool_type="network",
+        )
+        assert DEFAULT_REGISTRY.get_type("UtBridgePluginTool") == "network"
+        policy = GovernancePolicy(execution_level="smart")
+        decision = policy.evaluate(_tc("UtBridgePluginTool"))
+        assert decision.action is not GovernanceAction.DENY
+        assert "Unregistered tool" not in (decision.reason or "")
+
     def test_unknown_still_denied(self):
         policy = GovernancePolicy(execution_level="smart")
         decision = policy.evaluate(_tc("TotallyUnknownToolXYZ"))
         assert decision.action is GovernanceAction.DENY
         assert "Unregistered tool" in decision.reason
+
+
+class TestAutoDefaultUserRules:
+    def test_websearch_rule_generated(self):
+        rules = _auto_default_user_rules()
+        by_match = {r.match: r for r in rules}
+        assert "WebSearch(**)" in by_match
+        assert by_match["WebSearch(**)"].action is GovernanceAction.ALLOW
+
+    def test_write_has_no_global_allow_auto_rule(self):
+        """Write must not get Write(**) — path-scoped rules stay manual."""
+        matches = {r.match for r in _auto_default_user_rules()}
+        assert "Write(**)" not in matches
+        assert "Edit(**)" not in matches
+        assert "Append(**)" not in matches
+
+    def test_default_user_rules_proxy_matches_getter(self):
+        via_proxy = list(DEFAULT_USER_RULES)
+        via_fn = get_default_user_rules()
+        assert len(via_proxy) == len(via_fn)
+        assert [r.match for r in via_proxy] == [r.match for r in via_fn]
+
+
+class TestBuiltinToolConfigFromDescriptors:
+    def test_delegate_external_agent_disabled_by_default(self):
+        tools = _default_builtin_tools()
+        assert "delegate_external_agent" in tools
+        assert tools["delegate_external_agent"].enabled is False
+        desc = getattr(delegate_external_agent, "_tool_descriptor")
+        assert desc.enabled_by_default is False
+
+    def test_append_file_disabled_by_default(self):
+        tools = _default_builtin_tools()
+        assert tools["append_file"].enabled is False
+        desc = getattr(append_file, "_tool_descriptor")
+        assert desc.enabled_by_default is False
+
+    def test_web_search_ui_metadata(self):
+        tools = _default_builtin_tools()
+        assert tools["web_search"].icon == "🔎"
+        assert tools["view_image"].display_to_user is False

--- a/tests/unit/governance/test_unified_tool_registration.py
+++ b/tests/unit/governance/test_unified_tool_registration.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+import threading
+from unittest.mock import patch
+
+import pytest
+
 from qwenpaw.agents.tools.delegate_external_agent import (
     delegate_external_agent,
 )
@@ -18,12 +23,15 @@ from qwenpaw.governance.policy import (
 )
 from qwenpaw.governance.tool_registry import (
     DEFAULT_REGISTRY,
+    GovernanceRegistrationConflict,
     ToolRegistry,
     assert_no_governance_gaps,
     register_tool_governance,
     snake_to_pascal,
+    _collect_governance_gaps,
 )
 from qwenpaw.plugins.api import _register_to_governance
+from qwenpaw.runtime.tool_registry import ToolDescriptor, ToolGovernanceSpec
 
 
 def _tc(tool_name: str, target: str = "") -> ToolCallSpec:
@@ -36,7 +44,7 @@ def _tc(tool_name: str, target: str = "") -> ToolCallSpec:
 
 
 class TestRegisterToolGovernance:
-    def test_idempotent_register(self):
+    def test_idempotent_register_identical_metadata(self):
         registry = ToolRegistry()
         pname = register_tool_governance(
             registry,
@@ -46,13 +54,57 @@ class TestRegisterToolGovernance:
         )
         assert pname == "UtPluginTool"
         assert registry.get_type("UtPluginTool") == "network"
+        # Same python_name + identical metadata is idempotent.
         register_tool_governance(
             registry,
             python_name="__ut_plugin_tool__",
-            tool_type="shell",  # ignored — already registered
+            tool_type="network",
             policy_name="UtPluginTool",
         )
         assert registry.get_type("UtPluginTool") == "network"
+
+    def test_reject_metadata_change_on_reregister(self):
+        registry = ToolRegistry()
+        register_tool_governance(
+            registry,
+            python_name="__ut_plugin_tool_meta__",
+            tool_type="network",
+            policy_name="UtPluginToolMeta",
+        )
+        with pytest.raises(GovernanceRegistrationConflict):
+            register_tool_governance(
+                registry,
+                python_name="__ut_plugin_tool_meta__",
+                tool_type="shell",
+                policy_name="UtPluginToolMeta",
+            )
+        assert registry.get_type("UtPluginToolMeta") == "network"
+
+    def test_reject_name_fold_collision(self):
+        """Distinct python names must not share a folded policy identity."""
+        registry = ToolRegistry()
+        register_tool_governance(
+            registry,
+            python_name="get_current_time",
+            tool_type="internal",
+            policy_name="GetCurrentTime",
+        )
+        with pytest.raises(GovernanceRegistrationConflict):
+            register_tool_governance(
+                registry,
+                python_name="get__current_time",
+                tool_type="internal",
+                # snake_to_pascal("get__current_time") == "GetCurrentTime"
+            )
+
+    def test_reject_plugin_collision_with_builtin_internal(self):
+        with pytest.raises(GovernanceRegistrationConflict):
+            register_tool_governance(
+                DEFAULT_REGISTRY,
+                python_name="__collide_get_current_time__",
+                tool_type="network",
+                policy_name="GetCurrentTime",
+            )
 
     def test_snake_to_pascal(self):
         assert snake_to_pascal("generate_image_qwen") == "GenerateImageQwen"
@@ -62,6 +114,29 @@ class TestBuiltinDescriptorGovernance:
     def test_no_governance_gaps(self):
         gaps = assert_no_governance_gaps()
         assert not gaps
+
+    def test_empty_tool_type_is_governance_gap(self):
+        registry = ToolRegistry()
+
+        class _Fn:
+            __name__ = "missing_gov_tool"
+
+        fn = _Fn()
+        setattr(
+            fn,
+            "_tool_descriptor",
+            ToolDescriptor(
+                name="missing_gov_tool",
+                func=lambda: None,
+                governance=ToolGovernanceSpec(tool_type=""),
+            ),
+        )
+        with patch(
+            "qwenpaw.runtime.tool_registry.get_builtin_tool_funcs",
+            return_value=[fn],
+        ):
+            gaps = _collect_governance_gaps(registry)
+        assert "missing_gov_tool" in gaps
 
     def test_ast_search_registered(self):
         assert DEFAULT_REGISTRY.get_type("AstSearch") == "file"
@@ -78,6 +153,7 @@ class TestBuiltinDescriptorGovernance:
             "WebFetch": "network",
             "Browser": "network",
             "GetCurrentTime": "internal",
+            "SetUserTimezone": "internal",
             "RecallHistory": "internal",
             "RecallHistoryPython": "shell",
             "MemorySearch": "internal",
@@ -95,15 +171,17 @@ class TestBuiltinDescriptorGovernance:
             DEFAULT_REGISTRY.python_to_policy_name("web_search") == "WebSearch"
         )
 
-    def test_set_user_timezone_target_param_matches_signature(self):
-        """extract_target must use the real function parameter name."""
+    def test_set_user_timezone_target_not_joined_to_workspace(self):
+        """Timezone names must not be treated as relative file paths."""
         assert (
             DEFAULT_REGISTRY.get_target_param("SetUserTimezone")
             == "timezone_name"
         )
+        assert DEFAULT_REGISTRY.get_type("SetUserTimezone") == "internal"
         target = DEFAULT_REGISTRY.extract_target(
             "SetUserTimezone",
             {"timezone_name": "Asia/Shanghai"},
+            workspace_dir="/tmp/fake-workspace",
         )
         assert target == "Asia/Shanghai"
 
@@ -122,6 +200,7 @@ class TestPluginGovernanceIssue6114:
             "reference_to_video_wan",
         ]
         for py_name in plugin_tools:
+            # Idempotent when metadata matches (may already be registered).
             register_tool_governance(
                 DEFAULT_REGISTRY,
                 python_name=py_name,
@@ -155,6 +234,41 @@ class TestPluginGovernanceIssue6114:
         decision = policy.evaluate(_tc("TotallyUnknownToolXYZ"))
         assert decision.action is GovernanceAction.DENY
         assert "Unregistered tool" in decision.reason
+
+
+class TestLazyRegistryConcurrency:
+    def test_lazy_registry_single_instance_under_contention(self):
+        """Double-checked locking must yield one shared registry instance."""
+        import time
+
+        from qwenpaw.governance import tool_registry as tr
+
+        # pylint: disable=protected-access
+        proxy = tr._LazyDefaultRegistry()
+        create_count = 0
+
+        def _slow_create() -> ToolRegistry:
+            nonlocal create_count
+            create_count += 1
+            time.sleep(0.05)
+            return ToolRegistry()
+
+        results: list[ToolRegistry] = []
+
+        def _worker() -> None:
+            results.append(proxy._get())
+
+        with patch.object(tr, "_create_default_registry", _slow_create):
+            threads = [threading.Thread(target=_worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+        # pylint: enable=protected-access
+
+        assert create_count == 1
+        assert len(results) == 8
+        assert all(r is results[0] for r in results)
 
 
 class TestAutoDefaultUserRules:

--- a/tests/unit/governance/test_unified_tool_registration.py
+++ b/tests/unit/governance/test_unified_tool_registration.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""Tests for unified tool governance registration (issue #6114)."""
+
+from __future__ import annotations
+
+from qwenpaw.governance.policy import (
+    GovernanceAction,
+    GovernancePolicy,
+    ToolCallSpec,
+)
+from qwenpaw.governance.tool_registry import (
+    DEFAULT_REGISTRY,
+    ToolRegistry,
+    assert_no_governance_gaps,
+    register_tool_governance,
+    snake_to_pascal,
+)
+
+
+def _tc(tool_name: str, target: str = "") -> ToolCallSpec:
+    return ToolCallSpec(
+        tool_name=tool_name,
+        target=target,
+        agent_id="test-agent",
+        session_id="test-session",
+    )
+
+
+class TestRegisterToolGovernance:
+    def test_idempotent_register(self):
+        registry = ToolRegistry()
+        pname = register_tool_governance(
+            registry,
+            python_name="__ut_plugin_tool__",
+            tool_type="network",
+            policy_name="UtPluginTool",
+        )
+        assert pname == "UtPluginTool"
+        assert registry.get_type("UtPluginTool") == "network"
+        register_tool_governance(
+            registry,
+            python_name="__ut_plugin_tool__",
+            tool_type="shell",  # ignored — already registered
+            policy_name="UtPluginTool",
+        )
+        assert registry.get_type("UtPluginTool") == "network"
+
+    def test_snake_to_pascal(self):
+        assert snake_to_pascal("generate_image_qwen") == "GenerateImageQwen"
+
+
+class TestBuiltinDescriptorGovernance:
+    def test_no_governance_gaps(self):
+        gaps = assert_no_governance_gaps()
+        assert not gaps
+
+    def test_ast_search_registered(self):
+        assert DEFAULT_REGISTRY.get_type("AstSearch") == "file"
+        assert (
+            DEFAULT_REGISTRY.python_to_policy_name("ast_search") == "AstSearch"
+        )
+
+    def test_core_builtins_registered(self):
+        expected = {
+            "Read": "file",
+            "Write": "file",
+            "Bash": "shell",
+            "WebSearch": "network",
+            "WebFetch": "network",
+            "Browser": "network",
+            "GetCurrentTime": "internal",
+            "RecallHistory": "internal",
+            "RecallHistoryPython": "shell",
+            "MemorySearch": "internal",
+        }
+        for name, tool_type in expected.items():
+            assert DEFAULT_REGISTRY.get_type(name) == tool_type, name
+
+    def test_python_name_mappings(self):
+        assert (
+            DEFAULT_REGISTRY.python_to_policy_name("execute_shell_command")
+            == "Bash"
+        )
+        assert DEFAULT_REGISTRY.python_to_policy_name("read_file") == "Read"
+        assert (
+            DEFAULT_REGISTRY.python_to_policy_name("web_search") == "WebSearch"
+        )
+
+
+class TestPluginGovernanceIssue6114:
+    """Plugin tools must pass Phase 0 after register_tool_governance."""
+
+    def test_plugin_tools_not_denied_as_unregistered(self):
+        plugin_tools = [
+            "generate_image_qwen",
+            "edit_image_qwen",
+            "generate_image_gpt",
+            "edit_image_gpt",
+            "text_to_video_wan",
+            "image_to_video_wan",
+            "reference_to_video_wan",
+        ]
+        for py_name in plugin_tools:
+            register_tool_governance(
+                DEFAULT_REGISTRY,
+                python_name=py_name,
+                tool_type="network",
+            )
+
+        policy = GovernancePolicy(execution_level="smart")
+        for py_name in plugin_tools:
+            pname = DEFAULT_REGISTRY.python_to_policy_name(py_name)
+            assert DEFAULT_REGISTRY.get_type(pname) == "network"
+            decision = policy.evaluate(_tc(pname))
+            assert (
+                decision.action is not GovernanceAction.DENY
+            ), f"{pname} denied: {decision.reason}"
+            assert "Unregistered tool" not in (decision.reason or "")
+
+    def test_unknown_still_denied(self):
+        policy = GovernancePolicy(execution_level="smart")
+        decision = policy.evaluate(_tc("TotallyUnknownToolXYZ"))
+        assert decision.action is GovernanceAction.DENY
+        assert "Unregistered tool" in decision.reason


### PR DESCRIPTION
## Description

Unify built-in / plugin tool registration around `@tool_descriptor` and
`PluginApi.register_tool`, so governance whitelist, tool-level default
rules, UI `BuiltinToolConfig`, and `agents.tools.__all__` are derived
from a single metadata source instead of hand-maintained lists.

This fixes the structural gap where plugin tools appear in the agent
toolkit/UI but are denied at governance Phase 0 as unregistered
(e.g. `Unregistered tool: GenerateImageQwen`). Official image/video
plugins and external plugins using `register_tool` (default
`tool_type="network"`) are covered without requiring caller changes.

Also migrates existing built-ins onto decorator governance/UI metadata,
removes the handwritten governance builtin registry, and keeps
path-level policy rules (e.g. `Write(WORKSPACE_DIR/**)`) manual so
tool-level `Write(**)` is not auto-generated.

**Related Issue:** Fixes #6114

**Security Considerations:** Plugin tools default to governance type
`network` (Phase 1 deep scan still applies; not `internal` bypass).
File-write tools intentionally omit `default_policy="allow"` so
path-scoped workspace rules remain the authoritative allow path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Unit:
   - `pytest tests/unit/governance/ tests/unit/agents/tools/ -q`
   - Covers registry parity, `ast_search` gap closure, and plugin tools
     (qwen-image / gpt-image2 / wan27) no longer Phase-0 DENY.
2. Manual (optional, reproduces #6114):
   - Plugin Manager → enable official Qwen-Image Tool
   - Ask the agent to generate an image
   - Expect success instead of `Unregistered tool: GenerateImageQwen`


## Additional Notes

- Path-level `DEFAULT_USER_RULES` (workspace/`/tmp`/coding-project/`gh`) remain
  manually maintained by design.
- New built-in tools still need one side-effect import in
  `agents/tools/__init__.py`; `__all__`, governance, tool-level default
  rules, and UI defaults are generated from the decorator.