### PR TITLE
fix(model_factory): resolve file:// URIs in DataBlock to local paths before formatting

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -46,14 +46,29 @@ from ..token_usage import TokenRecordingModelWrapper
 
 
 def _file_url_to_path(url: str) -> str:
+    """Convert a file:// URI to a local filesystem path.
+
+    Handles Windows drive letters, UNC authority, and
+    percent-encoded characters.  Non-file:// URLs are
+    returned with only percent-decoding applied.
+
+    Examples:
+        file:///C:/path       -> C:/path
+        file:///tmp/path      -> /tmp/path
+        file://server/share/x -> //server/share/x  (UNC)
     """
-    Strip file:// to path. On Windows file:///C:/path -> C:/path not /C:/path.
-    Percent-decodes the path so non-ASCII filenames resolve correctly.
-    """
-    s = url.removeprefix("file://")
-    # Windows: file:///C:/path yields "/C:/path"; remove leading slash.
+    if not url.startswith("file://"):
+        return unquote(url)
+    s = url[7:]  # strip "file://"
+    # Windows drive letter: /C:/path -> C:/path (three-slash form)
     if len(s) >= 3 and s.startswith("/") and s[1].isalpha() and s[2] == ":":
         s = s[1:]
+    # Windows drive letter: C:/path (two-slash form file://C:/...)
+    elif len(s) >= 2 and s[0].isalpha() and s[1] == ":":
+        pass  # already correct
+    elif not s.startswith("/"):
+        # UNC authority form: server/share/x -> //server/share/x
+        s = f"//{s}"
     return unquote(s)
 
 

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -768,8 +768,8 @@ def _fixup_media_list(items: list) -> None:
                             f" — file deleted from disk]"
                         ),
                     )
-                elif unquote(url_str) != url_str:
-                    source.url = unquote(url_str)
+                else:
+                    source.url = local_path
         elif btype == "file":
             if isinstance(block, dict):
                 source = block.get("source") or {}

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -60,6 +60,9 @@ def _file_url_to_path(url: str) -> str:
     if not url.startswith("file://"):
         return unquote(url)
     s = url[7:]  # strip "file://"
+    # Strip localhost authority: localhost/path -> /path
+    if s.startswith("localhost/"):
+        s = s[9:]  # len("localhost") == 9
     # Windows drive letter: /C:/path -> C:/path (three-slash form)
     if len(s) >= 3 and s.startswith("/") and s[1].isalpha() and s[2] == ":":
         s = s[1:]

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -63,13 +63,26 @@ def _resolve_local_path(url: str) -> str | None:
     """Resolve a URL or bare path to a local filesystem path.
 
     Returns ``None`` for remote URLs / data URIs.
-    Handles both ``file://`` URIs and bare local paths
-    (produced by ``_fixup_media_list`` normalization).
+    Handles both ``file://`` URIs (including UNC authority
+    form) and bare local paths (produced by
+    ``_fixup_media_list`` normalization).
     """
     if _is_remote_url(url):
         return None
     if url.startswith("file://"):
-        return url2pathname(urlparse(url).path)
+        parsed = urlparse(url)
+        if parsed.netloc:
+            # Distinguish drive letter (e.g. "C:") from UNC server.
+            nl = parsed.netloc
+            if len(nl) == 2 and nl[0].isalpha() and nl[1] == ":":
+                # Two-slash Windows: file://C:/path
+                full_path = f"{nl}{parsed.path}"
+            else:
+                # UNC: file://server/share/path
+                full_path = f"//{nl}{parsed.path}"
+        else:
+            full_path = parsed.path
+        return url2pathname(full_path)
     return url
 
 

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -54,36 +54,42 @@ from pydantic import Field
 MAX_INLINE_MEDIA_BYTES = 2 * 1024 * 1024  # 2 MB
 
 
-def _is_remote_url(url: str) -> bool:
-    """Return True if *url* is a remote/data scheme (not local)."""
-    return url.startswith(("http://", "https://", "data:"))
-
-
 def _resolve_local_path(url: str) -> str | None:
     """Resolve a URL or bare path to a local filesystem path.
 
-    Returns ``None`` for remote URLs / data URIs.
-    Handles both ``file://`` URIs (including UNC authority
-    form) and bare local paths (produced by
-    ``_fixup_media_list`` normalization).
+    Returns ``None`` for any non-local scheme (http, https, s3,
+    oss, ftp, data, etc.).  Handles ``file://`` URIs (including
+    UNC and localhost authority) and bare local paths produced
+    by ``_fixup_media_list`` normalization.
     """
-    if _is_remote_url(url):
-        return None
-    if url.startswith("file://"):
-        parsed = urlparse(url)
-        if parsed.netloc:
-            # Distinguish drive letter (e.g. "C:") from UNC server.
-            nl = parsed.netloc
-            if len(nl) == 2 and nl[0].isalpha() and nl[1] == ":":
-                # Two-slash Windows: file://C:/path
-                full_path = f"{nl}{parsed.path}"
-            else:
-                # UNC: file://server/share/path
-                full_path = f"//{nl}{parsed.path}"
-        else:
+    parsed = urlparse(url)
+    scheme = parsed.scheme
+
+    if scheme == "file":
+        nl = parsed.netloc
+        if not nl or nl.lower() == "localhost":
+            # file:///path or file://localhost/path -> local
             full_path = parsed.path
+        elif len(nl) == 2 and nl[0].isalpha() and nl[1] == ":":
+            # Two-slash Windows: file://C:/path
+            full_path = f"{nl}{parsed.path}"
+        else:
+            # UNC: file://server/share/path
+            full_path = f"//{nl}{parsed.path}"
         return url2pathname(full_path)
-    return url
+
+    if scheme == "":
+        # Bare local path (e.g. /tmp/x.png, C:/Temp/x.png,
+        # //server/share/x.png).
+        return url
+
+    # Single-letter scheme on Windows is a drive letter,
+    # e.g. urlparse("C:/Temp/x.png") gives scheme="c".
+    if len(scheme) == 1 and scheme.isalpha():
+        return url
+
+    # Any other scheme (http, https, s3, oss, ftp, data, ...)
+    return None
 
 
 def inline_media_size(source: Any) -> int | None:

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -54,6 +54,25 @@ from pydantic import Field
 MAX_INLINE_MEDIA_BYTES = 2 * 1024 * 1024  # 2 MB
 
 
+def _is_remote_url(url: str) -> bool:
+    """Return True if *url* is a remote/data scheme (not local)."""
+    return url.startswith(("http://", "https://", "data:"))
+
+
+def _resolve_local_path(url: str) -> str | None:
+    """Resolve a URL or bare path to a local filesystem path.
+
+    Returns ``None`` for remote URLs / data URIs.
+    Handles both ``file://`` URIs and bare local paths
+    (produced by ``_fixup_media_list`` normalization).
+    """
+    if _is_remote_url(url):
+        return None
+    if url.startswith("file://"):
+        return url2pathname(urlparse(url).path)
+    return url
+
+
 def inline_media_size(source: Any) -> int | None:
     """Return the byte size of *source* if it would be inlined locally.
 
@@ -61,14 +80,13 @@ def inline_media_size(source: Any) -> int | None:
     unrecognised source types so the caller leaves them untouched.
     """
     if isinstance(source, URLSource):
-        url = str(source.url)
-        if url.startswith("file://"):
-            path = url2pathname(urlparse(url).path)
-            try:
-                return os.path.getsize(path)
-            except OSError:
-                return None
-        return None
+        path = _resolve_local_path(str(source.url))
+        if path is None:
+            return None
+        try:
+            return os.path.getsize(path)
+        except OSError:
+            return None
     if isinstance(source, Base64Source):
         # base64 length -> approximate raw byte count.
         return len(source.data or "") * 3 // 4
@@ -125,18 +143,18 @@ class CappingFormatterMixin:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _local_source_to_base64(source: Any) -> Any:
-        """Convert a local ``file://`` URLSource to a Base64Source.
+        """Convert a local URLSource to a Base64Source.
 
-        Non-local sources (remote URLs, already-base64 sources, anything
-        else) are returned unchanged so the base formatter handles them as
-        before.
+        Handles both ``file://`` URIs and bare local paths
+        (produced by ``_fixup_media_list`` normalization).
+        Non-local sources (remote URLs, already-base64 sources,
+        anything else) are returned unchanged.
         """
         if not isinstance(source, URLSource):
             return source
-        url = str(source.url)
-        if not url.startswith("file://"):
+        path = _resolve_local_path(str(source.url))
+        if path is None:
             return source
-        path = url2pathname(urlparse(url).path)
         with open(path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("utf-8")
         return Base64Source(data=encoded, media_type=source.media_type)

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -454,3 +454,19 @@ def test_datablock_percent_encoded_uri_resolved(
     model_factory._fixup_media_list(items)
 
     assert items[0].source.url == "/tmp/中文.png"
+
+
+def test_datablock_unc_file_uri_resolved(
+    monkeypatch,
+) -> None:
+    """file://server/share/x.png → //server/share/x.png (UNC)."""
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    block = _data_block(
+        "image/png",
+        "file://server/share/x.png",
+    )
+    items: list = [block]
+    model_factory._fixup_media_list(items)
+
+    assert items[0].source.url == "//server/share/x.png"

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -407,3 +407,50 @@ def test_extra_content_original_preserved(monkeypatch) -> None:
     )
 
     assert msgs[0].to_dict() == original_dict
+
+
+# -----------------------------------------------------------------
+# _fixup_media_list: Windows file URI → local path for DataBlock
+# -----------------------------------------------------------------
+
+
+def test_datablock_windows_file_uri_resolved_to_local_path(
+    monkeypatch,
+) -> None:
+    """file:///C:/Temp/x.png must become C:/Temp/x.png in source.url."""
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    block = _data_block("image/png", "file:///C:/Temp/x.png")
+    items: list = [block]
+    model_factory._fixup_media_list(items)
+
+    assert items[0].source.url == "C:/Temp/x.png"
+
+
+def test_datablock_unix_file_uri_resolved_to_local_path(
+    monkeypatch,
+) -> None:
+    """file:///tmp/demo.png must become /tmp/demo.png."""
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    block = _data_block("image/png", "file:///tmp/demo.png")
+    items: list = [block]
+    model_factory._fixup_media_list(items)
+
+    assert items[0].source.url == "/tmp/demo.png"
+
+
+def test_datablock_percent_encoded_uri_resolved(
+    monkeypatch,
+) -> None:
+    """file:///tmp/%E4%B8%AD%E6%96%87.png → /tmp/中文.png."""
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    block = _data_block(
+        "image/png",
+        "file:///tmp/%E4%B8%AD%E6%96%87.png",
+    )
+    items: list = [block]
+    model_factory._fixup_media_list(items)
+
+    assert items[0].source.url == "/tmp/中文.png"

--- a/tests/unit/providers/test_capping_formatter.py
+++ b/tests/unit/providers/test_capping_formatter.py
@@ -260,3 +260,47 @@ def test_dashscope_remote_video_passthrough_unchanged() -> None:
         "type": "video_url",
         "video_url": {"url": "https://cdn.example.com/v.mp4"},
     }
+
+
+# -----------------------------------------------------------------
+# Bare local path support (after _fixup_media_list normalization)
+# -----------------------------------------------------------------
+
+
+def _source_with_bare_path(path, media_type: str):
+    """Create URLSource then assign bare path (mimics _fixup_media_list)."""
+    from agentscope.message import URLSource
+
+    source = URLSource(url=f"file://{path}", media_type=media_type)
+    source.url = str(path)
+    return source
+
+
+def test_bare_local_path_size_is_measured(tmp_path) -> None:
+    """inline_media_size handles bare paths (no file:// prefix)."""
+    path = tmp_path / "img.png"
+    path.write_bytes(b"\x89PNG" + b"\0" * 500)
+    source = _source_with_bare_path(path, "image/png")
+    assert inline_media_size(source) == 504
+
+
+def test_bare_local_path_base64_conversion(tmp_path) -> None:
+    """_local_source_to_base64 converts bare paths to Base64Source."""
+    from agentscope.message import Base64Source
+
+    path = tmp_path / "photo.jpg"
+    path.write_bytes(b"\xff\xd8" + b"\0" * 100)
+    source = _source_with_bare_path(path, "image/jpeg")
+    result = _CappingOpenAIFormatter._local_source_to_base64(source)
+    assert isinstance(result, Base64Source)
+    assert result.media_type == "image/jpeg"
+
+
+def test_bare_local_path_image_formatted(tmp_path) -> None:
+    """Capping formatter produces data URI from bare local path."""
+    path = tmp_path / "pic.png"
+    path.write_bytes(b"\x89PNG" + b"\0" * 50)
+    source = _source_with_bare_path(path, "image/png")
+    out = _CappingOpenAIFormatter()._format_image_source(source)
+    assert out["type"] == "image_url"
+    assert out["image_url"]["url"].startswith("data:image/png;base64,")

--- a/tests/unit/providers/test_capping_formatter.py
+++ b/tests/unit/providers/test_capping_formatter.py
@@ -304,3 +304,20 @@ def test_bare_local_path_image_formatted(tmp_path) -> None:
     out = _CappingOpenAIFormatter()._format_image_source(source)
     assert out["type"] == "image_url"
     assert out["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_non_http_remote_scheme_passthrough() -> None:
+    """s3://, oss://, ftp:// etc. pass through unchanged (#5934 H1)."""
+    from agentscope.message import URLSource
+
+    for scheme_url in [
+        "s3://bucket/image.png",
+        "oss://bucket/image.png",
+        "ftp://host/file.txt",
+    ]:
+        source = URLSource(url=scheme_url, media_type="image/png")
+        result = _CappingOpenAIFormatter._local_source_to_base64(source)
+        # Must return source unchanged (not try to open)
+        assert result is source, f"{scheme_url} was not passed through"
+        # inline_media_size must return None (not try getsize)
+        assert inline_media_size(source) is None


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
