### PR TITLE
fix(deploy): mount host timezone files to sync container time with host

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y --fix-missing \
     supervisor  \
     vim  \
     gettext-base \
+    tzdata \
     xfce4 \
     xfce4-terminal \
     xvfb \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,5 @@ services:
       - qwenpaw-data:/app/working
       - qwenpaw-secrets:/app/working.secret
       - qwenpaw-backups:/app/working.backups
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro


### PR DESCRIPTION
## Summary

Docker container defaults to UTC timezone (8 hours behind Asia/Shanghai), causing cron tasks, logs, and file timestamps to be inaccurate.

## Changes

1. ****: Add  package to ensure timezone data is available in the container
2. ****: Mount host  and  as read-only volumes

## How it works

No manual  environment variable needed — the container automatically follows the host's timezone via mounted files. This is the standard Docker community approach (used by MySQL, Redis, nginx official images, etc.).

## Related

- Closes #6188
- Closes #(if there is an existing issue)