### PR TITLE
fix(cli): cron update preserves untouched runtime and request fields

### DIFF
--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -134,9 +134,7 @@ def _validate_and_apply_scheduled_repeat(
         raise click.UsageError(
             "--repeat-end-type requires --repeat-every-days",
         )
-    if repeat_until and (
-        repeat_end_type != "until" or repeat_every_days is None
-    ):
+    if repeat_until and (repeat_end_type != "until" or repeat_every_days is None):
         raise click.UsageError(
             "--repeat-until requires --repeat-every-days and "
             "--repeat-end-type until",
@@ -429,10 +427,7 @@ def _build_spec_from_cli(
 @click.option(
     "--target-session",
     default=None,
-    help=(
-        "Target session_id for the channel. "
-        "Required when not using -f/--file."
-    ),
+    help=("Target session_id for the channel. " "Required when not using -f/--file."),
 )
 @click.option(
     "--text",
@@ -722,9 +717,9 @@ def _resolve_update_spec(
                     },
                 ]
             else:
-                payload["request"]["input"][0]["content"][0]["text"] = (
-                    text.strip()
-                )
+                payload["request"]["input"][0]["content"][0][
+                    "text"
+                ] = text.strip()
         else:
             payload["text"] = text.strip()
 

--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -639,118 +639,97 @@ def _resolve_update_spec(
 ) -> Dict[str, Any]:
     """Merge CLI overrides with an existing cron-job spec.
 
-    Only fields provided as non-None by the CLI are applied; everything
-    else is retained from *spec*.  Returns a payload dict suitable for
-    PUT /cron/jobs/{id}.
+    Deep-copies the existing spec and only patches fields explicitly
+    provided by the CLI.  Unspecified fields, including advanced
+    runtime settings (max_concurrency, misfire_grace_seconds) and
+    request extensions (model, request_context, etc.), are preserved
+    as-is.
     """
-    ext_schedule = spec.get("schedule", {})
-    cli_schedule_type = schedule_type or ext_schedule.get("type", "cron")
-    if cli_schedule_type in ("scheduled", "once"):
-        cli_schedule_type_norm = "scheduled"
-    else:
-        cli_schedule_type_norm = cli_schedule_type
+    import copy
 
-    tz = timezone or ext_schedule.get("timezone", "UTC")
+    payload = copy.deepcopy(spec)
 
-    cli_cron = cron or ext_schedule.get("cron", "")
-    cli_run_at = run_at or ext_schedule.get("run_at")
-    cli_repeat_days = (
-        repeat_every_days
-        if repeat_every_days is not None
-        else ext_schedule.get("repeat_every_days")
-    )
-    cli_repeat_end = (
-        repeat_end_type
-        if repeat_end_type is not None
-        else ext_schedule.get("repeat_end_type")
-    )
-    cli_repeat_until = (  # fmt: skip
-        repeat_until
-        if repeat_until is not None
-        else ext_schedule.get("repeat_until")
-    )
-    cli_repeat_count = (  # fmt: skip
-        repeat_count
-        if repeat_count is not None
-        else ext_schedule.get("repeat_count")
-    )
+    if name is not None:
+        payload["name"] = name
+    if enabled is not None:
+        payload["enabled"] = enabled
+    if task_type is not None:
+        payload["task_type"] = task_type
 
-    # --- resolve other fields with CLI-override semantics ---
-    t_type = task_type or spec.get("task_type", "text")
-    t_name = name if name is not None else spec.get("name", "")
-    t_enabled = enabled if enabled is not None else spec.get("enabled", True)
-    t_mode = mode or spec.get("dispatch", {}).get("mode", "final")
-    t_silent = (
-        silent
-        if silent is not None
-        else spec.get("dispatch", {}).get("silent", False)
-    )
-    t_save = (
-        save_result_to_inbox
-        if save_result_to_inbox is not None
-        else spec.get("save_result_to_inbox")
-    )
-    t_share = (
-        share_session
-        if share_session is not None
-        else spec.get("runtime", {}).get("share_session", True)
-    )
-    t_timeout = (
-        timeout_seconds
-        if timeout_seconds is not None
-        else spec.get("runtime", {}).get("timeout_seconds", 120)
-    )
-    t_tool_safety = (
-        tool_safety
-        if tool_safety is not None
-        else spec.get("runtime", {}).get("tool_safety", False)
-    )
+    # schedule
+    if "schedule" not in payload:
+        payload["schedule"] = {}
+    sch = payload["schedule"]
+    if schedule_type is not None:
+        if schedule_type in ("scheduled", "once"):
+            sch["type"] = "scheduled"
+        else:
+            sch["type"] = schedule_type
+    if cron is not None:
+        sch["cron"] = cron
+    if run_at is not None:
+        sch["run_at"] = run_at
+    if timezone is not None:
+        sch["timezone"] = timezone
+    if repeat_every_days is not None:
+        sch["repeat_every_days"] = repeat_every_days
+    if repeat_end_type is not None:
+        sch["repeat_end_type"] = repeat_end_type
+    if repeat_until is not None:
+        sch["repeat_until"] = repeat_until
+    if repeat_count is not None:
+        sch["repeat_count"] = repeat_count
 
-    ext_dispatch = spec.get("dispatch", {})
-    ext_target = ext_dispatch.get("target", {})
-    t_channel = channel or ext_dispatch.get("channel", DEFAULT_CHANNEL)
-    t_user = target_user or ext_target.get("user_id", "")
-    t_session = target_session or ext_target.get("session_id", "")
-    t_text = text
-    if t_text is None and spec.get("task_type") == "agent":
-        try:
-            t_text = spec["request"]["input"][0]["content"][0]["text"]
-        except (KeyError, IndexError, TypeError):
-            t_text = None
-    if t_text is None:
-        t_text = spec.get("text")
+    # dispatch
+    if "dispatch" not in payload:
+        payload["dispatch"] = {}
+    dsp = payload["dispatch"]
+    if channel is not None:
+        dsp["channel"] = channel
+    if mode is not None:
+        dsp["mode"] = mode
+    if silent is not None:
+        dsp["silent"] = silent
+    if "target" not in dsp:
+        dsp["target"] = {}
+    if target_user is not None:
+        dsp["target"]["user_id"] = target_user
+    if target_session is not None:
+        dsp["target"]["session_id"] = target_session
 
-    payload = _build_spec_from_cli(
-        task_type=t_type,
-        schedule_type=cli_schedule_type_norm,
-        name=t_name,
-        cron=cli_cron,
-        run_at=cli_run_at,
-        repeat_every_days=cli_repeat_days,
-        repeat_end_type=cli_repeat_end,
-        repeat_until=cli_repeat_until,
-        repeat_count=cli_repeat_count,
-        channel=t_channel,
-        target_user=t_user,
-        target_session=t_session,
-        text=t_text,
-        timezone=tz,
-        enabled=t_enabled,
-        mode=t_mode,
-        silent=t_silent,
-        save_result_to_inbox=t_save,
-        share_session=t_share,
-        timeout_seconds=t_timeout,
-        tool_safety=t_tool_safety,
-    )
+    # runtime
+    if "runtime" not in payload:
+        payload["runtime"] = {}
+    run = payload["runtime"]
+    if share_session is not None:
+        run["share_session"] = share_session
+    if timeout_seconds is not None:
+        run["timeout_seconds"] = timeout_seconds
+    if tool_safety is not None:
+        run["tool_safety"] = tool_safety
 
-    # Preserve existing meta
-    existing_meta = spec.get("meta")
-    if existing_meta:
-        payload["meta"] = existing_meta
-    existing_dispatch_meta = spec.get("dispatch", {}).get("meta")
-    if existing_dispatch_meta:
-        payload["dispatch"]["meta"] = existing_dispatch_meta
+    # text / request
+    if text is not None:
+        if payload.get("task_type") == "agent":
+            if "request" not in payload:
+                payload["request"] = {}
+            if not payload["request"].get("input"):
+                payload["request"]["input"] = [
+                    {
+                        "role": "user",
+                        "type": "message",
+                        "content": [{"type": "text", "text": text.strip()}],
+                    },
+                ]
+            else:
+                payload["request"]["input"][0]["content"][0]["text"] = (
+                    text.strip()
+                )
+        else:
+            payload["text"] = text.strip()
+
+    if save_result_to_inbox is not None:
+        payload["save_result_to_inbox"] = save_result_to_inbox
 
     return payload
 

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -3,7 +3,11 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from qwenpaw.cli.cron_cmd import _build_spec_from_cli, cron_group
+from qwenpaw.cli.cron_cmd import (
+    _build_spec_from_cli,
+    _resolve_update_spec,
+    cron_group,
+)
 
 
 def _agent_spec(**overrides):
@@ -46,3 +50,143 @@ def test_create_help_exposes_silent_delivery_flag():
 
     assert result.exit_code == 0
     assert "--silent / --no-silent" in result.output
+
+
+# --- _resolve_update_spec regression tests ---
+
+
+def _update(full_spec: dict, **overrides) -> dict:
+    """Thin wrapper: call _resolve_update_spec with all opt-out defaults."""
+    return _resolve_update_spec(
+        spec=full_spec,
+        task_type=overrides.pop("task_type", None),
+        schedule_type=overrides.pop("schedule_type", None),
+        name=overrides.pop("name", None),
+        cron=overrides.pop("cron", None),
+        run_at=overrides.pop("run_at", None),
+        repeat_every_days=overrides.pop("repeat_every_days", None),
+        repeat_end_type=overrides.pop("repeat_end_type", None),
+        repeat_until=overrides.pop("repeat_until", None),
+        repeat_count=overrides.pop("repeat_count", None),
+        channel=overrides.pop("channel", None),
+        target_user=overrides.pop("target_user", None),
+        target_session=overrides.pop("target_session", None),
+        text=overrides.pop("text", None),
+        timezone=overrides.pop("timezone", None),
+        enabled=overrides.pop("enabled", None),
+        mode=overrides.pop("mode", None),
+        silent=overrides.pop("silent", None),
+        save_result_to_inbox=overrides.pop("save_result_to_inbox", None),
+        share_session=overrides.pop("share_session", None),
+        timeout_seconds=overrides.pop("timeout_seconds", None),
+        tool_safety=overrides.pop("tool_safety", None),
+    )
+
+
+def test_update_preserves_runtime_fields():
+    """Renaming a job should not reset max_concurrency or misfire_grace_seconds."""
+    spec = {
+        "name": "original",
+        "enabled": True,
+        "schedule": {"type": "cron", "cron": "0 4 * * *", "timezone": "Asia/Shanghai"},
+        "task_type": "text",
+        "text": "hello",
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {"user_id": "u1", "session_id": "s1"},
+            "mode": "final",
+        },
+        "runtime": {
+            "max_concurrency": 4,
+            "misfire_grace_seconds": 1800,
+            "timeout_seconds": 300,
+            "share_session": True,
+            "tool_safety": False,
+        },
+    }
+
+    result = _update(spec, name="renamed")
+
+    assert result["name"] == "renamed"
+    assert result["runtime"]["max_concurrency"] == 4
+    assert result["runtime"]["misfire_grace_seconds"] == 1800
+    assert result["runtime"]["timeout_seconds"] == 300
+
+
+def test_update_preserves_request_extensions():
+    """Updating an agent job should preserve model and request_context."""
+    spec = {
+        "name": "agent-job",
+        "enabled": True,
+        "schedule": {"type": "cron", "cron": "*/5 * * * *", "timezone": "UTC"},
+        "task_type": "agent",
+        "request": {
+            "input": [
+                {
+                    "role": "user",
+                    "type": "message",
+                    "content": [{"type": "text", "text": "run task"}],
+                },
+            ],
+            "session_id": "s1",
+            "user_id": "u1",
+            "model": "custom-model",
+            "request_context": {"source_tag": "ops"},
+        },
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {"user_id": "u1", "session_id": "s1"},
+            "mode": "final",
+        },
+        "runtime": {
+            "max_concurrency": 1,
+            "timeout_seconds": 120,
+            "misfire_grace_seconds": 600,
+            "share_session": False,
+            "tool_safety": False,
+        },
+    }
+
+    result = _update(spec, name="renamed-agent")
+
+    assert result["name"] == "renamed-agent"
+    assert result["request"]["model"] == "custom-model"
+    assert result["request"]["request_context"] == {"source_tag": "ops"}
+
+
+def test_update_cli_override_applies():
+    """CLI-provided values should override existing fields."""
+    spec = {
+        "name": "original",
+        "enabled": False,
+        "schedule": {"type": "cron", "cron": "0 * * * *", "timezone": "UTC"},
+        "task_type": "text",
+        "text": "old",
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {"user_id": "u1", "session_id": "s1"},
+            "mode": "final",
+        },
+        "runtime": {
+            "max_concurrency": 1,
+            "timeout_seconds": 120,
+            "misfire_grace_seconds": 600,
+        },
+    }
+
+    result = _update(
+        spec,
+        name="new-name",
+        enabled=True,
+        timeout_seconds=900,
+    )
+
+    assert result["name"] == "new-name"
+    assert result["enabled"] is True
+    assert result["runtime"]["timeout_seconds"] == 900
+    # untouched fields preserved
+    assert result["runtime"]["max_concurrency"] == 1
+    assert result["runtime"]["misfire_grace_seconds"] == 600

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -84,11 +84,15 @@ def _update(full_spec: dict, **overrides) -> dict:
 
 
 def test_update_preserves_runtime_fields():
-    """Renaming a job should not reset max_concurrency or misfire_grace_seconds."""
+    """Renaming a job should keep max_concurrency & misfire_grace_seconds."""
     spec = {
         "name": "original",
         "enabled": True,
-        "schedule": {"type": "cron", "cron": "0 4 * * *", "timezone": "Asia/Shanghai"},
+        "schedule": {
+            "type": "cron",
+            "cron": "0 4 * * *",
+            "timezone": "Asia/Shanghai",
+        },
         "task_type": "text",
         "text": "hello",
         "dispatch": {
@@ -119,7 +123,11 @@ def test_update_preserves_request_extensions():
     spec = {
         "name": "agent-job",
         "enabled": True,
-        "schedule": {"type": "cron", "cron": "*/5 * * * *", "timezone": "UTC"},
+        "schedule": {
+            "type": "cron",
+            "cron": "*/5 * * * *",
+            "timezone": "UTC",
+        },
         "task_type": "agent",
         "request": {
             "input": [


### PR DESCRIPTION
## Problem

`qwenpaw cron update` was calling `_build_spec_from_cli` (designed for **create**) to reconstruct the entire spec.  That function hardcodes `max_concurrency=1` and `misfire_grace_seconds=600`, and only builds the request/structured fields defined for create.  Any field without a corresponding CLI option — including advanced runtime settings and request extensions like `model` or `request_context` — was silently dropped on update.

Closes #6176.

## Fix

Rewrote `_resolve_update_spec` to **deep-copy** the existing spec and only **patch** fields explicitly provided by the CLI.  This means:
- `max_concurrency`, `misfire_grace_seconds` — preserved
- `request.model`, `request.request_context` — preserved  
- `dispatch.meta`, `meta` — preserved
- All CLI-provided overrides still work correctly

## How tested

- Added 3 unit tests in `tests/unit/cli/test_cron_cmd.py`:
  - rename-only preserves `max_concurrency` / `misfire_grace_seconds`
  - rename-only preserves `request.model` / `request.request_context`
  - CLI overrides correctly apply while untouched fields survive
- End-to-end: created job with `max_concurrency=4`, renamed it, verified value survived
- All existing tests still pass