### PR TITLE
fix(utils): drop redundant nvidia-smi probe in get_vram_size_gb

### DIFF
--- a/src/qwenpaw/utils/system_info.py
+++ b/src/qwenpaw/utils/system_info.py
@@ -103,10 +103,11 @@ def get_memory_size_gb() -> float:
 
 
 def get_vram_size_gb() -> float:
-    """Return the largest CUDA GPU memory size in GB, or 0 when absent."""
-    if get_cuda_version() is None:
-        return 0.0
+    """Return the largest CUDA GPU memory size in GB, or 0 when absent.
 
+    The query below already fails on hosts without a working nvidia-smi,
+    so it needs no separate CUDA probe to guard it.
+    """
     output = _run_command(
         [
             "nvidia-smi",

--- a/tests/unit/utils/test_system_info.py
+++ b/tests/unit/utils/test_system_info.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+from __future__ import annotations
+
+import pytest
+
+import qwenpaw.utils.system_info as system_info_module
+from qwenpaw.utils.system_info import get_system_info, get_vram_size_gb
+
+_NVIDIA_SMI_HEADER = (
+    "NVIDIA-SMI 560.94    Driver Version: 560.94    CUDA Version: 12.6\n"
+)
+
+
+def _fake_run_command(
+    responses: dict[str, str | None],
+    calls: list[list[str]],
+):
+    """Build a _run_command stand-in that records every probe."""
+
+    def _runner(args: list[str], **_kwargs: object) -> str | None:
+        calls.append(list(args))
+        for key, value in responses.items():
+            if key in args:
+                return value
+        return None
+
+    return _runner
+
+
+# ---------------------------------------------------------------------------
+# get_system_info
+# ---------------------------------------------------------------------------
+
+
+def test_get_system_info_does_not_probe_nvidia_smi_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        system_info_module,
+        "_run_command",
+        _fake_run_command(
+            {
+                "--query-gpu=memory.total": "8188",
+                "nvidia-smi": _NVIDIA_SMI_HEADER,
+            },
+            calls,
+        ),
+    )
+
+    info = get_system_info()
+
+    nvidia_calls = [call for call in calls if call[0] == "nvidia-smi"]
+    # One probe for the CUDA version, one for VRAM. A third means
+    # get_vram_size_gb re-ran the CUDA probe the caller already did.
+    assert len(nvidia_calls) == 2
+    assert info["cuda_version"] == "12.6"
+    assert info["vram_gb"] == 8.0
+
+
+def test_get_system_info_skips_vram_probe_without_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        system_info_module,
+        "_run_command",
+        _fake_run_command({}, calls),
+    )
+
+    info = get_system_info()
+
+    assert info["cuda_version"] is None
+    assert info["vram_gb"] == 0.0
+    assert not any("--query-gpu=memory.total" in call for call in calls)
+
+
+# ---------------------------------------------------------------------------
+# get_vram_size_gb
+# ---------------------------------------------------------------------------
+
+
+def test_get_vram_size_gb_returns_zero_without_nvidia_smi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        system_info_module,
+        "_run_command",
+        _fake_run_command({}, calls),
+    )
+
+    assert get_vram_size_gb() == 0.0
+
+
+def test_get_vram_size_gb_picks_largest_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        system_info_module,
+        "_run_command",
+        _fake_run_command(
+            {"--query-gpu=memory.total": "8188\n24564\n"},
+            calls,
+        ),
+    )
+
+    assert get_vram_size_gb() == 23.99
+
+
+def test_get_vram_size_gb_ignores_unparsable_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        system_info_module,
+        "_run_command",
+        _fake_run_command(
+            {"--query-gpu=memory.total": "\n[N/A]\n8188\n"},
+            calls,
+        ),
+    )
+
+    assert get_vram_size_gb() == 8.0


### PR DESCRIPTION
## Description

`get_vram_size_gb()` in `src/qwenpaw/utils/system_info.py` opens with a guard that re-runs the CUDA probe:

```python
def get_vram_size_gb() -> float:
    if get_cuda_version() is None:      # spawns nvidia-smi
        return 0.0
    output = _run_command(["nvidia-smi", "--query-gpu=memory.total", ...])
```

`get_cuda_version()` spawns `nvidia-smi` itself, so on a CUDA host a single `get_system_info()` call spawns `nvidia-smi` **three times** where two suffice:

```
get_system_info()
├─ get_cuda_version()      -> nvidia-smi                      # spawn 1
└─ get_vram_size_gb()      (already gated on `if cuda_version`)
   ├─ get_cuda_version()   -> nvidia-smi                      # spawn 2, redundant
   └─ _run_command(...)    -> nvidia-smi --query-gpu=memory.total   # spawn 3
```

`get_system_info()` already computes `cuda_version` and already gates the VRAM call on it (`"vram_gb": get_vram_size_gb() if cuda_version else 0.0`), so the guard inside `get_vram_size_gb()` is the same check performed a second time.

**The guard is redundant even when `get_vram_size_gb()` is called on its own.** The `--query-gpu=memory.total` query is self-sufficient: on a host with no working `nvidia-smi` it fails, `_run_command()` returns `None`, and the function returns `0.0` — exactly what the guard returned. The behaviour is identical in every case, including the "nvcc present but nvidia-smi absent" case, where the guard passes but the query then fails and still yields `0.0`. Removing it changes cost, not semantics.

This matters most on two paths:

- **Startup.** `LlamaCppBackend.__init__` resolves the CUDA version during `LocalModelManager.get_instance()`, which the FastAPI lifespan runs synchronously. When `nvidia-smi` is slow or wedged, every redundant spawn costs another full `timeout=5` window. This is a contributing factor to (not a full fix for) #6197, where a hung `nvidia-smi` stalls Desktop startup.
- **Per request.** `GET /models` reaches `get_vram_size_gb()` via `ModelManager._detect_available_memory_gb()`. It is an `async def` endpoint calling blocking `subprocess.run`, so each redundant spawn blocks the event loop for its whole duration. This halves that: two spawns per request become one.

**Related Issue:** Relates to #6197. That issue's root cause is a stale PyInstaller bundle shipping pre-`timeout` code, which this PR does not address — it only removes a redundant probe that multiplies the stall when `nvidia-smi` misbehaves.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest`) and they pass
- [ ] Documentation updated (if needed) — internal helper, no docs change
- [x] Ready for review

## Testing

`src/qwenpaw/utils/system_info.py` had no direct test coverage at all — even the `errors="replace"` fix from #6140 landed without a regression test. This PR adds `tests/unit/utils/test_system_info.py` as the module's first tests, following the conventions in `tests/unit/utils/test_stdio.py` (function-style, `monkeypatch.setattr` on the module object).

Coverage added:

- `test_get_system_info_does_not_probe_nvidia_smi_twice` — counts every probe and asserts `nvidia-smi` is spawned exactly twice, which is the regression guard for this change.
- `test_get_system_info_skips_vram_probe_without_cuda` — the caller-side gate still short-circuits the VRAM query when there is no CUDA.
- `test_get_vram_size_gb_returns_zero_without_nvidia_smi` — pins the behaviour the removed guard used to provide.
- `test_get_vram_size_gb_picks_largest_gpu` and `test_get_vram_size_gb_ignores_unparsable_lines` — multi-GPU selection and `[N/A]` rows.

## Evidence

All measurements below are from a real Windows 11 machine with an NVIDIA RTX 4070 and a healthy driver — the same OS/GPU combination reported in #6197.

**The VRAM query does not need the CUDA probe in front of it.** Run on its own, it succeeds immediately:

```
$ nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits
8188

$ python -c "...subprocess.run of the same query..."
rc= 0 out= '8188' elapsed=0.03s
```

**Dropping the redundant spawn is ~40% faster even when the driver is healthy.** Averaged over 5 runs with the driver already warmed up (so the one-off cold-start cost is excluded from both sides):

```
WARM driver, avg of 5 runs:
  current (3 spawns): 0.333s
  proposed(2 spawns): 0.200s
  saved: 0.133s (40%)
```

On a wedged driver the saving is bounded by `_run_command`'s `timeout=5` per spawn instead, which is the case #6197 describes.

**The new test fails against the current code and passes with the fix.** Reverting only the `get_vram_size_gb` change:

```
$ pytest tests/unit/utils/test_system_info.py -q
>       assert get_vram_size_gb() == 8.0
E       assert 0.0 == 8.0
FAILED tests/unit/utils/test_system_info.py::test_get_system_info_does_not_probe_nvidia_smi_twice
FAILED tests/unit/utils/test_system_info.py::test_get_vram_size_gb_picks_largest_gpu
FAILED tests/unit/utils/test_system_info.py::test_get_vram_size_gb_ignores_unparsable_lines
3 failed, 2 passed in 0.27s
```

**With the fix applied:**

```
$ pytest tests/unit/utils/test_system_info.py -q
5 passed in 0.19s
```

**No regressions across the whole unit suite:**

```
$ pytest tests/unit -q
4804 passed, 52 skipped, 56 warnings in 247.88s (0:04:07)
```

**Every pre-commit hook passes on the touched files:**

```
$ pre-commit run --files src/qwenpaw/utils/system_info.py \
                        tests/unit/utils/test_system_info.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```
