### PR TITLE
fix(memory): bound summary task history

### DIFF
--- a/src/qwenpaw/agents/memory/base_memory_manager.py
+++ b/src/qwenpaw/agents/memory/base_memory_manager.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 AUTO_MEMORY_TURN_STATE_TTL_SECONDS = 24 * 60 * 60
 MAX_QUERY_CHARS = 50
 SUMMARY_WORKER_CLOSE_TIMEOUT_SECONDS = 5.0
+MAX_SUMMARY_TASK_HISTORY = 100
+SUMMARY_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
 
 
 class BaseMemoryManager(ABC):
@@ -389,6 +391,8 @@ class BaseMemoryManager(ABC):
                 info["status"] = "failed"
                 info["error"] = str(e)
                 logger.error(f"Summary task {task_id} failed: {e}")
+            finally:
+                self._prune_summary_task_info()
 
     async def _shutdown_summarize_worker(
         self,
@@ -445,7 +449,6 @@ class BaseMemoryManager(ABC):
 
         self._summary_task_info[task_id] = {
             "task_id": task_id,
-            "task": self._worker_task,  # Reference to the worker task
             "start_time": datetime.now(),
             "status": "pending",
             "result": None,
@@ -454,6 +457,16 @@ class BaseMemoryManager(ABC):
 
         # Enqueue for serial execution
         self._task_queue.put_nowait((task_id, messages, kwargs))
+
+    def _prune_summary_task_info(self) -> None:
+        """Keep active tasks and only the latest terminal task history."""
+        terminal_ids = [
+            task_id
+            for task_id, info in self._summary_task_info.items()
+            if info["status"] in SUMMARY_TERMINAL_STATUSES
+        ]
+        for task_id in terminal_ids[:-MAX_SUMMARY_TASK_HISTORY]:
+            self._summary_task_info.pop(task_id, None)
 
     def _update_task_statuses(self) -> None:
         """Update status for pending/running tasks if worker was cancelled."""
@@ -476,6 +489,7 @@ class BaseMemoryManager(ABC):
                         info["status"] = "failed"
                         info["error"] = str(exc)
                         logger.error(f"Summary task {task_id} failed: {exc}")
+        self._prune_summary_task_info()
 
     def list_summarize_status(self) -> list[dict]:
         """Return status of all summary tasks as list of dicts.

--- a/tests/unit/agents/memory/test_base_memory_manager.py
+++ b/tests/unit/agents/memory/test_base_memory_manager.py
@@ -189,6 +189,65 @@ class TestBaseMemoryManagerAddSummarizeTask:
             except (asyncio.CancelledError, Exception):
                 pass
 
+    async def test_task_info_does_not_retain_worker(self, manager):
+        manager.add_summarize_task([MagicMock()])
+
+        info = next(iter(manager._summary_task_info.values()))
+        assert "task" not in info
+
+        await manager._shutdown_summarize_worker()
+
+    async def test_keeps_only_latest_terminal_tasks(
+        self,
+        manager,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            base_memory_manager,
+            "MAX_SUMMARY_TASK_HISTORY",
+            2,
+        )
+        completed = asyncio.Event()
+        calls = 0
+
+        async def summarize(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 3:
+                completed.set()
+            return f"result-{calls}"
+
+        manager.summarize = summarize
+        for _ in range(3):
+            manager.add_summarize_task([MagicMock()])
+
+        await asyncio.wait_for(completed.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+        assert list(manager._summary_task_info) == ["task_2", "task_3"]
+        await manager._shutdown_summarize_worker()
+
+    def test_pruning_keeps_non_terminal_tasks(self, manager, monkeypatch):
+        monkeypatch.setattr(
+            base_memory_manager,
+            "MAX_SUMMARY_TASK_HISTORY",
+            1,
+        )
+        manager._summary_task_info = {
+            "task_1": {"status": "completed"},
+            "task_2": {"status": "running"},
+            "task_3": {"status": "failed"},
+            "task_4": {"status": "pending"},
+        }
+
+        manager._prune_summary_task_info()
+
+        assert list(manager._summary_task_info) == [
+            "task_2",
+            "task_3",
+            "task_4",
+        ]
+
     async def test_shutdown_exits_when_nested_call_swallows_cancellation(
         self,
         manager,


### PR DESCRIPTION
## Description

修复 BaseMemoryManager 中摘要任务历史无上限增长的问题。

每次添加摘要任务时，原实现都会在 _summary_task_info 中永久保留状态、结果文本以及共享 worker 引用。对于长期运行且启用周期性 auto-memory 的实例，该字典会随摘要次数持续增长。

本次修改：

- 所有 pending 和 running 任务继续保留，避免影响任务状态查询。
- completed、failed 和 cancelled 记录仅保留最近 100 条。
- 移除每条记录中冗余的共享 worker Task 引用。
- 在任务进入终态后统一执行历史裁剪。
- 补充历史上限、活跃任务保留和 worker 引用释放测试。

**Related Issue:** 无

**Security Considerations:** 不涉及安全边界、认证信息或配置处理。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran pre-commit run --all-files locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (pytest or as relevant) and they pass
- [x] Documentation updated (本次无需更新文档)
- [x] Ready for review

## Testing

运行 memory 模块单元测试以及相关文件的 Flake8 检查。

## Evidence

    $ .venv/bin/pytest tests/unit/agents/memory -q
    ........................................................................ [ 91%]
    .......                                                                  [100%]
    79 passed in 0.53s

    $ .venv/bin/flake8 --extend-ignore=E203 src/qwenpaw/agents/memory/base_memory_manager.py tests/unit/agents/memory/test_base_memory_manager.py
    # 无输出，退出码为 0

    $ git diff --check upstream/main...HEAD
    # 无输出，退出码为 0

## Additional Notes

终态记录上限当前固定为 100；活跃任务不计入该上限。