### PR TITLE
fix(channels): bound SIP, Matrix, and Slack channel state

### DIFF
--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -17,6 +17,7 @@ import os
 import re
 import time
 import urllib.parse
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -83,6 +84,10 @@ TYPING_SERVER_TIMEOUT_MS = 30000
 TYPING_RENEWAL_INTERVAL_S = 25
 TYPING_MAX_DURATION_S = 120
 DM_CACHE_TTL_MS = 30_000
+DM_ROOM_CACHE_MAX_ENTRIES = 1_000
+ROOM_HISTORY_MAX_ROOMS = 256
+VERIFICATION_STATE_MAX_ENTRIES = 1_024
+VERIFICATION_STATE_TTL_S = 60 * 60
 
 # Known QwenPaw slash commands — used to decide whether to strip
 # @mention prefix
@@ -247,12 +252,25 @@ class MatrixChannel(BaseChannel):
         self._user_id: Optional[str] = None
         self._sync_task: Optional[asyncio.Task] = None
         self._typing_tasks: Dict[str, asyncio.Task] = {}
-        self._room_histories: Dict[str, List[HistoryEntry]] = {}
-        self._dm_room_cache: Dict[str, Dict[str, Any]] = {}
+        self._room_histories: OrderedDict[
+            str,
+            List[HistoryEntry],
+        ] = OrderedDict()
+        self._dm_room_cache: OrderedDict[str, Dict[str, Any]] = OrderedDict()
         self._http_client: Optional[httpx.AsyncClient] = None
-        self._handled_verification_requests: set[str] = set()
-        self._verification_tx_peers: dict[str, tuple[str, str]] = {}
-        self._sent_verification_done: set[str] = set()
+        self._handled_verification_requests: OrderedDict[
+            str,
+            float,
+        ] = OrderedDict()
+        self._verification_tx_peers: OrderedDict[
+            str,
+            tuple[str, str],
+        ] = OrderedDict()
+        self._verification_tx_timestamps: OrderedDict[
+            str,
+            float,
+        ] = OrderedDict()
+        self._sent_verification_done: OrderedDict[str, float] = OrderedDict()
 
     # ------------------------------------------------------------------
     # Debounce key — serialize by room_id (avoid concurrent session access)
@@ -752,6 +770,12 @@ class MatrixChannel(BaseChannel):
             self._http_client = None
         if self._client:
             await self._client.close()
+        self._room_histories.clear()
+        self._dm_room_cache.clear()
+        self._handled_verification_requests.clear()
+        self._verification_tx_peers.clear()
+        self._verification_tx_timestamps.clear()
+        self._sent_verification_done.clear()
         logger.info("MatrixChannel: stopped")
 
     # ------------------------------------------------------------------
@@ -971,6 +995,7 @@ class MatrixChannel(BaseChannel):
                         event.sender,
                         getattr(event, "reason", ""),
                     )
+                self._clear_verification_transaction(event.transaction_id)
             else:
                 logger.info(
                     "MatrixChannel: unhandled verification event type=%s "
@@ -1060,6 +1085,7 @@ class MatrixChannel(BaseChannel):
         methods = content.get("methods", []) or []
 
         request_key = f"{sender}|{from_device}|{transaction_id}"
+        self._prune_verification_state()
         if request_key in self._handled_verification_requests:
             logger.debug(
                 "MatrixChannel: verification request already handled "
@@ -1069,7 +1095,7 @@ class MatrixChannel(BaseChannel):
                 transaction_id,
             )
             return
-        self._handled_verification_requests.add(request_key)
+        self._remember_verification_request(request_key)
 
         if not sender or not from_device:
             logger.warning(
@@ -1081,7 +1107,11 @@ class MatrixChannel(BaseChannel):
             )
             return
 
-        self._verification_tx_peers[transaction_id] = (sender, from_device)
+        self._remember_verification_peer(
+            transaction_id,
+            sender,
+            from_device,
+        )
 
         our_device = getattr(self._client, "device_id", "") or ""
         if not our_device:
@@ -1163,7 +1193,9 @@ class MatrixChannel(BaseChannel):
         """Accept Element's SAS start, querying device keys if needed."""
         if not self._client or not self._client.olm:
             return
-        self._verification_tx_peers[event.transaction_id] = (
+        self._prune_verification_state()
+        self._remember_verification_peer(
+            event.transaction_id,
             event.sender,
             event.from_device,
         )
@@ -1259,7 +1291,8 @@ class MatrixChannel(BaseChannel):
             )
             return
 
-        self._sent_verification_done.add(transaction_id)
+        self._remember_sent_verification_done(transaction_id)
+        self._clear_verification_transaction(transaction_id)
         logger.info(
             "MatrixChannel: sent verification done "
             "(tx=%s, sender=%s, device=%s)",
@@ -1267,6 +1300,62 @@ class MatrixChannel(BaseChannel):
             sender,
             device_id,
         )
+
+    def _prune_verification_state(self) -> None:
+        """Expire old verification dedupe state and enforce hard caps."""
+        cutoff = time.monotonic() - VERIFICATION_STATE_TTL_S
+        for store in (
+            self._handled_verification_requests,
+            self._sent_verification_done,
+        ):
+            while store:
+                key, timestamp = next(iter(store.items()))
+                if (
+                    timestamp >= cutoff
+                    and len(store) <= VERIFICATION_STATE_MAX_ENTRIES
+                ):
+                    break
+                store.pop(key)
+
+        while self._verification_tx_timestamps:
+            transaction_id, timestamp = next(
+                iter(self._verification_tx_timestamps.items()),
+            )
+            if (
+                timestamp >= cutoff
+                and len(self._verification_tx_timestamps)
+                <= VERIFICATION_STATE_MAX_ENTRIES
+            ):
+                break
+            self._verification_tx_timestamps.pop(transaction_id)
+            self._verification_tx_peers.pop(transaction_id, None)
+
+    def _remember_verification_request(self, request_key: str) -> None:
+        self._handled_verification_requests[request_key] = time.monotonic()
+        self._handled_verification_requests.move_to_end(request_key)
+        self._prune_verification_state()
+
+    def _remember_sent_verification_done(self, transaction_id: str) -> None:
+        self._sent_verification_done[transaction_id] = time.monotonic()
+        self._sent_verification_done.move_to_end(transaction_id)
+        self._prune_verification_state()
+
+    def _remember_verification_peer(
+        self,
+        transaction_id: str,
+        sender: str,
+        device_id: str,
+    ) -> None:
+        self._verification_tx_peers[transaction_id] = (sender, device_id)
+        self._verification_tx_peers.move_to_end(transaction_id)
+        self._verification_tx_timestamps[transaction_id] = time.monotonic()
+        self._verification_tx_timestamps.move_to_end(transaction_id)
+        self._prune_verification_state()
+
+    def _clear_verification_transaction(self, transaction_id: str) -> None:
+        """Release peer metadata after a cancelled or completed transaction."""
+        self._verification_tx_peers.pop(transaction_id, None)
+        self._verification_tx_timestamps.pop(transaction_id, None)
 
     async def _recover_key_verification_start(
         self,
@@ -1710,15 +1799,19 @@ class MatrixChannel(BaseChannel):
         if limit <= 0:
             return
         history = self._room_histories.setdefault(room_id, [])
+        self._room_histories.move_to_end(room_id)
         history.append(entry)
         while len(history) > limit:
             history.pop(0)
+        while len(self._room_histories) > ROOM_HISTORY_MAX_ROOMS:
+            self._room_histories.popitem(last=False)
 
     def _build_history_prefix(self, room_id: str) -> str:
         """Format buffered history entries as a multi-line text block."""
         entries = self._room_histories.get(room_id, [])
         if not entries:
             return ""
+        self._room_histories.move_to_end(room_id)
         lines: list[str] = []
         for e in entries:
             line = f"{e.sender}: {e.body}"
@@ -2244,6 +2337,18 @@ class MatrixChannel(BaseChannel):
         except Exception:
             return False
 
+    def _prune_dm_room_cache(self, now_ms: int) -> None:
+        """Evict expired or least-recently-used room membership entries."""
+        cutoff = now_ms - DM_CACHE_TTL_MS
+        while self._dm_room_cache:
+            room_id, cached = next(iter(self._dm_room_cache.items()))
+            if (
+                cached["ts"] >= cutoff
+                and len(self._dm_room_cache) <= DM_ROOM_CACHE_MAX_ENTRIES
+            ):
+                break
+            self._dm_room_cache.pop(room_id)
+
     async def _is_dm_room(
         self,
         room_id: str,
@@ -2270,6 +2375,7 @@ class MatrixChannel(BaseChannel):
         # Check cache
         cached = self._dm_room_cache.get(room_id)
         if cached and (now - cached["ts"]) < DM_CACHE_TTL_MS:
+            self._dm_room_cache.move_to_end(room_id)
             members = cached["members"]
             is_dm = (
                 len(members) == 2
@@ -2290,7 +2396,12 @@ class MatrixChannel(BaseChannel):
             if isinstance(resp, JoinedMembersResponse):
                 members = [m.user_id for m in resp.members]
                 # Update cache
-                self._dm_room_cache[room_id] = {"members": members, "ts": now}
+                self._dm_room_cache[room_id] = {
+                    "members": members,
+                    "ts": now,
+                }
+                self._dm_room_cache.move_to_end(room_id)
+                self._prune_dm_room_cache(now)
 
                 is_dm = (
                     len(members) == 2

--- a/src/qwenpaw/app/channels/sip/livekit_backend.py
+++ b/src/qwenpaw/app/channels/sip/livekit_backend.py
@@ -40,6 +40,22 @@ from .backend import CallEndedCallback, IncomingCallCallback
 
 logger = logging.getLogger(__name__)
 
+# Audio older than a few seconds is no longer useful to real-time STT.
+_AUDIO_QUEUE_MAX_FRAMES = 150
+
+
+def _put_latest_audio(
+    queue: asyncio.Queue,
+    frame: bytes | None,
+) -> None:
+    """Queue *frame*, discarding stale audio when the consumer falls behind."""
+    if queue.full():
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+    queue.put_nowait(frame)
+
 
 class LiveKitBackend:
     """SipBackend backed by LiveKit SIP Server (event-driven).
@@ -397,7 +413,7 @@ class LiveKitBackend:
                         getattr(frame, "num_channels", "?"),
                         len(bytes(frame.data)),
                     )
-                self._audio_queue.put_nowait(bytes(frame.data))
+                _put_latest_audio(self._audio_queue, bytes(frame.data))
         except Exception:
             logger.debug(
                 "Audio read ended: %s",
@@ -406,7 +422,7 @@ class LiveKitBackend:
             )
         finally:
             if self._audio_queue:
-                self._audio_queue.put_nowait(None)
+                _put_latest_audio(self._audio_queue, None)
 
     async def _notify_incoming(
         self,
@@ -414,7 +430,9 @@ class LiveKitBackend:
         from_uri: str,
     ) -> None:
         """Notify SIPChannel of a new incoming call."""
-        audio_queue: asyncio.Queue = asyncio.Queue()
+        audio_queue: asyncio.Queue = asyncio.Queue(
+            maxsize=_AUDIO_QUEUE_MAX_FRAMES,
+        )
         self._audio_queue = audio_queue
 
         async def write_audio(data: bytes) -> None:

--- a/src/qwenpaw/app/channels/sip/mini_registrar.py
+++ b/src/qwenpaw/app/channels/sip/mini_registrar.py
@@ -19,9 +19,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from typing import Optional, cast
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_REGISTER_EXPIRES_S = 3600
+_MAX_REGISTER_EXPIRES_S = 24 * 60 * 60
+_TRANSACTION_TTL_S = 5 * 60
 
 
 def _user(uri: str) -> str:
@@ -44,6 +49,34 @@ def _method_and_uri(msg: str) -> tuple[str, str]:
     return "", ""
 
 
+def _register_expires(msg: str) -> int:
+    """Return a safe REGISTER lifetime; malformed values use the default."""
+    contact = _hdr(msg, "Contact")
+    contact_match = re.search(
+        r"(?:^|;)\s*expires\s*=\s*\"?(\d+)\"?",
+        contact,
+        flags=re.IGNORECASE,
+    )
+    raw = contact_match.group(1) if contact_match else _hdr(msg, "Expires")
+    try:
+        expires = int(raw) if raw else _DEFAULT_REGISTER_EXPIRES_S
+    except ValueError:
+        return _DEFAULT_REGISTER_EXPIRES_S
+    return max(0, min(expires, _MAX_REGISTER_EXPIRES_S))
+
+
+def _is_final_response(msg: str) -> bool:
+    """Whether *msg* is a SIP response that terminates a transaction."""
+    first_line = msg.split("\r\n", 1)[0]
+    parts = first_line.split()
+    if len(parts) < 2 or not first_line.startswith("SIP/"):
+        return False
+    try:
+        return int(parts[1]) >= 200
+    except ValueError:
+        return False
+
+
 def _build_200(msg: str) -> str:
     lines = ["SIP/2.0 200 OK"]
     for h in ("Via", "From", "To", "Call-ID", "CSeq"):
@@ -57,8 +90,8 @@ def _build_200(msg: str) -> str:
 class _SIPProxy(asyncio.DatagramProtocol):
     def __init__(self) -> None:
         self.transport: Optional[asyncio.DatagramTransport] = None
-        self.registry: dict[str, tuple[str, int]] = {}
-        self.transactions: dict[str, tuple[str, int]] = {}
+        self.registry: dict[str, tuple[tuple[str, int], float]] = {}
+        self.transactions: dict[str, tuple[tuple[str, int], float]] = {}
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
@@ -73,6 +106,7 @@ class _SIPProxy(asyncio.DatagramProtocol):
         except Exception:
             return
 
+        self._prune_expired()
         method, req_uri = _method_and_uri(msg)
         if method == "REGISTER":
             self._register(msg, addr)
@@ -83,7 +117,22 @@ class _SIPProxy(asyncio.DatagramProtocol):
 
     def _register(self, msg: str, addr: tuple[str, int]) -> None:
         user = _user(_hdr(msg, "To"))
-        self.registry[user] = addr
+        expires = _register_expires(msg)
+        if not user:
+            return
+        if expires == 0:
+            registration = self.registry.get(user)
+            if registration and registration[0] == addr:
+                self.registry.pop(user, None)
+                logger.debug("SIP unregistered %s", user)
+            elif registration:
+                logger.debug(
+                    "Ignoring stale SIP unregister for %s from %s",
+                    user,
+                    addr,
+                )
+        else:
+            self.registry[user] = (addr, time.monotonic() + expires)
         logger.debug("SIP REG %s -> %s", user, addr)
         self.transport.sendto(_build_200(msg).encode(), addr)
 
@@ -95,8 +144,8 @@ class _SIPProxy(asyncio.DatagramProtocol):
         addr: tuple[str, int],
     ) -> None:
         target = _user(uri)
-        dest = self.registry.get(target)
-        if not dest:
+        registration = self.registry.get(target)
+        if not registration:
             if method == "INVITE":
                 resp = msg.replace(
                     msg.split("\r\n", 1)[0],
@@ -105,12 +154,16 @@ class _SIPProxy(asyncio.DatagramProtocol):
                 )
                 self.transport.sendto(resp.encode(), addr)
             return
+        dest, _expires_at = registration
 
         call_id = _hdr(msg, "Call-ID")
-        if method == "INVITE":
-            self.transactions[call_id] = addr
-        elif call_id not in self.transactions:
-            self.transactions[call_id] = addr
+        if call_id and (
+            method == "INVITE" or call_id not in self.transactions
+        ):
+            self.transactions[call_id] = (
+                addr,
+                time.monotonic() + _TRANSACTION_TTL_S,
+            )
 
         self.transport.sendto(msg.encode(), dest)
 
@@ -120,14 +173,24 @@ class _SIPProxy(asyncio.DatagramProtocol):
         addr: tuple[str, int],
     ) -> None:
         call_id = _hdr(msg, "Call-ID")
-        dest = self.transactions.get(call_id)
+        transaction = self.transactions.get(call_id)
+        dest = transaction[0] if transaction else None
         if dest and dest != addr:
             self.transport.sendto(msg.encode(), dest)
             return
-        for _user_name, uaddr in self.registry.items():
+        for _user_name, (uaddr, _expires_at) in self.registry.items():
             if uaddr != addr:
                 self.transport.sendto(msg.encode(), uaddr)
                 break
+
+    def _prune_expired(self) -> None:
+        now = time.monotonic()
+        for user, (_addr, expires_at) in list(self.registry.items()):
+            if expires_at <= now:
+                self.registry.pop(user, None)
+        for call_id, (_addr, expires_at) in list(self.transactions.items()):
+            if expires_at <= now:
+                self.transactions.pop(call_id, None)
 
 
 class MiniRegistrar:

--- a/src/qwenpaw/app/channels/sip/pyvoip_backend.py
+++ b/src/qwenpaw/app/channels/sip/pyvoip_backend.py
@@ -15,6 +15,22 @@ from .backend import CallEndedCallback, IncomingCallCallback
 
 logger = logging.getLogger(__name__)
 
+# At roughly 18 ms per input frame this retains less than three seconds.
+_AUDIO_QUEUE_MAX_FRAMES = 150
+
+
+def _put_latest_audio(
+    queue: asyncio.Queue,
+    frame: bytes | None,
+) -> None:
+    """Queue *frame*, discarding stale audio when STT falls behind."""
+    if queue.full():
+        try:
+            queue.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+    queue.put_nowait(frame)
+
 
 class PyVoIPBackend:
     """SipBackend backed by pyVoIP 1.6.x."""
@@ -133,7 +149,9 @@ class PyVoIPBackend:
 
         self._active_calls[call_id] = call
 
-        audio_queue: asyncio.Queue = asyncio.Queue()
+        audio_queue: asyncio.Queue = asyncio.Queue(
+            maxsize=_AUDIO_QUEUE_MAX_FRAMES,
+        )
 
         async def _write_audio(data: bytes) -> None:
             c = self._active_calls.get(call_id)
@@ -167,7 +185,8 @@ class PyVoIPBackend:
                     break
                 if pcm and self._loop:
                     self._loop.call_soon_threadsafe(
-                        audio_queue.put_nowait,
+                        _put_latest_audio,
+                        audio_queue,
                         pcm,
                     )
                 time.sleep(0.018)
@@ -180,7 +199,8 @@ class PyVoIPBackend:
         finally:
             if self._loop:
                 self._loop.call_soon_threadsafe(
-                    audio_queue.put_nowait,
+                    _put_latest_audio,
+                    audio_queue,
                     None,
                 )
             self._active_calls.pop(call_id, None)

--- a/src/qwenpaw/app/channels/sip/stt_tts.py
+++ b/src/qwenpaw/app/channels/sip/stt_tts.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import queue as thread_queue
+import threading
 from typing import AsyncIterator
 
 from .stt_engine import AliyunSTTStream, STTStreamEngine
 
 logger = logging.getLogger(__name__)
+
+# Enough for short scheduling jitter without allowing a whole response to sit
+# in memory when the audio output blocks.
+_TTS_QUEUE_MAX_CHUNKS = 64
 
 
 def _resolve_dashscope_key(api_key: str = "") -> str:
@@ -135,28 +141,30 @@ async def _stream_aliyun(
         AudioFormat.PCM_8000HZ_MONO_16BIT,
     )
 
-    loop = asyncio.get_running_loop()
-    queue: asyncio.Queue = asyncio.Queue()
+    queue: thread_queue.Queue[bytes | None] = thread_queue.Queue(
+        maxsize=_TTS_QUEUE_MAX_CHUNKS,
+    )
+    stopped = threading.Event()
+
+    def _enqueue(chunk: bytes | None) -> None:
+        """Block the SDK callback until playback makes room or is cancelled."""
+        while not stopped.is_set():
+            try:
+                queue.put(chunk, timeout=0.1)
+                return
+            except thread_queue.Full:
+                pass
 
     class _Callback(ResultCallback):
         def on_data(self, data: bytes) -> None:
-            loop.call_soon_threadsafe(
-                queue.put_nowait,
-                data,
-            )
+            _enqueue(data)
 
         def on_complete(self) -> None:
-            loop.call_soon_threadsafe(
-                queue.put_nowait,
-                None,
-            )
+            _enqueue(None)
 
         def on_error(self, message: str) -> None:
             logger.error("TTS stream error: %s", message)
-            loop.call_soon_threadsafe(
-                queue.put_nowait,
-                None,
-            )
+            _enqueue(None)
 
         def on_close(self) -> None:
             pass
@@ -184,12 +192,26 @@ async def _stream_aliyun(
         text,
     )
 
-    # Drain the queue concurrently while synthesis is running
-    while True:
-        chunk = await queue.get()
-        if chunk is None:
-            break
-        yield chunk
+    completed = False
+    try:
+        # ``Queue.get`` is synchronous because DashScope invokes callbacks
+        # from its own thread. A timed get also lets us notice a producer that
+        # exited without delivering its terminal callback.
+        while True:
+            try:
+                chunk = await asyncio.to_thread(queue.get, True, 0.1)
+            except thread_queue.Empty:
+                if synth_task.done():
+                    break
+                continue
+            if chunk is None:
+                break
+            yield chunk
+        completed = True
+    finally:
+        stopped.set()
 
-    # Ensure the background thread finishes cleanly
-    await synth_task
+    # Surface synthesis failures after normal completion. On cancellation the
+    # callback observes ``stopped`` and the executor future finishes itself.
+    if completed:
+        await synth_task

--- a/src/qwenpaw/app/channels/slack/constants.py
+++ b/src/qwenpaw/app/channels/slack/constants.py
@@ -15,6 +15,10 @@ SLACK_DEDUP_WINDOW_SECONDS: int = 300
 # Maximum number of entries in the deduplication cache
 SLACK_DEDUP_MAX_ENTRIES: int = 10000
 
+# User profiles change occasionally, and a channel can run for months.
+SLACK_USER_NAME_CACHE_MAX_ENTRIES: int = 10000
+SLACK_USER_NAME_CACHE_TTL_S: float = 6 * 60 * 60
+
 # ── SSRF Protection ──
 
 # Whitelist of allowed domains for file downloads/uploads

--- a/src/qwenpaw/app/channels/slack/handler.py
+++ b/src/qwenpaw/app/channels/slack/handler.py
@@ -43,6 +43,8 @@ from qwenpaw.schemas import (
 from .constants import (
     SLACK_DEDUP_MAX_ENTRIES,
     SLACK_DEDUP_WINDOW_SECONDS,
+    SLACK_USER_NAME_CACHE_MAX_ENTRIES,
+    SLACK_USER_NAME_CACHE_TTL_S,
 )
 from .utils import (
     build_dedup_key,
@@ -98,7 +100,10 @@ class SlackEventHandler:
         self._dedup_lock = asyncio.Lock()
         self._dedup_map: OrderedDict[str, float] = OrderedDict()
         self._http_session: Optional[aiohttp.ClientSession] = None
-        self._user_name_cache: Dict[str, str] = {}
+        self._user_name_cache: OrderedDict[
+            str,
+            tuple[str, float],
+        ] = OrderedDict()
 
     # ── Registration ──
 
@@ -519,8 +524,14 @@ class SlackEventHandler:
         Falls back to the user ID when the API call fails or the user
         is not found.  Results are cached per user_id.
         """
-        if user_id in self._user_name_cache:
-            return self._user_name_cache[user_id]
+        cached = self._user_name_cache.get(user_id)
+        if (
+            cached
+            and time.monotonic() - cached[1] < SLACK_USER_NAME_CACHE_TTL_S
+        ):
+            self._user_name_cache.move_to_end(user_id)
+            return cached[0]
+        self._user_name_cache.pop(user_id, None)
         try:
             resp = await with_retry(
                 client.users_info,
@@ -532,23 +543,30 @@ class SlackEventHandler:
                 if isinstance(profile, dict):
                     display = profile.get("display_name")
                     if display:
-                        self._user_name_cache[user_id] = display
+                        self._cache_user_name(user_id, display)
                         return display
                     real = profile.get("real_name")
                     if real:
-                        self._user_name_cache[user_id] = real
+                        self._cache_user_name(user_id, real)
                         return real
                 name = info.get("real_name") or info.get("name")
                 if name:
-                    self._user_name_cache[user_id] = name
+                    self._cache_user_name(user_id, name)
                     return name
         except Exception:
             logger.debug(
                 "slack handler: users_info failed for %s",
                 user_id,
             )
-        self._user_name_cache[user_id] = ""
+        self._cache_user_name(user_id, "")
         return ""
+
+    def _cache_user_name(self, user_id: str, name: str) -> None:
+        """Cache a profile lookup with bounded, expiring LRU retention."""
+        self._user_name_cache[user_id] = (name, time.monotonic())
+        self._user_name_cache.move_to_end(user_id)
+        while len(self._user_name_cache) > SLACK_USER_NAME_CACHE_MAX_ENTRIES:
+            self._user_name_cache.popitem(last=False)
 
     async def handle_slash_command(self, command: dict) -> None:
         slash_name = (command.get("command") or "").lstrip("/")

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -152,6 +152,79 @@ class TestMatrixChannelInit:
         assert channel._filter_thinking is True
 
 
+class TestMatrixChannelBoundedState:
+    """Bounded local state must not alter normal recent-room behavior."""
+
+    def test_room_history_evicts_least_recent_room(
+        self,
+        matrix_channel,
+        monkeypatch,
+    ):
+        from qwenpaw.app.channels.matrix import channel as matrix_module
+        from qwenpaw.app.channels.matrix.channel import HistoryEntry
+
+        monkeypatch.setattr(matrix_module, "ROOM_HISTORY_MAX_ROOMS", 2)
+        for room_id in ("!one", "!two", "!three"):
+            matrix_channel._record_history(
+                room_id,
+                HistoryEntry(sender="user", body=room_id),
+            )
+
+        assert list(matrix_channel._room_histories) == ["!two", "!three"]
+
+    def test_dm_cache_prunes_expired_and_oldest_entries(
+        self,
+        matrix_channel,
+        monkeypatch,
+    ):
+        from qwenpaw.app.channels.matrix import channel as matrix_module
+
+        monkeypatch.setattr(matrix_module, "DM_ROOM_CACHE_MAX_ENTRIES", 2)
+        matrix_channel._dm_room_cache.update(
+            {
+                "!old": {"members": [], "ts": 0},
+                "!two": {"members": [], "ts": 30_001},
+                "!three": {"members": [], "ts": 30_001},
+            },
+        )
+
+        matrix_channel._prune_dm_room_cache(
+            30_001,
+        )
+
+        assert list(matrix_channel._dm_room_cache) == ["!two", "!three"]
+
+    def test_verification_state_expires_and_cancel_clears_peer(
+        self,
+        matrix_channel,
+        monkeypatch,
+    ):
+        from qwenpaw.app.channels.matrix import channel as matrix_module
+
+        monkeypatch.setattr(matrix_module, "VERIFICATION_STATE_MAX_ENTRIES", 1)
+        matrix_channel._remember_verification_peer("old", "@old", "D1")
+        matrix_channel._remember_verification_peer("new", "@new", "D2")
+        matrix_channel._clear_verification_transaction("new")
+
+        assert "old" not in matrix_channel._verification_tx_peers
+        assert "new" not in matrix_channel._verification_tx_peers
+
+    async def test_failed_done_keeps_peer_for_retry(self, matrix_channel):
+        matrix_channel._remember_verification_peer("tx", "@user:hs", "D1")
+        client = MagicMock()
+        client.to_device = AsyncMock(side_effect=RuntimeError("network down"))
+        matrix_channel._client = client
+
+        event = MagicMock()
+        event.sender = "@user:hs"
+        event.source = {"content": {"transaction_id": "tx"}}
+
+        await matrix_channel._handle_unknown_key_verification_done(event)
+
+        assert "tx" in matrix_channel._verification_tx_peers
+        assert "tx" not in matrix_channel._sent_verification_done
+
+
 class TestMatrixChannelFromConfig:
     """Test MatrixChannel factory methods."""
 

--- a/tests/unit/channels/test_sip_memory_bounds.py
+++ b/tests/unit/channels/test_sip_memory_bounds.py
@@ -1,0 +1,91 @@
+"""Regression tests for bounded SIP channel state."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from qwenpaw.app.channels.sip.livekit_backend import (
+    _put_latest_audio as lk_put,
+)
+from qwenpaw.app.channels.sip.mini_registrar import _SIPProxy
+from qwenpaw.app.channels.sip.pyvoip_backend import (
+    _put_latest_audio as voip_put,
+)
+
+
+def test_audio_queue_discards_oldest_frame() -> None:
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=2)
+    queue.put_nowait(b"old")
+    queue.put_nowait(b"recent")
+
+    lk_put(queue, b"latest")
+
+    assert list(queue._queue) == [b"recent", b"latest"]
+
+
+def test_audio_queue_keeps_end_marker_when_full() -> None:
+    queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=1)
+    queue.put_nowait(b"stale")
+
+    voip_put(queue, None)
+
+    assert queue.get_nowait() is None
+
+
+def test_registrar_honors_unregister_and_keeps_response_route() -> None:
+    proxy = _SIPProxy()
+    transport = MagicMock()
+    proxy.connection_made(transport)
+    address = ("127.0.0.1", 5062)
+    register = "REGISTER sip:test SIP/2.0\r\nTo: <sip:alice@test>\r\n\r\n"
+    proxy._register(register, address)
+    assert proxy.registry["alice"][0] == address
+
+    unregister = (
+        "REGISTER sip:test SIP/2.0\r\nTo: <sip:alice@test>\r\n"
+        "Expires: 0\r\n\r\n"
+    )
+    proxy._register(unregister, address)
+    assert "alice" not in proxy.registry
+
+    proxy.transactions["call-1"] = (address, float("inf"))
+    response = "SIP/2.0 200 OK\r\nCall-ID: call-1\r\n\r\n"
+    proxy._forward_response(response, ("127.0.0.1", 5063))
+    proxy._forward_response(response, ("127.0.0.1", 5063))
+
+    assert "call-1" in proxy.transactions
+    assert transport.sendto.call_count == 4
+
+
+def test_stale_unregister_does_not_remove_new_registration() -> None:
+    proxy = _SIPProxy()
+    proxy.connection_made(MagicMock())
+    old_address = ("127.0.0.1", 5062)
+    new_address = ("127.0.0.1", 5063)
+    register = "REGISTER sip:test SIP/2.0\r\nTo: <sip:alice@test>\r\n\r\n"
+    unregister = (
+        "REGISTER sip:test SIP/2.0\r\nTo: <sip:alice@test>\r\n"
+        "Expires: 0\r\n\r\n"
+    )
+
+    proxy._register(register, old_address)
+    proxy._register(register, new_address)
+    proxy._register(unregister, old_address)
+
+    assert proxy.registry["alice"][0] == new_address
+
+
+def test_registrar_honors_contact_expires_unregister() -> None:
+    proxy = _SIPProxy()
+    proxy.connection_made(MagicMock())
+    address = ("127.0.0.1", 5062)
+    register = "REGISTER sip:test SIP/2.0\r\nTo: <sip:alice@test>\r\n\r\n"
+    unregister = (
+        "REGISTER sip:test SIP/2.0\r\nTo: <sip:alice@test>\r\n"
+        "Contact: <sip:alice@127.0.0.1>;expires=0\r\n\r\n"
+    )
+
+    proxy._register(register, address)
+    proxy._register(unregister, address)
+
+    assert "alice" not in proxy.registry

--- a/tests/unit/channels/test_sip_memory_bounds.py
+++ b/tests/unit/channels/test_sip_memory_bounds.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 """Regression tests for bounded SIP channel state."""
+# pylint: disable=missing-function-docstring,protected-access
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit/channels/test_slack.py
+++ b/tests/unit/channels/test_slack.py
@@ -2349,6 +2349,47 @@ class TestSlackEventHandlerUserResolution:
         )
         assert name == ""
 
+    async def test_user_name_cache_is_lru_bounded(
+        self,
+        slack_event_handler,
+        monkeypatch,
+    ):
+        from qwenpaw.app.channels.slack import handler as handler_module
+
+        monkeypatch.setattr(
+            handler_module,
+            "SLACK_USER_NAME_CACHE_MAX_ENTRIES",
+            2,
+        )
+        slack_event_handler._cache_user_name("U1", "one")
+        slack_event_handler._cache_user_name("U2", "two")
+        slack_event_handler._cache_user_name("U3", "three")
+
+        assert list(slack_event_handler._user_name_cache) == ["U2", "U3"]
+
+    async def test_user_name_cache_expires(
+        self,
+        slack_event_handler,
+        monkeypatch,
+    ):
+        from qwenpaw.app.channels.slack import handler as handler_module
+
+        monkeypatch.setattr(
+            handler_module,
+            "SLACK_USER_NAME_CACHE_TTL_S",
+            0,
+        )
+        slack_event_handler._cache_user_name("U123", "Old Name")
+        client = AsyncMock()
+        client.users_info.return_value = {
+            "user": {"profile": {"display_name": "New Name"}},
+        }
+
+        name = await slack_event_handler._resolve_user_name("U123", client)
+
+        assert name == "New Name"
+        client.users_info.assert_awaited_once()
+
 
 # =============================================================================
 # P1: Handler Slash Command


### PR DESCRIPTION
## Summary

This PR prevents unbounded in-memory state growth across SIP, Matrix, and Slack channels while preserving real-time behavior and protocol retry semantics.

- Bound SIP inbound audio queues and discard stale frames when STT falls behind.
- Apply backpressure to the DashScope streaming TTS callback queue.
- Add TTL-based cleanup for SIP registrar registrations and transaction routes.
- Support SIP unregister requests via both `Expires: 0` and `Contact;expires=0`.
- Preserve SIP transaction routing for UDP final-response retransmissions until the transaction TTL expires.
- Bound Matrix room history and DM membership caches with LRU eviction.
- Add TTL and capacity cleanup for Matrix verification state, while retaining failed `done` responses for retry.
- Bound Slack user-name caching with TTL and LRU eviction.

## Tests

- `QWENPAW_WORKING_DIR=/private/tmp/qwenpaw-final-review conda run -n qwenpaw pytest -q tests/unit/channels/test_sip_memory_bounds.py tests/unit/channels/test_slack.py tests/unit/channels/test_matrix.py`
  - `280 passed`
- `flake8` on the changed SIP files and tests
- `ruff check`
- Python compilation check
- `git diff --check`

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
