### PR TITLE
fix(skill): skill-hub related memory leakage

### DIFF
--- a/src/qwenpaw/agents/skill_system/hub.py
+++ b/src/qwenpaw/agents/skill_system/hub.py
@@ -12,6 +12,7 @@ import os
 import re
 import time
 import zipfile
+from collections import OrderedDict
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -105,17 +106,23 @@ SKILL_PACKAGE_MAX_BYTES = 200 * 1024 * 1024
 HTTP_READ_CHUNK_BYTES = 256 * 1024
 
 _GITHUB_CACHE_DEFAULT_TTL = 300  # 5 minutes
+_GITHUB_CACHE_MAX_ENTRIES = 500
 _GITHUB_CACHE_MISS = object()
 
 # ---------- Module-level mutable state -------------------------------------
 
 # GitHub response cache: key → (timestamp, value).
-_github_cache: dict[str, tuple[float, Any]] = {}
+_github_cache: OrderedDict[str, tuple[float, Any]] = OrderedDict()
 
-# Per-key locks for the GitHub response cache. Without these, two
-# concurrent callers seeing the same cache miss both fire the same HTTP
-# request and burn the GitHub rate-limit budget twice.
-_github_cache_key_locks: dict[str, asyncio.Lock] = {}
+
+@dataclass
+class _GitHubCacheLockEntry:
+    lock: asyncio.Lock
+    users: int = 0
+
+
+# Locks exist only while a cache miss for that key is running or waiting.
+_github_cache_key_locks: dict[str, _GitHubCacheLockEntry] = {}
 _github_cache_locks_lock = asyncio.Lock()
 
 # Lazy module-level httpx singleton.
@@ -258,14 +265,30 @@ def _with_cancel_checker(checker: Any | None):
 # ---------- GitHub response cache ------------------------------------------
 
 
+def _github_cache_prune(*, now: float | None = None) -> None:
+    """Globally expire old entries and enforce the LRU size threshold."""
+    current_time = time.monotonic() if now is None else now
+    ttl = _github_cache_ttl()
+    expired = [
+        key
+        for key, (timestamp, _) in _github_cache.items()
+        if current_time - timestamp > ttl
+    ]
+    for key in expired:
+        _github_cache.pop(key, None)
+    while len(_github_cache) > _GITHUB_CACHE_MAX_ENTRIES:
+        _github_cache.popitem(last=False)
+
+
 def _github_cache_get(key: str) -> Any:
     entry = _github_cache.get(key)
     if entry is None:
         return None
-    ts, value = entry
-    if time.monotonic() - ts > _github_cache_ttl():
-        del _github_cache[key]
+    timestamp, value = entry
+    if time.monotonic() - timestamp > _github_cache_ttl():
+        _github_cache.pop(key, None)
         return None
+    _github_cache.move_to_end(key)
     return value
 
 
@@ -276,22 +299,35 @@ def _github_cached(key: str) -> Any:
 
 def _github_cache_set(key: str, value: Any) -> None:
     _github_cache[key] = (time.monotonic(), value)
+    _github_cache.move_to_end(key)
+    if len(_github_cache) > _GITHUB_CACHE_MAX_ENTRIES:
+        _github_cache_prune()
 
 
-async def _github_cache_lock_for(key: str) -> asyncio.Lock:
+@asynccontextmanager
+async def _github_cache_lock(key: str) -> Any:
     async with _github_cache_locks_lock:
-        lock = _github_cache_key_locks.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _github_cache_key_locks[key] = lock
-        return lock
+        entry = _github_cache_key_locks.get(key)
+        if entry is None:
+            entry = _GitHubCacheLockEntry(lock=asyncio.Lock())
+            _github_cache_key_locks[key] = entry
+        entry.users += 1
+
+    try:
+        async with entry.lock:
+            yield
+    finally:
+        async with _github_cache_locks_lock:
+            entry.users -= 1
+            if entry.users == 0 and _github_cache_key_locks.get(key) is entry:
+                _github_cache_key_locks.pop(key, None)
 
 
 async def _github_cached_call(
     key: str,
     factory: Callable[[], Awaitable[Any]],
 ) -> Any:
-    """Return cached value or run factory under a per-key lock.
+    """Return cached value or run factory under a temporary per-key lock.
 
     Prevents thundering-herd when multiple coroutines miss the same key:
     only the first one fires the network call; the rest wait on the lock
@@ -300,8 +336,7 @@ async def _github_cached_call(
     cached = _github_cached(key)
     if cached is not _GITHUB_CACHE_MISS:
         return cached
-    lock = await _github_cache_lock_for(key)
-    async with lock:
+    async with _github_cache_lock(key):
         cached = _github_cached(key)
         if cached is not _GITHUB_CACHE_MISS:
             return cached

--- a/src/qwenpaw/app/routers/skills.py
+++ b/src/qwenpaw/app/routers/skills.py
@@ -365,6 +365,16 @@ _hub_install_runtime_tasks: dict[str, asyncio.Task] = {}
 _hub_install_cancel_events: dict[str, threading.Event] = {}
 _hub_install_lock = asyncio.Lock()
 
+_HUB_INSTALL_TASK_TTL_SECONDS = 10 * 60
+_HUB_INSTALL_TASK_MAX_HISTORY = 100
+_HUB_INSTALL_TERMINAL_STATUSES = frozenset(
+    {
+        HubInstallTaskStatus.COMPLETED,
+        HubInstallTaskStatus.FAILED,
+        HubInstallTaskStatus.CANCELLED,
+    },
+)
+
 _ALLOWED_ZIP_TYPES = {
     "application/zip",
     "application/x-zip-compressed",
@@ -461,17 +471,46 @@ async def _hub_task_set_status(
 
 async def _hub_task_get(task_id: str) -> HubInstallTask | None:
     async with _hub_install_lock:
+        _hub_task_cleanup_locked()
         return _hub_install_tasks.get(task_id)
 
 
-async def _hub_task_register_runtime(task_id: str, task: asyncio.Task) -> None:
-    async with _hub_install_lock:
-        _hub_install_runtime_tasks[task_id] = task
+def _hub_task_cleanup_locked(*, now: float | None = None) -> None:
+    """Remove expired/excess finished tasks while the registry lock is held."""
+    current_time = time.time() if now is None else now
+    finished = [
+        task
+        for task_id, task in _hub_install_tasks.items()
+        if task.status in _HUB_INSTALL_TERMINAL_STATUSES
+        and task_id not in _hub_install_runtime_tasks
+    ]
+
+    expired_ids = {
+        task.task_id
+        for task in finished
+        if current_time - task.updated_at > _HUB_INSTALL_TASK_TTL_SECONDS
+    }
+    retained = [task for task in finished if task.task_id not in expired_ids]
+    excess = max(0, len(retained) - _HUB_INSTALL_TASK_MAX_HISTORY)
+    if excess:
+        retained.sort(key=lambda task: (task.updated_at, task.created_at))
+        expired_ids.update(task.task_id for task in retained[:excess])
+
+    for expired_id in expired_ids:
+        _hub_install_tasks.pop(expired_id, None)
+        _hub_install_cancel_events.pop(expired_id, None)
 
 
-async def _hub_task_pop_runtime(task_id: str) -> asyncio.Task | None:
+async def _hub_task_finish_runtime(task_id: str) -> None:
     async with _hub_install_lock:
-        return _hub_install_runtime_tasks.pop(task_id, None)
+        _hub_install_runtime_tasks.pop(task_id, None)
+        _hub_install_cancel_events.pop(task_id, None)
+        task = _hub_install_tasks.get(task_id)
+        if task is not None and task.status in _HUB_INSTALL_TERMINAL_STATUSES:
+            # Retention starts when the worker actually stops, which can be
+            # later than the cancel endpoint's terminal response.
+            task.updated_at = time.time()
+        _hub_task_cleanup_locked()
 
 
 async def _read_validated_zip_upload(file: UploadFile) -> bytes:
@@ -552,6 +591,9 @@ async def _run_hub_install_task(
         if imported_skill_name:
             _cleanup_imported_skill(workspace_dir, imported_skill_name)
         await _hub_task_set_status(task_id, HubInstallTaskStatus.CANCELLED)
+    except asyncio.CancelledError:
+        await _hub_task_set_status(task_id, HubInstallTaskStatus.CANCELLED)
+        raise
     except SkillScanError as exc:
         await _hub_task_set_status(
             task_id,
@@ -585,7 +627,7 @@ async def _run_hub_install_task(
             error=f"Skill hub import failed: {exc}",
         )
     finally:
-        await _hub_task_pop_runtime(task_id)
+        await _hub_task_finish_runtime(task_id)
 
 
 def _build_workspace_skill_specs(workspace_dir: Path) -> list[SkillSpec]:
@@ -767,19 +809,19 @@ async def start_install_from_hub(
     )
     cancel_event = threading.Event()
     async with _hub_install_lock:
+        _hub_task_cleanup_locked()
         _hub_install_tasks[task.task_id] = task
         _hub_install_cancel_events[task.task_id] = cancel_event
-
-    runtime_task = asyncio.create_task(
-        _run_hub_install_task(
-            task_id=task.task_id,
-            workspace_dir=workspace_dir,
-            body=request_body,
-            cancel_event=cancel_event,
-        ),
-        name=f"skill-hub-install-{task.task_id}",
-    )
-    await _hub_task_register_runtime(task.task_id, runtime_task)
+        runtime_task = asyncio.create_task(
+            _run_hub_install_task(
+                task_id=task.task_id,
+                workspace_dir=workspace_dir,
+                body=request_body,
+                cancel_event=cancel_event,
+            ),
+            name=f"skill-hub-install-{task.task_id}",
+        )
+        _hub_install_runtime_tasks[task.task_id] = runtime_task
     return task
 
 
@@ -800,11 +842,7 @@ async def cancel_hub_install(task_id: str) -> dict[str, Any]:
                 status_code=404,
                 detail="install task not found",
             )
-        if task.status in (
-            HubInstallTaskStatus.COMPLETED,
-            HubInstallTaskStatus.FAILED,
-            HubInstallTaskStatus.CANCELLED,
-        ):
+        if task.status in _HUB_INSTALL_TERMINAL_STATUSES:
             return {"task_id": task_id, "status": task.status.value}
         cancel_event = _hub_install_cancel_events.get(task_id)
         if cancel_event is not None:


### PR DESCRIPTION
## Description
Fixes unbounded memory growth in Skill Hub installs and GitHub caching.
  - Retains terminal install results for 10 minutes, capped at 100 tasks.
  - Releases runtime tasks and cancellation events when workers exit.
  - Bounds the GitHub cache with TTL/LRU eviction.
  - Removes per-key locks when no callers remain.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review