### PR TITLE
fix(website): switch GA tag ID and add Jul 17 developer day session

### DIFF
--- a/website/public/blog/qwenpaw-developer-day-collection.en.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.en.md
@@ -1,15 +1,19 @@
 ---
 title: "QwenPaw Developer Day Collection"
-date: 2026-07-14
+date: 2026-07-17
 author: QwenPaw Team
 tags: [DeveloperDay, MeetingNotes, SessionRecordings]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "Replay archive from QwenPaw developer day sessions — in-depth technical talks and practical insights for every QwenPaw developer and enthusiast."
 ---
 
-Last updated July 14, 2026
+Last updated July 17, 2026
 
 ---
+
+**07-17 QwenPaw Developer Day: AgentScope-Java 2.0 GA Deep Dive & AgentScope-Go Preview**
+
+Meeting link: https://shanji.dingtalk.com/app/transcribes/76327569643336373839363436365f323034353035363233375f39
 
 **07-14 QwenPaw Developer Day: QwenPaw 2.0 WorkSpace & Sandbox Deep Dive**
 

--- a/website/public/blog/qwenpaw-developer-day-collection.zh.md
+++ b/website/public/blog/qwenpaw-developer-day-collection.zh.md
@@ -1,15 +1,19 @@
 ---
 title: "QwenPaw 开发者日会合集"
-date: 2026-07-14
+date: 2026-07-17
 author: QwenPaw Team
 tags: [开发者日会, 会议纪要, 会议录屏]
 cover: /blog/qwenpaw-developer-day-collection-cover.png
 excerpt: "QwenPaw团队召开开发者日会，为每一位 QwenPaw 开发者与爱好者提供一份兼具理论深度与落地价值的完整技术交流档案。"
 ---
 
-最近更新 2026 年 7 月 14 日
+最近更新 2026 年 7 月 17 日
 
 ---
+
+**07-17 QwenPaw 开发者日会：AgentScope-Java 2.0 正式版详解 & AgentScope-Go 预透**
+
+会议链接：https://shanji.dingtalk.com/app/transcribes/76327569643336373839363436365f323034353035363233375f39
 
 **07-14 QwenPaw 开发者日会：QwenPaw 2.0 WorkSpace & Sandbox 模块详解**
 

--- a/website/src/lib/analytics.ts
+++ b/website/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-export const GA_ID = "G-EG8R8PT98F";
+export const GA_ID = "GT-PHWNG2NC";
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Description

Fix website Google Analytics loading and add the latest developer day session to the collection blog.

- The previous measurement ID `G-EG8R8PT98F` was invalid for install: `https://www.googletagmanager.com/gtag/js?id=G-EG8R8PT98F` returned **404**, so the GA script never loaded and no traffic was collected
- Switch the site GA ID to `GT-PHWNG2NC`, which can load successfully via gtag
- Add the 07-17 session: AgentScope-Java 2.0 GA deep dive & AgentScope-Go preview (ZH/EN)
- Bump the collection post date / last-updated to 2026-07-17

**Related Issue:** N/A (website analytics + blog content update)

**Security Considerations:** No secrets added. GA loads only in production (`DEV` still skips tracking). Meeting link is a public DingTalk transcript URL.

## Evidence

- [x] Confirmed `G-EG8R8PT98F` gtag endpoint returns 404
- [x] Diff reviewed: `website/src/lib/analytics.ts` uses `GT-PHWNG2NC`
- [x] Blog ZH/EN both list the 07-17 session with the DingTalk transcript link
- [ ] After deploy: open production site → Console shows GA loaded; Network `gtag/js?id=GT-PHWNG2NC` is 200
- [ ] After deploy: Analytics realtime shows traffic for the new tag
- [ ] After deploy: `/blog/qwenpaw-developer-day-collection` shows the new session at the top

## Test plan

- [ ] Confirm local `pnpm dev` still skips GA (expected)
- [ ] Deploy website and verify gtag script loads with `GT-PHWNG2NC` (not 404)
- [ ] Open ZH and EN collection pages and click the new meeting link
<img width="1794" height="610" alt="image" src="https://github.com/user-attachments/assets/113ac983-07ad-41c8-9d5b-843aa3815f72" />
