### PR TITLE
fix: expand regex shorthands in tool schema patterns for GBNF compatibility

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Callable
@@ -532,12 +533,56 @@ def _expand_schema_refs(schema: Any) -> Any:
     return _inline_schema_refs(schema, defs, frozenset())
 
 
+# ECMA-262 regex shorthands → GBNF-safe character classes.
+# JSON Schema ``pattern`` uses ECMA-262 regex where these are
+# exact equivalences (no Unicode-extended digits/words).
+# Backends like llama.cpp convert schemas to GBNF grammar
+# which only recognises ``[0-9]``-style classes, not ``\d``.
+_REGEX_SHORTHAND_MAP: dict[str, str] = {
+    r"\d": "[0-9]",
+    r"\D": "[^0-9]",
+    r"\w": "[a-zA-Z0-9_]",
+    r"\W": "[^a-zA-Z0-9_]",
+    r"\s": r"[\t\n\r\f\v ]",
+    r"\S": r"[^\t\n\r\f\v ]",
+}
+
+_SHORTHAND_RE = re.compile(r"\\[dDwWsS]")
+
+
+def _expand_regex_shorthands(pattern: str) -> str:
+    """Replace ECMA-262 regex shorthands with character classes.
+
+    ``\\d`` → ``[0-9]`` etc.  This is a lossless, semantically
+    equivalent transformation in every regex engine.
+    """
+    return _SHORTHAND_RE.sub(
+        lambda m: _REGEX_SHORTHAND_MAP[m.group()],
+        pattern,
+    )
+
+
+def _expand_pattern_fields(schema: Any) -> Any:
+    """Recursively expand regex shorthands in ``pattern`` fields."""
+    if isinstance(schema, list):
+        return [_expand_pattern_fields(s) for s in schema]
+    if not isinstance(schema, dict):
+        return schema
+    result: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key == "pattern" and isinstance(value, str):
+            result[key] = _expand_regex_shorthands(value)
+        else:
+            result[key] = _expand_pattern_fields(value)
+    return result
+
+
 def _sanitize_tool_schemas(
     tools: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Sanitize tool function schemas to be compatible with strict providers.
 
-    Applies three passes over each tool's ``parameters`` schema:
+    Applies four passes over each tool's ``parameters`` schema:
 
     1. **$ref / $defs expansion** — inlines all local ``$ref`` references so
        that models which do not support ``$defs`` (e.g. GLM-5.x) receive a
@@ -547,6 +592,10 @@ def _sanitize_tool_schemas(
     3. **Nullable schema sanitization** — removes JSON Schema ``null`` type
        branches that OpenAI-compatible relays to Gemini-style providers reject
        in function declarations.
+    4. **Pattern shorthand expansion** — converts ECMA-262 regex shorthands
+       (``\\d``, ``\\w``, ``\\s``, etc.) in ``pattern`` fields to character
+       classes (``[0-9]``, ``[a-zA-Z0-9_]``, etc.).  llama.cpp's GBNF grammar
+       parser does not support these escape sequences (#6201).
     """
     sanitized = []
     for tool in tools:
@@ -561,9 +610,11 @@ def _sanitize_tool_schemas(
         if not isinstance(params, dict):
             sanitized.append(tool)
             continue
-        sanitized_params = _sanitize_nullable_schemas(
-            _sanitize_boolean_schemas(
-                _expand_schema_refs(params),
+        sanitized_params = _expand_pattern_fields(
+            _sanitize_nullable_schemas(
+                _sanitize_boolean_schemas(
+                    _expand_schema_refs(params),
+                ),
             ),
         )
         sanitized.append(

--- a/tests/unit/providers/test_openai_tool_schema_compat.py
+++ b/tests/unit/providers/test_openai_tool_schema_compat.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
 from agentscope.tool import Toolkit
 
 from qwenpaw.agents.tools.file_io import read_file
 from qwenpaw.agents.tools.shell import execute_shell_command
 from qwenpaw.governance import PolicyGuardedTool
-from qwenpaw.providers.openai_chat_model_compat import _sanitize_tool_schemas
+from qwenpaw.providers.openai_chat_model_compat import (
+    _expand_regex_shorthands,
+    _sanitize_tool_schemas,
+)
 
 
 def _type_null_paths(node: Any, path: tuple[str, ...] = ()) -> list[str]:
@@ -208,3 +212,75 @@ def test_sanitize_tool_schemas_removes_null_from_type_arrays() -> None:
         "multiple": {"type": ["integer", "number"]},
         "null_only": {"type": "object", "default": None},
     }
+
+
+# -- Pattern shorthand expansion (#6201) --
+
+
+@pytest.mark.parametrize(
+    ("input_pat", "expected"),
+    [
+        (r"^\d+$", r"^[0-9]+$"),
+        (r"\D+", r"[^0-9]+"),
+        (r"\w+", "[a-zA-Z0-9_]+"),
+        (r"\W", "[^a-zA-Z0-9_]"),
+        (r"\s+", r"[\t\n\r\f\v ]+"),
+        (r"\S", r"[^\t\n\r\f\v ]"),
+        (r"^\d{4}-\d{2}-\d{2}$", r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"),
+        (r"^[A-Z]{2,3}$", r"^[A-Z]{2,3}$"),
+        (r"(PMC)?\d+", r"(PMC)?[0-9]+"),
+    ],
+    ids=[
+        "d",
+        "D",
+        "w",
+        "W",
+        "s",
+        "S",
+        "multi",
+        "no-op",
+        "pubmed-pmc",
+    ],
+)
+def test_expand_regex_shorthands(
+    input_pat: str,
+    expected: str,
+) -> None:
+    assert _expand_regex_shorthands(input_pat) == expected
+
+
+def test_sanitize_tool_schemas_expands_pattern_shorthands() -> None:
+    """End-to-end: patterns in tool schemas are expanded (#6201)."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo",
+                "description": "demo",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "pmid": {
+                            "type": "string",
+                            "pattern": r"^\d+$",
+                        },
+                        "ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "pattern": r"\d+",
+                            },
+                        },
+                        "name": {"type": "string"},
+                    },
+                },
+            },
+        },
+    ]
+
+    sanitized = _sanitize_tool_schemas(tools)
+    props = sanitized[0]["function"]["parameters"]["properties"]
+
+    assert props["pmid"]["pattern"] == r"^[0-9]+$"
+    assert props["ids"]["items"]["pattern"] == "[0-9]+"
+    assert "pattern" not in props["name"]


### PR DESCRIPTION
## Description

MCP tools (e.g. PubMed) may declare JSON Schema pattern fields containing ECMA-262 regex shorthands (\d, \w, \s, etc.). llama.cpp’s GBNF grammar parser does not recognise these escape sequences and throws failed to parse grammar. This PR adds a fourth sanitization pass to _sanitize_tool_schemas() that expands all six ECMA-262 shorthand classes to their character-class equivalents (\d → [0-9], etc.). This is a lossless, semantically equivalent transformation that is safe for all providers.

**Related Issue:** Fixes #6201

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
