### PR TITLE
fix(token_usage): don't persist an unseeded cache on shutdown

### DIFF
--- a/src/qwenpaw/token_usage/buffer.py
+++ b/src/qwenpaw/token_usage/buffer.py
@@ -147,6 +147,11 @@ class TokenUsageBuffer:
 
     async def _flush_once(self, force: bool = False) -> None:
         """Write ``_disk_cache`` to disk if dirty."""
+        if not self._cache_loaded:
+            # The cache was never seeded, so no event can have reached
+            # ``_disk_cache`` and it still holds the initial empty dict.
+            # Writing it out would replace the stored history with ``{}``.
+            return
         if not self._dirty and not force:
             return
         self._dirty = False

--- a/tests/unit/token_usage/test_token_usage.py
+++ b/tests/unit/token_usage/test_token_usage.py
@@ -202,6 +202,87 @@ class TestTokenUsageBuffer:
         assert entry["prompt_tokens"] == 300
         assert entry["call_count"] == 3
 
+    @pytest.mark.asyncio
+    async def test_stop_does_not_wipe_history_when_seed_interrupted(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A stop() that races cache seeding must not clobber the file."""
+        path = tmp_path / "test.json"
+        existing = {
+            "2026-04-24": {
+                "openai:gpt-4": {
+                    "provider_id": "openai",
+                    "model_name": "gpt-4",
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "call_count": 1,
+                },
+            },
+        }
+        path.write_text(json.dumps(existing), encoding="utf-8")
+
+        seeding = asyncio.Event()
+
+        async def _never_returns(_path):
+            # Park the consumer inside the seed so stop() runs while
+            # ``_disk_cache`` is still the initial empty dict.
+            seeding.set()
+            await asyncio.Event().wait()
+            return {}
+
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.buffer.load_data",
+            _never_returns,
+        )
+
+        buffer = TokenUsageBuffer(path, flush_interval=3600)
+        buffer.start()
+        await asyncio.wait_for(seeding.wait(), timeout=1)
+        await buffer.stop()
+
+        assert json.loads(path.read_text(encoding="utf-8")) == existing
+
+    @pytest.mark.asyncio
+    async def test_stop_flushes_after_seed_completes(self, tmp_path):
+        """Normal shutdown still merges new events into stored history."""
+        path = tmp_path / "test.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "2026-04-23": {
+                        "openai:gpt-4": {
+                            "provider_id": "openai",
+                            "model_name": "gpt-4",
+                            "prompt_tokens": 7,
+                            "completion_tokens": 3,
+                            "call_count": 1,
+                        },
+                    },
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        buffer = TokenUsageBuffer(path, flush_interval=3600)
+        buffer.start()
+        buffer.enqueue(
+            _UsageEvent(
+                provider_id="openai",
+                model_name="gpt-4",
+                prompt_tokens=100,
+                completion_tokens=50,
+                date_str="2026-04-24",
+                now_iso="2026-04-24T10:00:00+00:00",
+            ),
+        )
+        await buffer.stop()
+
+        written = json.loads(path.read_text(encoding="utf-8"))
+        assert written["2026-04-23"]["openai:gpt-4"]["prompt_tokens"] == 7
+        assert written["2026-04-24"]["openai:gpt-4"]["prompt_tokens"] == 100
+
 
 # =============================================================================
 # Test Pydantic Models


### PR DESCRIPTION
## Description

`TokenUsageBuffer.stop()` ends with an unconditional `await self._flush_once(force=True)`, but `_flush_once()` never checks whether `_disk_cache` was ever populated from disk. `_disk_cache` starts as `{}` and is only ever filled by `_seed_cache()`.

In `_consumer_loop()` the seed runs *outside* the `try:` that guards the loop:

```python
async def _consumer_loop(self) -> None:
    # Ensure cache is loaded before processing events.
    if not self._cache_loaded:
        await self._seed_cache()      # <- outside the try below
    try:
        while True:
            event = await self._queue.get()
            ...
    except asyncio.CancelledError:
        ...
```

So when the consumer is cancelled while suspended inside `_seed_cache()` -> `load_data()` -> `aiofiles.open()`, the `CancelledError` propagates straight out of `_consumer_loop`, leaving `_cache_loaded` as `False` and `_disk_cache` as `{}`. `stop()` then force-flushes that empty dict, and `save_data_sync()` commits it through an atomic `os.replace()` — so `token_usage.json` is replaced by `{}` and every recorded day of usage is gone. There is no backup and nothing is logged.

Nothing in `stop()` prevents that ordering. The drain step is `await self._queue.join()`, which returns immediately when the queue is empty — precisely the case when no LLM call has happened yet — so it does not wait for the seed to finish:

```python
async def stop(self) -> None:
    ...
    if self._consumer_task is not None:
        await self._queue.join()      # returns at once when queue is empty
        self._consumer_task.cancel()  # consumer may still be in _seed_cache
        ...
    await self._flush_once(force=True)
```

The window opens exactly for the users who have something to lose. `load_data()` returns synchronously through `if not path.exists(): return {}` when the file is absent, so a fresh install never suspends and can never hit this. When `token_usage.json` does exist, the `aiofiles` read genuinely suspends, and any shutdown shortly after startup lands in the window: a startup error after the buffer is started, `Ctrl-C` during boot, `uvicorn --reload`, or a quick desktop restart. The live path is `app/_app.py:455` `token_usage_manager.start(flush_interval=10)` -> `app/_app.py:757` `await token_usage_manager.stop()`.

The fix is to refuse to persist a cache that was never loaded. When `_cache_loaded` is `False`, no event can have reached `_disk_cache` — the consumer seeds before it applies anything, and `get_merged_data()` folds pending events into a copy rather than into `_disk_cache` — so returning early cannot drop data that would otherwise have been written. Behaviour on every seeded path is unchanged.

The `_flush_loop()` periodic path was already safe by accident, since `_dirty` can only become `True` after seeding; only the `force=True` call in `stop()` bypasses that.

**Related Issue:** none

**Security Considerations:** none — no credential, auth, sandbox, or external input handling is involved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran pre-commit locally and it passes — scoped to the two changed files (`pre-commit run --files ...`), since `--all-files` on a Windows checkout renormalizes line endings across ~100 unrelated files
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks — no hook made any change
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Two tests were added to `TestTokenUsageBuffer`.

`test_stop_does_not_wipe_history_when_seed_interrupted` is the regression test. It writes a real `token_usage.json`, replaces `buffer.load_data` with a coroutine that parks forever so the consumer is deterministically suspended inside the seed, then calls `stop()` and asserts the file still holds the original history. Stubbing the load is what makes it deterministic — relying on the timing of a real `aiofiles` read would make the test flaky.

`test_stop_flushes_after_seed_completes` is the positive control that pins the behaviour the guard must not break: with seeding allowed to complete normally, `stop()` must still merge a newly enqueued event into the stored history and write both to disk. It passes before and after the fix, so it proves the new early-return does not suppress legitimate writes.

Run them with:

```bash
pytest tests/unit/token_usage/ -v
```

## Evidence

The regression test fails on the unpatched code, and the assertion shows the concrete data loss — the file that held a day of usage now contains an empty dict:

```
$ pytest tests/unit/token_usage/test_token_usage.py -k "test_stop_does_not_wipe_history_when_seed_interrupted or test_stop_flushes_after_seed_completes" -v

>       assert json.loads(path.read_text(encoding="utf-8")) == existing
E       AssertionError: assert {} == {'2026-04-24'...s': 50, ...}}}
E
E         Right contains 1 more item:
E         {'2026-04-24': {'openai:gpt-4': {'call_count': 1,
E                                          'completion_tokens': 50,
E                                          'model_name': 'gpt-4',
E                                          'prompt_tokens': 100,
E                                          'provider_id': 'openai'}}}

tests\unit\token_usage\test_token_usage.py:245: AssertionError
=========================== short test summary info ===========================
FAILED tests/unit/token_usage/test_token_usage.py::TestTokenUsageBuffer::test_stop_does_not_wipe_history_when_seed_interrupted
================= 1 failed, 1 passed, 28 deselected in 0.93s ==================
```

Note that the positive control (`test_stop_flushes_after_seed_completes`) already passes here, before any change — the unpatched code writes correctly once seeding has completed. That is the behaviour the guard has to preserve.

With the guard in place, the whole `token_usage` suite is green:

```
$ pytest tests/unit/token_usage/ -v

tests/unit/token_usage/test_token_usage.py::TestTokenUsageBuffer::test_stop_does_not_wipe_history_when_seed_interrupted PASSED [ 36%]
tests/unit/token_usage/test_token_usage.py::TestTokenUsageBuffer::test_stop_flushes_after_seed_completes PASSED [ 40%]
...
============================= 30 passed in 1.87s ==============================
```

The full unit suite shows no regressions:

```
$ pytest tests/unit/ -q

1 failed, 4844 passed, 52 skipped, 57 warnings in 281.91s (0:04:41)
```

The single failure is `tests/unit/governance/test_off_mode_sandbox.py::TestSandboxSwitchHotReload::test_sandbox_usable_follows_switch_without_restart`, which is pre-existing and unrelated to this change. It is environmental: the local run is Windows without an elevated process, and the test logs `Windows sandbox inactive for this session: sandbox_enabled is true but the process lacks administrator privileges`. It fails identically on a clean checkout of `main` with this branch's changes stashed.

All pinned pre-commit hooks pass on the two changed files:

```
$ pre-commit run --files src/qwenpaw/token_usage/buffer.py tests/unit/token_usage/test_token_usage.py

check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

Environment: Windows 11, Python 3.12.0, `pip install -e .` from this branch.
