### PR TITLE
feat(runtime): preserve event metadata in realtime envelopes

### DIFF
--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -14,7 +14,8 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Dict
+from functools import wraps
+from typing import Any, AsyncGenerator, Callable, Dict
 
 from .message_convert import _media_type_to_block_type
 
@@ -30,6 +31,53 @@ class _EventMetadataExcludedOutput:
     """An output that must not inherit metadata from the current event."""
 
     output: Any
+
+
+def _with_event_metadata(obj: Any, event: Any) -> Any:
+    """Return a real-time output carrying its source event metadata.
+
+    Envelope state objects are reused when a message is completed and later
+    embedded in ``AgentResponse.output``. Attach metadata to a shallow output
+    copy so event-scoped extension data cannot leak into those durable
+    objects. Empty metadata follows the exact legacy path.
+    """
+    event_metadata = getattr(event, "metadata", None)
+    if not isinstance(event_metadata, dict) or not event_metadata:
+        return obj
+
+    output_metadata = dict(event_metadata)
+    host_metadata = getattr(obj, "metadata", None)
+    if isinstance(host_metadata, dict):
+        # Host-owned metadata wins on conflicts with extension metadata.
+        output_metadata.update(host_metadata)
+
+    return obj.model_copy(
+        update={"metadata": output_metadata},
+        deep=False,
+    )
+
+
+_EventTranslator = Callable[[Any, Any], AsyncGenerator[Any, None]]
+
+
+def _propagate_event_metadata(
+    translator: _EventTranslator,
+) -> _EventTranslator:
+    """Decorate event outputs with metadata from their source event."""
+
+    @wraps(translator)
+    async def wrapped(
+        envelope: Any,
+        event: Any,
+    ) -> AsyncGenerator[Any, None]:
+        async for output in translator(envelope, event):
+            if isinstance(output, _EventMetadataExcludedOutput):
+                yield output.output
+                continue
+
+            yield _with_event_metadata(output, event)
+
+    return wrapped
 
 
 class Envelope:
@@ -93,30 +141,6 @@ class Envelope:
         obj.sequence_number = self._next_seq()
         return obj
 
-    @staticmethod
-    def _with_event_metadata(obj: Any, event: Any) -> Any:
-        """Return a real-time output carrying its source event metadata.
-
-        Envelope state objects are reused when a message is completed and
-        later embedded in ``AgentResponse.output``.  Attach metadata to a
-        shallow output copy so event-scoped extension data cannot leak into
-        those durable objects.  Empty metadata follows the exact legacy path.
-        """
-        event_metadata = getattr(event, "metadata", None)
-        if not isinstance(event_metadata, dict) or not event_metadata:
-            return obj
-
-        output_metadata = dict(event_metadata)
-        host_metadata = getattr(obj, "metadata", None)
-        if isinstance(host_metadata, dict):
-            # Host-owned metadata wins on conflicts with extension metadata.
-            output_metadata.update(host_metadata)
-
-        return obj.model_copy(
-            update={"metadata": output_metadata},
-            deep=False,
-        )
-
     # ------------------------------------------------------------------
     # Response lifecycle
     # ------------------------------------------------------------------
@@ -165,25 +189,14 @@ class Envelope:
     # Event translation
     # ------------------------------------------------------------------
 
-    async def translate_event(
+    # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-branches,too-many-statements
+    @_propagate_event_metadata
+    async def translate_event(  # noqa: C901, PLR0912, PLR0915
         self,
         event: Any,
     ) -> AsyncGenerator[Any, None]:
         """Translate an AgentScope event into real-time Host objects."""
-        async for raw_output in self._translate_event_raw(event):
-            if isinstance(raw_output, _EventMetadataExcludedOutput):
-                yield raw_output.output
-                continue
-
-            yield self._with_event_metadata(raw_output, event)
-
-    # pylint: disable=too-many-return-statements
-    # pylint: disable=too-many-branches,too-many-statements
-    async def _translate_event_raw(  # noqa: C901, PLR0912, PLR0915
-        self,
-        event: Any,
-    ) -> AsyncGenerator[Any, None]:
-        """Translate one event without applying event-scoped metadata."""
         from agentscope.event import EventType
         from ..schemas import (
             ContentType,

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -85,6 +85,30 @@ class Envelope:
         obj.sequence_number = self._next_seq()
         return obj
 
+    @staticmethod
+    def _with_event_metadata(obj: Any, event: Any) -> Any:
+        """Return a real-time output carrying its source event metadata.
+
+        Envelope state objects are reused when a message is completed and
+        later embedded in ``AgentResponse.output``.  Attach metadata to a
+        shallow output copy so event-scoped extension data cannot leak into
+        those durable objects.  Empty metadata follows the exact legacy path.
+        """
+        event_metadata = getattr(event, "metadata", None)
+        if not isinstance(event_metadata, dict) or not event_metadata:
+            return obj
+
+        output_metadata = dict(event_metadata)
+        host_metadata = getattr(obj, "metadata", None)
+        if isinstance(host_metadata, dict):
+            # Host-owned metadata wins on conflicts with extension metadata.
+            output_metadata.update(host_metadata)
+
+        return obj.model_copy(
+            update={"metadata": output_metadata},
+            deep=False,
+        )
+
     # ------------------------------------------------------------------
     # Response lifecycle
     # ------------------------------------------------------------------
@@ -165,7 +189,10 @@ class Envelope:
         # === TEXT BLOCK ===
         if evt_type == EventType.TEXT_BLOCK_START.value:
             if not self._message_started:
-                yield self._tag_seq(self._completed_message)
+                yield self._with_event_metadata(
+                    self._tag_seq(self._completed_message),
+                    event,
+                )
                 self._message_started = True
             block_id = event.block_id
             index = len(self._text_blocks)
@@ -173,7 +200,10 @@ class Envelope:
 
         elif evt_type == EventType.TEXT_BLOCK_DELTA.value:
             if not self._message_started:
-                yield self._tag_seq(self._completed_message)
+                yield self._with_event_metadata(
+                    self._tag_seq(self._completed_message),
+                    event,
+                )
                 self._message_started = True
             block_id = event.block_id
             delta = event.delta or ""
@@ -189,7 +219,7 @@ class Envelope:
                 index=state["index"],
             )
             chunk.msg_id = self._message_id
-            yield self._tag_seq(chunk)
+            yield self._with_event_metadata(self._tag_seq(chunk), event)
 
         elif evt_type == EventType.TEXT_BLOCK_END.value:
             block_id = event.block_id
@@ -203,7 +233,10 @@ class Envelope:
                 index=state["index"],
             )
             final_chunk.msg_id = self._message_id
-            yield self._tag_seq(final_chunk)
+            yield self._with_event_metadata(
+                self._tag_seq(final_chunk),
+                event,
+            )
             self._completed_message.content.append(
                 TextContent(
                     type=ContentType.TEXT,
@@ -231,7 +264,7 @@ class Envelope:
                 "envelope": r_envelope,
                 "text": "",
             }
-            yield self._tag_seq(r_envelope)
+            yield self._with_event_metadata(self._tag_seq(r_envelope), event)
 
         elif evt_type == EventType.THINKING_BLOCK_DELTA.value:
             block_id = event.block_id
@@ -254,7 +287,10 @@ class Envelope:
                     "text": "",
                 }
                 self._reasoning_blocks[block_id] = state
-                yield self._tag_seq(r_envelope)
+                yield self._with_event_metadata(
+                    self._tag_seq(r_envelope),
+                    event,
+                )
             state["text"] += delta
             r_chunk = TextContent(
                 type=ContentType.TEXT,
@@ -263,7 +299,7 @@ class Envelope:
                 index=0,
             )
             r_chunk.msg_id = state["msg_id"]
-            yield self._tag_seq(r_chunk)
+            yield self._with_event_metadata(self._tag_seq(r_chunk), event)
 
         elif evt_type == EventType.THINKING_BLOCK_END.value:
             block_id = event.block_id
@@ -277,7 +313,7 @@ class Envelope:
                 index=0,
             )
             r_final.msg_id = state["msg_id"]
-            yield self._tag_seq(r_final)
+            yield self._with_event_metadata(self._tag_seq(r_final), event)
             state["envelope"].content.append(
                 TextContent(
                     type=ContentType.TEXT,
@@ -288,7 +324,10 @@ class Envelope:
             )
             state["envelope"].status = RunStatus.Completed
             self._response.output.append(state["envelope"])
-            yield self._tag_seq(state["envelope"])
+            yield self._with_event_metadata(
+                self._tag_seq(state["envelope"]),
+                event,
+            )
 
         # === TOOL CALL ===
         elif evt_type == EventType.TOOL_CALL_START.value:
@@ -321,8 +360,14 @@ class Envelope:
             )
             stub_content.msg_id = msg_id
 
-            yield self._tag_seq(plugin_call_message.in_progress())
-            yield self._tag_seq(stub_content.in_progress())
+            yield self._with_event_metadata(
+                self._tag_seq(plugin_call_message.in_progress()),
+                event,
+            )
+            yield self._with_event_metadata(
+                self._tag_seq(stub_content.in_progress()),
+                event,
+            )
 
             self._tool_calls[call_id] = {
                 "name": event.tool_call_name,
@@ -350,7 +395,10 @@ class Envelope:
                 index=0,
             )
             delta_content.msg_id = state["message"].id
-            yield self._tag_seq(delta_content.in_progress())
+            yield self._with_event_metadata(
+                self._tag_seq(delta_content.in_progress()),
+                event,
+            )
 
         elif evt_type == EventType.TOOL_CALL_END.value:
             call_id = event.tool_call_id
@@ -368,9 +416,15 @@ class Envelope:
                 delta=False,
             )
             state["message"].add_content(new_content=final_content)
-            yield self._tag_seq(final_content.completed())
+            yield self._with_event_metadata(
+                self._tag_seq(final_content.completed()),
+                event,
+            )
             self._response.output.append(state["message"])
-            yield self._tag_seq(state["message"].completed())
+            yield self._with_event_metadata(
+                self._tag_seq(state["message"].completed()),
+                event,
+            )
 
         # === TOOL RESULT ===
         elif evt_type == EventType.TOOL_RESULT_START.value:
@@ -408,8 +462,14 @@ class Envelope:
             )
             stub_content.msg_id = out_msg_id
 
-            yield self._tag_seq(out_message.in_progress())
-            yield self._tag_seq(stub_content.in_progress())
+            yield self._with_event_metadata(
+                self._tag_seq(out_message.in_progress()),
+                event,
+            )
+            yield self._with_event_metadata(
+                self._tag_seq(stub_content.in_progress()),
+                event,
+            )
 
             state["output_message"] = out_message
             state["output_text_acc"] = ""
@@ -429,7 +489,10 @@ class Envelope:
                 FunctionCallOutput,
             )
             delta_content.msg_id = state["output_message"].id
-            yield self._tag_seq(delta_content.in_progress())
+            yield self._with_event_metadata(
+                self._tag_seq(delta_content.in_progress()),
+                event,
+            )
 
         elif evt_type == EventType.TOOL_RESULT_DATA_DELTA.value:
             call_id = event.tool_call_id
@@ -477,7 +540,10 @@ class Envelope:
                 FunctionCallOutput,
             )
             delta_content.msg_id = state["output_message"].id
-            yield self._tag_seq(delta_content.in_progress())
+            yield self._with_event_metadata(
+                self._tag_seq(delta_content.in_progress()),
+                event,
+            )
 
         elif evt_type == EventType.TOOL_RESULT_END.value:
             call_id = event.tool_call_id
@@ -510,9 +576,15 @@ class Envelope:
                 out_message.object = "message"
 
             out_message.add_content(new_content=final_content)
-            yield self._tag_seq(final_content.completed())
+            yield self._with_event_metadata(
+                self._tag_seq(final_content.completed()),
+                event,
+            )
             self._response.output.append(out_message)
-            yield self._tag_seq(out_message.completed())
+            yield self._with_event_metadata(
+                self._tag_seq(out_message.completed()),
+                event,
+            )
 
         # === DATA BLOCK ===
         elif evt_type == EventType.DATA_BLOCK_START.value:
@@ -520,7 +592,10 @@ class Envelope:
             media_type = getattr(event, "media_type", "")
 
             if not self._message_started:
-                yield self._tag_seq(self._completed_message)
+                yield self._with_event_metadata(
+                    self._tag_seq(self._completed_message),
+                    event,
+                )
                 self._message_started = True
 
             self._data_blocks[block_id] = {
@@ -577,7 +652,10 @@ class Envelope:
 
             content_block.msg_id = self._message_id
             self._completed_message.content.append(content_block)
-            yield self._tag_seq(content_block)
+            yield self._with_event_metadata(
+                self._tag_seq(content_block),
+                event,
+            )
 
         # === MODEL_CALL_END ===
         elif evt_type == EventType.MODEL_CALL_END.value:
@@ -604,7 +682,10 @@ class Envelope:
             )
             err_message.name = "assistant"
             err_message.object = "message"
-            yield self._tag_seq(err_message)
+            yield self._with_event_metadata(
+                self._tag_seq(err_message),
+                event,
+            )
 
             err_text = TextContent(
                 type=ContentType.TEXT,
@@ -616,12 +697,15 @@ class Envelope:
                 index=0,
             )
             err_text.msg_id = err_msg_id
-            yield self._tag_seq(err_text)
+            yield self._with_event_metadata(self._tag_seq(err_text), event)
 
             err_message.content.append(err_text)
             err_message.status = RunStatus.Completed
             self._response.output.append(err_message)
-            yield self._tag_seq(err_message)
+            yield self._with_event_metadata(
+                self._tag_seq(err_message),
+                event,
+            )
 
         # === HINT_BLOCK (P2-2: warn and drop) ===
         # ``EventType.HINT_BLOCK`` does not exist in every agentscope version;

--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict
 
@@ -22,6 +23,13 @@ logger = logging.getLogger(__name__)
 
 def _gen_msg_id() -> str:
     return "msg_" + uuid.uuid4().hex
+
+
+@dataclass(frozen=True)
+class _EventMetadataExcludedOutput:
+    """An output that must not inherit metadata from the current event."""
+
+    output: Any
 
 
 class Envelope:
@@ -157,15 +165,25 @@ class Envelope:
     # Event translation
     # ------------------------------------------------------------------
 
-    # pylint: disable=too-many-return-statements
-    # pylint: disable=too-many-branches,too-many-statements
-    async def translate_event(  # noqa: C901, PLR0912, PLR0915
+    async def translate_event(
         self,
         event: Any,
     ) -> AsyncGenerator[Any, None]:
-        """Translate one agentscope ``EventType`` event
-        into 0..N envelope objects.
-        """
+        """Translate an AgentScope event into real-time Host objects."""
+        async for raw_output in self._translate_event_raw(event):
+            if isinstance(raw_output, _EventMetadataExcludedOutput):
+                yield raw_output.output
+                continue
+
+            yield self._with_event_metadata(raw_output, event)
+
+    # pylint: disable=too-many-return-statements
+    # pylint: disable=too-many-branches,too-many-statements
+    async def _translate_event_raw(  # noqa: C901, PLR0912, PLR0915
+        self,
+        event: Any,
+    ) -> AsyncGenerator[Any, None]:
+        """Translate one event without applying event-scoped metadata."""
         from agentscope.event import EventType
         from ..schemas import (
             ContentType,
@@ -189,10 +207,7 @@ class Envelope:
         # === TEXT BLOCK ===
         if evt_type == EventType.TEXT_BLOCK_START.value:
             if not self._message_started:
-                yield self._with_event_metadata(
-                    self._tag_seq(self._completed_message),
-                    event,
-                )
+                yield self._tag_seq(self._completed_message)
                 self._message_started = True
             block_id = event.block_id
             index = len(self._text_blocks)
@@ -200,10 +215,7 @@ class Envelope:
 
         elif evt_type == EventType.TEXT_BLOCK_DELTA.value:
             if not self._message_started:
-                yield self._with_event_metadata(
-                    self._tag_seq(self._completed_message),
-                    event,
-                )
+                yield self._tag_seq(self._completed_message)
                 self._message_started = True
             block_id = event.block_id
             delta = event.delta or ""
@@ -219,7 +231,7 @@ class Envelope:
                 index=state["index"],
             )
             chunk.msg_id = self._message_id
-            yield self._with_event_metadata(self._tag_seq(chunk), event)
+            yield self._tag_seq(chunk)
 
         elif evt_type == EventType.TEXT_BLOCK_END.value:
             block_id = event.block_id
@@ -233,10 +245,7 @@ class Envelope:
                 index=state["index"],
             )
             final_chunk.msg_id = self._message_id
-            yield self._with_event_metadata(
-                self._tag_seq(final_chunk),
-                event,
-            )
+            yield self._tag_seq(final_chunk)
             self._completed_message.content.append(
                 TextContent(
                     type=ContentType.TEXT,
@@ -264,7 +273,7 @@ class Envelope:
                 "envelope": r_envelope,
                 "text": "",
             }
-            yield self._with_event_metadata(self._tag_seq(r_envelope), event)
+            yield self._tag_seq(r_envelope)
 
         elif evt_type == EventType.THINKING_BLOCK_DELTA.value:
             block_id = event.block_id
@@ -287,10 +296,7 @@ class Envelope:
                     "text": "",
                 }
                 self._reasoning_blocks[block_id] = state
-                yield self._with_event_metadata(
-                    self._tag_seq(r_envelope),
-                    event,
-                )
+                yield self._tag_seq(r_envelope)
             state["text"] += delta
             r_chunk = TextContent(
                 type=ContentType.TEXT,
@@ -299,7 +305,7 @@ class Envelope:
                 index=0,
             )
             r_chunk.msg_id = state["msg_id"]
-            yield self._with_event_metadata(self._tag_seq(r_chunk), event)
+            yield self._tag_seq(r_chunk)
 
         elif evt_type == EventType.THINKING_BLOCK_END.value:
             block_id = event.block_id
@@ -313,7 +319,7 @@ class Envelope:
                 index=0,
             )
             r_final.msg_id = state["msg_id"]
-            yield self._with_event_metadata(self._tag_seq(r_final), event)
+            yield self._tag_seq(r_final)
             state["envelope"].content.append(
                 TextContent(
                     type=ContentType.TEXT,
@@ -324,17 +330,14 @@ class Envelope:
             )
             state["envelope"].status = RunStatus.Completed
             self._response.output.append(state["envelope"])
-            yield self._with_event_metadata(
-                self._tag_seq(state["envelope"]),
-                event,
-            )
+            yield self._tag_seq(state["envelope"])
 
         # === TOOL CALL ===
         elif evt_type == EventType.TOOL_CALL_START.value:
             # P0-5: finalize current text message if needed
             if self._should_finalize_text_message():
                 async for obj in self._finalize_text_message():
-                    yield obj
+                    yield _EventMetadataExcludedOutput(obj)
 
             call_id = event.tool_call_id
             msg_id = _gen_msg_id()
@@ -360,14 +363,8 @@ class Envelope:
             )
             stub_content.msg_id = msg_id
 
-            yield self._with_event_metadata(
-                self._tag_seq(plugin_call_message.in_progress()),
-                event,
-            )
-            yield self._with_event_metadata(
-                self._tag_seq(stub_content.in_progress()),
-                event,
-            )
+            yield self._tag_seq(plugin_call_message.in_progress())
+            yield self._tag_seq(stub_content.in_progress())
 
             self._tool_calls[call_id] = {
                 "name": event.tool_call_name,
@@ -395,10 +392,7 @@ class Envelope:
                 index=0,
             )
             delta_content.msg_id = state["message"].id
-            yield self._with_event_metadata(
-                self._tag_seq(delta_content.in_progress()),
-                event,
-            )
+            yield self._tag_seq(delta_content.in_progress())
 
         elif evt_type == EventType.TOOL_CALL_END.value:
             call_id = event.tool_call_id
@@ -416,15 +410,9 @@ class Envelope:
                 delta=False,
             )
             state["message"].add_content(new_content=final_content)
-            yield self._with_event_metadata(
-                self._tag_seq(final_content.completed()),
-                event,
-            )
+            yield self._tag_seq(final_content.completed())
             self._response.output.append(state["message"])
-            yield self._with_event_metadata(
-                self._tag_seq(state["message"].completed()),
-                event,
-            )
+            yield self._tag_seq(state["message"].completed())
 
         # === TOOL RESULT ===
         elif evt_type == EventType.TOOL_RESULT_START.value:
@@ -462,14 +450,8 @@ class Envelope:
             )
             stub_content.msg_id = out_msg_id
 
-            yield self._with_event_metadata(
-                self._tag_seq(out_message.in_progress()),
-                event,
-            )
-            yield self._with_event_metadata(
-                self._tag_seq(stub_content.in_progress()),
-                event,
-            )
+            yield self._tag_seq(out_message.in_progress())
+            yield self._tag_seq(stub_content.in_progress())
 
             state["output_message"] = out_message
             state["output_text_acc"] = ""
@@ -489,10 +471,7 @@ class Envelope:
                 FunctionCallOutput,
             )
             delta_content.msg_id = state["output_message"].id
-            yield self._with_event_metadata(
-                self._tag_seq(delta_content.in_progress()),
-                event,
-            )
+            yield self._tag_seq(delta_content.in_progress())
 
         elif evt_type == EventType.TOOL_RESULT_DATA_DELTA.value:
             call_id = event.tool_call_id
@@ -540,10 +519,7 @@ class Envelope:
                 FunctionCallOutput,
             )
             delta_content.msg_id = state["output_message"].id
-            yield self._with_event_metadata(
-                self._tag_seq(delta_content.in_progress()),
-                event,
-            )
+            yield self._tag_seq(delta_content.in_progress())
 
         elif evt_type == EventType.TOOL_RESULT_END.value:
             call_id = event.tool_call_id
@@ -576,15 +552,9 @@ class Envelope:
                 out_message.object = "message"
 
             out_message.add_content(new_content=final_content)
-            yield self._with_event_metadata(
-                self._tag_seq(final_content.completed()),
-                event,
-            )
+            yield self._tag_seq(final_content.completed())
             self._response.output.append(out_message)
-            yield self._with_event_metadata(
-                self._tag_seq(out_message.completed()),
-                event,
-            )
+            yield self._tag_seq(out_message.completed())
 
         # === DATA BLOCK ===
         elif evt_type == EventType.DATA_BLOCK_START.value:
@@ -592,10 +562,7 @@ class Envelope:
             media_type = getattr(event, "media_type", "")
 
             if not self._message_started:
-                yield self._with_event_metadata(
-                    self._tag_seq(self._completed_message),
-                    event,
-                )
+                yield self._tag_seq(self._completed_message)
                 self._message_started = True
 
             self._data_blocks[block_id] = {
@@ -652,10 +619,7 @@ class Envelope:
 
             content_block.msg_id = self._message_id
             self._completed_message.content.append(content_block)
-            yield self._with_event_metadata(
-                self._tag_seq(content_block),
-                event,
-            )
+            yield self._tag_seq(content_block)
 
         # === MODEL_CALL_END ===
         elif evt_type == EventType.MODEL_CALL_END.value:
@@ -682,10 +646,7 @@ class Envelope:
             )
             err_message.name = "assistant"
             err_message.object = "message"
-            yield self._with_event_metadata(
-                self._tag_seq(err_message),
-                event,
-            )
+            yield self._tag_seq(err_message)
 
             err_text = TextContent(
                 type=ContentType.TEXT,
@@ -697,15 +658,12 @@ class Envelope:
                 index=0,
             )
             err_text.msg_id = err_msg_id
-            yield self._with_event_metadata(self._tag_seq(err_text), event)
+            yield self._tag_seq(err_text)
 
             err_message.content.append(err_text)
             err_message.status = RunStatus.Completed
             self._response.output.append(err_message)
-            yield self._with_event_metadata(
-                self._tag_seq(err_message),
-                event,
-            )
+            yield self._tag_seq(err_message)
 
         # === HINT_BLOCK (P2-2: warn and drop) ===
         # ``EventType.HINT_BLOCK`` does not exist in every agentscope version;

--- a/tests/unit/runtime/test_envelope_metadata.py
+++ b/tests/unit/runtime/test_envelope_metadata.py
@@ -10,7 +10,24 @@ import pytest
 from agentscope.event import EventType
 
 from qwenpaw.runtime.envelope import Envelope
-from qwenpaw.schemas import MessageType, RunStatus
+from qwenpaw.schemas import ContentType, MessageType, RunStatus, TextContent
+
+
+class _SyntheticEnvelope(Envelope):
+    """Envelope with one raw output for testing the public boundary."""
+
+    async def _translate_event_raw(
+        self,
+        event: Any,
+    ) -> AsyncGenerator[Any, None]:
+        del event
+        output = TextContent(
+            type=ContentType.TEXT,
+            text="synthetic",
+            delta=True,
+            index=0,
+        )
+        yield self._tag_seq(output)
 
 
 def _event(event_type: EventType, **fields: Any) -> SimpleNamespace:
@@ -44,6 +61,20 @@ def _assert_no_metadata(value: Any) -> None:
     elif isinstance(value, list):
         for nested in value:
             _assert_no_metadata(nested)
+
+
+@pytest.mark.asyncio
+async def test_translate_event_decorates_raw_outputs_by_default():
+    envelope = _SyntheticEnvelope()
+    event = _event(
+        EventType.TEXT_BLOCK_DELTA,
+        metadata={"route": "node-a"},
+    )
+
+    [payload] = await _translate(envelope, event)
+
+    assert payload["sequence_number"] == 1
+    assert payload["metadata"] == {"route": "node-a"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_envelope_metadata.py
+++ b/tests/unit/runtime/test_envelope_metadata.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""Tests for AgentScope event metadata in real-time envelopes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator
+
+import pytest
+from agentscope.event import EventType
+
+from qwenpaw.runtime.envelope import Envelope
+from qwenpaw.schemas import MessageType, RunStatus
+
+
+def _event(event_type: EventType, **fields: Any) -> SimpleNamespace:
+    metadata = fields.pop("metadata", {"event": event_type.value})
+    return SimpleNamespace(
+        type=event_type.value,
+        metadata=metadata,
+        **fields,
+    )
+
+
+async def _dump(
+    stream: AsyncGenerator[Any, None],
+) -> list[dict[str, Any]]:
+    """Dump each yielded object immediately, as the SSE consumer does."""
+    return [item.model_dump(mode="python") async for item in stream]
+
+
+async def _translate(
+    envelope: Envelope,
+    event: SimpleNamespace,
+) -> list[dict[str, Any]]:
+    return await _dump(envelope.translate_event(event))
+
+
+def _assert_no_metadata(value: Any) -> None:
+    if isinstance(value, dict):
+        assert not value.get("metadata")
+        for nested in value.values():
+            _assert_no_metadata(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            _assert_no_metadata(nested)
+
+
+@pytest.mark.asyncio
+async def test_metadata_is_added_to_existing_stream_outputs():
+    cases = [
+        (
+            [
+                _event(EventType.TEXT_BLOCK_START, block_id="text"),
+                _event(
+                    EventType.TEXT_BLOCK_DELTA,
+                    block_id="text",
+                    delta="hello",
+                ),
+                _event(EventType.TEXT_BLOCK_END, block_id="text"),
+            ],
+            [1, 1, 1],
+        ),
+        (
+            [
+                _event(EventType.THINKING_BLOCK_START, block_id="thinking"),
+                _event(
+                    EventType.THINKING_BLOCK_DELTA,
+                    block_id="thinking",
+                    delta="considering",
+                ),
+                _event(EventType.THINKING_BLOCK_END, block_id="thinking"),
+            ],
+            [1, 1, 2],
+        ),
+        (
+            [
+                _event(
+                    EventType.TOOL_CALL_START,
+                    tool_call_id="call",
+                    tool_call_name="lookup",
+                ),
+                _event(
+                    EventType.TOOL_CALL_DELTA,
+                    tool_call_id="call",
+                    delta='{"q":"hello"}',
+                ),
+                _event(EventType.TOOL_CALL_END, tool_call_id="call"),
+            ],
+            [2, 1, 2],
+        ),
+        (
+            [
+                _event(
+                    EventType.TOOL_RESULT_START,
+                    tool_call_id="result",
+                    tool_call_name="lookup",
+                ),
+                _event(
+                    EventType.TOOL_RESULT_TEXT_DELTA,
+                    tool_call_id="result",
+                    delta="done",
+                ),
+                _event(
+                    EventType.TOOL_RESULT_DATA_DELTA,
+                    tool_call_id="result",
+                    block_id="image",
+                    media_type="image/png",
+                    data="YWJj",
+                    url=None,
+                ),
+                _event(
+                    EventType.TOOL_RESULT_END,
+                    tool_call_id="result",
+                    state="success",
+                ),
+            ],
+            [2, 1, 1, 2],
+        ),
+        (
+            [
+                _event(
+                    EventType.DATA_BLOCK_START,
+                    block_id="data",
+                    media_type="image/png",
+                ),
+                _event(
+                    EventType.DATA_BLOCK_DELTA,
+                    block_id="data",
+                    data="YWJj",
+                ),
+                _event(EventType.DATA_BLOCK_END, block_id="data"),
+            ],
+            [1, 0, 1],
+        ),
+    ]
+
+    for events, expected_counts in cases:
+        envelope = Envelope()
+        for event, expected_count in zip(events, expected_counts):
+            payloads = await _translate(envelope, event)
+            assert len(payloads) == expected_count
+            assert all(
+                payload["metadata"] == event.metadata for payload in payloads
+            )
+
+
+@pytest.mark.asyncio
+async def test_tool_metadata_is_scoped_to_its_own_outputs():
+    envelope = Envelope()
+    text_metadata = {"route": "text"}
+    for event in (
+        _event(
+            EventType.TEXT_BLOCK_START,
+            metadata=text_metadata,
+            block_id="text",
+        ),
+        _event(
+            EventType.TEXT_BLOCK_DELTA,
+            metadata=text_metadata,
+            block_id="text",
+            delta="before tool",
+        ),
+        _event(
+            EventType.TEXT_BLOCK_END,
+            metadata=text_metadata,
+            block_id="text",
+        ),
+    ):
+        await _translate(envelope, event)
+
+    tool_metadata = {"route": "call-a"}
+    payloads = await _translate(
+        envelope,
+        _event(
+            EventType.TOOL_CALL_START,
+            metadata=tool_metadata,
+            tool_call_id="call-a",
+            tool_call_name="lookup",
+        ),
+    )
+
+    # The first payload finalizes the preceding text message and is not
+    # produced by the tool call itself.
+    assert len(payloads) == 3
+    assert payloads[0]["type"] == MessageType.MESSAGE
+    assert payloads[0]["metadata"] is None
+    assert all(
+        payload["metadata"] == tool_metadata for payload in payloads[1:]
+    )
+
+    await _translate(
+        envelope,
+        _event(
+            EventType.TOOL_CALL_START,
+            metadata={"route": "call-b"},
+            tool_call_id="call-b",
+            tool_call_name="lookup",
+        ),
+    )
+    for call_id in ("call-b", "call-a"):
+        metadata = {"route": call_id}
+        [payload] = await _translate(
+            envelope,
+            _event(
+                EventType.TOOL_CALL_DELTA,
+                metadata=metadata,
+                tool_call_id=call_id,
+                delta=call_id,
+            ),
+        )
+        assert payload["metadata"] == metadata
+        assert payload["data"]["call_id"] == call_id
+
+
+@pytest.mark.asyncio
+async def test_metadata_cannot_override_host_fields():
+    reserved = {
+        "object": "plugin-object",
+        "status": "failed",
+        "sequence_number": 999,
+        "msg_id": "plugin-message",
+        "id": "plugin-id",
+        "type": "plugin-type",
+    }
+    message, content = await _translate(
+        Envelope(),
+        _event(
+            EventType.TOOL_CALL_START,
+            metadata=reserved,
+            tool_call_id="call",
+            tool_call_name="lookup",
+        ),
+    )
+
+    assert message["metadata"] == reserved
+    assert message["object"] == "message"
+    assert message["status"] == RunStatus.InProgress
+    assert message["sequence_number"] == 1
+    assert message["id"] != "plugin-id"
+    assert message["type"] == MessageType.PLUGIN_CALL
+
+    assert content["metadata"] == reserved
+    assert content["object"] == "content"
+    assert content["sequence_number"] == 2
+    assert content["msg_id"] == message["id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finalizer", ["normal", "cancel", "error"])
+async def test_finalize_does_not_promote_event_metadata(finalizer):
+    envelope = Envelope()
+    metadata = {"temporary_route": "node"}
+    await _translate(
+        envelope,
+        _event(
+            EventType.TEXT_BLOCK_DELTA,
+            metadata=metadata,
+            block_id="text",
+            delta="partial",
+        ),
+    )
+
+    if finalizer == "normal":
+        payloads = await _dump(envelope.finalize())
+    elif finalizer == "cancel":
+        payloads = await _dump(envelope.cancel_envelope())
+    else:
+        payloads = await _dump(
+            envelope.error_envelope("failed", "test_error"),
+        )
+
+    _assert_no_metadata(payloads)
+
+
+@pytest.mark.asyncio
+async def test_empty_metadata_keeps_existing_content_shape():
+    envelope = Envelope()
+    [message, delta] = await _translate(
+        envelope,
+        _event(
+            EventType.TEXT_BLOCK_DELTA,
+            metadata={},
+            block_id="text",
+            delta="hello",
+        ),
+    )
+
+    assert message["metadata"] is None
+    assert "metadata" not in delta

--- a/tests/unit/runtime/test_envelope_metadata.py
+++ b/tests/unit/runtime/test_envelope_metadata.py
@@ -9,14 +9,15 @@ from typing import Any, AsyncGenerator
 import pytest
 from agentscope.event import EventType
 
-from qwenpaw.runtime.envelope import Envelope
+from qwenpaw.runtime.envelope import Envelope, _propagate_event_metadata
 from qwenpaw.schemas import ContentType, MessageType, RunStatus, TextContent
 
 
 class _SyntheticEnvelope(Envelope):
-    """Envelope with one raw output for testing the public boundary."""
+    """Envelope with one output for testing metadata propagation."""
 
-    async def _translate_event_raw(
+    @_propagate_event_metadata
+    async def translate_event(
         self,
         event: Any,
     ) -> AsyncGenerator[Any, None]:
@@ -64,7 +65,7 @@ def _assert_no_metadata(value: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_translate_event_decorates_raw_outputs_by_default():
+async def test_event_metadata_decorator_applies_to_outputs_by_default():
     envelope = _SyntheticEnvelope()
     event = _event(
         EventType.TEXT_BLOCK_DELTA,


### PR DESCRIPTION
## Description

Preserves AgentScope event extension metadata when converting events into real-time Host envelope objects.

Each emitted Host `Content` or `Message` receives a copy of the metadata from the AgentScope event that produced it. Metadata is attached to a shallow real-time output copy, preventing event-scoped data from leaking into reusable internal messages or the durable `AgentResponse.output`.

This change:

- Covers text, thinking, tool call, tool result, data block, and max-iteration event outputs.
- Preserves existing SSE object types, ordering, sequence numbers, and content.
- Keeps sequence tagging and metadata tagging as separate operations.
- Prevents plugin metadata from overriding Host fields such as `object`, `status`, `sequence_number`, `msg_id`, `id`, or `type`.
- Keeps the existing serialization path unchanged when an event has no metadata.
- Does not aggregate metadata across events, blocks, or messages.
- Does not promote temporary event metadata during normal, cancellation, or error finalization.

**Related Issue:** N/A

**Security Considerations:** Event metadata is confined to the Host object's `metadata` field and cannot override Host-owned top-level fields. This PR does not introduce new persistence, payload validation, or authorization behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit` locally for all files changed by this PR and it passes
- [x] Pre-commit did not produce additional changes
- [x] I ran tests locally (`pytest`) and they pass
- [x] Documentation updated (not needed for this internal behavior fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable — this PR does not change channel behavior.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/**init**.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The new unit tests verify:

- Metadata propagation for text, thinking, tool call, tool result, and data block outputs.
- Start, delta, and end event handling where the existing conversion emits an object.
- Isolation between interleaved tool calls carrying different metadata.
- Protection of Host-owned fields from metadata collisions.
- No metadata promotion during normal, cancellation, or error finalization.
- Unchanged output shape for events with empty metadata.

Run the targeted tests:

```bash
.venv/bin/pytest tests/unit/runtime/test_envelope_metadata.py -q