### PR TITLE
perf(console): cache and compress static assets

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -14,7 +14,6 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
-from fastapi.staticfiles import StaticFiles
 
 from ..__version__ import __version__
 from ..backup._utils.safe_swap import cleanup_startup_restore_artifacts
@@ -42,6 +41,7 @@ from .auth import (
     auto_register_from_env,
     check_proxy_config_sanity,
 )
+from .console_static import ConsoleAssetFiles
 from .migration import (
     ensure_default_agent_exists,
     ensure_qa_agent_exists,
@@ -960,7 +960,7 @@ if os.path.isdir(_CONSOLE_STATIC_DIR):
     if _assets_dir.is_dir():
         app.mount(
             "/assets",
-            StaticFiles(directory=str(_assets_dir)),
+            ConsoleAssetFiles(directory=str(_assets_dir)),
             name="assets",
         )
 

--- a/src/qwenpaw/app/console_static.py
+++ b/src/qwenpaw/app/console_static.py
@@ -34,10 +34,17 @@ def _is_compressible_path(path: str) -> bool:
 
 
 def _accepts_gzip(headers: Headers) -> bool:
-    """Return whether ``Accept-Encoding`` explicitly permits gzip."""
+    """Return whether ``Accept-Encoding`` permits gzip.
+
+    An explicit gzip preference takes precedence over the wildcard, as
+    required for requests such as ``gzip;q=0, *;q=1``.
+    """
+    gzip_quality: float | None = None
+    wildcard_quality: float | None = None
     for item in headers.get("accept-encoding", "").split(","):
         coding, *parameters = (part.strip() for part in item.split(";"))
-        if coding.lower() != "gzip":
+        coding = coding.lower()
+        if coding not in {"gzip", "*"}:
             continue
         quality = 1.0
         for parameter in parameters:
@@ -47,8 +54,24 @@ def _accepts_gzip(headers: Headers) -> bool:
                     quality = float(value.strip())
                 except ValueError:
                     quality = 0.0
-        return quality > 0
-    return False
+        if coding == "gzip":
+            gzip_quality = quality
+        else:
+            wildcard_quality = quality
+    if gzip_quality is not None:
+        return gzip_quality > 0
+    return wildcard_quality is not None and wildcard_quality > 0
+
+
+def _gzip_scope(scope: Scope) -> Scope:
+    """Return a scope that reflects the already-negotiated gzip variant."""
+    headers = [
+        (name, value)
+        for name, value in scope.get("headers", [])
+        if name.lower() != b"accept-encoding"
+    ]
+    headers.append((b"accept-encoding", b"gzip"))
+    return {**scope, "headers": headers}
 
 
 class _ImmutableStaticFiles(StaticFiles):
@@ -115,8 +138,9 @@ class ConsoleAssetFiles:
             await send(message)
 
         asset_send = send_with_vary if is_compressible else send
+        method = scope.get("method")
         should_compress = (
-            scope.get("method") == "GET"
+            method in {"GET", "HEAD"}
             and is_compressible
             and _accepts_gzip(headers)
             and "range" not in headers
@@ -125,6 +149,25 @@ class ConsoleAssetFiles:
             await self._files(scope, receive, asset_send)
             return
 
+        # The negotiation decision above is authoritative. Normalize the
+        # header so GZipMiddleware does not reinterpret case or wildcard
+        # syntax differently.
+        scope = _gzip_scope(scope)
+
+        # A HEAD response must expose the same representation headers as GET.
+        # Generate the GET variant through the middleware, then suppress its
+        # body while preserving the compressed Content-Length and validators.
+        gzip_send = asset_send
+        if method == "HEAD":
+            scope = {**scope, "method": "GET"}
+
+            async def send_without_body(message) -> None:
+                if message["type"] == "http.response.body":
+                    message = {**message, "body": b""}
+                await asset_send(message)
+
+            gzip_send = send_without_body
+
         # FileResponse may delegate directly to servers that advertise
         # pathsend. Remove that optional fast path only for gzip responses so
         # the middleware always receives the file bytes to compress.
@@ -132,4 +175,4 @@ class ConsoleAssetFiles:
         if "http.response.pathsend" in extensions:
             extensions.pop("http.response.pathsend")
             scope = {**scope, "extensions": extensions}
-        await self._gzip_files(scope, receive, asset_send)
+        await self._gzip_files(scope, receive, gzip_send)

--- a/src/qwenpaw/app/console_static.py
+++ b/src/qwenpaw/app/console_static.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""Cache and compression policy for content-hashed Console assets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.middleware.gzip import GZipMiddleware
+from starlette.responses import Response
+from starlette.staticfiles import StaticFiles
+from starlette.types import Receive, Scope, Send
+
+ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
+_COMPRESSIBLE_SUFFIXES = frozenset(
+    {
+        ".css",
+        ".csv",
+        ".html",
+        ".js",
+        ".json",
+        ".map",
+        ".mjs",
+        ".svg",
+        ".txt",
+        ".wasm",
+        ".xml",
+    },
+)
+
+
+def _is_compressible_path(path: str) -> bool:
+    return Path(path).suffix.lower() in _COMPRESSIBLE_SUFFIXES
+
+
+def _accepts_gzip(headers: Headers) -> bool:
+    """Return whether ``Accept-Encoding`` explicitly permits gzip."""
+    for item in headers.get("accept-encoding", "").split(","):
+        coding, *parameters = (part.strip() for part in item.split(";"))
+        if coding.lower() != "gzip":
+            continue
+        quality = 1.0
+        for parameter in parameters:
+            name, separator, value = parameter.partition("=")
+            if separator and name.strip().lower() == "q":
+                try:
+                    quality = float(value.strip())
+                except ValueError:
+                    quality = 0.0
+        return quality > 0
+    return False
+
+
+class _ImmutableStaticFiles(StaticFiles):
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        response = await super().get_response(path, scope)
+        if response.status_code in {200, 206, 304}:
+            response.headers["Cache-Control"] = ASSET_CACHE_CONTROL
+        return response
+
+
+class ConsoleAssetFiles:
+    """Serve hashed Console assets.
+
+    Applies immutable caching and selective gzip compression.
+    """
+
+    def __init__(
+        self,
+        directory: str,
+        *,
+        gzip_minimum_size: int = 1024,
+        gzip_compresslevel: int = 6,
+    ) -> None:
+        self._files = _ImmutableStaticFiles(directory=directory)
+        self._gzip_files = GZipMiddleware(
+            self._files,
+            minimum_size=gzip_minimum_size,
+            compresslevel=gzip_compresslevel,
+        )
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        headers = Headers(scope=scope)
+        is_compressible = _is_compressible_path(
+            str(scope.get("path", "")),
+        )
+
+        async def send_with_vary(message) -> None:
+            if message["type"] == "http.response.start" and message[
+                "status"
+            ] in {200, 206, 304}:
+                response_headers = MutableHeaders(
+                    scope=message,
+                )
+                vary_values = {
+                    value.strip().lower()
+                    for value in response_headers.get("vary", "").split(",")
+                }
+                if "accept-encoding" not in vary_values:
+                    response_headers.add_vary_header("Accept-Encoding")
+            await send(message)
+
+        asset_send = send_with_vary if is_compressible else send
+        should_compress = (
+            scope.get("method") == "GET"
+            and is_compressible
+            and _accepts_gzip(headers)
+            and "range" not in headers
+        )
+        if not should_compress:
+            await self._files(scope, receive, asset_send)
+            return
+
+        # FileResponse may delegate directly to servers that advertise
+        # pathsend. Remove that optional fast path only for gzip responses so
+        # the middleware always receives the file bytes to compress.
+        extensions = dict(scope.get("extensions") or {})
+        if "http.response.pathsend" in extensions:
+            extensions.pop("http.response.pathsend")
+            scope = {**scope, "extensions": extensions}
+        await self._gzip_files(scope, receive, asset_send)

--- a/src/qwenpaw/app/console_static.py
+++ b/src/qwenpaw/app/console_static.py
@@ -103,6 +103,15 @@ class ConsoleAssetFiles:
                 }
                 if "accept-encoding" not in vary_values:
                     response_headers.add_vary_header("Accept-Encoding")
+                etag = response_headers.get("etag")
+                if (
+                    message["status"] in {200, 304}
+                    and etag
+                    and etag[:2] != "W/"
+                ):
+                    # Identity and gzip share one opaque validator. Mark it
+                    # weak because their representation bytes differ.
+                    response_headers["etag"] = f"W/{etag}"
             await send(message)
 
         asset_send = send_with_vary if is_compressible else send

--- a/tests/unit/app/test_console_static.py
+++ b/tests/unit/app/test_console_static.py
@@ -98,7 +98,8 @@ async def test_compresses_text_assets_and_sets_immutable_cache(
 
 
 @pytest.mark.parametrize(
-    "accept_encoding", [b"GZip;q=1, identity;q=0", b"*;q=1, identity;q=0"]
+    "accept_encoding",
+    [b"GZip;q=1, identity;q=0", b"*;q=1, identity;q=0"],
 )
 async def test_normalizes_accepted_gzip_codings(
     assets: tuple[ConsoleAssetFiles, bytes, bytes],

--- a/tests/unit/app/test_console_static.py
+++ b/tests/unit/app/test_console_static.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Console static asset cache and compression behavior."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+from starlette.types import Message, Scope
+
+from qwenpaw.app.console_static import ASSET_CACHE_CONTROL, ConsoleAssetFiles
+
+
+def _scope(
+    path: str,
+    *,
+    headers: list[tuple[bytes, bytes]] | None = None,
+    extensions: dict | None = None,
+) -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers or [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "extensions": extensions or {},
+    }
+
+
+async def _request(app: ConsoleAssetFiles, scope: Scope) -> list[Message]:
+    messages: list[Message] = []
+
+    async def receive() -> Message:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    await app(scope, receive, send)
+    return messages
+
+
+def _response_headers(messages: list[Message]) -> dict[str, str]:
+    start = next(
+        message
+        for message in messages
+        if message["type"] == "http.response.start"
+    )
+    return {
+        key.decode("latin-1").lower(): value.decode("latin-1")
+        for key, value in start["headers"]
+    }
+
+
+def _response_body(messages: list[Message]) -> bytes:
+    return b"".join(
+        message.get("body", b"")
+        for message in messages
+        if message["type"] == "http.response.body"
+    )
+
+
+@pytest.fixture(name="assets")
+def assets_fixture(tmp_path: Path) -> tuple[ConsoleAssetFiles, bytes, bytes]:
+    javascript = b"const value = 'compressible';\n" * 400
+    image = b"\x89PNG\r\n\x1a\n" + (b"not-compressible" * 400)
+    (tmp_path / "app-12345678.js").write_bytes(javascript)
+    (tmp_path / "logo-12345678.png").write_bytes(image)
+    return ConsoleAssetFiles(str(tmp_path)), javascript, image
+
+
+async def test_compresses_text_assets_and_sets_immutable_cache(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, javascript, _ = assets
+    messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[(b"accept-encoding", b"br, gzip")],
+        ),
+    )
+
+    headers = _response_headers(messages)
+    assert headers["cache-control"] == ASSET_CACHE_CONTROL
+    assert headers["content-encoding"] == "gzip"
+    assert headers["vary"] == "Accept-Encoding"
+    assert gzip.decompress(_response_body(messages)) == javascript
+
+
+async def test_forces_streaming_when_server_advertises_pathsend(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, javascript, _ = assets
+    messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[(b"accept-encoding", b"gzip")],
+            extensions={"http.response.pathsend": {}},
+        ),
+    )
+
+    assert not any(
+        message["type"] == "http.response.pathsend" for message in messages
+    )
+    assert gzip.decompress(_response_body(messages)) == javascript
+
+
+@pytest.mark.parametrize(
+    "accept_encoding",
+    [b"identity", b"gzip;q=0", b"br"],
+)
+async def test_respects_clients_that_do_not_accept_gzip(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+    accept_encoding: bytes,
+) -> None:
+    app, javascript, _ = assets
+    messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[(b"accept-encoding", accept_encoding)],
+        ),
+    )
+
+    headers = _response_headers(messages)
+    assert "content-encoding" not in headers
+    assert headers["vary"] == "Accept-Encoding"
+    assert _response_body(messages) == javascript
+
+
+async def test_does_not_compress_binary_assets(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, _, image = assets
+    messages = await _request(
+        app,
+        _scope(
+            "/logo-12345678.png",
+            headers=[(b"accept-encoding", b"gzip")],
+        ),
+    )
+
+    headers = _response_headers(messages)
+    assert headers["cache-control"] == ASSET_CACHE_CONTROL
+    assert "content-encoding" not in headers
+    assert "vary" not in headers
+    assert _response_body(messages) == image
+
+
+async def test_range_requests_are_not_compressed(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, javascript, _ = assets
+    messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[
+                (b"accept-encoding", b"gzip"),
+                (b"range", b"bytes=0-31"),
+            ],
+        ),
+    )
+
+    headers = _response_headers(messages)
+    assert headers["cache-control"] == ASSET_CACHE_CONTROL
+    assert "content-encoding" not in headers
+    assert headers["content-range"].startswith("bytes 0-31/")
+    assert _response_body(messages) == javascript[:32]
+
+
+async def test_conditional_request_preserves_cache_policy(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, _, _ = assets
+    initial = await _request(app, _scope("/app-12345678.js"))
+    etag = _response_headers(initial)["etag"]
+
+    messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[(b"if-none-match", etag.encode())],
+        ),
+    )
+
+    start = next(
+        message
+        for message in messages
+        if message["type"] == "http.response.start"
+    )
+    assert start["status"] == 304
+    headers = _response_headers(messages)
+    assert headers["cache-control"] == ASSET_CACHE_CONTROL
+    assert headers["vary"] == "Accept-Encoding"

--- a/tests/unit/app/test_console_static.py
+++ b/tests/unit/app/test_console_static.py
@@ -115,6 +115,25 @@ async def test_forces_streaming_when_server_advertises_pathsend(
     assert gzip.decompress(_response_body(messages)) == javascript
 
 
+async def test_compressible_variants_share_weak_etag(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, _, _ = assets
+    identity = await _request(app, _scope("/app-12345678.js"))
+    compressed = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[(b"accept-encoding", b"gzip")],
+        ),
+    )
+
+    identity_etag = _response_headers(identity)["etag"]
+    compressed_etag = _response_headers(compressed)["etag"]
+    assert identity_etag == compressed_etag
+    assert identity_etag.startswith('W/"')
+
+
 @pytest.mark.parametrize(
     "accept_encoding",
     [b"identity", b"gzip;q=0", b"br"],
@@ -154,6 +173,7 @@ async def test_does_not_compress_binary_assets(
     assert headers["cache-control"] == ASSET_CACHE_CONTROL
     assert "content-encoding" not in headers
     assert "vary" not in headers
+    assert not headers["etag"].startswith("W/")
     assert _response_body(messages) == image
 
 
@@ -176,6 +196,7 @@ async def test_range_requests_are_not_compressed(
     assert headers["cache-control"] == ASSET_CACHE_CONTROL
     assert "content-encoding" not in headers
     assert headers["content-range"].startswith("bytes 0-31/")
+    assert not headers["etag"].startswith("W/")
     assert _response_body(messages) == javascript[:32]
 
 
@@ -185,6 +206,7 @@ async def test_conditional_request_preserves_cache_policy(
     app, _, _ = assets
     initial = await _request(app, _scope("/app-12345678.js"))
     etag = _response_headers(initial)["etag"]
+    assert etag.startswith('W/"')
 
     messages = await _request(
         app,
@@ -203,3 +225,4 @@ async def test_conditional_request_preserves_cache_policy(
     headers = _response_headers(messages)
     assert headers["cache-control"] == ASSET_CACHE_CONTROL
     assert headers["vary"] == "Accept-Encoding"
+    assert headers["etag"] == etag

--- a/tests/unit/app/test_console_static.py
+++ b/tests/unit/app/test_console_static.py
@@ -15,6 +15,7 @@ from qwenpaw.app.console_static import ASSET_CACHE_CONTROL, ConsoleAssetFiles
 def _scope(
     path: str,
     *,
+    method: str = "GET",
     headers: list[tuple[bytes, bytes]] | None = None,
     extensions: dict | None = None,
 ) -> Scope:
@@ -22,7 +23,7 @@ def _scope(
         "type": "http",
         "asgi": {"version": "3.0", "spec_version": "2.4"},
         "http_version": "1.1",
-        "method": "GET",
+        "method": method,
         "scheme": "http",
         "path": path,
         "raw_path": path.encode(),
@@ -96,6 +97,58 @@ async def test_compresses_text_assets_and_sets_immutable_cache(
     assert gzip.decompress(_response_body(messages)) == javascript
 
 
+@pytest.mark.parametrize(
+    "accept_encoding", [b"GZip;q=1, identity;q=0", b"*;q=1, identity;q=0"]
+)
+async def test_normalizes_accepted_gzip_codings(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+    accept_encoding: bytes,
+) -> None:
+    app, javascript, _ = assets
+    messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            headers=[(b"accept-encoding", accept_encoding)],
+        ),
+    )
+
+    headers = _response_headers(messages)
+    assert headers["content-encoding"] == "gzip"
+    assert gzip.decompress(_response_body(messages)) == javascript
+
+
+async def test_head_matches_gzip_get_representation_headers(
+    assets: tuple[ConsoleAssetFiles, bytes, bytes],
+) -> None:
+    app, _, _ = assets
+    request_headers = [(b"accept-encoding", b"gzip, identity;q=0")]
+    get_messages = await _request(
+        app,
+        _scope("/app-12345678.js", headers=request_headers),
+    )
+    head_messages = await _request(
+        app,
+        _scope(
+            "/app-12345678.js",
+            method="HEAD",
+            headers=request_headers,
+        ),
+    )
+
+    get_headers = _response_headers(get_messages)
+    head_headers = _response_headers(head_messages)
+    for name in (
+        "cache-control",
+        "content-encoding",
+        "content-length",
+        "etag",
+        "vary",
+    ):
+        assert head_headers[name] == get_headers[name]
+    assert _response_body(head_messages) == b""
+
+
 async def test_forces_streaming_when_server_advertises_pathsend(
     assets: tuple[ConsoleAssetFiles, bytes, bytes],
 ) -> None:
@@ -136,7 +189,7 @@ async def test_compressible_variants_share_weak_etag(
 
 @pytest.mark.parametrize(
     "accept_encoding",
-    [b"identity", b"gzip;q=0", b"br"],
+    [b"identity", b"gzip;q=0", b"gzip;q=0, *;q=1", b"br"],
 )
 async def test_respects_clients_that_do_not_accept_gzip(
     assets: tuple[ConsoleAssetFiles, bytes, bytes],


### PR DESCRIPTION
## Description

The Console ships content-hashed bundles under `/assets`, but the backend served
them without an explicit cache policy or response compression. On bandwidth-
limited connections, the largest JavaScript bundle therefore had to be
transferred uncompressed and could not be retained as an immutable asset.

This PR adds a focused ASGI static asset service for `/assets` that:

- sets `Cache-Control: public, max-age=31536000, immutable` on successful,
  partial, and conditional asset responses;
- gzip-compresses compressible asset types larger than 1 KiB when the client
  accepts gzip;
- preserves `Vary: Accept-Encoding` for compressible assets;
- leaves binary assets and range responses uncompressed;
- leaves `index.html`, API responses, and streaming/SSE routes outside the
  compression middleware.

No new runtime dependency is introduced.

**Related Issue:** Fixes #6205

**Security Considerations:** The change only modifies response headers and
encoding for the existing `/assets` mount. Runtime and integration validation
used isolated temporary directories with model, IM, and tracing credentials
explicitly removed from the environment.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and the change-related suites pass
- [x] Documentation updated (not needed: no configuration or public API change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable: this changes the Console web asset mount, not a messaging
channel implementation or contract.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Added ASGI-level regression coverage for:

- gzip negotiation and byte-for-byte decompression;
- immutable cache headers;
- clients that reject gzip;
- binary asset bypass;
- range requests;
- conditional `304` responses;
- ASGI servers that advertise `http.response.pathsend`.

Also built the production Console and launched a real isolated QwenPaw process
to verify the response headers and rendered UI through HTTP and a browser.

## Evidence

```text
uv run pre-commit run --all-files
# all hooks passed

uv run pytest tests/unit/app/test_console_static.py -q
8 passed in 0.16s

uv run pytest tests/unit -q
4926 passed, 6 skipped, 57 warnings in 187.93s

env -u SSL_CERT_FILE -u REQUESTS_CA_BUNDLE uv run pytest tests/contract -q
262 passed, 3 skipped, 1 warning in 6.76s

uv run pytest tests/integration -m 'integration and p0' -q
127 passed, 287 deselected in 655.68s

cd console && npm run build
15109 modules transformed
built in 28.21s
```

Real process HTTP verification against the generated production bundle:

```text
GET /assets/index-DuU_YjY9.js (identity)
200 OK
content-length: 1713086
cache-control: public, max-age=31536000, immutable
vary: Accept-Encoding

GET /assets/index-DuU_YjY9.js (Accept-Encoding: gzip)
200 OK
content-encoding: gzip
cache-control: public, max-age=31536000, immutable
vary: Accept-Encoding
compressed bytes: 493910 (28.8% of identity size)

SHA-256(identity) == SHA-256(gzip-decompressed)
fa9b1139fc1f58081a7f4e7c1456a0bdfb08affde79cfc2fc6a69637e921a867

Conditional request: 304 with immutable cache policy and Vary
Range request: 206, 32-byte body, no Content-Encoding
GET /: no-cache, no-store, must-revalidate
GET /api/healthz: 200, no Content-Encoding
```

Browser verification loaded the real Console at `/chat`, found the chat input,
reported no console warnings/errors, and observed the main JavaScript response
with `content-encoding: gzip` and the immutable cache policy.

## Additional Notes

The unfiltered `pytest` run was stopped after an unrelated existing integration
test failed while downloading a skill from `raw.githubusercontent.com`:

```text
tests/integration/test_skills_pool.py::test_hub_install_start_poll_complete
task stuck at importing
1 failed, 647 passed, 7 skipped, 1 xpassed, 3 warnings in 1200.38s
```

The same single test was reproduced in a clean detached `origin/main` worktree
with the same result (`1 failed in 81.59s`), confirming it is a network-dependent
baseline failure rather than a regression from this change.

The production build also emits existing warnings about circular/manual chunks,
mixed dynamic/static imports, and bundles larger than 1 MB. They are not changed
by this backend-only asset serving PR.
