### PR TITLE
fix: use absolute import in Tauri entry point

### DIFF
--- a/src/qwenpaw/tauri/entry.py
+++ b/src/qwenpaw/tauri/entry.py
@@ -362,7 +362,7 @@ def main() -> None:
     # On Windows, auto-disable sandbox when not running as admin so the
     # desktop backend starts without a half-broken sandbox layer (mirrors
     # the same guard in cli/app_cmd.py for `qwenpaw app`).
-    from ..utils.platform import auto_disable_sandbox_on_windows
+    from qwenpaw.utils.platform import auto_disable_sandbox_on_windows
 
     auto_disable_sandbox_on_windows()
 

--- a/tests/unit/tauri/test_entry.py
+++ b/tests/unit/tauri/test_entry.py
@@ -135,3 +135,31 @@ def test_socket_port_returns_bound_port():
         sock.bind(("127.0.0.1", 0))
 
         assert entry._socket_port(sock) == sock.getsockname()[1]
+
+
+def test_main_supports_frozen_entry_without_package_context(
+    monkeypatch,
+    tmp_path,
+):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(entry, "__package__", None)
+    monkeypatch.setattr(entry, "_is_frozen_desktop", lambda: False)
+    monkeypatch.setattr(entry, "_ensure_utf8_stdio", lambda: None)
+    monkeypatch.setattr(entry, "_install_subprocess_guard", lambda: None)
+    monkeypatch.setattr(entry, "_install_desktop_runtime", lambda: None)
+    monkeypatch.setattr(entry, "install_sidecar_logging", lambda path: None)
+    monkeypatch.setattr(entry, "_install_certifi_env", lambda: None)
+    monkeypatch.setattr(entry, "_run_backend_server", calls.append)
+    monkeypatch.setattr("qwenpaw.constant.WORKING_DIR", tmp_path)
+    monkeypatch.setattr(
+        "qwenpaw.utils.platform.auto_disable_sandbox_on_windows",
+        lambda: calls.append("sandbox-check"),
+    )
+    monkeypatch.delenv("QWENPAW_LOG_LEVEL", raising=False)
+
+    entry.main()
+
+    assert calls == ["sandbox-check", "info"]

--- a/tests/unit/tauri/test_entry.py
+++ b/tests/unit/tauri/test_entry.py
@@ -146,6 +146,8 @@ def test_main_supports_frozen_entry_without_package_context(
     calls = []
 
     monkeypatch.setattr(entry, "__package__", None)
+    monkeypatch.setattr(entry, "__spec__", None)
+    monkeypatch.setattr(entry, "__name__", "__main__")
     monkeypatch.setattr(entry, "_is_frozen_desktop", lambda: False)
     monkeypatch.setattr(entry, "_ensure_utf8_stdio", lambda: None)
     monkeypatch.setattr(entry, "_install_subprocess_guard", lambda: None)


### PR DESCRIPTION
## Summary

- use an absolute package import for the Windows sandbox startup helper in the PyInstaller Tauri entry point
- add a regression test that runs the entry point with no package context

## Root cause

PyInstaller executes `src/qwenpaw/tauri/entry.py` as a top-level script, so `__package__` is unset. The relative import added for `auto_disable_sandbox_on_windows` therefore raised `ImportError: attempted relative import with no known parent package` on both macOS and Windows before the backend server could start.

## User impact

Packaged Tauri applications can proceed from first-run initialization to backend startup instead of exiting before writing the desktop port file.

## Validation

- `PYTHONPATH="$PWD/src" conda run -n QwenPaw python -m pytest tests/unit/tauri/test_entry.py -q` — 11 passed
- `PYTHONPATH="$PWD/src" conda run -n QwenPaw python -m pytest tests/unit/utils/test_platform.py tests/unit/tauri/test_entry.py -q` — 21 passed
- `conda run -n QwenPaw pre-commit run --files src/qwenpaw/tauri/entry.py tests/unit/tauri/test_entry.py` — passed