### PR TITLE
fix(cli): cron update preserves untouched runtime and request fields

### DIFF
--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -637,120 +638,89 @@ def _resolve_update_spec(
     timeout_seconds: Optional[int],
     tool_safety: Optional[bool] = None,
 ) -> Dict[str, Any]:
+    # pylint: disable=too-many-branches,too-many-statements
     """Merge CLI overrides with an existing cron-job spec.
 
-    Only fields provided as non-None by the CLI are applied; everything
-    else is retained from *spec*.  Returns a payload dict suitable for
+    Deep-copies the existing spec and only patches fields explicitly
+    provided by the CLI.  Unspecified fields — including advanced
+    runtime settings (``max_concurrency``, ``misfire_grace_seconds``)
+    and request extensions (``model``, ``request_context``, …) — are
+    preserved as-is.  Returns a payload dict suitable for
     PUT /cron/jobs/{id}.
     """
-    ext_schedule = spec.get("schedule", {})
-    cli_schedule_type = schedule_type or ext_schedule.get("type", "cron")
-    if cli_schedule_type in ("scheduled", "once"):
-        cli_schedule_type_norm = "scheduled"
-    else:
-        cli_schedule_type_norm = cli_schedule_type
+    payload = copy.deepcopy(spec)
 
-    tz = timezone or ext_schedule.get("timezone", "UTC")
+    if name is not None:
+        payload["name"] = name
+    if enabled is not None:
+        payload["enabled"] = enabled
+    if task_type is not None:
+        payload["task_type"] = task_type
 
-    cli_cron = cron or ext_schedule.get("cron", "")
-    cli_run_at = run_at or ext_schedule.get("run_at")
-    cli_repeat_days = (
-        repeat_every_days
-        if repeat_every_days is not None
-        else ext_schedule.get("repeat_every_days")
-    )
-    cli_repeat_end = (
-        repeat_end_type
-        if repeat_end_type is not None
-        else ext_schedule.get("repeat_end_type")
-    )
-    cli_repeat_until = (  # fmt: skip
-        repeat_until
-        if repeat_until is not None
-        else ext_schedule.get("repeat_until")
-    )
-    cli_repeat_count = (  # fmt: skip
-        repeat_count
-        if repeat_count is not None
-        else ext_schedule.get("repeat_count")
-    )
+    # --- schedule ---
+    sch = payload.setdefault("schedule", {})
+    if schedule_type is not None:
+        # CLI exposes "scheduled"; the API model stores it as "once".
+        sch["type"] = (
+            "once" if schedule_type in ("scheduled", "once") else schedule_type
+        )
+    if cron is not None:
+        sch["cron"] = cron
+    if run_at is not None:
+        sch["run_at"] = run_at
+    if timezone is not None:
+        sch["timezone"] = timezone
+    if repeat_every_days is not None:
+        sch["repeat_every_days"] = repeat_every_days
+    if repeat_end_type is not None:
+        sch["repeat_end_type"] = repeat_end_type
+    if repeat_until is not None:
+        sch["repeat_until"] = repeat_until
+    if repeat_count is not None:
+        sch["repeat_count"] = repeat_count
 
-    # --- resolve other fields with CLI-override semantics ---
-    t_type = task_type or spec.get("task_type", "text")
-    t_name = name if name is not None else spec.get("name", "")
-    t_enabled = enabled if enabled is not None else spec.get("enabled", True)
-    t_mode = mode or spec.get("dispatch", {}).get("mode", "final")
-    t_silent = (
-        silent
-        if silent is not None
-        else spec.get("dispatch", {}).get("silent", False)
-    )
-    t_save = (
-        save_result_to_inbox
-        if save_result_to_inbox is not None
-        else spec.get("save_result_to_inbox")
-    )
-    t_share = (
-        share_session
-        if share_session is not None
-        else spec.get("runtime", {}).get("share_session", True)
-    )
-    t_timeout = (
-        timeout_seconds
-        if timeout_seconds is not None
-        else spec.get("runtime", {}).get("timeout_seconds", 120)
-    )
-    t_tool_safety = (
-        tool_safety
-        if tool_safety is not None
-        else spec.get("runtime", {}).get("tool_safety", False)
-    )
+    # --- dispatch ---
+    dsp = payload.setdefault("dispatch", {})
+    if channel is not None:
+        dsp["channel"] = channel
+    if mode is not None:
+        dsp["mode"] = mode
+    if silent is not None:
+        dsp["silent"] = silent
+    target = dsp.setdefault("target", {})
+    if target_user is not None:
+        target["user_id"] = target_user
+    if target_session is not None:
+        target["session_id"] = target_session
 
-    ext_dispatch = spec.get("dispatch", {})
-    ext_target = ext_dispatch.get("target", {})
-    t_channel = channel or ext_dispatch.get("channel", DEFAULT_CHANNEL)
-    t_user = target_user or ext_target.get("user_id", "")
-    t_session = target_session or ext_target.get("session_id", "")
-    t_text = text
-    if t_text is None and spec.get("task_type") == "agent":
-        try:
-            t_text = spec["request"]["input"][0]["content"][0]["text"]
-        except (KeyError, IndexError, TypeError):
-            t_text = None
-    if t_text is None:
-        t_text = spec.get("text")
+    # --- runtime ---
+    run = payload.setdefault("runtime", {})
+    if share_session is not None:
+        run["share_session"] = share_session
+    if timeout_seconds is not None:
+        run["timeout_seconds"] = timeout_seconds
+    if tool_safety is not None:
+        run["tool_safety"] = tool_safety
 
-    payload = _build_spec_from_cli(
-        task_type=t_type,
-        schedule_type=cli_schedule_type_norm,
-        name=t_name,
-        cron=cli_cron,
-        run_at=cli_run_at,
-        repeat_every_days=cli_repeat_days,
-        repeat_end_type=cli_repeat_end,
-        repeat_until=cli_repeat_until,
-        repeat_count=cli_repeat_count,
-        channel=t_channel,
-        target_user=t_user,
-        target_session=t_session,
-        text=t_text,
-        timezone=tz,
-        enabled=t_enabled,
-        mode=t_mode,
-        silent=t_silent,
-        save_result_to_inbox=t_save,
-        share_session=t_share,
-        timeout_seconds=t_timeout,
-        tool_safety=t_tool_safety,
-    )
+    # --- text / request ---
+    if text is not None:
+        if payload.get("task_type") == "agent":
+            req = payload.setdefault("request", {})
+            try:
+                req["input"][0]["content"][0]["text"] = text.strip()
+            except (KeyError, IndexError, TypeError):
+                req["input"] = [
+                    {
+                        "role": "user",
+                        "type": "message",
+                        "content": [{"type": "text", "text": text.strip()}],
+                    },
+                ]
+        else:
+            payload["text"] = text.strip()
 
-    # Preserve existing meta
-    existing_meta = spec.get("meta")
-    if existing_meta:
-        payload["meta"] = existing_meta
-    existing_dispatch_meta = spec.get("dispatch", {}).get("meta")
-    if existing_dispatch_meta:
-        payload["dispatch"]["meta"] = existing_dispatch_meta
+    if save_result_to_inbox is not None:
+        payload["save_result_to_inbox"] = save_result_to_inbox
 
     return payload
 

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
+import copy
+
 import click
 import pytest
 from click.testing import CliRunner
 
-from qwenpaw.cli.cron_cmd import _build_spec_from_cli, cron_group
+from qwenpaw.cli.cron_cmd import (
+    _build_spec_from_cli,
+    _resolve_update_spec,
+    cron_group,
+)
 
 
 def _agent_spec(**overrides):
@@ -46,3 +52,229 @@ def test_create_help_exposes_silent_delivery_flag():
 
     assert result.exit_code == 0
     assert "--silent / --no-silent" in result.output
+
+
+# --- _resolve_update_spec regression tests (issue #6176) ---
+
+
+def _update(full_spec: dict, **overrides) -> dict:
+    """Thin wrapper: call _resolve_update_spec with all opt-out defaults."""
+    defaults = {
+        "task_type": None,
+        "schedule_type": None,
+        "name": None,
+        "cron": None,
+        "run_at": None,
+        "repeat_every_days": None,
+        "repeat_end_type": None,
+        "repeat_until": None,
+        "repeat_count": None,
+        "channel": None,
+        "target_user": None,
+        "target_session": None,
+        "text": None,
+        "timezone": None,
+        "enabled": None,
+        "mode": None,
+        "silent": None,
+        "save_result_to_inbox": None,
+        "share_session": None,
+        "timeout_seconds": None,
+        "tool_safety": None,
+    }
+    defaults.update(overrides)
+    return _resolve_update_spec(spec=full_spec, **defaults)
+
+
+def _text_job_spec() -> dict:
+    return {
+        "name": "original",
+        "enabled": True,
+        "schedule": {
+            "type": "cron",
+            "cron": "0 4 * * *",
+            "timezone": "Asia/Shanghai",
+        },
+        "task_type": "text",
+        "text": "hello",
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {"user_id": "u1", "session_id": "s1"},
+            "mode": "final",
+            "meta": {"origin": "console"},
+        },
+        "runtime": {
+            "max_concurrency": 4,
+            "misfire_grace_seconds": 1800,
+            "timeout_seconds": 300,
+            "share_session": True,
+            "tool_safety": False,
+        },
+        "meta": {"team": "ops"},
+    }
+
+
+def _agent_job_spec() -> dict:
+    return {
+        "name": "agent-job",
+        "enabled": True,
+        "schedule": {
+            "type": "cron",
+            "cron": "*/5 * * * *",
+            "timezone": "UTC",
+        },
+        "task_type": "agent",
+        "request": {
+            "input": [
+                {
+                    "role": "user",
+                    "type": "message",
+                    "content": [{"type": "text", "text": "run task"}],
+                },
+            ],
+            "session_id": "s1",
+            "user_id": "u1",
+            "model": "custom-model",
+            "request_context": {"source_tag": "ops"},
+        },
+        "dispatch": {
+            "type": "channel",
+            "channel": "console",
+            "target": {"user_id": "u1", "session_id": "s1"},
+            "mode": "final",
+        },
+        "runtime": {
+            "max_concurrency": 1,
+            "timeout_seconds": 120,
+            "misfire_grace_seconds": 600,
+            "share_session": False,
+            "tool_safety": False,
+        },
+    }
+
+
+def test_update_preserves_runtime_fields():
+    """Renaming a job must keep max_concurrency & misfire_grace_seconds."""
+    result = _update(_text_job_spec(), name="renamed")
+
+    assert result["name"] == "renamed"
+    assert result["runtime"]["max_concurrency"] == 4
+    assert result["runtime"]["misfire_grace_seconds"] == 1800
+    assert result["runtime"]["timeout_seconds"] == 300
+
+
+def test_update_preserves_request_extensions():
+    """Renaming an agent job must preserve model and request_context."""
+    result = _update(_agent_job_spec(), name="renamed-agent")
+
+    assert result["name"] == "renamed-agent"
+    assert result["request"]["model"] == "custom-model"
+    assert result["request"]["request_context"] == {"source_tag": "ops"}
+
+
+def test_update_preserves_meta_and_dispatch_meta():
+    """Job meta and dispatch.meta survive a partial update."""
+    result = _update(_text_job_spec(), name="renamed")
+
+    assert result["meta"] == {"team": "ops"}
+    assert result["dispatch"]["meta"] == {"origin": "console"}
+
+
+def test_update_cli_override_applies():
+    """CLI-provided values override; untouched fields survive."""
+    result = _update(
+        _text_job_spec(),
+        name="new-name",
+        enabled=False,
+        timeout_seconds=900,
+        channel="dingtalk",
+        target_user="u2",
+    )
+
+    assert result["name"] == "new-name"
+    assert result["enabled"] is False
+    assert result["runtime"]["timeout_seconds"] == 900
+    assert result["dispatch"]["channel"] == "dingtalk"
+    assert result["dispatch"]["target"]["user_id"] == "u2"
+    # untouched fields preserved
+    assert result["runtime"]["max_concurrency"] == 4
+    assert result["runtime"]["misfire_grace_seconds"] == 1800
+    assert result["dispatch"]["target"]["session_id"] == "s1"
+
+
+def test_update_does_not_mutate_input_spec():
+    """The existing spec dict must not be modified in place."""
+    spec = _text_job_spec()
+    snapshot = copy.deepcopy(spec)
+
+    _update(spec, name="renamed", timeout_seconds=900)
+
+    assert spec == snapshot
+
+
+def test_update_schedule_type_scheduled_maps_to_once():
+    """--schedule-type scheduled must write API value 'once'."""
+    spec = _text_job_spec()
+    spec["schedule"] = {
+        "type": "once",
+        "run_at": "2026-08-01T09:00:00",
+        "timezone": "UTC",
+    }
+
+    result = _update(
+        spec,
+        schedule_type="scheduled",
+        run_at="2026-09-01T10:00:00",
+    )
+
+    assert result["schedule"]["type"] == "once"
+    assert result["schedule"]["run_at"] == "2026-09-01T10:00:00"
+
+
+def test_update_once_schedule_survives_rename():
+    """A once-schedule with repeat fields is kept intact on rename."""
+    spec = _text_job_spec()
+    spec["schedule"] = {
+        "type": "once",
+        "run_at": "2026-08-01T09:00:00",
+        "timezone": "Asia/Shanghai",
+        "repeat_every_days": 2,
+        "repeat_end_type": "count",
+        "repeat_count": 5,
+    }
+
+    result = _update(spec, name="renamed")
+
+    assert result["schedule"] == spec["schedule"]
+
+
+def test_update_agent_text_replaces_prompt_keeps_extensions():
+    """--text on an agent job replaces the prompt but keeps model etc."""
+    result = _update(_agent_job_spec(), text="new prompt")
+
+    content = result["request"]["input"][0]["content"][0]
+    assert content["text"] == "new prompt"
+    assert result["request"]["model"] == "custom-model"
+    assert result["request"]["request_context"] == {"source_tag": "ops"}
+
+
+def test_update_agent_text_with_malformed_input_rebuilds():
+    """--text on an agent job with empty/malformed input rebuilds it."""
+    spec = _agent_job_spec()
+    spec["request"]["input"] = []
+
+    result = _update(spec, text="fresh prompt")
+
+    content = result["request"]["input"][0]["content"][0]
+    assert content["text"] == "fresh prompt"
+
+    spec2 = _agent_job_spec()
+    spec2["request"]["input"] = [
+        {"role": "user", "type": "message", "content": []},
+    ]
+
+    result2 = _update(spec2, text="fresh prompt")
+
+    content2 = result2["request"]["input"][0]["content"][0]
+    assert content2["text"] == "fresh prompt"


### PR DESCRIPTION
## Description

`qwenpaw cron update` documented that only explicitly provided options are changed, but it actually rebuilt the entire job spec via `_build_spec_from_cli` (designed for **create**). That function hardcodes `max_concurrency=1` and `misfire_grace_seconds=600`, and only emits fields that have a corresponding CLI option. Any other field — advanced runtime settings, request extensions like `model` / `request_context`, etc. — was silently reset or dropped on update.

**Related Issue:** Fixes #6176

**What this PR does:** rewrote `_resolve_update_spec` to **deep-copy** the existing spec and only **patch** fields explicitly provided by the CLI:

- `runtime.max_concurrency`, `runtime.misfire_grace_seconds` — preserved
- `request.model`, `request.request_context` and other request extensions — preserved
- `meta`, `dispatch.meta` — preserved
- All CLI-provided overrides still apply correctly

Two extra bugs fixed along the way (both found while testing against the real API model):

1. `--schedule-type scheduled` previously wrote `"scheduled"` into `schedule.type`, which the server rejects with 422 (`CronJobSpec` only accepts `cron`/`once`). It now maps to the API value `"once"`.
2. `--text` on an agent job whose `request.input` is empty/malformed previously crashed with `IndexError`; it now rebuilds the message structure.

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] CLI
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — not needed, behavior now matches existing docs
- [x] Ready for review

## Testing

```bash
pytest tests/unit/cli/test_cron_cmd.py -v
```

9 new regression tests in `tests/unit/cli/test_cron_cmd.py`:

- rename-only preserves `max_concurrency` / `misfire_grace_seconds` / `timeout_seconds`
- rename-only preserves `request.model` / `request.request_context`
- rename-only preserves `meta` / `dispatch.meta`
- CLI overrides (`--name` / `--no-enabled` / `--timeout` / `--channel` / `--target-user`) apply while untouched fields survive
- input spec dict is not mutated in place
- `--schedule-type scheduled` maps to API value `once`
- once-schedule with repeat fields survives a rename
- `--text` on agent job replaces prompt but keeps request extensions
- `--text` on agent job with empty/malformed `request.input` rebuilds it

## Evidence

Unit + surrounding suites (309 passed):

```text
$ pytest tests/unit/cli/ tests/unit/app/crons/ -q
........................................................................ [ 29%]
........................................................................ [ 59%]
........................................................................ [ 93%]
.....................                                                    [100%]
309 passed in 32.15s
```

pre-commit:

```text
$ pre-commit run --files src/qwenpaw/cli/cron_cmd.py tests/unit/cli/test_cron_cmd.py
check python ast.................................Passed
mypy.............................................Passed
black............................................Passed
flake8...........................................Passed
pylint...........................................Passed
... (all 17 hooks passed/skipped, none failed)
```

End-to-end against the real FastAPI cron router (create job with advanced fields via JSON → update via real CLI command → read back):

```text
1) created job 6710753f-...   max_concurrency=4
2) CLI update --name renamed -> exit 0
   PASS: name == renamed
   PASS: runtime.max_concurrency == 4
   PASS: runtime.misfire_grace_seconds == 1800
   PASS: runtime.timeout_seconds == 300
   PASS: request.model == custom-model
   PASS: request.request_context preserved
   PASS: dispatch.meta preserved
   PASS: meta preserved
   PASS: schedule.timezone preserved
4) CLI override --timeout 900 --no-enabled -> PASS (max_concurrency still 4)
5) CLI --text updates prompt, model preserved -> PASS
6) once job rename keeps schedule/repeat/runtime -> PASS
7) --schedule-type scheduled maps to once, server accepts -> PASS
```

The same end-to-end script against the **unfixed** code fails immediately with `KeyError: 'model'` (request extensions dropped), confirming the regression and the fix.

## Additional Notes

This is a re-open of #6200 (closed while fixing CI): rebased onto latest `main`, fixed the black/pylint pre-commit failures, and added the `scheduled`→`once` mapping fix plus malformed-input handling.
