### PR TITLE
perf(drivers): initialize handlers concurrently

### DIFF
--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -40,6 +40,8 @@ from .storage import (
 )
 
 logger = logging.getLogger(__name__)
+# Start common multi-MCP setups in one wave without unbounded process launches.
+_DRIVER_STARTUP_CONCURRENCY = 8
 _SHUTDOWN_TIMEOUT_SECONDS = 10.0
 EndpointValidator = Callable[[DriverCard], None]
 
@@ -88,7 +90,7 @@ class DriverManager:
 
     async def build_drivers(self) -> None:
         """Scan cards_dir and build enabled handlers."""
-        built: dict[str, DriverHandler] = {}
+        cards: list[DriverCard] = []
         for path in await self._card_store.list_paths():
             try:
                 card = await self._card_store.load_path(path)
@@ -100,15 +102,25 @@ class DriverManager:
                     exc_info=True,
                 )
                 continue
+            if not card.enabled:
+                logger.debug(
+                    "Driver '%s' is disabled; skipping",
+                    card.name,
+                )
+                continue
+            cards.append(card)
+
+        startup_limit = asyncio.Semaphore(_DRIVER_STARTUP_CONCURRENCY)
+        initialized_handlers: list[DriverHandler] = []
+
+        async def build_handler(
+            card: DriverCard,
+        ) -> tuple[str, DriverHandler | None]:
             try:
-                if not card.enabled:
-                    logger.debug(
-                        "Driver '%s' is disabled; skipping",
-                        card.name,
-                    )
-                    continue
-                handler = await self._build_and_init_handler(card)
-                built[card.name] = handler
+                async with startup_limit:
+                    handler = await self._build_and_init_handler(card)
+                initialized_handlers.append(handler)
+                return card.name, handler
             except Exception as exc:
                 logger.warning(
                     "Failed to build Driver '%s': %s",
@@ -116,10 +128,27 @@ class DriverManager:
                     exc,
                     exc_info=True,
                 )
+                return card.name, None
 
-        async with self._lock:
-            old_handlers = self._handlers
-            self._handlers = built
+        published = False
+        try:
+            results = await asyncio.gather(
+                *(build_handler(card) for card in cards),
+            )
+            built = {
+                name: handler
+                for name, handler in results
+                if handler is not None
+            }
+
+            async with self._lock:
+                old_handlers = self._handlers
+                self._handlers = built
+                published = True
+        except asyncio.CancelledError:
+            if not published:
+                await self._shutdown_handlers(initialized_handlers)
+            raise
 
         await self._shutdown_handlers(old_handlers.values())
 

--- a/tests/unit/drivers/test_manager.py
+++ b/tests/unit/drivers/test_manager.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""Tests for DriverManager startup lifecycle behavior."""
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import qwenpaw.drivers.manager as manager_module
+from qwenpaw.drivers.contracts import DriverCard
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.manager import DriverManager
+from qwenpaw.drivers.storage import AsyncDriverCardStore
+
+
+class _MemoryCardStore(AsyncDriverCardStore):
+    """Minimal in-memory card store for manager lifecycle tests."""
+
+    def __init__(self, cards: list[DriverCard]) -> None:
+        self._cards = {card.name: card for card in cards}
+
+    async def list_paths(self) -> list[Path]:
+        return [Path(f"{name}.yaml") for name in self._cards]
+
+    async def load_path(self, path: Path) -> DriverCard:
+        return self._cards[path.stem]
+
+
+def _card(name: str, *, enabled: bool = True) -> DriverCard:
+    return DriverCard(
+        name=name,
+        protocol="test",
+        endpoint={},
+        enabled=enabled,
+    )
+
+
+def _manager(tmp_path: Path, cards: list[DriverCard]) -> DriverManager:
+    return DriverManager(
+        cards_dir=tmp_path,
+        credential_store=AsyncCredentialStore(tmp_path / "credentials.yaml"),
+        card_store=_MemoryCardStore(cards),
+    )
+
+
+def _handler(card: DriverCard) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=card.name,
+        card=card,
+        shutdown=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_drivers_initializes_enabled_handlers_concurrently(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cards = [_card("alpha"), _card("beta"), _card("gamma")]
+    manager = _manager(tmp_path, cards)
+    active = 0
+    peak = 0
+
+    async def build_handler(card: DriverCard):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return _handler(card)
+
+    monkeypatch.setattr(manager, "_build_and_init_handler", build_handler)
+
+    await manager.build_drivers()
+
+    assert peak == len(cards)
+    assert set(manager._handlers) == {"alpha", "beta", "gamma"}
+
+
+@pytest.mark.asyncio
+async def test_build_drivers_bounds_parallel_initialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cards = [_card(f"driver-{index}") for index in range(6)]
+    manager = _manager(tmp_path, cards)
+    monkeypatch.setattr(
+        manager_module,
+        "_DRIVER_STARTUP_CONCURRENCY",
+        2,
+        raising=False,
+    )
+    active = 0
+    peak = 0
+
+    async def build_handler(card: DriverCard):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return _handler(card)
+
+    monkeypatch.setattr(manager, "_build_and_init_handler", build_handler)
+
+    await manager.build_drivers()
+
+    assert peak == 2
+    assert len(manager._handlers) == len(cards)
+
+
+@pytest.mark.asyncio
+async def test_build_drivers_isolates_failures_and_skips_disabled_cards(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cards = [
+        _card("healthy"),
+        _card("broken"),
+        _card("disabled", enabled=False),
+    ]
+    manager = _manager(tmp_path, cards)
+    old_handler = _handler(_card("old"))
+    manager._handlers = {"old": old_handler}
+    attempted: list[str] = []
+
+    async def build_handler(card: DriverCard):
+        attempted.append(card.name)
+        if card.name == "broken":
+            raise RuntimeError("failed to connect")
+        return _handler(card)
+
+    monkeypatch.setattr(manager, "_build_and_init_handler", build_handler)
+
+    await manager.build_drivers()
+
+    assert attempted == ["healthy", "broken"]
+    assert set(manager._handlers) == {"healthy"}
+    old_handler.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_build_drivers_cancellation_closes_unpublished_handlers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cards = [_card("ready"), _card("blocked")]
+    manager = _manager(tmp_path, cards)
+    old_handler = _handler(_card("old"))
+    ready_handler = _handler(cards[0])
+    manager._handlers = {"old": old_handler}
+    blocked_started = asyncio.Event()
+    never_release = asyncio.Event()
+
+    async def build_handler(card: DriverCard):
+        if card.name == "ready":
+            return ready_handler
+        blocked_started.set()
+        await never_release.wait()
+        return _handler(card)
+
+    monkeypatch.setattr(manager, "_build_and_init_handler", build_handler)
+    build_task = asyncio.create_task(manager.build_drivers())
+    await asyncio.wait_for(blocked_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    build_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await build_task
+
+    ready_handler.shutdown.assert_awaited_once()
+    old_handler.shutdown.assert_not_awaited()
+    assert manager._handlers == {"old": old_handler}


### PR DESCRIPTION
## Description

Initialize enabled Driver handlers concurrently instead of awaiting each
connection serially. Startup is bounded to eight handlers at a time so common
multi-MCP setups can connect in one wave without an unbounded subprocess burst.

The change remains in the protocol-neutral `DriverManager` lifecycle layer. It
preserves card loading, disabled-card handling, per-handler failure isolation,
atomic publication, and old-handler shutdown. If batch startup is cancelled,
handlers that finished initialization but were not published are shut down.

**Related Issue:** Fixes #6193

**Security Considerations:** No credential, endpoint-validation, or approval
behavior changes. The concurrency bound limits simultaneous external process
and connection initialization.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed: no user-facing configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Verification matrix:

- Shared DriverManager startup: covered by focused unit tests
- Concurrency bound: covered with a forced limit of two
- Partial initialization failure: covered; successful handlers are published
- Startup cancellation: covered; unpublished handlers are closed
- MCP stdio / HTTP / OAuth / env-ref flows: covered by integration tests
- Individual register/reload paths: unchanged
- Console and channels: not applicable

## Evidence

The concurrency tests failed against the serial implementation with a measured
peak of `1`, then passed after the change:

```bash
.venv/bin/pytest tests/unit/drivers/test_manager.py -q
# 4 passed in 0.40s

.venv/bin/pytest tests/unit/drivers -q
# 32 passed in 1.99s

.venv/bin/pytest tests/integration/test_driver_mcp_approval_level_policy.py \
  tests/integration/test_driver_mcp_env_ref_flow.py \
  tests/integration/test_driver_mcp_http_flow.py \
  tests/integration/test_driver_mcp_oauth_flow.py \
  tests/integration/test_driver_mcp_stdio_flow.py \
  tests/integration/test_driver_workspace_lifecycle.py -q
# 18 passed in 2.39s

.venv/bin/pre-commit run --files \
  src/qwenpaw/drivers/manager.py tests/unit/drivers/test_manager.py
# All hooks passed, including mypy, black, flake8, and pylint
```

Full-repository local checks reached unrelated existing failures:

- `pre-commit run --all-files`: pylint reports four `E1120` errors in the
  unchanged `src/qwenpaw/sandbox/windows_restricted_sandbox.py`.
- `pytest tests/unit/ -x -q --tb=line`: stopped at the unchanged OneBot
  watchdog test after `2147 passed, 4 skipped`; the failing test also fails
  when run alone.

## Additional Notes

Card files are still loaded sequentially because local YAML reads are not the
reported bottleneck. Only external handler initialization is parallelized.
