### PR TITLE
fix(embedding): expose use_dimensions toggle for OpenAI-compatible APIs

### DIFF
--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2097,6 +2097,8 @@
     "embeddingMaxCacheSizeRequired": "Max cache size is required",
     "embeddingUseDimensions": "Use Custom Dimensions",
     "embeddingUseDimensionsTooltip": "Use custom embedding dimensions (only supported by some models)",
+    "useCustomDimensions": "Pass Custom Dimensions",
+    "useCustomDimensionsTooltip": "When enabled, the configured embedding dimensions will be passed to the API. Required for OpenAI-compatible APIs whose default output dimension differs from your target.",
     "embeddingDimensions": "Embedding Dimensions",
     "embeddingDimensionsTooltip": "Number of embedding dimensions; takes effect when custom dimensions are enabled",
     "embeddingDimensionsRequired": "Embedding dimensions is required",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -2116,6 +2116,8 @@
     "embeddingMaxCacheSizeRequired": "Ukuran cache maksimum wajib diisi",
     "embeddingUseDimensions": "Gunakan Dimensi Kustom",
     "embeddingUseDimensionsTooltip": "Gunakan dimensi embedding kustom (hanya didukung oleh beberapa model)",
+    "useCustomDimensions": "Pass Custom Dimensions",
+    "useCustomDimensionsTooltip": "When enabled, the configured embedding dimensions will be passed to the API.",
     "embeddingDimensions": "Dimensi Embedding",
     "embeddingDimensionsTooltip": "Jumlah dimensi embedding; berlaku ketika dimensi kustom diaktifkan",
     "embeddingDimensionsRequired": "Dimensi embedding wajib diisi",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -1719,6 +1719,8 @@
     "embeddingMaxCacheSizeRequired": "最大キャッシュサイズは必須です",
     "embeddingUseDimensions": "カスタム次元を使用",
     "embeddingUseDimensionsTooltip": "カスタム埋め込み次元を使用します（一部のモデルのみ対応）",
+    "useCustomDimensions": "Pass Custom Dimensions",
+    "useCustomDimensionsTooltip": "When enabled, the configured embedding dimensions will be passed to the API.",
     "embeddingDimensions": "埋め込み次元数",
     "embeddingDimensionsTooltip": "埋め込みの次元数。カスタム次元が有効な場合に適用されます",
     "embeddingDimensionsRequired": "埋め込み次元数は必須です",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -1947,6 +1947,8 @@
     "embeddingMaxCacheSizeRequired": "Max cache Tamanho e obrigatorio",
     "embeddingUseDimensions": "Use Personalizado Dimensions",
     "embeddingUseDimensionsTooltip": "Use custom embedding dimensions (only supported by some models)",
+    "useCustomDimensions": "Pass Custom Dimensions",
+    "useCustomDimensionsTooltip": "When enabled, the configured embedding dimensions will be passed to the API.",
     "embeddingDimensions": "Embedding Dimensions",
     "embeddingDimensionsTooltip": "Number of embedding dimensions; takes effect when custom dimensions are enabled",
     "embeddingDimensionsRequired": "Embedding dimensions is Obrigatorio",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -1734,6 +1734,8 @@
     "embeddingMaxCacheSizeRequired": "Требуется указать макс. размер кэша",
     "embeddingUseDimensions": "Использовать пользовательские размерности",
     "embeddingUseDimensionsTooltip": "Использовать пользовательские размерности эмбеддинга (поддерживается только некоторыми моделями)",
+    "useCustomDimensions": "Pass Custom Dimensions",
+    "useCustomDimensionsTooltip": "When enabled, the configured embedding dimensions will be passed to the API.",
     "embeddingDimensions": "Размерности эмбеддинга",
     "embeddingDimensionsTooltip": "Количество размерностей эмбеддинга; вступает в силу при включённых пользовательских размерностях",
     "embeddingDimensionsRequired": "Требуется указать размерности эмбеддинга",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -926,6 +926,8 @@
     "embeddingMaxCacheSizeRequired": "Bắt buộc nhập kích thước cache tối đa",
     "embeddingUseDimensions": "Dùng số chiều tùy chỉnh",
     "embeddingUseDimensionsTooltip": "Dùng số chiều embedding tùy chỉnh (chỉ một số mô hình hỗ trợ)",
+    "useCustomDimensions": "Pass Custom Dimensions",
+    "useCustomDimensionsTooltip": "When enabled, the configured embedding dimensions will be passed to the API.",
     "embeddingDimensions": "Số chiều embedding",
     "embeddingDimensionsTooltip": "Số chiều của embedding; có hiệu lực khi bật số chiều tùy chỉnh",
     "embeddingDimensionsRequired": "Bắt buộc nhập số chiều embedding",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -1956,6 +1956,8 @@
     "embeddingMaxCacheSizeRequired": "最大缓存条目数为必填项",
     "embeddingUseDimensions": "使用自定义维度",
     "embeddingUseDimensionsTooltip": "是否使用自定义向量维度（仅部分模型支持）",
+    "useCustomDimensions": "传递自定义维度",
+    "useCustomDimensionsTooltip": "启用后，配置的嵌入维度将传递给 API。当 OpenAI 兼容 API 的默认输出维度与目标维度不同时，必须开启此项。",
     "embeddingDimensions": "向量维度",
     "embeddingDimensionsTooltip": "向量嵌入的维度数，启用自定义维度后生效",
     "embeddingDimensionsRequired": "向量维度为必填项",

--- a/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
+++ b/console/src/pages/Agent/Config/components/ReMeLightMemoryCard.tsx
@@ -320,6 +320,19 @@ export function ReMeLightMemoryCard() {
                 )}
 
                 <Form.Item
+                  label={t("agentConfig.useCustomDimensions")}
+                  name={[
+                    "reme_light_memory_config",
+                    "embedding_model_config",
+                    "use_dimensions",
+                  ]}
+                  valuePropName="checked"
+                  tooltip={t("agentConfig.useCustomDimensionsTooltip")}
+                >
+                  <Switch disabled={!embeddingEnabled} />
+                </Form.Item>
+
+                <Form.Item
                   label={t("agentConfig.embeddingDimensions")}
                   name={[
                     "reme_light_memory_config",

--- a/src/qwenpaw/agents/memory/reme_config.py
+++ b/src/qwenpaw/agents/memory/reme_config.py
@@ -657,7 +657,8 @@ def _apply_embedding_config(
             "credential": _embedding_credential(embedding_config),
         },
     )
-    if embedding_config.backend == "openai":
+    # Pass dimensions to all OpenAI-compatible backends when explicitly enabled
+    if embedding_config.backend in _OPENAI_COMPAT_EMBEDDING_BACKENDS:
         components["as_embedding"]["default"][
             "pass_dimensions"
         ] = embedding_config.use_dimensions

--- a/tests/unit/agents/memory/test_reme_config.py
+++ b/tests/unit/agents/memory/test_reme_config.py
@@ -109,6 +109,55 @@ def test_openai_compatible_embedding_can_pass_dimensions() -> None:
     assert as_embedding["pass_dimensions"] is True
 
 
+def test_dashscope_embedding_can_pass_dimensions() -> None:
+    """Test that dashscope backend also supports pass_dimensions."""
+    cfg = _config_for_embedding(
+        EmbeddingModelConfig(
+            backend="dashscope",
+            api_key="dashscope-key",
+            model_name="text-embedding-v3",
+            dimensions=1024,
+            use_dimensions=True,
+        ),
+    )
+
+    as_embedding = cfg["components"]["as_embedding"]["default"]
+    assert as_embedding["dimensions"] == 1024
+    assert as_embedding["pass_dimensions"] is True
+
+
+def test_dashscope_embedding_omits_pass_dimensions_by_default() -> None:
+    """Test that dashscope backend omits pass_dimensions when not explicitly enabled."""
+    cfg = _config_for_embedding(
+        EmbeddingModelConfig(
+            backend="dashscope",
+            api_key="dashscope-key",
+            model_name="text-embedding-v3",
+            dimensions=1024,
+        ),
+    )
+
+    as_embedding = cfg["components"]["as_embedding"]["default"]
+    assert as_embedding["dimensions"] == 1024
+    assert as_embedding["pass_dimensions"] is False
+
+
+def test_gemini_embedding_omits_pass_dimensions() -> None:
+    """Test that non-OpenAI-compatible backends (gemini) don't set pass_dimensions."""
+    cfg = _config_for_embedding(
+        EmbeddingModelConfig(
+            backend="gemini",
+            api_key="gemini-key",
+            model_name="text-embedding-004",
+            dimensions=768,
+            use_dimensions=True,
+        ),
+    )
+
+    as_embedding = cfg["components"]["as_embedding"]["default"]
+    assert "pass_dimensions" not in as_embedding
+
+
 def test_openai_compatible_embedding_omits_blank_base_url() -> None:
     cfg = _config_for_embedding(
         EmbeddingModelConfig(


### PR DESCRIPTION
The Console UI exposed an 'Embedding dimensions' field but did not expose the 'use_dimensions' switch. When a user entered a custom dimension value, QwenPaw persisted use_dimensions=false, so the dimension was never passed to the embedding API. This caused dimension mismatches for OpenAI-compatible APIs whose default output dimension differs from the user's target.

Changes:
- Backend (reme_config.py): Apply pass_dimensions to all OpenAI-compatible backends (openai, dashscope, dashscope_multimodal), not just 'openai'
- Frontend (ReMeLightMemoryCard.tsx): Add 'Pass Custom Dimensions' switch before the dimensions input field
- i18n: Add translations for useCustomDimensions in all 7 locale files
- Tests: Add test cases for dashscope and gemini backends

Fixes #6242

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
