### PR TITLE
fix: distinguish offload vs cancel to prevent subprocess kill on deadline

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -625,6 +625,15 @@ async def execute_shell_command(
                 returncode = proc.returncode
 
             except (asyncio.TimeoutError, asyncio.CancelledError):
+                # Check if this is an offload (deadline reached) vs a cancel.
+                # For offload, do NOT kill the subprocess — let it continue
+                # in background under coordinator supervision.
+                from ...tool_calls import get_call_context
+                ctx = get_call_context()
+                if ctx is not None and ctx.offload_reason is not None:
+                    # Re-raise without killing; coordinator handles offload.
+                    raise
+
                 stderr_suffix = (
                     f"⚠️ TimeoutError: The command execution exceeded "
                     f"the timeout of {timeout} seconds. "

--- a/src/qwenpaw/tool_calls/_timeout_helper.py
+++ b/src/qwenpaw/tool_calls/_timeout_helper.py
@@ -48,13 +48,20 @@ async def cancellable_wait(
         )
 
         if cancel_waiter in done:
+            # Distinguish between cancel (user stop) and offload (deadline).
+            # For offload, do NOT cancel the task — let the subprocess
+            # continue running under background supervision.
+            if ctx.offload_reason is not None:
+                raise asyncio.CancelledError(
+                    f"tool offloaded (reason={ctx.offload_reason.value})"
+                )
             task.cancel()
             try:
                 await task
             except (asyncio.CancelledError, Exception):
                 pass
             raise asyncio.CancelledError(
-                f"tool cancelled by manager (reason={ctx.cancel_reason})",
+                f"tool cancelled by manager (reason={ctx.cancel_reason})"
             )
 
         return task.result()

--- a/tests/unit/tool_calls/test_cancellable_wait_offload.py
+++ b/tests/unit/tool_calls/test_cancellable_wait_offload.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Tests for offload-aware cancellable_wait.
+
+Verifies that:
+- When offload_reason is set, the task is NOT cancelled (subprocess keeps running)
+- When offload_reason is NOT set, the task IS cancelled (normal cancel behavior)
+"""
+import asyncio
+import pytest
+from unittest.mock import MagicMock, patch
+
+from qwenpaw.tool_calls._timeout_helper import cancellable_wait
+from qwenpaw.tool_calls._context import (
+    ToolCallContext,
+    OffloadReason,
+    CancelReason,
+)
+from qwenpaw.tool_calls._ctxvars import set_call_context
+
+
+@pytest.fixture
+def mock_ctx():
+    """Create a mock ToolCallContext."""
+    import time
+    ctx = ToolCallContext(
+        tool_call_id="test-123",
+        tool_name="execute_shell_command",
+        session_id="sess-1",
+        agent_id="default",
+        root_session_id="root-1",
+        started_at=time.monotonic(),
+        deadline=time.monotonic() + 10.0,
+        cancel_event=asyncio.Event(),
+    )
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_cancellable_wait_offload_does_not_cancel_task(mock_ctx):
+    """When offload_reason is set, task should NOT be cancelled."""
+    mock_ctx.offload_reason = OffloadReason.TIMEOUT
+    mock_ctx.cancel_event.set()
+
+    task_cancelled = False
+
+    async def long_running_task():
+        nonlocal task_cancelled
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            task_cancelled = True
+            raise
+
+    from qwenpaw.tool_calls._ctxvars import reset_call_context
+    token = set_call_context(mock_ctx)
+    try:
+        with pytest.raises(asyncio.CancelledError, match="offloaded"):
+            await cancellable_wait(long_running_task(), fallback_secs=1.0)
+    finally:
+        reset_call_context(token)
+
+    assert not task_cancelled, "Task should NOT be cancelled when offloading"
+
+
+@pytest.mark.asyncio
+async def test_cancellable_wait_cancel_does_cancel_task(mock_ctx):
+    """When offload_reason is NOT set (user cancel), task SHOULD be cancelled."""
+    mock_ctx.cancel_reason = CancelReason.USER
+    mock_ctx.cancel_event.set()
+
+    task_cancelled = False
+
+    async def long_running_task():
+        nonlocal task_cancelled
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            task_cancelled = True
+            raise
+
+    from qwenpaw.tool_calls._ctxvars import reset_call_context
+    token = set_call_context(mock_ctx)
+    try:
+        with pytest.raises(asyncio.CancelledError, match="cancelled by manager"):
+            await cancellable_wait(long_running_task(), fallback_secs=1.0)
+    finally:
+        reset_call_context(token)
+
+    assert task_cancelled, "Task SHOULD be cancelled when user cancels"


### PR DESCRIPTION
## Root Cause

`cancel_event` is used for **two different purposes**:
1. **User cancel** (stop button) → should kill subprocess
2. **Deadline offload** (timeout) → should keep subprocess running in background

The original code didn't distinguish between these two cases. When `_handle_deadline_reached` set `cancel_event`, `cancellable_wait` would cancel the asyncio task, and `shell.py` would kill the subprocess process group. This made offload a no-op — the subprocess was already dead before background supervision could begin.

## Fix

### `_timeout_helper.py` — `cancellable_wait()`
When `cancel_event` fires, check `ctx.offload_reason`:
- **Offload** (reason is set): raise `CancelledError` WITHOUT cancelling the task. The subprocess continues running.
- **Cancel** (reason is None): cancel the task as before (kill subprocess).

### `shell.py` — `execute_shell_command()`
When catching `CancelledError`, check `ctx.offload_reason`:
- **Offload**: re-raise without killing the subprocess. The coordinator handles background supervision.
- **Cancel**: kill the process group as before.

## Tests

Added unit tests verifying:
- Offload: task is NOT cancelled, subprocess keeps running
- Cancel: task IS cancelled, subprocess is killed

Fixes #6056
Fixes #6245
