### PR TITLE
feat(cli): add scriptable environment reads

### DIFF
--- a/src/qwenpaw/cli/env_cmd.py
+++ b/src/qwenpaw/cli/env_cmd.py
@@ -2,6 +2,8 @@
 """CLI commands for environment variable management."""
 from __future__ import annotations
 
+import json
+
 import click
 
 from ..envs import load_envs, set_env_var, delete_env_var
@@ -18,9 +20,20 @@ def env_group() -> None:
 
 
 @env_group.command("list")
-def list_cmd() -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output configured variables as a JSON object.",
+)
+def list_cmd(as_json: bool) -> None:
     """List all environment variables."""
     envs = load_envs()
+    if as_json:
+        click.echo(
+            json.dumps(envs, indent=2, ensure_ascii=False, sort_keys=True),
+        )
+        return
     if not envs:
         click.echo("No environment variables configured.")
         return
@@ -29,6 +42,21 @@ def list_cmd() -> None:
     for key in sorted(envs):
         click.echo(f"  {key:<30s}  {envs[key]}")
     click.echo()
+
+
+# ---------------------------------------------------------------
+# get
+# ---------------------------------------------------------------
+
+
+@env_group.command("get")
+@click.argument("key")
+def get_cmd(key: str) -> None:
+    """Print the value of a configured environment variable."""
+    envs = load_envs()
+    if key not in envs:
+        raise click.ClickException(f"Env var '{key}' not found.")
+    click.echo(envs[key])
 
 
 # ---------------------------------------------------------------

--- a/tests/unit/cli/test_env_cmd.py
+++ b/tests/unit/cli/test_env_cmd.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ``qwenpaw env`` CLI surface."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from qwenpaw.cli import env_cmd
+
+
+def test_env_list_json_outputs_sorted_mapping(monkeypatch) -> None:
+    monkeypatch.setattr(
+        env_cmd,
+        "load_envs",
+        lambda: {"ZEBRA_TOKEN": "last", "ALPHA_TOKEN": "first"},
+    )
+
+    result = CliRunner().invoke(env_cmd.env_group, ["list", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "ALPHA_TOKEN": "first",
+        "ZEBRA_TOKEN": "last",
+    }
+    assert result.output.index("ALPHA_TOKEN") < result.output.index(
+        "ZEBRA_TOKEN",
+    )
+
+
+def test_env_list_json_outputs_empty_object(monkeypatch) -> None:
+    monkeypatch.setattr(env_cmd, "load_envs", lambda: {})
+
+    result = CliRunner().invoke(env_cmd.env_group, ["list", "--json"])
+
+    assert result.exit_code == 0
+    assert result.output == "{}\n"
+
+
+def test_env_get_outputs_raw_value(monkeypatch) -> None:
+    monkeypatch.setattr(
+        env_cmd,
+        "load_envs",
+        lambda: {"SERVICE_TOKEN": "value with spaces"},
+    )
+
+    result = CliRunner().invoke(
+        env_cmd.env_group,
+        ["get", "SERVICE_TOKEN"],
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "value with spaces\n"
+
+
+def test_env_get_missing_key_exits_nonzero(monkeypatch) -> None:
+    monkeypatch.setattr(env_cmd, "load_envs", lambda: {})
+
+    result = CliRunner().invoke(env_cmd.env_group, ["get", "MISSING_TOKEN"])
+
+    assert result.exit_code == 1
+    assert "Env var 'MISSING_TOKEN' not found." in result.output

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -276,18 +276,26 @@ qwenpaw models set-llm          # Switch to a different Ollama model
 
 Manage environment variables used by tools and skills at runtime.
 
-| Command                     | What it does                  |
-| --------------------------- | ----------------------------- |
-| `qwenpaw env list`          | List all configured variables |
-| `qwenpaw env set KEY VALUE` | Set or update a variable      |
-| `qwenpaw env delete KEY`    | Delete a variable             |
+| Command                     | What it does                             |
+| --------------------------- | ---------------------------------------- |
+| `qwenpaw env list [--json]` | List variables as a table or JSON object |
+| `qwenpaw env get KEY`       | Print one variable value                 |
+| `qwenpaw env set KEY VALUE` | Set or update a variable                 |
+| `qwenpaw env delete KEY`    | Delete a variable                        |
 
 ```bash
 qwenpaw env list
+qwenpaw env list --json
+qwenpaw env get TAVILY_API_KEY
 qwenpaw env set TAVILY_API_KEY "tvly-xxxxxxxx"
 qwenpaw env set GITHUB_TOKEN "ghp_xxxxxxxx"  # fine-grained PATs starting with github_pat_ are also supported
 qwenpaw env delete TAVILY_API_KEY
 ```
+
+`get` and `list --json` read the encrypted environment store on every
+invocation, so scripts can observe values written by another process without
+restarting the backend. Both commands print unmasked values; do not send their
+output to shared logs.
 
 > **Note:** QwenPaw only stores and loads these values; you are responsible for
 > ensuring they are correct. See
@@ -779,7 +787,7 @@ See [Config & Working Directory](./config) and [Multi-Agent](./multi-agent) for 
 | `qwenpaw doctor`    | `fix`                                                                                |        No        |
 | `qwenpaw daemon`    | `status` · `restart` · `reload-config` · `version` · `logs`                          |        No        |
 | `qwenpaw models`    | `list` · `config` · `config-key` · `set-llm` · `download` · `local` · `remove-local` |        No        |
-| `qwenpaw env`       | `list` · `set` · `delete`                                                            |        No        |
+| `qwenpaw env`       | `list` · `get` · `set` · `delete`                                                    |        No        |
 | `qwenpaw channels`  | `list` · `send` · `install` · `add` · `remove` · `config`                            |     **Yes**      |
 | `qwenpaw agents`    | `list` · `create` · `delete` · `chat`                                                |    Partial ¹     |
 | `qwenpaw cron`      | `list` · `get` · `state` · `create` · `delete` · `pause` · `resume` · `run`          |     **Yes**      |

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -263,18 +263,24 @@ qwenpaw models set-llm          # 切换到其他 Ollama 模型
 
 管理工具和技能在运行时使用的环境变量。
 
-| 命令                        | 说明                 |
-| --------------------------- | -------------------- |
-| `qwenpaw env list`          | 列出所有已配置的变量 |
-| `qwenpaw env set KEY VALUE` | 设置或更新变量       |
-| `qwenpaw env delete KEY`    | 删除变量             |
+| 命令                        | 说明                           |
+| --------------------------- | ------------------------------ |
+| `qwenpaw env list [--json]` | 以表格或 JSON 对象列出所有变量 |
+| `qwenpaw env get KEY`       | 输出一个变量的值               |
+| `qwenpaw env set KEY VALUE` | 设置或更新变量                 |
+| `qwenpaw env delete KEY`    | 删除变量                       |
 
 ```bash
 qwenpaw env list
+qwenpaw env list --json
+qwenpaw env get TAVILY_API_KEY
 qwenpaw env set TAVILY_API_KEY "tvly-xxxxxxxx"
 qwenpaw env set GITHUB_TOKEN "ghp_xxxxxxxx"  # 也支持以 github_pat_ 开头的 fine-grained PAT
 qwenpaw env delete TAVILY_API_KEY
 ```
+
+`get` 和 `list --json` 每次执行都会读取加密环境变量存储，因此脚本无需重启后端，
+也能读取其他进程刚写入的值。这两个命令会输出未脱敏的值，请勿将输出写入共享日志。
 
 > **注意：** QwenPaw 只负责存储和加载，值的有效性需要用户自行保证。
 > 详见 [配置 — 环境变量](./config#环境变量)。
@@ -761,7 +767,7 @@ qwenpaw --host 0.0.0.0 --port 9090 cron list
 | `qwenpaw doctor`    | `fix`                                                                                |        否         |
 | `qwenpaw daemon`    | `status` · `restart` · `reload-config` · `version` · `logs`                          |        否         |
 | `qwenpaw models`    | `list` · `config` · `config-key` · `set-llm` · `download` · `local` · `remove-local` |        否         |
-| `qwenpaw env`       | `list` · `set` · `delete`                                                            |        否         |
+| `qwenpaw env`       | `list` · `get` · `set` · `delete`                                                    |        否         |
 | `qwenpaw channels`  | `list` · `send` · `install` · `add` · `remove` · `config`                            |      **是**       |
 | `qwenpaw agents`    | `list` · `create` · `delete` · `chat`                                                |    部分需要 ¹     |
 | `qwenpaw cron`      | `list` · `get` · `state` · `create` · `delete` · `pause` · `resume` · `run`          |      **是**       |


### PR DESCRIPTION
## Description

Add script-friendly reads for QwenPaw's canonical encrypted environment store:

- `qwenpaw env get KEY` prints one value without labels and exits non-zero when the key is missing.
- `qwenpaw env list --json` emits a stable, sorted JSON object, including `{}` for an empty store.
- The existing human-readable `qwenpaw env list` behavior remains unchanged.
- English and Chinese CLI references document both commands and their secret-output behavior.

Each command reads the store on invocation, so a newly launched script can observe updates written by another process without restarting the backend. This deliberately avoids special-casing only `execute_shell_command`, which would leave ACP, plugin, and other process callers with inconsistent behavior.

**Related Issue:** Fixes #4641

**Security Considerations:** These commands intentionally expose the same unmasked values already available through `qwenpaw env list`. They do not add logging or change encrypted persistence and file permissions. The documentation warns against sending command output to shared logs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Verification matrix:

- `env get`, existing key: raw value covered
- `env get`, missing key: exit status 1 covered
- `env list --json`, populated store: valid, sorted JSON covered
- `env list --json`, empty store: stable `{}` covered
- Existing CLI commands: full CLI unit suite covered
- Persistence/encryption: unchanged
- Console, channels, providers: not applicable

## Evidence

The new tests failed before implementation because Click returned exit status 2 for the unknown command and option. After implementation:

```bash
.venv/bin/pytest tests/unit/cli/test_env_cmd.py -q
# 4 passed in 0.17s

.venv/bin/pytest tests/unit/cli/ -q
# 244 passed in 25.67s

.venv/bin/pre-commit run --files \
  src/qwenpaw/cli/env_cmd.py \
  tests/unit/cli/test_env_cmd.py \
  website/public/docs/cli.en.md \
  website/public/docs/cli.zh.md
# All applicable hooks passed, including mypy, black, flake8, and pylint.

cd website
node_modules/.bin/prettier --check .
# All matched files use Prettier code style!
```

## Additional Notes

This PR provides an explicit cross-process read path; it does not mutate the environment snapshot of an already-running backend. Callers that need a newly stored value should invoke `qwenpaw env get` or parse `qwenpaw env list --json`.

The full website TypeScript check could not run in this checkout because local website dependencies are incomplete (`js-yaml` and `@supabase/supabase-js` are missing), and the restricted environment prevents writing `tsconfig.tsbuildinfo`. No TypeScript files are changed.