### PR TITLE
fix(scroll): retry once after context overflow

### DIFF
--- a/src/qwenpaw/agents/context/base.py
+++ b/src/qwenpaw/agents/context/base.py
@@ -2,11 +2,12 @@
 """The pluggable context-manager interface.
 
 A ``ContextManager`` is an injectable strategy that owns an agent's context
-management. :class:`~qwenpaw.agents.react_agent.QwenPawAgent` delegates its two
-AgentScope hooks to it:
+management. :class:`~qwenpaw.agents.react_agent.QwenPawAgent` delegates its
+AgentScope hooks and provider-overflow recovery to it:
 
 * ``_save_to_context`` -> :meth:`on_save` (after the base append)
 * ``compress_context`` -> :meth:`compress` (instead of the base compression)
+* overflow retry -> :meth:`recover_from_context_overflow`
 
 When no manager is injected, the agent keeps its native AgentScope behavior —
 so a strategy is purely additive and fully opt-in.
@@ -19,6 +20,13 @@ from typing import Any, Protocol, Sequence, runtime_checkable
 @runtime_checkable
 class ContextManager(Protocol):
     """Strategy that drives an agent's context management."""
+
+    async def recover_from_context_overflow(self, agent: Any) -> bool:
+        """Try to shorten an input rejected by the model provider.
+
+        Return ``True`` only when recovery changed the model input enough to
+        justify rebuilding it and retrying the provider request once.
+        """
 
     async def compress(
         self,

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -59,6 +59,7 @@ _PROTECTED_RECENT_TOOL_RESULTS = 5
 _OUTPUT_RESERVE_RATIO = 0.05
 _MAX_OUTPUT_RESERVE_TOKENS = 4096
 _SUMMARY_UPDATE_TIMEOUT_SECONDS = 60.0
+_OVERFLOW_FORCE_TRIGGER_RATIO = 1e-6
 _SummaryRecords = tuple[
     list[tuple[int, str]],
     list[tuple[int, str]],
@@ -82,9 +83,6 @@ class ScrollContextManager:
     agent; ``session_id`` (the conversation) and ``agent_id`` (which agent) are
     threaded onto each row so cross-session, per-agent recall works.
     """
-
-    # Opt in to QwenPawAgent's one-shot provider-overflow recovery.
-    supports_context_overflow_recovery = True
 
     def __init__(
         self,
@@ -340,6 +338,29 @@ class ScrollContextManager:
             await self._offloader.offload_context(self._session_id, middle)
         except Exception:  # noqa: BLE001 - archive is best-effort
             logger.warning("scroll dialog offload failed", exc_info=True)
+
+    async def recover_from_context_overflow(self, agent: Any) -> bool:
+        """Force one compaction after a provider rejects an oversized input."""
+        base_config = getattr(agent, "context_config", None)
+        if base_config is None:
+            return False
+        try:
+            forced_config = base_config.model_copy(
+                update={"trigger_ratio": _OVERFLOW_FORCE_TRIGGER_RATIO},
+            )
+        except Exception:
+            logger.warning(
+                "Could not clone context_config for context-overflow "
+                "recovery; skipping the recovery attempt.",
+                exc_info=True,
+            )
+            return False
+
+        await self.compress(agent, forced_config)
+        return bool(
+            self.last_compress.get("evicted")
+            or self.last_compress.get("folded"),
+        )
 
     # pylint: disable-next=too-many-statements,too-many-branches
     async def compress(

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -83,6 +83,9 @@ class ScrollContextManager:
     threaded onto each row so cross-session, per-agent recall works.
     """
 
+    # Opt in to QwenPawAgent's one-shot provider-overflow recovery.
+    supports_context_overflow_recovery = True
+
     def __init__(
         self,
         *,

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -46,6 +46,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Context-overflow recovery must bypass Scroll's normal token trigger: the
+# provider has already established that the request is too large, even if the
+# local estimator says otherwise.  ContextConfig constrains the ratio to be
+# positive, so use the same negligible value as the manual /compact path.
+_CONTEXT_OVERFLOW_FORCE_TRIGGER_RATIO = 1e-6
+
 
 def _effective_artifact_retention_days(light_context_config: Any) -> int:
     """Return the independently configured tool-result artifact lifetime."""
@@ -452,6 +458,116 @@ class QwenPawAgent(CodingModeMixin, Agent):
         if formatter is None:
             return
         setattr(formatter, "_qwenpaw_force_strip_media", enabled)
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        """Return whether *exc* is a provider 400 for an oversized input.
+
+        A bare 400 is deliberately insufficient: malformed tool schemas,
+        unsupported parameters, and media errors must keep their existing
+        handling.  Prefer the structured status code when the SDK exposes it,
+        with the rendered exception as a compatibility fallback for gateways
+        that wrap the original response.
+        """
+        status = getattr(exc, "status_code", None)
+        if status is None:
+            response = getattr(exc, "response", None)
+            status = getattr(response, "status_code", None)
+
+        error_str = str(exc).lower()
+        if status != 400 and "error code: 400" not in error_str:
+            return False
+
+        overflow_markers = (
+            "range of input length",
+            "context length exceeded",
+            "context_length_exceeded",
+            "maximum context length",
+            "maximum context window",
+            "max input length",
+            "input length should be",
+            "input is too long",
+            "prompt is too long",
+            "prompt too long",
+            "too many input tokens",
+        )
+        return any(marker in error_str for marker in overflow_markers)
+
+    def _context_overflow_compact_config(self) -> Any:
+        """Clone ContextConfig with an effectively unconditional trigger."""
+        base = getattr(self, "context_config", None)
+        if base is None:
+            return None
+        try:
+            return base.model_copy(
+                update={
+                    "trigger_ratio": _CONTEXT_OVERFLOW_FORCE_TRIGGER_RATIO,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "Could not clone context_config for context-overflow "
+                "recovery; skipping the recovery attempt.",
+                exc_info=True,
+            )
+            return None
+
+    async def _call_model(
+        self,
+        messages: list[Msg],
+        tools: list[dict],
+        tool_choice: Any = None,
+    ) -> Any:
+        """Call the model, recovering once from a provider input overflow.
+
+        The normal Scroll gate depends on an approximate local token count.
+        When the provider rejects the request as too large, force one Scroll
+        pass regardless of that estimate, rebuild the complete model input,
+        and retry exactly once.  The retry calls AgentScope directly, so a
+        second overflow propagates instead of entering a recovery loop.
+        """
+        try:
+            return await super()._call_model(
+                messages=messages,
+                tools=tools,
+                tool_choice=tool_choice,
+            )
+        except Exception as exc:
+            context_manager = getattr(self, "_context_manager", None)
+            if (
+                context_manager is None
+                or not hasattr(context_manager, "compress")
+                or not self._is_context_overflow_error(exc)
+            ):
+                raise
+
+            forced_config = self._context_overflow_compact_config()
+            if forced_config is None:
+                raise
+
+            before = len(getattr(self.state, "context", []) or [])
+            logger.warning(
+                "Model input exceeded the provider context limit; forcing "
+                "one Scroll compaction and retry.",
+            )
+            await context_manager.compress(self, forced_config)
+            after = len(getattr(self.state, "context", []) or [])
+
+            # The original `messages` list was prepared before compaction and
+            # can still reference evicted turns.  Always rebuild it from the
+            # updated agent state before retrying.
+            refreshed = await self._prepare_model_input()
+            logger.info(
+                "Context-overflow recovery rebuilt model input after Scroll "
+                "compaction (messages %d -> %d).",
+                before,
+                after,
+            )
+            return await super()._call_model(
+                messages=refreshed["messages"],
+                tools=refreshed.get("tools", []),
+                tool_choice=tool_choice,
+            )
 
     # pylint: disable=too-many-branches,too-many-statements
     async def _reasoning(

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal, Optional, TYPE_CHECKING
 
@@ -29,6 +28,7 @@ from agentscope.model import FinishedReason
 from agentscope.state import AgentState
 from agentscope.tool import Toolkit
 
+from .context.base import ContextManager
 from .skill_system import get_workspace_skills_dir
 from ..modes.coding import CodingModeMixin
 from ..utils.io_utils import run_sync_io
@@ -47,12 +47,6 @@ if TYPE_CHECKING:
     from ..config.config import AgentProfileConfig
 
 logger = logging.getLogger(__name__)
-
-# Context-overflow recovery must bypass Scroll's normal token trigger: the
-# provider has already established that the request is too large, even if the
-# local estimator says otherwise.  ContextConfig constrains the ratio to be
-# positive, so use the same negligible value as the manual /compact path.
-_CONTEXT_OVERFLOW_FORCE_TRIGGER_RATIO = 1e-6
 
 
 def _effective_artifact_retention_days(light_context_config: Any) -> int:
@@ -89,7 +83,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
         memory_manager: "BaseMemoryManager | None" = None,
         offloader: Any = None,
         context_config: Any = None,
-        context_manager: Any = None,
+        context_manager: ContextManager | None = None,
         effective_skills: Optional[list[str]] = None,
         governor: Any = None,
     ):
@@ -491,32 +485,6 @@ class QwenPawAgent(CodingModeMixin, Agent):
         )
         return any(marker in error_str for marker in overflow_markers)
 
-    def _context_overflow_compact_config(self) -> Any:
-        """Clone ContextConfig with an effectively unconditional trigger."""
-        base = getattr(self, "context_config", None)
-        if base is None:
-            return None
-        try:
-            return base.model_copy(
-                update={
-                    "trigger_ratio": _CONTEXT_OVERFLOW_FORCE_TRIGGER_RATIO,
-                },
-            )
-        except Exception:
-            logger.warning(
-                "Could not clone context_config for context-overflow "
-                "recovery; skipping the recovery attempt.",
-                exc_info=True,
-            )
-            return None
-
-    @staticmethod
-    def _conversation_model_input(messages: list[Any]) -> list[Any]:
-        """Return model messages excluding the regenerated system message."""
-        if messages and getattr(messages[0], "role", None) == "system":
-            return messages[1:]
-        return messages
-
     async def _call_model(
         self,
         messages: list[Msg],
@@ -525,11 +493,10 @@ class QwenPawAgent(CodingModeMixin, Agent):
     ) -> Any:
         """Call the model, recovering once from a provider input overflow.
 
-        The normal Scroll gate depends on an approximate local token count.
-        When the provider rejects the request as too large, force one Scroll
-        pass regardless of that estimate, rebuild the complete model input,
-        and retry exactly once.  The retry calls AgentScope directly, so a
-        second overflow propagates instead of entering a recovery loop.
+        When the provider rejects the request as too large, let the configured
+        context manager attempt recovery. Rebuild and retry only when that
+        recovery changed the model input. The retry calls AgentScope directly,
+        so a second overflow propagates instead of entering a recovery loop.
         """
         try:
             return await super()._call_model(
@@ -539,37 +506,26 @@ class QwenPawAgent(CodingModeMixin, Agent):
             )
         except Exception as exc:
             context_manager = getattr(self, "_context_manager", None)
-            if (
-                context_manager is None
-                or not getattr(
-                    context_manager,
-                    "supports_context_overflow_recovery",
-                    False,
-                )
-                or not self._is_context_overflow_error(exc)
-            ):
-                raise
-
-            forced_config = self._context_overflow_compact_config()
-            if forced_config is None:
+            if not isinstance(
+                context_manager,
+                ContextManager,
+            ) or not self._is_context_overflow_error(exc):
                 raise
 
             before = len(getattr(self.state, "context", []) or [])
             logger.warning(
-                "Model input exceeded the provider context limit; forcing "
-                "one Scroll compaction and retry.",
+                "Model input exceeded the provider context limit; attempting "
+                "one context recovery.",
             )
-            tracks_compress_stats = isinstance(
-                getattr(context_manager, "last_compress", None),
-                dict,
+            input_changed = (
+                await context_manager.recover_from_context_overflow(self)
             )
-            original_messages = (
-                None
-                if tracks_compress_stats
-                else deepcopy(self._conversation_model_input(messages))
-            )
-            original_tools = None if tracks_compress_stats else deepcopy(tools)
-            await self.compress_context(forced_config)
+            if not input_changed:
+                logger.warning(
+                    "Context-overflow recovery did not change the model "
+                    "input; skipping the retry.",
+                )
+                raise
             after = len(getattr(self.state, "context", []) or [])
 
             # The original `messages` list was prepared before compaction and
@@ -578,29 +534,9 @@ class QwenPawAgent(CodingModeMixin, Agent):
             refreshed = await self._prepare_model_input()
             refreshed_messages = refreshed["messages"]
             refreshed_tools = refreshed.get("tools", [])
-            compress_stats = getattr(context_manager, "last_compress", None)
-            if isinstance(compress_stats, dict):
-                input_changed = bool(
-                    compress_stats.get("evicted")
-                    or compress_stats.get("folded"),
-                )
-            else:
-                assert original_messages is not None
-                assert original_tools is not None
-                input_changed = not (
-                    self._conversation_model_input(refreshed_messages)
-                    == original_messages
-                    and refreshed_tools == original_tools
-                )
-            if not input_changed:
-                logger.warning(
-                    "Context-overflow recovery did not change the model "
-                    "input; skipping the retry.",
-                )
-                raise
             logger.info(
-                "Context-overflow recovery rebuilt model input after Scroll "
-                "compaction (messages %d -> %d).",
+                "Context-overflow recovery rebuilt model input "
+                "(messages %d -> %d).",
                 before,
                 after,
             )

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -483,7 +483,23 @@ class QwenPawAgent(CodingModeMixin, Agent):
             "prompt too long",
             "too many input tokens",
         )
-        return any(marker in error_str for marker in overflow_markers)
+        if any(marker in error_str for marker in overflow_markers):
+            return True
+
+        gemini_overflow_marker_groups = (
+            (
+                "input token count",
+                "exceeds the maximum number of tokens allowed",
+            ),
+            (
+                "input token count",
+                "model only supports up to",
+            ),
+        )
+        return any(
+            all(marker in error_str for marker in marker_group)
+            for marker_group in gemini_overflow_marker_groups
+        )
 
     async def _call_model(
         self,

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal, Optional, TYPE_CHECKING
 
@@ -38,6 +39,7 @@ from ..constant import (
     WORKING_DIR,
 )
 from ..loop.gates import StopAction, StopHandlerResult
+from ..providers.error_utils import extract_status_code
 from ..providers.model_capability_cache import get_capability_cache
 
 if TYPE_CHECKING:
@@ -469,11 +471,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
         with the rendered exception as a compatibility fallback for gateways
         that wrap the original response.
         """
-        status = getattr(exc, "status_code", None)
-        if status is None:
-            response = getattr(exc, "response", None)
-            status = getattr(response, "status_code", None)
-
+        status = extract_status_code(exc)
         error_str = str(exc).lower()
         if status != 400 and "error code: 400" not in error_str:
             return False
@@ -511,6 +509,13 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 exc_info=True,
             )
             return None
+
+    @staticmethod
+    def _conversation_model_input(messages: list[Any]) -> list[Any]:
+        """Return model messages excluding the regenerated system message."""
+        if messages and getattr(messages[0], "role", None) == "system":
+            return messages[1:]
+        return messages
 
     async def _call_model(
         self,
@@ -554,6 +559,16 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 "Model input exceeded the provider context limit; forcing "
                 "one Scroll compaction and retry.",
             )
+            tracks_compress_stats = isinstance(
+                getattr(context_manager, "last_compress", None),
+                dict,
+            )
+            original_messages = (
+                None
+                if tracks_compress_stats
+                else deepcopy(self._conversation_model_input(messages))
+            )
+            original_tools = None if tracks_compress_stats else deepcopy(tools)
             await self.compress_context(forced_config)
             after = len(getattr(self.state, "context", []) or [])
 
@@ -561,6 +576,28 @@ class QwenPawAgent(CodingModeMixin, Agent):
             # can still reference evicted turns.  Always rebuild it from the
             # updated agent state before retrying.
             refreshed = await self._prepare_model_input()
+            refreshed_messages = refreshed["messages"]
+            refreshed_tools = refreshed.get("tools", [])
+            compress_stats = getattr(context_manager, "last_compress", None)
+            if isinstance(compress_stats, dict):
+                input_changed = bool(
+                    compress_stats.get("evicted")
+                    or compress_stats.get("folded"),
+                )
+            else:
+                assert original_messages is not None
+                assert original_tools is not None
+                input_changed = not (
+                    self._conversation_model_input(refreshed_messages)
+                    == original_messages
+                    and refreshed_tools == original_tools
+                )
+            if not input_changed:
+                logger.warning(
+                    "Context-overflow recovery did not change the model "
+                    "input; skipping the retry.",
+                )
+                raise
             logger.info(
                 "Context-overflow recovery rebuilt model input after Scroll "
                 "compaction (messages %d -> %d).",
@@ -568,8 +605,8 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 after,
             )
             return await super()._call_model(
-                messages=refreshed["messages"],
-                tools=refreshed.get("tools", []),
+                messages=refreshed_messages,
+                tools=refreshed_tools,
                 tool_choice=tool_choice,
             )
 

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -536,7 +536,11 @@ class QwenPawAgent(CodingModeMixin, Agent):
             context_manager = getattr(self, "_context_manager", None)
             if (
                 context_manager is None
-                or not hasattr(context_manager, "compress")
+                or not getattr(
+                    context_manager,
+                    "supports_context_overflow_recovery",
+                    False,
+                )
                 or not self._is_context_overflow_error(exc)
             ):
                 raise
@@ -550,7 +554,7 @@ class QwenPawAgent(CodingModeMixin, Agent):
                 "Model input exceeded the provider context limit; forcing "
                 "one Scroll compaction and retry.",
             )
-            await context_manager.compress(self, forced_config)
+            await self.compress_context(forced_config)
             after = len(getattr(self.state, "context", []) or [])
 
             # The original `messages` list was prepared before compaction and

--- a/src/qwenpaw/providers/error_utils.py
+++ b/src/qwenpaw/providers/error_utils.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Shared helpers for normalizing provider SDK exceptions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _as_http_status(value: Any) -> int | None:
+    """Return *value* as a valid HTTP status code, if possible."""
+    if isinstance(value, bool):
+        return None
+    try:
+        status = int(value)
+    except (TypeError, ValueError):
+        return None
+    return status if 100 <= status <= 599 else None
+
+
+def extract_status_code(exc: Exception) -> int | None:
+    """Best-effort HTTP status extraction across supported provider SDKs."""
+    for value in (
+        getattr(exc, "status_code", None),
+        getattr(exc, "code", None),
+    ):
+        status = _as_http_status(value)
+        if status is not None:
+            return status
+
+    response = getattr(exc, "response", None)
+    for value in (
+        getattr(response, "status_code", None),
+        getattr(response, "status", None),
+    ):
+        status = _as_http_status(value)
+        if status is not None:
+            return status
+
+    for payload in (
+        getattr(exc, "body", None),
+        getattr(exc, "details", None),
+    ):
+        if not isinstance(payload, dict):
+            continue
+        for container in (payload, payload.get("error")):
+            if not isinstance(container, dict):
+                continue
+            for key in ("status_code", "code"):
+                status = _as_http_status(container.get(key))
+                if status is not None:
+                    return status
+
+    return None

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -46,6 +46,7 @@ from ..constant import (
     LLM_RATE_LIMIT_JITTER,
     LLM_RATE_LIMIT_PAUSE,
 )
+from .error_utils import extract_status_code as _extract_status_code
 from .model_capability_cache import get_capability_cache
 from .rate_limiter import LLMRateLimiter, get_rate_limiter
 
@@ -150,40 +151,6 @@ def _get_httpx_retryable() -> tuple[type[Exception], ...]:
         except ImportError:
             _httpx_retryable = ()
     return _httpx_retryable
-
-
-def _extract_status_code(exc: Exception) -> int | None:
-    """Best-effort HTTP status extraction from SDK exceptions.
-
-    Streaming SSE errors are raised as plain ``openai.APIError`` without a
-    ``status_code`` attribute; the gateway status is often only present in
-    ``body`` (e.g. ``{"status_code": 502, "error": {...}}``).
-    """
-    status = getattr(exc, "status_code", None)
-    if status is not None:
-        try:
-            return int(status)
-        except (TypeError, ValueError):
-            pass
-
-    body = getattr(exc, "body", None)
-    if not isinstance(body, dict):
-        return None
-
-    for container in (body, body.get("error")):
-        if not isinstance(container, dict):
-            continue
-        raw = container.get("status_code")
-        if raw is None:
-            raw = container.get("code")
-        if raw is None:
-            continue
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
-            continue
-
-    return None
 
 
 def _is_retryable(exc: Exception) -> bool:

--- a/tests/unit/agents/context/test_scroll_manager.py
+++ b/tests/unit/agents/context/test_scroll_manager.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from agentscope.message import (
@@ -22,6 +23,7 @@ from agentscope.message import (
 )
 from agentscope.model import ChatResponse
 
+from qwenpaw.agents.context.base import ContextManager
 from qwenpaw.agents.context.scroll import manager as scroll_manager_module
 from qwenpaw.agents.context.scroll.history import HistoryStore
 from qwenpaw.agents.context.scroll.manager import ScrollContextManager
@@ -744,6 +746,15 @@ class _RealisticScrollConfig:
     reserve_ratio = 0.1
 
 
+class _CopyableScrollConfig(_RealisticScrollConfig):
+    def model_copy(self, *, update):
+        """Return a config clone with the requested field updates."""
+        return SimpleNamespace(
+            trigger_ratio=update.get("trigger_ratio", self.trigger_ratio),
+            reserve_ratio=update.get("reserve_ratio", self.reserve_ratio),
+        )
+
+
 _VALID_CONTINUATION_SUMMARY = """## Active Task
 Fix provider discovery.
 Status: in_progress
@@ -1385,6 +1396,38 @@ async def test_manual_compact_skips_pretrim_and_performs_eviction(
     assert mgr.last_compress["pre_folded"] == 0
     assert mgr.last_compress["evicted"] == 4
     assert agent.state.context[-1].id == current.id
+
+
+@pytest.mark.parametrize(
+    ("compress_stats", "expected"),
+    [
+        ({"evicted": 1, "folded": 0}, True),
+        ({"evicted": 0, "folded": 1}, True),
+        ({"evicted": 0, "folded": 0}, False),
+    ],
+)
+async def test_overflow_recovery_forces_compaction_and_reports_change(
+    store: HistoryStore,
+    compress_stats: dict[str, int],
+    expected: bool,
+):
+    """Overflow recovery owns its force config and reports effective work."""
+    mgr = make_manager(store)
+    agent = FakeAgent([user("current")])
+    agent.context_config = _CopyableScrollConfig()
+
+    async def fake_compress(actual_agent, context_config):
+        assert actual_agent is agent
+        mgr.last_compress.update(compress_stats)
+
+    mgr.compress = AsyncMock(side_effect=fake_compress)
+
+    assert isinstance(mgr, ContextManager)
+    assert await mgr.recover_from_context_overflow(agent) is expected
+    mgr.compress.assert_awaited_once()
+    forced_config = mgr.compress.await_args.args[1]
+    assert forced_config.trigger_ratio == pytest.approx(1e-6)
+    assert forced_config.reserve_ratio == pytest.approx(0.1)
 
 
 async def test_fold_not_triggered_between_reserve_and_trigger(

--- a/tests/unit/agents/test_context_overflow_recovery.py
+++ b/tests/unit/agents/test_context_overflow_recovery.py
@@ -7,20 +7,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 from agentscope.agent import Agent
-from agentscope.message import SystemMsg
 from google.genai import errors as genai_errors
 
 from qwenpaw.agents.react_agent import QwenPawAgent
-
-
-class _ContextConfig:
-    def __init__(self, trigger_ratio: float = 0.8) -> None:
-        self.trigger_ratio = trigger_ratio
-
-    def model_copy(self, *, update):
-        return _ContextConfig(
-            trigger_ratio=update.get("trigger_ratio", self.trigger_ratio),
-        )
 
 
 class _ContextOverflowError(Exception):
@@ -28,32 +17,42 @@ class _ContextOverflowError(Exception):
 
 
 class _ScrollManager:
-    supports_context_overflow_recovery = True
-
     def __init__(self, refreshed_context):
         self.refreshed_context = refreshed_context
         self.calls = []
-        self.last_compress = {"evicted": 0, "folded": 0}
+
+    async def recover_from_context_overflow(self, agent):
+        self.calls.append(agent)
+        agent.state.context = list(self.refreshed_context)
+        return True
 
     async def compress(self, agent, context_config):
-        self.calls.append(context_config)
-        agent.state.context = list(self.refreshed_context)
-        self.last_compress["evicted"] = 1
+        raise AssertionError("normal compression must not be used")
+
+    def on_save(self, agent, blocks):
+        raise AssertionError("on_save must not be used")
 
 
-class _OtherContextManager(_ScrollManager):
-    supports_context_overflow_recovery = False
+class _OtherContextManager:
+    def __init__(self):
+        self.calls = []
+
+    async def compress(self, agent, context_config):
+        self.calls.append((agent, context_config))
+
+    def on_save(self, agent, blocks):
+        self.calls.append((agent, blocks))
 
 
 class _NoOpScrollManager(_ScrollManager):
-    async def compress(self, agent, context_config):
-        self.calls.append(context_config)
+    async def recover_from_context_overflow(self, agent):
+        self.calls.append(agent)
+        return False
 
 
 def _agent(*, context_manager=None):
     agent = object.__new__(QwenPawAgent)
     agent._context_manager = context_manager
-    agent.context_config = _ContextConfig()
     agent.state = SimpleNamespace(context=["old-1", "old-2"])
     agent._prepare_model_input = AsyncMock(
         return_value={
@@ -92,8 +91,8 @@ async def test_context_overflow_forces_scroll_rebuilds_and_retries_once(
 
     assert result == "ok"
     assert len(scroll.calls) == 1
-    assert scroll.calls[0].trigger_ratio == pytest.approx(1e-6)
-    agent.compress_context.assert_awaited_once_with(scroll.calls[0])
+    assert scroll.calls[0] is agent
+    agent.compress_context.assert_not_awaited()
     agent._prepare_model_input.assert_awaited_once()
     assert calls == [
         (
@@ -148,28 +147,16 @@ async def test_context_overflow_skips_retry_when_input_is_unchanged(
     monkeypatch.setattr(Agent, "_call_model", fake_call_model)
     manager = _NoOpScrollManager(["unused"])
     agent = _agent(context_manager=manager)
-    agent._prepare_model_input = AsyncMock(
-        return_value={
-            "messages": [
-                SystemMsg(name="system", content="same prompt"),
-                "old",
-            ],
-            "tools": [{"name": "same-tool"}],
-        },
-    )
 
     with pytest.raises(_ContextOverflowError, match="context length"):
         await agent._call_model(
-            messages=[
-                SystemMsg(name="system", content="same prompt"),
-                "old",
-            ],
+            messages=["system", "old"],
             tools=[{"name": "same-tool"}],
         )
 
     assert calls == 1
     assert len(manager.calls) == 1
-    agent._prepare_model_input.assert_awaited_once()
+    agent._prepare_model_input.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -228,7 +215,7 @@ async def test_context_overflow_with_other_manager_does_not_retry(monkeypatch):
         )
 
     monkeypatch.setattr(Agent, "_call_model", fake_call_model)
-    manager = _OtherContextManager(["compacted"])
+    manager = _OtherContextManager()
     agent = _agent(context_manager=manager)
 
     with pytest.raises(_ContextOverflowError, match="prompt is too long"):

--- a/tests/unit/agents/test_context_overflow_recovery.py
+++ b/tests/unit/agents/test_context_overflow_recovery.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
+"""Tests for the one-shot Scroll recovery on provider context overflow."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from agentscope.agent import Agent
+
+from qwenpaw.agents.react_agent import QwenPawAgent
+
+
+class _ContextConfig:
+    def __init__(self, trigger_ratio: float = 0.8) -> None:
+        self.trigger_ratio = trigger_ratio
+
+    def model_copy(self, *, update):
+        return _ContextConfig(
+            trigger_ratio=update.get("trigger_ratio", self.trigger_ratio),
+        )
+
+
+class _ContextOverflowError(Exception):
+    status_code = 400
+
+
+class _ScrollManager:
+    def __init__(self, refreshed_context):
+        self.refreshed_context = refreshed_context
+        self.calls = []
+
+    async def compress(self, agent, context_config):
+        self.calls.append(context_config)
+        agent.state.context = list(self.refreshed_context)
+
+
+def _agent(*, context_manager=None):
+    agent = object.__new__(QwenPawAgent)
+    agent._context_manager = context_manager
+    agent.context_config = _ContextConfig()
+    agent.state = SimpleNamespace(context=["old-1", "old-2"])
+    agent._prepare_model_input = AsyncMock(
+        return_value={
+            "messages": ["system", "compacted"],
+            "tools": [{"name": "tool-after-compact"}],
+        },
+    )
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_forces_scroll_rebuilds_and_retries_once(
+    monkeypatch,
+):
+    calls = []
+
+    async def fake_call_model(self, messages, tools, tool_choice=None):
+        calls.append((messages, tools, tool_choice))
+        if len(calls) == 1:
+            raise _ContextOverflowError(
+                "Error code: 400 - Range of input length should be "
+                "[1, 983616]",
+            )
+        return "ok"
+
+    monkeypatch.setattr(Agent, "_call_model", fake_call_model)
+    scroll = _ScrollManager(["compacted"])
+    agent = _agent(context_manager=scroll)
+
+    result = await agent._call_model(
+        messages=["system", "old-1", "old-2"],
+        tools=[{"name": "old-tool"}],
+        tool_choice="auto",
+    )
+
+    assert result == "ok"
+    assert len(scroll.calls) == 1
+    assert scroll.calls[0].trigger_ratio == pytest.approx(1e-6)
+    agent._prepare_model_input.assert_awaited_once()
+    assert calls == [
+        (
+            ["system", "old-1", "old-2"],
+            [{"name": "old-tool"}],
+            "auto",
+        ),
+        (
+            ["system", "compacted"],
+            [{"name": "tool-after-compact"}],
+            "auto",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_retries_only_once(monkeypatch):
+    calls = 0
+
+    async def fake_call_model(self, messages, tools, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        raise _ContextOverflowError(
+            "Error code: 400 - context length exceeded",
+        )
+
+    monkeypatch.setattr(Agent, "_call_model", fake_call_model)
+    scroll = _ScrollManager(["compacted"])
+    agent = _agent(context_manager=scroll)
+
+    with pytest.raises(_ContextOverflowError, match="context length"):
+        await agent._call_model(messages=["old"], tools=[])
+
+    assert calls == 2
+    assert len(scroll.calls) == 1
+    agent._prepare_model_input.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unrelated_bad_request_does_not_compact_or_retry(monkeypatch):
+    calls = 0
+
+    async def fake_call_model(self, messages, tools, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        raise _ContextOverflowError(
+            "Error code: 400 - unsupported parameter: temperature",
+        )
+
+    monkeypatch.setattr(Agent, "_call_model", fake_call_model)
+    scroll = _ScrollManager(["compacted"])
+    agent = _agent(context_manager=scroll)
+
+    with pytest.raises(_ContextOverflowError, match="unsupported parameter"):
+        await agent._call_model(messages=["old"], tools=[])
+
+    assert calls == 1
+    assert not scroll.calls
+    agent._prepare_model_input.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_without_scroll_does_not_retry(monkeypatch):
+    calls = 0
+
+    async def fake_call_model(self, messages, tools, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        raise _ContextOverflowError(
+            "Error code: 400 - prompt is too long",
+        )
+
+    monkeypatch.setattr(Agent, "_call_model", fake_call_model)
+    agent = _agent(context_manager=None)
+
+    with pytest.raises(_ContextOverflowError, match="prompt is too long"):
+        await agent._call_model(messages=["old"], tools=[])
+
+    assert calls == 1
+    agent._prepare_model_input.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("Error code: 400 - maximum context length is 128000", True),
+        ("<400> input length should be between 1 and 983616", False),
+        ("Error code: 400 - image_url is unsupported", False),
+        ("Error code: 500 - context length exceeded", False),
+    ],
+)
+def test_context_overflow_classifier_requires_400_and_specific_marker(
+    message,
+    expected,
+):
+    exc = Exception(message)
+    assert QwenPawAgent._is_context_overflow_error(exc) is expected

--- a/tests/unit/agents/test_context_overflow_recovery.py
+++ b/tests/unit/agents/test_context_overflow_recovery.py
@@ -26,6 +26,8 @@ class _ContextOverflowError(Exception):
 
 
 class _ScrollManager:
+    supports_context_overflow_recovery = True
+
     def __init__(self, refreshed_context):
         self.refreshed_context = refreshed_context
         self.calls = []
@@ -33,6 +35,10 @@ class _ScrollManager:
     async def compress(self, agent, context_config):
         self.calls.append(context_config)
         agent.state.context = list(self.refreshed_context)
+
+
+class _OtherContextManager(_ScrollManager):
+    supports_context_overflow_recovery = False
 
 
 def _agent(*, context_manager=None):
@@ -67,6 +73,7 @@ async def test_context_overflow_forces_scroll_rebuilds_and_retries_once(
     monkeypatch.setattr(Agent, "_call_model", fake_call_model)
     scroll = _ScrollManager(["compacted"])
     agent = _agent(context_manager=scroll)
+    agent.compress_context = AsyncMock(wraps=agent.compress_context)
 
     result = await agent._call_model(
         messages=["system", "old-1", "old-2"],
@@ -77,6 +84,7 @@ async def test_context_overflow_forces_scroll_rebuilds_and_retries_once(
     assert result == "ok"
     assert len(scroll.calls) == 1
     assert scroll.calls[0].trigger_ratio == pytest.approx(1e-6)
+    agent.compress_context.assert_awaited_once_with(scroll.calls[0])
     agent._prepare_model_input.assert_awaited_once()
     assert calls == [
         (
@@ -156,6 +164,29 @@ async def test_context_overflow_without_scroll_does_not_retry(monkeypatch):
         await agent._call_model(messages=["old"], tools=[])
 
     assert calls == 1
+    agent._prepare_model_input.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_context_overflow_with_other_manager_does_not_retry(monkeypatch):
+    calls = 0
+
+    async def fake_call_model(self, messages, tools, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        raise _ContextOverflowError(
+            "Error code: 400 - prompt is too long",
+        )
+
+    monkeypatch.setattr(Agent, "_call_model", fake_call_model)
+    manager = _OtherContextManager(["compacted"])
+    agent = _agent(context_manager=manager)
+
+    with pytest.raises(_ContextOverflowError, match="prompt is too long"):
+        await agent._call_model(messages=["old"], tools=[])
+
+    assert calls == 1
+    assert not manager.calls
     agent._prepare_model_input.assert_not_awaited()
 
 

--- a/tests/unit/agents/test_context_overflow_recovery.py
+++ b/tests/unit/agents/test_context_overflow_recovery.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 from agentscope.agent import Agent
+from agentscope.message import SystemMsg
+from google.genai import errors as genai_errors
 
 from qwenpaw.agents.react_agent import QwenPawAgent
 
@@ -31,14 +33,21 @@ class _ScrollManager:
     def __init__(self, refreshed_context):
         self.refreshed_context = refreshed_context
         self.calls = []
+        self.last_compress = {"evicted": 0, "folded": 0}
 
     async def compress(self, agent, context_config):
         self.calls.append(context_config)
         agent.state.context = list(self.refreshed_context)
+        self.last_compress["evicted"] = 1
 
 
 class _OtherContextManager(_ScrollManager):
     supports_context_overflow_recovery = False
+
+
+class _NoOpScrollManager(_ScrollManager):
+    async def compress(self, agent, context_config):
+        self.calls.append(context_config)
 
 
 def _agent(*, context_manager=None):
@@ -124,6 +133,46 @@ async def test_context_overflow_retries_only_once(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_context_overflow_skips_retry_when_input_is_unchanged(
+    monkeypatch,
+):
+    calls = 0
+
+    async def fake_call_model(self, messages, tools, tool_choice=None):
+        nonlocal calls
+        calls += 1
+        raise _ContextOverflowError(
+            "Error code: 400 - context length exceeded",
+        )
+
+    monkeypatch.setattr(Agent, "_call_model", fake_call_model)
+    manager = _NoOpScrollManager(["unused"])
+    agent = _agent(context_manager=manager)
+    agent._prepare_model_input = AsyncMock(
+        return_value={
+            "messages": [
+                SystemMsg(name="system", content="same prompt"),
+                "old",
+            ],
+            "tools": [{"name": "same-tool"}],
+        },
+    )
+
+    with pytest.raises(_ContextOverflowError, match="context length"):
+        await agent._call_model(
+            messages=[
+                SystemMsg(name="system", content="same prompt"),
+                "old",
+            ],
+            tools=[{"name": "same-tool"}],
+        )
+
+    assert calls == 1
+    assert len(manager.calls) == 1
+    agent._prepare_model_input.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_unrelated_bad_request_does_not_compact_or_retry(monkeypatch):
     calls = 0
 
@@ -205,3 +254,22 @@ def test_context_overflow_classifier_requires_400_and_specific_marker(
 ):
     exc = Exception(message)
     assert QwenPawAgent._is_context_overflow_error(exc) is expected
+
+
+def test_context_overflow_classifier_supports_gemini_client_error():
+    exc = genai_errors.ClientError(
+        400,
+        {
+            "error": {
+                "status": "INVALID_ARGUMENT",
+                "message": "context length exceeded",
+            },
+        },
+    )
+    assert QwenPawAgent._is_context_overflow_error(exc) is True
+
+
+def test_context_overflow_classifier_supports_aiohttp_response_status():
+    exc = Exception("context length exceeded")
+    exc.response = SimpleNamespace(status=400)
+    assert QwenPawAgent._is_context_overflow_error(exc) is True

--- a/tests/unit/agents/test_context_overflow_recovery.py
+++ b/tests/unit/agents/test_context_overflow_recovery.py
@@ -243,13 +243,26 @@ def test_context_overflow_classifier_requires_400_and_specific_marker(
     assert QwenPawAgent._is_context_overflow_error(exc) is expected
 
 
-def test_context_overflow_classifier_supports_gemini_client_error():
+@pytest.mark.parametrize(
+    "message",
+    [
+        (
+            "The input token count (1337419) exceeds the maximum number "
+            "of tokens allowed (1048576)."
+        ),
+        (
+            "Unable to submit request because the input token count is "
+            "135538 but model only supports up to 32768"
+        ),
+    ],
+)
+def test_context_overflow_classifier_supports_gemini_client_error(message):
     exc = genai_errors.ClientError(
         400,
         {
             "error": {
                 "status": "INVALID_ARGUMENT",
-                "message": "context length exceeded",
+                "message": message,
             },
         },
     )


### PR DESCRIPTION
## Description

Adds one-shot recovery when a provider rejects an oversized model input.

On an explicit context-overflow `400`, QwenPaw now:

1. Confirms that the active context manager explicitly supports overflow recovery.
2. Forces Scroll compaction through the agent's unified `compress_context()` path.
3. Rebuilds messages and tools from the compacted state.
4. Retries the model call exactly once.

This handles cases where the provider's actual input limit differs from the locally estimated context size.

Unrelated `400` errors, native context sessions, and context managers that do not opt in to overflow recovery remain unchanged. A second failure propagates normally.

**Related Issue:** Fixes #6255

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend
- [x] Tests

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] Relevant commit hooks pass
- [x] Relevant tests pass
- [x] Documentation not required
- [x] Ready for review

## Testing

Coverage includes:

- successful Scroll compaction and retry;
- rebuilding messages and tools after compaction;
- retrying only once;
- preserving `tool_choice`;
- ignoring unrelated `400` errors;
- skipping recovery without a context manager;
- skipping recovery for context managers that do not explicitly opt in;
- exercising the unified `compress_context()` path.

## Evidence

```text
Commit hooks:
check python ast: Passed
mypy: Passed
black: Passed
flake8: Passed
pylint: Passed
detect private key: Passed

pytest -q \
  tests/unit/agents/test_context_overflow_recovery.py \
  tests/unit/agents/test_react_agent_scroll_seen.py \
  tests/unit/agents/context/test_scroll_manager.py

80 passed, 1 warning