### PR TITLE
fix: register background chats and remove legacy runner

### DIFF
--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -6,7 +6,6 @@ import mimetypes
 import os
 import sys
 import time
-import uuid
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
@@ -73,92 +72,6 @@ mimetypes.add_type("image/svg+xml", ".svg")
 # Load persisted env vars into os.environ at module import time
 # so they are available before the lifespan starts.
 load_envs_into_environ()
-
-
-# Dynamic runner that selects the correct workspace based on request
-class DynamicMultiAgentRunner:
-    """Routes each request to the correct Workspace and runs it
-    through ``Runtime.run()``.
-    """
-
-    def __init__(self):
-        self.framework_type = "agentscope"
-        self._workspace_registry = None
-        self._app_services = None
-
-    def set_app_services(self, app_services):
-        """Set the cross-workspace AppServiceManager reference."""
-        self._app_services = app_services
-
-    def set_workspace_registry(self, workspace_registry):
-        """Set the WorkspaceRegistry (sole workspace manager)."""
-        self._workspace_registry = workspace_registry
-
-    async def _get_workspace(self, request):
-        """Get the correct Workspace based on request."""
-        from .agent_context import get_current_agent_id
-
-        agent_id = get_current_agent_id()
-        logger.debug("_get_workspace: agent_id=%s", agent_id)
-
-        if self._workspace_registry is None:
-            raise RuntimeError("WorkspaceRegistry not initialized")
-
-        workspace = await self._workspace_registry.get_agent(agent_id)
-        logger.debug("Got workspace: %s", workspace.agent_id)
-        return workspace
-
-    async def stream_query(self, request, *args, **kwargs):
-        """Route to the correct Workspace and run via Runtime.
-
-        Registers the task with the workspace's TaskTracker so that
-        graceful shutdown during agent reload can detect in-flight
-        background tasks.
-        """
-        logger.debug("DynamicMultiAgentRunner.stream_query called")
-        workspace = None
-        run_key = None
-        try:
-            workspace = await self._get_workspace(request)
-
-            run_key = f"ext-{uuid.uuid4().hex}"
-            await workspace.task_tracker.register_external_task(
-                run_key,
-            )
-
-            from ..runtime.runtime import Runtime
-
-            rt = Runtime(
-                workspace=workspace,
-                app_services=self._app_services,
-            )
-            async for item in rt.run(request):
-                yield item
-        except Exception as e:
-            logger.error(
-                f"Error in stream_query: {e}",
-                exc_info=True,
-            )
-            yield {
-                "error": str(e),
-                "type": "error",
-            }
-        finally:
-            if workspace is not None and run_key is not None:
-                await workspace.task_tracker.unregister_external_task(
-                    run_key,
-                )
-
-    async def __aenter__(self):
-        """No-op context manager entry."""
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """No-op context manager exit."""
-        return None
-
-
-runner = DynamicMultiAgentRunner()
 
 
 @asynccontextmanager
@@ -463,12 +376,6 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
     app.state.local_model_manager = local_model_manager
     app.state.plugin_loader = None
     app.state.plugin_registry = None
-
-    if isinstance(runner, DynamicMultiAgentRunner):
-        if app_services is not None:
-            runner.set_app_services(app_services)
-        if workspace_registry is not None:
-            runner.set_workspace_registry(workspace_registry)
 
     async def _get_agent_by_id(agent_id: str = None):
         """Get agent instance by ID, or active agent if not specified."""

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -547,6 +547,13 @@ async def post_console_chat_task(
         sender_id=native_payload["sender_id"],
         channel_meta=native_payload["meta"],
     )
+    name, _ = _extract_placeholder_name(native_payload["content_parts"])
+    await workspace.chat_manager.get_or_create_chat(
+        session_id,
+        native_payload["sender_id"],
+        native_payload["channel_id"],
+        name=name,
+    )
 
     task_timeout: Optional[float] = None
     if isinstance(request_data, dict):

--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 """Task tracker for background runs: streaming, reconnect, multi-subscriber.
 
-For internal streaming runs, ``run_key`` is typically ``ChatSpec.id``
-(chat_id). For externally-managed tasks (registered via
-:meth:`TaskTracker.register_external_task`), ``run_key`` is an opaque
-identifier chosen by the caller (e.g. a UUID prefixed with ``"ext-"``).
-Per run: task, queues, event buffer. Reconnects get buffer replay + new
-events. Cleanup when task completes.
+``run_key`` is typically ``ChatSpec.id`` (chat_id). Per run: task, queues,
+event buffer. Reconnects get buffer replay + new events. Cleanup when task
+completes.
 """
 from __future__ import annotations
 
@@ -127,64 +124,6 @@ class TaskTracker:
             return True
         except asyncio.TimeoutError:
             return False
-
-    async def register_external_task(self, run_key: str) -> None:
-        """Register an externally-managed task so it is visible to
-        :meth:`has_active_tasks` and :meth:`wait_all_done`.
-
-        This is used for tasks managed outside of QwenPaw's own streaming
-        pipeline (e.g. background tasks dispatched through a third-party
-        scheduler).  The caller **must** call
-        :meth:`unregister_external_task` when the task completes.
-
-        Args:
-            run_key: Unique identifier for the external task.
-        """
-        start_time = datetime.now(timezone.utc)
-        async with self._lock:
-            if run_key in self._runs and not self._runs[run_key].task.done():
-                logger.debug(
-                    "External task already registered: %s",
-                    run_key,
-                )
-                return
-            # Use an unresolved Future as the "task" — it stays not-done
-            # until unregister_external_task resolves it.
-            future: asyncio.Future = asyncio.get_running_loop().create_future()
-            self._runs[run_key] = _RunState(
-                task=future,
-                queues=[],
-                buffer=[],
-                start_time=start_time,
-            )
-            self._global_last_run_at = start_time
-            logger.debug("Registered external task: %s", run_key)
-
-    async def unregister_external_task(self, run_key: str) -> None:
-        """Mark an externally-managed task as done and remove it.
-
-        Sends the sentinel value to any subscriber queues so their
-        :meth:`stream_from_queue` consumers terminate cleanly instead of
-        hanging. Idempotent — safe to call even if *run_key* was never
-        registered or was already unregistered.
-
-        Args:
-            run_key: Unique identifier previously passed to
-                :meth:`register_external_task`.
-        """
-        finish_time = datetime.now(timezone.utc)
-        async with self._lock:
-            state = self._runs.pop(run_key, None)
-            if state is None:
-                return
-            # Notify any subscriber queues so consumers exit cleanly.
-            for q in state.queues:
-                q.put_nowait(_SENTINEL)
-            if not state.task.done():
-                state.task.set_result(None)
-            state.finish_time = finish_time
-            self._global_last_finish_at = finish_time
-            logger.debug("Unregistered external task: %s", run_key)
 
     async def attach(self, run_key: str) -> asyncio.Queue | None:
         """Attach to an existing run.

--- a/tests/integration/test_console_chat_task.py
+++ b/tests/integration/test_console_chat_task.py
@@ -98,7 +98,7 @@ def test_chat_task_get_unknown_returns_404(app_server) -> None:
 
 @pytest.mark.integration
 @pytest.mark.p0
-def test_chat_task_submit_returns_task_id_and_completes(
+def test_chat_task_submit_registers_chat_and_completes(
     app_server,
     mock_llm,  # pylint: disable=redefined-outer-name
 ) -> None:
@@ -106,21 +106,24 @@ def test_chat_task_submit_returns_task_id_and_completes(
 
     Test purpose:
       - Verify a chat/task submission returns a fresh ``task-<hex12>``,
-        the task runs to completion in the background, and the GET
-        endpoint eventually reports ``status='finished'`` with the
+        registers its session in the chat index, runs to completion in the
+        background, and eventually reports ``status='finished'`` with the
         expected ``session_id`` in the result payload.
 
     API endpoints:
     - POST /api/console/chat/task
     - GET  /api/console/chat/task/{task_id}
+    - GET  /api/chats
     """
     _srv, mock_url = mock_llm
     unregister_mock_provider(app_server, MOCK_LLM_PROVIDER_ID)
     provider_id = register_mock_provider(app_server, mock_url)
     user_id = "integ-tc-task-happy"
+    session_id = "sub-integ-tc-task-happy"
     body = {
         "channel": "console",
         "user_id": user_id,
+        "session_id": session_id,
         "input": [
             {
                 "role": "user",
@@ -141,6 +144,15 @@ def test_chat_task_submit_returns_task_id_and_completes(
         assert task_id.startswith("task-"), task_id
         # ``uuid.uuid4().hex[:12]`` is 12 hex chars.
         assert len(task_id) == len("task-") + 12, task_id
+
+        chats_resp = app_server.api_request(
+            "GET",
+            "/api/chats",
+            params={"user_id": user_id, "channel": "console"},
+            timeout=_HTTP_TIMEOUT,
+        )
+        assert chats_resp.status_code == 200, app_server.logs_tail()
+        assert session_id in {chat["session_id"] for chat in chats_resp.json()}
 
         # Immediately poll — status may be running or finished.
         first = app_server.api_request(

--- a/tests/unit/app/test_task_tracker.py
+++ b/tests/unit/app/test_task_tracker.py
@@ -276,73 +276,6 @@ async def test_stream_from_queue_yields_until_sentinel_and_detaches():
 
 
 # ---------------------------------------------------------------------------
-# External task lifecycle
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_external_task_register_and_unregister_round_trip():
-    tracker = TaskTracker()
-
-    await tracker.register_external_task("ext-1")
-
-    assert await tracker.get_status("ext-1") == "running"
-    assert await tracker.has_active_tasks() is True
-    assert "ext-1" in await tracker.list_active_tasks()
-
-    summary = await tracker.get_global_status()
-    assert summary["status"] == "running"
-    assert summary["running_task_count"] == 1
-    assert summary["last_run_at"] is not None
-
-    await tracker.unregister_external_task("ext-1")
-
-    assert await tracker.get_status("ext-1") == "idle"
-    assert await tracker.has_active_tasks() is False
-    after = await tracker.get_global_status()
-    assert after["status"] == "idle"
-    assert after["running_task_count"] == 0
-    assert after["last_finish_at"] is not None
-
-
-@pytest.mark.asyncio
-async def test_external_task_register_is_idempotent_for_live_run():
-    tracker = TaskTracker()
-
-    await tracker.register_external_task("ext-dup")
-    first_state = tracker._runs["ext-dup"]
-    await tracker.register_external_task("ext-dup")  # second call is no-op
-
-    assert tracker._runs["ext-dup"] is first_state
-
-    await tracker.unregister_external_task("ext-dup")
-
-
-@pytest.mark.asyncio
-async def test_unregister_external_task_unknown_is_safe():
-    tracker = TaskTracker()
-
-    # Should not raise.
-    await tracker.unregister_external_task("never-registered")
-
-
-@pytest.mark.asyncio
-async def test_unregister_external_task_drains_subscriber_queues():
-    tracker = TaskTracker()
-    await tracker.register_external_task("ext-sub")
-
-    # Manually attach a queue (external tasks bypass attach_or_start).
-    q: asyncio.Queue = asyncio.Queue()
-    async with tracker._lock:
-        tracker._runs["ext-sub"].queues.append(q)
-
-    await tracker.unregister_external_task("ext-sub")
-
-    sentinel = await asyncio.wait_for(q.get(), timeout=1)
-    assert sentinel is None
-
-
-# ---------------------------------------------------------------------------
 # wait_all_done: timeout behaviour
 # ---------------------------------------------------------------------------
 
@@ -357,12 +290,24 @@ async def test_wait_all_done_returns_true_when_idle():
 @pytest.mark.asyncio
 async def test_wait_all_done_times_out_when_task_runs():
     tracker = TaskTracker()
-    await tracker.register_external_task("ext-long")
+    release = asyncio.Event()
+
+    async def producer(_payload):
+        await release.wait()
+        yield "data: done\n\n"
+
+    queue, _ = await tracker.attach_or_start(
+        "run-long",
+        payload=None,
+        stream_fn=producer,
+    )
 
     try:
         assert await tracker.wait_all_done(timeout=0.2) is False
     finally:
-        await tracker.unregister_external_task("ext-long")
+        release.set()
+        async for _ in tracker.stream_from_queue(queue, "run-long"):
+            pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR fixes missing chat-index entries for background agent tasks and removes the unused dynamic runner infrastructure discovered while tracing the execution path.

Background tasks submitted through `/api/console/chat/task` now register their sessions in the chat index before execution. This makes completed `background=True` subagent conversations and `submit_to_agent` sessions discoverable through the chats API and visible in the target agent's Console session list.

The root cause was that the background task endpoint invoked `console_channel.stream_one()` directly and bypassed the `get_or_create_chat()` call used by the regular `/api/console/chat` endpoint. Session state was saved to disk, but no corresponding `ChatSpec` was created.

The investigation also found that `DynamicMultiAgentRunner` was no longer connected to request processing after `Workspace.stream_query()` became the active runtime entry point. Its module-level instance, startup injection, and the `TaskTracker.register_external_task()` proxy API had no remaining production callers. This PR removes that dead path and keeps `wait_all_done()` timeout coverage using a real tracked streaming task.

**Related Issue:** N/A

**Security Considerations:** None. The behavior change only registers existing background sessions in the per-agent chat index; the remaining changes remove unreachable runtime code.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

Targeted pre-commit checks were run for all changed Python files and passed. No user-facing documentation update is needed.

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] I ran `./scripts/check-channels.sh --changed` and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

The contract-test items are not applicable because this PR does not modify a channel implementation. The channel checker reported that no channel changes were detected.

## Testing

The background-task regression test first reproduced the issue by confirming that the submitted session was absent from `/api/chats`. After the fix, it verifies that the session is registered immediately and that the task still completes normally.

TaskTracker and multi-agent lifecycle tests verify that removing the legacy runner does not affect active streaming-task status, completion waiting, workspace reload, or application startup.

```bash
PYTHONPATH="$PWD/src" conda run -n QwenPaw pytest \
  tests/unit/app/test_task_tracker.py \
  tests/integration/test_multi_agent_lifecycle.py \
  tests/integration/test_console_chat_task.py -q

conda run -n QwenPaw pre-commit run --files \
  src/qwenpaw/app/routers/console.py \
  src/qwenpaw/app/_app.py \
  src/qwenpaw/app/task_tracker.py \
  tests/integration/test_console_chat_task.py \
  tests/unit/app/test_task_tracker.py

conda run -n QwenPaw ./scripts/check-channels.sh --changed
```

## Evidence

```text
$ pytest tests/unit/app/test_task_tracker.py tests/integration/test_multi_agent_lifecycle.py tests/integration/test_console_chat_task.py -q
.....................................                                    [100%]
37 passed in 17.52s

$ pre-commit run --files <changed Python files>
check python ast.........................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

$ ./scripts/check-channels.sh --changed
Detecting changed channels...
No channel changes detected
```

## Additional Notes

This PR intentionally does not redesign same-session concurrency or task aggregation. Background tasks remain process-local, and subagents remain one-shot sessions. A separate issue draft documents the broader task-tracking inconsistencies for follow-up.
