### PR TITLE
fix(console): make tool Output copy work outside secure contexts

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/DefaultBlock.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/DefaultBlock.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for DefaultBlock Output copy button.
+ */
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@agentscope-ai/chat", () => ({
+  Markdown: ({ content }: { content: string }) => (
+    <div data-testid="markdown">{content}</div>
+  ),
+}));
+
+vi.mock("react-syntax-highlighter", () => ({
+  Prism: ({ children }: { children: string }) => (
+    <pre data-testid="syntax">{children}</pre>
+  ),
+}));
+
+vi.mock("react-syntax-highlighter/dist/esm/styles/prism", () => ({
+  oneDark: {},
+}));
+
+const { copyTextMock } = vi.hoisted(() => ({
+  copyTextMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/utils/clipboard", () => ({
+  copyText: copyTextMock,
+}));
+
+import DefaultBlock from "./DefaultBlock";
+import * as clipboard from "@/utils/clipboard";
+
+describe("DefaultBlock copy", () => {
+  beforeEach(() => {
+    copyTextMock.mockReset();
+    copyTextMock.mockResolvedValue(undefined);
+  });
+
+  it("copies output content through copyText helper", async () => {
+    expect(clipboard.copyText).toBe(copyTextMock);
+
+    render(<DefaultBlock title="Output" content={"Table 0\nRow 0"} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(copyTextMock).toHaveBeenCalledTimes(1);
+    });
+    expect(copyTextMock).toHaveBeenCalledWith("Table 0\nRow 0");
+  });
+
+  it("shows copied state after copyText resolves", async () => {
+    render(<DefaultBlock title="Output" content="shell output body" />);
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("check")).toBeInTheDocument();
+    });
+  });
+});

--- a/console/src/components/Chat/ToolCards/shared/DefaultBlock.tsx
+++ b/console/src/components/Chat/ToolCards/shared/DefaultBlock.tsx
@@ -13,6 +13,7 @@ import { Markdown } from "@agentscope-ai/chat";
 import { CopyOutlined, CheckOutlined } from "@ant-design/icons";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { copyText } from "@/utils/clipboard";
 import { looksLikeMarkdown } from "./utils";
 import styles from "./toolCards.module.less";
 
@@ -62,8 +63,7 @@ const DefaultBlock: React.FC<DefaultBlockProps> = ({
   );
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard
-      .writeText(content)
+    void copyText(content)
       .then(() => {
         if (timerRef.current) clearTimeout(timerRef.current);
         setCopied(true);
@@ -109,6 +109,7 @@ const DefaultBlock: React.FC<DefaultBlockProps> = ({
       <div className={styles.defaultBlockHeader}>
         <span className={styles.defaultBlockTitle}>{title}</span>
         <button
+          type="button"
           className={styles.defaultBlockCopy}
           onClick={handleCopy}
           title={copyTitle}

--- a/console/src/pages/Chat/utils.ts
+++ b/console/src/pages/Chat/utils.ts
@@ -79,33 +79,7 @@ export function extractTextFromMessage(msg: any): string {
 // Clipboard utilities
 // ---------------------------------------------------------------------------
 
-/** Copy text to clipboard with fallback for non-secure contexts. */
-export async function copyText(text: string): Promise<void> {
-  if (navigator.clipboard && window.isSecureContext) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.setAttribute("readonly", "");
-  textarea.style.position = "absolute";
-  textarea.style.left = "-9999px";
-  document.body.appendChild(textarea);
-
-  let copied = false;
-  try {
-    textarea.focus();
-    textarea.select();
-    copied = document.execCommand("copy");
-  } finally {
-    document.body.removeChild(textarea);
-  }
-
-  if (!copied) {
-    throw new Error("Failed to copy text");
-  }
-}
+export { copyText } from "../../utils/clipboard";
 
 // ---------------------------------------------------------------------------
 // Timestamp formatting utilities

--- a/console/src/utils/clipboard.test.ts
+++ b/console/src/utils/clipboard.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for clipboard copy helper with secure-context fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("copyText", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalIsSecureContext = window.isSecureContext;
+  const originalExecCommand = document.execCommand;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: originalIsSecureContext,
+    });
+    document.execCommand = originalExecCommand;
+    vi.restoreAllMocks();
+  });
+
+  it("uses clipboard API in a secure context", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+
+    const { copyText } = await import("./clipboard");
+    await copyText("hello output");
+
+    expect(writeText).toHaveBeenCalledWith("hello output");
+  });
+
+  it("falls back to execCommand when clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    const { copyText } = await import("./clipboard");
+    await copyText("fallback content");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+});

--- a/console/src/utils/clipboard.ts
+++ b/console/src/utils/clipboard.ts
@@ -1,0 +1,27 @@
+/** Copy text to clipboard with fallback for non-secure contexts. */
+export async function copyText(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "absolute";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+
+  let copied = false;
+  try {
+    textarea.focus();
+    textarea.select();
+    copied = document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+
+  if (!copied) {
+    throw new Error("Failed to copy text");
+  }
+}


### PR DESCRIPTION
---

## Description

修复聊天页工具卡片 `Output` 复制按钮点击后无法复制内容的问题。

工具执行结果（如 shell Output）通过 `DefaultBlock` 渲染，标题栏右侧有 copy 图标。原实现直接调用 `navigator.clipboard.writeText()`，未判断安全上下文，且失败被 `.catch(() => {})` 静默吞掉，导致在 HTTP + IP 等非安全上下文中点击 copy 无效、也无勾选反馈。

**本次修改：**
- 将 clipboard 兜底逻辑抽为共享 `copyText`（`console/src/utils/clipboard.ts`）
- `DefaultBlock` 改为调用 `copyText`，在非 secure context / Clipboard API 不可用时回退到 `document.execCommand("copy")`
- `Chat/utils.ts` 改为复用该共享实现
- 补充单元测试，覆盖 secure / fallback 复制路径及 Output copy 按钮行为

**Related Issue:** Relates to chat tool Output copy failure on non-secure contexts

**Security Considerations:** N/A（仅前端剪贴板写入，无新增权限面）

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

---

## 复现方式

1. 升级到最新版本
2. 打开聊天页，触发带 `Output` 的工具调用（例如 shell / `execute_shell_command`）
3. 点击 Output 标题栏右侧的 copy 图标
4. 粘贴到别处，发现无法复制 Output 内容（无效）

---

## Problem / Root Cause

### 现象

聊天页工具卡片展开后，`Output` 区块内容可见，点击右上角 copy 图标：
- 剪贴板无内容 / 粘贴无效
- 图标不会切换为勾选（成功反馈缺失）

### 原有实现

```tsx
const handleCopy = useCallback(() => {
  navigator.clipboard
    .writeText(content)
    .then(() => {
      setCopied(true);
      // ...
    })
    .catch(() => {}); // 失败被静默吞掉
}, [content]);
```

同仓库中 `MarkdownCopy`、`Chat/utils.copyText` 已有 secure-context 判断与 `execCommand` 兜底，但 `DefaultBlock` 未复用。

### 根因分析

| 检查项 | 实际情况 | 结果 |
|---|---|---|
| 复制 API | 仅调用 `navigator.clipboard.writeText` | 非安全上下文常失败 |
| `window.isSecureContext` | HTTP + IP / 非 localhost 时为 `false` | Clipboard API 不可用或不被允许 |
| 错误处理 | `.catch(() => {})` | 无提示、无勾选反馈，表现为“点了没反应” |
| 内容传递 | `ShellCard` → `stringifyResult` → `content` | 内容本身存在，不是空字符串问题 |

---

## Fix

```ts
export async function copyText(text: string): Promise<void> {
  if (navigator.clipboard && window.isSecureContext) {
    await navigator.clipboard.writeText(text);
    return;
  }
  // fallback: textarea + document.execCommand("copy")
  ...
}
```

```tsx
const handleCopy = useCallback(() => {
  void copyText(content)
    .then(() => { setCopied(true); /* ... */ })
    .catch(() => {});
}, [content]);
```

---

## Testing

本地验证：

1. `cd console && npm run test:run -- src/utils/clipboard.test.ts src/components/Chat/ToolCards/shared/DefaultBlock.test.tsx`
2. HTTP/IP 打开控制台，点击工具 Output 的 copy，确认可粘贴完整内容
3. HTTPS / localhost 下同样验证 copy 正常，并出现短暂勾选反馈

## Evidence

Local vitest verification passed on 2026-07-20:

Command: `cd console && npm run test:run -- src/utils/clipboard.test.ts src/components/Chat/ToolCards/shared/DefaultBlock.test.tsx`

Result: Test Files 2 passed (2); Tests 4 passed (4). Covered secure-context Clipboard API path, execCommand fallback when clipboard is unavailable, DefaultBlock copy button calling copyText(content), and copied-state check icon after success.

Also confirmed by code review that DefaultBlock no longer calls navigator.clipboard directly and reuses shared copyText with fallback.

## Checklist

- [x] I ran tests locally (`vitest`) and they pass
- [x] Ready for review

## Additional Notes

典型触发环境：非 HTTPS 部署、或通过局域网 IP 访问控制台。影响组件为 ToolCards 共用的 `DefaultBlock`（Shell / ReadFile / Grep 等 Output）。

---