### PR TITLE
fix(observability): use valid Langfuse trace IDs

### DIFF
--- a/src/qwenpaw/hooks/observability/langfuse_hook.py
+++ b/src/qwenpaw/hooks/observability/langfuse_hook.py
@@ -60,7 +60,7 @@ class LangfuseTraceHook(LifecycleHook):
             await scope.__aenter__()
             ctx.extras[_LANGFUSE_SCOPE_KEY] = scope
         except Exception:
-            logger.debug("langfuse trace scope open failed", exc_info=True)
+            logger.warning("langfuse trace scope open failed", exc_info=True)
         return HookResult()
 
 

--- a/tests/unit/observability/test_langfuse_integration.py
+++ b/tests/unit/observability/test_langfuse_integration.py
@@ -151,7 +151,7 @@ class TestLangfuseTraceHook:
         assert lf.get_current_trace().name == "qwenpaw.agent.react_loop"
         assert len(client.started) == 1
 
-    async def test_handles_scope_open_failure(self, monkeypatch):
+    async def test_handles_scope_open_failure(self, monkeypatch, caplog):
         """Hook swallows exceptions from scope.__aenter__ gracefully."""
         from qwenpaw.hooks.observability.langfuse_hook import (
             LangfuseTraceHook,
@@ -168,10 +168,12 @@ class TestLangfuseTraceHook:
         hook = LangfuseTraceHook()
         ctx = _make_hook_context()
 
-        result = await hook.run(ctx)
+        with caplog.at_level("WARNING"):
+            result = await hook.run(ctx)
 
         assert _LANGFUSE_SCOPE_KEY not in ctx.extras
         assert result.action.value == "continue"
+        assert "langfuse trace scope open failed" in caplog.text
 
     async def test_trace_id_is_hex_without_dashes(self, monkeypatch):
         """Hook emits a 32-char hex trace_id (uuid4().hex), not a dashed UUID.


### PR DESCRIPTION
## Description

Log Langfuse root trace initialization failures at warning level instead of debug level, so observability failures do not remain silent when Langfuse is enabled.

This PR also adds a caplog assertion covering the warning behavior. The trace ID fix and its regression coverage are already provided by #5922.

**Related Issue:** Relates to #5128

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [x] Tests

## Testing

uv run --with pytest --with pytest-asyncio --with langfuse python -m pytest -q tests/unit/observability/test_langfuse_context.py tests/unit/observability/test_langfuse_integration.py

Result: 20 passed.