### PR TITLE
fix(tools): expose structured failure outcomes

### DIFF
--- a/src/qwenpaw/agents/tools/ast_tool.py
+++ b/src/qwenpaw/agents/tools/ast_tool.py
@@ -30,6 +30,7 @@ from ...config.context import get_current_workspace_dir
 from ...constant import WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
 from .file_io import _resolve_file_path
+from .tool_outcome import error_tool_chunk
 
 # ---------------------------------------------------------------------
 # Constants
@@ -59,6 +60,22 @@ def _make_response(text: str) -> ToolChunk:
         is_last=True,
         state=ToolResultState.SUCCESS,
         content=[TextBlock(type="text", text=text)],
+    )
+
+
+def _make_error(
+    text: str,
+    *,
+    code: str,
+    retryable: bool = False,
+    next_action: str,
+) -> ToolChunk:
+    return error_tool_chunk(
+        text,
+        code=code,
+        retryable=retryable,
+        same_args_retry_useful=False,
+        next_action=next_action,
     )
 
 
@@ -104,20 +121,26 @@ def _resolve_search_path(
     try:
         candidate_resolved = candidate.resolve()
     except OSError as exc:
-        return _make_response(
+        return _make_error(
             f"Error: cannot resolve path {candidate} — {exc}",
+            code="PATH_RESOLUTION_ERROR",
+            next_action="change_search_path",
         )
     root_resolved = root.resolve()
     try:
         candidate_resolved.relative_to(root_resolved)
     except ValueError:
-        return _make_response(
+        return _make_error(
             f"Error: path {path} is outside the project root "
             f"{root_resolved}.",
+            code="PATH_OUTSIDE_WORKSPACE",
+            next_action="use_path_inside_workspace",
         )
     if not candidate_resolved.exists():
-        return _make_response(
+        return _make_error(
             f"Error: path {candidate_resolved} does not exist.",
+            code="PATH_NOT_FOUND",
+            next_action="change_search_path",
         )
     return candidate_resolved
 
@@ -255,15 +278,25 @@ async def ast_search(  # pylint: disable=too-many-return-statements
             1000.
     """
     if not pattern:
-        return _make_response("Error: empty `pattern`.")
+        return _make_error(
+            "Error: empty `pattern`.",
+            code="MISSING_PATTERN",
+            next_action="provide_ast_pattern",
+        )
     if not language:
-        return _make_response("Error: missing `language`.")
+        return _make_error(
+            "Error: missing `language`.",
+            code="MISSING_LANGUAGE",
+            next_action="provide_source_language",
+        )
 
     binary = _ast_grep_binary()
     if binary is None:
-        return _make_response(
+        return _make_error(
             "Error: ast-grep CLI not found on PATH.  Install with "
             "`pip install ast-grep-cli` and retry.",
+            code="DEPENDENCY_MISSING",
+            next_action="install_ast_grep_or_use_grep_search",
         )
 
     max_matches = max(1, min(int(max_matches), _MAX_MATCHES_CAP))
@@ -293,25 +326,36 @@ async def ast_search(  # pylint: disable=too-many-return-statements
             fallback_secs=_AST_GREP_TIMEOUT + 5,
         )
     except (asyncio.TimeoutError, asyncio.CancelledError):
-        return _make_response(
+        return _make_error(
             f"Error: ast_search timed out after {_AST_GREP_TIMEOUT}s. "
             f"Try a narrower `path` or a more specific pattern.",
+            code="SEARCH_TIMEOUT",
+            retryable=True,
+            next_action="narrow_search_scope",
         )
 
     if returncode != 0:
         msg = (stderr or stdout or "unknown error").strip()
-        return _make_response(f"Error: ast-grep failed — {msg}")
+        return _make_error(
+            f"Error: ast-grep failed — {msg}",
+            code="AST_GREP_FAILED",
+            next_action="change_pattern_language_or_path",
+        )
 
     try:
         raw = json.loads(stdout) if stdout.strip() else []
     except json.JSONDecodeError as exc:
-        return _make_response(
+        return _make_error(
             f"Error: could not parse ast-grep output — {exc}",
+            code="INVALID_TOOL_OUTPUT",
+            next_action="use_grep_search_or_report_tool_error",
         )
 
     if not isinstance(raw, list):
-        return _make_response(
+        return _make_error(
             "Error: unexpected ast-grep output (expected a JSON list).",
+            code="INVALID_TOOL_OUTPUT",
+            next_action="use_grep_search_or_report_tool_error",
         )
 
     matches, truncated = _format_matches(raw, root, max_matches)

--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -22,6 +22,7 @@ from ...config.context import (
 )
 from ...constant import WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
+from .tool_outcome import error_tool_chunk
 
 
 def _path_to_file_url(path: str) -> str:
@@ -373,15 +374,13 @@ async def edit_file(
         )
 
     if old_text not in content:
-        return ToolChunk(
-            is_last=True,
-            state=ToolResultState.ERROR,
-            content=[
-                TextBlock(
-                    type="text",
-                    text=f"Error: The text to replace was not found in {file_path}.",
-                ),
-            ],
+        return error_tool_chunk(
+            f"Error: The text to replace was not found in {file_path}.",
+            code="MATCH_NOT_FOUND",
+            retryable=False,
+            same_args_retry_useful=False,
+            next_action="re_read_file_or_change_old_text",
+            metadata={"changed": False, "match_count": 0},
         )
 
     new_content = content.replace(old_text, new_text)
@@ -390,10 +389,8 @@ async def edit_file(
         content=new_content,
     )
 
-    if write_response.content and len(write_response.content) > 0:
-        write_text = getattr(write_response.content[0], "text", "")
-        if write_text.startswith("Error:"):
-            return write_response
+    if write_response.state == ToolResultState.ERROR:
+        return write_response
 
     return ToolChunk(
         is_last=True,

--- a/src/qwenpaw/agents/tools/file_search.py
+++ b/src/qwenpaw/agents/tools/file_search.py
@@ -20,6 +20,7 @@ from ...constant import WORKING_DIR
 from ...config.context import get_current_workspace_dir
 from ...runtime.tool_registry import tool_descriptor
 from .file_io import _resolve_file_path
+from .tool_outcome import error_tool_chunk
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -137,6 +138,22 @@ def _make_response(text: str) -> ToolChunk:
     )
 
 
+def _make_error(
+    text: str,
+    *,
+    code: str,
+    retryable: bool = False,
+    next_action: str,
+) -> ToolChunk:
+    return error_tool_chunk(
+        text,
+        code=code,
+        retryable=retryable,
+        same_args_retry_useful=False,
+        next_action=next_action,
+    )
+
+
 def _compile_search_pattern(
     pattern: str,
     is_regex: bool,
@@ -177,16 +194,22 @@ def _resolve_search_root(
     try:
         exists = search_root.exists()
     except OSError as e:
-        return _make_response(
+        return _make_error(
             f"Error: Cannot access path {search_root} — {e}",
+            code="PATH_ACCESS_ERROR",
+            next_action="check_path_and_permissions",
         )
     if not exists:
-        return _make_response(
+        return _make_error(
             f"Error: The path {search_root} does not exist.",
+            code="PATH_NOT_FOUND",
+            next_action="change_search_path",
         )
     if require_dir and not search_root.is_dir():
-        return _make_response(
+        return _make_error(
             f"Error: The path {search_root} is not a directory.",
+            code="PATH_NOT_DIRECTORY",
+            next_action="change_search_path",
         )
     return search_root
 
@@ -544,8 +567,11 @@ def _walk_and_grep(  # noqa: C901  pylint: disable=too-many-branches,too-many-lo
                         )
                         break
 
-        except OSError:
-            continue
+        except OSError as exc:
+            if single_file or not matches:
+                return matches, f"error: cannot read {file_path}: {exc}"
+            status = f"partial_error: cannot read {file_path}: {exc}"
+            break
 
         if status != "ok":
             break
@@ -557,10 +583,10 @@ def _walk_and_glob(
     search_root: Path,
     pattern: str,
     cancel: threading.Event,
-) -> tuple[list[str], bool]:
+) -> tuple[list[str], bool, str | None]:
     """Iterate ``search_root.glob(pattern)`` with cancellation support.
 
-    Returns ``(result_lines, truncated)``.
+    Returns ``(result_lines, truncated, error)``.
     """
     results: list[str] = []
     truncated = False
@@ -581,11 +607,11 @@ def _walk_and_glob(
             if len(results) >= _MAX_MATCHES:
                 truncated = True
                 break
-    except OSError:
-        pass
+    except OSError as exc:
+        return results, truncated, str(exc)
 
     results.sort()
-    return results, truncated
+    return results, truncated, None
 
 
 # ---------------------------------------------------------------------------
@@ -632,7 +658,11 @@ async def grep_search(
             path shown once per file and ``---`` between file groups.
     """
     if not pattern:
-        return _make_response("Error: No search `pattern` provided.")
+        return _make_error(
+            "Error: No search `pattern` provided.",
+            code="MISSING_PATTERN",
+            next_action="provide_search_pattern",
+        )
 
     root_or_err = _resolve_search_root(path)
     if isinstance(root_or_err, ToolChunk):
@@ -643,7 +673,11 @@ async def grep_search(
     try:
         regex = _compile_search_pattern(pattern, is_regex, flags)
     except re.error as e:
-        return _make_response(f"Error: Invalid regex pattern — {e}")
+        return _make_error(
+            f"Error: Invalid regex pattern — {e}",
+            code="INVALID_REGEX",
+            next_action="change_regex_pattern",
+        )
 
     cancel = threading.Event()
 
@@ -670,13 +704,20 @@ async def grep_search(
     except (asyncio.TimeoutError, asyncio.CancelledError):
         cancel.set()
         await asyncio.sleep(0.05)
-        return _make_response(
+        return _make_error(
             f"Error: Search timed out after {_GREP_TIMEOUT}s. "
             f"Try narrowing the search path or using a more specific pattern.",
+            code="SEARCH_TIMEOUT",
+            retryable=True,
+            next_action="narrow_search_scope",
         )
 
     if status.startswith("error:"):
-        result = f"Error: grep failed — {status}"
+        return _make_error(
+            f"Error: grep failed — {status}",
+            code="SEARCH_EXECUTION_ERROR",
+            next_action="check_path_and_search_parameters",
+        )
     elif status.startswith("truncated:"):
         # Even if no matches were appended (e.g., first match exceeded limit),
         # we should report truncation, not "No matches found"
@@ -701,6 +742,8 @@ async def grep_search(
                 f"\n\n(Partial results — search timed out after {_GREP_TIMEOUT}s. "
                 f"Try narrowing the search scope.)"
             )
+        elif status.startswith("partial_error:"):
+            result += f"\n\n(Partial results — {status})"
 
     return _make_response(result)
 
@@ -720,7 +763,11 @@ async def glob_search(
             Root directory to search from.  Defaults to WORKING_DIR.
     """
     if not pattern:
-        return _make_response("Error: No glob `pattern` provided.")
+        return _make_error(
+            "Error: No glob `pattern` provided.",
+            code="MISSING_PATTERN",
+            next_action="provide_glob_pattern",
+        )
 
     root_or_err = _resolve_search_root(path, require_dir=True)
     if isinstance(root_or_err, ToolChunk):
@@ -729,25 +776,35 @@ async def glob_search(
 
     cancel = threading.Event()
 
-    def _worker() -> tuple[list[str], bool]:
+    def _worker() -> tuple[list[str], bool, str | None]:
         try:
             return _walk_and_glob(search_root, pattern, cancel)
-        except Exception:
-            return [], False
+        except Exception as exc:
+            return [], False, str(exc)
 
     try:
         from ...tool_calls import cancellable_wait
 
-        results, truncated = await cancellable_wait(
+        results, truncated, error = await cancellable_wait(
             asyncio.to_thread(_worker),
             fallback_secs=_GLOB_TIMEOUT,
         )
     except (asyncio.TimeoutError, asyncio.CancelledError):
         cancel.set()
         await asyncio.sleep(0.05)
-        return _make_response(
+        return _make_error(
             f"Error: Glob search timed out after {_GLOB_TIMEOUT}s. "
             f"Try a more specific pattern or narrower search path.",
+            code="SEARCH_TIMEOUT",
+            retryable=True,
+            next_action="narrow_search_scope",
+        )
+
+    if error is not None:
+        return _make_error(
+            f"Error: Glob search failed — {error}",
+            code="SEARCH_EXECUTION_ERROR",
+            next_action="check_path_and_glob_pattern",
         )
 
     if not results:

--- a/src/qwenpaw/agents/tools/lsp_tool.py
+++ b/src/qwenpaw/agents/tools/lsp_tool.py
@@ -22,6 +22,7 @@ from ...constant import WORKING_DIR
 from . import _lsp_client as lsp_client
 from . import _lsp_servers as lsp_servers
 from .file_io import _resolve_file_path
+from .tool_outcome import error_tool_chunk
 
 # ---------------------------------------------------------------------
 # Constants
@@ -55,6 +56,22 @@ def _make_response(text: str) -> ToolChunk:
     )
 
 
+def _make_error(
+    text: str,
+    *,
+    code: str,
+    retryable: bool = False,
+    next_action: str,
+) -> ToolChunk:
+    return error_tool_chunk(
+        text,
+        code=code,
+        retryable=retryable,
+        same_args_retry_useful=False,
+        next_action=next_action,
+    )
+
+
 def _resolve_root() -> Path:
     workspace = get_current_workspace_dir()
     if workspace is not None:
@@ -68,28 +85,40 @@ def _resolve_file(
 ) -> "Path | ToolChunk":
     """Resolve ``file_path`` and ensure it lives inside ``root``."""
     if not file_path:
-        return _make_response("Error: missing `file_path`.")
+        return _make_error(
+            "Error: missing `file_path`.",
+            code="MISSING_FILE_PATH",
+            next_action="provide_file_path",
+        )
     candidate = Path(_resolve_file_path(file_path)).expanduser()
     try:
         resolved = candidate.resolve()
     except OSError as exc:
-        return _make_response(
+        return _make_error(
             f"Error: cannot resolve path {candidate} — {exc}",
+            code="PATH_RESOLUTION_ERROR",
+            next_action="change_file_path",
         )
     try:
         resolved.relative_to(root.resolve())
     except ValueError:
-        return _make_response(
+        return _make_error(
             f"Error: path {file_path} is outside the project root "
             f"{root.resolve()}.",
+            code="PATH_OUTSIDE_WORKSPACE",
+            next_action="use_path_inside_workspace",
         )
     if not resolved.exists():
-        return _make_response(
+        return _make_error(
             f"Error: path {resolved} does not exist.",
+            code="PATH_NOT_FOUND",
+            next_action="change_file_path",
         )
     if not resolved.is_file():
-        return _make_response(
+        return _make_error(
             f"Error: path {resolved} is not a regular file.",
+            code="PATH_NOT_FILE",
+            next_action="provide_regular_file_path",
         )
     return resolved
 
@@ -183,9 +212,11 @@ def make_lsp_tool(  # noqa: C901  pylint: disable=too-many-statements
     ) -> ToolChunk:
         # pylint: disable=too-many-return-statements,too-many-branches
         if operation not in _ALL_OPERATIONS:
-            return _make_response(
+            return _make_error(
                 f"Error: unknown operation `{operation}`. Valid: "
                 f"{sorted(_ALL_OPERATIONS)}.",
+                code="UNKNOWN_OPERATION",
+                next_action="choose_supported_operation",
             )
 
         root = _resolve_root()
@@ -194,12 +225,16 @@ def make_lsp_tool(  # noqa: C901  pylint: disable=too-many-statements
         # a language since workspace/symbol is server-scoped.
         if operation == "workspaceSymbol":
             if not query:
-                return _make_response(
+                return _make_error(
                     "Error: `query` is required for workspaceSymbol.",
+                    code="MISSING_QUERY",
+                    next_action="provide_symbol_query",
                 )
             if not frozen_available:
-                return _make_response(
+                return _make_error(
                     "Error: no LSP servers available in this workspace.",
+                    code="LSP_SERVER_UNAVAILABLE",
+                    next_action="use_grep_search_or_ast_search",
                 )
             # Prefer Python if discovered, otherwise the first language
             # in the registry order so the choice is deterministic.
@@ -216,26 +251,32 @@ def make_lsp_tool(  # noqa: C901  pylint: disable=too-many-statements
             target_file = resolved_or_err
             language_id = lsp_servers.language_for_file(target_file) or ""
             if not language_id:
-                return _make_response(
+                return _make_error(
                     f"Error: cannot infer language for {target_file.name}. "
                     "Fall back to grep_search / ast_search.",
+                    code="LANGUAGE_NOT_DETECTED",
+                    next_action="use_grep_search_or_ast_search",
                 )
             if language_id not in frozen_available:
                 supported = _format_languages(
                     list(frozen_available.keys()),
                 )
                 pretty = lsp_servers.display_name(language_id)
-                return _make_response(
+                return _make_error(
                     f"Error: LSP for {pretty} is not available in this "
                     f"workspace. Supported: {supported}. Use grep_search "
                     f"/ ast_search for {target_file.name}.",
+                    code="LSP_SERVER_UNAVAILABLE",
+                    next_action="use_grep_search_or_ast_search",
                 )
 
         if operation in _OPERATIONS_REQUIRING_POSITION:
             if line < 1 or character < 1:
-                return _make_response(
+                return _make_error(
                     "Error: `line` and `character` must be 1-based "
                     "integers >= 1.",
+                    code="INVALID_POSITION",
+                    next_action="provide_one_based_position",
                 )
 
         argv = frozen_available[language_id]
@@ -261,12 +302,19 @@ def make_lsp_tool(  # noqa: C901  pylint: disable=too-many-statements
                 fallback_secs=_REQUEST_TIMEOUT,
             )
         except (asyncio.TimeoutError, asyncio.CancelledError):
-            return _make_response(
+            return _make_error(
                 f"Error: LSP {operation} timed out after "
                 f"{_REQUEST_TIMEOUT}s.",
+                code="LSP_TIMEOUT",
+                retryable=True,
+                next_action="retry_once_or_use_search_fallback",
             )
         except lsp_client.LspError as exc:
-            return _make_response(f"Error: LSP {operation} failed — {exc}")
+            return _make_error(
+                f"Error: LSP {operation} failed — {exc}",
+                code="LSP_REQUEST_FAILED",
+                next_action="use_grep_search_or_ast_search",
+            )
 
         if result is None:
             return _make_response(f"No result for {operation}.")

--- a/src/qwenpaw/agents/tools/run_tool_batch.py
+++ b/src/qwenpaw/agents/tools/run_tool_batch.py
@@ -10,10 +10,11 @@ import re
 from pathlib import Path
 from typing import Any
 
-from agentscope.message import TextBlock
+from agentscope.message import TextBlock, ToolResultState
 from agentscope.tool import ToolResponse
 
 from ...config.context import get_current_toolkit
+from .tool_outcome import TOOL_OUTCOME_METADATA_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ _STEP_REF_INLINE_PATTERN = re.compile(
 
 def _json_tool_response(payload: dict[str, Any]) -> ToolResponse:
     """Wrap a JSON-serialisable dict in a single-TextBlock ToolResponse."""
+    ok = payload.get("ok", True) is not False
     return ToolResponse(
         content=[
             TextBlock(
@@ -45,6 +47,7 @@ def _json_tool_response(payload: dict[str, Any]) -> ToolResponse:
                 text=json.dumps(payload, ensure_ascii=False),
             ),
         ],
+        state=(ToolResultState.SUCCESS if ok else ToolResultState.ERROR),
     )
 
 
@@ -92,7 +95,8 @@ def _is_error_text(text: str) -> bool:
 def _response_payload(response: ToolResponse) -> dict[str, Any]:
     """Convert a ToolResponse into a normalised result dict.
 
-    The ``ok`` field is inferred from:
+    The ``ok`` field is inferred from, in priority order:
+    - The ToolResponse execution state and structured outcome metadata.
     - JSON responses with an explicit ``ok`` field (``browser_use``,
       ``desktop_screenshot``).
     - Plain-text error prefixes (``Error:``, ``Command failed``).
@@ -104,6 +108,27 @@ def _response_payload(response: ToolResponse) -> dict[str, Any]:
     """
     text = _extract_text(response)
     content = list(response.content or [])
+    metadata = response.metadata if isinstance(response.metadata, dict) else {}
+    outcome = metadata.get(TOOL_OUTCOME_METADATA_KEY)
+    outcome = outcome if isinstance(outcome, dict) else {}
+    state = getattr(response.state, "value", response.state)
+    state = str(state or "").lower()
+
+    error_states = {
+        ToolResultState.ERROR.value,
+        ToolResultState.DENIED.value,
+        ToolResultState.INTERRUPTED.value,
+    }
+    if state in error_states:
+        payload = {
+            "ok": False,
+            "error": text or f"Tool ended with state={state}",
+            "state": state,
+            "_raw_blocks": content,
+        }
+        if outcome:
+            payload["outcome"] = outcome
+        return payload
 
     # Try JSON first — some tools return structured JSON with ``ok``.
     try:
@@ -478,7 +503,10 @@ def _build_batch_response(
         type="text",
         text=json.dumps(payload, ensure_ascii=False),
     )
-    return ToolResponse(content=[summary, *all_content_blocks])
+    return ToolResponse(
+        content=[summary, *all_content_blocks],
+        state=(ToolResultState.SUCCESS if all_ok else ToolResultState.ERROR),
+    )
 
 
 # --- Main entry point -----------------------------------------------------

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -26,6 +26,7 @@ from ...config.context import (
 from ...constant import WORKING_DIR
 from ...runtime.tool_registry import tool_descriptor
 from ...sandbox import ExecutionResult
+from .tool_outcome import error_tool_chunk
 
 
 def _kill_process_tree_win32(pid: int) -> None:
@@ -218,7 +219,8 @@ def _extract_powershell_command(cmd: str) -> tuple[str | None, str]:
     return ps_exe, inner
 
 
-# pylint: disable=too-many-branches, too-many-statements
+# pylint: disable=too-many-branches, too-many-return-statements
+# pylint: disable=too-many-statements
 def _execute_subprocess_sync(
     cmd: str,
     cwd: str,
@@ -534,19 +536,13 @@ async def execute_shell_command(
     cmd = _collapse_embedded_newlines((command or "").strip())
 
     if _is_dangerous_self_kill(cmd):
-        return ToolChunk(
-            is_last=True,
-            state=ToolResultState.ERROR,
-            content=[
-                TextBlock(
-                    type="text",
-                    text=(
-                        "Blocked: this command would terminate the "
-                        "QwenPaw process or its parent. "
-                        "Refusing to execute."
-                    ),
-                ),
-            ],
+        return error_tool_chunk(
+            "Blocked: this command would terminate the QwenPaw process "
+            "or its parent. Refusing to execute.",
+            code="SELF_TERMINATION_BLOCKED",
+            retryable=False,
+            same_args_retry_useful=False,
+            next_action="change_command",
         )
 
     if isinstance(timeout, str):
@@ -618,22 +614,36 @@ async def execute_shell_command(
             )
             if result.stderr:
                 response_text += f"\n[stderr]\n{result.stderr}"
-        else:
-            parts = [f"Command failed with exit code {result.exit_code}."]
-            if result.stdout:
-                parts.append(f"\n[stdout]\n{result.stdout}")
-            if result.stderr:
-                parts.append(f"\n[stderr]\n{result.stderr}")
-            response_text = "".join(parts)
-        return ToolChunk(
-            is_last=True,
-            state=ToolResultState.SUCCESS,
-            content=[
-                TextBlock(
-                    type="text",
-                    text=response_text,
-                ),
-            ],
+            return ToolChunk(
+                is_last=True,
+                state=ToolResultState.SUCCESS,
+                content=[TextBlock(type="text", text=response_text)],
+            )
+
+        parts = [f"Command failed with exit code {result.exit_code}."]
+        if result.stdout:
+            parts.append(f"\n[stdout]\n{result.stdout}")
+        if result.stderr:
+            parts.append(f"\n[stderr]\n{result.stderr}")
+        response_text = "".join(parts)
+        timed_out = (
+            result.exit_code == -1
+            and "timeout" in (result.stderr or "").lower()
+        )
+        return error_tool_chunk(
+            response_text,
+            code="COMMAND_TIMEOUT" if timed_out else "NON_ZERO_EXIT",
+            retryable=timed_out,
+            same_args_retry_useful=False,
+            next_action=(
+                "increase_timeout_or_narrow_command"
+                if timed_out
+                else "inspect_stderr_and_change_command"
+            ),
+            metadata={
+                "exit_code": result.exit_code,
+                "timed_out": timed_out,
+            },
         )
 
     import logging as _logging
@@ -729,35 +739,39 @@ async def execute_shell_command(
                 response_text = "Command executed successfully (no output)."
             if stderr_str:
                 response_text += f"\n[stderr]\n{stderr_str}"
-        else:
-            response_parts = [f"Command failed with exit code {returncode}."]
-            if stdout_str:
-                response_parts.append(f"\n[stdout]\n{stdout_str}")
-            if stderr_str:
-                response_parts.append(f"\n[stderr]\n{stderr_str}")
-            response_text = "".join(response_parts)
+            return ToolChunk(
+                is_last=True,
+                state=ToolResultState.SUCCESS,
+                content=[TextBlock(type="text", text=response_text)],
+            )
 
-        return ToolChunk(
-            is_last=True,
-            state=ToolResultState.SUCCESS,
-            content=[
-                TextBlock(
-                    type="text",
-                    text=response_text,
-                ),
-            ],
+        response_parts = [f"Command failed with exit code {returncode}."]
+        if stdout_str:
+            response_parts.append(f"\n[stdout]\n{stdout_str}")
+        if stderr_str:
+            response_parts.append(f"\n[stderr]\n{stderr_str}")
+        response_text = "".join(response_parts)
+        timed_out = returncode == -1
+        return error_tool_chunk(
+            response_text,
+            code="COMMAND_TIMEOUT" if timed_out else "NON_ZERO_EXIT",
+            retryable=timed_out,
+            same_args_retry_useful=False,
+            next_action=(
+                "increase_timeout_or_narrow_command"
+                if timed_out
+                else "inspect_stderr_and_change_command"
+            ),
+            metadata={"exit_code": returncode, "timed_out": timed_out},
         )
 
     except Exception as e:
-        return ToolChunk(
-            is_last=True,
-            state=ToolResultState.SUCCESS,
-            content=[
-                TextBlock(
-                    type="text",
-                    text=f"Error: Shell command execution failed due to \n{e}",
-                ),
-            ],
+        return error_tool_chunk(
+            f"Error: Shell command execution failed due to\n{e}",
+            code="SHELL_EXECUTION_ERROR",
+            retryable=False,
+            same_args_retry_useful=False,
+            next_action="inspect_environment_or_change_command",
         )
 
 

--- a/src/qwenpaw/agents/tools/tool_outcome.py
+++ b/src/qwenpaw/agents/tools/tool_outcome.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Helpers for consistent machine- and model-readable tool outcomes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentscope.message import TextBlock, ToolResultState
+from agentscope.tool import ToolChunk
+
+TOOL_OUTCOME_METADATA_KEY = "tool_outcome"
+
+
+def error_tool_chunk(
+    message: str,
+    *,
+    code: str,
+    retryable: bool,
+    same_args_retry_useful: bool,
+    next_action: str,
+    metadata: dict[str, Any] | None = None,
+) -> ToolChunk:
+    """Build an error result that remains clear after model formatting.
+
+    Provider formatters currently omit ``ToolResultState`` and tool metadata
+    from model requests. The short outcome footer therefore mirrors the
+    machine-readable metadata without replacing the human-readable error.
+    """
+    outcome = {
+        "status": "error",
+        "code": code,
+        "retryable": retryable,
+        "same_args_retry_useful": same_args_retry_useful,
+        "next_action": next_action,
+    }
+    chunk_metadata = dict(metadata or {})
+    chunk_metadata[TOOL_OUTCOME_METADATA_KEY] = outcome
+    outcome_text = (
+        f"{message}\n\n"
+        f"TOOL_OUTCOME: status=error; code={code}; "
+        f"retryable={str(retryable).lower()}; "
+        f"same_args_retry_useful="
+        f"{str(same_args_retry_useful).lower()}; "
+        f"next_action={next_action}"
+    )
+    return ToolChunk(
+        is_last=True,
+        state=ToolResultState.ERROR,
+        content=[TextBlock(type="text", text=outcome_text)],
+        metadata=chunk_metadata,
+    )

--- a/tests/unit/agents/tools/test_file_io.py
+++ b/tests/unit/agents/tools/test_file_io.py
@@ -14,6 +14,7 @@ Covers:
 from unittest.mock import patch
 
 import pytest
+from agentscope.message import ToolResultState
 
 from qwenpaw.agents.tools.file_io import (
     _get_encoding_for_file,
@@ -232,6 +233,12 @@ class TestEditFile:
         f.write_text("hello world", encoding="utf-8")
         result = await edit_file(str(f), "missing", "replacement")
         assert "not found" in result.content[0].text
+        assert result.state == ToolResultState.ERROR
+        outcome = result.metadata["tool_outcome"]
+        assert outcome["code"] == "MATCH_NOT_FOUND"
+        assert outcome["same_args_retry_useful"] is False
+        assert result.metadata["changed"] is False
+        assert result.metadata["match_count"] == 0
 
     @pytest.mark.asyncio
     async def test_edit_nonexistent_file(self, tmp_path):

--- a/tests/unit/agents/tools/test_file_search.py
+++ b/tests/unit/agents/tools/test_file_search.py
@@ -533,7 +533,7 @@ def test_walk_and_grep_empty_directory(temp_dir):
 
 
 def test_walk_and_grep_file_read_error(temp_dir):
-    """Test that unreadable files are skipped gracefully."""
+    """Test that an unreadable-only search is not reported as no match."""
     if os.name != "nt":
         f = temp_dir / "noperm.txt"
         f.write_text("secret\n")
@@ -547,7 +547,7 @@ def test_walk_and_grep_file_read_error(temp_dir):
                 FakeCancel(),
                 None,
             )
-            assert status == "ok"
+            assert status.startswith("error:")
             assert not matches
         finally:
             os.chmod(str(f), 0o644)

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agentscope.message import ToolResultState
 
 from qwenpaw.agents.tools.shell import (
     _collapse_embedded_newlines,
@@ -452,6 +453,10 @@ class TestExecuteShellCommand:
             result = await execute_shell_command("false")
             text = result.content[0].text
             assert "failed" in text.lower() or "error" in text.lower()
+            assert result.state == ToolResultState.ERROR
+            outcome = result.metadata["tool_outcome"]
+            assert outcome["code"] == "NON_ZERO_EXIT"
+            assert outcome["same_args_retry_useful"] is False
 
     @pytest.mark.asyncio
     @patch("qwenpaw.agents.tools.shell.get_current_shell_command_timeout")

--- a/tests/unit/agents/tools/test_tool_failure_outcomes.py
+++ b/tests/unit/agents/tools/test_tool_failure_outcomes.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for structured tool failure outcomes."""
+
+from agentscope.message import TextBlock, ToolResultState
+from agentscope.tool import ToolResponse
+import pytest
+
+from qwenpaw.agents.tools.ast_tool import ast_search
+from qwenpaw.agents.tools.file_search import grep_search
+from qwenpaw.agents.tools.lsp_tool import make_lsp_tool
+from qwenpaw.agents.tools.run_tool_batch import (
+    _json_tool_response,
+    _response_payload,
+)
+
+
+@pytest.mark.asyncio
+async def test_grep_missing_pattern_is_error():
+    result = await grep_search("")
+
+    assert result.state == ToolResultState.ERROR
+    assert result.metadata["tool_outcome"]["code"] == "MISSING_PATTERN"
+    assert "TOOL_OUTCOME:" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_grep_no_match_is_success(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("present", encoding="utf-8")
+
+    result = await grep_search("absent", path=str(source))
+
+    assert result.state == ToolResultState.SUCCESS
+    assert "No matches found" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_ast_missing_pattern_is_error():
+    result = await ast_search("", "python")
+
+    assert result.state == ToolResultState.ERROR
+    assert result.metadata["tool_outcome"]["code"] == "MISSING_PATTERN"
+
+
+@pytest.mark.asyncio
+async def test_lsp_unknown_operation_is_error():
+    lsp = make_lsp_tool({})
+
+    result = await lsp("unknown")
+
+    assert result.state == ToolResultState.ERROR
+    assert result.metadata["tool_outcome"]["code"] == "UNKNOWN_OPERATION"
+
+
+def test_batch_prefers_tool_state_and_outcome_metadata():
+    response = ToolResponse(
+        content=[TextBlock(type="text", text="plain failure")],
+        state=ToolResultState.ERROR,
+        metadata={
+            "tool_outcome": {
+                "status": "error",
+                "code": "TEST_FAILURE",
+                "retryable": False,
+                "same_args_retry_useful": False,
+                "next_action": "change_input",
+            },
+        },
+    )
+
+    payload = _response_payload(response)
+
+    assert payload["ok"] is False
+    assert payload["state"] == "error"
+    assert payload["outcome"]["code"] == "TEST_FAILURE"
+
+
+def test_batch_json_error_response_has_error_state():
+    response = _json_tool_response({"ok": False, "error": "invalid"})
+
+    assert response.state == ToolResultState.ERROR


### PR DESCRIPTION
## Description

This PR makes tool failures consistently machine-readable and visible to the model.

Several built-in tools returned failure text while marking the result as `ToolResultState.SUCCESS`. This prevented the tool coordinator and batch execution from reliably distinguishing failures from successful empty results. Provider formatters also omit the tool state and metadata from model requests, so changing the state alone would not tell the model whether an identical retry is useful.

The change introduces a shared error outcome helper that:

- returns `ToolResultState.ERROR`;
- stores a structured `tool_outcome` object in `ToolChunk.metadata`;
- appends a concise `TOOL_OUTCOME` footer to the model-visible output;
- communicates an error code, retryability, whether identical arguments are useful, and the recommended next action.

Shell execution, file editing, file search, AST search, and LSP failures now use these semantics. `run_tool_batch` prioritizes the real tool state and structured metadata while retaining its legacy text heuristics for compatibility. Valid empty search results remain successful.

**Related Issue:** Relates to #6116

**Security Considerations:** No new permissions or external data flows are introduced. Existing sandbox denial behavior is preserved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the tool, coordinator, and history recall unit tests in the `Codex-QwenPaw` environment:

```bash
PYTHONPATH=src conda run -n Codex-QwenPaw pytest -q \
  tests/unit/agents/tools \
  tests/unit/tool_calls \
  tests/unit/agents/context/test_recall_tool.py
```

Run all pre-commit hooks against the changed source and test files.

## Evidence

```text
223 passed, 1 skipped in 1.43s
```

```text
check python ast........................Passed
fix python encoding pragma.............Passed
Add trailing commas....................Passed
mypy....................................Passed
black...................................Passed
flake8..................................Passed
pylint..................................Passed
```

Regression coverage verifies that:

- non-zero shell exits are errors with `NON_ZERO_EXIT` outcomes;
- an unchanged `edit_file` retry reports `MATCH_NOT_FOUND` and `changed=false`;
- invalid search, AST, and LSP requests are errors;
- legitimate empty search results remain successful;
- batch execution trusts tool state and outcome metadata before text heuristics.

## Additional Notes

The model provider APIs do not consistently accept an arbitrary tool-result state field. The model-visible outcome footer therefore complements, rather than replaces, the internal state and metadata.
