### PR TITLE
fix(agents): align reasoning with tool segments

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -646,10 +646,11 @@ _MEDIA_BLOCK_TYPES = ("image", "audio", "video")
 # message survives formatting.
 _SURVIVOR_BLOCK_TYPES = frozenset({"text", "tool_use", "tool_call"})
 
-# Block types the base formatter silently skips.  A message consisting
-# entirely of these (plus any ``DataBlock`` with unsupported media)
-# will be discarded.  Used by ``_is_block_dropped_by_formatter``
-# to predict which assistant messages vanish from the formatted output.
+# Block types that do not contribute content to an assistant wire message.
+# Thinking and file blocks are skipped, while a hint becomes a separate user
+# message. A source segment consisting entirely of these (plus any
+# ``DataBlock`` with unsupported media) emits no assistant message. Used by
+# ``_is_block_dropped_by_formatter`` to predict assistant-message survival.
 #
 # ``file`` is kept for completeness but is effectively dead code:
 # ``_fixup_media_list`` converts file blocks to ``TextBlock`` before
@@ -661,18 +662,17 @@ def _is_block_dropped_by_formatter(
     block: Any,
     formatter: "FormatterBase",
 ) -> bool:
-    """Predict whether the base formatter silently skips *block*.
+    """Predict whether *block* is absent from assistant wire content.
 
     The base ``OpenAIChatFormatter.format()`` only adds a block to
     ``content_blocks`` (text, DataBlock with supported media) or
-    ``tool_calls`` (ToolCallBlock).  Everything else — ThinkingBlock,
-    HintBlock, unknown types, and DataBlock with unsupported media — is
-    skipped.  If **all** blocks in an assistant message are skipped, the
-    message itself is discarded (see ``_openai_formatter.py:360``).
+    ``tool_calls`` (ToolCallBlock). ThinkingBlock, unknown types, and
+    unsupported DataBlock values are skipped. HintBlock is emitted as a
+    separate user message, so it does not keep an assistant segment alive.
 
     This function returns ``True`` when a block is predicted to be
-    skipped, enabling ``aligned_reasoning`` to correctly predict message
-    drops and stay in sync with the formatted output.  #5858
+    absent from assistant content, enabling ``aligned_reasoning`` to predict
+    message drops and stay in sync with the formatted output.  #5858
     """
     btype = (
         block.get("type")
@@ -717,9 +717,9 @@ def _reasoning_by_assistant_segment(
     """Align thinking content with emitted assistant wire messages.
 
     OpenAI-family formatters flush the current assistant message before each
-    tool result. AgentScope can keep several reasoning/tool cycles in one
-    assistant ``Msg``, so each resulting wire segment must receive only the
-    thinking blocks that belong to that segment.
+    tool result or hint. AgentScope can keep several reasoning/tool cycles in
+    one assistant ``Msg``, so each resulting wire segment must receive only
+    the thinking blocks that belong to that segment.
     """
 
     def _get(block: Any, key: str, default: Any = None) -> Any:
@@ -739,7 +739,7 @@ def _reasoning_by_assistant_segment(
                 reasoning_parts.append(thinking)
             continue
 
-        if block_type == "tool_result":
+        if block_type in ("tool_result", "hint"):
             if segment_survives:
                 aligned.append("\n".join(reasoning_parts) or None)
             reasoning_parts = []

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -710,6 +710,51 @@ def _is_block_dropped_by_formatter(
     return True
 
 
+def _reasoning_by_assistant_segment(
+    blocks: list[Any],
+    formatter: "FormatterBase",
+) -> list[str | None]:
+    """Align thinking content with emitted assistant wire messages.
+
+    OpenAI-family formatters flush the current assistant message before each
+    tool result. AgentScope can keep several reasoning/tool cycles in one
+    assistant ``Msg``, so each resulting wire segment must receive only the
+    thinking blocks that belong to that segment.
+    """
+
+    def _get(block: Any, key: str, default: Any = None) -> Any:
+        if isinstance(block, dict):
+            return block.get(key, default)
+        return getattr(block, key, default)
+
+    aligned: list[str | None] = []
+    reasoning_parts: list[str] = []
+    segment_survives = False
+
+    for block in blocks:
+        block_type = _get(block, "type")
+        if block_type == "thinking":
+            thinking = _get(block, "thinking", "")
+            if thinking:
+                reasoning_parts.append(thinking)
+            continue
+
+        if block_type == "tool_result":
+            if segment_survives:
+                aligned.append("\n".join(reasoning_parts) or None)
+            reasoning_parts = []
+            segment_survives = False
+            continue
+
+        if not _is_block_dropped_by_formatter(block, formatter):
+            segment_survives = True
+
+    if segment_survives:
+        aligned.append("\n".join(reasoning_parts) or None)
+
+    return aligned
+
+
 # pylint: disable=too-many-branches
 def _fixup_media_list(items: list) -> None:
     """Normalize media blocks in a list in-place.
@@ -931,7 +976,7 @@ def _create_file_block_support_formatter(
                 self,
             )
 
-            reasoning_contents = {}
+            has_reasoning = False
             extra_contents: dict[str, Any] = {}
             for msg in normalized_msgs:
                 if msg.role != "assistant":
@@ -940,8 +985,7 @@ def _create_file_block_support_formatter(
                     if _battr(block, "type") == "thinking":
                         thinking = _battr(block, "thinking", "")
                         if thinking:
-                            reasoning_contents[id(msg)] = thinking
-                        break
+                            has_reasoning = True
                 for block in msg.content or []:
                     btype = _battr(block, "type")
                     if btype in ("tool_use", "tool_call"):
@@ -996,7 +1040,7 @@ def _create_file_block_support_formatter(
                             tc["extra_content"] = ec
 
             if (
-                reasoning_contents
+                has_reasoning
                 and not is_anthropic_formatter
                 and not _is_response_formatter
                 and getattr(
@@ -1012,40 +1056,8 @@ def _create_file_block_support_formatter(
                     blocks = (
                         list(m.content) if isinstance(m.content, list) else []
                     )
-                    types = [_battr(b, "type") for b in blocks]
-                    # Drop prediction: a message is discarded when
-                    # *every* block is skipped by the base formatter
-                    # (thinking, hint, file, DataBlock with unsupported
-                    # media, unknown types).  See #5858.
-                    is_dropped_by_formatter = bool(blocks) and all(
-                        _is_block_dropped_by_formatter(b, self) for b in blocks
-                    )
-                    if is_dropped_by_formatter:
-                        continue
-                    # Split prediction: DashScope / OpenAI-family
-                    # formatters produce one assistant wire msg per
-                    # "segment" — where tool_result blocks act as
-                    # separators (they become role="tool" messages).
-                    # Each contiguous run of text/tool_call between
-                    # tool_results becomes one assistant message.
-                    non_thinking = [t for t in types if t != "thinking"]
-                    segments = 0
-                    in_segment = False
-                    for bt in non_thinking:
-                        if bt == "tool_result":
-                            in_segment = False
-                        else:
-                            if not in_segment:
-                                segments += 1
-                                in_segment = True
-                    # Within a segment, text+tool_call still counts as
-                    # one wire msg (content + tool_calls merged).  But
-                    # if a segment has text ONLY or tool_call ONLY,
-                    # that's also 1.  The only extra split is text that
-                    # follows tool_calls (rare in model output).
-                    wire_count = max(segments, 1)
                     aligned_reasoning.extend(
-                        [reasoning_contents.get(id(m))] * wire_count,
+                        _reasoning_by_assistant_segment(blocks, self),
                     )
 
                 out_assistant = [

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -9,6 +9,7 @@ import pytest
 from agentscope.formatter import OpenAIChatFormatter
 from agentscope.message import (
     DataBlock,
+    HintBlock,
     Msg,
     TextBlock,
     ThinkingBlock,
@@ -309,6 +310,35 @@ async def test_openai_formatter_aligns_reasoning_with_split_segments() -> None:
             ),
             ThinkingBlock(thinking="second reasoning"),
             TextBlock(text="done"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert [item.get("reasoning_content") for item in assistant_messages] == [
+        "first reasoning",
+        "second reasoning",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_aligns_reasoning_across_hint() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(relay_reasoning_content=True)
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="first reasoning"),
+            TextBlock(text="before hint"),
+            HintBlock(hint="continue"),
+            ThinkingBlock(thinking="second reasoning"),
+            TextBlock(text="after hint"),
         ],
     )
 

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -11,8 +11,10 @@ from agentscope.message import (
     DataBlock,
     Msg,
     TextBlock,
+    ThinkingBlock,
     ToolCallBlock,
     ToolResultBlock,
+    ToolResultState,
     URLSource,
 )
 
@@ -28,6 +30,7 @@ except ImportError:
 
 from qwenpaw.agents import model_factory
 from qwenpaw.constant import MEDIA_UNSUPPORTED_PLACEHOLDER
+from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 
 
 def _data_block(media_type: str, url: str) -> DataBlock:
@@ -277,6 +280,102 @@ def test_original_messages_not_modified_by_formatter_prep() -> None:
 
     assert original.to_dict() == original_dict
     assert original.content[1].type == "data"
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_aligns_reasoning_with_split_segments() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(relay_reasoning_content=True)
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="first reasoning"),
+            ToolCallBlock(id="call_1", name="first", input="{}"),
+            ToolCallBlock(id="call_2", name="second", input="{}"),
+            ToolResultBlock(
+                id="call_1",
+                name="first",
+                output=[TextBlock(text="first result")],
+                state=ToolResultState.SUCCESS,
+            ),
+            ToolResultBlock(
+                id="call_2",
+                name="second",
+                output=[TextBlock(text="second result")],
+                state=ToolResultState.SUCCESS,
+            ),
+            ThinkingBlock(thinking="second reasoning"),
+            TextBlock(text="done"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert [item.get("reasoning_content") for item in assistant_messages] == [
+        "first reasoning",
+        "second reasoning",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_does_not_carry_reasoning_forward() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(relay_reasoning_content=True)
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="tool reasoning"),
+            ToolCallBlock(id="call_1", name="tool", input="{}"),
+            ToolResultBlock(
+                id="call_1",
+                name="tool",
+                output=[TextBlock(text="result")],
+                state=ToolResultState.SUCCESS,
+            ),
+            TextBlock(text="done"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert assistant_messages[0]["reasoning_content"] == "tool reasoning"
+    assert "reasoning_content" not in assistant_messages[1]
+
+
+@pytest.mark.asyncio
+async def test_openai_formatter_respects_disabled_reasoning_relay() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(relay_reasoning_content=False)
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="private reasoning"),
+            TextBlock(text="answer"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert assistant_messages
+    assert all("reasoning_content" not in item for item in assistant_messages)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

AgentScope 2.0 can retain several reasoning/tool cycles in one assistant `Msg`. The shared formatter wrapper predicted the assistant messages emitted around tool-result boundaries, but copied the first `ThinkingBlock` onto every emitted segment. That duplicated reasoning A and dropped later reasoning B when reasoning relay was enabled.

This change aligns each reasoning group with the surviving assistant segment that owns it, including tool-result and hint boundaries. It also prevents a later text-only segment from inheriting earlier reasoning and preserves the disabled-relay behavior. The fix is in the shared formatter path rather than a SenseNova-specific workaround.

**Related Issue:** Fixes #6282 #5657 #5759 #2055; Relates to #6257

**Security Considerations:** No authentication, permissions, secrets, or configuration handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `pytest tests/unit/agents/test_model_factory_message_normalization.py -q`
- `pytest tests/unit/agents -q`
- `pytest tests/unit/providers -q`
- `pre-commit run --files src/qwenpaw/agents/model_factory.py tests/unit/agents/test_model_factory_message_normalization.py`

Verification matrix:

| Surface | Result |
| --- | --- |
| OpenAI-compatible relay enabled | Covered |
| Parallel tool calls and later reasoning | Covered |
| Later segment without reasoning | Covered |
| HintBlock assistant boundary | Covered |
| Reasoning relay disabled | Covered |
| Anthropic / OpenAI Responses guards | Unchanged |
| Console / channels | No direct rendering change |

## Evidence

The new regression first failed against `main` with the duplicated formatter output:

```text
1 failed, 18 passed
actual reasoning_content: ["first reasoning", "first reasoning"]
expected: ["first reasoning", "second reasoning"]
```

After the fix:

```text
21 passed in 0.80s
805 passed, 2 skipped in 11.53s
305 passed in 2.04s
```

All changed-file pre-commit hooks passed, including mypy, Black, flake8, and pylint.

## Additional Notes

No live SenseNova credentials were used. This PR addresses the deterministic QwenPaw-side formatter duplication reproduced without a provider call; reporter verification can confirm the end-to-end model behavior.
