### PR TITLE
fix(console): load Monaco from local bundle for offline coding preview

### DIFF
--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -1,6 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./i18n";
+// Configure Monaco to load from the local bundle instead of the CDN so the
+// Coding page works offline (issue #6261). Side-effect import, must run before
+// any Monaco editor mounts.
+import "./monacoSetup";
 import { installHostExternals } from "./plugins/hostExternals";
 import { installHostSdk } from "./plugins/hostSdk/install";
 import { registerHostModulesDynamic } from "./plugins/dynamicModuleRegistry";

--- a/console/src/monacoSetup.ts
+++ b/console/src/monacoSetup.ts
@@ -1,0 +1,49 @@
+/**
+ * Monaco offline setup.
+ *
+ * By default `@monaco-editor/react` (via `@monaco-editor/loader`) fetches the
+ * Monaco core from the jsDelivr CDN at runtime, which breaks the Coding page
+ * file preview/editing in offline / air-gapped environments (issue #6261).
+ *
+ * Here we:
+ *   1. Wire `self.MonacoEnvironment.getWorker` to the workers bundled by Vite
+ *      (`?worker` imports resolve to local blobs — no network needed).
+ *   2. Point the loader at the locally installed `monaco-editor` package so it
+ *      never touches the CDN.
+ *
+ * This module has side effects and must be imported once, before any Monaco
+ * editor mounts (see main.tsx).
+ */
+
+import * as monaco from "monaco-editor";
+import { loader } from "@monaco-editor/react";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
+
+self.MonacoEnvironment = {
+  getWorker(_workerId: string, label: string) {
+    switch (label) {
+      case "json":
+        return new jsonWorker();
+      case "css":
+      case "scss":
+      case "less":
+        return new cssWorker();
+      case "html":
+      case "handlebars":
+      case "razor":
+        return new htmlWorker();
+      case "typescript":
+      case "javascript":
+        return new tsWorker();
+      default:
+        return new editorWorker();
+    }
+  },
+};
+
+// Use the locally bundled monaco instance instead of loading it from the CDN.
+loader.config({ monaco });

--- a/console/src/monacoSetup.ts
+++ b/console/src/monacoSetup.ts
@@ -24,6 +24,9 @@ import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
 import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 
 self.MonacoEnvironment = {
+  // Merge instead of overwrite so any MonacoEnvironment fields set elsewhere
+  // (e.g. a future CSP / Trusted Types policy) are preserved.
+  ...self.MonacoEnvironment,
   getWorker(_workerId: string, label: string) {
     switch (label) {
       case "json":


### PR DESCRIPTION
The Coding page editor loaded Monaco from the jsDelivr CDN at runtime via @monaco-editor/loader's default config, so offline/air-gapped environments could not preview or edit file content (issue #6261).

Configure the loader to use the locally installed monaco-editor package and wire MonacoEnvironment workers via Vite ?worker imports, removing the runtime CDN dependency.

Closes #6261
<img width="2560" height="1239" alt="image" src="https://github.com/user-attachments/assets/131897c5-8502-472f-bac2-67ff44fe0df5" />
<img width="2560" height="1234" alt="image" src="https://github.com/user-attachments/assets/b8695646-f8e9-4a67-9ed0-3ffd4baf93a8" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
