### PR TITLE
feat(providers): add qwen3.8 to Aliyun Token Plan

### DIFF
--- a/src/qwenpaw/providers/context_windows.py
+++ b/src/qwenpaw/providers/context_windows.py
@@ -48,6 +48,7 @@ _KNOWN_CONTEXT_WINDOWS: tuple[tuple[str, int], ...] = (
     ("qwen-flash", 1_000_000),
     ("qwen-turbo-latest", 1_000_000),
     ("qwen-turbo", 131_072),  # stable alias: snapshot windows vary
+    ("qwen3.8-max-preview", 1_000_000),
     ("qwen3.7-max", 1_000_000),
     ("qwen3.7-plus", 1_000_000),
     ("qwen3.6-plus", 1_000_000),

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -4,6 +4,7 @@ It provides a unified interface to manage providers, such as listing available
 providers, adding/removing custom providers, and fetching provider details."""
 
 import asyncio
+from copy import deepcopy
 import json
 import logging
 import os
@@ -964,7 +965,7 @@ PROVIDER_ALIYUN_TOKENPLAN = OpenAIProvider(
         "https://token-plan.cn-beijing.maas.aliyuncs.com/" "compatible-mode/v1"
     ),
     api_key_prefix="sk-sp",
-    models=ALIYUN_TOKENPLAN_MODELS,
+    models=deepcopy(ALIYUN_TOKENPLAN_MODELS),
     support_connection_check=False,
     freeze_url=True,
     provider_group="aliyun",
@@ -980,7 +981,7 @@ PROVIDER_ALIYUN_TOKENPLAN_INTL = OpenAIProvider(
         "compatible-mode/v1"
     ),
     api_key_prefix="sk-sp",
-    models=ALIYUN_TOKENPLAN_MODELS,
+    models=deepcopy(ALIYUN_TOKENPLAN_MODELS),
     support_connection_check=False,
     freeze_url=True,
     provider_group="aliyun",

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -133,6 +133,14 @@ MIMO_TOKENPLAN_MODELS: List[ModelInfo] = [
 
 ALIYUN_TOKENPLAN_MODELS: List[ModelInfo] = [
     ModelInfo(
+        id="qwen3.8-max-preview",
+        name="Qwen3.8 Max Preview",
+        supports_image=True,
+        supports_video=False,
+        probe_source="documentation",
+        max_tokens=65_536,
+    ),
+    ModelInfo(
         id="qwen3.7-plus",
         name="Qwen3.7 Plus",
         supports_image=True,

--- a/tests/unit/providers/test_context_windows.py
+++ b/tests/unit/providers/test_context_windows.py
@@ -26,6 +26,7 @@ from qwenpaw.providers.provider import ModelInfo, Provider
     [
         # Qwen family, including the specific over the generic.
         ("qwen-long", 10_000_000),
+        ("qwen3.8-max-preview", 1_000_000),
         ("qwen3.7-max", 1_000_000),
         ("qwen3.7-plus-2026-01-01", 1_000_000),
         ("qwen3.6-plus", 1_000_000),

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -131,6 +131,84 @@ def test_builtin_zhipu_providers_registered(isolated_secret_dir) -> None:
         assert len(model_ids) == len(set(model_ids))
 
 
+@pytest.mark.parametrize(
+    "provider_id",
+    ("aliyun-tokenplan", "aliyun-tokenplan-intl"),
+)
+def test_aliyun_tokenplan_includes_qwen3_8_max_preview(
+    isolated_secret_dir,
+    provider_id: str,
+) -> None:
+    manager = ProviderManager()
+    provider = manager.get_provider(provider_id)
+
+    assert provider is not None
+    model = provider.get_model_info("qwen3.8-max-preview")
+    assert model == ModelInfo(
+        id="qwen3.8-max-preview",
+        name="Qwen3.8 Max Preview",
+        supports_multimodal=True,
+        supports_image=True,
+        supports_video=False,
+        probe_source="documentation",
+        max_tokens=65_536,
+    )
+    assert provider.get_context_size(model.id) == 1_000_000
+    assert (
+        provider.get_effective_generate_kwargs(model.id)["max_tokens"]
+        == 65_536
+    )
+
+
+def test_aliyun_tokenplan_promotes_saved_qwen3_8_model(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    builtin = provider_manager_module.PROVIDER_ALIYUN_TOKENPLAN.model_copy(
+        deep=True,
+    )
+    monkeypatch.setattr(
+        provider_manager_module,
+        "PROVIDER_ALIYUN_TOKENPLAN",
+        builtin,
+    )
+    manager = ProviderManager()
+    provider = manager.get_provider("aliyun-tokenplan")
+    assert provider is not None
+
+    data = provider.model_dump()
+    data["models"] = [
+        model
+        for model in data["models"]
+        if model["id"] != "qwen3.8-max-preview"
+    ]
+    data["extra_models"].append(
+        ModelInfo(
+            id="qwen3.8-max-preview",
+            name="Custom Qwen3.8",
+            max_tokens=4096,
+        ).model_dump(),
+    )
+    builtin_path = isolated_secret_dir / "providers" / "builtin"
+    (builtin_path / "aliyun-tokenplan.json").write_text(
+        json.dumps(data, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    reloaded = ProviderManager().get_provider("aliyun-tokenplan")
+    assert reloaded is not None
+    assert [
+        model.id
+        for model in reloaded.models
+        if model.id == "qwen3.8-max-preview"
+    ] == ["qwen3.8-max-preview"]
+    assert all(
+        model.id != "qwen3.8-max-preview" for model in reloaded.extra_models
+    )
+    assert reloaded.get_model_info("qwen3.8-max-preview").max_tokens == 4096
+    assert reloaded.get_context_size("qwen3.8-max-preview") == 1_000_000
+
+
 async def test_add_custom_provider_and_reload_from_storage(
     isolated_secret_dir,
 ) -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
@@ -131,46 +132,25 @@ def test_builtin_zhipu_providers_registered(isolated_secret_dir) -> None:
         assert len(model_ids) == len(set(model_ids))
 
 
-@pytest.mark.parametrize(
-    "provider_id",
-    ("aliyun-tokenplan", "aliyun-tokenplan-intl"),
-)
-def test_aliyun_tokenplan_includes_qwen3_8_max_preview(
-    isolated_secret_dir,
-    provider_id: str,
-) -> None:
-    manager = ProviderManager()
-    provider = manager.get_provider(provider_id)
-
-    assert provider is not None
-    model = provider.get_model_info("qwen3.8-max-preview")
-    assert model == ModelInfo(
-        id="qwen3.8-max-preview",
-        name="Qwen3.8 Max Preview",
-        supports_multimodal=True,
-        supports_image=True,
-        supports_video=False,
-        probe_source="documentation",
-        max_tokens=65_536,
-    )
-    assert provider.get_context_size(model.id) == 1_000_000
-    assert (
-        provider.get_effective_generate_kwargs(model.id)["max_tokens"]
-        == 65_536
-    )
-
-
-def test_aliyun_tokenplan_promotes_saved_qwen3_8_model(
+def test_aliyun_tokenplan_promotes_saved_qwen3_8_model_without_cross_leak(
     isolated_secret_dir,
     monkeypatch,
 ) -> None:
-    builtin = provider_manager_module.PROVIDER_ALIYUN_TOKENPLAN.model_copy(
-        deep=True,
+    china_builtin, intl_builtin = deepcopy(
+        (
+            provider_manager_module.PROVIDER_ALIYUN_TOKENPLAN,
+            provider_manager_module.PROVIDER_ALIYUN_TOKENPLAN_INTL,
+        ),
     )
     monkeypatch.setattr(
         provider_manager_module,
         "PROVIDER_ALIYUN_TOKENPLAN",
-        builtin,
+        china_builtin,
+    )
+    monkeypatch.setattr(
+        provider_manager_module,
+        "PROVIDER_ALIYUN_TOKENPLAN_INTL",
+        intl_builtin,
     )
     manager = ProviderManager()
     provider = manager.get_provider("aliyun-tokenplan")
@@ -195,8 +175,11 @@ def test_aliyun_tokenplan_promotes_saved_qwen3_8_model(
         encoding="utf-8",
     )
 
-    reloaded = ProviderManager().get_provider("aliyun-tokenplan")
+    reloaded_manager = ProviderManager()
+    reloaded = reloaded_manager.get_provider("aliyun-tokenplan")
+    reloaded_intl = reloaded_manager.get_provider("aliyun-tokenplan-intl")
     assert reloaded is not None
+    assert reloaded_intl is not None
     assert [
         model.id
         for model in reloaded.models
@@ -207,6 +190,10 @@ def test_aliyun_tokenplan_promotes_saved_qwen3_8_model(
     )
     assert reloaded.get_model_info("qwen3.8-max-preview").max_tokens == 4096
     assert reloaded.get_context_size("qwen3.8-max-preview") == 1_000_000
+    assert (
+        reloaded_intl.get_model_info("qwen3.8-max-preview").max_tokens
+        == 65_536
+    )
 
 
 async def test_add_custom_provider_and_reload_from_storage(


### PR DESCRIPTION
## Description

Registers `qwen3.8-max-preview` in the Aliyun Token Plan catalog used by both the China and international provider variants. The model is exposed with text/image capability, a 1,000,000-token context window, and a 65,536-token output limit.

The change stays in QwenPaw's provider layer because `ALIYUN_TOKENPLAN_MODELS`, rather than AgentScope package YAML, drives the Console selector. Each regional provider receives a deep copy of the catalog so restoring a saved per-model override for one region cannot mutate the other. Previously saved custom `qwen3.8-max-preview` entries are promoted without losing user overrides.

**Related Issue:** Fixes #6285

**Security Considerations:** None. This changes static provider metadata and in-memory model isolation only; it does not alter credentials, requests, or authorization.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user workflow or configuration changed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; this PR does not change a channel or Console implementation.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/providers/ -q` (`307 passed`)
- `pre-commit run --files src/qwenpaw/providers/provider_manager.py tests/unit/providers/test_provider_manager.py`

Verification matrix:

| Surface | Result |
| --- | --- |
| Aliyun Token Plan (China) | Saved Qwen3.8 override is preserved |
| Aliyun Token Plan (international) | Default `max_tokens=65536` remains isolated |
| Context window | Qwen3.8 resolves to 1,000,000 tokens |
| DashScope / Coding Plan | Unchanged |
| Console | No code change; consumes the provider catalog |

## Evidence

With the deep-copy fix temporarily removed, the regression test failed because the China override leaked into the international provider:

```text
assert 4096 == 65536
```

With the fix restored:

```text
307 passed in 2.82s
pre-commit: all applicable hooks passed
```

## Additional Notes

Aliyun documentation lists `qwen3.8-max-preview` as available to Token Plan users: https://help.aliyun.com/zh/model-studio/text-generation-model

No live request was made because this metadata path requires an Aliyun Token Plan credential.
