### PR TITLE
fix(subagent): route and resolve approvals from the root session

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -657,6 +657,56 @@ def _generate_subagent_session_id() -> str:
     return f"sub-{str(uuid4())[:8]}"
 
 
+def _json_safe_channel_meta(value: Any) -> Any:
+    """Keep channel routing metadata safe to include in an HTTP payload."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        safe: dict[str, Any] = {}
+        for key, raw_value in value.items():
+            safe_value = _json_safe_channel_meta(raw_value)
+            if safe_value is not None:
+                safe[str(key)] = safe_value
+        return safe
+    if isinstance(value, (list, tuple)):
+        safe_list = []
+        for raw_value in value:
+            safe_value = _json_safe_channel_meta(raw_value)
+            if safe_value is not None:
+                safe_list.append(safe_value)
+        return safe_list
+    return None
+
+
+def _build_spawn_request_context(current_agent_id: str) -> dict[str, Any]:
+    """Build approval routing metadata without changing child identity."""
+    from ...app.agent_context import (
+        get_current_approval_route,
+        get_current_channel,
+        get_current_root_session_id,
+        get_current_session_id,
+        get_current_user_id,
+    )
+
+    inherited = get_current_approval_route() or {}
+    context: dict[str, Any] = {
+        "root_session_id": (
+            inherited.get("root_session_id")
+            or get_current_root_session_id()
+            or get_current_session_id()
+            or ""
+        ),
+        "root_agent_id": current_agent_id,
+        "user_id": inherited.get("user_id") or get_current_user_id() or "",
+        "channel": inherited.get("channel") or get_current_channel() or "",
+        "_spawn_subagent": True,
+    }
+    safe_meta = _json_safe_channel_meta(inherited.get("channel_meta") or {})
+    if isinstance(safe_meta, dict) and safe_meta:
+        context["channel_meta"] = safe_meta
+    return context
+
+
 @tool_descriptor(async_execution=True)
 async def spawn_subagent(
     task: str,
@@ -714,6 +764,7 @@ async def spawn_subagent(
             timeout=timeout,
         )
 
+    request_context = _build_spawn_request_context(current_agent_id)
     request_payload = {
         "session_id": subagent_session_id,
         "input": [
@@ -722,7 +773,7 @@ async def spawn_subagent(
                 "content": [{"type": "text", "text": task}],
             },
         ],
-        "request_context": {},
+        "request_context": request_context,
     }
 
     if background:
@@ -869,7 +920,7 @@ async def _spawn_forked_subagent(
     worktree_path = fork_result.get("worktree_path", "")
     worktree_branch = fork_result.get("worktree_branch", "")
 
-    request_context: dict = {}
+    request_context = _build_spawn_request_context(current_agent_id)
     if worktree_path:
         request_context["fork_project_dir"] = worktree_path
 

--- a/src/qwenpaw/app/agent_context.py
+++ b/src/qwenpaw/app/agent_context.py
@@ -41,6 +41,11 @@ _current_channel: ContextVar[Optional[str]] = ContextVar(
     default=None,
 )
 
+_current_approval_route: ContextVar[Optional[dict]] = ContextVar(
+    "current_approval_route",
+    default=None,
+)
+
 
 async def get_agent_for_request(
     request: Request,
@@ -228,3 +233,13 @@ def set_current_channel(channel: Optional[str]) -> None:
 def get_current_channel() -> Optional[str]:
     """Get current channel from context."""
     return _current_channel.get()
+
+
+def set_current_approval_route(route: Optional[dict]) -> None:
+    """Set routing metadata used only for spawned-child approvals."""
+    _current_approval_route.set(route)
+
+
+def get_current_approval_route() -> Optional[dict]:
+    """Return routing metadata used only for spawned-child approvals."""
+    return _current_approval_route.get()

--- a/src/qwenpaw/app/approvals/driver_gate.py
+++ b/src/qwenpaw/app/approvals/driver_gate.py
@@ -94,6 +94,14 @@ class QwenPawDriverApprovalGate:
                     "name": driver_label,
                     "input": context.extras,
                 },
+                **(
+                    {
+                        "channel_meta": ctx.get("channel_meta"),
+                        "_spawn_subagent": True,
+                    }
+                    if ctx.get("_spawn_subagent")
+                    else {}
+                ),
             },
         )
         decision = await svc.wait_for_approval(

--- a/src/qwenpaw/app/approvals/service.py
+++ b/src/qwenpaw/app/approvals/service.py
@@ -64,6 +64,16 @@ class PendingApproval:
     scope: ApprovalScope | None = None
 
 
+def _is_spawn_child_approval(pending: PendingApproval) -> bool:
+    """Return whether this approval belongs to a same-agent spawned child."""
+    return bool(
+        pending.extra.get("_spawn_subagent")
+        and pending.agent_id == pending.owner_agent_id
+        and pending.session_id != pending.root_session_id
+        and pending.root_session_id,
+    )
+
+
 # ------------------------------------------------------------------
 # Service
 # ------------------------------------------------------------------
@@ -79,12 +89,15 @@ class ApprovalService:
     def __init__(self) -> None:
         self._lock = asyncio.Lock()
         self._pending: dict[str, PendingApproval] = {}
+        self._channel_managers: dict[str, Any] = {}
 
     def set_channel_manager(
         self,
         channel_manager: Any,
-    ) -> None:  # noqa: ARG002
-        """Legacy no-op kept for backward compat."""
+        agent_id: str = "default",
+    ) -> None:
+        """Register an agent's channel manager for spawned-child routing."""
+        self._channel_managers[agent_id] = channel_manager
 
     async def _notify_channel(
         self,
@@ -94,13 +107,26 @@ class ApprovalService:
         """Fire-and-forget: push approval notification to channel."""
         if not pending.channel or pending.channel == "console":
             return
-        channel_instance = (pending.extra or {}).get("_channel_instance")
-        if channel_instance is None:
-            return
-        channel_meta = (pending.extra or {}).get("channel_meta")
+        is_spawn_child = _is_spawn_child_approval(pending)
         try:
+            channel_instance = (pending.extra or {}).get("_channel_instance")
+            if is_spawn_child:
+                channel_manager = self._channel_managers.get(pending.agent_id)
+                if channel_manager is None:
+                    return
+                channel_instance = await channel_manager.get_channel(
+                    pending.channel,
+                )
+            if channel_instance is None:
+                return
+            channel_meta = (pending.extra or {}).get("channel_meta")
+            delivery_session_id = (
+                pending.root_session_id
+                if is_spawn_child
+                else pending.session_id
+            )
             await channel_instance.send_approval_notification(
-                session_id=pending.session_id,
+                session_id=delivery_session_id,
                 user_id=pending.user_id,
                 request_id=pending.request_id,
                 tool_name=pending.tool_name,
@@ -178,7 +204,10 @@ class ApprovalService:
         if (
             channel
             and channel != "console"
-            and (extra or {}).get("_channel_instance")
+            and (
+                (extra or {}).get("_channel_instance")
+                or _is_spawn_child_approval(pending)
+            )
         ):
             channel_body = format_channel_approval_body(result)
             asyncio.create_task(
@@ -243,7 +272,10 @@ class ApprovalService:
         if (
             channel
             and channel != "console"
-            and (extra or {}).get("_channel_instance")
+            and (
+                (extra or {}).get("_channel_instance")
+                or _is_spawn_child_approval(pending)
+            )
         ):
             asyncio.create_task(
                 self._notify_channel(pending, pending.result_summary),

--- a/src/qwenpaw/app/workspace/service_factories.py
+++ b/src/qwenpaw/app/workspace/service_factories.py
@@ -144,6 +144,9 @@ async def create_channel_service(ws: "Workspace", _):
     ws._service_manager.services["channel_manager"] = cm
 
     cm.set_workspace(ws)
+    from ..approvals import get_approval_service
+
+    get_approval_service().set_channel_manager(cm, agent_id=ws.agent_id)
 
     agent_language = getattr(ws._config, "language", "zh") or "zh"
     for ch in cm.channels:

--- a/src/qwenpaw/governance/tool_adapter.py
+++ b/src/qwenpaw/governance/tool_adapter.py
@@ -669,6 +669,9 @@ async def _ask_user_approval(
             },
             "channel_meta": ctx.get("channel_meta"),
             "_channel_instance": ctx.get("_channel_instance"),
+            **(
+                {"_spawn_subagent": True} if ctx.get("_spawn_subagent") else {}
+            ),
         },
     )
 

--- a/src/qwenpaw/hooks/request_setup/contextvars_hook.py
+++ b/src/qwenpaw/hooks/request_setup/contextvars_hook.py
@@ -33,6 +33,7 @@ class ContextVarsSetupHook(LifecycleHook):
         )
         from ...app.agent_context import (
             set_current_agent_id,
+            set_current_approval_route,
             set_current_channel,
             set_current_root_session_id,
             set_current_session_id as _set_app_session_id,
@@ -50,6 +51,27 @@ class ContextVarsSetupHook(LifecycleHook):
         )
         set_current_user_id(ctx.request.user_id)
         set_current_channel(getattr(ctx.request, "channel", None))
+        request_context = getattr(ctx.request, "request_context", None)
+        if isinstance(request_context, dict) and request_context.get(
+            "_spawn_subagent",
+        ):
+            approval_route = {
+                key: request_context.get(key)
+                for key in (
+                    "root_session_id",
+                    "user_id",
+                    "channel",
+                    "channel_meta",
+                )
+            }
+        else:
+            approval_route = {
+                "root_session_id": ctx.root_session_id or ctx.session_id or "",
+                "user_id": getattr(ctx.request, "user_id", None) or "",
+                "channel": getattr(ctx.request, "channel", None) or "",
+                "channel_meta": getattr(ctx.request, "channel_meta", None),
+            }
+        set_current_approval_route(approval_route)
 
         try:
             from ...config.config import load_agent_config

--- a/src/qwenpaw/runtime/commands/control/approval_handler.py
+++ b/src/qwenpaw/runtime/commands/control/approval_handler.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import logging
 import time
 
-from ....app.approvals import get_approval_service
+from ....app.approvals import (
+    ApprovalService,
+    PendingApproval,
+    get_approval_service,
+)
 from ....security.tool_guard.approval import ApprovalDecision, ApprovalScope
 
 from .base import BaseControlCommandHandler, ControlContext
@@ -34,6 +38,25 @@ class ApprovalCommandHandler(BaseControlCommandHandler):
     """
 
     command_name = "/approval"
+
+    @staticmethod
+    async def _get_spawn_child_queue_head(
+        context: ControlContext,
+        svc: ApprovalService,
+    ) -> PendingApproval | None:
+        """Return the oldest spawned child approval owned by this session."""
+        pending_list = await svc.get_pending_by_root_session(
+            context.session_id,
+        )
+        for pending in pending_list:
+            if (
+                pending.session_id != context.session_id
+                and pending.agent_id == context.agent_id
+                and pending.owner_agent_id == context.agent_id
+                and (pending.extra or {}).get("_spawn_subagent")
+            ):
+                return pending
+        return None
 
     async def handle(self, context: ControlContext) -> str:
         """Handle /approval command with various actions.
@@ -73,6 +96,8 @@ class ApprovalCommandHandler(BaseControlCommandHandler):
         # If no request_id provided, get queue head (FIFO)
         if not request_id:
             pending = await svc.get_pending_by_session(context.session_id)
+            if pending is None:
+                pending = await self._get_spawn_child_queue_head(context, svc)
             if pending is None:
                 return "❌ **无待审批工具**\n\n" "当前会话没有需要审批的工具调用。"
             request_id = pending.request_id
@@ -132,6 +157,8 @@ class ApprovalCommandHandler(BaseControlCommandHandler):
         # If no request_id provided, get queue head
         if not request_id:
             pending = await svc.get_pending_by_session(context.session_id)
+            if pending is None:
+                pending = await self._get_spawn_child_queue_head(context, svc)
             if pending is None:
                 return "❌ **无待审批工具**\n\n" "当前会话没有需要审批的工具调用。"
             request_id = pending.request_id

--- a/src/qwenpaw/runtime/tool_guard.py
+++ b/src/qwenpaw/runtime/tool_guard.py
@@ -367,6 +367,9 @@ async def _ask_user_approval(
             },
             "channel_meta": ctx.get("channel_meta"),
             "_channel_instance": ctx.get("_channel_instance"),
+            **(
+                {"_spawn_subagent": True} if ctx.get("_spawn_subagent") else {}
+            ),
         },
     )
 

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -391,3 +391,54 @@ async def test_chat_with_agent_returns_clear_error_when_agent_missing(
     )
 
     assert response.content[0].text == "Agent [missing_bot] not exists"
+
+
+async def test_spawn_subagent_inherits_root_channel_context(monkeypatch):
+    captured = {}
+
+    def fake_collect(_base_url, request_payload, to_agent, _timeout):
+        captured["payload"] = request_payload
+        captured["agent_id"] = to_agent
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: {
+            "root_session_id": "root-session",
+            "root_agent_id": "bot-a",
+            "user_id": "u1",
+            "channel": "qq",
+            "channel_meta": {"group_openid": "g1", "opaque": object()},
+        },
+    )
+
+    response = await agent_management.spawn_subagent("do work")
+
+    context = captured["payload"]["request_context"]
+    assert captured["agent_id"] == "bot-a"
+    assert "user_id" not in captured["payload"]
+    assert "channel" not in captured["payload"]
+    assert context["root_session_id"] == "root-session"
+    assert context["root_agent_id"] == "bot-a"
+    assert context["channel"] == "qq"
+    assert context["user_id"] == "u1"
+    assert context["channel_meta"] == {"group_openid": "g1"}
+    assert context["_spawn_subagent"] is True
+    assert "done" in response.content[0].text

--- a/tests/unit/app/approvals/test_service.py
+++ b/tests/unit/app/approvals/test_service.py
@@ -345,6 +345,62 @@ async def test_get_all_pending_by_agent_no_cross_agent_leak():
     assert found_c == []
 
 
+async def test_spawn_child_notification_targets_root_session():
+    class _Channel:
+        def __init__(self):
+            self.calls = []
+
+        async def send_approval_notification(self, **kwargs):
+            self.calls.append(kwargs)
+
+    channel = _Channel()
+
+    class _Manager:
+        async def get_channel(self, channel_name):
+            assert channel_name == "qq"
+            return channel
+
+    svc = ApprovalService()
+    svc.set_channel_manager(_Manager(), agent_id="agent-A")
+    await svc.create_pending(
+        session_id="child-session",
+        root_session_id="root-session",
+        owner_agent_id="agent-A",
+        user_id="u1",
+        channel="qq",
+        agent_id="agent-A",
+        tool_name="Bash",
+        result=_make_result(),
+        extra={"_spawn_subagent": True},
+    )
+    await asyncio.sleep(0)
+
+    assert channel.calls[0]["session_id"] == "root-session"
+
+
+async def test_non_spawn_notification_keeps_pending_session():
+    class _Channel:
+        def __init__(self):
+            self.calls = []
+
+        async def send_approval_notification(self, **kwargs):
+            self.calls.append(kwargs)
+
+    channel = _Channel()
+    svc = ApprovalService()
+    pending = _make_pending(
+        "other",
+        session_id="child-session",
+        root_session_id="root-session",
+        extra={"_channel_instance": channel},
+    )
+    pending.channel = "qq"
+
+    await svc._notify_channel(pending, "approval")
+
+    assert channel.calls[0]["session_id"] == "child-session"
+
+
 # ---------------------------------------------------------------------------
 # wait_for_approval
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_approval_commands.py
+++ b/tests/unit/runtime/test_approval_commands.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Tests for root-session approval fallback to spawned subagents."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from qwenpaw.app.approvals.service import ApprovalService
+from qwenpaw.runtime.commands.control.approval_handler import (
+    ApprovalCommandHandler,
+)
+from qwenpaw.runtime.commands.control.base import ControlContext
+from qwenpaw.security.tool_guard.models import (
+    GuardFinding,
+    GuardSeverity,
+    GuardThreatCategory,
+    ToolGuardResult,
+)
+
+
+def _result() -> ToolGuardResult:
+    return ToolGuardResult(
+        tool_name="Bash",
+        params={},
+        findings=[
+            GuardFinding(
+                id="f1",
+                rule_id="r1",
+                category=GuardThreatCategory.CODE_EXECUTION,
+                severity=GuardSeverity.HIGH,
+                title="risk",
+                description="risk",
+                tool_name="Bash",
+            ),
+        ],
+    )
+
+
+def _context() -> ControlContext:
+    return ControlContext(
+        workspace=SimpleNamespace(),
+        payload=None,
+        channel=None,
+        session_id="root-session",
+        user_id="u1",
+        agent_id="agent-a",
+        args={},
+    )
+
+
+async def test_approve_without_id_only_falls_back_to_spawned_child(
+    monkeypatch,
+):
+    svc = ApprovalService()
+    unmarked = await svc.create_pending(
+        session_id="other-child-session",
+        root_session_id="root-session",
+        owner_agent_id="agent-a",
+        user_id="u1",
+        channel="console",
+        agent_id="agent-a",
+        tool_name="Bash",
+        result=_result(),
+    )
+    pending = await svc.create_pending(
+        session_id="child-session",
+        root_session_id="root-session",
+        owner_agent_id="agent-a",
+        user_id="u1",
+        channel="console",
+        agent_id="agent-a",
+        tool_name="Bash",
+        result=_result(),
+        extra={"_spawn_subagent": True},
+    )
+    monkeypatch.setattr(
+        "qwenpaw.runtime.commands.control.approval_handler."
+        "get_approval_service",
+        lambda: svc,
+    )
+
+    response = await ApprovalCommandHandler()._handle_approve(_context())
+
+    assert "工具已批准" in response
+    assert await svc.get_request(pending.request_id) is None
+    assert await svc.get_request(unmarked.request_id) is unmarked

--- a/tests/unit/runtime/test_approval_commands.py
+++ b/tests/unit/runtime/test_approval_commands.py
@@ -51,6 +51,7 @@ def _context() -> ControlContext:
 async def test_approve_without_id_only_falls_back_to_spawned_child(
     monkeypatch,
 ):
+    """Root approval skips unmarked children and resolves spawned children."""
     svc = ApprovalService()
     unmarked = await svc.create_pending(
         session_id="other-child-session",
@@ -79,7 +80,7 @@ async def test_approve_without_id_only_falls_back_to_spawned_child(
         lambda: svc,
     )
 
-    response = await ApprovalCommandHandler()._handle_approve(_context())
+    response = await ApprovalCommandHandler().handle(_context())
 
     assert "工具已批准" in response
     assert await svc.get_request(pending.request_id) is None


### PR DESCRIPTION
## Description

Allow approval requests created by `spawn_subagent` child sessions to be delivered to and resolved from the root session.

This PR:

- Propagates the root session's approval routing metadata through the spawned child's serializable `request_context`.
- Keeps the child request's original `channel` and `user_id` behavior unchanged and does not pass Channel instances to child agents.
- Resolves the target Channel at notification time through the requesting agent's registered `ChannelManager`.
- Sends spawned-child approval notifications to the root session's original channel.
- Allows `/approve` and `/deny` without a request ID in the root session to resolve pending approvals from its spawned child sessions.
- Preserves current-session approval priority before checking spawned children.
- Restricts the new routing behavior to marked, same-agent `spawn_subagent` requests.
- Keeps explicit request ID handling and non-`spawn_subagent` approval flows unchanged.
- Supports both regular and forked subagent spawning, including nested spawned subagents.

**Related Issue:** Fixes #5295 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
