### PR TITLE
fix(desktop): open markdown links externally instead of navigating We…

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -38,6 +38,8 @@ import { useUploadLimitStore } from "./stores/uploadLimitStore";
 import { getApiUrl, getApiToken, clearAuthToken } from "./api/config";
 import CloseWindowPrompt from "./tauri/CloseWindowPrompt";
 import { isTauri } from "@tauri-apps/api/core";
+import { isDesktopTauriRuntime } from "./utils/openExternalLink";
+import { interceptBlankLinkClicks } from "./utils/interceptBlankLinkClicks";
 import "./styles/layout.css";
 import "./styles/form-override.css";
 
@@ -177,6 +179,14 @@ function AppInner() {
     const preventContextMenu = (e: MouseEvent) => e.preventDefault();
     window.addEventListener("contextmenu", preventContextMenu);
     return () => window.removeEventListener("contextmenu", preventContextMenu);
+  }, []);
+
+  // Vendor-rendered markdown (e.g. chat bubbles) emits native
+  // `<a target="_blank">` anchors we cannot override at the React level. The
+  // Tauri WebView ignores such clicks, so route them to the system browser.
+  useEffect(() => {
+    if (!isDesktopTauriRuntime()) return;
+    return interceptBlankLinkClicks();
   }, []);
 
   // Wait for plugins to load before rendering routes that might be patched

--- a/console/src/components/Markdown/externalLinkComponents.test.tsx
+++ b/console/src/components/Markdown/externalLinkComponents.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for the shared external-link markdown renderer.
+ *
+ * Covers the regression where markdown links opened inside the Tauri WebView
+ * (navigating the current window and replacing the whole app):
+ * - Clicking a rendered link calls openExternalLink with its href.
+ * - The click's default navigation is prevented.
+ * - The renderer is applied when passed to <ReactMarkdown> as `components`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+
+const openExternalLink = vi.fn();
+vi.mock("@/utils/openExternalLink", () => ({
+  openExternalLink: (...args: unknown[]) => openExternalLink(...args),
+}));
+
+import {
+  ExternalMarkdownLink,
+  externalLinkMarkdownComponents,
+} from "./externalLinkComponents";
+
+describe("ExternalMarkdownLink", () => {
+  beforeEach(() => {
+    openExternalLink.mockReset();
+  });
+
+  it("opens the href via openExternalLink and prevents default navigation", () => {
+    render(
+      <ExternalMarkdownLink href="https://example.com/news">
+        news
+      </ExternalMarkdownLink>,
+    );
+
+    const link = screen.getByText("news");
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevented = !link.dispatchEvent(event);
+
+    expect(prevented).toBe(true);
+    expect(openExternalLink).toHaveBeenCalledWith("https://example.com/news");
+  });
+
+  it("does not call openExternalLink when href is missing", () => {
+    render(<ExternalMarkdownLink>no link</ExternalMarkdownLink>);
+
+    fireEvent.click(screen.getByText("no link"));
+
+    expect(openExternalLink).not.toHaveBeenCalled();
+  });
+
+  it("routes markdown-rendered links through openExternalLink", () => {
+    render(
+      <ReactMarkdown components={externalLinkMarkdownComponents}>
+        {"[open](https://example.com/detail)"}
+      </ReactMarkdown>,
+    );
+
+    fireEvent.click(screen.getByText("open"));
+
+    expect(openExternalLink).toHaveBeenCalledWith("https://example.com/detail");
+  });
+});

--- a/console/src/components/Markdown/externalLinkComponents.tsx
+++ b/console/src/components/Markdown/externalLinkComponents.tsx
@@ -1,0 +1,43 @@
+/**
+ * Shared react-markdown renderer overrides.
+ *
+ * The default markdown <a> becomes a native anchor, and in the Tauri WebView a
+ * click navigates the current window — replacing the whole app with the target
+ * page and stranding the user with no way back. This renderer intercepts the
+ * click and hands the URL to `openExternalLink`, which opens it in the system
+ * browser (Tauri/pywebview) or a new tab (plain browser).
+ */
+import type { ComponentPropsWithoutRef } from "react";
+import { openExternalLink } from "@/utils/openExternalLink";
+
+// react-markdown injects an AST `node` prop alongside the standard anchor
+// attributes; it must be kept off the rendered DOM element.
+type AnchorProps = ComponentPropsWithoutRef<"a"> & { node?: unknown };
+
+/** Markdown <a> renderer that opens links externally instead of navigating. */
+export function ExternalMarkdownLink({
+  node,
+  href,
+  children,
+  ...rest
+}: AnchorProps) {
+  void node;
+  return (
+    <a
+      {...rest}
+      href={href}
+      onClick={(event) => {
+        event.preventDefault();
+        if (href) openExternalLink(href);
+      }}
+      style={{ cursor: "pointer", ...rest.style }}
+    >
+      {children}
+    </a>
+  );
+}
+
+/** Drop-in `components` value for <ReactMarkdown> that safely opens links. */
+export const externalLinkMarkdownComponents = {
+  a: ExternalMarkdownLink,
+};

--- a/console/src/layouts/Header.tsx
+++ b/console/src/layouts/Header.tsx
@@ -19,6 +19,7 @@ import { Button, Modal } from "@agentscope-ai/design";
 import styles from "./index.module.less";
 import api from "../api";
 import { openExternalLink } from "../utils/openExternalLink";
+import { ExternalMarkdownLink } from "../components/Markdown/externalLinkComponents";
 import {
   GITHUB_URL,
   getDocsUrl,
@@ -526,21 +527,7 @@ export default function Header() {
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
-                a({ href, children, ...props }: any) {
-                  return (
-                    <a
-                      {...props}
-                      href={href}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        if (href) handleNavClick(href);
-                      }}
-                      style={{ cursor: "pointer" }}
-                    >
-                      {children}
-                    </a>
-                  );
-                },
+                a: ExternalMarkdownLink,
                 code({ node, className, children, ...props }: any) {
                   const match = /language-(\w+)/.exec(className || "");
                   const isBlock =

--- a/console/src/pages/Coding/FilePreview.tsx
+++ b/console/src/pages/Coding/FilePreview.tsx
@@ -17,6 +17,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { workspaceApi } from "../../api/modules/workspace";
 import { buildAuthHeaders } from "../../api/authHeaders";
 import { isDesktopTauriRuntime } from "../../utils/openExternalLink";
+import { ExternalMarkdownLink } from "../../components/Markdown/externalLinkComponents";
 import { useAgentStore } from "../../stores/agentStore";
 import styles from "./FilePreview.module.less";
 
@@ -197,6 +198,7 @@ function PdfPreview({ filePath }: { filePath: string }) {
 }
 
 const markdownComponents = {
+  a: ExternalMarkdownLink,
   pre({ children }: { children?: React.ReactNode }) {
     return <>{children}</>;
   },

--- a/console/src/pages/Inbox/index.tsx
+++ b/console/src/pages/Inbox/index.tsx
@@ -26,6 +26,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/PageHeader";
+import { externalLinkMarkdownComponents } from "@/components/Markdown/externalLinkComponents";
 import { ApprovalCard as GlobalApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
 import { commandsApi } from "../../api/modules/commands";
@@ -69,7 +70,12 @@ const resolveInitialTab = (): TabKey => {
 
 const renderMarkdownText = (text: string, className: string) => (
   <div className={className}>
-    <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={externalLinkMarkdownComponents}
+    >
+      {text}
+    </ReactMarkdown>
   </div>
 );
 

--- a/console/src/utils/interceptBlankLinkClicks.test.ts
+++ b/console/src/utils/interceptBlankLinkClicks.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const openExternalLink = vi.fn();
+vi.mock("./openExternalLink", async () => {
+  const actual = await vi.importActual<typeof import("./openExternalLink")>(
+    "./openExternalLink",
+  );
+  return {
+    ...actual,
+    openExternalLink: (...args: unknown[]) => openExternalLink(...args),
+  };
+});
+
+import { interceptBlankLinkClicks } from "./interceptBlankLinkClicks";
+
+/** Render an anchor into the document body and return it. */
+function mountAnchor(attrs: Record<string, string>, text = "link") {
+  const anchor = document.createElement("a");
+  Object.entries(attrs).forEach(([key, value]) => {
+    anchor.setAttribute(key, value);
+  });
+  anchor.textContent = text;
+  document.body.appendChild(anchor);
+  return anchor;
+}
+
+function clickWith(el: Element, init: MouseEventInit = {}) {
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...init,
+  });
+  el.dispatchEvent(event);
+  return event;
+}
+
+describe("interceptBlankLinkClicks", () => {
+  let dispose: () => void;
+
+  beforeEach(() => {
+    openExternalLink.mockReset();
+    dispose = interceptBlankLinkClicks();
+  });
+
+  afterEach(() => {
+    dispose();
+    document.body.innerHTML = "";
+  });
+
+  it("opens target=_blank external links via openExternalLink and prevents default", () => {
+    const anchor = mountAnchor({
+      href: "https://example.com/page",
+      target: "_blank",
+    });
+
+    const event = clickWith(anchor);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openExternalLink).toHaveBeenCalledWith("https://example.com/page");
+  });
+
+  it("handles clicks on nested children of a _blank anchor", () => {
+    const anchor = mountAnchor({
+      href: "https://example.com/detail",
+      target: "_blank",
+    });
+    const inner = document.createElement("span");
+    inner.textContent = "click me";
+    anchor.appendChild(inner);
+
+    const event = clickWith(inner);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openExternalLink).toHaveBeenCalledWith("https://example.com/detail");
+  });
+
+  it("ignores anchors without target=_blank (e.g. SPA navigation)", () => {
+    const anchor = mountAnchor({ href: "/console/settings" });
+
+    const event = clickWith(anchor);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(openExternalLink).not.toHaveBeenCalled();
+  });
+
+  it("ignores unsupported protocols even with target=_blank", () => {
+    const anchor = mountAnchor({
+      href: "javascript:alert(1)",
+      target: "_blank",
+    });
+
+    const event = clickWith(anchor);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(openExternalLink).not.toHaveBeenCalled();
+  });
+
+  it("ignores modifier-key clicks", () => {
+    const anchor = mountAnchor({
+      href: "https://example.com",
+      target: "_blank",
+    });
+
+    clickWith(anchor, { metaKey: true });
+
+    expect(openExternalLink).not.toHaveBeenCalled();
+  });
+
+  it("stops intercepting after disposal", () => {
+    dispose();
+    const anchor = mountAnchor({
+      href: "https://example.com",
+      target: "_blank",
+    });
+
+    clickWith(anchor);
+
+    expect(openExternalLink).not.toHaveBeenCalled();
+  });
+});

--- a/console/src/utils/interceptBlankLinkClicks.ts
+++ b/console/src/utils/interceptBlankLinkClicks.ts
@@ -1,0 +1,60 @@
+/**
+ * Global click interceptor for `target="_blank"` anchors inside the Tauri
+ * WebView.
+ *
+ * Some content (e.g. chat markdown) is rendered by vendor components we cannot
+ * override at the React level, so their links become native
+ * `<a target="_blank" rel="noopener noreferrer">` anchors. The Tauri WebView
+ * ignores such clicks entirely — no new window, no navigation — so the link
+ * appears dead. This delegate catches those clicks and routes the URL through
+ * `openExternalLink`, which opens it in the system browser.
+ *
+ * Scope is intentionally narrow to avoid hijacking in-app SPA navigation:
+ * only anchors that carry `target="_blank"` are handled, and only when the URL
+ * resolves to a supported external protocol (http/https/mailto/tel).
+ */
+import {
+  openExternalLink,
+  resolveSupportedExternalUrl,
+} from "./openExternalLink";
+
+/**
+ * Attach a capture-phase click listener that opens `_blank` links externally.
+ * Returns a disposer that removes the listener.
+ */
+export function interceptBlankLinkClicks(): () => void {
+  const handleClick = (event: MouseEvent) => {
+    // Respect modifier-key clicks and non-primary buttons (let the OS/WebView
+    // do whatever it would normally do for those).
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    const target = event.target as Element | null;
+    const anchor = target?.closest?.("a[href]") as HTMLAnchorElement | null;
+    if (!anchor || anchor.target !== "_blank") {
+      return;
+    }
+
+    // Use the raw attribute so we validate the author's URL rather than the
+    // DOM-resolved `.href`, which would rewrite relative links to same-origin.
+    const href = anchor.getAttribute("href");
+    if (!href) return;
+
+    const externalUrl = resolveSupportedExternalUrl(href);
+    if (!externalUrl) return;
+
+    event.preventDefault();
+    openExternalLink(externalUrl);
+  };
+
+  document.addEventListener("click", handleClick, true);
+  return () => document.removeEventListener("click", handleClick, true);
+}

--- a/console/src/utils/openExternalLink.ts
+++ b/console/src/utils/openExternalLink.ts
@@ -64,7 +64,7 @@ function isSupportedExternalUrl(url: string): boolean {
 }
 
 /** Resolve an input URL only if its protocol is safe to hand to external openers. */
-function resolveSupportedExternalUrl(url: string): string | null {
+export function resolveSupportedExternalUrl(url: string): string | null {
   const resolvedUrl = resolveExternalUrl(url);
   if (!resolvedUrl || !isSupportedExternalUrl(resolvedUrl)) {
     return null;


### PR DESCRIPTION
Markdown links rendered inside the Tauri WebView hijacked the current window: react-markdown produced native <a href> anchors (Inbox trace viewer) that replaced the whole workspace on click, while vendor-rendered chat bubbles emitted <a target="_blank"> anchors the WebView silently ignored (dead click).

- Add shared ExternalMarkdownLink renderer that preventDefault()s and routes href through openExternalLink; wire into Inbox, FilePreview and Header (dedup existing handler).
- Add global capture-phase click interceptor for target="_blank" anchors (desktop Tauri only) to cover vendor markdown we cannot override via props; validates protocol allowlist before opening in system browser.
- Export resolveSupportedExternalUrl for reuse.
- Cover both paths with unit tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
