### PR TITLE
feat(desktop): add workspace shortcut to sidebar

### DIFF
--- a/console/src-tauri/capabilities/default.json
+++ b/console/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "dialog:allow-open",
     "dialog:allow-save",
     "open-external-link",
+    "open-workspace",
     "tray"
   ]
 }

--- a/console/src-tauri/permissions/open-workspace.toml
+++ b/console/src-tauri/permissions/open-workspace.toml
@@ -1,0 +1,4 @@
+[[permission]]
+identifier = "open-workspace"
+description = "Allows the frontend to open an agent workspace in the system file manager."
+commands.allow = ["open_workspace_directory"]

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod backend_download;
 mod external_link;
 mod updates;
 mod tray;
+mod workspace;
 
 use tauri::{Manager, RunEvent, WebviewWindow, WindowEvent};
 
@@ -35,6 +36,7 @@ pub fn run() {
             backend::backend_startup_error,
             backend::restart_backend,
             external_link::open_external_link,
+            workspace::open_workspace_directory,
             updates::check_desktop_update,
             updates::install_desktop_update,
             updates::download_desktop_update,

--- a/console/src-tauri/src/workspace.rs
+++ b/console/src-tauri/src/workspace.rs
@@ -1,0 +1,119 @@
+//! Tauri command for opening an agent workspace in the system file manager.
+
+use std::path::PathBuf;
+use tauri_plugin_shell::ShellExt;
+
+/// Open a validated workspace directory through the OS shell.
+#[tauri::command]
+pub(crate) fn open_workspace_directory(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<(), String> {
+    let workspace_path = validate_workspace_directory(&path).map_err(|err| {
+        log::warn!("[workspace] command rejected: {err}");
+        err
+    })?;
+
+    #[allow(deprecated)]
+    let open_result = app
+        .shell()
+        .open(workspace_path.to_string_lossy().into_owned(), None);
+
+    match open_result {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            log::warn!("[workspace] open failed: {err}");
+            Err(err.to_string())
+        }
+    }
+}
+
+/// Resolve a safe, existing directory before passing it to the OS shell.
+fn validate_workspace_directory(path: &str) -> Result<PathBuf, String> {
+    let trimmed_path = path.trim();
+    if trimmed_path.is_empty() {
+        return Err("workspace path is empty".into());
+    }
+    if trimmed_path != path {
+        return Err("workspace path has leading or trailing whitespace".into());
+    }
+    if trimmed_path.chars().any(char::is_control) {
+        return Err("workspace path contains control characters".into());
+    }
+
+    let workspace_path = PathBuf::from(trimmed_path);
+    if !workspace_path.is_absolute() {
+        return Err("workspace path must be absolute".into());
+    }
+
+    let canonical_path = workspace_path
+        .canonicalize()
+        .map_err(|err| format!("failed to resolve workspace path: {err}"))?;
+    if !canonical_path.is_dir() {
+        return Err("workspace path is not a directory".into());
+    }
+
+    Ok(canonical_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_workspace_directory;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn accepts_an_existing_absolute_directory() {
+        let workspace = tempdir().expect("create temporary workspace");
+
+        let result = validate_workspace_directory(
+            workspace.path().to_str().expect("temporary path is UTF-8"),
+        )
+        .expect("existing directory should be valid");
+
+        assert_eq!(
+            result,
+            workspace.path().canonicalize().expect("canonicalize path")
+        );
+    }
+
+    #[test]
+    fn rejects_empty_ambiguous_and_relative_paths() {
+        assert_eq!(
+            validate_workspace_directory("").unwrap_err(),
+            "workspace path is empty"
+        );
+        assert_eq!(
+            validate_workspace_directory(" C:\\workspace").unwrap_err(),
+            "workspace path has leading or trailing whitespace"
+        );
+        assert_eq!(
+            validate_workspace_directory("C:\\work\nspace").unwrap_err(),
+            "workspace path contains control characters"
+        );
+        assert_eq!(
+            validate_workspace_directory("relative/workspace").unwrap_err(),
+            "workspace path must be absolute"
+        );
+    }
+
+    #[test]
+    fn rejects_files_and_missing_directories() {
+        let workspace = tempdir().expect("create temporary workspace");
+        let file_path = workspace.path().join("artifact.txt");
+        fs::write(&file_path, "artifact").expect("create temporary file");
+
+        assert_eq!(
+            validate_workspace_directory(file_path.to_str().expect("file path is UTF-8"))
+                .unwrap_err(),
+            "workspace path is not a directory"
+        );
+
+        let missing_path = workspace.path().join("missing");
+        assert!(
+            validate_workspace_directory(missing_path.to_str().expect("missing path is UTF-8"))
+                .unwrap_err()
+                .starts_with("failed to resolve workspace path:")
+        );
+    }
+}

--- a/console/src/components/WorkspaceOpenButton/WorkspaceOpenButton.test.tsx
+++ b/console/src/components/WorkspaceOpenButton/WorkspaceOpenButton.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/test/common_setup";
+import { invoke, isTauri } from "@/test/tauri-mock";
+import WorkspaceOpenButton from "./index";
+
+const mocks = vi.hoisted(() => ({
+  messageError: vi.fn(),
+  storeState: {
+    selectedAgent: "default",
+    agents: [
+      {
+        id: "default",
+        name: "Default",
+        description: "",
+        workspace_dir: "C:\\Users\\tester\\.qwenpaw\\workspaces\\default",
+        enabled: true,
+      },
+    ],
+  },
+}));
+
+vi.mock("@/hooks/useAppMessage", () => ({
+  useAppMessage: () => ({
+    message: { error: mocks.messageError },
+  }),
+}));
+
+vi.mock("@/stores/agentStore", () => ({
+  useAgentStore: () => mocks.storeState,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("WorkspaceOpenButton", () => {
+  beforeEach(() => {
+    isTauri.mockReturnValue(true);
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+    mocks.storeState.selectedAgent = "default";
+    mocks.storeState.agents[0].workspace_dir =
+      "C:\\Users\\tester\\.qwenpaw\\workspaces\\default";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("opens the selected agent workspace through Tauri", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<WorkspaceOpenButton />);
+
+    await user.click(screen.getByRole("button", { name: "nav.workspace" }));
+
+    expect(invoke).toHaveBeenCalledWith("open_workspace_directory", {
+      path: "C:\\Users\\tester\\.qwenpaw\\workspaces\\default",
+    });
+  });
+
+  it("stays hidden in the browser console", () => {
+    isTauri.mockReturnValue(false);
+
+    renderWithProviders(<WorkspaceOpenButton />);
+
+    expect(
+      screen.queryByRole("button", { name: "nav.workspace" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the action when the selected agent has no workspace", () => {
+    mocks.storeState.agents[0].workspace_dir = "";
+
+    renderWithProviders(<WorkspaceOpenButton />);
+
+    expect(
+      screen.getByRole("button", { name: "nav.workspace" }),
+    ).toBeDisabled();
+  });
+
+  it("reports a native command failure without throwing", async () => {
+    const user = userEvent.setup();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    invoke.mockRejectedValue(new Error("permission denied"));
+    renderWithProviders(<WorkspaceOpenButton />);
+
+    await user.click(screen.getByRole("button", { name: "nav.workspace" }));
+
+    await waitFor(() => {
+      expect(mocks.messageError).toHaveBeenCalledWith("common.operationFailed");
+    });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/console/src/components/WorkspaceOpenButton/index.tsx
+++ b/console/src/components/WorkspaceOpenButton/index.tsx
@@ -1,0 +1,55 @@
+import { invoke } from "@tauri-apps/api/core";
+import { Button, Tooltip } from "antd";
+import { FolderOpen } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppMessage } from "../../hooks/useAppMessage";
+import { useAgentStore } from "../../stores/agentStore";
+import { isDesktopTauriRuntime } from "../../utils/openExternalLink";
+
+interface WorkspaceOpenButtonProps {
+  className?: string;
+}
+
+export default function WorkspaceOpenButton(props: WorkspaceOpenButtonProps) {
+  const { className } = props;
+  const { t } = useTranslation();
+  const { message } = useAppMessage();
+  const { agents, selectedAgent } = useAgentStore();
+  const [opening, setOpening] = useState(false);
+  const workspacePath = agents.find((agent) => agent.id === selectedAgent)
+    ?.workspace_dir;
+
+  if (!isDesktopTauriRuntime()) {
+    return null;
+  }
+
+  const handleOpenWorkspace = async () => {
+    if (!workspacePath || opening) return;
+
+    setOpening(true);
+    try {
+      await invoke("open_workspace_directory", { path: workspacePath });
+    } catch (error) {
+      console.warn("[workspace] failed to open workspace directory", error);
+      message.error(t("common.operationFailed"));
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  const label = t("nav.workspace");
+  return (
+    <Tooltip title={label} placement="top">
+      <Button
+        type="text"
+        aria-label={label}
+        className={className}
+        icon={<FolderOpen size={18} />}
+        loading={opening}
+        disabled={!workspacePath}
+        onClick={() => void handleOpenWorkspace()}
+      />
+    </Tooltip>
+  );
+}

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -14,6 +14,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "../hooks/useAppMessage";
 import AgentSelector from "../components/AgentSelector";
+import WorkspaceOpenButton from "../components/WorkspaceOpenButton";
 import {
   SparkChatTabFill,
   SparkExitFullscreenLine,
@@ -615,6 +616,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
       )}
 
       <div className={styles.collapseToggleContainer}>
+        <WorkspaceOpenButton className={styles.collapseToggle} />
         {!collapsed && (
           <Popover
             open={settingsOpen}


### PR DESCRIPTION
## What Problem This Solves

Desktop users currently need to locate an agent's workspace manually when opening generated files or other artifacts outside QwenPaw.

Closes #6083.

## Solution

Add a Desktop-only folder action to the sidebar utility area. The action reads the selected agent's workspace path and asks a dedicated Tauri command to open it in the system file manager.

The native command validates that the path is absolute, unambiguous, exists, and points to a directory before handing it to the OS shell.

## Changes

- Add a reusable `WorkspaceOpenButton`
- Show the action only in the Tauri Desktop runtime
- Add a dedicated `open_workspace_directory` Tauri command
- Add a minimal capability permission for the new command
- Handle missing workspaces and native command failures
- Add frontend and Rust path-validation tests

## Testing

- [x] WorkspaceOpenButton and AgentSelector tests: 10 passed
- [x] ESLint
- [x] TypeScript type checking
- [x] Console production build
- [x] `git diff --check`
- [ ] Rust tests, pending local Rust toolchain
- [ ] Windows Desktop manual verification

## Notes for Reviewer

The browser Console remains unchanged. This PR only implements the minimal system-file-manager shortcut and does not add an in-app file browser or preview panel.
