### PR TITLE
fix(chats): convert session timestamps across timezones

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -3,7 +3,7 @@ import json
 import logging
 import platform
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import List, Optional, Union
 from urllib.parse import unquote, urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -420,6 +420,19 @@ def clean_display_text(text: str, role: str) -> str:
     return strip_injected_skill_block(strip_headline(text) or "", role)
 
 
+def _timestamp_to_user_timezone(value: str, user_tz: tzinfo) -> str:
+    """Convert an AgentScope timestamp to the configured user timezone."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return value
+
+    # AgentScope creates naive timestamps with ``datetime.now()``. Python's
+    # astimezone() therefore applies the backend process timezone before
+    # converting them; timezone-aware values retain their encoded offset.
+    return parsed.astimezone(user_tz).isoformat()
+
+
 # pylint: disable=too-many-branches,too-many-statements, too-many-nested-blocks
 def agentscope_msg_to_message(
     messages: Union[Msg, List[Msg]],
@@ -458,11 +471,7 @@ def agentscope_msg_to_message(
 
         ts_value = msg.timestamp
         if ts_value:
-            try:
-                dt_obj = datetime.strptime(ts_value, "%Y-%m-%d %H:%M:%S.%f")
-                ts_value = dt_obj.replace(tzinfo=user_tz).isoformat()
-            except ValueError:
-                pass
+            ts_value = _timestamp_to_user_timezone(ts_value, user_tz)
 
         metadata = {
             "original_id": msg.id,

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
 from agentscope.message import Msg
 
 from qwenpaw.app.chats.utils import (
@@ -136,6 +140,65 @@ def test_msg_to_message_hides_headline_in_history_path():
     rendered = "".join(c.text for c in message.content)
     assert "⟦" not in rendered and "shipped" not in rendered
     assert "all set" in rendered
+
+
+def test_msg_to_message_converts_naive_process_local_timestamp(monkeypatch):
+    timestamp = "2026-01-02 03:04:05.123456"
+    local_dt = datetime.fromisoformat(timestamp).astimezone()
+    if local_dt.utcoffset() == timedelta(0):
+        user_tz_name = "Asia/Shanghai"
+    else:
+        user_tz_name = "UTC"
+    user_tz = ZoneInfo(user_tz_name)
+    monkeypatch.setattr(
+        "qwenpaw.app.chats.utils.load_config",
+        lambda: SimpleNamespace(user_timezone=user_tz_name),
+    )
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "done"}],
+        created_at=timestamp,
+    )
+
+    [message] = agentscope_msg_to_message(msg)
+
+    expected = local_dt.astimezone(user_tz).isoformat()
+    assert message.metadata["timestamp"] == expected
+
+
+def test_msg_to_message_converts_aware_timestamp_to_user_timezone(monkeypatch):
+    monkeypatch.setattr(
+        "qwenpaw.app.chats.utils.load_config",
+        lambda: SimpleNamespace(user_timezone="Asia/Shanghai"),
+    )
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "done"}],
+        created_at="2026-07-21T07:00:00+00:00",
+    )
+
+    [message] = agentscope_msg_to_message(msg)
+
+    assert message.metadata["timestamp"] == "2026-07-21T15:00:00+08:00"
+
+
+def test_msg_to_message_preserves_invalid_timestamp(monkeypatch):
+    monkeypatch.setattr(
+        "qwenpaw.app.chats.utils.load_config",
+        lambda: SimpleNamespace(user_timezone="Asia/Shanghai"),
+    )
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "done"}],
+        created_at="not-a-timestamp",
+    )
+
+    [message] = agentscope_msg_to_message(msg)
+
+    assert message.metadata["timestamp"] == "not-a-timestamp"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix session message timestamps that were being assigned the configured user timezone without converting the underlying instant.

The shared AgentScope-to-runtime conversion now:

- parses legacy space-separated and ISO-8601 timestamps with `datetime.fromisoformat()`;
- treats naive AgentScope timestamps as process-local time, which is UTC in the reported container deployment;
- converts timezone-aware timestamps from their encoded offset;
- preserves unparseable legacy values unchanged.

The fix belongs in `agentscope_msg_to_message()` because chat history, PawApp context, and proactive-memory serialization all use this conversion. No per-route or per-channel workaround is needed.

**Related Issue:** Fixes #6301

**Security Considerations:** None. This changes display metadata conversion only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this internal bug fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

Not applicable: no channel implementation changed.

## Testing

Regression coverage verifies naive process-local timestamps, timezone-aware ISO timestamps, and invalid-value compatibility. The timestamp tests were also run under UTC and non-UTC process timezones.

Verification matrix:

- UTC container to configured user timezone: covered
- Non-UTC process to configured user timezone: covered
- Timezone-aware ISO input: covered
- Legacy space-separated input: covered
- Invalid legacy input: preserved
- Channels and stream behavior: unchanged

## Evidence

The following local runs exercise the fixed conversion under both UTC-container and non-UTC process timezones, and verify the complete chat test suite and changed-file quality checks.

```text
$ .venv/bin/pytest tests/unit/app/chats/ -q
88 passed in 0.86s

$ env TZ=UTC .venv/bin/pytest tests/unit/app/chats/test_utils.py -q
26 passed in 0.55s

$ env TZ=America/New_York .venv/bin/pytest tests/unit/app/chats/test_utils.py -q
26 passed in 0.53s

$ .venv/bin/pre-commit run --files \
    src/qwenpaw/app/chats/utils.py \
    tests/unit/app/chats/test_utils.py
check python ast.........................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

## Additional Notes

A local `pre-commit run --all-files` passed every hook except pylint, which reported four existing `E1120` findings in the unmodified `src/qwenpaw/sandbox/windows_restricted_sandbox.py`. The latest upstream `main` pre-commit workflow is green, and the complete changed-file hook run above passes.