### PR TITLE
fix(governance): refresh plugin tool defaults, validate tool_type, warm caches off-loop

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -454,7 +454,7 @@ async def list_agents(
 @tool_descriptor(
     async_execution=True,
     tool_type="internal",
-    target_param="agent_id",
+    target_param="to_agent",
     policy_name="ChatWithAgent",
     ui_description=(
         "Send a message to another configured agent and wait for "
@@ -548,7 +548,7 @@ async def chat_with_agent(
 @tool_descriptor(
     async_execution=True,
     tool_type="internal",
-    target_param="agent_id",
+    target_param="to_agent",
     policy_name="SubmitToAgent",
     ui_description="Submit a background task to another configured agent",
     ui_icon="📨",

--- a/src/qwenpaw/app/_app.py
+++ b/src/qwenpaw/app/_app.py
@@ -230,10 +230,9 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             # pylint: disable-next=protected-access
             workspace_registry._bootstrap_kwargs[key] = value
 
-        # Warm descriptor-driven caches before serving requests so the
-        # first /tools or agent-config path does not pay full import cost
-        # on the event loop (macos integration tests use a 15s timeout).
-        try:
+        # Warm descriptor-driven caches off the event loop so the first
+        # /tools or agent-config path does not pay full import cost inline.
+        def _warm_descriptor_caches() -> None:
             from ..config.config import _default_builtin_tools
             from ..governance.policy import get_default_user_rules
             from ..governance.tool_registry import DEFAULT_REGISTRY
@@ -241,6 +240,9 @@ async def lifespan(  # pylint: disable=too-many-statements,too-many-branches
             DEFAULT_REGISTRY.get_all_tool_names()
             _default_builtin_tools()
             get_default_user_rules()
+
+        try:
+            await asyncio.to_thread(_warm_descriptor_caches)
         except Exception:
             logger.debug(
                 "Descriptor cache warm-up skipped",

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2015,101 +2015,127 @@ def _copy_builtin_tools(
     return {name: cfg.model_copy() for name, cfg in tools.items()}
 
 
-# pylint: disable=too-many-nested-blocks
+def _add_plugin_tool_default(
+    tools: Dict[str, BuiltinToolConfig],
+    tool_name: str,
+    *,
+    description: str,
+    icon: str,
+) -> None:
+    """Insert a disabled-by-default plugin tool if *tool_name* is absent."""
+    if tool_name in tools:
+        return
+    tools[tool_name] = BuiltinToolConfig(
+        name=tool_name,
+        enabled=False,
+        description=description,
+        display_to_user=True,
+        async_execution=False,
+        icon=icon,
+    )
+
+
+def _merge_plugin_manifest_tools(
+    tools: Dict[str, BuiltinToolConfig],
+) -> None:
+    """Merge current plugin manifests into *tools* (disabled by default).
+
+    Mutates *tools* in place. Manifests are always read live so late-loaded
+    or unloaded plugins are reflected without process restart.
+    """
+    try:
+        from ..plugins.registry import PluginRegistry
+
+        registry = PluginRegistry()
+        all_manifests = registry.get_all_plugin_manifests()
+    except Exception as exc:
+        logger.debug("Plugin tool merge skipped: %s", exc)
+        return
+
+    for plugin_id, manifest in all_manifests.items():
+        meta = manifest.get("meta", {})
+        if meta.get("tool_name"):
+            _add_plugin_tool_default(
+                tools,
+                meta["tool_name"],
+                description=meta.get(
+                    "tool_description",
+                    f"Tool from plugin {plugin_id}",
+                ),
+                icon=meta.get("tool_icon", "🔧"),
+            )
+        tools_list = meta.get("tools", [])
+        if not isinstance(tools_list, list):
+            continue
+        for tool_info in tools_list:
+            if not isinstance(tool_info, dict) or "name" not in tool_info:
+                continue
+            _add_plugin_tool_default(
+                tools,
+                tool_info["name"],
+                description=tool_info.get(
+                    "description",
+                    f"Tool from plugin {plugin_id}",
+                ),
+                icon=tool_info.get("icon", "🔧"),
+            )
+
+
 def _default_builtin_tools() -> Dict[str, BuiltinToolConfig]:
     """Return built-in tool definitions from ``@tool_descriptor`` UI metadata.
 
-    Plugin tools from manifests are merged afterwards (disabled by default).
-    Successful builds are cached; descriptor import failure fails closed
-    (raises) unless a previous successful snapshot exists.
+    Descriptor-derived configs are process-cached (stable). Plugin tools from
+    manifests are merged on every call (disabled by default) so late-loaded
+    plugins are not permanently omitted after startup warm-up.
+    Descriptor import failure fails closed (raises).
     """
     global _BUILTIN_TOOLS_CACHE
     with _BUILTIN_TOOLS_LOCK:
-        if _BUILTIN_TOOLS_CACHE is not None:
-            return _copy_builtin_tools(_BUILTIN_TOOLS_CACHE)
+        if _BUILTIN_TOOLS_CACHE is None:
+            tools: Dict[str, BuiltinToolConfig] = {}
+            try:
+                # Side-effect import via importlib (not `from ..agents import
+                # tools`) so mypy --follow-imports=skip does not form a static
+                # cycle with agents.tools → delegate_external_agent → config.
+                importlib.import_module("qwenpaw.agents.tools")
+                from ..runtime.tool_registry import get_builtin_tool_funcs
 
-        tools: Dict[str, BuiltinToolConfig] = {}
-        try:
-            # Side-effect import via importlib (not `from ..agents import
-            # tools`) so mypy --follow-imports=skip does not form a static
-            # cycle with agents.tools → delegate_external_agent → config.
-            importlib.import_module("qwenpaw.agents.tools")
-            from ..runtime.tool_registry import get_builtin_tool_funcs
-
-            for fn in get_builtin_tool_funcs():
-                desc = getattr(fn, "_tool_descriptor", None)
-                if desc is None:
-                    continue
-                ui = getattr(desc, "ui", None)
-                tools[desc.name] = BuiltinToolConfig(
-                    name=desc.name,
-                    enabled=desc.enabled_by_default,
-                    description=(
-                        (ui.description if ui and ui.description else "")
-                        or desc.description
-                        or ""
-                    ),
-                    display_to_user=(
-                        ui.display_to_user if ui is not None else True
-                    ),
-                    async_execution=desc.async_execution,
-                    icon=(ui.icon if ui and ui.icon else None),
+                for fn in get_builtin_tool_funcs():
+                    desc = getattr(fn, "_tool_descriptor", None)
+                    if desc is None:
+                        continue
+                    ui = getattr(desc, "ui", None)
+                    tools[desc.name] = BuiltinToolConfig(
+                        name=desc.name,
+                        enabled=desc.enabled_by_default,
+                        description=(
+                            (ui.description if ui and ui.description else "")
+                            or desc.description
+                            or ""
+                        ),
+                        display_to_user=(
+                            ui.display_to_user if ui is not None else True
+                        ),
+                        async_execution=desc.async_execution,
+                        icon=(ui.icon if ui and ui.icon else None),
+                    )
+            except Exception as exc:
+                logger.error(
+                    "Failed to build BuiltinToolConfig from tool "
+                    "descriptors: %s",
+                    exc,
+                    exc_info=True,
                 )
-        except Exception as exc:
-            logger.error(
-                "Failed to build BuiltinToolConfig from tool descriptors: %s",
-                exc,
-                exc_info=True,
-            )
-            raise RuntimeError(
-                "Failed to build built-in tool config from descriptors; "
-                "refusing to persist an empty/incomplete ToolsConfig",
-            ) from exc
+                raise RuntimeError(
+                    "Failed to build built-in tool config from descriptors; "
+                    "refusing to persist an empty/incomplete ToolsConfig",
+                ) from exc
 
-        # Merge dynamically registered tools from plugins
-        try:
-            from ..plugins.registry import PluginRegistry
+            _BUILTIN_TOOLS_CACHE = tools
 
-            registry = PluginRegistry()
-            all_manifests = registry.get_all_plugin_manifests()
-            for plugin_id, manifest in all_manifests.items():
-                meta = manifest.get("meta", {})
-                if meta.get("tool_name"):
-                    tool_name = meta["tool_name"]
-                    if tool_name not in tools:
-                        tools[tool_name] = BuiltinToolConfig(
-                            name=tool_name,
-                            enabled=False,
-                            description=meta.get(
-                                "tool_description",
-                                f"Tool from plugin {plugin_id}",
-                            ),
-                            display_to_user=True,
-                            async_execution=False,
-                            icon=meta.get("tool_icon", "🔧"),
-                        )
-                tools_list = meta.get("tools", [])
-                if isinstance(tools_list, list):
-                    for tool_info in tools_list:
-                        if isinstance(tool_info, dict) and "name" in tool_info:
-                            tool_name = tool_info["name"]
-                            if tool_name not in tools:
-                                tools[tool_name] = BuiltinToolConfig(
-                                    name=tool_name,
-                                    enabled=False,
-                                    description=tool_info.get(
-                                        "description",
-                                        f"Tool from plugin {plugin_id}",
-                                    ),
-                                    display_to_user=True,
-                                    async_execution=False,
-                                    icon=tool_info.get("icon", "🔧"),
-                                )
-        except Exception as exc:
-            logger.debug("Plugin tool merge skipped: %s", exc)
-
-        _BUILTIN_TOOLS_CACHE = tools
-        return _copy_builtin_tools(tools)
+        merged = _copy_builtin_tools(_BUILTIN_TOOLS_CACHE)
+        _merge_plugin_manifest_tools(merged)
+        return merged
 
 
 class ToolsConfig(BaseModel):

--- a/src/qwenpaw/governance/policy.py
+++ b/src/qwenpaw/governance/policy.py
@@ -513,9 +513,13 @@ def _auto_default_user_rules() -> List[GovernanceRule]:
             gov = getattr(desc, "governance", None)
             if gov is None or not gov.default_policy:
                 continue
-            action = action_map.get(gov.default_policy.lower())
+            policy_key = gov.default_policy.strip().lower()
+            action = action_map.get(policy_key)
             if action is None:
-                continue
+                raise ValueError(
+                    f"Invalid default_policy {gov.default_policy!r} on "
+                    f"tool {desc.name!r}; expected allow|ask|deny",
+                )
             pname = gov.policy_name or snake_to_pascal(desc.name)
             rules.append(
                 GovernanceRule(
@@ -556,14 +560,15 @@ def get_default_user_rules() -> List[GovernanceRule]:
 
 # Backward-compatible name used by tests and callers. Resolved lazily so
 # descriptor imports are available when the list is first read.
-class _DefaultUserRulesProxy(list):
-    """Lazy list-like view over :func:`get_default_user_rules`.
+class _DefaultUserRulesProxy:
+    """Lazy sequence view over :func:`get_default_user_rules`.
 
     Supported: iteration, ``len()``, integer index, ``repr``.
 
-    Unsupported / unsafe on the proxy itself: ``+``, ``==``, slice
-    assignment, in-place mutation. Prefer
-    ``list(DEFAULT_USER_RULES)`` / :func:`get_default_user_rules` first.
+    This intentionally does **not** subclass ``list`` — inherited ``+``,
+    ``==``, and in-place mutation would operate on an empty backing list
+    and silently diverge from the lazy rules. Prefer
+    ``list(DEFAULT_USER_RULES)`` / :func:`get_default_user_rules`.
     """
 
     def _rules(self) -> List[GovernanceRule]:

--- a/src/qwenpaw/governance/tool_registry.py
+++ b/src/qwenpaw/governance/tool_registry.py
@@ -180,8 +180,34 @@ def snake_to_pascal(name: str) -> str:
     return "".join(p.capitalize() for p in name.split("_"))
 
 
+ALLOWED_TOOL_TYPES = frozenset({"file", "network", "shell", "internal"})
+ALLOWED_DEFAULT_POLICIES = frozenset({"allow", "ask", "deny", ""})
+
+
 class GovernanceRegistrationConflict(ValueError):
     """Raised when a governance policy identity would be reused unsafely."""
+
+
+def validate_tool_type(tool_type: str) -> str:
+    """Return *tool_type* or raise if it is not a known governance type."""
+    if tool_type not in ALLOWED_TOOL_TYPES:
+        raise GovernanceRegistrationConflict(
+            f"Invalid governance tool_type {tool_type!r}; "
+            f"expected one of {sorted(ALLOWED_TOOL_TYPES)}",
+        )
+    return tool_type
+
+
+def validate_default_policy(default_policy: str) -> str:
+    """Return normalized *default_policy* or raise on unknown values."""
+    normalized = (default_policy or "").strip().lower()
+    if normalized not in ALLOWED_DEFAULT_POLICIES:
+        allowed = sorted(p for p in ALLOWED_DEFAULT_POLICIES if p)
+        raise GovernanceRegistrationConflict(
+            f"Invalid governance default_policy {default_policy!r}; "
+            f"expected one of {allowed} or empty",
+        )
+    return normalized
 
 
 def register_tool_governance(
@@ -207,6 +233,7 @@ def register_tool_governance(
     Returns the policy-layer tool name that was registered
     (or already present with identical metadata).
     """
+    tool_type = validate_tool_type(tool_type)
     pname = policy_name or snake_to_pascal(python_name)
     new_identity = (
         tool_type,

--- a/src/qwenpaw/plugins/api.py
+++ b/src/qwenpaw/plugins/api.py
@@ -2,6 +2,7 @@
 """Plugin API for plugin developers."""
 
 import logging
+import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type
 
@@ -49,6 +50,37 @@ def get_tool_config(tool_name: str) -> Optional[Dict[str, Any]]:
 # -------------------------------------------------------------------
 # Helpers for PluginApi.register_tool
 # -------------------------------------------------------------------
+
+# tool_name → owning plugin_id. Same plugin may re-register idempotently;
+# a different plugin claiming the same name fails closed.
+_TOOL_PLUGIN_OWNERS: Dict[str, str] = {}
+_TOOL_PLUGIN_OWNERS_LOCK = threading.Lock()
+
+
+def _claim_tool_ownership(tool_name: str, plugin_id: str) -> None:
+    """Record plugin ownership for *tool_name* or raise on conflict."""
+    from ..governance.tool_registry import GovernanceRegistrationConflict
+
+    with _TOOL_PLUGIN_OWNERS_LOCK:
+        owner = _TOOL_PLUGIN_OWNERS.get(tool_name)
+        if owner is not None and owner != plugin_id:
+            raise GovernanceRegistrationConflict(
+                f"Tool {tool_name!r} is already owned by plugin "
+                f"{owner!r}; plugin {plugin_id!r} cannot re-register it",
+            )
+        _TOOL_PLUGIN_OWNERS[tool_name] = plugin_id
+
+
+def release_tool_ownership_for_plugin(plugin_id: str) -> None:
+    """Drop ownership records for tools registered by *plugin_id*."""
+    with _TOOL_PLUGIN_OWNERS_LOCK:
+        stale = [
+            name
+            for name, owner in _TOOL_PLUGIN_OWNERS.items()
+            if owner == plugin_id
+        ]
+        for name in stale:
+            del _TOOL_PLUGIN_OWNERS[name]
 
 
 def _register_to_governance(
@@ -690,9 +722,11 @@ class PluginApi:  # pylint: disable=too-many-public-methods
         """
 
         def _startup_register():
-            # Governance first: fail closed before exposing the tool in
-            # toolkit/UI/runtime (avoids #6114-style visible-but-denied).
+            # Ownership + governance first: fail closed before exposing
+            # the tool in toolkit/UI/runtime (avoids #6114-style
+            # visible-but-denied, and cross-plugin name collisions).
             try:
+                _claim_tool_ownership(tool_name, self.plugin_id)
                 _register_to_governance(
                     tool_name,
                     tool_type=tool_type,

--- a/src/qwenpaw/plugins/registry.py
+++ b/src/qwenpaw/plugins/registry.py
@@ -944,6 +944,17 @@ class PluginRegistry:  # pylint:disable=too-many-public-methods
         self._unregister_plugin_http_routes(plugin_id)
         self._unregister_plugin_channels(plugin_id)
 
+        try:
+            from .api import release_tool_ownership_for_plugin
+
+            release_tool_ownership_for_plugin(plugin_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Tool ownership release skipped for plugin %s",
+                plugin_id,
+                exc_info=True,
+            )
+
         self._plugin_manifests.pop(plugin_id, None)
 
         providers_to_remove = [

--- a/src/qwenpaw/runtime/tool_registry.py
+++ b/src/qwenpaw/runtime/tool_registry.py
@@ -251,12 +251,23 @@ def tool_descriptor(
     def deco(fn: Callable[..., Any]) -> Callable[..., Any]:
         import inspect
 
+        from ..governance.tool_registry import (
+            validate_default_policy,
+            validate_tool_type,
+        )
+
         resolved_name = name or fn.__name__
         is_async = (
             async_execution
             if async_execution is not None
             else inspect.iscoroutinefunction(fn)
         )
+        # Empty tool_type is allowed here (governance gap / non-collected
+        # tools); non-empty values must be one of the known types.
+        resolved_tool_type = tool_type
+        if resolved_tool_type:
+            resolved_tool_type = validate_tool_type(resolved_tool_type)
+        resolved_default_policy = validate_default_policy(default_policy)
         # pylint: disable=protected-access
         fn._tool_descriptor = ToolDescriptor(  # type: ignore[attr-defined]
             name=resolved_name,
@@ -274,12 +285,12 @@ def tool_descriptor(
             ),
             metadata=dict(metadata),
             governance=ToolGovernanceSpec(
-                tool_type=tool_type,
+                tool_type=resolved_tool_type,
                 target_param=target_param,
                 pattern_param=pattern_param,
                 policy_name=policy_name,
                 fail_without_sandbox=fail_without_sandbox,
-                default_policy=default_policy,
+                default_policy=resolved_default_policy,
                 policy_reason=policy_reason,
             ),
             ui=ToolUISpec(

--- a/tests/integration/test_agent_scoped_misc.py
+++ b/tests/integration/test_agent_scoped_misc.py
@@ -16,9 +16,7 @@ from tests.integration.helpers import (
     scoped,
 )
 
-# Same floor as Windows CI (QWENPAW_INTEGRATION_HTTP_TIMEOUT=120): list tools
-# awaits workspace startup and can exceed the 15s default on slow runners.
-_HTTP_TIMEOUT = default_http_timeout(120.0)
+_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/test_multi_agent_lifecycle.py
+++ b/tests/integration/test_multi_agent_lifecycle.py
@@ -21,9 +21,7 @@ from tests.integration.helpers import (
     toggle_agent,
 )
 
-# Same floor as Windows CI (QWENPAW_INTEGRATION_HTTP_TIMEOUT=120): concurrent
-# agent create/reorder/delete can exceed the 15s default on slow runners.
-_AGENT_HTTP_TIMEOUT = default_http_timeout(120.0)
+_AGENT_HTTP_TIMEOUT = default_http_timeout(15.0)
 
 
 # ------------------------------------------------------------------ #

--- a/tests/unit/governance/test_unified_tool_registration.py
+++ b/tests/unit/governance/test_unified_tool_registration.py
@@ -12,12 +12,17 @@ from qwenpaw.agents.tools.delegate_external_agent import (
     delegate_external_agent,
 )
 from qwenpaw.agents.tools.file_io import append_file
-from qwenpaw.config.config import _default_builtin_tools
+from qwenpaw.config.config import (
+    ToolsConfig,
+    _default_builtin_tools,
+    _reset_builtin_tools_cache_for_tests,
+)
 from qwenpaw.governance.policy import (
     DEFAULT_USER_RULES,
     GovernanceAction,
     GovernancePolicy,
     ToolCallSpec,
+    _DefaultUserRulesProxy,
     _auto_default_user_rules,
     get_default_user_rules,
 )
@@ -28,9 +33,17 @@ from qwenpaw.governance.tool_registry import (
     assert_no_governance_gaps,
     register_tool_governance,
     snake_to_pascal,
+    validate_default_policy,
+    validate_tool_type,
     _collect_governance_gaps,
 )
-from qwenpaw.plugins.api import _register_to_governance
+from qwenpaw.plugins.api import (
+    _TOOL_PLUGIN_OWNERS,
+    _claim_tool_ownership,
+    _register_to_governance,
+    release_tool_ownership_for_plugin,
+)
+from qwenpaw.plugins.registry import PluginRegistry
 from qwenpaw.runtime.tool_registry import ToolDescriptor, ToolGovernanceSpec
 
 
@@ -310,3 +323,127 @@ class TestBuiltinToolConfigFromDescriptors:
         tools = _default_builtin_tools()
         assert tools["web_search"].icon == "🔎"
         assert tools["view_image"].display_to_user is False
+
+    def test_late_plugin_manifest_merged_after_cache_warm(
+        self,
+    ) -> None:
+        """Descriptor cache must not permanently omit late plugin tools."""
+        plugin_id = "__ut_late_plugin_manifest__"
+        tool_name = "__ut_late_plugin_tool__"
+        registry = PluginRegistry()
+        registry.unregister_plugin(plugin_id)
+        _reset_builtin_tools_cache_for_tests()
+        try:
+            before = _default_builtin_tools()
+            assert tool_name not in before
+
+            registry.register_plugin_manifest(
+                plugin_id,
+                {
+                    "name": plugin_id,
+                    "meta": {
+                        "tool_name": tool_name,
+                        "tool_description": "late plugin tool",
+                        "tool_icon": "🧪",
+                    },
+                },
+            )
+            cfg = ToolsConfig()
+            assert tool_name in cfg.builtin_tools
+            assert cfg.builtin_tools[tool_name].enabled is False
+
+            registry.unregister_plugin(plugin_id)
+            after = _default_builtin_tools()
+            assert tool_name not in after
+        finally:
+            registry.unregister_plugin(plugin_id)
+            _reset_builtin_tools_cache_for_tests()
+
+
+class TestToolTypeAndDefaultPolicyValidation:
+    def test_reject_bogus_tool_type(self):
+        registry = ToolRegistry()
+        with pytest.raises(GovernanceRegistrationConflict):
+            register_tool_governance(
+                registry,
+                python_name="__ut_bogus_type__",
+                tool_type="bogus",
+            )
+
+    def test_accept_known_tool_types(self):
+        registry = ToolRegistry()
+        for tool_type in ("file", "network", "shell", "internal"):
+            register_tool_governance(
+                registry,
+                python_name=f"__ut_type_{tool_type}__",
+                tool_type=tool_type,
+            )
+
+    def test_validate_default_policy_rejects_typo(self):
+        with pytest.raises(GovernanceRegistrationConflict):
+            validate_default_policy("alow")
+
+    def test_validate_tool_type_helpers(self):
+        assert validate_tool_type("network") == "network"
+        with pytest.raises(GovernanceRegistrationConflict):
+            validate_tool_type("")
+
+
+class TestPluginToolOwnership:
+    def test_different_plugin_same_tool_name_conflicts(self):
+        tool_name = "__ut_owned_tool__"
+        _TOOL_PLUGIN_OWNERS.pop(tool_name, None)
+        try:
+            _claim_tool_ownership(tool_name, "plugin-a")
+            with pytest.raises(GovernanceRegistrationConflict):
+                _claim_tool_ownership(tool_name, "plugin-b")
+            # Same plugin is idempotent.
+            _claim_tool_ownership(tool_name, "plugin-a")
+        finally:
+            release_tool_ownership_for_plugin("plugin-a")
+            release_tool_ownership_for_plugin("plugin-b")
+
+    def test_release_ownership_allows_other_plugin(self):
+        tool_name = "__ut_owned_tool_release__"
+        _TOOL_PLUGIN_OWNERS.pop(tool_name, None)
+        try:
+            _claim_tool_ownership(tool_name, "plugin-a")
+            release_tool_ownership_for_plugin("plugin-a")
+            _claim_tool_ownership(tool_name, "plugin-b")
+        finally:
+            release_tool_ownership_for_plugin("plugin-a")
+            release_tool_ownership_for_plugin("plugin-b")
+
+
+class TestDefaultUserRulesProxy:
+    def test_proxy_is_not_list_subclass(self):
+        assert not isinstance(DEFAULT_USER_RULES, list)
+        assert isinstance(DEFAULT_USER_RULES, _DefaultUserRulesProxy)
+
+
+class TestWindowsStylePathExtraction:
+    def test_extract_target_joins_backslash_relative_path(self):
+        """Relative targets with backslash segments still join to workspace."""
+        import ntpath
+
+        registry = ToolRegistry()
+        register_tool_governance(
+            registry,
+            python_name="__ut_win_read__",
+            tool_type="file",
+            target_param="file_path",
+            policy_name="UtWinRead",
+        )
+        # Use an absolute POSIX workspace so join works on all platforms;
+        # relative path keeps Windows-style separators as segments.
+        workspace = "/tmp/ut_win_workspace"
+        relative = r"src\main.py"
+        target = registry.extract_target(
+            "UtWinRead",
+            {"file_path": relative},
+            workspace_dir=workspace,
+        )
+        assert target.startswith(workspace)
+        assert "main.py" in target
+        # ntpath.basename still sees the leaf under Windows separators.
+        assert ntpath.basename(relative) == "main.py"


### PR DESCRIPTION
## Description

Follow-up to #6190 review feedback. Keeps the descriptor-driven tool
registration direction, and fixes three post-merge gaps:

1. **Plugin defaults no longer frozen at warm-up** — `_default_builtin_tools()`
   caches only stable `@tool_descriptor` built-ins and merges current plugin
   manifests on every call, so late-loaded / unloaded plugins appear in new
   `ToolsConfig` without restarting the process.
2. **Fail-closed `tool_type` / `default_policy` validation** — invalid values
   (e.g. `tool_type="bogus"`, `default_policy="alow"`) raise
   `GovernanceRegistrationConflict` at registration / descriptor construction
   instead of silently bypassing Phase-0 unknown-tool semantics or shell-only
   checks.
3. **Descriptor warm-up off the event loop** — lifespan uses
   `asyncio.to_thread(...)` for registry/config/rules warm-up; integration
   HTTP timeouts for the previously raised modules are restored to 15s
   (Windows CI can still lift via `QWENPAW_INTEGRATION_HTTP_TIMEOUT`).

Also includes small structural fixes from review: `target_param="to_agent"`
for `chat_with_agent` / `submit_to_agent`; `_DefaultUserRulesProxy` no longer
subclasses `list`; plugin tool ownership keyed by `plugin_id`; minimal
Windows-style path extraction coverage.

**Related Issue:** Relates to #6190 (follow-up). Relates to #6114.

**Security Considerations:** Invalid governance `tool_type` values are rejected
at registration so mislabeled shell plugins cannot skip shell danger / sandbox
fallback paths. Cross-plugin same-name tool registration fails closed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Unit:
   ```bash
   pytest tests/unit/governance/ -q
   pytest tests/unit/governance/test_unified_tool_registration.py -q
   ```
   Covers late plugin manifest merge after cache warm-up, `tool_type` /
   `default_policy` rejection, plugin ownership conflicts, and path extraction.
2. Integration (smoke):
   ```bash
   pytest \
     tests/integration/test_agent_scoped_misc.py::test_tools_list_returns_array \
     tests/integration/test_multi_agent_lifecycle.py::test_multi_agent_reorder_and_delete_order_adjusts \
     -q
   ```
3. Lint:
   ```bash
   pre-commit run --files \
     src/qwenpaw/config/config.py \
     src/qwenpaw/governance/tool_registry.py \
     src/qwenpaw/governance/policy.py \
     src/qwenpaw/runtime/tool_registry.py \
     src/qwenpaw/plugins/api.py \
     src/qwenpaw/plugins/registry.py \
     src/qwenpaw/app/_app.py \
     src/qwenpaw/agents/tools/agent_management.py \
     tests/unit/governance/test_unified_tool_registration.py \
     tests/integration/test_agent_scoped_misc.py \
     tests/integration/test_multi_agent_lifecycle.py
   ```

## Evidence

```bash
# pre-commit (changed files)
# All hooks Passed (mypy / black / flake8 / pylint)

# unit
pytest tests/unit/governance/ -q
# 249 passed

# focused + integration smoke
pytest tests/unit/governance/test_unified_tool_registration.py \
  tests/integration/test_agent_scoped_misc.py::test_tools_list_returns_array \
  tests/integration/test_multi_agent_lifecycle.py::test_multi_agent_reorder_and_delete_order_adjusts \
  -q
# 32 passed
```