### PR TITLE
feat(chat): enable drag-and-drop file upload in desktop app (#6297)

### DIFF
--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "minWidth": 960,
         "minHeight": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -34,6 +34,23 @@ registerBuiltinCards();
 void registerHostModulesDynamic();
 
 if (typeof window !== "undefined") {
+  // Prevent the browser/WebView from navigating away (replacing the whole
+  // app) when a file is dropped outside a drop zone like the chat sender.
+  // Required for drag-and-drop upload on desktop (issue #6297): the Tauri
+  // window sets dragDropEnabled=false so OS file drags reach the page as
+  // HTML5 drag events, and any drop not consumed by a drop zone would
+  // otherwise open the file directly. Drop zones stop propagation, so this
+  // only sees unhandled drops. Scoped to file drags to keep element
+  // drag-and-drop (e.g. queue reordering) untouched.
+  const isFileDrag = (e: DragEvent) =>
+    !!e.dataTransfer && Array.from(e.dataTransfer.types).includes("Files");
+  window.addEventListener("dragover", (e) => {
+    if (isFileDrag(e)) e.preventDefault();
+  });
+  window.addEventListener("drop", (e) => {
+    if (isFileDrag(e)) e.preventDefault();
+  });
+
   const originalError = console.error;
   const originalWarn = console.warn;
 

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -36,12 +36,11 @@ void registerHostModulesDynamic();
 if (typeof window !== "undefined") {
   // Prevent the browser/WebView from navigating away (replacing the whole
   // app) when a file is dropped outside a drop zone like the chat sender.
-  // Required for drag-and-drop upload on desktop (issue #6297): the Tauri
-  // window sets dragDropEnabled=false so OS file drags reach the page as
-  // HTML5 drag events, and any drop not consumed by a drop zone would
-  // otherwise open the file directly. Drop zones stop propagation, so this
-  // only sees unhandled drops. Scoped to file drags to keep element
-  // drag-and-drop (e.g. queue reordering) untouched.
+  // The Tauri window disables native drag-drop interception so OS file
+  // drags reach the page as HTML5 drag events; any drop not consumed by a
+  // drop zone would otherwise open the file directly. Drop zones stop
+  // propagation, so this only sees unhandled drops. Scoped to file drags
+  // to keep element drag-and-drop (e.g. queue reordering) untouched.
   const isFileDrag = (e: DragEvent) =>
     !!e.dataTransfer && Array.from(e.dataTransfer.types).includes("Files");
   window.addEventListener("dragover", (e) => {

--- a/console/src/tauri/bootstrap.tsx
+++ b/console/src/tauri/bootstrap.tsx
@@ -4,9 +4,9 @@ import { ThemeProvider } from "../contexts/ThemeContext";
 import BackendReadyGate from "./BackendReadyGate";
 import CloseWindowPrompt from "./CloseWindowPrompt";
 
-// The window has dragDropEnabled=false (see tauri.conf.json, issue #6297),
-// so OS file drags arrive as HTML5 drag events. Block the default "navigate
-// to dropped file" behavior on this bootstrap page; the console app installs
+// Native drag-drop interception is disabled on the window, so OS file
+// drags arrive as HTML5 drag events. Block the default "navigate to
+// dropped file" behavior on this bootstrap page; the console app installs
 // its own guard in main.tsx after navigation.
 window.addEventListener("dragover", (e) => e.preventDefault());
 window.addEventListener("drop", (e) => e.preventDefault());

--- a/console/src/tauri/bootstrap.tsx
+++ b/console/src/tauri/bootstrap.tsx
@@ -4,6 +4,13 @@ import { ThemeProvider } from "../contexts/ThemeContext";
 import BackendReadyGate from "./BackendReadyGate";
 import CloseWindowPrompt from "./CloseWindowPrompt";
 
+// The window has dragDropEnabled=false (see tauri.conf.json, issue #6297),
+// so OS file drags arrive as HTML5 drag events. Block the default "navigate
+// to dropped file" behavior on this bootstrap page; the console app installs
+// its own guard in main.tsx after navigation.
+window.addEventListener("dragover", (e) => e.preventDefault());
+window.addEventListener("drop", (e) => e.preventDefault());
+
 createRoot(document.getElementById("root")!).render(
   <ThemeProvider>
     <CloseWindowPrompt />


### PR DESCRIPTION
Fixes #6297 
Tauri v2 intercepts OS file drags by default (dragDropEnabled=true), which prevents HTML5 drag events from reaching the WebView on Windows, so the chat sender's built-in drop-to-upload never triggered.

- Set dragDropEnabled=false on the main window so HTML5 drag events flow through to the SDK sender's existing drop handling
- Guard against the WebView navigating to a file dropped outside a drop zone (main.tsx for the console, bootstrap.tsx for the desktop loading page)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
