### PR TITLE
feat(ci): unified release orchestrator gating web on desktop build

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,279 @@
+# Reusable "prepare" half of the desktop release: build the Tauri desktop
+# packages (Windows + macOS), run the install/launch/chat UI verification,
+# and upload the installers + updater sidecars as run artifacts.
+#
+# This workflow performs NO publishing. It is called by release.yml during the
+# prepare phase (pinned to the release commit via `ref`), and can also be run
+# standalone via workflow_dispatch to validate a packaging change.
+#
+# The matching publish half lives in desktop-publish.yml.
+
+name: Desktop Build (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref/SHA to build (pins the build to the release commit)"
+        type: string
+        required: false
+        default: ""
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref/SHA to build (default: this workflow's ref)"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build-tauri-windows:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        uses: ./.github/actions/get-version
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: console/src-tauri
+
+      - name: Install NSIS
+        uses: negrutiu/nsis-install@v2
+
+      - name: Clean dist directory
+        shell: pwsh
+        run: |
+          if (Test-Path dist) {
+            Remove-Item -Recurse -Force dist
+          }
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+
+      - name: Build Tauri Windows package
+        shell: pwsh
+        env:
+          # Authenticate the python-build-standalone release lookup in
+          # stage_python_runtime.py to avoid anonymous API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ vars.TAURI_UPDATER_PUBKEY }}
+          TAURI_UPDATER_ENDPOINTS: ${{ vars.TAURI_UPDATER_ENDPOINTS }}
+        run: ./scripts/pack-tauri/build_win_pyinstaller.ps1
+
+      - name: Stage Tauri Windows installer and updater assets
+        shell: pwsh
+        run: |
+          python scripts/pack-tauri/generate_update_manifest.py stage `
+            --bundle-dir console/src-tauri/target/release/bundle/nsis `
+            --pattern '*-setup.exe' `
+            --target windows-x86_64 `
+            --output "dist/QwenPaw-Tauri-${{ steps.version.outputs.version }}-Windows-setup.exe" `
+            --pubkey-config console/src-tauri/tauri.version.conf.json
+
+      - name: Verify desktop (Tauri Windows)
+        timeout-minutes: 10
+        uses: ./.github/actions/verify-tauri-windows
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+
+      - name: Stop desktop server (Tauri Windows)
+        if: always()
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          # Kill the Tauri shell and its sidecar subprocess by name.
+          Get-Process -Name "qwenpaw-desktop" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name "qwenpaw-backend" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 2
+          Get-Process -Name "qwenpaw-desktop" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          Get-Process -Name "qwenpaw-backend" -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+          exit 0
+
+      - name: Upload desktop verify logs (Tauri Windows)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-logs-tauri-windows-${{ steps.version.outputs.version }}
+          path: |
+            ${{ runner.temp }}/qwenpaw-desktop-stdout.log
+            ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+            ~/AppData/Local/com.qwenpaw.desktop/logs/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload verify screenshots (Tauri Windows)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-screenshots-tauri-windows-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/verify-screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Tauri Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QwenPaw-Desktop-Tauri-Windows-${{ steps.version.outputs.version }}
+          path: dist/QwenPaw-Tauri-*-Windows-setup.exe
+
+      - name: Upload Tauri Windows updater metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-updater-meta-windows
+          path: |
+            dist/QwenPaw-Tauri-*-Windows-setup.exe.sig
+            dist/tauri-windows-x86_64-updater.json
+
+  build-tauri-macos:
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        uses: ./.github/actions/get-version
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        env:
+          PIP_NO_CACHE_DIR: "1"
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: console/src-tauri
+
+      - name: Clean dist directory
+        run: rm -rf dist && mkdir -p dist
+
+      - name: Build Tauri macOS package
+        env:
+          NODE_OPTIONS: "--max-old-space-size=8192"
+          # Authenticate the python-build-standalone release lookup in
+          # stage_python_runtime.py to avoid anonymous API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_UPDATER_PUBKEY: ${{ vars.TAURI_UPDATER_PUBKEY }}
+          TAURI_UPDATER_ENDPOINTS: ${{ vars.TAURI_UPDATER_ENDPOINTS }}
+        run: |
+          chmod +x scripts/pack-tauri/build_macos_pyinstaller.sh
+          bash scripts/pack-tauri/build_macos_pyinstaller.sh
+
+      - name: Verify desktop (Tauri macOS)
+        timeout-minutes: 10
+        uses: ./.github/actions/verify-tauri-macos
+        with:
+          dashscope-api-key: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+
+      - name: Stop desktop server (Tauri macOS)
+        if: always()
+        run: |
+          # Kill the Tauri shell and its sidecar subprocess.
+          pkill -f "QwenPaw Desktop" 2>/dev/null || true
+          pkill -f "qwenpaw-backend" 2>/dev/null || true
+          sleep 2
+          pkill -9 -f "QwenPaw Desktop" 2>/dev/null || true
+          pkill -9 -f "qwenpaw-backend" 2>/dev/null || true
+          # Best-effort: kill anything sitting on the detected port.
+          if [ -n "${BASE_URL:-}" ]; then
+            PORT="${BASE_URL##*:}"
+            lsof -ti:"$PORT" | xargs kill 2>/dev/null || true
+          fi
+          rm -rf dist/verify-tauri
+
+      - name: Upload desktop verify logs (Tauri macOS)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-logs-tauri-macos-${{ steps.version.outputs.version }}
+          path: |
+            ${{ runner.temp }}/qwenpaw-desktop-stdout.log
+            ${{ runner.temp }}/qwenpaw-desktop-stderr.log
+            ~/Library/Logs/com.qwenpaw.desktop/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload verify screenshots (Tauri macOS)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-verify-screenshots-tauri-macos-${{ steps.version.outputs.version }}
+          path: ${{ runner.temp }}/verify-screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Tauri macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QwenPaw-Desktop-Tauri-macOS-${{ steps.version.outputs.version }}
+          path: dist/QwenPaw-Tauri-*-macOS.zip
+
+      - name: Upload Tauri macOS updater metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: tauri-updater-meta-macos
+          path: |
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz
+            dist/QwenPaw-Tauri-*-macOS.app.tar.gz.sig
+            dist/tauri-darwin-*-updater.json

--- a/.github/workflows/desktop-promote.yml
+++ b/.github/workflows/desktop-promote.yml
@@ -1,0 +1,262 @@
+# Reusable "promote" step of the desktop release — runs ONLY after the release
+# has been flipped to published (called by release.yml's post-finalize job).
+#
+# It promotes the already-uploaded versioned OSS files to `latest`, generates
+# and uploads the Tauri auto-update manifest (qwenpaw-tauri-latest.json), and
+# refreshes the desktop + main index. Splitting this out of desktop-publish.yml
+# ensures existing users' auto-updater is never pointed at a version whose
+# release/PyPI/Docker publish might still have failed.
+#
+# Skipped entirely when dry_run=true (fork verification never touches prod OSS).
+
+name: Desktop Promote (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Published release tag (for updater manifest notes)"
+        type: string
+        required: true
+      ref:
+        description: "Git ref/SHA to checkout for the packaging scripts"
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: "Skip promotion entirely (fork verification)"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  promote-oss:
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    env:
+      OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
+      OSS_PUBLIC_BASE_URL: ${{ vars.OSS_PUBLIC_BASE_URL || 'https://download.qwenpaw.agentscope.io/files/apps/desktop' }}
+    steps:
+      - name: Checkout (for scripts)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
+      - name: Get version
+        id: version
+        uses: ./.github/actions/get-version
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Install ossutil
+        run: |
+          wget https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip
+          unzip ossutil-v1.7.18-linux-amd64.zip
+          chmod +x ossutil-v1.7.18-linux-amd64/ossutil64
+          sudo mv ossutil-v1.7.18-linux-amd64/ossutil64 /usr/local/bin/ossutil
+          ossutil --version
+
+      - name: Configure ossutil
+        run: |
+          ossutil config -e ${{ secrets.OSS_ENDPOINT }} \
+            -i ${{ secrets.OSS_ACCESS_KEY_ID }} \
+            -k ${{ secrets.OSS_ACCESS_KEY_SECRET }} \
+            -L CH
+
+      - name: Promote versioned files to latest
+        if: hashFiles('QwenPaw-Desktop-Tauri-*/*') != ''
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          promote_latest() {
+            local dirs="$1"
+            local pattern="$2"
+            local platform="$3"
+            local versioned_name="$4"
+            local latest_name="$5"
+
+            local artifact
+            artifact=$(find ${dirs} -name "${pattern}" 2>/dev/null | head -1 || true)
+            if [ -z "${artifact}" ]; then
+              echo "No ${platform} artifact; skipping latest promotion"
+              return 0
+            fi
+
+            echo "Promoting ${platform} ${versioned_name} -> ${latest_name}"
+            ossutil cp \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}" \
+              --acl public-read \
+              --force
+            ossutil cp \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json" \
+              --acl public-read \
+              --force
+          }
+
+          promote_latest \
+            "QwenPaw-Desktop-Tauri-Windows-*" \
+            "QwenPaw-Tauri-*-Windows-setup.exe" \
+            "win-tauri" \
+            "QwenPaw-Tauri-${VERSION}-Windows-setup.exe" \
+            "QwenPaw-Tauri-latest-Windows-setup.exe"
+
+          promote_latest \
+            "QwenPaw-Desktop-Tauri-macOS-*" \
+            "QwenPaw-Tauri-*-macOS.zip" \
+            "mac-tauri" \
+            "QwenPaw-Tauri-${VERSION}-macOS.zip" \
+            "QwenPaw-Tauri-latest-macOS.zip"
+
+      - name: Link artifacts into updater-meta dirs for manifest generation
+        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
+        run: |
+          # The manifest generator expects the artifact binary alongside the
+          # sidecar JSON.  After artifact splitting the exe lives in a separate
+          # artifact directory, so we symlink it into the meta directory.
+          for f in QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe; do
+            [ -f "$f" ] && ln -sf "../$f" tauri-updater-meta-windows/ 2>/dev/null || true
+          done
+
+      - name: Generate and upload OSS updater manifest
+        # The Tauri auto-updater uses OSS only; GitHub Releases only carry
+        # first-install artifacts.
+        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RELEASE_BODY="$(gh release view "${{ inputs.tag }}" --json body -q .body --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)"
+          OSS_BASE="${OSS_PUBLIC_BASE_URL%/}"
+          metadata_args=()
+          for f in tauri-updater-meta-windows/tauri-windows-*-updater.json \
+                   tauri-updater-meta-macos/tauri-darwin-*-updater.json; do
+            [ -f "$f" ] && metadata_args+=(--metadata "$f")
+          done
+          if [ ${#metadata_args[@]} -eq 0 ]; then
+            echo "No Tauri updater sidecars found, skipping OSS manifest"
+            exit 0
+          fi
+          NOTES="${RELEASE_BODY:-QwenPaw Desktop ${VERSION}}"
+          python scripts/pack-tauri/generate_update_manifest.py manifest \
+            --version "$VERSION" \
+            --base-url "$OSS_BASE" \
+            --target-base "windows-x86_64=${OSS_BASE}/win-tauri" \
+            --target-base "darwin-aarch64=${OSS_BASE}/mac-tauri" \
+            "${metadata_args[@]}" \
+            --notes "$NOTES" \
+            --output qwenpaw-tauri-latest-oss.json
+          ossutil cp qwenpaw-tauri-latest-oss.json \
+            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json" \
+            --acl public-read \
+            --force
+
+      - name: Update desktop index
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Download existing desktop/index.json if exists
+          ossutil cp "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
+            desktop-index.json 2>/dev/null || cat > desktop-index.json << 'EOF'
+          {
+            "product": "desktop",
+            "updated_at": "",
+            "platforms": {},
+            "files": {}
+          }
+          EOF
+
+          merge_tauri_metadata() {
+            local metadata="$1"
+            local dirs="$2"
+            local pattern="$3"
+            local platform="$4"
+            local artifact
+            artifact=$(find ${dirs} -name "${pattern}" 2>/dev/null | head -1 || true)
+            if [ -z "${artifact}" ]; then
+              return 0
+            fi
+            python scripts/pack/generate_oss_metadata.py \
+              --file "${artifact}" \
+              --product desktop \
+              --platform "${platform}" \
+              --version "$VERSION" \
+              --output "${metadata}" \
+              --merge-index desktop-index.json \
+              --output-index desktop-index.json
+          }
+
+          merge_tauri_metadata \
+            "win-tauri-metadata.json" \
+            "QwenPaw-Desktop-Tauri-Windows-*" \
+            "QwenPaw-Tauri-*-Windows-setup.exe" \
+            "win-tauri"
+          merge_tauri_metadata \
+            "mac-tauri-metadata.json" \
+            "QwenPaw-Desktop-Tauri-macOS-*" \
+            "QwenPaw-Tauri-*-macOS.zip" \
+            "mac-tauri"
+
+          # Upload updated desktop/index.json
+          ossutil cp desktop-index.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
+            --acl public-read \
+            --force
+
+          echo "✓ Desktop index updated"
+
+      - name: Update main index
+        run: |
+          # Download main index if exists
+          ossutil cp "oss://${OSS_BUCKET}/metadata/index.json" \
+            main-index.json 2>/dev/null || cat > main-index.json << 'EOF'
+          {
+            "version": "1.0",
+            "updated_at": "",
+            "products": {}
+          }
+          EOF
+
+          # Ensure desktop product is in main index
+          python3 << 'PYTHON'
+          import json
+          from datetime import datetime, timezone
+
+          with open("main-index.json", "r") as f:
+              index = json.load(f)
+
+          index["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+          if "desktop" not in index["products"]:
+              index["products"]["desktop"] = {
+                  "name": {
+                      "zh-CN": "桌面客户端",
+                      "en-US": "Desktop Client"
+                  },
+                  "index_url": "/metadata/apps/desktop/index.json"
+              }
+
+          with open("main-index.json", "w") as f:
+              json.dump(index, f, indent=2, ensure_ascii=False)
+          PYTHON
+
+          # Upload main index
+          ossutil cp main-index.json \
+            "oss://${OSS_BUCKET}/metadata/index.json" \
+            --acl public-read \
+            --force
+
+          echo "✓ Main index updated"

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -100,18 +100,21 @@ jobs:
             -k ${{ secrets.OSS_ACCESS_KEY_SECRET }} \
             -L CH
 
-      - name: Process and upload Tauri artifacts
+      - name: Process and upload Tauri artifacts (versioned only)
+        # Only versioned files are uploaded here. The `latest` files, updater
+        # manifest and index are promoted AFTER the release is published — see
+        # desktop-promote.yml — so the auto-updater is never pointed at a version
+        # whose release/PyPI/Docker publish might still fail.
         if: hashFiles('QwenPaw-Desktop-Tauri-*/*') != ''
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
-          upload_tauri_artifact() {
+          upload_versioned() {
             local dirs="$1"
             local pattern="$2"
             local platform="$3"
             local versioned_name="$4"
-            local latest_name="$5"
-            local metadata="$6"
+            local metadata="$5"
 
             local artifact
             artifact=$(find ${dirs} -name "${pattern}" 2>/dev/null | head -1 || true)
@@ -132,34 +135,24 @@ jobs:
               "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
               --acl public-read \
               --force
-            ossutil cp "${artifact}" \
-              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}" \
-              --acl public-read \
-              --force
             ossutil cp "${metadata}" \
               "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
               --acl public-read \
               --force
-            ossutil cp "${metadata}" \
-              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json" \
-              --acl public-read \
-              --force
           }
 
-          upload_tauri_artifact \
+          upload_versioned \
             "QwenPaw-Desktop-Tauri-Windows-*" \
             "QwenPaw-Tauri-*-Windows-setup.exe" \
             "win-tauri" \
             "QwenPaw-Tauri-${VERSION}-Windows-setup.exe" \
-            "QwenPaw-Tauri-latest-Windows-setup.exe" \
             "win-tauri-metadata.json"
 
-          upload_tauri_artifact \
+          upload_versioned \
             "QwenPaw-Desktop-Tauri-macOS-*" \
             "QwenPaw-Tauri-*-macOS.zip" \
             "mac-tauri" \
             "QwenPaw-Tauri-${VERSION}-macOS.zip" \
-            "QwenPaw-Tauri-latest-macOS.zip" \
             "mac-tauri-metadata.json"
 
       - name: Upload Tauri macOS updater archive to OSS
@@ -177,142 +170,8 @@ jobs:
             --acl public-read \
             --force
 
-      - name: Link artifacts into updater-meta dirs for manifest generation
-        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
-        run: |
-          # The manifest generator expects the artifact binary alongside the
-          # sidecar JSON.  After artifact splitting the exe lives in a separate
-          # artifact directory, so we symlink it into the meta directory.
-          for f in QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe; do
-            [ -f "$f" ] && ln -sf "../$f" tauri-updater-meta-windows/ 2>/dev/null || true
-          done
-
-      - name: Generate and upload OSS updater manifest
-        # The Tauri auto-updater uses OSS only; GitHub Releases only carry
-        # first-install artifacts.
-        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          # Release notes come from the draft release body (fetched by tag),
-          # replacing the old github.event.release.body reference.
-          RELEASE_BODY="$(gh release view "${{ inputs.tag }}" --json body -q .body --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)"
-          OSS_BASE="${OSS_PUBLIC_BASE_URL%/}"
-          metadata_args=()
-          for f in tauri-updater-meta-windows/tauri-windows-*-updater.json \
-                   tauri-updater-meta-macos/tauri-darwin-*-updater.json; do
-            [ -f "$f" ] && metadata_args+=(--metadata "$f")
-          done
-          if [ ${#metadata_args[@]} -eq 0 ]; then
-            echo "No Tauri updater sidecars found, skipping OSS manifest"
-            exit 0
-          fi
-          NOTES="${RELEASE_BODY:-QwenPaw Desktop ${VERSION}}"
-          python scripts/pack-tauri/generate_update_manifest.py manifest \
-            --version "$VERSION" \
-            --base-url "$OSS_BASE" \
-            --target-base "windows-x86_64=${OSS_BASE}/win-tauri" \
-            --target-base "darwin-aarch64=${OSS_BASE}/mac-tauri" \
-            "${metadata_args[@]}" \
-            --notes "$NOTES" \
-            --output qwenpaw-tauri-latest-oss.json
-          ossutil cp qwenpaw-tauri-latest-oss.json \
-            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json" \
-            --acl public-read \
-            --force
-
-      - name: Update desktop index
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
-          # Download existing desktop/index.json if exists
-          ossutil cp "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
-            desktop-index.json 2>/dev/null || cat > desktop-index.json << 'EOF'
-          {
-            "product": "desktop",
-            "updated_at": "",
-            "platforms": {},
-            "files": {}
-          }
-          EOF
-
-          merge_tauri_metadata() {
-            local metadata="$1"
-            local dirs="$2"
-            local pattern="$3"
-            local platform="$4"
-            if [ ! -f "${metadata}" ]; then
-              return 0
-            fi
-            python scripts/pack/generate_oss_metadata.py \
-              --file "$(find ${dirs} -name "${pattern}" | head -1)" \
-              --product desktop \
-              --platform "${platform}" \
-              --version "$VERSION" \
-              --output "${metadata}" \
-              --merge-index desktop-index.json \
-              --output-index desktop-index.json
-          }
-
-          merge_tauri_metadata \
-            "win-tauri-metadata.json" \
-            "QwenPaw-Desktop-Tauri-Windows-*" \
-            "QwenPaw-Tauri-*-Windows-setup.exe" \
-            "win-tauri"
-          merge_tauri_metadata \
-            "mac-tauri-metadata.json" \
-            "QwenPaw-Desktop-Tauri-macOS-*" \
-            "QwenPaw-Tauri-*-macOS.zip" \
-            "mac-tauri"
-
-          # Upload updated desktop/index.json
-          ossutil cp desktop-index.json \
-            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
-            --acl public-read \
-            --force
-
-          echo "✓ Desktop index updated"
-
-      - name: Update main index
-        run: |
-          # Download main index if exists
-          ossutil cp "oss://${OSS_BUCKET}/metadata/index.json" \
-            main-index.json 2>/dev/null || cat > main-index.json << 'EOF'
-          {
-            "version": "1.0",
-            "updated_at": "",
-            "products": {}
-          }
-          EOF
-
-          # Ensure desktop product is in main index
-          python3 << 'PYTHON'
-          import json
-          from datetime import datetime, timezone
-
-          with open("main-index.json", "r") as f:
-              index = json.load(f)
-
-          index["updated_at"] = datetime.now(timezone.utc).isoformat()
-
-          if "desktop" not in index["products"]:
-              index["products"]["desktop"] = {
-                  "name": {
-                      "zh-CN": "桌面客户端",
-                      "en-US": "Desktop Client"
-                  },
-                  "index_url": "/metadata/apps/desktop/index.json"
-              }
-
-          with open("main-index.json", "w") as f:
-              json.dump(index, f, indent=2, ensure_ascii=False)
-          PYTHON
-
-          # Upload main index
-          ossutil cp main-index.json \
-            "oss://${OSS_BUCKET}/metadata/index.json" \
-            --acl public-read \
-            --force
-
-          echo "✓ Main index updated"
+      # NOTE: the `latest` files, the updater manifest
+      # (qwenpaw-tauri-latest.json) and the index are intentionally NOT uploaded
+      # here. They are promoted only AFTER the release is flipped to published —
+      # see desktop-promote.yml — so existing users' auto-updater is never
+      # pointed at a version whose release might still fail to publish.

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -1,0 +1,318 @@
+# Reusable "publish" half of the desktop release: take the desktop artifacts
+# produced by desktop-build.yml (same run) and publish them.
+#
+# Called by release.yml during the gated publish phase. Performs two things:
+#   - upload-release: attach the installers to the (draft) GitHub Release by tag
+#     (this is safe to run on a fork, where it targets the fork's own release).
+#   - upload-oss: push versioned + latest files, updater sidecars and index
+#     metadata to the download OSS bucket. Skipped when dry_run=true so fork
+#     verification never touches the shared production bucket.
+
+name: Desktop Publish (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Target (draft) release tag to attach assets to"
+        type: string
+        required: true
+      ref:
+        description: "Git ref/SHA to checkout for the packaging scripts"
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: "Skip the production OSS upload (fork verification)"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Attach installers to the (draft) GitHub Release ────────────────────────
+  upload-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Attach desktop installers to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          shopt -s nullglob
+          mv QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe . 2>/dev/null || true
+          mv QwenPaw-Desktop-Tauri-macOS-*/QwenPaw-Tauri-*-macOS.zip . 2>/dev/null || true
+          mv tauri-updater-meta-macos/QwenPaw-Tauri-*-macOS.app.tar.gz . 2>/dev/null || true
+          files=(QwenPaw-Tauri-*-Windows-setup.exe QwenPaw-Tauri-*-macOS.zip QwenPaw-Tauri-*-macOS.app.tar.gz)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No desktop installers found to attach to the release"
+            exit 1
+          fi
+          echo "Attaching to draft release ${{ inputs.tag }}: ${files[*]}"
+          gh release upload "${{ inputs.tag }}" "${files[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+
+  # ── Publish files + updater metadata to OSS (skipped on dry_run) ───────────
+  upload-oss:
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    env:
+      OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
+      OSS_PUBLIC_BASE_URL: ${{ vars.OSS_PUBLIC_BASE_URL || 'https://download.qwenpaw.agentscope.io/files/apps/desktop' }}
+    steps:
+      - name: Checkout (for scripts)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging helper dependencies
+        run: python -m pip install packaging
+
+      - name: Get version
+        id: version
+        uses: ./.github/actions/get-version
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Install ossutil
+        run: |
+          wget https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip
+          unzip ossutil-v1.7.18-linux-amd64.zip
+          chmod +x ossutil-v1.7.18-linux-amd64/ossutil64
+          sudo mv ossutil-v1.7.18-linux-amd64/ossutil64 /usr/local/bin/ossutil
+          ossutil --version
+
+      - name: Configure ossutil
+        run: |
+          ossutil config -e ${{ secrets.OSS_ENDPOINT }} \
+            -i ${{ secrets.OSS_ACCESS_KEY_ID }} \
+            -k ${{ secrets.OSS_ACCESS_KEY_SECRET }} \
+            -L CH
+
+      - name: Process and upload Tauri artifacts
+        if: hashFiles('QwenPaw-Desktop-Tauri-*/*') != ''
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          upload_tauri_artifact() {
+            local dirs="$1"
+            local pattern="$2"
+            local platform="$3"
+            local versioned_name="$4"
+            local latest_name="$5"
+            local metadata="$6"
+
+            local artifact
+            artifact=$(find ${dirs} -name "${pattern}" 2>/dev/null | head -1 || true)
+            if [ -z "${artifact}" ]; then
+              echo "No ${platform} Tauri artifact found, skipping"
+              return 0
+            fi
+
+            echo "Processing ${platform} Tauri artifact: ${artifact}"
+            python scripts/pack/generate_oss_metadata.py \
+              --file "${artifact}" \
+              --product desktop \
+              --platform "${platform}" \
+              --version "${VERSION}" \
+              --output "${metadata}"
+
+            ossutil cp "${artifact}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${versioned_name}" \
+              --acl public-read \
+              --force
+            ossutil cp "${artifact}" \
+              "oss://${OSS_BUCKET}/files/apps/desktop/${platform}/${latest_name}" \
+              --acl public-read \
+              --force
+            ossutil cp "${metadata}" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${versioned_name}.json" \
+              --acl public-read \
+              --force
+            ossutil cp "${metadata}" \
+              "oss://${OSS_BUCKET}/metadata/apps/desktop/${platform}/${latest_name}.json" \
+              --acl public-read \
+              --force
+          }
+
+          upload_tauri_artifact \
+            "QwenPaw-Desktop-Tauri-Windows-*" \
+            "QwenPaw-Tauri-*-Windows-setup.exe" \
+            "win-tauri" \
+            "QwenPaw-Tauri-${VERSION}-Windows-setup.exe" \
+            "QwenPaw-Tauri-latest-Windows-setup.exe" \
+            "win-tauri-metadata.json"
+
+          upload_tauri_artifact \
+            "QwenPaw-Desktop-Tauri-macOS-*" \
+            "QwenPaw-Tauri-*-macOS.zip" \
+            "mac-tauri" \
+            "QwenPaw-Tauri-${VERSION}-macOS.zip" \
+            "QwenPaw-Tauri-latest-macOS.zip" \
+            "mac-tauri-metadata.json"
+
+      - name: Upload Tauri macOS updater archive to OSS
+        # The .zip is for first-install; the auto-updater pulls .app.tar.gz.
+        if: hashFiles('tauri-updater-meta-macos/*.app.tar.gz') != ''
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          APP_TAR_GZ=$(find tauri-updater-meta-macos -name "QwenPaw-Tauri-*-macOS.app.tar.gz" | head -1)
+          if [ -z "$APP_TAR_GZ" ]; then
+            echo "No macOS .app.tar.gz found, skipping"
+            exit 0
+          fi
+          ossutil cp "$APP_TAR_GZ" \
+            "oss://${OSS_BUCKET}/files/apps/desktop/mac-tauri/QwenPaw-Tauri-${VERSION}-macOS.app.tar.gz" \
+            --acl public-read \
+            --force
+
+      - name: Link artifacts into updater-meta dirs for manifest generation
+        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
+        run: |
+          # The manifest generator expects the artifact binary alongside the
+          # sidecar JSON.  After artifact splitting the exe lives in a separate
+          # artifact directory, so we symlink it into the meta directory.
+          for f in QwenPaw-Desktop-Tauri-Windows-*/QwenPaw-Tauri-*-Windows-setup.exe; do
+            [ -f "$f" ] && ln -sf "../$f" tauri-updater-meta-windows/ 2>/dev/null || true
+          done
+
+      - name: Generate and upload OSS updater manifest
+        # The Tauri auto-updater uses OSS only; GitHub Releases only carry
+        # first-install artifacts.
+        if: hashFiles('tauri-updater-meta-*/tauri-*-updater.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Release notes come from the draft release body (fetched by tag),
+          # replacing the old github.event.release.body reference.
+          RELEASE_BODY="$(gh release view "${{ inputs.tag }}" --json body -q .body --repo "$GITHUB_REPOSITORY" 2>/dev/null || true)"
+          OSS_BASE="${OSS_PUBLIC_BASE_URL%/}"
+          metadata_args=()
+          for f in tauri-updater-meta-windows/tauri-windows-*-updater.json \
+                   tauri-updater-meta-macos/tauri-darwin-*-updater.json; do
+            [ -f "$f" ] && metadata_args+=(--metadata "$f")
+          done
+          if [ ${#metadata_args[@]} -eq 0 ]; then
+            echo "No Tauri updater sidecars found, skipping OSS manifest"
+            exit 0
+          fi
+          NOTES="${RELEASE_BODY:-QwenPaw Desktop ${VERSION}}"
+          python scripts/pack-tauri/generate_update_manifest.py manifest \
+            --version "$VERSION" \
+            --base-url "$OSS_BASE" \
+            --target-base "windows-x86_64=${OSS_BASE}/win-tauri" \
+            --target-base "darwin-aarch64=${OSS_BASE}/mac-tauri" \
+            "${metadata_args[@]}" \
+            --notes "$NOTES" \
+            --output qwenpaw-tauri-latest-oss.json
+          ossutil cp qwenpaw-tauri-latest-oss.json \
+            "oss://${OSS_BUCKET}/metadata/qwenpaw-tauri-latest.json" \
+            --acl public-read \
+            --force
+
+      - name: Update desktop index
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Download existing desktop/index.json if exists
+          ossutil cp "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
+            desktop-index.json 2>/dev/null || cat > desktop-index.json << 'EOF'
+          {
+            "product": "desktop",
+            "updated_at": "",
+            "platforms": {},
+            "files": {}
+          }
+          EOF
+
+          merge_tauri_metadata() {
+            local metadata="$1"
+            local dirs="$2"
+            local pattern="$3"
+            local platform="$4"
+            if [ ! -f "${metadata}" ]; then
+              return 0
+            fi
+            python scripts/pack/generate_oss_metadata.py \
+              --file "$(find ${dirs} -name "${pattern}" | head -1)" \
+              --product desktop \
+              --platform "${platform}" \
+              --version "$VERSION" \
+              --output "${metadata}" \
+              --merge-index desktop-index.json \
+              --output-index desktop-index.json
+          }
+
+          merge_tauri_metadata \
+            "win-tauri-metadata.json" \
+            "QwenPaw-Desktop-Tauri-Windows-*" \
+            "QwenPaw-Tauri-*-Windows-setup.exe" \
+            "win-tauri"
+          merge_tauri_metadata \
+            "mac-tauri-metadata.json" \
+            "QwenPaw-Desktop-Tauri-macOS-*" \
+            "QwenPaw-Tauri-*-macOS.zip" \
+            "mac-tauri"
+
+          # Upload updated desktop/index.json
+          ossutil cp desktop-index.json \
+            "oss://${OSS_BUCKET}/metadata/apps/desktop/index.json" \
+            --acl public-read \
+            --force
+
+          echo "✓ Desktop index updated"
+
+      - name: Update main index
+        run: |
+          # Download main index if exists
+          ossutil cp "oss://${OSS_BUCKET}/metadata/index.json" \
+            main-index.json 2>/dev/null || cat > main-index.json << 'EOF'
+          {
+            "version": "1.0",
+            "updated_at": "",
+            "products": {}
+          }
+          EOF
+
+          # Ensure desktop product is in main index
+          python3 << 'PYTHON'
+          import json
+          from datetime import datetime, timezone
+
+          with open("main-index.json", "r") as f:
+              index = json.load(f)
+
+          index["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+          if "desktop" not in index["products"]:
+              index["products"]["desktop"] = {
+                  "name": {
+                      "zh-CN": "桌面客户端",
+                      "en-US": "Desktop Client"
+                  },
+                  "index_url": "/metadata/apps/desktop/index.json"
+              }
+
+          with open("main-index.json", "w") as f:
+              json.dump(index, f, indent=2, ensure_ascii=False)
+          PYTHON
+
+          # Upload main index
+          ossutil cp main-index.json \
+            "oss://${OSS_BUCKET}/metadata/index.json" \
+            --acl public-read \
+            --force
+
+          echo "✓ Main index updated"

--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -4,9 +4,11 @@
 # Called by release.yml during the gated publish phase. Performs two things:
 #   - upload-release: attach the installers to the (draft) GitHub Release by tag
 #     (this is safe to run on a fork, where it targets the fork's own release).
-#   - upload-oss: push versioned + latest files, updater sidecars and index
-#     metadata to the download OSS bucket. Skipped when dry_run=true so fork
-#     verification never touches the shared production bucket.
+#   - upload-oss: push the VERSIONED files + metadata to the download OSS
+#     bucket. The `latest` files, updater manifest and index are promoted
+#     separately AFTER the release is published — see desktop-promote.yml.
+#     Skipped when dry_run=true so fork verification never touches the shared
+#     production bucket.
 
 name: Desktop Publish (reusable)
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -6,6 +6,11 @@
 name: QwenPaw Desktop Build
 
 on:
+  # NOTE: legacy fallback path. The standard release flow is now release.yml
+  # (see RELEASING.md), which builds desktop via desktop-build.yml +
+  # desktop-publish.yml and gates the web release on the desktop build.
+  # Publishing a GitHub Release directly still triggers this OLD, un-gated
+  # desktop build. Kept only as an emergency rollback.
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,6 +6,10 @@
 name: Docker Build and Push on Release
 
 on:
+  # NOTE: legacy fallback path. The standard release flow is now release.yml
+  # (see RELEASING.md). Publishing a GitHub Release directly still triggers this
+  # OLD publish, which is NOT gated on the desktop build. Kept only as an
+  # emergency rollback until the old release workflows are removed.
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/plugins-release.yml
+++ b/.github/workflows/plugins-release.yml
@@ -4,6 +4,10 @@
 name: QwenPaw Plugins Release
 
 on:
+  # NOTE: legacy fallback path. The standard release flow is now release.yml
+  # (see RELEASING.md). Publishing a GitHub Release directly still triggers this
+  # OLD publish, which is NOT gated on the desktop build. Kept only as an
+  # emergency rollback until the old release workflows are removed.
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: boolean
         default: false
+  # NOTE: legacy fallback path. The standard release flow is now release.yml
+  # (see RELEASING.md). Publishing a GitHub Release directly still triggers this
+  # OLD publish, which is NOT gated on the desktop build. Kept only as an
+  # emergency rollback until the old release workflows are removed.
   release:
     types: [published]
 

--- a/.github/workflows/release-duty.yml
+++ b/.github/workflows/release-duty.yml
@@ -28,6 +28,17 @@ on:
           - dev
           - post
           - stable
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to create the duty issue for"
+        required: true
+        type: string
+      release_type:
+        description: "Override release type (empty = auto-detect from tag)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   issues: write
@@ -55,10 +66,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           CURRENT_TAG: >-
-            ${{ github.event_name == 'workflow_dispatch'
-                && github.event.inputs.tag
-                || github.event.release.tag_name }}
-          TYPE_OVERRIDE: ${{ github.event.inputs.release_type || '' }}
+            ${{ github.event_name == 'release'
+                && github.event.release.tag_name
+                || inputs.tag }}
+          TYPE_OVERRIDE: ${{ inputs.release_type || '' }}
         run: |
           python - << 'EOF'
           import os
@@ -156,13 +167,10 @@ jobs:
           ASSIGNEES_JSON: ${{ steps.meta.outputs.assignees }}
           RELEASE_TYPE: ${{ steps.meta.outputs.release_type }}
           DUE_TIME: ${{ steps.due.outputs.due }}
-          INPUT_TAG: >-
-            ${{ github.event_name == 'workflow_dispatch'
-                && github.event.inputs.tag
-                || '' }}
+          INPUT_TAG: ${{ inputs.tag }}
         with:
           script: |
-            const isManual = context.eventName === 'workflow_dispatch';
+            const isManual = context.eventName !== 'release';
             let tag, releaseUrl;
 
             if (isManual) {

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -27,6 +27,10 @@ on:
         description: "Override Dockerfile UV_IMAGE build-arg (for fork without ACR access)"
         type: string
         default: ""
+      ref:
+        description: "Git ref/SHA to checkout for docker/script verification (empty = default)"
+        type: string
+        default: ""
 
 jobs:
   # ── pip install wheel ──────────────────────────────────────────────────────
@@ -166,6 +170,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Log in to Aliyun ACR (when credentials available)
         if: env.ACR_USERNAME != ''
@@ -257,6 +263,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Node.js (for console build during from-source install)
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,40 @@ jobs:
             echo "sha=$sha"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Checkout the resolved commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pick.outputs.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate tag matches src/qwenpaw/__version__.py
+        run: |
+          python -m pip install --quiet packaging
+          ver="$(sed -n 's/^__version__[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' src/qwenpaw/__version__.py)"
+          tag="${{ steps.pick.outputs.tag }}"
+          python - "${tag#v}" "$ver" <<'PY'
+          import sys
+          from packaging.version import InvalidVersion, Version
+
+          tag_ver, ver = sys.argv[1], sys.argv[2]
+          try:
+              if Version(tag_ver) != Version(ver):
+                  print(
+                      f"::error::Draft tag '{tag_ver}' does not match "
+                      f"src/qwenpaw/__version__.py '{ver}'. "
+                      f"Fix the tag or bump the version before releasing."
+                  )
+                  sys.exit(1)
+          except InvalidVersion as exc:
+              print(f"::error::Cannot parse versions for comparison ({exc}).")
+              sys.exit(1)
+          print(f"OK: tag normalizes to __version__ ({ver}).")
+          PY
+
       - name: Ensure release secrets present (skip on dry_run)
         env:
           QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
@@ -297,6 +331,8 @@ jobs:
   publish-plugins:
     needs: [resolve, build-wheel, verify-web, build-desktop, build-plugins]
     runs-on: ubuntu-latest
+    env:
+      OSS_BUCKET: ${{ vars.OSS_BUCKET || 'qwenpaw-download' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -344,7 +380,7 @@ jobs:
               rel="${f#dist/plugins/}"
               echo "Uploading $f -> files/plugins/${rel}"
               ossutil cp "$f" \
-                "oss://qwenpaw-download/files/plugins/${rel}" \
+                "oss://${OSS_BUCKET}/files/plugins/${rel}" \
                 --acl public-read \
                 --force \
                 --meta "Cache-Control:public, max-age=31536000, immutable"
@@ -354,7 +390,7 @@ jobs:
       - name: Merge historical versions into index
         if: ${{ !inputs.dry_run }}
         run: |
-          ossutil cp "oss://qwenpaw-download/metadata/plugins/index.json" \
+          ossutil cp "oss://${OSS_BUCKET}/metadata/plugins/index.json" \
             existing-index.json 2>/dev/null || echo '{}' > existing-index.json
           python3 scripts/pack/merge_plugin_index.py \
             --new dist/plugins/index.json \
@@ -365,7 +401,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         run: |
           ossutil cp dist/plugins/index.json \
-            "oss://qwenpaw-download/metadata/plugins/index.json" \
+            "oss://${OSS_BUCKET}/metadata/plugins/index.json" \
             --acl public-read \
             --force \
             --meta "Cache-Control:public, max-age=60, must-revalidate"
@@ -373,7 +409,7 @@ jobs:
       - name: Patch main metadata index to advertise plugins product
         if: ${{ !inputs.dry_run }}
         run: |
-          ossutil cp "oss://qwenpaw-download/metadata/index.json" \
+          ossutil cp "oss://${OSS_BUCKET}/metadata/index.json" \
             main-index.json 2>/dev/null || cat > main-index.json << 'EOF'
           {
             "version": "1.0",
@@ -385,7 +421,7 @@ jobs:
             --index main-index.json \
             --out   main-index.json
           ossutil cp main-index.json \
-            "oss://qwenpaw-download/metadata/index.json" \
+            "oss://${OSS_BUCKET}/metadata/index.json" \
             --acl public-read \
             --force \
             --meta "Cache-Control:public, max-age=60, must-revalidate"
@@ -404,6 +440,18 @@ jobs:
         run: |
           echo "Flipping draft $TAG -> published, pinned to $SHA"
           gh release edit "$TAG" --repo "$REPO" --draft=false --target "$SHA"
+
+  # ── Post-publish: promote desktop latest + updater manifest + index ─────────
+  # Runs only after the release is published, so the auto-updater is pointed at
+  # the new version only once the release actually exists.
+  promote-desktop:
+    needs: [resolve, finalize]
+    uses: ./.github/workflows/desktop-promote.yml
+    with:
+      tag: ${{ needs.resolve.outputs.tag }}
+      ref: ${{ needs.resolve.outputs.sha }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
 
   # ── Post-publish: create the Release Duty verification issue (inline) ───────
   duty-issue:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,414 @@
+# QwenPaw unified release orchestrator (draft-driven, all-or-nothing).
+#
+# Flow (方案二 · 草稿变体):
+#   1. A maintainer creates a DRAFT GitHub Release (tag + notes), does NOT publish.
+#   2. They run this workflow (Actions ▸ Run workflow). It resolves the draft,
+#      pins every job to the draft's target commit, then builds + verifies ALL
+#      products in parallel (wheel / web verify / desktop win+mac / plugins).
+#   3. Only if EVERY prepare job is green does the publish phase run: PyPI,
+#      Docker, desktop (GitHub assets + OSS), plugins. The draft is flipped to
+#      published LAST, then the Release Duty issue is created inline.
+#   4. If anything fails, nothing is published and the draft is left untouched
+#      (zero external trace; just fix and re-run).
+#
+# dry_run=true stubs the three production-external publishes (PyPI / Docker /
+# OSS) so fork CI can exercise the gating + draft flip without touching prod.
+# Draft-asset upload, the draft→published flip and the duty issue still run for
+# real because on a fork they only affect the fork's own resources.
+
+name: Release (unified)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Draft release tag to publish (empty = auto-detect the single draft)"
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Stub production publishes (PyPI/Docker/OSS) — use on forks"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: release-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Resolve the draft, pin the commit, fail fast on missing secrets ─────────
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.pick.outputs.tag }}
+      sha: ${{ steps.pick.outputs.sha }}
+    steps:
+      - name: Resolve target draft release and commit
+        id: pick
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="$INPUT_TAG"
+          if [ -z "$TAG" ]; then
+            drafts="$(gh release list --repo "$REPO" --limit 100 \
+              --json tagName,isDraft --jq '[.[] | select(.isDraft) | .tagName]')"
+            count="$(echo "$drafts" | jq 'length')"
+            if [ "$count" -eq 0 ]; then
+              echo "::error::No draft release found. Create a draft first or pass an explicit tag."
+              exit 1
+            fi
+            if [ "$count" -gt 1 ]; then
+              echo "::error::Multiple draft releases found: $(echo "$drafts" | jq -r 'join(", ")'). Pass an explicit tag to disambiguate."
+              exit 1
+            fi
+            TAG="$(echo "$drafts" | jq -r '.[0]')"
+          fi
+          echo "Target tag: $TAG"
+          isDraft="$(gh release view "$TAG" --repo "$REPO" --json isDraft --jq '.isDraft')"
+          if [ "$isDraft" != "true" ]; then
+            echo "::error::Release $TAG is not a draft; refusing to operate on a published release."
+            exit 1
+          fi
+          target="$(gh release view "$TAG" --repo "$REPO" --json targetCommitish --jq '.targetCommitish')"
+          sha="$(gh api "repos/$REPO/commits/$target" --jq '.sha')"
+          echo "Target commitish '$target' resolved to SHA $sha"
+          {
+            echo "tag=$TAG"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ensure release secrets present (skip on dry_run)
+        env:
+          QWENPAW_DASHSCOPE_API_KEY: ${{ secrets.QWENPAW_DASHSCOPE_API_KEY }}
+        run: |
+          if [ "${{ inputs.dry_run }}" != "true" ] && [ -z "${QWENPAW_DASHSCOPE_API_KEY:-}" ]; then
+            echo "::error::QWENPAW_DASHSCOPE_API_KEY is not set; desktop verification cannot validate the LLM chat round."
+            exit 1
+          fi
+          echo "Secret check OK (dry_run=${{ inputs.dry_run }})"
+
+  # ── Prepare phase: build + verify everything, publish nothing ──────────────
+  build-wheel:
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node (for console build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: console/package-lock.json
+
+      - name: Build console frontend
+        run: |
+          cd console && npm ci && npm run build
+
+      - name: Copy console build into package
+        run: |
+          rm -rf src/qwenpaw/console/*
+          mkdir -p src/qwenpaw/console
+          cp -R console/dist/* src/qwenpaw/console/
+
+      - name: Bundle docs into package
+        run: |
+          rm -rf src/qwenpaw/docs
+          mkdir -p src/qwenpaw/docs
+          cp website/public/docs/*.md src/qwenpaw/docs/
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist/
+          retention-days: 7
+
+      - name: Upload version metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-version
+          path: src/qwenpaw/__version__.py
+          retention-days: 7
+
+  verify-web:
+    needs: [resolve, build-wheel]
+    uses: ./.github/workflows/release-verify.yml
+    with:
+      verify_pip: true
+      verify_docker: true
+      verify_script_install: true
+      ref: ${{ needs.resolve.outputs.sha }}
+      # On dry_run (fork) the private ACR base images are unreachable, so fall
+      # back to public images for the Docker health-check build.
+      docker_node_image: ${{ inputs.dry_run && 'node:20-slim' || '' }}
+      docker_uv_image: ${{ inputs.dry_run && 'ghcr.io/astral-sh/uv:latest' || '' }}
+    secrets: inherit
+
+  build-desktop:
+    needs: [resolve]
+    uses: ./.github/workflows/desktop-build.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+    secrets: inherit
+
+  build-plugins:
+    needs: [resolve]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Pack plugins and build index
+        run: |
+          python scripts/pack/generate_plugin_metadata.py \
+            --plugins-root plugins \
+            --dist dist/plugins \
+            --metadata-out dist/plugins/index.json \
+            --cdn-prefix /files/plugins
+
+      - name: Upload plugins dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwenpaw-plugins-dist
+          path: dist/plugins
+          retention-days: 7
+
+  # ── Gate: publish jobs below run only if every prepare job above is green ──
+
+  publish-pypi:
+    needs: [resolve, build-wheel, verify-web, build-desktop, build-plugins]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-dist
+          path: dist
+
+      - name: Publish package to PyPI
+        if: ${{ !inputs.dry_run }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY-RUN: would publish $(ls dist) to PyPI"
+
+  push-docker:
+    needs: [resolve, build-wheel, verify-web, build-desktop, build-plugins]
+    runs-on: ubuntu-latest
+    env:
+      ACR_REGISTRY: agentscope-registry.ap-southeast-1.cr.aliyuncs.com
+      IMAGE: agentscope/qwenpaw
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to DockerHub
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to Aliyun ACR
+        if: ${{ !inputs.dry_run }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACR_REGISTRY }}
+          username: ${{ secrets.ALIYUN_ACR_USERNAME }}
+          password: ${{ secrets.ALIYUN_ACR_PASSWORD }}
+
+      - name: Build and push multi-arch (version + pre [+ latest])
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ needs.resolve.outputs.tag }}
+          QWENPAW_DISABLED_CHANNELS: "imessage"
+        run: |
+          if [[ "$VERSION" =~ (beta|alpha|rc|dev) ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+          TAGS="-t ${ACR_REGISTRY}/${IMAGE}:${VERSION} -t ${ACR_REGISTRY}/${IMAGE}:pre"
+          TAGS="${TAGS} -t docker.io/${IMAGE}:${VERSION} -t docker.io/${IMAGE}:pre"
+          if [ "${IS_PRERELEASE}" != "true" ]; then
+            TAGS="${TAGS} -t ${ACR_REGISTRY}/${IMAGE}:latest -t docker.io/${IMAGE}:latest"
+          fi
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            -f deploy/Dockerfile \
+            --build-arg QWENPAW_DISABLED_CHANNELS="${QWENPAW_DISABLED_CHANNELS}" \
+            ${TAGS} --push .
+
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY-RUN: would build+push docker image for ${{ needs.resolve.outputs.tag }}"
+
+  publish-desktop:
+    needs: [resolve, build-wheel, verify-web, build-desktop, build-plugins]
+    uses: ./.github/workflows/desktop-publish.yml
+    with:
+      tag: ${{ needs.resolve.outputs.tag }}
+      ref: ${{ needs.resolve.outputs.sha }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+
+  publish-plugins:
+    needs: [resolve, build-wheel, verify-web, build-desktop, build-plugins]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download plugins dist
+        uses: actions/download-artifact@v4
+        with:
+          name: qwenpaw-plugins-dist
+          path: dist/plugins
+
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY-RUN: would sync $(find dist/plugins -name '*.zip' | wc -l) plugin zips + index to OSS"
+
+      - name: Install ossutil
+        if: ${{ !inputs.dry_run }}
+        run: |
+          wget -q https://gosspublic.alicdn.com/ossutil/1.7.18/ossutil-v1.7.18-linux-amd64.zip
+          unzip -q ossutil-v1.7.18-linux-amd64.zip
+          chmod +x ossutil-v1.7.18-linux-amd64/ossutil64
+          sudo mv ossutil-v1.7.18-linux-amd64/ossutil64 /usr/local/bin/ossutil
+          ossutil --version
+
+      - name: Configure ossutil
+        if: ${{ !inputs.dry_run }}
+        run: |
+          ossutil config -e ${{ secrets.OSS_ENDPOINT }} \
+            -i ${{ secrets.OSS_ACCESS_KEY_ID }} \
+            -k ${{ secrets.OSS_ACCESS_KEY_SECRET }} \
+            -L CH
+
+      - name: Sync plugin zips to OSS (long-cache, immutable)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          shopt -s nullglob
+          for kind in bundle tool apps; do
+            while IFS= read -r -d '' f; do
+              rel="${f#dist/plugins/}"
+              echo "Uploading $f -> files/plugins/${rel}"
+              ossutil cp "$f" \
+                "oss://qwenpaw-download/files/plugins/${rel}" \
+                --acl public-read \
+                --force \
+                --meta "Cache-Control:public, max-age=31536000, immutable"
+            done < <(find "dist/plugins/${kind}" -type f -name '*.zip' -print0 2>/dev/null || true)
+          done
+
+      - name: Merge historical versions into index
+        if: ${{ !inputs.dry_run }}
+        run: |
+          ossutil cp "oss://qwenpaw-download/metadata/plugins/index.json" \
+            existing-index.json 2>/dev/null || echo '{}' > existing-index.json
+          python3 scripts/pack/merge_plugin_index.py \
+            --new dist/plugins/index.json \
+            --old existing-index.json \
+            --out dist/plugins/index.json
+
+      - name: Upload plugins index (short-cache)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          ossutil cp dist/plugins/index.json \
+            "oss://qwenpaw-download/metadata/plugins/index.json" \
+            --acl public-read \
+            --force \
+            --meta "Cache-Control:public, max-age=60, must-revalidate"
+
+      - name: Patch main metadata index to advertise plugins product
+        if: ${{ !inputs.dry_run }}
+        run: |
+          ossutil cp "oss://qwenpaw-download/metadata/index.json" \
+            main-index.json 2>/dev/null || cat > main-index.json << 'EOF'
+          {
+            "version": "1.0",
+            "updated_at": "",
+            "products": {}
+          }
+          EOF
+          python3 scripts/pack/patch_main_index.py \
+            --index main-index.json \
+            --out   main-index.json
+          ossutil cp main-index.json \
+            "oss://qwenpaw-download/metadata/index.json" \
+            --acl public-read \
+            --force \
+            --meta "Cache-Control:public, max-age=60, must-revalidate"
+
+  # ── Finalize: flip the draft to published LAST (pinned to the built SHA) ────
+  finalize:
+    needs: [resolve, publish-pypi, push-docker, publish-desktop, publish-plugins]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          echo "Flipping draft $TAG -> published, pinned to $SHA"
+          gh release edit "$TAG" --repo "$REPO" --draft=false --target "$SHA"
+
+  # ── Post-publish: create the Release Duty verification issue (inline) ───────
+  duty-issue:
+    needs: [resolve, finalize]
+    uses: ./.github/workflows/release-duty.yml
+    with:
+      tag: ${{ needs.resolve.outputs.tag }}
+    secrets: inherit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -102,6 +102,7 @@ jobs succeed. If anything fails, the release stays a draft.
 | `promote-desktop` fails | Release is published, but the desktop `latest` files / updater manifest / index were not refreshed (existing users' auto-updater does not see the new version yet; versioned downloads still work) | Re-run the job — it is idempotent (`ossutil cp --force`). Non-blocking for first-install users. |
 | "Multiple draft releases found" | More than one draft exists | Re-run *Run workflow* with an explicit `tag`. |
 | "No draft release found" / "not a draft" | No draft, or wrong tag | Create the draft / fix the tag, then re-run. |
+| resolve rejects the tag (version mismatch) | The draft tag doesn't match `src/qwenpaw/__version__.py` | Align the tag with the version (packaging-normalized, e.g. `v2.0.1-beta.1` ↔ `2.0.1b1`), then re-run. |
 
 ## Rollback to the legacy flow
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,12 @@ A full run is ~60–75 min, dominated by the desktop Tauri builds.
      gh release create v2.0.0-beta.8 --draft --prerelease \
        --target main --title "v2.0.0-beta.8" --notes "..."
      ```
-   - The tag should correspond to `src/qwenpaw/__version__.py`.
+   - The tag should correspond to `src/qwenpaw/__version__.py` (`resolve`
+     validates this with `packaging` normalization and fails on a mismatch, e.g.
+     tag `v2.0.1-beta.1` must match version `2.0.1b1`).
+   - Prefer pinning the draft to a commit (`--target <sha>`). If you use
+     `--target main`, avoid merging to `main` between creating the draft and
+     running the workflow, otherwise the build uses the newer `main` HEAD.
 2. **Run the workflow**: Actions → **Release (unified)** → *Run workflow* on
    `main`. Leave `tag` empty to auto-detect the single draft (or set it
    explicitly); leave `dry_run` **unchecked**.
@@ -115,3 +120,7 @@ draft→published flip **without** touching production: PyPI upload, Docker push
 and OSS upload become no-ops, while the desktop build/verify, the draft flip and
 the duty issue still run for real. On a fork this only affects the fork's own
 release page.
+
+Note: the desktop build's install → launch → chat UI verification still runs
+under `dry_run` and needs the `QWENPAW_DASHSCOPE_API_KEY` secret — `dry_run` only
+skips the resolve-stage fail-fast check, not the verification itself.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,115 @@
+# Releasing QwenPaw
+
+QwenPaw ships four artifacts from a single version — the **PyPI** wheel, the
+**Docker** image, the **desktop** apps (Tauri, Windows + macOS) and the
+**plugins** bundle. They are published together by one orchestrated workflow so
+that a failure in any one of them blocks the whole release: you can never end up
+with, e.g., a web release that has no matching desktop build.
+
+> Orchestrator: [`.github/workflows/release.yml`](.github/workflows/release.yml).
+> The older per-artifact workflows are kept as a fallback — see
+> [Rollback to the legacy flow](#rollback-to-the-legacy-flow).
+
+## TL;DR
+
+1. Create a **draft** GitHub Release (tag + notes). Do **not** click *Publish*.
+2. Actions → **Release (unified)** → *Run workflow* (leave `dry_run` off).
+3. It builds + verifies everything; only if all of it passes does it publish all
+   artifacts and flip the release to *published*.
+4. If anything fails, nothing is published and the draft is left untouched — fix
+   and re-run.
+
+## How a release works
+
+`release.yml` runs in three phases:
+
+1. **Resolve** — finds the target draft (the `tag` input, or auto-detects the
+   single existing draft), resolves the draft's `target_commitish` to a concrete
+   SHA, and pins every downstream job to that SHA (so *what is built* == *what is
+   published*). On a real release it also fails fast if the DashScope secret is
+   missing.
+2. **Prepare** (build + verify, publishes nothing) — in parallel:
+   - `build-wheel` — build the Python wheel (with the bundled console).
+   - `verify-web` — pip-install, Docker health-check and install-script checks.
+   - `build-desktop` — build the Tauri Windows + macOS apps and run the
+     install → launch → real-chat UI verification.
+   - `build-plugins` — pack the plugin bundle.
+3. **Gate + Publish** — every publish job `needs` **all** prepare jobs, so a
+   single failure above skips the entire publish phase. When all prepare jobs are
+   green: publish to PyPI, push the multi-arch Docker image, attach the desktop
+   installers to the release + upload them to OSS, publish plugins — then, as the
+   **last** step, flip the draft to *published* (pinned to the built SHA) and open
+   the Release Duty verification issue.
+
+A full run is ~60–75 min, dominated by the desktop Tauri builds.
+
+## Cutting a release
+
+1. **Create the draft release**
+   - UI: Releases → *Draft a new release* → set the tag + notes → **Save draft**
+     (do **not** publish). For a pre-release, tick *Set as a pre-release*.
+   - CLI:
+     ```bash
+     gh release create v2.0.0-beta.8 --draft --prerelease \
+       --target main --title "v2.0.0-beta.8" --notes "..."
+     ```
+   - The tag should correspond to `src/qwenpaw/__version__.py`.
+2. **Run the workflow**: Actions → **Release (unified)** → *Run workflow* on
+   `main`. Leave `tag` empty to auto-detect the single draft (or set it
+   explicitly); leave `dry_run` **unchecked**.
+3. **Watch it**: on success the release flips to *published* with all artifacts
+   attached and a Release Duty issue is opened. On failure, see
+   [Troubleshooting](#troubleshooting).
+
+## Version types: beta / stable / post
+
+The procedure is identical for all types — the type is inferred from the **tag**:
+
+| Type | Example tag | Draft "pre-release"? | Docker tags | PyPI |
+|------|-------------|----------------------|-------------|------|
+| beta / rc / alpha / dev | `v2.0.0-beta.8` | yes | `<version>` + `pre` (no `latest`) | uploaded; treated as a pre-release by pip (`--pre`) |
+| stable | `v2.0.0` | no | `<version>` + `pre` + `latest` | normal |
+| post | `v2.0.0.post4` | no | `<version>` + `pre` + `latest` | post release |
+
+Notes:
+
+- Pre-release detection is **tag-based**: a tag containing `beta`/`alpha`/`rc`/`dev`
+  is a pre-release (so use the `-beta.N` form); `stable` and `.postN` tags also
+  update the Docker `latest` tag.
+- The desktop OSS `latest` files and the Tauri auto-update manifest are currently
+  updated for **every** release, including betas (this matches the previous
+  `desktop-release.yml` behavior and is unchanged here). Making the desktop
+  `latest`/updater stable-only is a possible future improvement.
+
+## Troubleshooting
+
+**Guarantee:** the draft is flipped to *published* only after **all** publish
+jobs succeed. If anything fails, the release stays a draft.
+
+| Situation | What happened | What to do |
+|-----------|---------------|------------|
+| A prepare job fails (desktop / web verify / wheel / plugins) | All publish + `finalize` + `duty-issue` are **skipped**; nothing published; draft untouched | Read the failed job's logs and fix (or re-run if flaky) → **Re-run failed jobs**, or re-run the workflow. No cleanup needed. |
+| A publish job fails after the gate (e.g. Docker push fails after PyPI already uploaded) | `finalize` needs all publishes, so the draft is **not** flipped; but some artifacts may already be live | **Re-run failed jobs** (already-succeeded jobs are not re-run; Docker re-push is idempotent, OSS uses `--force`) → the draft flips once they pass. If a published PyPI version is now taken and cannot be reused, cut a `.postN` instead. |
+| `finalize` fails | All artifacts published but the release was not flipped | Re-run `finalize`, or manually `gh release edit <tag> --draft=false --target <sha>` (or click *Publish*). |
+| `duty-issue` fails | Release is published; only the tracking issue is missing | Re-run the job, or dispatch `release-duty.yml` with the `tag`. Non-blocking. |
+| "Multiple draft releases found" | More than one draft exists | Re-run *Run workflow* with an explicit `tag`. |
+| "No draft release found" / "not a draft" | No draft, or wrong tag | Create the draft / fix the tag, then re-run. |
+
+## Rollback to the legacy flow
+
+The pre-existing per-artifact workflows are intentionally retained. If the
+orchestrator is broken, publish the release the old way — **Publish** the GitHub
+Release (or `gh release create ...`), which triggers `publish-pypi` /
+`docker-release` / `desktop-release` / `plugins-release` on `release: published`.
+
+> **Warning:** the legacy flow does **not** gate the web release on the desktop
+> build (the very problem this orchestrator fixes), so use it only as an
+> emergency fallback.
+
+## Fork / dry-run testing
+
+Run **Release (unified)** with `dry_run: true` to exercise the gate and the
+draft→published flip **without** touching production: PyPI upload, Docker push
+and OSS upload become no-ops, while the desktop build/verify, the draft flip and
+the duty issue still run for real. On a fork this only affects the fork's own
+release page.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,7 @@
 # Releasing QwenPaw
 
+_中文版：[RELEASING_zh.md](RELEASING_zh.md)_
+
 QwenPaw ships four artifacts from a single version — the **PyPI** wheel, the
 **Docker** image, the **desktop** apps (Tauri, Windows + macOS) and the
 **plugins** bundle. They are published together by one orchestrated workflow so

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,6 +99,7 @@ jobs succeed. If anything fails, the release stays a draft.
 | A publish job fails after the gate (e.g. Docker push fails after PyPI already uploaded) | `finalize` needs all publishes, so the draft is **not** flipped; but some artifacts may already be live | **Re-run failed jobs** (already-succeeded jobs are not re-run; Docker re-push is idempotent, OSS uses `--force`) → the draft flips once they pass. If a published PyPI version is now taken and cannot be reused, cut a `.postN` instead. |
 | `finalize` fails | All artifacts published but the release was not flipped | Re-run `finalize`, or manually `gh release edit <tag> --draft=false --target <sha>` (or click *Publish*). |
 | `duty-issue` fails | Release is published; only the tracking issue is missing | Re-run the job, or dispatch `release-duty.yml` with the `tag`. Non-blocking. |
+| `promote-desktop` fails | Release is published, but the desktop `latest` files / updater manifest / index were not refreshed (existing users' auto-updater does not see the new version yet; versioned downloads still work) | Re-run the job — it is idempotent (`ossutil cp --force`). Non-blocking for first-install users. |
 | "Multiple draft releases found" | More than one draft exists | Re-run *Run workflow* with an explicit `tag`. |
 | "No draft release found" / "not a draft" | No draft, or wrong tag | Create the draft / fix the tag, then re-run. |
 

--- a/RELEASING_zh.md
+++ b/RELEASING_zh.md
@@ -48,7 +48,10 @@ QwenPaw 一个版本会发布四种产物——**PyPI** wheel、**Docker** 镜�
      gh release create v2.0.0-beta.8 --draft --prerelease \
        --target main --title "v2.0.0-beta.8" --notes "..."
      ```
-   - tag 应与 `src/qwenpaw/__version__.py` 对应。
+   - tag 应与 `src/qwenpaw/__version__.py` 对应（`resolve` 会用 `packaging` 归一化校验，
+     不一致直接 fail；如 tag `v2.0.1-beta.1` 须匹配版本 `2.0.1b1`）。
+   - 建议建草稿时用 `--target <sha>` 钉住 commit。若用 `--target main`，则建草稿到运行
+     workflow 之间**不要**再往 main 合入，否则构建的是更新后的 main HEAD。
 2. **运行 workflow**：Actions → **Release (unified)** → *Run workflow*，选 `main`。
    `tag` 留空可自动识别唯一草稿（也可显式填）；`dry_run` **不勾**。
 3. **观察**：成功后 release 翻成 *published*、资产齐全，并开出一个 Release Duty
@@ -100,3 +103,7 @@ Release **点 Publish**（或 `gh release create ...`），会在 `release: publ
 运行 **Release (unified)** 时勾 `dry_run: true`，可在**不触及生产**的前提下验证门禁与
 草稿→published 翻牌：PyPI 上传、Docker 推送、OSS 上传都变成 no-op，而桌面构建/验证、
 草稿翻牌、duty issue 仍会真实执行。（在 fork 上这些只影响 fork 自己的 release 页面。）
+
+注意：桌面构建的 装 → 启 → 问答 UI 验证在 `dry_run` 下**仍会真跑**，需要
+`QWENPAW_DASHSCOPE_API_KEY` secret——`dry_run` 只跳过 resolve 阶段的 fail-fast 检查，
+不跳过验证本身。

--- a/RELEASING_zh.md
+++ b/RELEASING_zh.md
@@ -86,6 +86,7 @@ release 就仍是草稿。
 | 发布阶段某 publish 失败（如 PyPI 已传、Docker 推失败） | `finalize` 需要全部 publish 成功，故草稿**未翻**；但部分产物可能已上线 | **Re-run failed jobs**（已成功的不会重跑；Docker 重推幂等、OSS 用 `--force`）→ 补齐后自动翻。若某个 PyPI 版本已被占用无法重用，改用 `.postN` 重发。 |
 | `finalize` 失败 | 产物都发了但 release 没翻 | 重跑 `finalize`，或手动 `gh release edit <tag> --draft=false --target <sha>`（或 UI 点 *Publish*）。 |
 | `duty-issue` 失败 | release 已发布，只是缺验收 issue | 重跑该 job，或用 `tag` 手动 dispatch `release-duty.yml`。不阻塞发布。 |
+| `promote-desktop` 失败 | release 已发布，但桌面 `latest` 文件 / 更新清单 / index 未刷新（存量用户的自动更新暂时看不到新版；版本化下载仍可用） | 重跑该 job，幂等（`ossutil cp --force`）。对首装用户不阻塞。 |
 | "Multiple draft releases found" | 存在多个草稿 | 重跑 *Run workflow* 时显式填 `tag`。 |
 | "No draft release found" / "not a draft" | 没有草稿，或 tag 填错 | 先建草稿 / 改正 tag，再重跑。 |
 

--- a/RELEASING_zh.md
+++ b/RELEASING_zh.md
@@ -1,0 +1,102 @@
+# 发布 QwenPaw
+
+_English: [RELEASING.md](RELEASING.md)_
+
+QwenPaw 一个版本会发布四种产物——**PyPI** wheel、**Docker** 镜像、**桌面**应用
+（Tauri，Windows + macOS）和**插件**包。它们由一个统一编排的 workflow 一起发布：
+任一产物失败都会拦下整个发布，绝不会出现"Web 版发了、却没有对应桌面版"这种情况。
+
+> 编排器：[`.github/workflows/release.yml`](.github/workflows/release.yml)。
+> 旧的按产物拆分的 workflow 作为回退保留——见
+> [回退到旧流程](#回退到旧流程)。
+
+## 速览
+
+1. 建一个**草稿** GitHub Release（tag + 说明），**不要**点 *Publish*。
+2. Actions → **Release (unified)** → *Run workflow*（`dry_run` 不勾）。
+3. 它会构建 + 验证所有产物；只有全部通过，才发布全部产物并把 release 翻成
+   *published*。
+4. 任一步失败则什么都不发、草稿原样保留——修好后重跑即可。
+
+## 发布流程原理
+
+`release.yml` 分三个阶段：
+
+1. **Resolve（解析草稿）**——按 `tag` 输入找到目标草稿（留空则自动识别唯一草稿），
+   把草稿的 `target_commitish` 解析成具体 SHA，并把后续所有 job 钉在该 SHA 上
+   （保证*构建的代码 == 发布的代码*）。正式发布时若缺 DashScope secret 会直接 fail。
+2. **Prepare（构建 + 验证，不发布任何东西）**——并行：
+   - `build-wheel`——构建 Python wheel（含打包好的 console）。
+   - `verify-web`——pip 安装、Docker 健康检查、安装脚本三类验证。
+   - `build-desktop`——构建 Tauri Windows + macOS 应用，并跑
+     安装 → 启动 → 真实问答 的 UI 验证。
+   - `build-plugins`——打包插件。
+3. **Gate + Publish（门禁 + 发布）**——每个 publish job 都 `needs` **全部** prepare
+   job，因此上面任一失败都会跳过整个发布阶段。全绿后：发布 PyPI、推多架构 Docker
+   镜像、把桌面安装包挂到 release 并上传 OSS、发布插件——然后**最后一步**才把草稿翻成
+   *published*（tag 钉到构建用的 SHA），并创建 Release Duty 验收 issue。
+
+整体约 60–75 分钟，主要耗时在桌面 Tauri 构建。
+
+## 发一个版本
+
+1. **建草稿 Release**
+   - UI：Releases → *Draft a new release* → 填 tag + 说明 → **Save draft**
+     （**不要** publish）。预发布请勾 *Set as a pre-release*。
+   - CLI：
+     ```bash
+     gh release create v2.0.0-beta.8 --draft --prerelease \
+       --target main --title "v2.0.0-beta.8" --notes "..."
+     ```
+   - tag 应与 `src/qwenpaw/__version__.py` 对应。
+2. **运行 workflow**：Actions → **Release (unified)** → *Run workflow*，选 `main`。
+   `tag` 留空可自动识别唯一草稿（也可显式填）；`dry_run` **不勾**。
+3. **观察**：成功后 release 翻成 *published*、资产齐全，并开出一个 Release Duty
+   issue。失败见 [故障处理](#故障处理)。
+
+## 版本类型：beta / 正式 / post
+
+流程完全一样——类型由 **tag** 推断：
+
+| 类型 | tag 示例 | 草稿勾 pre-release？ | Docker 标签 | PyPI |
+|------|----------|---------------------|-------------|------|
+| beta / rc / alpha / dev | `v2.0.0-beta.8` | 是 | `<version>` + `pre`（无 `latest`） | 上传；pip 视为预发布（`--pre`） |
+| 正式 | `v2.0.0` | 否 | `<version>` + `pre` + `latest` | 正常 |
+| post | `v2.0.0.post4` | 否 | `<version>` + `pre` + `latest` | post 版本 |
+
+说明：
+
+- 预发布判定是**基于 tag** 的：tag 含 `beta`/`alpha`/`rc`/`dev` 即为预发布
+  （所以用 `-beta.N` 写法）；`stable` 与 `.postN` 会更新 Docker 的 `latest` 标签。
+- ⚠️ 桌面 OSS 的 `latest` 文件与 Tauri 自动更新清单目前对**每个**版本（含 beta）
+  都会更新（与之前 `desktop-release.yml` 行为一致，本次未改）。让桌面
+  `latest`/自动更新只在正式版更新，可作为后续改进。
+
+## 故障处理
+
+**保证**：只有**全部** publish job 成功后，草稿才会被翻成 *published*；任一步失败，
+release 就仍是草稿。
+
+| 场景 | 发生了什么 | 怎么办 |
+|------|-----------|--------|
+| 准备阶段某 job 失败（桌面 / web 验证 / wheel / 插件） | 所有 publish + `finalize` + `duty-issue` 全被 **skip**；什么都没发；草稿不动 | 看失败 job 日志修复（flake 就直接重跑）→ **Re-run failed jobs** 或重跑 workflow。无需清理。 |
+| 发布阶段某 publish 失败（如 PyPI 已传、Docker 推失败） | `finalize` 需要全部 publish 成功，故草稿**未翻**；但部分产物可能已上线 | **Re-run failed jobs**（已成功的不会重跑；Docker 重推幂等、OSS 用 `--force`）→ 补齐后自动翻。若某个 PyPI 版本已被占用无法重用，改用 `.postN` 重发。 |
+| `finalize` 失败 | 产物都发了但 release 没翻 | 重跑 `finalize`，或手动 `gh release edit <tag> --draft=false --target <sha>`（或 UI 点 *Publish*）。 |
+| `duty-issue` 失败 | release 已发布，只是缺验收 issue | 重跑该 job，或用 `tag` 手动 dispatch `release-duty.yml`。不阻塞发布。 |
+| "Multiple draft releases found" | 存在多个草稿 | 重跑 *Run workflow* 时显式填 `tag`。 |
+| "No draft release found" / "not a draft" | 没有草稿，或 tag 填错 | 先建草稿 / 改正 tag，再重跑。 |
+
+## 回退到旧流程
+
+旧的按产物拆分的 workflow 是特意保留的。如果编排器坏了，就用旧方式发布——把 GitHub
+Release **点 Publish**（或 `gh release create ...`），会在 `release: published` 上触发
+`publish-pypi` / `docker-release` / `desktop-release` / `plugins-release`。
+
+> **警告**：旧流程**不会**用桌面构建来 gate Web 发布（这正是本编排器要修的问题），
+> 因此仅作应急回退使用。
+
+## Fork / dry-run 测试
+
+运行 **Release (unified)** 时勾 `dry_run: true`，可在**不触及生产**的前提下验证门禁与
+草稿→published 翻牌：PyPI 上传、Docker 推送、OSS 上传都变成 no-op，而桌面构建/验证、
+草稿翻牌、duty issue 仍会真实执行。（在 fork 上这些只影响 fork 自己的 release 页面。）

--- a/RELEASING_zh.md
+++ b/RELEASING_zh.md
@@ -89,6 +89,7 @@ release 就仍是草稿。
 | `promote-desktop` 失败 | release 已发布，但桌面 `latest` 文件 / 更新清单 / index 未刷新（存量用户的自动更新暂时看不到新版；版本化下载仍可用） | 重跑该 job，幂等（`ossutil cp --force`）。对首装用户不阻塞。 |
 | "Multiple draft releases found" | 存在多个草稿 | 重跑 *Run workflow* 时显式填 `tag`。 |
 | "No draft release found" / "not a draft" | 没有草稿，或 tag 填错 | 先建草稿 / 改正 tag，再重跑。 |
+| resolve 拒绝该 tag（版本不匹配） | 草稿 tag 与 `src/qwenpaw/__version__.py` 不一致 | 让 tag 与版本对齐（`packaging` 归一化，如 `v2.0.1-beta.1` ↔ `2.0.1b1`），再重跑。 |
 
 ## 回退到旧流程
 


### PR DESCRIPTION
## Problem
A recent release shipped the web artifacts (PyPI/Docker) while the desktop (Tauri) build failed, leaving a version with web but no desktop. The release workflows all fire independently on `release: published`, and the PyPI/Docker publishes gate only on their own build/verify — they have no dependency on the desktop build, so a desktop failure cannot stop the web release.

## Approach (purely additive; the old flow is kept as a rollback)
Add a draft-driven orchestrator `release.yml` that builds and verifies **every** product before publishing **any** of them (all-or-nothing). The existing per-artifact workflows keep their `release: published` triggers and behavior as a rollback (their trigger now carries a legacy-fallback warning comment), so this PR only adds to `main`. Operator docs: `RELEASING.md` / `RELEASING_zh.md`.

## Flow
Create a **draft** GitHub Release (do not publish) → Actions ▸ **Release (unified)** ▸ Run workflow → the orchestrator:
1. **resolve** the draft: validate the tag against `src/qwenpaw/__version__.py`, pin `target_commitish` to a concrete SHA (so *built == published*), fail fast on missing secrets / ambiguous drafts.
2. **prepare** (parallel, publishes nothing): build wheel, `verify-web` (pip + docker + script install), build desktop win+mac (+ strict install/launch/chat UI verify), pack plugins.
3. **gate**: every publish job `needs` all prepare jobs — a single failure skips the whole publish phase.
4. **publish**: PyPI, multi-arch Docker, desktop installers → the (draft) Release + versioned OSS, plugins.
5. **finalize**: flip the draft to *published* (pinned to the built SHA) — the last step.
6. **post-publish**: promote desktop `latest`/updater-manifest/index (only now, so the auto-updater is never pointed at a version whose release could still fail) + create the Release Duty issue inline.

Any failure → nothing is published and the draft is left untouched. `dry_run: true` stubs the production-external publishes (PyPI/Docker/OSS) so forks can exercise the gate without touching prod.

## Version types (beta / stable / post)
Same procedure; the type is inferred from the tag:

| Type | Example tag | Docker tags |
|---|---|---|
| beta/rc/alpha/dev | `v2.0.0-beta.8` | `<version>` + `pre` (no `latest`) |
| stable | `v2.0.0` | `<version>` + `pre` + `latest` |
| post | `v2.0.0.post4` | `<version>` + `pre` + `latest` |

## Changes (additive to main)
**New:** `release.yml` (orchestrator); reusable `desktop-build.yml` / `desktop-publish.yml` (versioned OSS) / `desktop-promote.yml` (post-publish latest/manifest/index); `RELEASING.md` + `RELEASING_zh.md`.
**Backward-compatible edits:** `release-duty.yml` +`workflow_call`; `release-verify.yml` +optional `ref`; legacy-fallback comments on the `release:` triggers of `publish-pypi`/`docker-release`/`desktop-release`/`plugins-release`; the plugins OSS bucket via `vars.OSS_BUCKET`.

## Verification
- **Local**: actionlint (all workflows) + pre-commit clean.
- **Fork** (`workflow_dispatch` + `dry_run`): 3 consecutive fully-green full runs (real Tauri build + strict UI verify, draft→published flip, beta pre-release flag preserved, assets attached, `upload-oss`/`promote-desktop` correctly skipped under dry_run, inline duty); a desktop-failure run confirming the gate holds (all publish/finalize/duty/promote skipped, draft not flipped); all four resolve guards triggered live (version mismatch, no draft, multiple drafts, not-a-draft).
- **Not covered** (a fork has no prod PyPI/Docker/OSS secrets and `dry_run` stubs them): the real production pushes — reviewed at the code level; recommend one real release after merge to confirm.

## Follow-up
Once proven in production, a separate PR will remove the old release workflows and their `release: published` triggers.