### PR TITLE
fix agent config copy md files silently

### DIFF
--- a/src/qwenpaw/app/routers/agents.py
+++ b/src/qwenpaw/app/routers/agents.py
@@ -593,6 +593,7 @@ async def copy_agent(
         workspace_dir,
         skill_names=[],
         language=language,
+        apply_md_templates=request.copy_md_files,
     )
     _copy_selected_workspace_files(
         request=request,
@@ -893,6 +894,8 @@ def _initialize_agent_workspace(
     skill_names: list[str] | None = None,
     md_template_id: str | None = None,
     language: str | None = None,
+    *,
+    apply_md_templates: bool = True,
 ) -> None:
     """Initialize agent workspace with only explicitly requested skills."""
     from ...config import load_config as load_global_config
@@ -905,12 +908,13 @@ def _initialize_agent_workspace(
     if not language:
         language = config.agents.language or "zh"
 
-    _apply_workspace_md_templates(
-        workspace_dir,
-        language,
-        md_template_id=md_template_id,
-    )
-    _ensure_heartbeat_file(workspace_dir, language)
+    if apply_md_templates:
+        _apply_workspace_md_templates(
+            workspace_dir,
+            language,
+            md_template_id=md_template_id,
+        )
+        _ensure_heartbeat_file(workspace_dir, language)
     _install_initial_skills(workspace_dir, skill_names)
 
     jobs_file = workspace_dir / "jobs.json"

--- a/tests/unit/app/routers/test_agents_router.py
+++ b/tests/unit/app/routers/test_agents_router.py
@@ -24,6 +24,7 @@ from qwenpaw.exceptions import AppBaseException
 from qwenpaw.app.agent_startup import AgentStartupStatus
 from qwenpaw.app.routers.agents import (
     CopyAgentRequest,
+    _initialize_agent_workspace,
     copy_agent,
     router as agents_router,
 )
@@ -579,6 +580,7 @@ def test_copy_agent_defaults_reset_channels_and_schedules_startup(
     assert not (new_ws / "chats.json").exists()
 
     init_mock.assert_called_once()
+    assert init_mock.call_args.kwargs["apply_md_templates"] is True
     manager_mock.schedule_agent_startup.assert_called_once_with("copied1")
     assert "copied1" in fake_config.agents.profiles
 
@@ -620,7 +622,9 @@ def test_copy_agent_copies_skills_and_jobs_when_requested(
         ),
         patch("qwenpaw.app.routers.agents.save_config"),
         patch("qwenpaw.app.routers.agents.save_agent_config"),
-        patch("qwenpaw.app.routers.agents._initialize_agent_workspace"),
+        patch(
+            "qwenpaw.app.routers.agents._initialize_agent_workspace",
+        ) as init_mock,
         patch(
             "qwenpaw.app.routers.agents._generate_unique_id",
             return_value="copied2",
@@ -644,6 +648,8 @@ def test_copy_agent_copies_skills_and_jobs_when_requested(
     assert not (new_ws / "AGENTS.md").exists()
     assert not (new_ws / "sessions").exists()
     assert not (new_ws / "chats.json").exists()
+    init_mock.assert_called_once()
+    assert init_mock.call_args.kwargs["apply_md_templates"] is False
     manager_mock.schedule_agent_startup.assert_called_once_with("copied2")
 
 
@@ -725,3 +731,59 @@ async def test_copy_agent_skips_startup_without_http_request(
     assert result.id == "copied3"
     get_manager.assert_not_called()
     manager_mock.schedule_agent_startup.assert_not_called()
+
+
+def test_initialize_agent_workspace_skips_md_templates_when_disabled(
+    tmp_path,
+    fake_config,
+):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    fake_config.agents.language = "en"
+
+    with patch(
+        "qwenpaw.config.load_config",
+        return_value=fake_config,
+    ):
+        _initialize_agent_workspace(
+            workspace,
+            skill_names=[],
+            language="en",
+            apply_md_templates=False,
+        )
+
+    assert (workspace / "sessions").is_dir()
+    assert (workspace / "memory").is_dir()
+    assert (workspace / "skills").is_dir()
+    assert (workspace / "jobs.json").is_file()
+    assert (workspace / "chats.json").is_file()
+    assert not (workspace / "AGENTS.md").exists()
+    assert not (workspace / "SOUL.md").exists()
+    assert not (workspace / "PROFILE.md").exists()
+    assert not (workspace / "HEARTBEAT.md").exists()
+    assert not (workspace / "BOOTSTRAP.md").exists()
+    assert not (workspace / "MEMORY.md").exists()
+
+
+def test_initialize_agent_workspace_applies_md_templates_by_default(
+    tmp_path,
+    fake_config,
+):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    fake_config.agents.language = "en"
+
+    with patch(
+        "qwenpaw.config.load_config",
+        return_value=fake_config,
+    ):
+        _initialize_agent_workspace(
+            workspace,
+            skill_names=[],
+            language="en",
+        )
+
+    assert (workspace / "AGENTS.md").is_file()
+    assert (workspace / "HEARTBEAT.md").is_file()
+    assert (workspace / "sessions").is_dir()
+    assert (workspace / "jobs.json").is_file()


### PR DESCRIPTION
## Description

Fixes Agent Configuration Copy so `copy_md_files=false` is actually respected.

`POST /api/agents/{agentId}/copy` already skipped copying whitelist MD files when `copy_md_files` was false, but `_initialize_agent_workspace` always applied language-pack MD templates (`AGENTS.md`, `SOUL.md`, `PROFILE.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`). That made the API return 201 while the new workspace still contained a full set of MD files — the option looked ignored.

This PR adds `apply_md_templates` to workspace init (default `True` for create-agent), wires `copy_agent` to `apply_md_templates=request.copy_md_files`, and covers the flag with unit tests.

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
