### PR TITLE
test(e2e): adapt Agents cases to the #6198 actions redesign

### DIFF
--- a/e2e/pages/agents_page.py
+++ b/e2e/pages/agents_page.py
@@ -53,16 +53,23 @@ class AgentsPage(BasePage):
     AGENT_WORKSPACE_CELL = 'td.qwenpaw-table-cell:nth-child(5)'
     AGENT_MODEL_CELL = 'td.qwenpaw-table-cell:nth-child(6)'
     AGENT_ACTIONS_CELL = 'td.qwenpaw-table-cell:nth-child(7)'
-    AGENT_STATUS = '.qwenpaw-tag'
+    # Post-#6198 the name cell shows an AgentStatusIndicator dot exposing a
+    # ``data-status`` attribute (disabled/pending/starting/running/failed)
+    # instead of a "Disabled" Tag.
+    AGENT_STATUS = '[data-status]'
 
     # Action buttons
     CREATE_AGENT_BTN = 'button:has-text("创建智能体"), button:has-text("Create Agent"), .qwenpaw-btn-primary'
-    # Inline action buttons in a table row (3 icon buttons: edit, toggle, delete)
-    # Locate via Ant Design icon class names (anticon-edit / anticon-delete), fallback to nth-child
-    EDIT_BTN = 'button:has(.anticon-edit), .qwenpaw-space-item:nth-child(1) button'
-    TOGGLE_BTN = '.qwenpaw-space-item:nth-child(2) button'
+    # Inline action buttons in a table row. Post-redesign (upstream #6198) the
+    # actions are 4 icon buttons in order: Pin | Edit | Toggle | Delete. Anchor
+    # on the icon (not Space position) so the added Pin button can't shift us:
+    #   Edit   = antd EditOutlined    -> .anticon-edit
+    #   Toggle = lucide Eye/EyeOff    -> svg.lucide-eye / svg.lucide-eye-off
+    #   Delete = antd DeleteOutlined  -> .anticon-delete (danger button)
+    EDIT_BTN = 'button:has(.anticon-edit)'
+    TOGGLE_BTN = 'button:has(svg.lucide-eye-off), button:has(svg.lucide-eye), .qwenpaw-space-item:nth-child(3) button'
     DELETE_BTN = 'button.qwenpaw-btn-dangerous, button:has(.anticon-delete)'
-    ENABLE_TOGGLE = '.qwenpaw-space-item:nth-child(2) button'
+    ENABLE_TOGGLE = 'button:has(svg.lucide-eye-off), button:has(svg.lucide-eye), .qwenpaw-space-item:nth-child(3) button'
     REFRESH_BTN = 'button:has(.anticon-reload), button:has(.spark-icon-spark-refresh-line)'
 
     # Create/edit form
@@ -134,11 +141,14 @@ class AgentsPage(BasePage):
             try:
                 name_cell = row.locator(self.AGENT_NAME_CELL).first
                 name_text = name_cell.inner_text() if name_cell.is_visible() else ""
-                # The name cell may contain a "Disabled" tag that needs to be stripped
-                status_tag = name_cell.locator(self.AGENT_STATUS).first
-                status = status_tag.inner_text().strip() if status_tag.is_visible() else ""
-                # Remove the status tag text from the raw name text
-                clean_name = name_text.replace(status, "").strip() if status else name_text.strip()
+                # Post-#6198 status is an AgentStatusIndicator dot exposing a
+                # ``data-status`` attribute (no visible text) — read the attribute.
+                status_dot = name_cell.locator(self.AGENT_STATUS).first
+                status = (
+                    (status_dot.get_attribute("data-status") or "").strip()
+                    if status_dot.count() > 0 else ""
+                )
+                clean_name = name_text.strip()
 
                 id_cell = row.locator(self.AGENT_ID_CELL).first
                 agent_id = id_cell.inner_text().strip() if id_cell.is_visible() else ""
@@ -367,7 +377,11 @@ class AgentsPage(BasePage):
 
     def toggle_agent_status(self, agent_name: str) -> "AgentsPage":
         """
-        Toggle the agent enabled status (clicks the second Actions button and confirms the Popconfirm).
+        Toggle the agent enabled status.
+
+        Clicks the Eye/EyeOff Toggle icon button and confirms the Popconfirm.
+        Post-#6198 the toggle is disabled while the agent is still starting
+        (startup_status pending/starting), so we wait for it to become enabled.
 
         Args:
             agent_name: Agent name.
@@ -377,6 +391,13 @@ class AgentsPage(BasePage):
         if agent_row:
             actions_cell = agent_row.locator(self.AGENT_ACTIONS_CELL).first
             toggle_btn = actions_cell.locator(self.TOGGLE_BTN).first
+            # Wait out the startup-readiness gate before clicking.
+            try:
+                expect(toggle_btn).to_be_enabled(timeout=20000)
+            except (AssertionError, TimeoutError, Exception):
+                logger.warning(
+                    "[toggle] toggle still disabled after 20s; clicking anyway"
+                )
             toggle_btn.click()
             self.wait(500)
             # The toggle action triggers a Popconfirm that must be confirmed
@@ -402,26 +423,23 @@ class AgentsPage(BasePage):
 
     def get_agent_status(self, agent_name: str) -> str:
         """
-        Return the agent status.
+        Return the agent's startup status.
 
-        Args:
-            agent_name: Agent name.
-
-        Returns:
-            Status text (e.g. "Disabled" or empty string when enabled).
+        Post-#6198 this is the AgentStatusIndicator ``data-status`` attribute
+        (e.g. "disabled" / "pending" / "starting" / "running" / "failed"),
+        or "" when the indicator is absent.
         """
         agent_row = self.find_agent_by_name(agent_name)
         if agent_row:
             name_cell = agent_row.locator(self.AGENT_NAME_CELL).first
-            status_tag = name_cell.locator(self.AGENT_STATUS).first
-            if status_tag.is_visible():
-                return status_tag.inner_text().strip()
+            status_dot = name_cell.locator(self.AGENT_STATUS).first
+            if status_dot.count() > 0:
+                return (status_dot.get_attribute("data-status") or "").strip()
         return ""
 
     def is_agent_enabled(self, agent_name: str) -> bool:
-        """Return whether the agent is enabled (no Disabled tag means enabled)."""
-        status = self.get_agent_status(agent_name)
-        return status == "" or "Enabled" in status or "active" in status.lower()
+        """Return whether the agent is enabled (data-status != "disabled")."""
+        return self.get_agent_status(agent_name) != "disabled"
 
     # ========== Agent file management ==========
 

--- a/e2e/tests/test_agents.py
+++ b/e2e/tests/test_agents.py
@@ -572,14 +572,16 @@ class TestToggleAgent:
             # Step 4: Verify the post-disable state (do not refresh the page,
             # since refreshing may filter out disabled agents)
             log_test_step("4. Verify the post-disable state")
-            # Approach 1: check whether the Disabled tag appears on the current page
-            disabled_tag = page.locator(f'.qwenpaw-table-row:has-text("{agent_name}") .qwenpaw-tag:has-text("Disabled")')
-            # Approach 2: check the success toast
+            # Post-#6198 the "Disabled" state is an AgentStatusIndicator dot with
+            # data-status="disabled" (no text tag); also accept the success toast.
+            disabled_dot = page.locator(
+                f'.qwenpaw-table-row:has-text("{agent_name}") [data-status="disabled"]'
+            )
             success_msg = page.locator('.qwenpaw-message-success, .qwenpaw-notification-success')
-            tag_visible = disabled_tag.count() > 0 and disabled_tag.first.is_visible()
+            dot_visible = disabled_dot.count() > 0 and disabled_dot.first.is_visible()
             msg_visible = success_msg.count() > 0
-            assert tag_visible or msg_visible, \
-                "Agent should be disabled (Disabled tag or success message should appear)"
+            assert dot_visible or msg_visible, \
+                "Agent should be disabled (data-status='disabled' or success message should appear)"
             logger.info("Disabled state verified")
 
             # Step 5: Enable the agent (operate directly on the current page, no refresh)
@@ -589,10 +591,12 @@ class TestToggleAgent:
 
             # Step 6: Verify the post-enable state is restored
             log_test_step("6. Verify the post-enable state")
-            # The Disabled tag should disappear
-            disabled_tag_after = page.locator(f'.qwenpaw-table-row:has-text("{agent_name}") .qwenpaw-tag:has-text("Disabled")')
-            is_still_disabled = disabled_tag_after.count() > 0 and disabled_tag_after.first.is_visible()
-            assert not is_still_disabled, "Agent should be enabled (Disabled tag should disappear)"
+            # The disabled dot should disappear once re-enabled.
+            disabled_dot_after = page.locator(
+                f'.qwenpaw-table-row:has-text("{agent_name}") [data-status="disabled"]'
+            )
+            is_still_disabled = disabled_dot_after.count() > 0 and disabled_dot_after.first.is_visible()
+            assert not is_still_disabled, "Agent should be enabled (disabled dot should disappear)"
             logger.info("Enabled state verified")
 
             log_test_result(test_name, "PASS", f"Agent status toggle verified: {agent_name}")
@@ -812,37 +816,39 @@ class TestAgentDragReorder:
         navigate_to_agents(page)
 
         log_test_step("Find rows in the agent list")
-        agent_rows = page.locator("tr[data-row-key], .ant-table-row, [class*='agent-row'], tbody tr").all()
+        agent_rows = page.locator("tr[data-row-key]").all()
 
         if len(agent_rows) < 2:
             pytest.skip(f"Not enough agents ({len(agent_rows)}); cannot run drag test")
 
-        log_test_step(f"Found {len(agent_rows)} agent(s); preparing drag test")
+        # Post-#6198 the default agent is pinned at the top and its drag handle
+        # is disabled (aria-disabled="true"); only rows with an enabled
+        # MenuOutlined handle can be reordered.
+        draggable_rows = [
+            r for r in agent_rows
+            if r.locator(
+                "button:has(.anticon-menu):not([aria-disabled='true'])"
+            ).count() > 0
+        ]
+        if len(draggable_rows) < 2:
+            pytest.skip(
+                f"Need >=2 reorderable (non-default) agents; got {len(draggable_rows)}"
+            )
 
-        first_row = agent_rows[0]
-        second_row = agent_rows[1]
+        log_test_step(
+            f"Found {len(agent_rows)} agent(s), {len(draggable_rows)} reorderable"
+        )
+
+        first_row = draggable_rows[0]
+        second_row = draggable_rows[1]
 
         log_test_step("Capture agent order before drag")
-        before_order = []
-        for row in agent_rows[:3]:
-            row_key = row.get_attribute("data-row-key")
-            if row_key:
-                before_order.append(row_key)
-            else:
-                name_cell = row.locator("td").nth(1)
-                if name_cell.count() > 0:
-                    name_text = name_cell.inner_text()
-                    before_order.append(name_text.strip())
-
-        assert len(before_order) >= 2, "Could not read identifiers for at least 2 agents"
+        before_order = [r.get_attribute("data-row-key") for r in agent_rows]
+        assert len([k for k in before_order if k]) >= 2, "Could not read >=2 agent keys"
         logger.info(f"Order before drag: {before_order}")
 
-        log_test_step("Find the drag handle")
-        drag_handle = first_row.locator(".drag-handle, [class*='drag-handle'], .anticon-menu, svg[data-icon='menu']").first
-
-        if drag_handle.count() == 0:
-            drag_handle = first_row.locator("button[class*='drag'], [class*='sortable-handle']").first
-
+        log_test_step("Find the drag handle (enabled, non-default row)")
+        drag_handle = first_row.locator("button:has(.anticon-menu)").first
         if drag_handle.count() == 0:
             pytest.skip("Drag handle not found; this page may not support drag reordering")
 
@@ -866,17 +872,8 @@ class TestAgentDragReorder:
         time.sleep(2)
 
         log_test_step("Drag finished; verifying the new order")
-        refreshed_rows = page.locator("tr[data-row-key], .ant-table-row, [class*='agent-row'], tbody tr").all()
-        after_order = []
-        for row in refreshed_rows[:3]:
-            row_key = row.get_attribute("data-row-key")
-            if row_key:
-                after_order.append(row_key)
-            else:
-                name_cell = row.locator("td").nth(1)
-                if name_cell.count() > 0:
-                    name_text = name_cell.inner_text()
-                    after_order.append(name_text.strip())
+        refreshed_rows = page.locator("tr[data-row-key]").all()
+        after_order = [r.get_attribute("data-row-key") for r in refreshed_rows]
 
         logger.info(f"Order after drag: {after_order}")
         assert before_order != after_order, "Agent order did not change after drag; reorder did not take effect"
@@ -887,17 +884,8 @@ class TestAgentDragReorder:
         page.wait_for_load_state("domcontentloaded")
         time.sleep(2)
 
-        persisted_rows = page.locator("tr[data-row-key], .ant-table-row, [class*='agent-row'], tbody tr").all()
-        persisted_order = []
-        for row in persisted_rows[:3]:
-            row_key = row.get_attribute("data-row-key")
-            if row_key:
-                persisted_order.append(row_key)
-            else:
-                name_cell = row.locator("td").nth(1)
-                if name_cell.count() > 0:
-                    name_text = name_cell.inner_text()
-                    persisted_order.append(name_text.strip())
+        persisted_rows = page.locator("tr[data-row-key]").all()
+        persisted_order = [r.get_attribute("data-row-key") for r in persisted_rows]
 
         logger.info(f"Order after refresh: {persisted_order}")
         assert after_order == persisted_order, \

--- a/e2e/tests/test_cross_module.py
+++ b/e2e/tests/test_cross_module.py
@@ -167,10 +167,7 @@ When invoked, respond with: "Cross-module test skill executed successfully."
             log_test_step("7. Find an editable agent and click edit")
             editable_agent_found = False
             for agent_row in agent_rows:
-                edit_btn = agent_row.locator(
-                    'button:has(.spark-icon-spark-edit-line), '
-                    '.qwenpaw-space-item:nth-child(1) button'
-                ).first
+                edit_btn = agent_row.locator('button:has(.anticon-edit)').first
                 if edit_btn.count() > 0 and edit_btn.is_enabled(timeout=1000):
                     edit_btn.click()
                     page.wait_for_timeout(1500)


### PR DESCRIPTION
## Summary
- PR #6198 ("bound multi-agent startup", `fef7e64d`) reworked the Agents settings page; the e2e selectors did not follow, so the agents / cross-module suite went red on `v2.0.0.post3`. Each failure was root-caused against the console source — all test fragility, zero product bug.
- New layout facts: actions column is now Pin(1) · Edit(2) · Toggle(3, Popconfirm) · Delete(4); the "Disabled" Tag was replaced by an `AgentStatusIndicator` dot (`data-status`, `role=status`, no text); Toggle uses lucide `Eye`/`EyeOff` and is disabled while `startup_status` is pending/starting; the default agent's controls and drag handle are disabled.
- Changes (e2e only): `agents_page.py` selectors (`AGENT_STATUS` → `[data-status]`, `EDIT_BTN` → `.anticon-edit`, `TOGGLE_BTN` → lucide eye/eye-off with an `nth-child(3)` fallback), status read via `data-status`, and a `to_be_enabled` wait for the startup gate before toggling; `test_agents.py` (disabled assertion → `[data-status="disabled"]`, drag reorder skips the default row and compares full `data-row-key` order); `test_cross_module.py` (agent edit selector).

## Test plan
- [x] fork CI (E2E Integration, marker `agents_* or cross_module`): **12 passed, 1 skipped**
- [x] The 4 previously-failing cases (edit / toggle / drag-reorder / skill→agent→chat) are green
- [x] UI-driven flow unchanged; changes are e2e-only (no product code touched)