### PR TITLE
test(e2e): add tool-approval level cases (#5685)

### DIFF
--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -866,43 +866,92 @@ class ChatPage(BasePage):
         The dropdown is triggered by the SparkMoreLine "more" button and
         holds Pin / Rename / Archive / Delete items. Returns True when the
         menu is visible.
+
+        The ``moreBtn`` is a ``<span>`` that is ``pointer-events:none`` until
+        the row is ``:hover``-ed, and antd opens the menu on a real click. In
+        headless CI the CSS ``:hover`` can be lost between hovering the row and
+        clicking, so a plain/force click may land on the element *behind* the
+        span and never open the menu. We therefore hover the row and the
+        button, try a normal click, and fall back to a DOM
+        ``dispatchEvent('click')`` that bypasses the pointer-events gate
+        (React's delegated onClick still fires). Two attempts total.
         """
         sessions = self.get_session_items()
         if not sessions or index >= len(sessions):
             logger.warning(f"Session at index {index} not found")
             return False
         target = sessions[index]
-        try:
-            target.scroll_into_view_if_needed(timeout=5000)
-            target.hover(timeout=8000)
-        except Exception:
+
+        # antd keeps closed menus in the DOM with a ``-hidden`` modifier; the
+        # open one is the menu WITHOUT it.
+        open_menu_item = (
+            '.qwenpaw-dropdown:not(.qwenpaw-dropdown-hidden) '
+            '.qwenpaw-dropdown-menu-item'
+        )
+
+        def _menu_visible(timeout: int) -> bool:
             try:
-                target.hover(force=True, timeout=5000)
-            except Exception as exc:
-                logger.warning(f"[_open_session_menu] hover failed: {exc}")
+                self.page.locator(open_menu_item).first.wait_for(
+                    state="visible", timeout=timeout
+                )
+                return True
+            except (TimeoutError, Exception):
                 return False
-        self.wait(300)
-        more_btn = target.locator(self.SESSION_MORE_BTN).first
-        if more_btn.count() == 0:
-            logger.warning("[_open_session_menu] more button not found")
-            return False
-        try:
-            more_btn.click(timeout=5000)
-        except Exception:
+
+        for attempt in range(2):
+            # Reset any stale hover / overlay before (re)trying.
             try:
-                more_btn.click(force=True, timeout=5000)
-            except Exception as exc:
-                logger.warning(f"[_open_session_menu] more click failed: {exc}")
+                self.page.mouse.move(0, 0)
+            except Exception:
+                pass
+            try:
+                target.scroll_into_view_if_needed(timeout=5000)
+                target.hover(timeout=8000)
+            except Exception:
+                try:
+                    target.hover(force=True, timeout=5000)
+                except Exception as exc:
+                    logger.warning(f"[_open_session_menu] hover failed: {exc}")
+            self.wait(300)
+
+            more_btn = target.locator(self.SESSION_MORE_BTN).first
+            if more_btn.count() == 0:
+                logger.warning("[_open_session_menu] more button not found")
                 return False
-        try:
-            self.page.locator(
-                '.qwenpaw-dropdown-menu-item'
-            ).first.wait_for(state="visible", timeout=5000)
-        except (TimeoutError, Exception):
-            logger.warning("[_open_session_menu] dropdown did not appear")
-            return False
-        self.wait(200)
-        return True
+
+            # Hover the button so the row stays :hover-ed (moreBtn is
+            # pointer-events:none otherwise), then click.
+            try:
+                more_btn.hover(timeout=3000)
+            except Exception:
+                pass
+            try:
+                more_btn.click(timeout=4000)
+            except Exception:
+                pass
+            if _menu_visible(4000):
+                self.wait(200)
+                return True
+
+            # The click may have been swallowed by the pointer-events gate;
+            # fire it via the DOM so React's delegated onClick still opens the
+            # menu.
+            try:
+                more_btn.dispatch_event("click")
+            except Exception as exc:
+                logger.warning(
+                    f"[_open_session_menu] dispatch click failed: {exc}"
+                )
+            if _menu_visible(3000):
+                self.wait(200)
+                return True
+
+            logger.warning(
+                f"[_open_session_menu] dropdown did not appear "
+                f"(attempt {attempt + 1})"
+            )
+
+        return False
 
     def rename_session(self, index: int, new_name: str) -> "ChatPage":
         """Rename a session via more-menu → Rename → inline input → Enter."""

--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -7,6 +7,7 @@ Wraps all interactions on the Chat page and exposes business-level methods.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Optional, List, Tuple
 from pathlib import Path
 from playwright.sync_api import Page, Locator, expect, TimeoutError
@@ -102,6 +103,27 @@ class ChatPage(BasePage):
     SESSION_PIN_BTN = 'button:has(.spark-icon-spark-mark-line), button:has(.anticon-pushpin)'
     SESSION_EDIT_BTN = 'button:has(.spark-icon-spark-edit-line), button:has(.anticon-edit)'
     SESSION_DELETE_BTN = 'button:has(.spark-icon-spark-delete-line), button:has(.anticon-delete)'
+
+    # --- Tool approval level toggle (composer / sender area) — upstream #5685 ---
+    # A single antd Tag whose text is one of the 4 levels; clicking it opens a
+    # dropdown of exactly 4 options. No CSS-module class or data-testid, so we
+    # anchor on the level texts (browser locale is en-US; ZH kept as fallback).
+    APPROVAL_LEVELS = {
+        "STRICT": ("Strict Mode", "严格模式"),
+        "SMART": ("Smart Mode", "智能模式"),
+        "AUTO": ("Auto Mode", "自动模式"),
+        "OFF": ("Off Mode", "关闭模式"),
+    }
+    _APPROVAL_LABEL_RE = re.compile(
+        r"Strict Mode|Smart Mode|Auto Mode|Off Mode|"
+        r"严格模式|智能模式|自动模式|关闭模式"
+    )
+    # Only items inside the currently-open dropdown (antd keeps closed menus in
+    # the DOM with a ``-hidden`` modifier).
+    APPROVAL_MENU_ITEM = (
+        '.qwenpaw-dropdown:not(.qwenpaw-dropdown-hidden) '
+        '.qwenpaw-dropdown-menu-item'
+    )
 
     # Settings and model
     MODEL_SELECTOR = '.qwenpaw-dropdown-trigger'
@@ -1009,6 +1031,57 @@ class ChatPage(BasePage):
             box.fill("")
             self.wait(800)
         return self
+
+    # ========== Tool approval level toggle ==========
+
+    def get_approval_toggle(self) -> Locator:
+        """Locate the approval-level Tag in the composer (matches any level)."""
+        return (
+            self.page.locator("span.qwenpaw-tag")
+            .filter(has_text=self._APPROVAL_LABEL_RE)
+            .first
+        )
+
+    def open_approval_menu(self) -> "ChatPage":
+        """Click the approval Tag and wait for its dropdown to render."""
+        self.get_approval_toggle().click()
+        self.page.locator(self.APPROVAL_MENU_ITEM).first.wait_for(
+            state="visible", timeout=5000
+        )
+        self.wait(200)
+        return self
+
+    def get_approval_menu_items(self) -> List[Locator]:
+        """Return the visible approval dropdown items (expected: 4)."""
+        return self.page.locator(self.APPROVAL_MENU_ITEM).all()
+
+    def select_approval_level(self, level: str) -> "ChatPage":
+        """Open the menu and pick a level by key (STRICT/SMART/AUTO/OFF)."""
+        en, zh = self.APPROVAL_LEVELS[level]
+        self.open_approval_menu()
+        item = self.page.locator(
+            f'{self.APPROVAL_MENU_ITEM}:has-text("{en}"), '
+            f'{self.APPROVAL_MENU_ITEM}:has-text("{zh}")'
+        ).first
+        item.click()
+        self.wait(500)
+        self.step_shot(f"approval_select_{level}")
+        return self
+
+    def get_approval_storage_entries(self) -> dict:
+        """Read all ``approval_level-*`` localStorage entries as {key: value}."""
+        return self.page.evaluate(
+            """() => {
+                const out = {};
+                for (let i = 0; i < localStorage.length; i++) {
+                    const k = localStorage.key(i);
+                    if (k && k.indexOf('approval_level-') === 0) {
+                        out[k] = localStorage.getItem(k);
+                    }
+                }
+                return out;
+            }"""
+        )
 
     # ========== Model and Agent switching ==========
     

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -31,6 +31,7 @@ markers =
     # ----- Modules (mapped to tests/test_*.py) -----
     chat: Chat module
     chat_core: Chat core scenarios (legacy alias, new tests should use chat)
+    tool_approval: Chat tool approval level toggle (Sprint 4, upstream #5685)
     channels: Channels module
     coding: Coding Mode module
     memory: Long-term memory module

--- a/e2e/tests/test_chat.py
+++ b/e2e/tests/test_chat.py
@@ -837,6 +837,143 @@ class TestChatIMEInput:
 
         log_test_result(test_name, True, 0)
 
+# ============================================================================
+# APPROVAL-001/002/003: Session-level tool approval toggle (upstream #5685)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.chat
+@pytest.mark.tool_approval
+class TestToolApproval:
+    """Session-level tool approval toggle in the chat composer.
+
+    Covers the ApprovalLevelToggle shipped in upstream #5685:
+    - APPROVAL-001: the toggle renders, offers exactly 4 levels, and the Tag
+      text follows the selection.
+    - APPROVAL-002: the chosen level is persisted in localStorage and survives
+      a page reload.
+    - APPROVAL-003: deleting a session clears its ``approval_level-<id>`` key.
+
+    None of these require an LLM — the toggle only writes localStorage and
+    injects ``request_context.approval_level`` into outbound requests.
+    """
+
+    @pytest.mark.p0
+    @pytest.mark.test_id("APPROVAL-001")
+    def test_approval_toggle_renders_and_switches(
+        self, clean_chat_page: ChatPage, request: pytest.FixtureRequest
+    ):
+        """Toggle renders, exposes 4 levels, and the Tag follows the choice."""
+        test_name = request.node.name
+
+        log_test_step("1. Open the Chat page")
+        chat = clean_chat_page.open()
+
+        log_test_step("2. Locate the approval toggle in the composer")
+        toggle = chat.get_approval_toggle()
+        expect(toggle).to_be_visible(timeout=10000)
+
+        log_test_step("3. Open the menu and assert exactly 4 levels")
+        chat.open_approval_menu()
+        items = chat.get_approval_menu_items()
+        assert len(items) == 4, f"expected 4 approval levels, got {len(items)}"
+        chat.page.keyboard.press("Escape")
+        chat.wait(300)
+
+        log_test_step("4. Select each level and verify the Tag text follows")
+        for level, (en_label, _zh) in ChatPage.APPROVAL_LEVELS.items():
+            chat.select_approval_level(level)
+            expect(chat.get_approval_toggle()).to_contain_text(en_label)
+
+        log_test_result(test_name, True, 0)
+
+    @pytest.mark.p0
+    @pytest.mark.test_id("APPROVAL-002")
+    def test_approval_level_persists_across_reload(
+        self, clean_chat_page: ChatPage, request: pytest.FixtureRequest
+    ):
+        """A selected level is stored in localStorage and survives a reload."""
+        test_name = request.node.name
+
+        log_test_step("1. Open the Chat page")
+        chat = clean_chat_page.open()
+
+        log_test_step("2. Select STRICT and confirm the Tag updates")
+        chat.select_approval_level("STRICT")
+        expect(chat.get_approval_toggle()).to_contain_text("Strict Mode")
+
+        log_test_step("3. Assert the choice is written to localStorage")
+        entries = chat.get_approval_storage_entries()
+        assert "STRICT" in entries.values(), f"STRICT not persisted: {entries}"
+
+        log_test_step("4. Reload and assert the level persists")
+        chat.page.reload()
+        chat.page.locator(chat.CHAT_INPUT).first.wait_for(
+            state="visible", timeout=30000
+        )
+        expect(chat.get_approval_toggle()).to_contain_text("Strict Mode")
+        entries_after = chat.get_approval_storage_entries()
+        assert "STRICT" in entries_after.values(), (
+            f"STRICT lost after reload: {entries_after}"
+        )
+
+        log_test_result(test_name, True, 0)
+
+    @pytest.mark.p2
+    @pytest.mark.test_id("APPROVAL-003")
+    def test_approval_level_cleared_on_session_delete(
+        self,
+        clean_chat_page: ChatPage,
+        api_context,
+        request: pytest.FixtureRequest,
+    ):
+        """Deleting a session removes its ``approval_level-<id>`` localStorage key."""
+        test_name = request.node.name
+
+        log_test_step("1. Seed a real chat via API so a deletable row exists (no LLM)")
+        seed = api_context.post(
+            "/api/chats",
+            data={
+                "name": "E2E Approval Cleanup",
+                "user_id": config.test.user_id,
+                "channel": config.test.channel,
+                "session_id": f"{config.test.channel}:{config.test.user_id}",
+            },
+        )
+        if not seed.ok:
+            pytest.skip(
+                f"chat seed failed ({seed.status}); cannot test delete cleanup"
+            )
+
+        log_test_step("2. Open chat, open the session list, select the seeded session")
+        chat = clean_chat_page.open()
+        chat.open_session_list()
+        if chat.get_session_count() == 0:
+            pytest.skip("seeded session not visible in drawer; skipping cleanup check")
+        chat.switch_to_session(0)
+        chat.wait(500)
+
+        log_test_step("3. Select STRICT and capture the persisted approval key(s)")
+        chat.select_approval_level("STRICT")
+        entries = chat.get_approval_storage_entries()
+        strict_keys = [k for k, v in entries.items() if v == "STRICT"]
+        assert strict_keys, f"no STRICT approval_level entry after select: {entries}"
+
+        log_test_step("4. Delete the session via the more-menu")
+        chat.open_session_list()
+        chat.delete_session(0)
+        chat.wait(800)
+
+        log_test_step("5. Assert the approval key(s) were cleared on delete")
+        after = chat.get_approval_storage_entries()
+        for k in strict_keys:
+            assert k not in after, (
+                f"approval key {k} not cleared after delete; still present: {after}"
+            )
+
+        log_test_result(test_name, True, 0)
+
+
 if __name__ == "__main__":
     pytest.main([
         __file__,


### PR DESCRIPTION
## Summary
- Adds Sprint-4 regression coverage for the tool-approval level toggle from #5685 (an antd Tag in the composer that opens a 4-level menu: STRICT / SMART / AUTO / OFF), previously untested.
- **APPROVAL-001** (p0): the Tag renders and the menu shows exactly 4 levels; switching updates the Tag. **APPROVAL-002** (p0): selecting STRICT persists to `localStorage[approval_level-<chatId>]` and survives a reload. **APPROVAL-003** (p2): deleting a session clears its `approval_level-<id>` (matches `ChatSessionDrawer`'s `removeItem`-on-delete).
- Also hardens the shared `_open_session_menu`: the SessionItem `moreBtn` is a `pointer-events:none` `<span>` until its row is hovered, so in headless CI a click can land on the element behind the span and never open the antd dropdown. It now retries hovering the row and button, then falls back to a DOM `dispatchEvent('click')` (React's delegated onClick still fires) — this also stabilizes rename / pin / delete.

## Test plan
- [x] fork CI (E2E Integration, marker `tool_approval`): **3 passed**
- [x] APPROVAL-001 / 002 / 003 all green; UI-driven primary assertions
- [x] e2e-only changes (page object + tests + `tool_approval` marker); no product code touched