### PR TITLE
fix: use absolute import in Tauri entry point (#6234)

### DIFF
--- a/src/qwenpaw/tauri/entry.py
+++ b/src/qwenpaw/tauri/entry.py
@@ -362,7 +362,7 @@ def main() -> None:
     # On Windows, auto-disable sandbox when not running as admin so the
     # desktop backend starts without a half-broken sandbox layer (mirrors
     # the same guard in cli/app_cmd.py for `qwenpaw app`).
-    from ..utils.platform import auto_disable_sandbox_on_windows
+    from qwenpaw.utils.platform import auto_disable_sandbox_on_windows
 
     auto_disable_sandbox_on_windows()
 

--- a/tests/unit/tauri/test_entry.py
+++ b/tests/unit/tauri/test_entry.py
@@ -135,3 +135,33 @@ def test_socket_port_returns_bound_port():
         sock.bind(("127.0.0.1", 0))
 
         assert entry._socket_port(sock) == sock.getsockname()[1]
+
+
+def test_main_supports_frozen_entry_without_package_context(
+    monkeypatch,
+    tmp_path,
+):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(entry, "__package__", None)
+    monkeypatch.setattr(entry, "__spec__", None)
+    monkeypatch.setattr(entry, "__name__", "__main__")
+    monkeypatch.setattr(entry, "_is_frozen_desktop", lambda: False)
+    monkeypatch.setattr(entry, "_ensure_utf8_stdio", lambda: None)
+    monkeypatch.setattr(entry, "_install_subprocess_guard", lambda: None)
+    monkeypatch.setattr(entry, "_install_desktop_runtime", lambda: None)
+    monkeypatch.setattr(entry, "install_sidecar_logging", lambda path: None)
+    monkeypatch.setattr(entry, "_install_certifi_env", lambda: None)
+    monkeypatch.setattr(entry, "_run_backend_server", calls.append)
+    monkeypatch.setattr("qwenpaw.constant.WORKING_DIR", tmp_path)
+    monkeypatch.setattr(
+        "qwenpaw.utils.platform.auto_disable_sandbox_on_windows",
+        lambda: calls.append("sandbox-check"),
+    )
+    monkeypatch.delenv("QWENPAW_LOG_LEVEL", raising=False)
+
+    entry.main()
+
+    assert calls == ["sandbox-check", "info"]


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
