### PR TITLE
fix(skill): Reapply #5146 Improve skill-slash-inject and display

### DIFF
--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -389,7 +389,8 @@ def _build_media_message_from_block(
 
 
 # Matches the trailing <skill> block appended to a user message by
-# slash-command skill expansion (runner._maybe_inject_skill).
+# slash-command skill expansion
+# (runtime.builtin_commands._skill_fallback_handler).
 _INJECTED_SKILL_BLOCK_RE = re.compile(
     r"\s*<skill\b[^>]*>.*</skill>\s*$",
     re.DOTALL,

--- a/src/qwenpaw/runtime/builtin_commands.py
+++ b/src/qwenpaw/runtime/builtin_commands.py
@@ -524,25 +524,34 @@ def _extract_block_text(block: Any) -> str:
 def _build_skill_injection(
     original_text: str,
     display_name: str,
+    description: str,
     skill_dir: "Path",
-    user_input: str,
     skill_body: str,
 ) -> str:
-    """Keep the typed text at the head; append the skill body in a
+    """Keep the typed command at the head; append the skill body in a
     trailing ``<skill>`` block (hidden from display by
     ``strip_injected_skill_block``).
+
+    The block uses a nested-element schema — ``<name>``/``<description>``/
+    ``<dir>``/``<content>`` — rather than XML attributes, so frontmatter
+    values (name, dir) need no attribute quoting/escaping. The typed
+    command stays at the head, so the user's request is not duplicated
+    inside the block.
     """
     return (
         f"{original_text}\n\n"
-        f'<skill name="{display_name}" dir="{skill_dir}">\n'
-        f"This block was injected because the user invoked the "
-        f"[{display_name}] skill above. It is the full content of "
-        f"the skill's SKILL.md — do not re-read that file. Follow "
-        f"these instructions to fulfill the user's task: "
-        f"{user_input}\n"
-        f"Relative paths inside the skill (e.g. `scripts/`) resolve "
-        f"against the skill directory.\n\n"
+        f"<skill>\n"
+        f"<name>{display_name}</name>\n"
+        f"<description>{description}</description>\n"
+        f"<dir>{skill_dir}</dir>\n"
+        f"<content>\n"
+        f"This skill has already been loaded because the user invoked "
+        f"it directly above. Do not call the Skill tool to read it "
+        f"again. Follow the skill instructions to fulfill the user's "
+        f"request above. Relative paths inside the skill (e.g. "
+        f"`scripts/`) resolve against the directory above.\n\n"
         f"{skill_body.strip()}\n"
+        f"</content>\n"
         f"</skill>"
     )
 
@@ -634,9 +643,10 @@ async def _skill_fallback_handler(
     raw = read_text_file_with_encoding_fallback(skill_md)
     post = fm.loads(raw)
     display_name = post.get("name") or skill_name
+    description = post.get("description") or ""
 
     if not user_input:
-        desc = post.get("description") or "No description."
+        desc = description or "No description."
         return Msg(
             name="assistant",
             role="assistant",
@@ -670,8 +680,8 @@ async def _skill_fallback_handler(
                     merged = _build_skill_injection(
                         _extract_block_text(block),
                         display_name,
+                        description,
                         skill_dir,
-                        user_input,
                         post.content,
                     )
                     content[i] = TextBlock(type="text", text=merged)
@@ -679,8 +689,8 @@ async def _skill_fallback_handler(
             merged = _build_skill_injection(
                 "",
                 display_name,
+                description,
                 skill_dir,
-                user_input,
                 post.content,
             )
             content.insert(0, TextBlock(type="text", text=merged))
@@ -688,8 +698,8 @@ async def _skill_fallback_handler(
             last.content = _build_skill_injection(
                 content,
                 display_name,
+                description,
                 skill_dir,
-                user_input,
                 post.content,
             )
     return None

--- a/src/qwenpaw/runtime/builtin_commands.py
+++ b/src/qwenpaw/runtime/builtin_commands.py
@@ -514,6 +514,39 @@ def _collect_conversation_specs() -> list[CommandSpec]:
 # ======================================================================
 
 
+def _extract_block_text(block: Any) -> str:
+    """Return the text of a message content block (dict or object)."""
+    if isinstance(block, dict):
+        return block.get("text") or ""
+    return getattr(block, "text", "") or ""
+
+
+def _build_skill_injection(
+    original_text: str,
+    display_name: str,
+    skill_dir: "Path",
+    user_input: str,
+    skill_body: str,
+) -> str:
+    """Keep the typed text at the head; append the skill body in a
+    trailing ``<skill>`` block (hidden from display by
+    ``strip_injected_skill_block``).
+    """
+    return (
+        f"{original_text}\n\n"
+        f'<skill name="{display_name}" dir="{skill_dir}">\n'
+        f"This block was injected because the user invoked the "
+        f"[{display_name}] skill above. It is the full content of "
+        f"the skill's SKILL.md — do not re-read that file. Follow "
+        f"these instructions to fulfill the user's task: "
+        f"{user_input}\n"
+        f"Relative paths inside the skill (e.g. `scripts/`) resolve "
+        f"against the skill directory.\n\n"
+        f"{skill_body.strip()}\n"
+        f"</skill>"
+    )
+
+
 def _parse_skill_query(query: str) -> tuple[str, str] | None:
     """Parse ``/name [input]`` or ``/[name with spaces] [input]``."""
     stripped = query.strip()
@@ -621,13 +654,7 @@ async def _skill_fallback_handler(
             ],
         )
 
-    # Rewrite last message with skill body — agent will execute with it
-    merged = (
-        f"Use the [{display_name}] skill in "
-        f"`{skill_dir}` to fulfill "
-        f"user's task: {user_input}\n\n"
-        f"{post.content}"
-    )
+    # Append the skill body as a trailing <skill> block; typed text stays.
     msgs = getattr(ctx, "input_msgs", None)
     if msgs:
         last = msgs[-1]
@@ -640,11 +667,31 @@ async def _skill_fallback_handler(
                     else getattr(block, "type", None)
                 )
                 if btype == "text":
+                    merged = _build_skill_injection(
+                        _extract_block_text(block),
+                        display_name,
+                        skill_dir,
+                        user_input,
+                        post.content,
+                    )
                     content[i] = TextBlock(type="text", text=merged)
                     return None
+            merged = _build_skill_injection(
+                "",
+                display_name,
+                skill_dir,
+                user_input,
+                post.content,
+            )
             content.insert(0, TextBlock(type="text", text=merged))
         elif isinstance(content, str):
-            last.content = merged
+            last.content = _build_skill_injection(
+                content,
+                display_name,
+                skill_dir,
+                user_input,
+                post.content,
+            )
     return None
 
 


### PR DESCRIPTION
## Description

The fix from #5146 regressed (caused by agentscope2.0 update); this PR re-applies it.

**Security Considerations:** None. Change only affects how a slash-command skill body is injected into the message and hidden from display; no auth, env, or config handling is affected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `/<skill_name> <input>`: model receives the full `SKILL.md` inside a trailing `<skill>` block, while the display transcript shows only the user's typed text.
- `/<skill_name>` with no input still returns the skill description (name / command / path) and does not inject.
- Unknown or channel-disabled skill name falls through to the normal agent (no injection).

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pytest tests/unit/app/chats/test_utils.py -q
# 23 passed in 0.33s
```

## Additional Notes

Only invocations made after this change fold; old-format messages already persisted have no `<skill>` block and still render in full.
