### PR TITLE
perf(runtime): join tool argument fragments once

### DIFF
--- a/src/qwenpaw/runtime/envelope.py
+++ b/src/qwenpaw/runtime/envelope.py
@@ -399,7 +399,7 @@ class Envelope:
 
             self._tool_calls[call_id] = {
                 "name": event.tool_call_name,
-                "args_json_acc": "",
+                "argument_fragments": [],
                 "message": plugin_call_message,
                 "output_text_acc": "",
                 "output_data_blocks": {},
@@ -410,7 +410,8 @@ class Envelope:
             state = self._tool_calls.get(call_id)
             if state is None:
                 return
-            state["args_json_acc"] += event.delta or ""
+            argument_delta = event.delta or ""
+            state["argument_fragments"].append(argument_delta)
 
             delta_content = DataContent(
                 type=ContentType.DATA,
@@ -418,7 +419,7 @@ class Envelope:
                 # send the incremental argument fragment here; repeating the
                 # call ID or name would concatenate those fields as well.
                 data=FunctionCall(
-                    arguments=event.delta or "",
+                    arguments=argument_delta,
                 ).model_dump(exclude_none=True),
                 delta=True,
                 index=0,
@@ -431,13 +432,14 @@ class Envelope:
             state = self._tool_calls.get(call_id)
             if state is None:
                 return
+            arguments = "".join(state.pop("argument_fragments", []))
 
             final_content = DataContent(
                 type=ContentType.DATA,
                 data=FunctionCall(
                     call_id=call_id,
                     name=state["name"],
-                    arguments=state["args_json_acc"],
+                    arguments=arguments,
                 ).model_dump(),
                 delta=False,
             )
@@ -453,7 +455,7 @@ class Envelope:
             if state is None:
                 state = {
                     "name": event.tool_call_name,
-                    "args_json_acc": "",
+                    "argument_fragments": [],
                     "output_text_acc": "",
                     "output_data_blocks": {},
                 }


### PR DESCRIPTION
## Description

This PR removes the remaining quadratic string concatenation in QwenPaw tool-call argument accumulation.

After #6343, QwenPaw forwards incremental argument deltas to the Console instead of serializing every cumulative snapshot. However, the runtime Envelope still rebuilt the complete argument string on every delta with string concatenation. Large tool calls such as write_file therefore continued to perform O(n²) cumulative copying inside the process even though the retained SSE volume was already linear.

The Envelope now stores argument fragments in a list, joins them once when TOOL_CALL_END arrives, and immediately removes the fragment list from per-call state. The streamed delta payload and the final FunctionCall payload are unchanged.

**Related Issue:** Relates to #6314  
**Follow-up to:** #6343

**Security Considerations:** No security behavior or validation is changed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Performance improvement

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable. This PR only changes the runtime Envelope accumulator.

## Testing

- `conda run -n Codex-QwenPaw pytest tests/unit/runtime -q`
- `conda run -n Codex-QwenPaw pre-commit run --files src/qwenpaw/runtime/envelope.py`

No test files are changed in this PR.

## Evidence

```text
............................................................             [100%]
60 passed in 23.72s

mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

Synthetic accumulation benchmark using 800-character fragments:

| Final input | Fragments | Repeated concatenation | List plus one join | Theoretical old copy volume |
| ---: | ---: | ---: | ---: | ---: |
| 1 MiB | 1,311 | 0.010629 s | 0.000081 s | 656.1 MiB |
| 2 MiB | 2,622 | 0.118772 s | 0.000206 s | 2,623.6 MiB |
| 4 MiB | 5,243 | 0.672555 s | 0.000417 s | 10,488.2 MiB |
| 8 MiB | 10,486 | 2.738893 s | 0.000745 s | 41,949.0 MiB |

## Additional Notes

The final complete argument string is still retained because it is required for tool execution. This change reduces cumulative allocation and event-loop blocking; it does not claim to eliminate the final O(n) argument storage.