### PR TITLE
fix(loop): wait for stopped task cleanup

### DIFF
--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -180,9 +180,14 @@ class TaskTracker:
                 "[STOP] Calling task.cancel() for run_key=%s",
                 run_key,
             )
-            state.task.cancel()
+            task = state.task
+            task.cancel()
             logger.debug("[STOP] task.cancel() called for run_key=%s", run_key)
-            return True
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return True
 
     async def attach_or_start(
         self,


### PR DESCRIPTION
## Description

Wait for a cancelled chat task to finish its cleanup before the stop API
returns.

Previously, `TaskTracker.request_stop()` returned immediately after calling
`task.cancel()`. The Console could then refresh loop status before the task
had reached its terminal state, causing Goal Mode and other loop modes to
remain displayed as running after the user stopped them.

The cancellation wait happens after releasing the tracker lock so the
producer can acquire the same lock and complete its cleanup without a
deadlock. Users now see the mode leave the running state when stop completes.

**Related Issue:** N/A (no issue provided)

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this internal behavior fix)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

Run the existing task tracker and loop status router test suites:

```bash
conda run -n Codex-QwenPaw pytest tests/unit/app/test_task_tracker.py -q
conda run -n Codex-QwenPaw pytest tests/unit/app/routers/test_loops_router.py -q
conda run -n Codex-QwenPaw pre-commit run --files src/qwenpaw/app/task_tracker.py
```

## Evidence

```text
tests/unit/app/test_task_tracker.py:
12 passed in 0.43s

tests/unit/app/routers/test_loops_router.py:
14 passed, 1 warning in 0.86s

pre-commit for src/qwenpaw/app/task_tracker.py:
check python ast, docstring, encoding, private key, whitespace,
trailing commas, mypy, black, flake8, pylint: Passed
```

The router test warning is an existing Starlette deprecation warning from
FastAPI's TestClient import.

## Additional Notes

No new tests were added. The existing cancellation and loop status tests
cover the affected paths.
