### PR TITLE
fix(mission): handle malformed user stories

### DIFF
--- a/src/qwenpaw/modes/mission/gates.py
+++ b/src/qwenpaw/modes/mission/gates.py
@@ -121,6 +121,15 @@ class MissionGate(LoopGate):
             )
 
         stories = prd.get("userStories", [])
+        if not isinstance(stories, list) or not all(
+            isinstance(story, dict) for story in stories
+        ):
+            self.deactivate()
+            return StopHandlerResult(
+                action=StopAction.TERMINATE,
+                reason="Invalid user stories in prd.json",
+            )
+
         if not stories:
             self.deactivate()
             return StopHandlerResult(

--- a/tests/unit/loop/test_mission_gate.py
+++ b/tests/unit/loop/test_mission_gate.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Regression tests for MissionGate PRD validation."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from qwenpaw.loop.gates.base import StopAction
+from qwenpaw.modes.mission.gates import MissionGate
+
+
+@pytest.mark.parametrize(
+    "stories",
+    [
+        pytest.param("invalid", id="scalar"),
+        pytest.param([None], id="non-object"),
+    ],
+)
+def test_malformed_user_stories_terminate_mission(tmp_path, stories):
+    """Malformed story data stops a mission without a continuation."""
+    gate = MissionGate()
+
+    with patch(
+        "qwenpaw.loop.gates.loop_gate._session_id",
+        return_value="mission-session",
+    ):
+        gate.activate_for_mission(tmp_path)
+
+        result = gate._eval_prd({"userStories": stories}, {})
+
+        assert result.action == StopAction.TERMINATE
+        assert result.reason == "Invalid user stories in prd.json"
+        assert gate._state() is None


### PR DESCRIPTION
## Description

MissionGate assumes that `userStories` is a list of JSON objects. A truthy scalar or a list containing a non-object currently reaches `get_all_passed()` and raises `AttributeError`, which prevents the Mission loop from closing cleanly.

This change validates `userStories` before evaluating completion. Invalid story data now deactivates the gate and returns `TERMINATE`; valid lists retain their existing behavior. Focused regression coverage includes a scalar and a non-object list entry.

**Related Issue:** Relates to #5918

**Security Considerations:** None. The change only rejects malformed local mission state before it reaches the continuation path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed: an isolated behavior check loading the real `gates.py` for `"invalid"` and `[None]`; both cases return `TERMINATE`, use the invalid-data reason, and clear MissionGate state.
- Passed: `python -m py_compile src/qwenpaw/modes/mission/gates.py tests/unit/loop/test_mission_gate.py`.
- Passed: `python -m black --check --line-length 79 src/qwenpaw/modes/mission/gates.py tests/unit/loop/test_mission_gate.py`.
- Passed: `python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/modes/mission/gates.py tests/unit/loop/test_mission_gate.py`.
- Not run: `pytest -q tests/unit/loop/test_mission_gate.py` could not collect because the local environment lacks `agentscope`. An isolated `.venv` install with `pip install -e ".[test,dev]"` timed out while downloading from PyPI.

## Evidence

An isolated check exercises both malformed cases: a scalar `userStories` value and a list containing `None` each return `TERMINATE`, deactivate the MissionGate, and avoid the previous `AttributeError`.

```
isolated MissionGate behavior check
handled 'invalid': terminate
handled [None]: terminate

python -m py_compile src/qwenpaw/modes/mission/gates.py tests/unit/loop/test_mission_gate.py
# passed

python -m black --check --line-length 79 src/qwenpaw/modes/mission/gates.py tests/unit/loop/test_mission_gate.py
# 2 files would be left unchanged

python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/modes/mission/gates.py tests/unit/loop/test_mission_gate.py
# passed
```

## Additional Notes

No dependency, public API, or documentation changes are required for this malformed persisted-state guard.

