### PR TITLE
feat(console): add sorting to plugin market

### DIFF
--- a/console/src/api/modules/pluginMarket.ts
+++ b/console/src/api/modules/pluginMarket.ts
@@ -23,6 +23,8 @@ export interface MarketPluginEntry {
   is_featured?: boolean;
 }
 
+export type MarketPluginSortBy = "downloads" | "updated_time" | "fauvarate";
+
 interface MarketPluginListResponse {
   success: boolean;
   message: string;
@@ -35,6 +37,7 @@ interface MarketPluginListResponse {
 export interface FetchMarketPluginsParams {
   search?: string;
   category?: string;
+  sort_by?: MarketPluginSortBy;
   page_number: number;
   page_size: number;
 }
@@ -50,6 +53,7 @@ export async function fetchMarketPlugins(
   url.searchParams.set("page_size", String(params.page_size));
   if (params.search) url.searchParams.set("search", params.search);
   if (params.category) url.searchParams.set("category", params.category);
+  if (params.sort_by) url.searchParams.set("sort_by", params.sort_by);
 
   const response = await fetch(url.toString(), {
     headers: buildAuthHeaders(),

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2896,6 +2896,10 @@
     "marketDetails": "Details",
     "marketDownloads": "Downloads",
     "marketDeveloper": "Developer",
+    "marketSortLabel": "Sort plugins",
+    "marketSortDownloads": "Most downloaded",
+    "marketSortUpdated": "Recently updated",
+    "marketSortFavorites": "Most favorited",
     "compatWarningTitle": "Compatibility Warning",
     "compatWarningContent": "This plugin is labeled for QwenPaw {{labels}}. Your QwenPaw version is {{version}}. Installing it may cause errors. Are you sure you want to continue?",
     "compatWarningConfirm": "Install anyway"

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -995,7 +995,11 @@
     "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
     "marketDetails": "Details",
     "marketDownloads": "Downloads",
-    "marketDeveloper": "Developer"
+    "marketDeveloper": "Developer",
+    "marketSortLabel": "Sort plugins",
+    "marketSortDownloads": "Most downloaded",
+    "marketSortUpdated": "Recently updated",
+    "marketSortFavorites": "Most favorited"
   },
   "debug": {
     "title": "Debug",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2676,7 +2676,11 @@
     "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
     "marketDetails": "Details",
     "marketDownloads": "Downloads",
-    "marketDeveloper": "Developer"
+    "marketDeveloper": "Developer",
+    "marketSortLabel": "Sort plugins",
+    "marketSortDownloads": "Most downloaded",
+    "marketSortUpdated": "Recently updated",
+    "marketSortFavorites": "Most favorited"
   },
   "inbox": {
     "title": "受信トレイ",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2731,7 +2731,11 @@
     "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
     "marketDetails": "Details",
     "marketDownloads": "Downloads",
-    "marketDeveloper": "Developer"
+    "marketDeveloper": "Developer",
+    "marketSortLabel": "Sort plugins",
+    "marketSortDownloads": "Most downloaded",
+    "marketSortUpdated": "Recently updated",
+    "marketSortFavorites": "Most favorited"
   },
   "inbox": {
     "title": "Colheita diária de IA",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2691,7 +2691,11 @@
     "marketSearchResult": "Found {{count}} plugins matching \"{{keyword}}\"",
     "marketDetails": "Details",
     "marketDownloads": "Downloads",
-    "marketDeveloper": "Developer"
+    "marketDeveloper": "Developer",
+    "marketSortLabel": "Sort plugins",
+    "marketSortDownloads": "Most downloaded",
+    "marketSortUpdated": "Recently updated",
+    "marketSortFavorites": "Most favorited"
   },
   "inbox": {
     "title": "Ежедневный AI-сбор",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2915,6 +2915,10 @@
     "marketDetails": "详情",
     "marketDownloads": "下载量",
     "marketDeveloper": "开发者",
+    "marketSortLabel": "插件排序",
+    "marketSortDownloads": "下载量最多",
+    "marketSortUpdated": "最近更新",
+    "marketSortFavorites": "收藏量最多",
     "compatWarningTitle": "兼容性警告",
     "compatWarningContent": "该插件标注适配 QwenPaw {{labels}}，而您当前的 QwenPaw 版本为 {{version}}。安装后可能出现错误，是否确认继续？",
     "compatWarningConfirm": "仍然安装"

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.test.tsx
@@ -9,6 +9,7 @@ import { MarketPluginList } from "./MarketPluginList";
 const hoisted = vi.hoisted(() => ({
   plugins: [] as MarketPluginEntry[],
   handleInstall: vi.fn(),
+  handleSortChange: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -27,11 +28,13 @@ vi.mock("../hooks/useMarketPlugins", () => ({
     page: 1,
     pageSize: 20,
     category: undefined,
+    sortBy: "downloads",
     installingId: null,
     qwenpawVersion: "2.0.0",
     isCompatible: () => true,
     handleSearch: vi.fn(),
     handleCategoryChange: vi.fn(),
+    handleSortChange: hoisted.handleSortChange,
     handlePageChange: vi.fn(),
     handleRefresh: vi.fn(),
     handleInstall: hoisted.handleInstall,
@@ -68,6 +71,7 @@ describe("MarketPluginList", () => {
   beforeEach(() => {
     hoisted.plugins.length = 0;
     hoisted.handleInstall.mockReset();
+    hoisted.handleSortChange.mockReset();
     invoke.mockReset();
     invoke.mockResolvedValue(undefined);
     isTauri.mockReturnValue(false);
@@ -113,5 +117,18 @@ describe("MarketPluginList", () => {
     render(<MarketPluginList onInstalled={vi.fn()} />);
 
     expect(screen.getByText("QwenPaw 1.x, 2.x")).toBeInTheDocument();
+  });
+
+  it("changes the plugin market sort order", () => {
+    render(<MarketPluginList onInstalled={vi.fn()} />);
+
+    fireEvent.mouseDown(
+      screen.getByRole("combobox", {
+        name: "pluginManager.marketSortLabel",
+      }),
+    );
+    fireEvent.click(screen.getByText("pluginManager.marketSortUpdated"));
+
+    expect(hoisted.handleSortChange.mock.calls[0]?.[0]).toBe("updated_time");
   });
 });

--- a/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
+++ b/console/src/pages/Settings/PluginManager/components/MarketPluginList.tsx
@@ -6,13 +6,17 @@ import {
   Input,
   Modal,
   Pagination,
+  Select,
   Spin,
   Tag,
   Tooltip,
   Typography,
 } from "antd";
 import { Download, ExternalLink, Package, RefreshCw } from "lucide-react";
-import type { MarketPluginEntry } from "@/api/modules/pluginMarket";
+import type {
+  MarketPluginEntry,
+  MarketPluginSortBy,
+} from "@/api/modules/pluginMarket";
 import { openExternalLink } from "@/utils/openExternalLink";
 import { useMarketPlugins } from "../hooks/useMarketPlugins";
 import styles from "./OfficialPluginList.module.less";
@@ -28,6 +32,15 @@ const PLUGIN_CATEGORIES = [
   { code: "hook", zh: "生命周期 Hook", en: "Lifecycle Hook" },
   { code: "frontend", zh: "UI 扩展", en: "UI Extension" },
   { code: "general", zh: "通用插件", en: "General" },
+];
+
+const MARKET_SORT_OPTIONS: Array<{
+  value: MarketPluginSortBy;
+  labelKey: string;
+}> = [
+  { value: "downloads", labelKey: "pluginManager.marketSortDownloads" },
+  { value: "updated_time", labelKey: "pluginManager.marketSortUpdated" },
+  { value: "fauvarate", labelKey: "pluginManager.marketSortFavorites" },
 ];
 
 function pickLocalizedDescription(
@@ -69,11 +82,13 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
     page,
     pageSize,
     category,
+    sortBy,
     installingId,
     qwenpawVersion,
     isCompatible,
     handleSearch,
     handleCategoryChange,
+    handleSortChange,
     handlePageChange,
     handleRefresh,
     handleInstall,
@@ -129,6 +144,16 @@ export function MarketPluginList({ onInstalled }: MarketPluginListProps) {
           </div>
         )}
         <div className={marketStyles.toolbarRight}>
+          <Select<MarketPluginSortBy>
+            aria-label={t("pluginManager.marketSortLabel")}
+            value={sortBy}
+            onChange={handleSortChange}
+            options={MARKET_SORT_OPTIONS.map((option) => ({
+              value: option.value,
+              label: t(option.labelKey),
+            }))}
+            style={{ width: 168 }}
+          />
           <Input.Search
             placeholder={t("pluginManager.marketSearch")}
             allowClear

--- a/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
+++ b/console/src/pages/Settings/PluginManager/hooks/useMarketPlugins.ts
@@ -5,6 +5,7 @@ import {
   fetchMarketPlugins,
   buildMarketDownloadUrl,
   type MarketPluginEntry,
+  type MarketPluginSortBy,
 } from "@/api/modules/pluginMarket";
 import { installPlugin } from "@/api/modules/plugin";
 
@@ -49,6 +50,7 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   const [pageSize] = useState(20);
   const [search, setSearch] = useState("");
   const [category, setCategory] = useState<string | undefined>(undefined);
+  const [sortBy, setSortBy] = useState<MarketPluginSortBy>("downloads");
   const [installingId, setInstallingId] = useState<string | null>(null);
   const [qwenpawVersion, setQwenpawVersion] = useState<string | null>(null);
 
@@ -80,7 +82,12 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   }, []);
 
   const loadPlugins = useCallback(
-    async (pageNum: number, keyword: string, cat?: string) => {
+    async (
+      pageNum: number,
+      keyword: string,
+      cat: string | undefined,
+      sort: MarketPluginSortBy,
+    ) => {
       setLoading(true);
       setError(null);
       try {
@@ -89,6 +96,7 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
           page_size: pageSize,
           search: keyword || undefined,
           category: cat || undefined,
+          sort_by: sort,
         });
         setPlugins(data.plugins ?? []);
         setTotal(data.total);
@@ -104,8 +112,8 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
   );
 
   useEffect(() => {
-    void loadPlugins(page, search, category);
-  }, [page, search, category, loadPlugins]);
+    void loadPlugins(page, search, category, sortBy);
+  }, [page, search, category, sortBy, loadPlugins]);
 
   const handleSearch = useCallback((keyword: string) => {
     setSearch(keyword);
@@ -117,13 +125,18 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
     setPage(1);
   }, []);
 
+  const handleSortChange = useCallback((sort: MarketPluginSortBy) => {
+    setSortBy(sort);
+    setPage(1);
+  }, []);
+
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);
   }, []);
 
   const handleRefresh = useCallback(() => {
-    void loadPlugins(page, search, category);
-  }, [loadPlugins, page, search, category]);
+    void loadPlugins(page, search, category, sortBy);
+  }, [loadPlugins, page, search, category, sortBy]);
 
   const isCompatible = useCallback(
     (entry: MarketPluginEntry) =>
@@ -163,11 +176,13 @@ export function useMarketPlugins({ onInstalled }: UseMarketPluginsOptions) {
     page,
     pageSize,
     category,
+    sortBy,
     installingId,
     qwenpawVersion,
     isCompatible,
     handleSearch,
     handleCategoryChange,
+    handleSortChange,
     handlePageChange,
     handleRefresh,
     handleInstall,

--- a/src/qwenpaw/app/routers/plugins.py
+++ b/src/qwenpaw/app/routers/plugins.py
@@ -902,6 +902,7 @@ async def search_market_plugins(
     page_size: int = 20,
     search: Optional[str] = None,
     category: Optional[str] = None,
+    sort_by: Optional[str] = None,
 ):
     """Proxy plugin search to AgentScope Platform to avoid CORS."""
     import httpx
@@ -914,6 +915,8 @@ async def search_market_plugins(
         params["search"] = search
     if category:
         params["category"] = category
+    if sort_by:
+        params["sort_by"] = sort_by
 
     try:
         async with httpx.AsyncClient(


### PR DESCRIPTION
## Description

- Add sorting by downloads, update time, and favorites.
- Forward sort_by through the plugin market proxy.
- Ensure English sorting labels display correctly.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
