### PR TITLE
fix(memory): guide failed memory edits

### DIFF
--- a/src/qwenpaw/agents/memory/prompts.py
+++ b/src/qwenpaw/agents/memory/prompts.py
@@ -13,6 +13,7 @@ MEMORY_GUIDANCE_ZH_TEMPLATE = """\
 - **MEMORY.md** — 长期记忆：持久的事实、偏好与决策。这是你精选、提炼的记忆（不是原始日志）；后台有一个定期运行的总结进程（dream），会自动把每日笔记里值得长期保留的内容整理进来。
 - **每日笔记**（`{daily_dir}/YYYY-MM-DD.md`）— 运行中的上下文与观察；这是轻量的短期记录，也是上述总结进程的来源。
 - **重要：** 避免覆盖 — 先 `read_file`，再用 `write_file` / `edit_file`。除非用户明确要求，否则不要记录敏感信息。
+- **编辑失败时：** `edit_file` 只在已知精确原文时使用。如果替换失败，不要对同一个 replacement 重试；重新 `read_file`，再用合并后的完整内容调用 `write_file`。
 
 因此你通常不必手动维护 MEMORY.md。只有当用户明确要求你记住某事，或形成了值得长期保留的决策或偏好时，才直接编辑它。
 
@@ -30,6 +31,7 @@ Each session is fresh; the working-directory files are your memory continuity.
 - **MEMORY.md** — long-term memory: durable facts, preferences, and decisions. Your curated, distilled memory (not a raw log); a background summarization job (the periodic "dream" process) automatically consolidates worthwhile daily-note content into it.
 - **Daily notes** (`{daily_dir}/YYYY-MM-DD.md`) — running context and observations; the lightweight short-term log that the summarization job draws from.
 - **Important:** Avoid overwriting — `read_file` first, then `write_file` / `edit_file`. Unless the user explicitly asks, do not record sensitive information.
+- **When an edit fails:** Use `edit_file` only when you know the exact existing text. If a replacement fails, do not retry the same replacement. Instead, read the file again and use `write_file` with the merged full content.
 
 So you usually don't need to maintain MEMORY.md by hand. Edit it directly only when the user explicitly asks you to remember something, or a decision or preference worth keeping long-term is settled.
 

--- a/tests/unit/agents/memory/test_prompts.py
+++ b/tests/unit/agents/memory/test_prompts.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Tests for memory guidance prompts."""
+
+import pytest
+
+from qwenpaw.agents.memory.prompts import build_memory_guidance_prompt
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_instructions"),
+    [
+        (
+            "zh",
+            (
+                "`edit_file` 只在已知精确原文时使用",
+                "不要对同一个 replacement 重试",
+                "重新 `read_file`，再用合并后的完整内容调用 `write_file`",
+            ),
+        ),
+        (
+            "en",
+            (
+                "Use `edit_file` only when you know the exact existing text.",
+                "do not retry the same replacement.",
+                (
+                    "read the file again and use `write_file` with the "
+                    "merged full content."
+                ),
+            ),
+        ),
+    ],
+)
+def test_memory_guidance_recovers_from_failed_edit(
+    language,
+    expected_instructions,
+):
+    """A failed replacement must direct the agent to a safe fallback."""
+    prompt = build_memory_guidance_prompt(
+        language,
+        daily_dir="memory/daily",
+    )
+
+    for instruction in expected_instructions:
+        assert instruction in prompt


### PR DESCRIPTION
## Description

Adds explicit recovery guidance to the Chinese and English MEMORY.md prompts. Agents now use `edit_file` only when the exact existing text is known; after a failed replacement, they reload the file and use `write_file` with merged full content instead of repeating the same replacement.

**Related Issue:** Fixes #3015

**Security Considerations:** None. The existing read-before-write guidance remains in place; this adds a safer failed-edit path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed: isolated recovery assertions for both the English and Chinese prompts.
- Passed: `python -m py_compile src/qwenpaw/agents/memory/prompts.py tests/unit/agents/memory/test_prompts.py`.
- Passed: Black, Flake8, and `git diff --check` for the changed files.
- Blocked: `python -m pytest tests/unit/agents/memory/test_prompts.py -q` cannot load the project because this environment has no installed `qwenpaw` package.
- Blocked: `pre-commit` is not installed in this environment, so the repository-wide pre-commit gate was not run.

## Evidence

Both rendered prompt variants now state that `edit_file` requires an exact current match and, after a failed edit, require rereading the file and using `write_file` with merged full content instead of repeating the same replacement.

```text
python -m black --check --line-length 79 src/qwenpaw/agents/memory/prompts.py tests/unit/agents/memory/test_prompts.py
All done! 2 files would be left unchanged.

python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/agents/memory/prompts.py tests/unit/agents/memory/test_prompts.py
exit 0

python -m py_compile src/qwenpaw/agents/memory/prompts.py tests/unit/agents/memory/test_prompts.py
exit 0

git diff --check
exit 0
```

## Additional Notes

The change intentionally does not alter file tools, memory file layout, retry policy, or the ReMe memory backend.

