### PR TITLE
fix(mission): avoid directory collisions

### DIFF
--- a/src/qwenpaw/modes/mission/state.py
+++ b/src/qwenpaw/modes/mission/state.py
@@ -139,10 +139,17 @@ async def detect_git_context(workspace_dir: Path) -> dict[str, Any]:
 def create_loop_dir(workspace_dir: Path) -> Path:
     """Create a new mission directory and return its path."""
     loop_id = f"mission-{_ts()}"
-    loop_dir = workspace_dir / "missions" / loop_id
-    loop_dir.mkdir(parents=True, exist_ok=True)
-    logger.info("Created mission dir: %s", loop_dir)
-    return loop_dir
+    suffix = 0
+    while True:
+        suffix_text = f"-{suffix:04d}" if suffix else ""
+        loop_dir = workspace_dir / "missions" / f"{loop_id}{suffix_text}"
+        try:
+            loop_dir.mkdir(parents=True, exist_ok=False)
+        except FileExistsError:
+            suffix += 1
+            continue
+        logger.info("Created mission dir: %s", loop_dir)
+        return loop_dir
 
 
 def write_loop_config(loop_dir: Path, config: dict[str, Any]) -> Path:

--- a/tests/unit/loop/test_mission_settings.py
+++ b/tests/unit/loop/test_mission_settings.py
@@ -13,7 +13,10 @@ from qwenpaw.modes.mission.handler import (
     start_mission,
 )
 from qwenpaw.modes.mission.prompts import build_master_prompt
-from qwenpaw.modes.mission.state import read_loop_config
+from qwenpaw.modes.mission.state import (
+    create_loop_dir,
+    read_loop_config,
+)
 
 
 def test_mission_config_defaults_and_bounds() -> None:
@@ -73,6 +76,25 @@ def test_master_prompt_includes_verification_instructions() -> None:
 
     assert "Check Windows path handling" in prompt
     assert "**Verify command**: pytest -q" in prompt
+
+
+def test_create_loop_dir_distinguishes_same_second_missions(
+    tmp_path,
+) -> None:
+    """Mission state remains isolated when starts share a timestamp."""
+    timestamp = "20260722-200000"
+    with patch(
+        "qwenpaw.modes.mission.state._ts",
+        return_value=timestamp,
+    ):
+        first = create_loop_dir(tmp_path)
+        second = create_loop_dir(tmp_path)
+
+    assert first.name == f"mission-{timestamp}"
+    assert second.name == f"mission-{timestamp}-0001"
+    assert first != second
+    assert first.is_dir()
+    assert second.is_dir()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Prevent Mission state collisions when two missions start within the same
second. Previously, `create_loop_dir()` generated a seconds-resolution name
and used `exist_ok=True`, so both workflows could receive the same directory.
Their later task, progress, and configuration writes could then overwrite each
other.

This change atomically creates the original `mission-<timestamp>` name and
retries with `-0001`, `-0002`, and so on when that name already exists. It adds
a regression test for a fixed timestamp.

**Related Issue:** N/A (discovery-backed; no matching open issue found)

**Security Considerations:** This does not introduce user-controlled paths or
new permissions. It preserves the existing workspace path and makes directory
allocation exclusive.

**Duplicate-work check:** Searched open PRs for `mission directory`, `same
second mission`, and `create_loop_dir`. GitHub code search found only the
existing state helper and its handler call site.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed an isolated regression that fixes the timestamp and creates two
  Mission directories; it verifies the original name and the `-0001` suffix.
- Passed the same regression with 8 concurrent creators; all received a unique
  directory from the base name through `-0007`.
- Passed `python -m py_compile`, Black, Flake8, and `git diff --check` for the
  changed files.
- `python -m pre_commit run --all-files` was not runnable because `pre_commit`
  is not installed in this environment.
- The focused and full `pytest` commands were blocked during root `conftest.py`
  collection because `qwenpaw` is not installed. A direct source import also
  encounters the current tree's missing `qwenpaw._compat` module.

## Evidence

With a fixed timestamp, the first allocation preserves the base directory and the next uses `-0001`; eight concurrent creators receive eight distinct Mission directory names.

```text
isolated same-second Mission directory regression: passed
concurrent same-second Mission directory regression: passed

python -m py_compile src/qwenpaw/modes/mission/state.py tests/unit/loop/test_mission_settings.py
# passed

python -m black --check --line-length 79 src/qwenpaw/modes/mission/state.py tests/unit/loop/test_mission_settings.py
# 2 files would be left unchanged

python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/modes/mission/state.py tests/unit/loop/test_mission_settings.py
# passed

git diff --check
# passed
```

## Additional Notes

The suffix is only used after a collision, so normal Mission directory names
remain unchanged. The explicit exclusive `mkdir` keeps simultaneous processes
from reusing the same state directory.

