### PR TITLE
feat(crons): support per-job model overrides

### DIFF
--- a/console/src/api/types/cronjob.ts
+++ b/console/src/api/types/cronjob.ts
@@ -41,6 +41,10 @@ export interface CronJobRequest {
   input: unknown;
   session_id?: string | null;
   user_id?: string | null;
+  model_slot_override?: {
+    provider_id: string;
+    model: string;
+  } | null;
   [key: string]: unknown;
 }
 

--- a/console/src/pages/Control/CronJobs/index.tsx
+++ b/console/src/pages/Control/CronJobs/index.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_FORM_VALUES,
 } from "./components";
 import { parseCron, serializeCron } from "./components/parseCron";
+import { mergeCronJobRequest } from "./mergeRequest";
 import { PageHeader } from "@/components/PageHeader";
 import styles from "./index.module.less";
 
@@ -386,10 +387,10 @@ function CronJobsPage() {
       // Remove request object entirely for text tasks
       delete processedValues.request;
     } else if (processedValues.task_type === "agent") {
-      //Ensure request object exists
-      if (!processedValues.request) {
-        processedValues.request = {};
-      }
+      processedValues.request = mergeCronJobRequest(
+        editingJob?.request,
+        processedValues.request,
+      );
 
       // Parse request input JSON
       if (

--- a/console/src/pages/Control/CronJobs/mergeRequest.test.ts
+++ b/console/src/pages/Control/CronJobs/mergeRequest.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { mergeCronJobRequest } from "./mergeRequest";
+
+describe("mergeCronJobRequest", () => {
+  it("preserves request extensions while applying submitted fields", () => {
+    const existing = {
+      input: ["old"],
+      model_slot_override: {
+        provider_id: "openai",
+        model: "gpt-4o-mini",
+      },
+      request_context: { source: "cli" },
+    };
+    const submitted = { input: ["new"] };
+
+    const merged = mergeCronJobRequest(existing, submitted);
+
+    expect(merged).toEqual({
+      input: ["new"],
+      model_slot_override: {
+        provider_id: "openai",
+        model: "gpt-4o-mini",
+      },
+      request_context: { source: "cli" },
+    });
+    expect(existing.input).toEqual(["old"]);
+    expect(submitted.input).toEqual(["new"]);
+  });
+
+  it("supports creating a request without an existing job", () => {
+    expect(mergeCronJobRequest(undefined, { input: [] })).toEqual({
+      input: [],
+    });
+  });
+});

--- a/console/src/pages/Control/CronJobs/mergeRequest.ts
+++ b/console/src/pages/Control/CronJobs/mergeRequest.ts
@@ -1,0 +1,12 @@
+import type { CronJobRequest } from "../../../api/types";
+
+export function mergeCronJobRequest(
+  existing: CronJobRequest | undefined,
+  submitted: Partial<CronJobRequest> | undefined,
+): CronJobRequest {
+  return {
+    input: [],
+    ...existing,
+    ...submitted,
+  };
+}

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1335,7 +1335,7 @@ def _strip_top_level_message_name(
     return messages
 
 
-def _resolve_model_slot_override(model_slot_override: Any):
+def resolve_model_slot_override(model_slot_override: Any):
     """Parse an optional per-request model override into a model slot."""
     from ..config.config import ModelSlotConfig
 
@@ -1455,7 +1455,7 @@ def create_model_and_formatter(
         except Exception:
             pass
 
-    slot = _resolve_model_slot_override(model_slot_override)
+    slot = resolve_model_slot_override(model_slot_override)
     if slot is not None and slot.provider_id and slot.model:
         model_slot = slot
 

--- a/src/qwenpaw/agents/skills/cron-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/cron-en/SKILL.md
@@ -2,7 +2,7 @@
 name: cron
 description: Use this skill only for scheduled or recurring tasks. Manage jobs with qwenpaw cron list/create/get/state/update/pause/resume/delete/run, and always pass --agent-id explicitly.
 metadata:
-  builtin_skill_version: "1.7"
+  builtin_skill_version: "1.8"
   qwenpaw:
     emoji: "⏰"
 ---
@@ -32,6 +32,7 @@ Use this skill only when you need to **automatically execute something at a futu
 4. **All cron commands must explicitly include `--agent-id`**
 5. **Do not rely on the default agent, or the task may end up in the default workspace**
 6. **For an agent task that should run without channel output, add `--silent`; execution, session history, trace, and optional Inbox recording still continue**
+7. **When the user requests a fixed model for an agent task, pass `--model provider/model`; use `--clear-model` on update to restore runtime defaults**
 
 ---
 
@@ -160,7 +161,18 @@ qwenpaw cron create \
   --target-user "CHANGEME" \
   --target-session "CHANGEME" \
   --text "What are my pending tasks?" \
+  --model openai/gpt-4o-mini \
   --timeout 600
+```
+
+`--model` is optional and only valid for `agent` tasks. It fixes that job's
+model without changing the agent configuration. Model IDs may contain `/`
+after the provider separator. To remove the override:
+
+```bash
+qwenpaw cron update <job_id> \
+  --agent-id <agent_id> \
+  --clear-model
 ```
 
 For a background agent task, add `--silent` to the command above. Do not use it
@@ -266,6 +278,7 @@ to find the correct `job_id`.
 - When showing commands to the user, provide complete, copy-pasteable versions
 - If the user mentions "save to inbox" (or not), explicitly include `--save-result-to-inbox` or `--no-save-result-to-inbox`
 - If the user asks for background or silent execution with no channel reply, use `--silent` on an `agent` task
+- If the user names a model for an `agent` task, use `--model provider/model`; never add it to a `text` task
 - Before creating, you can run `qwenpaw chats list --agent-id <agent_id>` to get valid `target-user` and `target-session`
 
 ---

--- a/src/qwenpaw/agents/skills/cron-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/cron-zh/SKILL.md
@@ -2,7 +2,7 @@
 name: cron
 description: 仅在需要未来定时执行或周期执行任务时，使用本 skill。使用 qwenpaw cron list/create/get/state/update/pause/resume/delete/run 管理任务，并始终显式传入 --agent-id。
 metadata:
-  builtin_skill_version: "1.7"
+  builtin_skill_version: "1.8"
   qwenpaw:
     emoji: "⏰"
 ---
@@ -32,6 +32,7 @@ metadata:
 4. **所有 cron 命令都必须显式传 `--agent-id`**
 5. **不要依赖默认 agent，否则任务可能落到 default workspace**
 6. **如果 agent 任务只需后台执行、不向渠道输出，添加 `--silent`；执行、会话历史、追踪和可选收件箱记录仍会继续**
+7. **用户要求 agent 任务固定模型时，传 `--model provider/model`；更新时用 `--clear-model` 恢复运行时默认模型**
 
 ---
 
@@ -160,7 +161,17 @@ qwenpaw cron create \
   --target-user "CHANGEME" \
   --target-session "CHANGEME" \
   --text "我有什么待办事项？" \
+  --model openai/gpt-4o-mini \
   --timeout 600
+```
+
+`--model` 是可选参数，且仅适用于 `agent` 任务。它只固定当前任务的模型，
+不会修改智能体配置；provider 后的模型 ID 可以继续包含 `/`。移除覆盖值：
+
+```bash
+qwenpaw cron update <job_id> \
+  --agent-id <agent_id> \
+  --clear-model
 ```
 
 如果是后台 agent 任务，可在上面的命令中添加 `--silent`。`text` 任务不能使用该参数。
@@ -265,6 +276,7 @@ qwenpaw cron list --agent-id <agent_id>
 - 给用户展示命令时，提供完整、可直接复制的版本
 - 用户提到“结果进收件箱/不进收件箱”时，显式加 `--save-result-to-inbox` 或 `--no-save-result-to-inbox`，否则不要添加该项。
 - 用户要求后台或静默执行且不向渠道回复时，对 `agent` 任务添加 `--silent`。
+- 用户为 `agent` 任务指定模型时，使用 `--model provider/model`；不要对 `text` 任务添加该参数。
 
 ---
 

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -8,10 +8,12 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_validator,
     model_validator,
 )
 
 from ..channels.schema import DEFAULT_CHANNEL
+from ...config.config import ModelSlotConfig
 
 # ---------------------------------------------------------------------------
 # APScheduler v3 uses ISO 8601 weekday numbering (0=Mon … 6=Sun) for
@@ -191,6 +193,48 @@ class CronJobRequest(BaseModel):
     input: Optional[Any] = None
     session_id: Optional[str] = None
     user_id: Optional[str] = None
+    model_slot_override: Optional[ModelSlotConfig] = Field(
+        default=None,
+        description=(
+            "Optional per-job model selection. It takes precedence over the "
+            "agent's active model without changing persisted configuration."
+        ),
+    )
+
+    @field_validator("model_slot_override", mode="before")
+    @classmethod
+    def _normalize_model_slot_override(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+
+        provider_id, separator, model = value.partition(":")
+        if not separator:
+            raise ValueError(
+                "model_slot_override requires non-empty provider_id and model",
+            )
+        return {
+            "provider_id": provider_id.strip(),
+            "model": model.strip(),
+        }
+
+    @field_validator("model_slot_override")
+    @classmethod
+    def _validate_model_slot_override(
+        cls,
+        value: Optional[ModelSlotConfig],
+    ) -> Optional[ModelSlotConfig]:
+        if value is None:
+            return None
+
+        provider_id = value.provider_id.strip()
+        model = value.model.strip()
+        if not provider_id or not model:
+            raise ValueError(
+                "model_slot_override requires non-empty provider_id and model",
+            )
+        return value.model_copy(
+            update={"provider_id": provider_id, "model": model},
+        )
 
 
 TaskType = Literal["text", "agent"]
@@ -216,6 +260,13 @@ class CronJobSpec(BaseModel):
         if self.task_type == "text":
             if not (self.text and self.text.strip()):
                 raise ValueError("task_type is text but text is empty")
+            if (
+                self.request is not None
+                and self.request.model_slot_override is not None
+            ):
+                raise ValueError(
+                    "model override is only supported for agent tasks",
+                )
             if self.dispatch.silent:
                 raise ValueError(
                     "silent delivery is only supported for agent tasks",

--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -215,6 +215,18 @@ def _build_schedule_from_cli(
     return {"type": "cron", "cron": cron, "timezone": timezone}
 
 
+def _parse_model_option(model: str) -> Dict[str, str]:
+    provider_id, separator, model_id = model.strip().partition("/")
+    if not separator or not provider_id.strip() or not model_id.strip():
+        raise click.UsageError(
+            "--model must use the provider/model format",
+        )
+    return {
+        "provider_id": provider_id.strip(),
+        "model": model_id.strip(),
+    }
+
+
 def _build_spec_from_cli(
     task_type: str,
     schedule_type: str,
@@ -233,6 +245,7 @@ def _build_spec_from_cli(
     enabled: bool,
     mode: str,
     silent: bool,
+    model: Optional[str] = None,
     save_result_to_inbox: Optional[bool] = None,
     share_session: bool = True,
     timeout_seconds: int = 120,
@@ -265,6 +278,10 @@ def _build_spec_from_cli(
         "tool_safety": tool_safety,
     }
     if task_type == "text":
+        if model is not None:
+            raise click.UsageError(
+                "--model is only supported when task type is 'agent'",
+            )
         if silent:
             raise click.UsageError(
                 "--silent is only supported when task type is 'agent'",
@@ -293,21 +310,25 @@ def _build_spec_from_cli(
                 "--text is required when task type is 'agent' "
                 "(the question/prompt sent to the agent)",
             )
+        request = {
+            "input": [
+                {
+                    "role": "user",
+                    "type": "message",
+                    "content": [{"type": "text", "text": text.strip()}],
+                },
+            ],
+        }
+        if model is not None:
+            request["model_slot_override"] = _parse_model_option(model)
+
         payload = {
             "id": "",
             "name": name,
             "enabled": enabled,
             "schedule": schedule,
             "task_type": "agent",
-            "request": {
-                "input": [
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": [{"type": "text", "text": text.strip()}],
-                    },
-                ],
-            },
+            "request": request,
             "dispatch": dispatch,
             "runtime": runtime,
             "meta": {},
@@ -445,6 +466,15 @@ def _build_spec_from_cli(
     ),
 )
 @click.option(
+    "--model",
+    default=None,
+    metavar="PROVIDER/MODEL",
+    help=(
+        "For agent tasks, use this model instead of the agent's active model. "
+        "Example: openai/gpt-4o-mini."
+    ),
+)
+@click.option(
     "--timezone",
     default=None,
     help=(
@@ -539,6 +569,7 @@ def create_job(
     target_user: Optional[str],
     target_session: Optional[str],
     text: Optional[str],
+    model: Optional[str],
     timezone: Optional[str],
     enabled: bool,
     mode: str,
@@ -598,6 +629,7 @@ def create_job(
             target_user=target_user or "",
             target_session=target_session or "",
             text=text,
+            model=model,
             timezone=timezone,
             enabled=enabled,
             mode=mode,
@@ -629,6 +661,8 @@ def _resolve_update_spec(
     target_user: Optional[str],
     target_session: Optional[str],
     text: Optional[str],
+    model: Optional[str],
+    clear_model: bool,
     timezone: Optional[str],
     enabled: Optional[bool],
     mode: Optional[str],
@@ -644,8 +678,8 @@ def _resolve_update_spec(
     Deep-copies the existing spec and only patches fields explicitly
     provided by the CLI.  Unspecified fields — including advanced
     runtime settings (``max_concurrency``, ``misfire_grace_seconds``)
-    and request extensions (``model``, ``request_context``, …) — are
-    preserved as-is.  Returns a payload dict suitable for
+    and request extensions (``model_slot_override``, ``request_context``, …)
+    — are preserved as-is.  Returns a payload dict suitable for
     PUT /cron/jobs/{id}.
     """
     payload = copy.deepcopy(spec)
@@ -656,6 +690,24 @@ def _resolve_update_spec(
         payload["enabled"] = enabled
     if task_type is not None:
         payload["task_type"] = task_type
+
+    if model is not None and clear_model:
+        raise click.UsageError(
+            "--model and --clear-model cannot be used together",
+        )
+    if model is not None or clear_model:
+        if payload.get("task_type") != "agent":
+            raise click.UsageError(
+                "--model and --clear-model are only supported for agent jobs",
+            )
+        request = payload.get("request")
+        if not isinstance(request, dict):
+            request = {}
+            payload["request"] = request
+        if model is not None:
+            request["model_slot_override"] = _parse_model_option(model)
+        else:
+            request.pop("model_slot_override", None)
 
     # --- schedule ---
     sch = payload.setdefault("schedule", {})
@@ -810,6 +862,18 @@ def _resolve_update_spec(
     help="Text content or agent prompt.",
 )
 @click.option(
+    "--model",
+    default=None,
+    metavar="PROVIDER/MODEL",
+    help="For agent jobs, override the agent's active model.",
+)
+@click.option(
+    "--clear-model",
+    is_flag=True,
+    default=False,
+    help="Remove an agent job's model override.",
+)
+@click.option(
     "--timezone",
     default=None,
     help="Timezone for the schedule.",
@@ -883,6 +947,8 @@ def update_job(
     target_user: Optional[str],
     target_session: Optional[str],
     text: Optional[str],
+    model: Optional[str],
+    clear_model: bool,
     timezone: Optional[str],
     enabled: Optional[bool],
     mode: Optional[str],
@@ -929,6 +995,8 @@ def update_job(
             target_user=target_user,
             target_session=target_session,
             text=text,
+            model=model,
+            clear_model=clear_model,
             timezone=timezone,
             enabled=enabled,
             mode=mode,

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -243,6 +243,7 @@ class AgentBuilder:
             ensure_skills_initialized,
             resolve_effective_skills,
         )
+        from ..agents.model_factory import resolve_model_slot_override
         from ..config.config import load_agent_config
         from ..constant import WORKING_DIR
         from ..providers.provider_manager import ProviderManager
@@ -256,8 +257,12 @@ class AgentBuilder:
         )
         ctx.agent_config = agent_config
 
-        # Validate model availability.
-        active = agent_config.active_model
+        model_slot_override = resolve_model_slot_override(
+            getattr(ctx.request, "model_slot_override", None),
+        )
+        active = model_slot_override
+        if not (active and active.provider_id and active.model):
+            active = agent_config.active_model
         if not (active and active.provider_id and active.model):
             active = ProviderManager.get_instance().get_active_model()
         if active is None or not active.provider_id or not active.model:
@@ -341,7 +346,6 @@ class AgentBuilder:
 
         # Model + formatter (built before the toolkit so the scroll context
         # strategy, which needs the model for token counting, can wire in).
-        model_slot_override = getattr(ctx.request, "model_slot_override", None)
         model, _formatter = self.build_model(
             agent_config,
             model_slot_override=model_slot_override,

--- a/tests/unit/app/crons/test_executor.py
+++ b/tests/unit/app/crons/test_executor.py
@@ -7,6 +7,7 @@ import pytest
 
 from qwenpaw.app.crons.executor import CronExecutor
 from qwenpaw.app.crons.models import DispatchSpec, DispatchTarget
+from qwenpaw.config.config import ModelSlotConfig
 from qwenpaw.schemas import Event, RunStatus
 from tests.unit.app.conftest import make_cron_job_spec
 
@@ -17,8 +18,10 @@ class _Workspace:
     def __init__(self, events=None) -> None:
         self.events_consumed = 0
         self.events = events if events is not None else ("first", "second")
+        self.last_request = None
 
-    async def stream_query(self, _request):
+    async def stream_query(self, request):
+        self.last_request = request
         for event in self.events:
             self.events_consumed += 1
             yield event
@@ -54,6 +57,11 @@ async def test_silent_agent_job_runs_without_channel_delivery(monkeypatch):
         target=DispatchTarget(user_id="u1", session_id="console:u1"),
         silent=True,
     )
+    assert job.request is not None
+    job.request.model_slot_override = ModelSlotConfig(
+        provider_id="openai",
+        model="gpt-4o-mini",
+    )
 
     finalize_trace = _patch_trace_storage(monkeypatch)
 
@@ -63,6 +71,10 @@ async def test_silent_agent_job_runs_without_channel_delivery(monkeypatch):
     ).execute(job)
 
     assert workspace.events_consumed == 2
+    assert workspace.last_request["model_slot_override"] == {
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+    }
     channel_manager.send_event.assert_not_awaited()
     assert result["delivery_status"] == "suppressed"
     finalize_trace.assert_awaited_once_with(result["run_id"], status="success")

--- a/tests/unit/app/crons/test_models.py
+++ b/tests/unit/app/crons/test_models.py
@@ -6,13 +6,13 @@ from pydantic import ValidationError
 
 from qwenpaw.app.crons.models import (
     CronJobSpec,
+    CronJobRequest,
     DispatchSpec,
     DispatchTarget,
     ScheduleSpec,
     _crontab_dow_to_name,
 )
 from tests.unit.app.conftest import make_cron_job_spec
-
 
 # ---------------------------------------------------------------------------
 # _crontab_dow_to_name — crontab numeric DOW → abbreviation
@@ -84,6 +84,53 @@ def test_schedule_once_requires_run_at():
 
 
 # ---------------------------------------------------------------------------
+# CronJobRequest model override
+# ---------------------------------------------------------------------------
+
+
+def test_cron_job_request_exposes_model_slot_override_in_schema():
+    properties = CronJobRequest.model_json_schema()["properties"]
+
+    assert "model_slot_override" in properties
+
+
+def test_cron_job_request_normalizes_model_slot_override():
+    request = CronJobRequest(
+        model_slot_override={
+            "provider_id": " openai ",
+            "model": " gpt-4o-mini ",
+        },
+    )
+
+    assert request.model_slot_override.provider_id == "openai"
+    assert request.model_slot_override.model == "gpt-4o-mini"
+    assert request.model_dump(mode="json")["model_slot_override"] == {
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+    }
+
+
+def test_cron_job_request_keeps_colon_string_compatibility():
+    request = CronJobRequest(model_slot_override="openai:gpt-4o:2024")
+
+    assert request.model_slot_override.provider_id == "openai"
+    assert request.model_slot_override.model == "gpt-4o:2024"
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"provider_id": "", "model": "gpt-4o-mini"},
+        {"provider_id": "openai", "model": ""},
+        "missing-separator",
+    ],
+)
+def test_cron_job_request_rejects_incomplete_model_override(override):
+    with pytest.raises(ValidationError, match="provider_id.*model"):
+        CronJobRequest(model_slot_override=override)
+
+
+# ---------------------------------------------------------------------------
 # CronJobSpec validation
 # ---------------------------------------------------------------------------
 
@@ -143,3 +190,19 @@ def test_cron_job_spec_text_rejects_silent_delivery():
                 silent=True,
             ),
         )
+
+
+def test_cron_job_spec_text_rejects_model_override():
+    payload = make_cron_job_spec(task_type="text").model_dump(mode="json")
+    payload["request"] = {
+        "model_slot_override": {
+            "provider_id": "openai",
+            "model": "gpt-4o-mini",
+        },
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match="model override is only supported for agent tasks",
+    ):
+        CronJobSpec.model_validate(payload)

--- a/tests/unit/cli/test_cron_cmd.py
+++ b/tests/unit/cli/test_cron_cmd.py
@@ -31,6 +31,7 @@ def _agent_spec(**overrides):
         "enabled": True,
         "mode": "final",
         "silent": False,
+        "model": None,
     }
     values.update(overrides)
     return _build_spec_from_cli(**values)
@@ -52,6 +53,42 @@ def test_create_help_exposes_silent_delivery_flag():
 
     assert result.exit_code == 0
     assert "--silent / --no-silent" in result.output
+
+
+def test_build_agent_spec_includes_model_override():
+    payload = _agent_spec(model="openai/gpt-4o-mini")
+
+    assert payload["request"]["model_slot_override"] == {
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+    }
+
+
+def test_build_agent_spec_allows_slash_in_model_id():
+    payload = _agent_spec(model="openrouter/meta-llama/llama-3.3-70b")
+
+    assert payload["request"]["model_slot_override"] == {
+        "provider_id": "openrouter",
+        "model": "meta-llama/llama-3.3-70b",
+    }
+
+
+@pytest.mark.parametrize("model", ["gpt-4o-mini", "/gpt-4o-mini", "openai/"])
+def test_build_agent_spec_rejects_invalid_model_override(model):
+    with pytest.raises(click.UsageError, match="provider/model"):
+        _agent_spec(model=model)
+
+
+def test_build_text_spec_rejects_model_override():
+    with pytest.raises(click.UsageError, match="only supported.*agent"):
+        _agent_spec(task_type="text", model="openai/gpt-4o-mini")
+
+
+def test_create_help_exposes_model_option():
+    result = CliRunner().invoke(cron_group, ["create", "--help"])
+
+    assert result.exit_code == 0
+    assert "--model" in result.output
 
 
 # --- _resolve_update_spec regression tests (issue #6176) ---
@@ -77,6 +114,8 @@ def _update(full_spec: dict, **overrides) -> dict:
         "enabled": None,
         "mode": None,
         "silent": None,
+        "model": None,
+        "clear_model": False,
         "save_result_to_inbox": None,
         "share_session": None,
         "timeout_seconds": None,
@@ -171,6 +210,52 @@ def test_update_preserves_request_extensions():
     assert result["name"] == "renamed-agent"
     assert result["request"]["model"] == "custom-model"
     assert result["request"]["request_context"] == {"source_tag": "ops"}
+
+
+def test_update_sets_model_override():
+    result = _update(
+        _agent_job_spec(),
+        model="openai/gpt-4o-mini",
+    )
+
+    assert result["request"]["model_slot_override"] == {
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+    }
+
+
+def test_update_clears_model_override():
+    spec = _agent_job_spec()
+    spec["request"]["model_slot_override"] = {
+        "provider_id": "openai",
+        "model": "gpt-4o-mini",
+    }
+
+    result = _update(spec, clear_model=True)
+
+    assert "model_slot_override" not in result["request"]
+
+
+def test_update_rejects_model_and_clear_model_together():
+    with pytest.raises(click.UsageError, match="cannot be used together"):
+        _update(
+            _agent_job_spec(),
+            model="openai/gpt-4o-mini",
+            clear_model=True,
+        )
+
+
+def test_update_rejects_model_override_for_text_job():
+    with pytest.raises(click.UsageError, match="only supported.*agent"):
+        _update(_text_job_spec(), model="openai/gpt-4o-mini")
+
+
+def test_update_help_exposes_model_options():
+    result = CliRunner().invoke(cron_group, ["update", "--help"])
+
+    assert result.exit_code == 0
+    assert "--model" in result.output
+    assert "--clear-model" in result.output
 
 
 def test_update_preserves_meta_and_dispatch_meta():

--- a/tests/unit/runtime/test_model_slot_override.py
+++ b/tests/unit/runtime/test_model_slot_override.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Per-request model selection in the shared runtime builder."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from qwenpaw.config.config import ModelSlotConfig
+from qwenpaw.runtime.builder import AgentBuilder
+
+
+class _ModelBuildReached(Exception):
+    """Stop the build after proving the override reached model creation."""
+
+
+@pytest.mark.parametrize(
+    ("agent_model", "override"),
+    [
+        (
+            None,
+            ModelSlotConfig(provider_id="openai", model="gpt-4o-mini"),
+        ),
+        (
+            ModelSlotConfig(provider_id="default", model="default-model"),
+            ModelSlotConfig(),
+        ),
+    ],
+    ids=["valid-request-override", "invalid-override-agent-fallback"],
+)
+@pytest.mark.asyncio
+async def test_request_model_selection_does_not_require_a_global_default(
+    monkeypatch,
+    tmp_path,
+    agent_model,
+    override,
+):
+    agent_config = SimpleNamespace(
+        id="default",
+        active_model=agent_model,
+        coding_mode=None,
+    )
+    ctx = SimpleNamespace(
+        agent_id="default",
+        request=SimpleNamespace(model_slot_override=override),
+        workspace_dir=str(tmp_path),
+        workspace=None,
+        extras={},
+    )
+    builder = AgentBuilder()
+
+    monkeypatch.setattr(
+        "qwenpaw.config.config.load_agent_config",
+        lambda _agent_id: agent_config,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.providers.provider_manager.ProviderManager.get_instance",
+        lambda: SimpleNamespace(get_active_model=lambda: None),
+    )
+    monkeypatch.setattr(
+        "qwenpaw.agents.skill_system.ensure_skills_initialized",
+        lambda _workspace_dir: None,
+    )
+    monkeypatch.setattr(
+        "qwenpaw.agents.skill_system.resolve_effective_skills",
+        lambda _workspace_dir, _channel: [],
+    )
+    monkeypatch.setattr(builder, "_build_request_context", lambda _ctx: {})
+    monkeypatch.setattr(
+        builder,
+        "_apply_request_project",
+        lambda config, _request_context: config,
+    )
+    monkeypatch.setattr(builder, "_init_governor", lambda *_args: None)
+    monkeypatch.setattr(builder, "_get_local_workspace", lambda _ctx: None)
+    monkeypatch.setattr(
+        builder,
+        "_collect_coding_mode_tools",
+        lambda *_args: [],
+    )
+    monkeypatch.setattr(
+        builder,
+        "_collect_visual_compression_tools",
+        lambda *_args: [],
+    )
+
+    async def _collect_driver_tools(*_args):
+        return [], []
+
+    monkeypatch.setattr(
+        builder,
+        "_collect_driver_tools_and_prompts",
+        _collect_driver_tools,
+    )
+
+    def _build_model(_agent_config, model_slot_override=None):
+        assert model_slot_override is override
+        raise _ModelBuildReached
+
+    monkeypatch.setattr(builder, "build_model", _build_model)
+
+    with pytest.raises(_ModelBuildReached):
+        await builder.build(ctx)

--- a/website/public/docs/cli.en.md
+++ b/website/public/docs/cli.en.md
@@ -513,6 +513,7 @@ ask QwenPaw and send the reply". **Requires `qwenpaw app` to be running.**
 | `qwenpaw cron get <job_id>`    | Show a job's spec                             |
 | `qwenpaw cron state <job_id>`  | Show runtime state (next run, last run, etc.) |
 | `qwenpaw cron create ...`      | Create a job                                  |
+| `qwenpaw cron update <job_id>` | Update selected fields of a job               |
 | `qwenpaw cron delete <job_id>` | Delete a job                                  |
 | `qwenpaw cron pause <job_id>`  | Pause a job                                   |
 | `qwenpaw cron resume <job_id>` | Resume a paused job                           |
@@ -551,7 +552,8 @@ qwenpaw cron create \
   --channel dingtalk \
   --target-user "your_user_id" \
   --target-session "session_id" \
-  --text "What are my todo items?"
+  --text "What are my todo items?" \
+  --model openai/gpt-4o-mini
 
 # Agent: run in the background without channel delivery
 qwenpaw cron create \
@@ -620,6 +622,8 @@ JSON structure matches the output of `qwenpaw cron get <job_id>`.
 | `--timezone`                                           | user timezone | Schedule timezone (defaults to `user_timezone` from config)                 |
 | `--enabled` / `--no-enabled`                           | enabled       | Create enabled or disabled                                                  |
 | `--mode`                                               | `final`       | `stream` (incremental) or `final` (complete response)                       |
+| `--model PROVIDER/MODEL`                               | agent default | Fix the model for an `agent` job without changing the agent configuration   |
+| `--clear-model`                                        | —             | `update` only; remove the fixed model and return to runtime defaults        |
 | `--silent` / `--no-silent`                             | disabled      | Run an `agent` task without delivering its response to the channel          |
 | `--save-result-to-inbox` / `--no-save-result-to-inbox` | server rules  | Save execution results to Inbox (if omitted, server-side defaults are used) |
 | `--repeat-every-days`                                  | no repeat     | `--schedule-type scheduled` only; repeat every N days                       |
@@ -627,6 +631,11 @@ JSON structure matches the output of `qwenpaw cron get <job_id>`.
 | `--repeat-until`                                       | —             | Required when `--repeat-end-type until`; ISO 8601 end datetime              |
 | `--repeat-count`                                       | —             | Required when `--repeat-end-type count`; max run count                      |
 | `--base-url`                                           | auto          | Override the API base URL                                                   |
+
+`--model` splits only on the first `/`, so model IDs such as
+`openrouter/meta-llama/llama-3.3-70b` are supported. Use
+`qwenpaw cron update <job_id> --clear-model` to make the job follow the
+agent or global active model again.
 
 ### Cron expression cheat sheet
 

--- a/website/public/docs/cli.zh.md
+++ b/website/public/docs/cli.zh.md
@@ -498,6 +498,7 @@ qwenpaw agents chat \
 | `qwenpaw cron get <job_id>`    | 查看任务配置                   |
 | `qwenpaw cron state <job_id>`  | 查看运行状态（下次运行时间等） |
 | `qwenpaw cron create ...`      | 创建任务                       |
+| `qwenpaw cron update <job_id>` | 更新任务的指定字段             |
 | `qwenpaw cron delete <job_id>` | 删除任务                       |
 | `qwenpaw cron pause <job_id>`  | 暂停任务                       |
 | `qwenpaw cron resume <job_id>` | 恢复暂停的任务                 |
@@ -536,7 +537,8 @@ qwenpaw cron create \
   --channel dingtalk \
   --target-user "你的用户ID" \
   --target-session "会话ID" \
-  --text "我有什么待办事项？"
+  --text "我有什么待办事项？" \
+  --model openai/gpt-4o-mini
 
 # agent：后台执行，不向渠道投递回复
 qwenpaw cron create \
@@ -600,18 +602,24 @@ JSON 结构见 `qwenpaw cron get <job_id>` 的返回。
 
 ### 额外选项
 
-| 选项                                                   | 默认值   | 说明                                                              |
-| ------------------------------------------------------ | -------- | ----------------------------------------------------------------- |
-| `--timezone`                                           | 用户时区 | 调度时区（默认使用 config 中的 `user_timezone`）                  |
-| `--enabled` / `--no-enabled`                           | 启用     | 创建时启用或禁用                                                  |
-| `--mode`                                               | `final`  | `stream`（逐步发送）或 `final`（完成后一次性发送）                |
-| `--silent` / `--no-silent`                             | 关闭     | 执行 `agent` 任务但不向渠道投递回复                               |
-| `--save-result-to-inbox` / `--no-save-result-to-inbox` | 自动规则 | 是否将执行结果写入收件箱（省略时由服务端默认策略决定）            |
-| `--repeat-every-days`                                  | 不重复   | 仅 `--schedule-type scheduled` 可用；每 N 天重复                  |
-| `--repeat-end-type`                                    | `never`  | 仅重复日程可用；`never` / `until` / `count`                       |
-| `--repeat-until`                                       | —        | 当 `--repeat-end-type until` 时必填；ISO 8601 结束时间            |
-| `--repeat-count`                                       | —        | 当 `--repeat-end-type count` 时必填；最大执行次数（不含手动执行） |
-| `--base-url`                                           | 自动     | 覆盖 API 地址                                                     |
+| 选项                                                   | 默认值     | 说明                                                              |
+| ------------------------------------------------------ | ---------- | ----------------------------------------------------------------- |
+| `--timezone`                                           | 用户时区   | 调度时区（默认使用 config 中的 `user_timezone`）                  |
+| `--enabled` / `--no-enabled`                           | 启用       | 创建时启用或禁用                                                  |
+| `--mode`                                               | `final`    | `stream`（逐步发送）或 `final`（完成后一次性发送）                |
+| `--model PROVIDER/MODEL`                               | 智能体默认 | 为 `agent` 任务固定模型，不修改智能体配置                         |
+| `--clear-model`                                        | —          | 仅用于 `update`；移除固定模型并恢复运行时默认值                   |
+| `--silent` / `--no-silent`                             | 关闭       | 执行 `agent` 任务但不向渠道投递回复                               |
+| `--save-result-to-inbox` / `--no-save-result-to-inbox` | 自动规则   | 是否将执行结果写入收件箱（省略时由服务端默认策略决定）            |
+| `--repeat-every-days`                                  | 不重复     | 仅 `--schedule-type scheduled` 可用；每 N 天重复                  |
+| `--repeat-end-type`                                    | `never`    | 仅重复日程可用；`never` / `until` / `count`                       |
+| `--repeat-until`                                       | —          | 当 `--repeat-end-type until` 时必填；ISO 8601 结束时间            |
+| `--repeat-count`                                       | —          | 当 `--repeat-end-type count` 时必填；最大执行次数（不含手动执行） |
+| `--base-url`                                           | 自动       | 覆盖 API 地址                                                     |
+
+`--model` 只按第一个 `/` 分隔，因此支持
+`openrouter/meta-llama/llama-3.3-70b` 这类模型 ID。执行
+`qwenpaw cron update <job_id> --clear-model` 后，任务会重新跟随智能体或全局活跃模型。
 
 ### Cron 表达式速查
 

--- a/website/public/docs/cron.en.md
+++ b/website/public/docs/cron.en.md
@@ -158,8 +158,13 @@ qwenpaw cron create \
   --channel dingtalk \
   --target-user "your_user_id" \
   --target-session "your_session_id" \
-  --text "Please review my todos and list the top three priorities."
+  --text "Please review my todos and list the top three priorities." \
+  --model openai/gpt-4o-mini
 ```
+
+For an `agent` task, `--model provider/model` fixes the model for that job
+without changing the agent's active model. Run
+`qwenpaw cron update <job_id> --clear-model` to return to the runtime default.
 
 Add `--silent` to an `agent` task when it should run in the background without
 sending its response to the channel. The task still keeps its session and
@@ -205,6 +210,8 @@ Parameter notes:
 - `--schedule-type cron`: requires `--cron`
 - `--schedule-type scheduled`: requires `--run-at`
 - For repeating `scheduled` tasks, pass `--repeat-every-days` and an end condition (`count` / `until` / `never`)
+- `--model provider/model` is available for `agent` tasks only; model IDs may contain additional `/` characters
+- `--clear-model` removes an existing override during `cron update`
 - `--silent` is available for `agent` tasks only and suppresses channel delivery, not execution
 - To control Inbox delivery, explicitly pass `--save-result-to-inbox` or `--no-save-result-to-inbox`
 

--- a/website/public/docs/cron.zh.md
+++ b/website/public/docs/cron.zh.md
@@ -136,8 +136,13 @@ qwenpaw cron create \
   --channel dingtalk \
   --target-user "你的用户ID" \
   --target-session "你的会话ID" \
-  --text "请检查我的待办，并输出优先级最高的三项。"
+  --text "请检查我的待办，并输出优先级最高的三项。" \
+  --model openai/gpt-4o-mini
 ```
+
+`agent` 任务可通过 `--model provider/model` 固定该任务使用的模型，且不会修改
+智能体的活跃模型。执行 `qwenpaw cron update <job_id> --clear-model` 可恢复为
+运行时默认模型。
 
 如果 `agent` 任务只需在后台运行、不向渠道发送回复，可添加 `--silent`。
 任务仍会保留会话和追踪记录，是否写入收件箱仍由 `--save-result-to-inbox` 独立控制。
@@ -182,6 +187,8 @@ qwenpaw cron create \
 - `--schedule-type cron`：需要 `--cron`
 - `--schedule-type scheduled`：需要 `--run-at`
 - `scheduled` 重复任务：需要 `--repeat-every-days`，并搭配结束条件（`count/until/never`）
+- `--model provider/model` 仅适用于 `agent` 任务；模型 ID 可继续包含 `/`
+- `--clear-model` 用于在 `cron update` 时移除已有模型覆盖
 - `--silent` 仅适用于 `agent` 任务，只抑制渠道投递，不跳过任务执行
 - 可选设置结果是否入收件箱：`--save-result-to-inbox` 或 `--no-save-result-to-inbox`
 


### PR DESCRIPTION
## Description

Allow agent cron jobs to pin a model without changing the agent's persisted
active model. This reuses the existing per-request `model_slot_override`
contract instead of adding a cron-specific model construction path.

- expose and validate `model_slot_override` in `CronJobRequest`, including
  compatibility with the existing `provider:model` request form
- add `--model provider/model` to cron create/update and `--clear-model` to
  update; text jobs reject model selection
- make the shared runtime availability check honor a valid request override,
  including when no agent/global default exists
- preserve request extensions when the Console performs a full cron-job PUT
- update the English/Chinese CLI docs, cron docs, and built-in cron skills

**Related Issue:** Fixes #6316

**Security Considerations:** No credential, authorization, or persisted agent
configuration changes. The override is validated at the cron API boundary and
used only for the current request.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [x] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Python cron, CLI, runtime, and shared model-factory unit tests
- Console Cron Vitest suite and production build
- changed-file pre-commit hooks and Markdown Prettier check

Verification matrix:

| Surface | Verification |
| --- | --- |
| API schema and serialization | dict and legacy string forms covered |
| CLI create/update/clear | covered, including nested `/` model IDs |
| text jobs | API and CLI rejection covered |
| executor/runtime | forwarding and no-default override covered |
| Console full PUT | request extensions preserved |
| persisted agent config | unchanged; request override only |

## Evidence

Observed locally: the affected Python matrix completed with 101 passing tests,
the Console Cron suite completed with 33 passing tests, the Console production
build succeeded, and every applicable pre-commit hook passed for changed files.
The terminal transcript is below.

```bash
pytest -q tests/unit/app/crons tests/unit/cli/test_cron_cmd.py \
  tests/unit/runtime/test_model_slot_override.py \
  tests/unit/agents/test_create_model_and_formatter_override.py
# 101 passed in 1.09s

cd console && npm run test:run -- src/pages/Control/CronJobs
# Test Files  5 passed (5)
# Tests       33 passed (33)

cd console && npm run build
# 16332 modules transformed
# built in 1m 52s

pre-commit run --files <changed-files>
# mypy, black, flake8, pylint, and all applicable hooks passed
```

## Additional Notes

`pre-commit run --all-files` was also attempted. Every hook except repository-
wide pylint passed; pylint reports four existing `E1120` findings in
`src/qwenpaw/sandbox/windows_restricted_sandbox.py` (lines 1822, 1824, 2244,
and 2316), which this PR does not modify. Changed-file pre-commit passes in
full.

The repository-wide unit run stalled in the early threaded history-store tests
in this local sandbox, so it was stopped. The complete affected test matrix
above passes, and CI can run the repository-wide suite.