### PR TITLE
fix(console): prioritize one-time approval

### DIFF
--- a/console/src/components/ApprovalCard/ApprovalCard.module.less
+++ b/console/src/components/ApprovalCard/ApprovalCard.module.less
@@ -476,6 +476,31 @@
   }
 
   .approveOnceButton {
+    background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
+    border: none;
+    color: #ffffff;
+    box-shadow: 0 2px 8px rgba(249, 115, 22, 0.2);
+
+    &:hover:not(:disabled) {
+      background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
+      box-shadow: 0 4px 14px rgba(249, 115, 22, 0.35);
+      transform: translateY(-1px);
+      border: none;
+    }
+
+    &:focus:not(:disabled) {
+      background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
+      box-shadow: 0 4px 14px rgba(249, 115, 22, 0.35);
+      border: none;
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(0);
+      box-shadow: 0 2px 8px rgba(249, 115, 22, 0.25);
+    }
+  }
+
+  .approveAlwaysButton {
     background: #f8fafc;
     border: 1.5px solid #e2e8f0;
     color: #475569;
@@ -499,31 +524,6 @@
     &:active:not(:disabled) {
       transform: translateY(0);
       box-shadow: 0 1px 3px rgba(71, 85, 105, 0.08);
-    }
-  }
-
-  .approveAlwaysButton {
-    background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-    border: none;
-    color: #ffffff;
-    box-shadow: 0 2px 8px rgba(249, 115, 22, 0.2);
-
-    &:hover:not(:disabled) {
-      background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
-      box-shadow: 0 4px 14px rgba(249, 115, 22, 0.35);
-      transform: translateY(-1px);
-      border: none;
-    }
-
-    &:focus:not(:disabled) {
-      background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
-      box-shadow: 0 4px 14px rgba(249, 115, 22, 0.35);
-      border: none;
-    }
-
-    &:active:not(:disabled) {
-      transform: translateY(0);
-      box-shadow: 0 2px 8px rgba(249, 115, 22, 0.25);
     }
   }
 }
@@ -735,6 +735,28 @@
     }
 
     .approveOnceButton {
+      background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
+      color: #ffffff;
+      box-shadow: 0 2px 8px rgba(249, 115, 22, 0.3);
+
+      &:hover:not(:disabled) {
+        background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
+        box-shadow: 0 4px 16px rgba(249, 115, 22, 0.45);
+        transform: translateY(-1px);
+      }
+
+      &:focus:not(:disabled) {
+        background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
+        box-shadow: 0 4px 16px rgba(249, 115, 22, 0.45);
+      }
+
+      &:active:not(:disabled) {
+        transform: translateY(0);
+        box-shadow: 0 2px 10px rgba(249, 115, 22, 0.35);
+      }
+    }
+
+    .approveAlwaysButton {
       background: #2a2a2a;
       border-color: #3a3a3a;
       color: #94a3b8;
@@ -757,28 +779,6 @@
       &:active:not(:disabled) {
         transform: translateY(0);
         box-shadow: 0 1px 4px rgba(148, 163, 184, 0.1);
-      }
-    }
-
-    .approveAlwaysButton {
-      background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
-      color: #ffffff;
-      box-shadow: 0 2px 8px rgba(249, 115, 22, 0.3);
-
-      &:hover:not(:disabled) {
-        background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
-        box-shadow: 0 4px 16px rgba(249, 115, 22, 0.45);
-        transform: translateY(-1px);
-      }
-
-      &:focus:not(:disabled) {
-        background: linear-gradient(135deg, #ea6c0e 0%, #dc2626 100%);
-        box-shadow: 0 4px 16px rgba(249, 115, 22, 0.45);
-      }
-
-      &:active:not(:disabled) {
-        transform: translateY(0);
-        box-shadow: 0 2px 10px rgba(249, 115, 22, 0.35);
       }
     }
   }
@@ -832,11 +832,11 @@
     }
 
     .approveOnceButton {
-      order: 2;
+      order: 1;
     }
 
     .approveAlwaysButton {
-      order: 1;
+      order: 2;
     }
   }
 }

--- a/console/src/components/ApprovalCard/ApprovalCard.test.tsx
+++ b/console/src/components/ApprovalCard/ApprovalCard.test.tsx
@@ -1,0 +1,93 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/test/common_setup";
+import styles from "./ApprovalCard.module.less";
+import { ApprovalCard, type ApprovalCardProps } from "./ApprovalCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderApprovalCard() {
+  const onApprove = vi
+    .fn<ApprovalCardProps["onApprove"]>()
+    .mockResolvedValue(undefined);
+  renderCard({ onApprove });
+  return onApprove;
+}
+
+function renderCard({
+  isGeneralized = true,
+  onApprove = async () => {},
+}: {
+  isGeneralized?: boolean;
+  onApprove?: ApprovalCardProps["onApprove"];
+} = {}) {
+  renderWithProviders(
+    <ApprovalCard
+      requestId="approval-1"
+      toolName="shell"
+      toolSource="tool"
+      severity="medium"
+      findingsCount={0}
+      findingsSummary=""
+      toolParams={{}}
+      createdAt={Date.now() / 1000}
+      timeoutSeconds={60}
+      agentId="default"
+      isGeneralized={isGeneralized}
+      exactTarget="pytest -q"
+      similarTarget="pytest *"
+      onApprove={onApprove}
+      onDeny={vi.fn().mockResolvedValue(undefined)}
+    />,
+  );
+
+  return onApprove;
+}
+
+describe("ApprovalCard generalized approval", () => {
+  it("prioritizes one-time approval without changing approval scopes", async () => {
+    const onApprove = renderApprovalCard();
+    const user = userEvent.setup();
+    const approveOnce = screen.getByRole("button", { name: "Just Once" });
+    const approveAlways = screen.getByRole("button", {
+      name: "Always Allow",
+    });
+
+    expect(approveOnce).toHaveClass(styles.approveOnceButton);
+    expect(approveAlways).toHaveClass(styles.approveAlwaysButton);
+    expect(approveOnce).toHaveClass("ant-btn-primary");
+    expect(approveAlways).not.toHaveClass("ant-btn-primary");
+    expect(
+      approveOnce.compareDocumentPosition(approveAlways) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+
+    await user.click(approveOnce);
+    await waitFor(() => {
+      expect(onApprove).toHaveBeenCalledWith("approval-1", "exact");
+    });
+    await waitFor(() => expect(approveAlways).not.toBeDisabled());
+
+    await user.click(approveAlways);
+    await waitFor(() => {
+      expect(onApprove).toHaveBeenLastCalledWith("approval-1", "similar");
+    });
+  });
+
+  it("keeps a single-scope approval visually primary", () => {
+    renderCard({ isGeneralized: false });
+
+    const approve = screen.getByRole("button", { name: "Approve" });
+    expect(approve).toHaveClass(styles.approveOnceButton);
+    expect(approve).toHaveClass("ant-btn-primary");
+  });
+});

--- a/console/src/components/ApprovalCard/ApprovalCard.tsx
+++ b/console/src/components/ApprovalCard/ApprovalCard.tsx
@@ -367,6 +367,8 @@ export function ApprovalCard({
             {isGeneralized ? (
               <>
                 <Button
+                  type="primary"
+                  icon={<Check size={14} />}
                   onClick={() => handleApprove("exact")}
                   loading={loading === "approve-exact"}
                   disabled={loading !== null}
@@ -385,8 +387,6 @@ export function ApprovalCard({
                   }
                 >
                   <Button
-                    type="primary"
-                    icon={<Check size={14} />}
                     onClick={() => handleApprove("similar")}
                     loading={loading === "approve-pattern"}
                     disabled={isAlwaysAllowDisabled || loading !== null}
@@ -405,7 +405,7 @@ export function ApprovalCard({
                   loading === "approve-exact" || loading === "approve-pattern"
                 }
                 disabled={loading !== null}
-                className={styles.approveAlwaysButton}
+                className={styles.approveOnceButton}
               >
                 {t("approval.approve", "Approve")}
               </Button>


### PR DESCRIPTION
## Description

Prioritizes the least-permissive one-time approval in the shared Console approval card. Generalized requests now render `Just Once` as the primary action and place it first on mobile, while `Always Allow` becomes a secondary action. The exact and similar scopes, STRICT-mode disable behavior, and single-scope approval all keep their existing semantics.

**Related Issue:** Fixes #6354

**Security Considerations:** This changes only visual hierarchy. It does not grant, broaden, or persist permissions; it makes the temporary `exact` scope prominent while retaining the permanent `similar` scope's existing disable guard.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes (the `pre-commit` executable is not installed)
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (not needed for this visual safety fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `npx vitest run src/components/ApprovalCard/ApprovalCard.test.tsx` (2 passed)
- `npx vitest run` (138 files and 1192 tests passed)
- `npx tsc -b --noEmit`
- `npx prettier --check src/components/ApprovalCard/ApprovalCard.tsx src/components/ApprovalCard/ApprovalCard.module.less src/components/ApprovalCard/ApprovalCard.test.tsx`
- `npm run build`

## Evidence

The added ApprovalCard test rendered both approval modes and verified that `Just Once` stays primary and dispatches `exact`, while `Always Allow` dispatches `similar`; the final Console test suite completed with 138 files and 1192 tests passing.

```text
Test Files  138 passed (138)
Tests  1192 passed (1192)
```

## Additional Notes

- `pre-commit` is not installed locally, so the project-wide pre-commit gate was not run.
- The package `test:run` script uses a POSIX `NODE_OPTIONS=...` prefix that cannot start on Windows; the equivalent direct `npx vitest run` command passed.
- Running ESLint on the production component reports the pre-existing unused `_onCancel` parameter at line 57; the new test file passes ESLint unchanged.