### PR TITLE
fix(console): run test scripts on Windows

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -16,8 +16,8 @@
     "preview:prod": "vite preview --mode production",
     "preview:test": "vite preview --mode test",
     "test": "vitest",
-    "test:run": "NODE_OPTIONS=--max-old-space-size=4096 vitest run",
-    "test:coverage": "NODE_OPTIONS=--max-old-space-size=4096 vitest run --coverage"
+    "test:run": "node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run",
+    "test:coverage": "node --max-old-space-size=4096 ./node_modules/vitest/vitest.mjs run --coverage"
   },
   "dependencies": {
     "@agentscope-ai/chat": "1.1.72-beta.1783494781362",


### PR DESCRIPTION
## Description

Windows contributors cannot run the Console's documented `test:run` or `test:coverage` npm scripts because npm invokes them through `cmd.exe`, where `NODE_OPTIONS=...` is interpreted as a command. This change invokes the installed Vitest Node entry point directly with the existing 4 GB heap limit, avoiding shell-specific environment-variable syntax without adding a dependency.

**Related Issue:** Fixes #6361

**Security Considerations:** No user input, authentication, authorization, or runtime permission behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`npm run test:run`) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `npm run test:run` passed: 138 test files and 1,192 tests.
- `npm run format:check` passed: TypeScript build with `--noEmit` and Prettier check.
- `npm run test:coverage` now starts Vitest on Windows; the full coverage suite later times out in `AgentLoopCard.render.test.tsx`, outside this shell-startup fix.

## Evidence

On Windows, `npm run test:run` now completed 138 test files and 1,192 tests after `cmd.exe` invoked the script; before this change it stopped with `'NODE_OPTIONS' is not recognized` before Vitest started. `npm run test:coverage` likewise now starts Vitest with coverage enabled; its full suite currently stops at a separate `AgentLoopCard.render` timeout rather than the shell parser.

## Additional Notes

The existing coverage-only timeout is intentionally not changed in this narrow cross-platform script fix.