### PR TITLE
test(console): stabilize Gate coverage test

### DIFF
--- a/console/src/pages/Agent/Config/components/AgentLoopCard.render.test.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.render.test.tsx
@@ -86,7 +86,7 @@ describe("AgentLoopCard custom mode rendering", () => {
     expect(form?.getFieldValue(["loop", "custom_modes", 0, "enabled"])).toBe(
       true,
     );
-  }, 15_000);
+  }, 30_000);
 
   it("renders Mission defaults as three separate gates", async () => {
     renderWithProviders(<LoopForm />);


### PR DESCRIPTION
## Description

The Console coverage suite can fail on a functional Gate-selection test because its fixed 15-second timeout leaves no headroom for V8 instrumentation. This change increases the timeout only for that interaction to 30 seconds. The rendered UI assertions and product code remain unchanged.

**Related Issue:** Fixes #6366

**Security Considerations:** No user input, authentication, authorization, or runtime permission behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`npm run test:coverage`) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `npm run test:coverage` passed: 138 test files and 1,192 tests, with coverage thresholds met.
- `npm run format:check` passed: TypeScript build with `--noEmit` and Prettier check.
- Focused V8 coverage test for the Gate-selection interaction passed.

## Evidence

On Windows, the full coverage run previously failed with `1 failed | 1191 passed (1192)` because the Gate-selection test reached its 15-second timeout. After changing only that timeout to 30 seconds, the same `npm run test:coverage` command exited successfully with 138 test files and 1,192 tests; all existing assertions remain intact.

## Additional Notes

The timeout is scoped to the one interaction whose V8-instrumented runtime approached the previous limit.