### PR TITLE
fix(governance): honor disabled audit logging

### DIFF
--- a/src/qwenpaw/governance/audit.py
+++ b/src/qwenpaw/governance/audit.py
@@ -200,11 +200,10 @@ class AuditLog:
         propagate into ``assert_policy`` and disrupt the policy
         decision returned to the caller.
 
-        TODO: honor ``GovernancePolicy.audit_level`` here.  The field
-        is currently declared (``"all"`` / ``"none"`` / ...) and
-        persisted in policy.yaml but ignored — every decision is
-        always written.  Once the level enum is finalised, gate the
-        INSERT on it (e.g. skip ALLOW events when level == "deny_only").
+        ``audit_level == "none"`` is handled by
+        ``ResourceGovernor.audit()`` before this method is called.
+        If finer-grained filtering is needed later (for example,
+        ``"write_only"``), apply it at the INSERT boundary.
         """
         try:
             with self._lock:

--- a/src/qwenpaw/governance/resource_governor.py
+++ b/src/qwenpaw/governance/resource_governor.py
@@ -330,6 +330,8 @@ class ResourceGovernor:
             decision = governor.assert_policy(tc_spec)
             governor.audit(tc_spec, decision)
         """
+        if self._policy is not None and self._policy.audit_level == "none":
+            return
         self.audit_log.record(
             str(self.workspace_dir),
             tc_spec,

--- a/tests/unit/governance/test_policy.py
+++ b/tests/unit/governance/test_policy.py
@@ -550,6 +550,28 @@ class TestAssertPolicySSHCommands:
             GovernanceAction.ALLOW,
         )
 
+    def test_audit_level_none_skips_persistence(self, governor):
+        """The explicit none level must not write to the audit database."""
+        governor.policy.audit_level = "none"
+        tc = _tc("Write", "/tmp/audit-level-none.txt")
+        decision = governor.assert_policy(tc)
+        before = governor.audit_log.count
+
+        governor.audit(tc, decision)
+
+        assert governor.audit_log.count == before
+
+    def test_audit_level_all_persists_decision(self, governor):
+        """The default all level continues to persist audit events."""
+        governor.policy.audit_level = "all"
+        tc = _tc("Write", "/tmp/audit-level-all.txt")
+        decision = governor.assert_policy(tc)
+        before = governor.audit_log.count
+
+        governor.audit(tc, decision)
+
+        assert governor.audit_log.count == before + 1
+
 
 # ---------------------------------------------------------------------------
 # Test: GovernancePolicy.evaluate directly (without governor / audit)


### PR DESCRIPTION
## Description

Honors `GovernancePolicy.audit_level: none` at the `ResourceGovernor.audit()` entry point. Previously, every call reached `AuditLog.record()`, so an explicitly disabled audit policy still inserted an SQLite event.

The guard only skips persistence for `none`. It leaves the default `all` behavior and calls made before `start()` unchanged.

**Related Issue:** Fixes #6368

**Security Considerations:** This follows the existing local policy setting and does not grant permissions or accept new input.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed an isolated real-source behavior check for `ResourceGovernor.audit()` and `AuditLog`.
- Passed `python -m py_compile`, Black, and Flake8 for the two changed files.
- Blocked: `python -m pytest -q tests/unit/governance/test_policy.py` stops during collection because this environment lacks `agentscope`.

## Evidence

An isolated check loading the repository's actual `ResourceGovernor.audit` and `AuditLog` recorded zero new events for `audit_level=none`, one for `audit_level=all`, and one for an audit call before `start()`.

```text
audit_level=none new_records=0
audit_level=all new_records=1
prestart new_records=1

python -m py_compile src/qwenpaw/governance/resource_governor.py tests/unit/governance/test_policy.py
# passed

python -m black --check --line-length 79 src/qwenpaw/governance/resource_governor.py tests/unit/governance/test_policy.py
# 2 files would be left unchanged

python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/governance/resource_governor.py tests/unit/governance/test_policy.py
# passed
```

## Additional Notes

The existing `write_only` value is intentionally unchanged because its event-selection semantics are not defined by this focused fix.
