### PR TITLE
fix(file-handling): continue fallback after downloader timeout

### DIFF
--- a/src/qwenpaw/agents/utils/file_handling.py
+++ b/src/qwenpaw/agents/utils/file_handling.py
@@ -176,7 +176,11 @@ def _download_remote_to_path(url: str, local_file_path: Path) -> None:
         )
         logger.debug("Downloaded file via wget to: %s", local_file_path)
         return
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ) as e:
         logger.debug("wget failed, trying curl: %s", e)
     try:
         subprocess.run(
@@ -187,7 +191,11 @@ def _download_remote_to_path(url: str, local_file_path: Path) -> None:
         )
         logger.debug("Downloaded file via curl to: %s", local_file_path)
         return
-    except (subprocess.CalledProcessError, FileNotFoundError) as curl_err:
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ) as curl_err:
         logger.debug("curl failed, trying urllib: %s", curl_err)
     try:
         urllib.request.urlretrieve(url, str(local_file_path))

--- a/tests/unit/agents/utils/test_file_handling.py
+++ b/tests/unit/agents/utils/test_file_handling.py
@@ -13,14 +13,17 @@ Covers:
 
 import os
 import stat
+import subprocess
 import urllib.parse
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import qwenpaw.agents.utils.file_handling as file_handling_module
 from qwenpaw.agents.utils.file_handling import (
     _default_download_dir,
+    _download_remote_to_path,
     _guess_suffix_from_file_content,
     _resolve_local_path,
     download_file_from_base64,
@@ -229,6 +232,54 @@ class TestDownloadFileFromBase64:
 # ---------------------------------------------------------------------------
 # download_file_from_url
 # ---------------------------------------------------------------------------
+
+
+class TestDownloadRemoteToPath:
+    """Tests for downloader fallback behavior."""
+
+    def test_wget_timeout_falls_back_to_curl(self, monkeypatch, tmp_path):
+        calls: list[str] = []
+        target = tmp_path / "download.bin"
+
+        def fake_run(args, **_kwargs):
+            calls.append(args[0])
+            if args[0] == "wget":
+                raise subprocess.TimeoutExpired(args, 60)
+            target.write_bytes(b"curl fallback")
+            return subprocess.CompletedProcess(args, 0)
+
+        monkeypatch.setattr(file_handling_module.subprocess, "run", fake_run)
+
+        _download_remote_to_path("https://example.com/file", target)
+
+        assert calls == ["wget", "curl"]
+        assert target.read_bytes() == b"curl fallback"
+
+    def test_curl_timeout_falls_back_to_urllib(self, monkeypatch, tmp_path):
+        calls: list[str] = []
+        target = tmp_path / "download.bin"
+
+        def fake_run(args, **_kwargs):
+            calls.append(args[0])
+            if args[0] == "wget":
+                raise FileNotFoundError("wget")
+            raise subprocess.TimeoutExpired(args, 60)
+
+        def fake_urlretrieve(_url, path):
+            Path(path).write_bytes(b"urllib fallback")
+            return path, None
+
+        monkeypatch.setattr(file_handling_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            file_handling_module.urllib.request,
+            "urlretrieve",
+            fake_urlretrieve,
+        )
+
+        _download_remote_to_path("https://example.com/file", target)
+
+        assert calls == ["wget", "curl"]
+        assert target.read_bytes() == b"urllib fallback"
 
 
 class TestDownloadFileFromUrl:


### PR DESCRIPTION
## Description

`_download_remote_to_path()` documents a `wget` -> `curl` -> `urllib` fallback chain, but a `subprocess.TimeoutExpired` from either subprocess escaped instead of advancing to the next downloader.

This change treats a downloader timeout like its existing command-failure and missing-executable cases. A timed-out `wget` now attempts `curl`; a timed-out `curl` now attempts `urllib`. The existing 60-second timeout and download order are unchanged.

**Related Issue:** Fixes #6370

**Security Considerations:** None. The change preserves the existing URL handling, downloader commands, timeout value, and final failure behavior; it only continues the documented fallback after a timeout.

**Duplicate-work check:** Searched open PRs for `_download_remote_to_path` and `TimeoutExpired`; no matching downloader fallback PR was open.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed: `pytest --confcutdir=tests/unit/agents/utils tests/unit/agents/utils/test_file_handling.py -q` (25 passed).
- Passed: the two new fallback regressions directly (2 passed).
- Passed: `python -m py_compile`, Black, and Flake8 for both changed files.
- Not run: `pre-commit run --all-files`; the original worktree has invalid Git metadata, so the commit was constructed from the verified upstream tree through the Git Data API instead.

## Evidence

On the upstream baseline, a mocked downloader timeout invoked only `wget` and propagated `TimeoutExpired`. With this change, the focused test suite verifies both `wget` -> `curl` and `curl` -> `urllib` timeout recovery paths, with all 25 file-handling tests passing.

```text
baseline_calls=['wget']
baseline_result=propagated_timeout

pytest --confcutdir=tests/unit/agents/utils tests/unit/agents/utils/test_file_handling.py -q
25 passed in 0.98s

pytest --confcutdir=tests/unit/agents/utils tests/unit/agents/utils/test_file_handling.py::TestDownloadRemoteToPath -q
2 passed in 0.81s

python -m py_compile src/qwenpaw/agents/utils/file_handling.py tests/unit/agents/utils/test_file_handling.py
# passed

python -m black --check --line-length 79 src/qwenpaw/agents/utils/file_handling.py tests/unit/agents/utils/test_file_handling.py
# 2 files would be left unchanged

python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/agents/utils/file_handling.py tests/unit/agents/utils/test_file_handling.py
# passed
```

## Additional Notes

No dependency, public API, configuration, or documentation changes are needed. The fallback only affects the previous timeout escape path.
