### PR TITLE
fix(channels): preserve recreated queue state

### DIFF
--- a/src/qwenpaw/app/channels/unified_queue_manager.py
+++ b/src/qwenpaw/app/channels/unified_queue_manager.py
@@ -263,7 +263,12 @@ class UnifiedQueueManager:
         finally:
             # Remove from queues dict when consumer exits
             async with self._lock:
-                self._queues.pop(queue_key, None)
+                current_state = self._queues.get(queue_key)
+                if (
+                    current_state is not None
+                    and current_state.consumer_task is asyncio.current_task()
+                ):
+                    self._queues.pop(queue_key, None)
 
             logger.info(
                 f"Consumer stopped: channel={channel_id} "

--- a/tests/unit/app/channels/test_unified_queue_manager.py
+++ b/tests/unit/app/channels/test_unified_queue_manager.py
@@ -193,6 +193,62 @@ class TestStartStop:
 
 class TestCleanupLoop:
     @pytest.mark.asyncio
+    async def test_old_consumer_exit_keeps_recreated_queue(self):
+        first_started = asyncio.Event()
+        first_cancelled = asyncio.Event()
+        allow_first_exit = asyncio.Event()
+        second_started = asyncio.Event()
+        stop_second = asyncio.Event()
+        consumer_count = 0
+
+        async def consumer(queue, *_args):
+            nonlocal consumer_count
+            consumer_count += 1
+            invocation = consumer_count
+            await queue.get()
+
+            if invocation == 1:
+                first_started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    first_cancelled.set()
+                    await allow_first_exit.wait()
+            else:
+                second_started.set()
+                await stop_second.wait()
+
+        mgr = UnifiedQueueManager(
+            consumer_fn=consumer,
+            queue_maxsize=10,
+            idle_timeout=0.05,
+            cleanup_interval=0.005,
+        )
+        key = ("console", "console:race", 0)
+        mgr.start_cleanup_loop()
+
+        try:
+            await mgr.enqueue(*key, "old")
+            await asyncio.wait_for(first_started.wait(), timeout=1)
+            old_task = mgr._queues[key].consumer_task
+
+            await asyncio.wait_for(first_cancelled.wait(), timeout=1)
+            await mgr.enqueue(*key, "new")
+            new_state = mgr._queues[key]
+            await asyncio.wait_for(second_started.wait(), timeout=1)
+
+            allow_first_exit.set()
+            with pytest.raises(asyncio.CancelledError):
+                await old_task
+
+            assert mgr._queues.get(key) is new_state
+        finally:
+            allow_first_exit.set()
+            stop_second.set()
+            await asyncio.sleep(0)
+            await mgr.stop_all()
+
+    @pytest.mark.asyncio
     async def test_cleanup_loop_does_not_leak_active_queue(self):
         # Stuck consumer keeps the queue non-empty (item not drained),
         # so cleanup must skip it even after idle_timeout elapses.


### PR DESCRIPTION
## Description

Prevent idle queue cleanup from removing a `QueueState` recreated for the same
key while the previous consumer is finishing cancellation. A consumer now
removes its queue mapping only when the mapping still belongs to that consumer
task, so a live replacement consumer remains tracked and later enqueues reuse
it instead of creating a duplicate consumer.

**Related Issue:** Fixes #6372

**Security Considerations:** None. This changes only internal queue ownership
tracking and does not add input, permissions, or network behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed: an isolated schedule against the parent commit confirms the bug: the
  replacement state exists before the old consumer exits and is absent after it
  exits.
- Passed: the same schedule against this commit keeps the replacement state
  registered after the old consumer exits.
- Passed: `PYTHONPATH=src python -m pytest --confcutdir=tests/unit/app/channels tests/unit/app/channels/test_unified_queue_manager.py -q` (`19 passed`).
- Passed: the new race regression ran five consecutive times (`1 passed` each run).
- Passed: `python -m py_compile`, Black, Flake8 with the repository config, and `git diff --check` for the two changed files.
- Not run: `pre-commit run --all-files`; the current Python environment has no `pre_commit` module.
- Not run: repository-wide pytest; this verification checkout intentionally contains only the affected files and their focused test dependencies.

## Evidence

On the parent commit, the controlled cancellation race leaves the recreated
state absent after the old consumer exits. On this branch, that state remains
registered (`new_state_after_old_exit=True`), and the focused queue-manager test
file passes all 19 tests; the added regression also passed five consecutive
runs.

```text
baseline new_state_before_old_exit=True
baseline new_state_after_old_exit=False

fixed new_state_before_old_exit=True
fixed new_state_after_old_exit=True

PYTHONPATH=src python -m pytest --confcutdir=tests/unit/app/channels tests/unit/app/channels/test_unified_queue_manager.py -q
19 passed in 1.49s

test_old_consumer_exit_keeps_recreated_queue: 1 passed (five consecutive runs)

python -m py_compile src/qwenpaw/app/channels/unified_queue_manager.py tests/unit/app/channels/test_unified_queue_manager.py
# passed

python -m black --check --line-length 79 src/qwenpaw/app/channels/unified_queue_manager.py tests/unit/app/channels/test_unified_queue_manager.py
# 2 files would be left unchanged

python -m flake8 --jobs 1 --extend-ignore=E203 src/qwenpaw/app/channels/unified_queue_manager.py tests/unit/app/channels/test_unified_queue_manager.py
# passed

git diff --check f3980509def60a8336698e4b6820261af0ee0e5b^ f3980509def60a8336698e4b6820261af0ee0e5b
# passed
```

## Additional Notes

The change does not alter idle timeout values, queue priority handling,
consumer cancellation policy, public APIs, or persisted data.
