### PR TITLE
fix(token-usage): retry token usage persistence

### DIFF
--- a/src/qwenpaw/token_usage/buffer.py
+++ b/src/qwenpaw/token_usage/buffer.py
@@ -157,7 +157,20 @@ class TokenUsageBuffer:
         self._dirty = False
 
         snapshot = copy.deepcopy(self._disk_cache)
-        await asyncio.to_thread(save_data_sync, self._path, snapshot)
+        try:
+            saved = await asyncio.to_thread(
+                save_data_sync,
+                self._path,
+                snapshot,
+            )
+        except Exception:
+            self._dirty = True
+            raise
+
+        if not saved:
+            self._dirty = True
+            return
+
         logger.debug("token_usage: flushed cache to disk")
 
     async def _flush_loop(self) -> None:

--- a/src/qwenpaw/token_usage/storage.py
+++ b/src/qwenpaw/token_usage/storage.py
@@ -32,11 +32,15 @@ async def load_data(path: Path) -> dict:
     return data
 
 
-def save_data_sync(path: Path, data: dict) -> None:
+def save_data_sync(path: Path, data: dict) -> bool:
     """Persist *data* to *path* using an atomic write (tmp → replace).
 
     This is intentionally synchronous so it can be called from the buffer
     flush task without blocking the event loop via ``asyncio.to_thread``.
+
+    Returns:
+        ``True`` when the atomic write succeeds, otherwise ``False`` after a
+        handled ``OSError``.
     """
     tmp_path = path.with_suffix(".tmp")
     try:
@@ -57,6 +61,9 @@ def save_data_sync(path: Path, data: dict) -> None:
                 tmp_path.unlink()
         except OSError:
             pass
+        return False
+
+    return True
 
 
 __all__ = [

--- a/tests/unit/token_usage/test_token_usage.py
+++ b/tests/unit/token_usage/test_token_usage.py
@@ -135,7 +135,7 @@ class TestStorage:
         """Should write data to file atomically."""
         path = tmp_path / "token_usage.json"
         data = {"2026-04-24": {"openai:gpt-4": {"prompt_tokens": 100}}}
-        save_data_sync(path, data)
+        assert save_data_sync(path, data) is True
         assert path.exists()
         loaded = json.loads(path.read_text())
         assert loaded == data
@@ -143,8 +143,27 @@ class TestStorage:
     def test_save_data_sync_creates_parent_dirs(self, tmp_path):
         """Should create parent directories if needed."""
         path = tmp_path / "subdir" / "token_usage.json"
-        save_data_sync(path, {"test": "data"})
+        assert save_data_sync(path, {"test": "data"}) is True
         assert path.exists()
+
+    def test_save_data_sync_reports_failed_atomic_write(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Should report a failed replace so callers can retry."""
+        path = tmp_path / "token_usage.json"
+
+        def fail_replace(*_args, **_kwargs):
+            raise OSError("simulated transient disk failure")
+
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.storage.os.replace",
+            fail_replace,
+        )
+
+        assert save_data_sync(path, {"test": "data"}) is False
+        assert not path.exists()
 
 
 # =============================================================================
@@ -201,6 +220,44 @@ class TestTokenUsageBuffer:
         entry = buffer._disk_cache["2026-04-24"]["openai:gpt-4"]
         assert entry["prompt_tokens"] == 300
         assert entry["call_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_flush_retries_after_save_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """A failed save should remain dirty for the next flush."""
+        buffer = TokenUsageBuffer(tmp_path / "test.json")
+        buffer._cache_loaded = True
+        _apply_event(
+            buffer._disk_cache,
+            _UsageEvent(
+                provider_id="openai",
+                model_name="gpt-4",
+                prompt_tokens=100,
+                completion_tokens=50,
+                date_str="2026-04-24",
+                now_iso="2026-04-24T10:00:00+00:00",
+            ),
+        )
+        buffer._dirty = True
+        attempts = 0
+
+        def fail_once(*_args, **_kwargs):
+            nonlocal attempts
+            attempts += 1
+            return attempts > 1
+
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.buffer.save_data_sync",
+            fail_once,
+        )
+
+        await buffer._flush_once()
+        assert buffer._dirty is True
+
+        await buffer._flush_once()
+        assert attempts == 2
+        assert buffer._dirty is False
 
     @pytest.mark.asyncio
     async def test_stop_does_not_wipe_history_when_seed_interrupted(


### PR DESCRIPTION
## Description

`TokenUsageBuffer._flush_once()` clears its dirty flag before writing a
snapshot. `save_data_sync()` handled `OSError` internally without telling the
buffer that persistence failed, so a transient atomic-write failure caused
later periodic flushes to skip unsaved token usage until another event arrived.

This change makes the storage helper report success and restores the dirty flag
after a failed write. The existing pre-write dirty reset remains, so an event
arriving while a snapshot is being persisted still requests a later flush.
Regression tests cover both the failed atomic write and the retry path.

**Related Issue:** Fixes #6374

**Security Considerations:** None. The change only preserves in-memory token
usage after a failed local file write; it does not add inputs, permissions, or
network behavior.

**Duplicate-work check:** Searched open PRs for `TokenUsageBuffer` and
`token usage flush`; neither search returned a matching PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- Passed: an isolated behavior check makes the first persistence attempt fail.
  The buffer remains dirty, the next flush makes a second write attempt, and
  the usage file is created.
- Passed: an isolated storage check where `os.replace()` raises `OSError`;
  `save_data_sync()` returns `False` and leaves no usage file.
- Passed: `python -m py_compile` for the three changed files.
- Passed: `python -m black --check --line-length 79`,
  `python -m flake8`, and `git diff --check` for the changed files.
- Not run: the focused pytest file cannot collect in this sparse worktree
  because `src/qwenpaw/constant.py` is absent. `pre_commit` is not installed
  in this environment, so the repository-wide pre-commit gate was not run.

## Evidence

An isolated regression forces one storage failure without adding a new usage
event. It shows that the buffer stays dirty, retries on the next flush, and
persists the original snapshot.

```text
fixed dirty_after_failed_flush=True
fixed write_attempts_after_retry=2
fixed file_exists_after_retry=True

fixed save_result_after_oserror=False
fixed file_exists_after_oserror=False

python -m py_compile src/qwenpaw/token_usage/storage.py src/qwenpaw/token_usage/buffer.py tests/unit/token_usage/test_token_usage.py
# passed

python -m black --check --line-length 79 src/qwenpaw/token_usage/storage.py src/qwenpaw/token_usage/buffer.py tests/unit/token_usage/test_token_usage.py
# 3 files would be left unchanged

python -m flake8 src/qwenpaw/token_usage/storage.py src/qwenpaw/token_usage/buffer.py tests/unit/token_usage/test_token_usage.py
# passed

git diff --check
# passed
```

## Additional Notes

No token-usage file format, flush interval, configuration, or public call
signature changes are required. Callers that previously ignored
`save_data_sync()` retain their behavior.

