### PR TITLE
perf(drivers): avoid blocking on stale capabilities

### DIFF
--- a/src/qwenpaw/drivers/handlers/mcp.py
+++ b/src/qwenpaw/drivers/handlers/mcp.py
@@ -59,6 +59,9 @@ class MCPDriverHandler(DriverHandler):
             ]
             | None
         ) = None
+        self._capability_refresh_task: (
+            asyncio.Task[list[DriverCapability]] | None
+        ) = None
 
     async def _setup(self) -> None:
         """Create and connect StdIOStatefulClient or HttpStatefulClient."""
@@ -103,6 +106,11 @@ class MCPDriverHandler(DriverHandler):
 
     async def _teardown(self) -> None:
         """Close connected MCP client if present."""
+        refresh_task = self._capability_refresh_task
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+            await asyncio.gather(refresh_task, return_exceptions=True)
+        self._capability_refresh_task = None
         self._capability_cache = None
         if self._client is not None:
             await self._client.close()
@@ -141,7 +149,46 @@ class MCPDriverHandler(DriverHandler):
             cached_at, cached = self._capability_cache
             if now - cached_at <= _CAPABILITY_CACHE_TTL_SECONDS:
                 return list(cached)
+            self._start_capability_refresh()
+            return list(cached)
 
+        refresh_task = self._start_capability_refresh()
+        return list(await asyncio.shield(refresh_task))
+
+    def _start_capability_refresh(
+        self,
+    ) -> asyncio.Task[list[DriverCapability]]:
+        """Start one shared capability refresh task."""
+        task = self._capability_refresh_task
+        if task is None or task.done():
+            task = asyncio.create_task(
+                self._refresh_capabilities(),
+                name=f"mcp-capability-refresh:{self.name}",
+            )
+            self._capability_refresh_task = task
+            task.add_done_callback(self._on_capability_refresh_done)
+        return task
+
+    def _on_capability_refresh_done(
+        self,
+        task: asyncio.Task[list[DriverCapability]],
+    ) -> None:
+        """Consume background failures and release the single-flight slot."""
+        if self._capability_refresh_task is task:
+            self._capability_refresh_task = None
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.warning(
+                "MCP Driver '%s' capability refresh failed: %s",
+                self.name,
+                error,
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    async def _refresh_capabilities(self) -> list[DriverCapability]:
+        """Fetch and cache the current MCP tool capability snapshot."""
         tools = await self.list_tools()
         capabilities = [
             _mcp_tool_to_capability(
@@ -151,7 +198,7 @@ class MCPDriverHandler(DriverHandler):
             )
             for tool in tools
         ]
-        self._capability_cache = (now, capabilities)
+        self._capability_cache = (time.monotonic(), capabilities)
         return list(capabilities)
 
     async def invoke_capability(

--- a/src/qwenpaw/drivers/manager.py
+++ b/src/qwenpaw/drivers/manager.py
@@ -417,13 +417,29 @@ class DriverManager:
             (request_context or {}).get(DRIVER_SCOPE_CONTEXT_KEY) or "",
         )
         handlers = self._iter_handlers(protocol, scope_id=scope_id)
-        capabilities: list[DriverCapability] = []
-        for handler in handlers:
-            for capability in await handler.list_capabilities(
-                request_context=request_context,
-            ):
-                if kind is None or capability.kind == kind:
-                    capabilities.append(capability)
+        tasks = [
+            asyncio.create_task(
+                handler.list_capabilities(
+                    request_context=request_context,
+                ),
+                name=f"driver-capabilities:{handler.name}",
+            )
+            for handler in handlers
+        ]
+        try:
+            capability_groups = await asyncio.gather(*tasks)
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+        capabilities = [
+            capability
+            for group in capability_groups
+            for capability in group
+            if kind is None or capability.kind == kind
+        ]
         return sorted(capabilities, key=lambda item: item.capability_id)
 
     async def list_driver_capabilities(

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -11,6 +11,7 @@ injects all dependencies into the agent constructor.
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
 
@@ -236,6 +237,15 @@ class AgentBuilder:
         middlewares.  The agent receives all dependencies externally —
         it does not build any of them internally.
         """
+        timing_started = timing_last = time.perf_counter()
+        timings: dict[str, float] = {}
+
+        def mark_timing(name: str) -> None:
+            nonlocal timing_last
+            now = time.perf_counter()
+            timings[name] = (now - timing_last) * 1000
+            timing_last = now
+
         from agentscope.agent import ReActConfig
 
         from ..agents.react_agent import QwenPawAgent
@@ -246,6 +256,8 @@ class AgentBuilder:
         from ..config.config import load_agent_config
         from ..constant import WORKING_DIR
         from ..providers.provider_manager import ProviderManager
+
+        mark_timing("imports")
 
         agent_id = getattr(ctx, "agent_id", None) or "default"
         agent_config = load_agent_config(agent_id)
@@ -266,9 +278,11 @@ class AgentBuilder:
             )
 
         workspace_dir = getattr(ctx, "workspace_dir", None)
+        mark_timing("load_config")
 
         # Resolve skills.
         ensure_skills_initialized(workspace_dir or WORKING_DIR)
+        mark_timing("reconcile_skills")
         channel_name = request_context.get("channel", "console")
         try:
             effective_skills = resolve_effective_skills(
@@ -282,6 +296,7 @@ class AgentBuilder:
         if isinstance(subagent_skills, list):
             parent_set = set(effective_skills)
             effective_skills = [s for s in subagent_skills if s in parent_set]
+        mark_timing("resolve_skills")
 
         # Compute active modes.
         active_modes: set[str] = set()
@@ -290,6 +305,7 @@ class AgentBuilder:
             plugins = getattr(workspace, "plugins", None)
             if plugins is not None:
                 active_modes = plugins.active_mode_names(ctx)
+        mark_timing("resolve_modes")
 
         # Governor (governance policy layer).
         _project_dir = getattr(agent_config, "project_dir", None)
@@ -304,6 +320,7 @@ class AgentBuilder:
         local_ws = self._get_local_workspace(ctx) if ctx else None
         if local_ws is not None:
             local_ws.set_governor(governor)
+        mark_timing("init_governor")
 
         # Toolkit.
         from ..agents.context.visual_compression.runtime.recovery import (
@@ -327,6 +344,7 @@ class AgentBuilder:
                 visual_recovery_store,
             ),
         )
+        mark_timing("collect_coding_tools")
         (
             driver_tools,
             driver_prompt_hints,
@@ -338,6 +356,7 @@ class AgentBuilder:
         if not hasattr(ctx, "extras") or ctx.extras is None:
             ctx.extras = {}
         ctx.extras["driver_prompt_hints"] = driver_prompt_hints
+        mark_timing("collect_driver_capabilities")
 
         # Model + formatter (built before the toolkit so the scroll context
         # strategy, which needs the model for token counting, can wire in).
@@ -346,6 +365,7 @@ class AgentBuilder:
             agent_config,
             model_slot_override=model_slot_override,
         )
+        mark_timing("build_model")
 
         # Built once and shared: the agent's native offloader, and (when
         # ``offload_dialog`` is on) scroll's optional dialog archive.
@@ -383,6 +403,7 @@ class AgentBuilder:
                 request_context,
                 governor,
             )
+        mark_timing("build_scroll")
 
         toolkit = await self.build_toolkit(
             agent_config,
@@ -395,15 +416,18 @@ class AgentBuilder:
             ctx=ctx,
             workspace_dir=workspace_dir,
         )
+        mark_timing("build_toolkit")
 
         # System prompt.
         sys_prompt = self.build_prompt(ctx, agent_config)
+        mark_timing("build_prompt")
 
         middlewares = self._build_middlewares(
             ctx,
             agent_config,
             visual_recovery_store,
         )
+        mark_timing("build_middlewares")
 
         running_config = agent_config.running
 
@@ -432,19 +456,47 @@ class AgentBuilder:
             effective_skills=effective_skills,
             governor=governor,
         )
+        mark_timing("agent_init")
 
         # Load session state if SessionLoadHook populated it.
         if ctx.session_state:
             agent.load_state_dict(ctx.session_state)
+        mark_timing("load_state")
+        total_ms = (time.perf_counter() - timing_started) * 1000
 
         _logger.info(
             "builder: built agent for session=%s agent=%s"
-            " model=%s/%s tools=%d",
+            " model=%s/%s tools=%d timing total=%.1fms"
+            " imports=%.1fms load_config=%.1fms"
+            " reconcile_skills=%.1fms resolve_skills=%.1fms"
+            " resolve_modes=%.1fms init_governor=%.1fms"
+            " collect_coding_tools=%.1fms"
+            " collect_driver_capabilities=%.1fms"
+            " build_model=%.1fms build_scroll=%.1fms"
+            " build_toolkit=%.1fms build_prompt=%.1fms"
+            " build_middlewares=%.1fms agent_init=%.1fms"
+            " load_state=%.1fms",
             getattr(ctx, "session_id", ""),
             agent_id,
             active.provider_id,
             active.model,
             len(agent.toolkit.tool_groups[0].tools),
+            total_ms,
+            timings["imports"],
+            timings["load_config"],
+            timings["reconcile_skills"],
+            timings["resolve_skills"],
+            timings["resolve_modes"],
+            timings["init_governor"],
+            timings["collect_coding_tools"],
+            timings["collect_driver_capabilities"],
+            timings["build_model"],
+            timings["build_scroll"],
+            timings["build_toolkit"],
+            timings["build_prompt"],
+            timings["build_middlewares"],
+            timings["agent_init"],
+            timings["load_state"],
         )
         return agent
 

--- a/tests/unit/drivers/test_capability_discovery.py
+++ b/tests/unit/drivers/test_capability_discovery.py
@@ -1,0 +1,321 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,protected-access
+"""Latency-sensitive Driver capability discovery behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from qwenpaw.drivers.capabilities import (
+    CapabilityExposure,
+    DriverCapability,
+)
+from qwenpaw.drivers.contracts import DriverCard
+from qwenpaw.drivers.credentials.store import AsyncCredentialStore
+from qwenpaw.drivers.handlers.mcp import MCPDriverHandler
+from qwenpaw.drivers.manager import DriverManager
+
+
+@dataclass
+class _Tool:
+    name: str
+    description: str = ""
+    inputSchema: dict[str, object] | None = None
+
+
+class _RefreshingClient:
+    """Return one tool immediately, then block the refresh until released."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.closed = False
+        self.refresh_started = asyncio.Event()
+        self.release_refresh = asyncio.Event()
+
+    async def list_tools(self) -> list[_Tool]:
+        self.calls += 1
+        if self.calls == 1:
+            return [_Tool("old_tool")]
+        self.refresh_started.set()
+        await self.release_refresh.wait()
+        return [_Tool("new_tool")]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _mcp_handler(client: Any) -> MCPDriverHandler:
+    handler = MCPDriverHandler.__new__(MCPDriverHandler)
+    handler._card = DriverCard(
+        name="slow_mcp",
+        protocol="mcp",
+        endpoint={},
+    )
+    handler._client = client
+    handler._capability_cache = None
+    handler._capability_refresh_task = None
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_expired_mcp_snapshot_does_not_block_current_request() -> None:
+    client = _RefreshingClient()
+    handler = _mcp_handler(client)
+    initial = await handler.list_capabilities()
+    handler._capability_cache = (
+        time.monotonic() - 60,
+        initial,
+    )
+
+    try:
+        cached = await asyncio.wait_for(
+            handler.list_capabilities(),
+            timeout=1.0,
+        )
+
+        assert [item.name for item in cached] == ["old_tool"]
+        await asyncio.wait_for(client.refresh_started.wait(), timeout=1.0)
+
+        refresh_task = handler._capability_refresh_task
+        assert refresh_task is not None
+        client.release_refresh.set()
+        await asyncio.wait_for(asyncio.shield(refresh_task), timeout=1.0)
+        refreshed = await handler.list_capabilities()
+
+        assert [item.name for item in refreshed] == ["new_tool"]
+        assert client.calls == 2
+    finally:
+        client.release_refresh.set()
+        await handler._teardown()
+
+
+@pytest.mark.asyncio
+async def test_expired_mcp_snapshot_refresh_is_single_flight() -> None:
+    client = _RefreshingClient()
+    handler = _mcp_handler(client)
+    initial = await handler.list_capabilities()
+    handler._capability_cache = (
+        time.monotonic() - 60,
+        initial,
+    )
+
+    try:
+        first, second = await asyncio.gather(
+            handler.list_capabilities(),
+            handler.list_capabilities(),
+        )
+        await asyncio.wait_for(client.refresh_started.wait(), timeout=1.0)
+
+        assert [item.name for item in first] == ["old_tool"]
+        assert [item.name for item in second] == ["old_tool"]
+        assert client.calls == 2
+    finally:
+        client.release_refresh.set()
+        await handler._teardown()
+
+
+@pytest.mark.asyncio
+async def test_mcp_teardown_cancels_in_progress_capability_refresh() -> None:
+    client = _RefreshingClient()
+    handler = _mcp_handler(client)
+    initial = await handler.list_capabilities()
+    handler._capability_cache = (
+        time.monotonic() - 60,
+        initial,
+    )
+
+    assert [item.name for item in await handler.list_capabilities()] == [
+        "old_tool",
+    ]
+    await asyncio.wait_for(client.refresh_started.wait(), timeout=1.0)
+
+    await asyncio.wait_for(handler._teardown(), timeout=1.0)
+
+    assert client.closed is True
+    assert handler._capability_cache is None
+    assert handler._capability_refresh_task is None
+
+
+class _ColdClient:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def list_tools(self) -> list[_Tool]:
+        self.calls += 1
+        self.started.set()
+        await self.release.wait()
+        return [_Tool("cold_tool")]
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_cold_mcp_capability_refresh_is_single_flight() -> None:
+    client = _ColdClient()
+    handler = _mcp_handler(client)
+
+    first_task = asyncio.create_task(handler.list_capabilities())
+    second_task = asyncio.create_task(handler.list_capabilities())
+    try:
+        await asyncio.wait_for(client.started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+        assert client.calls == 1
+
+        client.release.set()
+        first, second = await asyncio.gather(first_task, second_task)
+        assert [item.name for item in first] == ["cold_tool"]
+        assert [item.name for item in second] == ["cold_tool"]
+    finally:
+        client.release.set()
+        await handler._teardown()
+
+
+def _capability(driver_name: str) -> DriverCapability:
+    return DriverCapability(
+        capability_id=f"driver://fake/{driver_name}/tools/ping#invoke",
+        driver_name=driver_name,
+        protocol="fake",
+        kind="tool",
+        action="invoke",
+        name=f"{driver_name}_tool",
+        exposure=CapabilityExposure(
+            as_tool=True,
+            tool_name=f"{driver_name}_tool",
+        ),
+    )
+
+
+class _SlowHandler:
+    def __init__(
+        self,
+        name: str,
+        started: list[str],
+        all_started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        self.name = name
+        self.card = SimpleNamespace(protocol="fake")
+        self._started = started
+        self._all_started = all_started
+        self._release = release
+
+    async def list_capabilities(
+        self,
+        request_context: dict[str, str] | None = None,
+    ) -> list[DriverCapability]:
+        del request_context
+        self._started.append(self.name)
+        if len(self._started) == 2:
+            self._all_started.set()
+        await self._release.wait()
+        return [_capability(self.name)]
+
+
+class _FailingHandler:
+    def __init__(self, peer_started: asyncio.Event) -> None:
+        self.name = "failing"
+        self.card = SimpleNamespace(protocol="fake")
+        self._peer_started = peer_started
+
+    async def list_capabilities(
+        self,
+        request_context: dict[str, str] | None = None,
+    ) -> list[DriverCapability]:
+        del request_context
+        await self._peer_started.wait()
+        raise RuntimeError("capability discovery failed")
+
+
+class _CancellableHandler:
+    def __init__(
+        self,
+        started: asyncio.Event,
+        cancelled: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        self.name = "slow"
+        self.card = SimpleNamespace(protocol="fake")
+        self._started = started
+        self._cancelled = cancelled
+        self._release = release
+
+    async def list_capabilities(
+        self,
+        request_context: dict[str, str] | None = None,
+    ) -> list[DriverCapability]:
+        del request_context
+        self._started.set()
+        try:
+            await self._release.wait()
+        except asyncio.CancelledError:
+            self._cancelled.set()
+            raise
+        return [_capability(self.name)]
+
+
+@pytest.mark.asyncio
+async def test_manager_collects_independent_driver_capabilities_concurrently(
+    tmp_path: Path,
+) -> None:
+    manager = DriverManager(
+        tmp_path / "drivers",
+        AsyncCredentialStore(tmp_path / "credentials.yaml"),
+    )
+    started: list[str] = []
+    all_started = asyncio.Event()
+    release = asyncio.Event()
+    manager._handlers = {  # type: ignore[assignment]
+        name: _SlowHandler(name, started, all_started, release)
+        for name in ("alpha", "beta")
+    }
+
+    collect_task = asyncio.create_task(manager.list_capabilities())
+    try:
+        await asyncio.wait_for(all_started.wait(), timeout=1.0)
+    finally:
+        release.set()
+        capabilities = await collect_task
+
+    assert [item.name for item in capabilities] == [
+        "alpha_tool",
+        "beta_tool",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_manager_cancels_other_discovery_when_one_driver_fails(
+    tmp_path: Path,
+) -> None:
+    manager = DriverManager(
+        tmp_path / "drivers",
+        AsyncCredentialStore(tmp_path / "credentials.yaml"),
+    )
+    slow_started = asyncio.Event()
+    slow_cancelled = asyncio.Event()
+    release_slow = asyncio.Event()
+    manager._handlers = {  # type: ignore[assignment]
+        "failing": _FailingHandler(slow_started),
+        "slow": _CancellableHandler(
+            slow_started,
+            slow_cancelled,
+            release_slow,
+        ),
+    }
+
+    try:
+        with pytest.raises(RuntimeError, match="capability discovery failed"):
+            await manager.list_capabilities()
+        await asyncio.wait_for(slow_cancelled.wait(), timeout=1.0)
+    finally:
+        release_slow.set()
+        await asyncio.sleep(0)


### PR DESCRIPTION
## Description

Reduce recurring request-time Driver discovery latency in the shared
`AgentBuilder` path:

- serve the last valid MCP capability snapshot immediately after its 10-second
  TTL expires, while refreshing it in a single background task;
- collect cold capabilities from independent Drivers concurrently, with
  cancellation cleanup if one Driver fails;
- cancel an in-flight MCP capability refresh during handler teardown;
- add one INFO-level `perf_counter()` breakdown to the existing
  `builder: built agent` log line.

The new timing fields cover config loading, skill reconciliation, governor
initialization, Driver capability collection, model/Scroll/toolkit/prompt
construction, middleware and agent initialization, state loading, and total
Builder time.

This is implemented at the shared Runtime/Driver layer used by every channel.
It does not add a WeCom-specific workaround, cache mutable agent/session state,
or change the separate Scroll `index_evicted` path.

**Related Issue:** Relates to #6307

**Security Considerations:** Stale capability schemas still go through the
existing invocation-time Driver policy and approval checks. No credentials or
authorization results are cached.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The focused tests use blocked fake clients/handlers instead of elapsed-time
thresholds. They prove that:

- an expired MCP snapshot returns while refresh I/O is still blocked;
- stale and cold refreshes are single-flight;
- teardown cancels an active refresh;
- independent Drivers begin discovery concurrently;
- a failed Driver cancels and awaits sibling discovery tasks.

Verification matrix:

- MCP warm cache: unchanged
- MCP expired cache: stale-while-revalidate covered
- MCP cold cache: single-flight covered
- Multiple Drivers: concurrent discovery and failure cleanup covered
- Channels: shared Builder path; no channel-specific changes
- Scroll/native: timing only; context behavior unchanged

## Evidence

```bash
$ pytest tests/unit/drivers tests/unit/runtime -q --no-cov
94 passed in 24.24s

$ pytest \
    tests/integration/test_driver_mcp_approval_level_policy.py \
    tests/integration/test_driver_mcp_env_ref_flow.py \
    tests/integration/test_driver_mcp_http_flow.py \
    tests/integration/test_driver_mcp_oauth_flow.py \
    tests/integration/test_driver_mcp_stdio_flow.py \
    tests/integration/test_driver_workspace_lifecycle.py \
    -q --no-cov
18 passed in 4.66s

$ pre-commit run --files \
    src/qwenpaw/drivers/handlers/mcp.py \
    src/qwenpaw/drivers/manager.py \
    src/qwenpaw/runtime/builder.py \
    tests/unit/drivers/test_capability_discovery.py
# all hooks passed
```

A local synthetic check with two 200 ms Driver providers reduced collection
from 401.2 ms sequentially to 200.6 ms concurrently. Returning an expired
snapshot took 0.02 ms while refresh remained blocked.

`pre-commit run --all-files` passed every hook except full-repository pylint,
which reports four pre-existing `E1120` errors in the unchanged
`src/qwenpaw/sandbox/windows_restricted_sandbox.py` (lines 1822, 1824, 2244,
and 2316). The changed-file pre-commit run above passes pylint.

## Additional Notes

Cold discovery still waits for a valid first snapshot. Once a snapshot exists,
one request may observe it beyond the TTL while the refresh completes; a
failed refresh leaves that last known snapshot available and is logged for the
next retry.
