### PR TITLE
fix(chat): prevent stale channel identity leaking into new chats afte…

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1801,6 +1801,7 @@ export default function ChatPage() {
         return;
       }
       const queueText = prepareLoopModeMessage(val);
+      const enqueueIdentity = sessionApi.getSessionIdentity();
       useMessageQueueStore.getState().enqueue(queueSessionId, {
         text: queueText,
         attachments:
@@ -1812,8 +1813,8 @@ export default function ChatPage() {
                 size: f.size,
               }))
             : undefined,
-        userId: window.currentUserId || DEFAULT_USER_ID,
-        channel: window.currentChannel || DEFAULT_CHANNEL,
+        userId: enqueueIdentity.userId,
+        channel: enqueueIdentity.channel,
       });
       // Clear tracked attachments after enqueuing
       pendingFileListRef.current = [];
@@ -2159,6 +2160,12 @@ export default function ChatPage() {
       // agent's conversation.
       setChatLoading(true);
 
+      // Window identity globals are only rewritten when another session
+      // loads, so reset them explicitly — otherwise the new agent inherits
+      // the previous agent's session/channel (possibly a deleted channel)
+      // and the first message of a fresh chat would carry it.
+      sessionApi.resetWindowIdentity();
+
       // Save current chat ID for the agent we're leaving
       const currentChatId =
         chatIdRef.current || lastSessionIdRef.current || undefined;
@@ -2436,6 +2443,7 @@ export default function ChatPage() {
           return false;
         }
         const queueText = prepareLoopModeMessage(val);
+        const enqueueIdentity = sessionApi.getSessionIdentity();
         useMessageQueueStore.getState().enqueue(queueSessionId, {
           text: queueText,
           attachments:
@@ -2447,8 +2455,8 @@ export default function ChatPage() {
                   size: f.size,
                 }))
               : undefined,
-          userId: window.currentUserId || DEFAULT_USER_ID,
-          channel: window.currentChannel || DEFAULT_CHANNEL,
+          userId: enqueueIdentity.userId,
+          channel: enqueueIdentity.channel,
         });
         pendingFileListRef.current = [];
         if (textarea) setTextareaValue(textarea, "");

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -771,6 +771,16 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     window.currentChannel = session.channel || DEFAULT_CHANNEL;
   }
 
+  /** Resets window identity globals to their defaults. Called on agent
+   *  switch: the globals are otherwise only rewritten when another session
+   *  loads, so a new agent would inherit the previous agent's session and
+   *  channel (possibly one that has since been deleted). */
+  resetWindowIdentity(): void {
+    window.currentSessionId = "";
+    window.currentUserId = DEFAULT_USER_ID;
+    window.currentChannel = DEFAULT_CHANNEL;
+  }
+
   private findSession(id: string): ExtendedSession | undefined {
     return this.sessionList.find(
       (x) => x.id === id || (x as ExtendedSession).realId === id,
@@ -845,10 +855,32 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         channel: session.channel || DEFAULT_CHANNEL,
       };
     }
+    // Window globals can outlive the session they came from (they are only
+    // rewritten when another session loads), so trust them only when they
+    // still resolve to a session in the current list. After an agent switch
+    // the list is reloaded and a stale identity — including a channel that
+    // may no longer exist — fails this lookup and falls through to defaults.
+    const windowSessionId = window.currentSessionId || "";
+    const windowSession = windowSessionId
+      ? (this.sessionList.find(
+          (s) =>
+            (s as ExtendedSession).sessionId === windowSessionId ||
+            s.id === windowSessionId,
+        ) as ExtendedSession | undefined)
+      : undefined;
+    if (windowSession?.userId) {
+      return {
+        sessionId: windowSession.sessionId || "",
+        userId: windowSession.userId,
+        channel: windowSession.channel || DEFAULT_CHANNEL,
+      };
+    }
+    // A fresh local id is still safe to keep: blank chats are always
+    // created on the console channel.
     return {
-      sessionId: window.currentSessionId || "",
-      userId: window.currentUserId || DEFAULT_USER_ID,
-      channel: window.currentChannel || DEFAULT_CHANNEL,
+      sessionId: isLocalTimestamp(windowSessionId) ? windowSessionId : "",
+      userId: DEFAULT_USER_ID,
+      channel: DEFAULT_CHANNEL,
     };
   }
 

--- a/console/src/pages/Chat/tests/staleChannelIdentity.test.ts
+++ b/console/src/pages/Chat/tests/staleChannelIdentity.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression tests for the stale-channel identity leak:
+ * "After deleting a channel and creating a new agent, the first chat of the
+ *  new agent is created on the deleted channel instead of console."
+ *
+ * Root cause: `window.currentChannel` / `window.currentSessionId` are page
+ * globals that are only rewritten when another session loads. After an agent
+ * switch they still hold the previous agent's identity, and
+ * `getSessionIdentity()` blindly trusted them in its fallback branch, so the
+ * first message of a fresh chat could carry a channel that no longer exists.
+ *
+ * Fix under test:
+ *  - `getSessionIdentity()` only trusts the window globals when they resolve
+ *    to a session in the current session list; otherwise it falls back to
+ *    the console defaults.
+ *  - `resetWindowIdentity()` clears the globals (called on agent switch).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import type { ChatSpec, ChatHistory, Message } from "../../../api";
+import api from "../../../api";
+import sessionApi from "../sessionApi";
+
+interface IdentityWindow extends Window {
+  currentSessionId?: string;
+  currentUserId?: string;
+  currentChannel?: string;
+}
+
+declare const window: IdentityWindow;
+
+const T0 = "2026-07-20T10:00:00.000000+00:00";
+
+function makeChatSpec(id: string, channel: string, userId: string): ChatSpec {
+  return {
+    id,
+    name: `${channel} chat`,
+    session_id: `${channel}:${userId}`,
+    user_id: userId,
+    channel,
+    created_at: T0,
+    updated_at: T0,
+    meta: {},
+    status: "idle",
+    pinned: false,
+    archived: false,
+    archived_at: null,
+  } as unknown as ChatSpec;
+}
+
+function makeHistory(): ChatHistory {
+  const messages: Message[] = [
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+    } as unknown as Message,
+  ];
+  return { messages, status: "idle" } as unknown as ChatHistory;
+}
+
+/** Loads the given chats into sessionApi and opens the first one so the
+ *  window identity globals are populated from it. */
+async function openChat(spec: ChatSpec): Promise<void> {
+  vi.spyOn(api, "listChats").mockResolvedValue([spec]);
+  vi.spyOn(api, "getChat").mockResolvedValue(makeHistory());
+  await sessionApi.getSessionList();
+  await sessionApi.getSession(spec.id);
+}
+
+/** Simulates the session-list reload that happens after an agent switch:
+ *  the new agent owns none of the previous agent's chats. */
+async function reloadAsEmptyAgent(): Promise<void> {
+  vi.spyOn(api, "listChats").mockResolvedValue([]);
+  await sessionApi.getSessionList();
+}
+
+beforeEach(() => {
+  sessionApi.lastActiveChatId = null;
+  window.currentSessionId = "";
+  window.currentUserId = "";
+  window.currentChannel = "";
+});
+
+afterEach(async () => {
+  // Drain the singleton's session list so state never leaks across tests.
+  await reloadAsEmptyAgent();
+  vi.restoreAllMocks();
+});
+
+describe("getSessionIdentity stale-channel fallback", () => {
+  it("falls back to console defaults when the window identity no longer matches any session", async () => {
+    const spec = makeChatSpec(
+      "33333333-3333-4333-8333-333333333333",
+      "yuanbao",
+      "u1",
+    );
+    await openChat(spec);
+
+    // Precondition: viewing the yuanbao chat populated the window globals.
+    expect(window.currentChannel).toBe("yuanbao");
+    expect(window.currentSessionId).toBe("yuanbao:u1");
+
+    // Agent switch: list reloads for the new agent, globals go stale.
+    sessionApi.lastActiveChatId = null;
+    await reloadAsEmptyAgent();
+
+    const identity = sessionApi.getSessionIdentity();
+    expect(identity.channel).toBe("console");
+    expect(identity.sessionId).toBe("");
+    expect(identity.userId).toBe("default");
+  });
+
+  it("keeps trusting the window identity while its session is still in the list", async () => {
+    const spec = makeChatSpec(
+      "44444444-4444-4444-8444-444444444444",
+      "dingtalk",
+      "u2",
+    );
+    await openChat(spec);
+    sessionApi.lastActiveChatId = null;
+
+    // Same agent, session still listed: external-channel identity is valid.
+    const identity = sessionApi.getSessionIdentity();
+    expect(identity.channel).toBe("dingtalk");
+    expect(identity.sessionId).toBe("dingtalk:u2");
+    expect(identity.userId).toBe("u2");
+  });
+
+  it("prefers the lastActiveChatId session over the window globals", async () => {
+    const spec = makeChatSpec(
+      "55555555-5555-4555-8555-555555555555",
+      "feishu",
+      "u3",
+    );
+    await openChat(spec);
+
+    // Stale globals from elsewhere must not win over the active session.
+    window.currentSessionId = "yuanbao:gone";
+    window.currentChannel = "yuanbao";
+    sessionApi.lastActiveChatId = spec.id;
+
+    const identity = sessionApi.getSessionIdentity();
+    expect(identity.channel).toBe("feishu");
+    expect(identity.sessionId).toBe("feishu:u3");
+  });
+});
+
+describe("resetWindowIdentity", () => {
+  it("clears the window identity globals back to defaults", async () => {
+    const spec = makeChatSpec(
+      "66666666-6666-4666-8666-666666666666",
+      "yuanbao",
+      "u4",
+    );
+    await openChat(spec);
+    expect(window.currentChannel).toBe("yuanbao");
+
+    sessionApi.resetWindowIdentity();
+
+    expect(window.currentSessionId).toBe("");
+    expect(window.currentUserId).toBe("default");
+    expect(window.currentChannel).toBe("console");
+  });
+});


### PR DESCRIPTION
Fixes #6341
1. Layer 1 — Reset global `window` identity variables upon agent switch
`sessionApi/index.ts`: Added `resetWindowIdentity()` to reset `currentSessionId`, `currentUserId`, and `currentChannel` to default values.
Called within the agent-switching effect in `Chat/index.tsx` to eliminate the root cause of "new agents inheriting channels from old agents."
2. Layer 2 — Fallback validation via `getSessionIdentity()`
The global `window` state is trusted only if its `sessionId` can still be resolved within the current session list; since the list is reloaded after an agent switch, validation fails for stale identities (including deleted channels), triggering a fallback to the console defaults.
An exception is made for IDs based on local timestamps (as blank new sessions are created by the console itself) to avoid unintended side effects.
3. Layer 3 — Eliminate direct reads of global `window` state during message enqueuing
`handleEnterEnqueue` and `handleBeforeSubmit` (for non-owner tabs) now use `sessionApi.getSessionIdentity()`, ensuring a unified approach that relies on validated identity sources.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
