### PR TITLE
fix(console): clear stale media preview error and skip relative-path …

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for MediaPreview error handling.
+ *
+ * Covers the streaming race where the preview is first probed with a
+ * relative param path (404) and the tool result later provides an
+ * absolute URL — the stale error must be cleared.
+ */
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@agentscope-ai/chat", () => ({
+  Attachments: {
+    FileCard: ({ item }: { item: { name: string } }) => (
+      <div data-testid="file-card">{item.name}</div>
+    ),
+  },
+}));
+
+vi.mock("@agentscope-ai/design", () => ({
+  Audio: () => <div data-testid="audio" />,
+  Video: () => <div data-testid="video" />,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) =>
+      opts && "defaultValue" in opts ? opts.defaultValue ?? "" : key,
+  }),
+}));
+
+vi.mock("../../../../utils/openExternalLink", () => ({
+  openExternalLink: vi.fn(),
+}));
+
+import MediaPreview from "./MediaPreview";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+function mockFetchByUrl(responses: Record<string, number>) {
+  fetchMock.mockImplementation(async (url: string) => {
+    const status = responses[url] ?? 200;
+    return {
+      ok: status === 200,
+      status,
+      json: async () => ({ detail: status === 404 ? "NOT_FOUND" : "" }),
+    };
+  });
+}
+
+describe("MediaPreview error state", () => {
+  it("shows a warning when the file preview URL 404s", async () => {
+    mockFetchByUrl({ "/api/files/preview/file1.txt": 404 });
+
+    render(
+      <MediaPreview
+        media={{
+          url: "/api/files/preview/file1.txt",
+          name: "file1.txt",
+          type: "file",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("preview.error.NOT_FOUND")).toBeInTheDocument();
+    });
+  });
+
+  it("clears a stale error once the media URL changes to a valid one", async () => {
+    mockFetchByUrl({
+      "/api/files/preview/file1.txt": 404,
+      "/api/files/preview/abs/path/file1.txt": 200,
+    });
+
+    const { rerender } = render(
+      <MediaPreview
+        media={{
+          url: "/api/files/preview/file1.txt",
+          name: "file1.txt",
+          type: "file",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("preview.error.NOT_FOUND")).toBeInTheDocument();
+    });
+
+    // Tool result arrives with the resolved absolute path
+    rerender(
+      <MediaPreview
+        media={{
+          url: "/api/files/preview/abs/path/file1.txt",
+          name: "file1.txt",
+          type: "file",
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("preview.error.NOT_FOUND"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("file-card")).toBeInTheDocument();
+  });
+});

--- a/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
+++ b/console/src/components/Chat/ToolCards/shared/MediaPreview.tsx
@@ -61,6 +61,12 @@ const MediaPreview: React.FC<MediaPreviewProps> = ({ media }) => {
     fetchPreviewError(media.url).then(resolveError);
   }, [media.url, resolveError]);
 
+  // Reset any stale error when the media URL changes (e.g. the tool result
+  // arrives with a resolved absolute path after a relative-path probe 404'd).
+  useEffect(() => {
+    setError(null);
+  }, [media.url]);
+
   // For "file" type there is no native onError — proactively HEAD-check the URL
   useEffect(() => {
     if (media.type !== "file" || !media.url) return;

--- a/console/src/components/Chat/ToolCards/shared/utils.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { TFunction } from "i18next";
-import { formatAgentList, formatMemorySearch } from "./utils";
+
+vi.mock("@/api/modules/chat", () => ({
+  chatApi: {
+    filePreviewUrl: (p: string) => `/api/files/preview${p}`,
+  },
+}));
+
+import { formatAgentList, formatMemorySearch, getMediaInfo } from "./utils";
+import type { ToolCallContent } from "./types";
 
 const translate = ((key: string) => {
   const translations: Record<string, string> = {
@@ -82,6 +90,59 @@ describe("formatMemorySearch", () => {
     expect(formattedResult).toContain("# 记忆与反思 - 2026-05-18");
     expect(formattedResult).not.toContain('[ { "path"');
     expect(formattedResult).not.toContain('"snippet":');
+  });
+});
+
+describe("getMediaInfo", () => {
+  const baseToolCall = (
+    overrides: Partial<ToolCallContent>,
+  ): ToolCallContent => ({
+    type: "tool_call",
+    id: "tc-1",
+    name: "send_file_to_user",
+    params: {},
+    status: "calling",
+    ...overrides,
+  });
+
+  it("does not fall back to a relative param path (backend cannot preview it)", () => {
+    const media = getMediaInfo(
+      baseToolCall({ params: { file_path: "file1.txt" } }),
+    );
+    expect(media).toBeNull();
+  });
+
+  it("uses an absolute param path while the result is pending", () => {
+    const media = getMediaInfo(
+      baseToolCall({ params: { file_path: "/abs/path/file1.txt" } }),
+    );
+    expect(media?.url).toBe("/api/files/preview/abs/path/file1.txt");
+  });
+
+  it("uses a Windows drive-letter param path while the result is pending", () => {
+    const media = getMediaInfo(
+      baseToolCall({ params: { file_path: "C:/Users/a/file1.txt" } }),
+    );
+    expect(media).not.toBeNull();
+  });
+
+  it("prefers the resolved absolute URL from result blocks over params", () => {
+    const media = getMediaInfo(
+      baseToolCall({
+        params: { file_path: "file1.txt" },
+        status: "done",
+        result: JSON.stringify([
+          {
+            type: "file",
+            source: { type: "url", url: "file:///abs/path/file1.txt" },
+            filename: "file1.txt",
+          },
+          { type: "text", text: "File sent successfully." },
+        ]),
+      }),
+    );
+    expect(media?.url).toBe("/api/files/preview/abs/path/file1.txt");
+    expect(media?.name).toBe("file1.txt");
   });
 });
 

--- a/console/src/components/Chat/ToolCards/shared/utils.ts
+++ b/console/src/components/Chat/ToolCards/shared/utils.ts
@@ -192,6 +192,24 @@ function getPathFromParams(params: Record<string, unknown>): string {
     "") as string;
 }
 
+/**
+ * Whether a param path can actually be previewed by the backend.
+ * The preview endpoint only resolves absolute paths (plus `~`, drive
+ * letters and full URLs) — a bare relative path always 404s, so it
+ * must not be used as a preview URL fallback.
+ */
+function isPreviewablePath(path: string): boolean {
+  return (
+    path.startsWith("/") ||
+    path.startsWith("~") ||
+    /^[a-zA-Z]:[\\/]/.test(path) ||
+    path.startsWith("file://") ||
+    path.startsWith("http://") ||
+    path.startsWith("https://") ||
+    path.startsWith("data:")
+  );
+}
+
 /** Extract media info from tool params/result (unified for all tool names) */
 export function getMediaInfo(tc: ToolCallContent): MediaInfo | null {
   const params = tc.params || {};
@@ -206,7 +224,8 @@ export function getMediaInfo(tc: ToolCallContent): MediaInfo | null {
     textUrl = extractUrlFromText(tc.result) || "";
   }
 
-  const rawUrl = fromResult?.url || paramPath || textUrl || "";
+  const previewableParamPath = isPreviewablePath(paramPath) ? paramPath : "";
+  const rawUrl = fromResult?.url || previewableParamPath || textUrl || "";
   if (!rawUrl) return null;
 
   const name =


### PR DESCRIPTION
1. MediaPreview.tsx — Clears the "stuck" error state (core fix): Added a `useEffect` hook to reset the error status whenever `media.url` changes. This ensures that when the tool returns the resolved absolute path, any 404 warning triggered by the initial relative-path pre-check is cleared, allowing the file card to render correctly. 2. utils.ts — `getMediaInfo` no longer uses relative paths as a fallback for previews (robustness improvement): Added an `isPreviewablePath` check; a path is used as a fallback preview URL only if it is an absolute path (starting with `/`, `~`, or a Windows drive letter) or a full URL (e.g., `file://`, `http(s)://`, `data:`). Bare relative paths inevitably result in a 404 error when sent to the backend preview API, so they are now skipped entirely; this prevents the system from initiating doomed requests and displaying misleading warnings during the streaming process.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
