### PR TITLE
perf(console): stabilize chat options memo and reduce SSE re-parsing

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -557,6 +557,10 @@ const DEFAULT_USER_ID = "default";
 const DEFAULT_CHANNEL = "console";
 const WIDE_MODE_STORAGE_KEY = "qwenpaw_chat_wide_mode";
 
+// Stable fallback so an absent queue entry doesn't produce a fresh array
+// reference on every render (which would invalidate the options memo).
+const EMPTY_QUEUE: QueueItem[] = [];
+
 function isSkillAvailableInConsole(skill: SkillSpec): boolean {
   if (!skill.enabled) return false;
   const channels = skill.channels?.length ? skill.channels : ["all"];
@@ -1104,6 +1108,25 @@ const timestampStyle: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
+type SessionQueuePanelProps = Omit<
+  React.ComponentProps<typeof MessageQueuePanel>,
+  "items" | "runState"
+> & { sessionId: string };
+
+/**
+ * Self-subscribed queue panel: item/run-state changes re-render only this
+ * component instead of invalidating the whole ChatPage options memo (and
+ * with it the SDK options object) on every queue mutation.
+ */
+function SessionQueuePanel({ sessionId, ...handlers }: SessionQueuePanelProps) {
+  const items = useMessageQueueStore((s) => s.queues[sessionId]) ?? EMPTY_QUEUE;
+  const runState = useMessageQueueStore(
+    (s) => s.runStates[sessionId] ?? "idle",
+  );
+  if (items.length === 0) return null;
+  return <MessageQueuePanel items={items} runState={runState} {...handlers} />;
+}
+
 const HISTORY_PANEL_STORAGE_KEY = "qwenpaw_history_panel_open";
 
 export default function ChatPage() {
@@ -1179,7 +1202,7 @@ export default function ChatPage() {
   const queueSessionIdRef = useRef(queueSessionId);
   queueSessionIdRef.current = queueSessionId;
   const messageQueue =
-    useMessageQueueStore((s) => s.queues[queueSessionId]) ?? [];
+    useMessageQueueStore((s) => s.queues[queueSessionId]) ?? EMPTY_QUEUE;
   const messageQueueRef = useRef(messageQueue);
   messageQueueRef.current = messageQueue;
   const autoSendTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1224,10 +1247,6 @@ export default function ChatPage() {
       }));
     },
     [],
-  );
-
-  const runState = useMessageQueueStore(
-    (s) => s.runStates[queueSessionId] ?? "idle",
   );
 
   // Single-tab ownership: only one tab per conversation may send. Other tabs
@@ -2722,9 +2741,8 @@ export default function ChatPage() {
               />
             )}
             {hasQueueItems ? (
-              <MessageQueuePanel
-                items={messageQueue}
-                runState={runState}
+              <SessionQueuePanel
+                sessionId={queueSessionId}
                 onRemove={handleQueueRemove}
                 onEdit={handleQueueEdit}
                 onReorder={handleQueueReorder}
@@ -2996,7 +3014,9 @@ export default function ChatPage() {
     handleWhisperTranscription,
     isWideMode,
     toggleWideMode,
-    messageQueue,
+    hasQueueItems,
+    isQueueOnlyTab,
+    showSenderBeforeUI,
     handleQueueRemove,
     handleQueueEdit,
     handleQueueReorder,
@@ -3005,9 +3025,9 @@ export default function ChatPage() {
     handleQueuePauseResume,
     handleQueueRetry,
     handleQueueSkip,
-    runState,
-    isOwner,
-    syncLoopModeStatus,
+    effectiveIsFullMode,
+    historyPanelOpen,
+    toggleHistoryPanel,
     handleCompactCommand,
     handleNewCommand,
   ]);

--- a/console/src/pages/Chat/turnUsage.ts
+++ b/console/src/pages/Chat/turnUsage.ts
@@ -298,6 +298,9 @@ function parseSseDataLines(buffer: string): {
 }
 
 function snapshotFromSsePayload(raw: string): TurnUsageSnapshot | null {
+  // Fast path: skip the (second) JSON.parse for the vast majority of SSE
+  // events — only `type: "turn_usage"` payloads are relevant here.
+  if (!raw.includes("turn_usage")) return null;
   try {
     return parseTurnUsageSsePayload(JSON.parse(raw) as Record<string, unknown>);
   } catch {


### PR DESCRIPTION
#1 Stable empty array: Introduced a module-level `EMPTY_QUEUE` constant and updated the `messageQueue` fallback from `?? []` to `?? EMPTY_QUEUE`. This prevents the `options` memo from invalidating on every render and stabilizes the component identity of the plugin tool card (avoiding a full-tree remount).
#2 Queue panel self-subscription: Added a `SessionQueuePanel` container that subscribes directly to `items` and `runState` (rendering `null` for empty queues). Refactored `options.beforeUI` to utilize this component; consolidated `messageQueue` and `runState` dependencies into boolean flags (`hasQueueItems`, `isQueueOnlyTab`, `showSenderBeforeUI`). Consequently, item state changes during queue processing no longer trigger an `options` object recreation, limiting re-renders to the panel itself.
Addressed missing dependencies: Added `historyPanelOpen`, `effectiveIsFullMode`, and `toggleHistoryPanel` (to fix a "stale-props" bug exposed by the changes in #1); removed `isOwner` and `syncLoopModeStatus` (no longer referenced within the memo body) and deleted the orphaned `runState` subscription at the `ChatPage` level.
#4 SSE fast-path filtering: Updated `snapshotFromSsePayload` to perform a substring check for `"turn_usage"` on the raw payload first, allowing the vast majority of stream events to skip the secondary `JSON.parse` operation.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
