### PR TITLE
fix(tools): coerce LLM-stringified spawn_subagent batch/list args

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -882,42 +882,44 @@ def _coerce_timeout(
     """Parse a timeout tool field to ``int`` seconds.
 
     Accepts ``int`` / ``float`` / numeric strings (LLM mis-serialization).
-    Rejects bools and non-numeric values with ``ValueError``.
+    Rejects bools, non-numeric values, and non-positive timeouts.
     """
     if value is None:
         return default
     # bool is an int subclass — do not treat True/False as 1/0 seconds.
     if isinstance(value, bool):
         raise ValueError(
-            f"'{field_name}' must be a number (seconds)",
+            f"'{field_name}' must be a positive number (seconds)",
         )
     if isinstance(value, (int, float)):
         as_float = float(value)
-        if not math.isfinite(as_float):
-            raise ValueError(
-                f"'{field_name}' must be a finite number (seconds)",
-            )
-        return int(as_float)
-    if isinstance(value, str):
+    elif isinstance(value, str):
         text = value.strip()
         if not text:
             raise ValueError(
-                f"'{field_name}' must be a number (seconds)",
+                f"'{field_name}' must be a positive number (seconds)",
             )
         try:
             as_float = float(text)
         except ValueError as exc:
             raise ValueError(
-                f"'{field_name}' must be a number (seconds)",
+                f"'{field_name}' must be a positive number (seconds)",
             ) from exc
-        if not math.isfinite(as_float):
-            raise ValueError(
-                f"'{field_name}' must be a finite number (seconds)",
-            )
-        return int(as_float)
-    raise ValueError(
-        f"'{field_name}' must be a number (seconds)",
-    )
+    else:
+        raise ValueError(
+            f"'{field_name}' must be a positive number (seconds)",
+        )
+    if not math.isfinite(as_float):
+        raise ValueError(
+            f"'{field_name}' must be a positive number (seconds)",
+        )
+    # Truncation can turn (0, 1) into 0 — reject after int(), not before.
+    as_int = int(as_float)
+    if as_int <= 0:
+        raise ValueError(
+            f"'{field_name}' must be a positive number (seconds)",
+        )
+    return as_int
 
 
 def _normalize_batch(
@@ -961,8 +963,8 @@ def _build_subagent_request_context(
 )
 async def spawn_subagent(  # pylint: disable=too-many-return-statements
     task: str,
-    fork: bool | str = False,
-    background: bool | str = False,
+    fork: bool | str | int = False,
+    background: bool | str | int = False,
     timeout: int | float | str = 600,
     allowed_tools: Optional[list[str] | str] = None,
     skills: Optional[list[str] | str] = None,

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import logging
+import math
 import re
 import time
 from typing import Any, Callable, Dict, Optional
@@ -842,11 +843,17 @@ def _normalize_str_list(
     return list(coerced)
 
 
-def _coerce_bool(value: Any, default: bool = False) -> bool:
-    """Parse a bool tool field; reject ambiguous string truthiness.
+def _coerce_bool(
+    value: Any,
+    default: bool = False,
+    *,
+    field_name: str = "value",
+) -> bool:
+    """Parse a bool tool field; reject ambiguous truthiness.
 
-    ``bool("false")`` is ``True`` in Python — treat common string /
-    numeric forms explicitly instead.
+    ``bool("false")`` / ``bool("null")`` are ``True`` in Python — only
+    accept explicit bool / ``0|1`` / known true/false strings.  Anything
+    else raises ``ValueError`` (no ``bool(value)`` fallthrough).
     """
     if value is None:
         return default
@@ -858,9 +865,59 @@ def _coerce_bool(value: Any, default: bool = False) -> bool:
         text = value.strip().lower()
         if text in ("true", "1", "yes", "on"):
             return True
-        if text in ("false", "0", "no", "off", ""):
+        if text in ("false", "0", "no", "off"):
             return False
-    return bool(value)
+    raise ValueError(
+        f"'{field_name}' must be a boolean "
+        f"(or 0/1 / true/false / yes/no / on/off)",
+    )
+
+
+def _coerce_timeout(
+    value: Any,
+    default: int = 600,
+    *,
+    field_name: str = "timeout",
+) -> int:
+    """Parse a timeout tool field to ``int`` seconds.
+
+    Accepts ``int`` / ``float`` / numeric strings (LLM mis-serialization).
+    Rejects bools and non-numeric values with ``ValueError``.
+    """
+    if value is None:
+        return default
+    # bool is an int subclass — do not treat True/False as 1/0 seconds.
+    if isinstance(value, bool):
+        raise ValueError(
+            f"'{field_name}' must be a number (seconds)",
+        )
+    if isinstance(value, (int, float)):
+        as_float = float(value)
+        if not math.isfinite(as_float):
+            raise ValueError(
+                f"'{field_name}' must be a finite number (seconds)",
+            )
+        return int(as_float)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError(
+                f"'{field_name}' must be a number (seconds)",
+            )
+        try:
+            as_float = float(text)
+        except ValueError as exc:
+            raise ValueError(
+                f"'{field_name}' must be a number (seconds)",
+            ) from exc
+        if not math.isfinite(as_float):
+            raise ValueError(
+                f"'{field_name}' must be a finite number (seconds)",
+            )
+        return int(as_float)
+    raise ValueError(
+        f"'{field_name}' must be a number (seconds)",
+    )
 
 
 def _normalize_batch(
@@ -904,9 +961,9 @@ def _build_subagent_request_context(
 )
 async def spawn_subagent(  # pylint: disable=too-many-return-statements
     task: str,
-    fork: bool = False,
-    background: bool = False,
-    timeout: int = 600,
+    fork: bool | str = False,
+    background: bool | str = False,
+    timeout: int | float | str = 600,
     allowed_tools: Optional[list[str] | str] = None,
     skills: Optional[list[str] | str] = None,
     batch: Optional[list[Dict[str, Any]] | str] = None,
@@ -937,6 +994,8 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
                parent or other subagents.
             When False (default), the subagent starts with an empty
             session and works in the original project directory.
+            A JSON/string boolean (e.g. ``"false"``) is also accepted
+            for LLM mis-serialization; ambiguous values return ERROR.
         background: If True, submit as a background task and return
             immediately with a task_id.  The subagent typically runs for
             **minutes, not seconds** — do NOT poll immediately.  Wait at
@@ -944,22 +1003,28 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             and use 30-60 second intervals between subsequent polls.
             Prefer ``background=False`` (foreground) when only spawning
             a single subagent — it blocks until completion, eliminating
-            the need to poll entirely.
+            the need to poll entirely.  String booleans are accepted
+            like ``fork``; ambiguous values return ERROR.
         timeout: Foreground wait timeout in seconds (default 600).
-            Ignored when ``background=True``.
+            Ignored when ``background=True``.  Numeric strings (e.g.
+            ``"600"``) are accepted for LLM mis-serialization; invalid
+            values return ERROR.  Ignored entirely in batch mode.
         allowed_tools: Tool-name whitelist.  Only the listed tools are
             available to the subagent.  ``None`` (default) inherits the
             parent's full tool set.  An empty list denies all tools.
             A JSON array string is also accepted (LLM mis-serialization).
+            Ignored in batch mode (use per-item ``allowed_tools``).
         skills: Skill-name whitelist.  Only the listed SKILL.md files
             are loaded for the subagent.  ``None`` (default) inherits
             all skills resolved for this workspace.  A JSON array
-            string is also accepted.
+            string is also accepted.  Ignored in batch mode (use
+            per-item ``skills``).
         batch: List of task specs for batch mode.  When provided,
             ``task`` must be an empty string.  Each dict must contain a
-            ``task`` key; optional keys: ``fork``, ``allowed_tools``,
-            ``skills`` (top-level ``fork`` / ``timeout`` /
-            ``allowed_tools`` / ``skills`` are ignored in batch mode).
+            ``task`` key; optional keys: ``fork``, ``timeout``,
+            ``allowed_tools``, ``skills`` (top-level ``fork`` /
+            ``timeout`` / ``allowed_tools`` / ``skills`` /
+            ``background`` are ignored in batch mode).
             A JSON array string is also accepted so schema validation
             does not reject common LLM stringification.  All subagents
             run as background tasks.  Maximum length is
@@ -973,11 +1038,6 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
         Batch: per-subagent [TASK_ID: ...] + [SESSION: ...].
     """
     try:
-        allowed_tools = _normalize_str_list(
-            allowed_tools,
-            "allowed_tools",
-        )
-        skills = _normalize_str_list(skills, "skills")
         batch = _normalize_batch(batch)
     except ValueError as exc:
         return _tool_text_response(f"ERROR: {exc}")
@@ -988,6 +1048,9 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
                 "ERROR: 'task' and 'batch' are mutually exclusive. "
                 "Pass task='' with 'batch' for multiple subagents.",
             )
+        # Top-level fork/background/timeout/allowed_tools/skills are
+        # ignored in batch mode — do not normalize/coerce them here or
+        # LLM placeholder strings would block dispatch.
         return await _spawn_batch(batch)
 
     if not task or not task.strip():
@@ -995,6 +1058,22 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             "ERROR: 'task' is required for spawn_subagent "
             "(use task='' only with batch=...)",
         )
+
+    try:
+        allowed_tools = _normalize_str_list(
+            allowed_tools,
+            "allowed_tools",
+        )
+        skills = _normalize_str_list(skills, "skills")
+        fork = _coerce_bool(fork, default=False, field_name="fork")
+        background = _coerce_bool(
+            background,
+            default=False,
+            field_name="background",
+        )
+        timeout = _coerce_timeout(timeout, default=600, field_name="timeout")
+    except ValueError as exc:
+        return _tool_text_response(f"ERROR: {exc}")
 
     from ...app.agent_context import get_current_agent_id
 
@@ -1115,6 +1194,18 @@ async def _spawn_batch(
                         spec.get("skills"),
                         f"batch[{i}].skills",
                     ),
+                    # Validate fork/timeout before any dispatch so a bad
+                    # value cannot partially spawn siblings (gather).
+                    "fork": _coerce_bool(
+                        spec.get("fork"),
+                        default=False,
+                        field_name=f"batch[{i}].fork",
+                    ),
+                    "timeout": _coerce_timeout(
+                        spec.get("timeout"),
+                        default=600,
+                        field_name=f"batch[{i}].timeout",
+                    ),
                 },
             )
         except ValueError as exc:
@@ -1133,8 +1224,8 @@ async def _spawn_batch(
     async def _dispatch_one(spec: Dict[str, Any]) -> str:
         session_id = _generate_subagent_session_id()
         task_text = spec["task"]
-        spec_fork = _coerce_bool(spec.get("fork"), default=False)
-        spec_timeout = spec.get("timeout", 600)
+        spec_fork = bool(spec["fork"])
+        spec_timeout = int(spec["timeout"])
         spec_allowed = spec.get("allowed_tools")
         spec_skills = spec.get("skills")
 

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -786,25 +786,96 @@ def _build_spawn_request_context(current_agent_id: str) -> dict[str, Any]:
     return context
 
 
+def _coerce_json_list(value: Any, field_name: str) -> Optional[list[Any]]:
+    """Coerce a tool arg to ``list``; accept JSON-array strings from LLMs.
+
+    Returns ``None`` when *value* is ``None``.  Raises ``ValueError`` for
+    non-list values (after optional JSON decode of strings).
+    """
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError(
+                f"'{field_name}' must be a list or a JSON array string",
+            )
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError(
+                f"'{field_name}' must be a list or a JSON array string",
+            ) from exc
+        if not isinstance(parsed, list):
+            raise ValueError(
+                f"'{field_name}' JSON value must be an array, "
+                f"got {type(parsed).__name__}",
+            )
+        return parsed
+    raise ValueError(
+        f"'{field_name}' must be a list or a JSON array string",
+    )
+
+
 def _normalize_str_list(
     value: Any,
     field_name: str,
 ) -> Optional[list[str]]:
     """Validate an optional list[str] tool argument.
 
-    Returns ``None`` when *value* is ``None``.  Raises ``ValueError``
-    when the value is not a list of strings (prevents ``list("abc")``
-    character-splitting on mistaken string inputs).
+    Accepts a real ``list[str]`` or a JSON array string (common LLM
+    mis-serialization).  Returns ``None`` when *value* is ``None``.
+    Raises ``ValueError`` when the value is not a list of strings
+    (prevents ``list("abc")`` character-splitting on mistaken string
+    inputs that are not JSON arrays).
     """
     if value is None:
         return None
-    if not isinstance(value, list) or not all(
-        isinstance(item, str) for item in value
-    ):
+    coerced = _coerce_json_list(value, field_name)
+    assert coerced is not None
+    if not all(isinstance(item, str) for item in coerced):
         raise ValueError(
             f"'{field_name}' must be a list of strings or null",
         )
-    return list(value)
+    return list(coerced)
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Parse a bool tool field; reject ambiguous string truthiness.
+
+    ``bool("false")`` is ``True`` in Python — treat common string /
+    numeric forms explicitly instead.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in ("true", "1", "yes", "on"):
+            return True
+        if text in ("false", "0", "no", "off", ""):
+            return False
+    return bool(value)
+
+
+def _normalize_batch(
+    value: Any,
+) -> Optional[list[Dict[str, Any]]]:
+    """Normalize ``batch`` to ``list[dict]`` or ``None``.
+
+    Accepts a real list or a JSON array string.  Structural checks
+    (non-empty, per-item ``task``) remain in :func:`_spawn_batch`.
+    """
+    if value is None:
+        return None
+    coerced = _coerce_json_list(value, "batch")
+    assert coerced is not None
+    return coerced  # type: ignore[return-value]
 
 
 def _build_subagent_request_context(
@@ -836,9 +907,9 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
     fork: bool = False,
     background: bool = False,
     timeout: int = 600,
-    allowed_tools: Optional[list[str]] = None,
-    skills: Optional[list[str]] = None,
-    batch: Optional[list[Dict[str, Any]]] = None,
+    allowed_tools: Optional[list[str] | str] = None,
+    skills: Optional[list[str] | str] = None,
+    batch: Optional[list[Dict[str, Any]] | str] = None,
 ) -> ToolChunk:
     """Spawn an ephemeral subagent within the CURRENT workspace.
 
@@ -879,15 +950,19 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
         allowed_tools: Tool-name whitelist.  Only the listed tools are
             available to the subagent.  ``None`` (default) inherits the
             parent's full tool set.  An empty list denies all tools.
+            A JSON array string is also accepted (LLM mis-serialization).
         skills: Skill-name whitelist.  Only the listed SKILL.md files
             are loaded for the subagent.  ``None`` (default) inherits
-            all skills resolved for this workspace.
+            all skills resolved for this workspace.  A JSON array
+            string is also accepted.
         batch: List of task specs for batch mode.  When provided,
             ``task`` must be an empty string.  Each dict must contain a
             ``task`` key; optional keys: ``fork``, ``allowed_tools``,
             ``skills`` (top-level ``fork`` / ``timeout`` /
             ``allowed_tools`` / ``skills`` are ignored in batch mode).
-            All subagents run as background tasks.  Maximum length is
+            A JSON array string is also accepted so schema validation
+            does not reject common LLM stringification.  All subagents
+            run as background tasks.  Maximum length is
             ``MAX_SPAWN_BATCH_SIZE`` (10); concurrent dispatches are
             capped at ``MAX_SPAWN_BATCH_CONCURRENCY`` (3).
 
@@ -903,6 +978,7 @@ async def spawn_subagent(  # pylint: disable=too-many-return-statements
             "allowed_tools",
         )
         skills = _normalize_str_list(skills, "skills")
+        batch = _normalize_batch(batch)
     except ValueError as exc:
         return _tool_text_response(f"ERROR: {exc}")
 
@@ -1057,7 +1133,7 @@ async def _spawn_batch(
     async def _dispatch_one(spec: Dict[str, Any]) -> str:
         session_id = _generate_subagent_session_id()
         task_text = spec["task"]
-        spec_fork = bool(spec.get("fork", False))
+        spec_fork = _coerce_bool(spec.get("fork"), default=False)
         spec_timeout = spec.get("timeout", 600)
         spec_allowed = spec.get("allowed_tools")
         spec_skills = spec.get("skills")

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -500,6 +500,33 @@ def test_coerce_bool_rejects_ambiguous_values():
             raise AssertionError(f"expected ValueError for {bad!r}")
 
 
+def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
+    assert agent_management._coerce_timeout("600") == 600
+    assert agent_management._coerce_timeout(30.9) == 30
+    assert agent_management._coerce_timeout(1) == 1
+    # Truncation of (0, 1) must not silently become timeout=0.
+    for bad in (
+        0,
+        -1,
+        "0",
+        "-1",
+        0.5,
+        0.9,
+        "0.5",
+        "1e-9",
+        "abc",
+        True,
+        False,
+        "",
+    ):
+        try:
+            agent_management._coerce_timeout(bad, field_name="timeout")
+        except ValueError as exc:
+            assert "timeout" in str(exc)
+        else:
+            raise AssertionError(f"expected ValueError for {bad!r}")
+
+
 def test_spawn_subagent_schema_accepts_batch_string():
     """Tool JSON schema must allow string so AgentScope validation passes."""
     import jsonschema
@@ -532,6 +559,11 @@ def test_spawn_subagent_schema_accepts_batch_string():
     )
     jsonschema.validate(
         {"task": "do work", "fork": False, "background": True},
+        schema,
+    )
+    # Integer 0/1 aligns with _coerce_bool (common LLM numeric bools).
+    jsonschema.validate(
+        {"task": "do work", "fork": 0, "background": 1},
         schema,
     )
     # Top-level timeout string (LLM mis-serialization).
@@ -998,5 +1030,26 @@ async def test_spawn_subagent_batch_item_timeout_errors_before_dispatch(
     text = response.content[0].text
     assert text.startswith("ERROR:")
     assert "batch[1].timeout" in text
+    assert not submitted
+    assert not forked
+
+    # Sub-second values truncate to 0 and must not dispatch.
+    response2 = await agent_management.spawn_subagent(
+        task="",
+        batch=[{"task": "a", "timeout": 0.5}],
+    )
+    text2 = response2.content[0].text
+    assert text2.startswith("ERROR:")
+    assert "timeout" in text2.lower()
+    assert not submitted
+    assert not forked
+
+    response3 = await agent_management.spawn_subagent(
+        task="",
+        batch=json.dumps([{"task": "a", "timeout": "0.5"}]),
+    )
+    text3 = response3.content[0].text
+    assert text3.startswith("ERROR:")
+    assert "timeout" in text3.lower()
     assert not submitted
     assert not forked

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 """Tests for agent discovery and inter-agent chat helpers."""
 
 from __future__ import annotations
 
+import json
+
 import httpx
+from agentscope.tool import FunctionTool
 from agentscope.tool import Toolkit
 
-from agentscope.tool import FunctionTool
 from qwenpaw.agents.tools import agent_management
 
 
@@ -442,3 +445,200 @@ async def test_spawn_subagent_inherits_root_channel_context(monkeypatch):
     assert context["channel_meta"] == {"group_openid": "g1"}
     assert context["_spawn_subagent"] is True
     assert "done" in response.content[0].text
+
+
+def test_normalize_str_list_accepts_json_array_string():
+    assert agent_management._normalize_str_list(
+        '["read_file", "write_file"]',
+        "allowed_tools",
+    ) == ["read_file", "write_file"]
+    assert agent_management._normalize_str_list(None, "skills") is None
+    assert agent_management._normalize_str_list([], "skills") == []
+
+
+def test_normalize_str_list_rejects_plain_string():
+    try:
+        agent_management._normalize_str_list("read_file", "allowed_tools")
+    except ValueError as exc:
+        assert "allowed_tools" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for non-JSON string")
+
+
+def test_normalize_batch_accepts_json_array_string():
+    raw = json.dumps(
+        [
+            {"task": "do A", "fork": False},
+            {"task": "do B", "fork": True},
+        ],
+    )
+    out = agent_management._normalize_batch(raw)
+    assert isinstance(out, list)
+    assert len(out) == 2
+    assert out[0]["task"] == "do A"
+    assert out[1]["fork"] is True
+
+
+def test_coerce_bool_string_false_is_false():
+    assert agent_management._coerce_bool("false") is False
+    assert agent_management._coerce_bool("true") is True
+    assert agent_management._coerce_bool(False) is False
+    assert agent_management._coerce_bool(None, default=True) is True
+    # Python bool("false") is True — must not use that.
+    assert bool("false") is True
+
+
+def test_spawn_subagent_schema_accepts_batch_string():
+    """Tool JSON schema must allow string so AgentScope validation passes."""
+    import jsonschema
+
+    tool = FunctionTool(agent_management.spawn_subagent)
+    schema = tool.input_schema
+    # Stringified batch (the live LLM failure mode) must validate.
+    jsonschema.validate(
+        {
+            "task": "",
+            "batch": (
+                '[{"task": "Create A", "fork": false},'
+                ' {"task": "Create B"}]'
+            ),
+        },
+        schema,
+    )
+    # Native list still validates.
+    jsonschema.validate(
+        {
+            "task": "",
+            "batch": [{"task": "Create A"}, {"task": "Create B"}],
+        },
+        schema,
+    )
+
+
+async def test_spawn_subagent_batch_json_string_dispatches(monkeypatch):
+    submitted: list[dict] = []
+
+    def fake_submit(
+        _base,
+        payload,
+        agent_id,
+        _timeout,
+        task_timeout=None,  # pylint: disable=unused-argument
+    ):
+        submitted.append({"agent_id": agent_id, "payload": payload})
+        return {"task_id": f"t-{len(submitted)}"}
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    batch_json = json.dumps(
+        [
+            {"task": "create file a", "fork": False},
+            {"task": "create file b", "fork": "false"},
+        ],
+    )
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=batch_json,
+    )
+    text = response.content[0].text
+    assert "[1/2]" in text
+    assert "[2/2]" in text
+    assert len(submitted) == 2
+    assert submitted[0]["agent_id"] == "bot-a"
+    # fork="false" must not take the fork path (no fork_project_dir).
+    for item in submitted:
+        rc = item["payload"]["request_context"]
+        assert "fork_project_dir" not in rc
+
+
+async def test_spawn_subagent_batch_list_still_works(monkeypatch):
+    submitted: list[dict] = []
+
+    def fake_submit(
+        _base,
+        payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,  # pylint: disable=unused-argument
+    ):
+        submitted.append(payload)
+        return {"task_id": f"t-{len(submitted)}"}
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=[
+            {"task": "one", "allowed_tools": '["read_file"]'},
+            {"task": "two"},
+        ],
+    )
+    assert "[1/2]" in response.content[0].text
+    assert len(submitted) == 2
+    rc0 = submitted[0]["request_context"]
+    assert rc0.get("subagent_allowed_tools") == ["read_file"]
+
+
+async def test_spawn_subagent_batch_invalid_string_returns_error():
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch="not-json-array",
+    )
+    assert "ERROR" in response.content[0].text
+    assert "batch" in response.content[0].text.lower()

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -484,8 +484,20 @@ def test_coerce_bool_string_false_is_false():
     assert agent_management._coerce_bool("true") is True
     assert agent_management._coerce_bool(False) is False
     assert agent_management._coerce_bool(None, default=True) is True
+    assert agent_management._coerce_bool(0) is False
+    assert agent_management._coerce_bool(1) is True
     # Python bool("false") is True — must not use that.
     assert bool("false") is True
+
+
+def test_coerce_bool_rejects_ambiguous_values():
+    for bad in ("null", "None", "nope", "fals", "maybe", "", "2", 2, 0.5):
+        try:
+            agent_management._coerce_bool(bad, field_name="fork")
+        except ValueError as exc:
+            assert "fork" in str(exc)
+        else:
+            raise AssertionError(f"expected ValueError for {bad!r}")
 
 
 def test_spawn_subagent_schema_accepts_batch_string():
@@ -510,6 +522,28 @@ def test_spawn_subagent_schema_accepts_batch_string():
         {
             "task": "",
             "batch": [{"task": "Create A"}, {"task": "Create B"}],
+        },
+        schema,
+    )
+    # Top-level fork/background string forms (LLM mis-serialization).
+    jsonschema.validate(
+        {"task": "do work", "fork": "false", "background": "true"},
+        schema,
+    )
+    jsonschema.validate(
+        {"task": "do work", "fork": False, "background": True},
+        schema,
+    )
+    # Top-level timeout string (LLM mis-serialization).
+    jsonschema.validate(
+        {"task": "do work", "timeout": "600"},
+        schema,
+    )
+    jsonschema.validate(
+        {
+            "task": "",
+            "batch": [{"task": "ok"}],
+            "timeout": "600",
         },
         schema,
     )
@@ -642,3 +676,327 @@ async def test_spawn_subagent_batch_invalid_string_returns_error():
     )
     assert "ERROR" in response.content[0].text
     assert "batch" in response.content[0].text.lower()
+
+
+async def test_spawn_subagent_batch_ignores_top_level_ignored_fields(
+    monkeypatch,
+):
+    """Batch mode ignores invalid top-level fork/tools/skills/timeout."""
+    submitted: list[dict] = []
+
+    def fake_submit(
+        _base,
+        payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,  # pylint: disable=unused-argument
+    ):
+        submitted.append(payload)
+        return {"task_id": f"t-{len(submitted)}"}
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=[{"task": "ok"}],
+        fork="null",
+        background="maybe",
+        allowed_tools="null",
+        skills="null",
+        timeout="600",
+    )
+    text = response.content[0].text
+    assert "ERROR" not in text
+    assert "[1/1]" in text
+    assert len(submitted) == 1
+
+    # Plain non-JSON string for tools must also be ignored at top level.
+    submitted.clear()
+    response2 = await agent_management.spawn_subagent(
+        task="",
+        batch=[{"task": "ok2"}],
+        allowed_tools="read_file",
+        skills="read_file",
+    )
+    assert "ERROR" not in response2.content[0].text
+    assert len(submitted) == 1
+
+
+async def test_spawn_subagent_batch_ambiguous_fork_errors_before_dispatch(
+    monkeypatch,
+):
+    """Illegal batch fork must ERROR with zero submits / fork spawns."""
+    submitted: list[dict] = []
+    forked: list[str] = []
+
+    def fake_submit(
+        _base,
+        payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,  # pylint: disable=unused-argument
+    ):
+        submitted.append(payload)
+        return {"task_id": f"t-{len(submitted)}"}
+
+    async def fake_forked(**kwargs):
+        forked.append(kwargs.get("task", ""))
+        return agent_management._tool_text_response("forked")
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "_spawn_forked_subagent",
+        fake_forked,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=[{"task": "t", "fork": "null"}],
+    )
+    text = response.content[0].text
+    assert text.startswith("ERROR:")
+    assert "fork" in text.lower()
+    assert not submitted
+    assert not forked
+
+    # Mixed batch: one good item must not partially dispatch.
+    response2 = await agent_management.spawn_subagent(
+        task="",
+        batch=[
+            {"task": "ok-task", "fork": False},
+            {"task": "bad-task", "fork": "null"},
+        ],
+    )
+    text2 = response2.content[0].text
+    assert text2.startswith("ERROR:")
+    assert "batch[1].fork" in text2
+    assert not submitted
+    assert not forked
+
+
+async def test_spawn_subagent_top_level_string_bools(monkeypatch):
+    """Top-level fork/background strings: schema-safe + no false fork."""
+    collected: list[dict] = []
+    forked: list[str] = []
+
+    def fake_collect(_base, payload, _agent_id, _timeout):
+        collected.append(payload)
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    async def fake_forked(**kwargs):
+        forked.append(kwargs.get("task", ""))
+        return agent_management._tool_text_response("forked")
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "_spawn_forked_subagent",
+        fake_forked,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    # fork="false" must NOT take the fork path.
+    response = await agent_management.spawn_subagent(
+        task="do work",
+        fork="false",
+        background="false",
+    )
+    assert "ERROR" not in response.content[0].text
+    assert "done" in response.content[0].text
+    assert not forked
+    assert len(collected) == 1
+    assert "fork_project_dir" not in collected[0]["request_context"]
+
+    collected.clear()
+    bad = await agent_management.spawn_subagent(
+        task="do work",
+        fork="null",
+    )
+    assert bad.content[0].text.startswith("ERROR:")
+    assert "fork" in bad.content[0].text.lower()
+    assert not collected
+    assert not forked
+
+    bad_bg = await agent_management.spawn_subagent(
+        task="do work",
+        background="maybe",
+    )
+    assert bad_bg.content[0].text.startswith("ERROR:")
+    assert "background" in bad_bg.content[0].text.lower()
+    assert not collected
+
+    # String timeout is accepted on the single-spawn path.
+    collected.clear()
+    ok_timeout = await agent_management.spawn_subagent(
+        task="do work",
+        timeout="600",
+    )
+    assert "ERROR" not in ok_timeout.content[0].text
+    assert len(collected) == 1
+
+    collected.clear()
+    bad_timeout = await agent_management.spawn_subagent(
+        task="do work",
+        timeout="abc",
+    )
+    assert bad_timeout.content[0].text.startswith("ERROR:")
+    assert "timeout" in bad_timeout.content[0].text.lower()
+    assert not collected
+
+
+async def test_spawn_subagent_batch_item_timeout_errors_before_dispatch(
+    monkeypatch,
+):
+    """Illegal batch item timeout must ERROR with zero submits."""
+    submitted: list[dict] = []
+    forked: list[str] = []
+
+    def fake_submit(
+        _base,
+        payload,
+        _agent_id,
+        _timeout,
+        task_timeout=None,  # pylint: disable=unused-argument
+    ):
+        submitted.append(payload)
+        return {"task_id": f"t-{len(submitted)}"}
+
+    async def fake_forked(**kwargs):
+        forked.append(kwargs.get("task", ""))
+        return agent_management._tool_text_response("forked")
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "submit_agent_chat_task",
+        fake_submit,
+    )
+    monkeypatch.setattr(
+        agent_management,
+        "_spawn_forked_subagent",
+        fake_forked,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.spawn_subagent(
+        task="",
+        batch=[
+            {"task": "a"},
+            {"task": "b", "timeout": "abc"},
+        ],
+    )
+    text = response.content[0].text
+    assert text.startswith("ERROR:")
+    assert "batch[1].timeout" in text
+    assert not submitted
+    assert not forked


### PR DESCRIPTION
## Description

LLMs often pass `spawn_subagent`'s `batch` / `allowed_tools` / `skills` as JSON **strings** (e.g. `"[{...}]"`) instead of native arrays. AgentScope runs `jsonschema.validate` before the tool body, so those calls were rejected with `Input validation failed` and never reached `_spawn_batch`.

This PR widens the tool annotations so the schema accepts `string`, then coerces JSON-array strings to real lists inside the tool. It also coerces string/numeric `fork` values (so `"false"` is not treated as truthy via Python `bool("false")`).

**Impact:** OMP workflows (Ultrawork / Autopilot / Team) that rely on `spawn_subagent(task="", batch=[...])` can dispatch parallel workers even when the model stringifies list args.

**Security Considerations:** N/A — argument normalization only; no auth/channel/config changes. Invalid non-array JSON strings still raise a clear `ERROR` and do not character-split strings into fake tool lists.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic


## Additional Notes

- Native `list` arguments remain unchanged (regression covered by unit tests).
- Coercion accepts only JSON **array** strings for list fields; plain strings like `"abc"` are still rejected (avoids `list("abc")` character-splitting).
- Batch-item `fork: "false"` is normalized via `_coerce_bool` so workers do not incorrectly take the fork/worktree path.