### PR TITLE
feat(inbox): wobble sidebar inbox on new approvals & color-code badge dot

### DIFF
--- a/console/src/hooks/useInboxWobble.ts
+++ b/console/src/hooks/useInboxWobble.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "qwenpaw.inbox.approvalWobble";
+const SYNC_EVENT = "qwenpaw:inbox-wobble-change";
+
+/**
+ * Shared hook for the "approval wobble notification" toggle.
+ *
+ * - Persisted in localStorage (default: **enabled**).
+ * - Cross-component: when one component toggles, others react instantly
+ *   via a CustomEvent on `window`.
+ */
+export function useInboxWobble(): [enabled: boolean, toggle: () => void] {
+  const [enabled, setEnabled] = useState(
+    () => localStorage.getItem(STORAGE_KEY) !== "false",
+  );
+
+  useEffect(() => {
+    const sync = () =>
+      setEnabled(localStorage.getItem(STORAGE_KEY) !== "false");
+    window.addEventListener(SYNC_EVENT, sync);
+    return () => window.removeEventListener(SYNC_EVENT, sync);
+  }, []);
+
+  const toggle = useCallback(() => {
+    const next = localStorage.getItem(STORAGE_KEY) === "false";
+    localStorage.setItem(STORAGE_KEY, String(next));
+    setEnabled(next);
+    window.dispatchEvent(new CustomEvent(SYNC_EVENT));
+  }, []);
+
+  return [enabled, toggle];
+}

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -36,6 +36,7 @@ import { useCodingMode } from "../stores/codingModeStore";
 import { useSidebarModeStore } from "../stores/sidebarModeStore";
 import { buildSessionPath, getSessionIdFromPath } from "../utils/sessionRoute";
 import sessionApi from "../pages/Chat/sessionApi";
+import { useInboxWobble } from "../hooks/useInboxWobble";
 import styles from "./index.module.less";
 import { useTheme } from "../contexts/ThemeContext";
 import { useMenuItems, useRoutes } from "../plugins/registry/hooks";
@@ -133,6 +134,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
   const [hasPendingApprovals, setHasPendingApprovals] = useState(false);
   const [shakeInbox, setShakeInbox] = useState(false);
+  const [wobbleEnabled] = useInboxWobble();
   const currentApprovalIdsRef = useRef<Set<string>>(new Set());
   const seenApprovalIdsRef = useRef<Set<string>>(new Set());
 
@@ -261,12 +263,12 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     };
   }, []);
 
-  // ── Inbox badge dot: orange when approvals pending, green when only unread
-  // messages, hidden when nothing.
+  // ── Inbox badge dot & wobble ─────────────────────────────────────────────
   const hasInboxUnread = hasUnreadMessages || hasPendingApprovals;
   const inboxDotColor = hasPendingApprovals
     ? "#e04848"
     : "rgba(255, 157, 77, 1)";
+  const effectiveShake = shakeInbox && wobbleEnabled;
 
   // ── Adapter: convert MenuItem trees to antd, with inbox badge decoration.
 
@@ -303,7 +305,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   };
 
   const getItemClassName = (item: MenuItem) => {
-    if (item.id === "core.inbox" && shakeInbox) {
+    if (item.id === "core.inbox" && effectiveShake) {
       return styles.inboxShake;
     }
     return undefined;
@@ -312,9 +314,14 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const agentMenuItems = useMemo(
     () =>
       toAntdItems(agentMenu, { collapsed, decorateLabel, getItemClassName }),
-    // hasUnreadMessages / hasPendingApprovals / shakeInbox closures — listed as deps explicitly.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agentMenu, collapsed, hasUnreadMessages, hasPendingApprovals, shakeInbox],
+    [
+      agentMenu,
+      collapsed,
+      hasUnreadMessages,
+      hasPendingApprovals,
+      effectiveShake,
+    ],
   );
 
   const settingsMenuItems = useMemo(
@@ -517,7 +524,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                   className={`${styles.collapsedNavItem} ${
                     isActive ? styles.collapsedNavItemActive : ""
                   }${
-                    item.key === "core.inbox" && shakeInbox
+                    item.key === "core.inbox" && effectiveShake
                       ? ` ${styles.inboxShake}`
                       : ""
                   }`}
@@ -553,7 +560,9 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                     key={entry.key}
                     className={`${styles.simpleNavItem} ${
                       isActive ? styles.simpleNavItemActive : ""
-                    }${isInbox && shakeInbox ? ` ${styles.inboxShake}` : ""}`}
+                    }${
+                      isInbox && effectiveShake ? ` ${styles.inboxShake}` : ""
+                    }`}
                     onMouseEnter={isInbox ? handleInboxHover : undefined}
                     onClick={() =>
                       entry.href

--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
   Badge,
   Popover,
 } from "antd";
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAppMessage } from "../hooks/useAppMessage";
@@ -130,7 +130,11 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
   const [collapsed, setCollapsed] = useState(isMobileSidebarViewport);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(isMobileSidebarViewport);
-  const [hasInboxUnread, setHasInboxUnread] = useState(false);
+  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
+  const [hasPendingApprovals, setHasPendingApprovals] = useState(false);
+  const [shakeInbox, setShakeInbox] = useState(false);
+  const currentApprovalIdsRef = useRef<Set<string>>(new Set());
+  const seenApprovalIdsRef = useRef<Set<string>>(new Set());
 
   // Sidebar mode: "simple" (only core items) or "full" (everything)
   const { mode: sidebarMode } = useSidebarModeStore();
@@ -208,9 +212,17 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
           api.getPushMessages(),
         ]);
         const hasUnreadEvents = (inboxRes?.events?.length || 0) > 0;
-        const hasPendingApprovals =
-          (pushRes?.pending_approvals?.length || 0) > 0;
-        setHasInboxUnread(hasUnreadEvents || hasPendingApprovals);
+        const approvals = pushRes?.pending_approvals || [];
+        const currentIds = new Set(
+          approvals.map((a: { request_id: string }) => a.request_id),
+        );
+        currentApprovalIdsRef.current = currentIds;
+        const hasNewApprovals =
+          currentIds.size > 0 &&
+          [...currentIds].some((id) => !seenApprovalIdsRef.current.has(id));
+        setShakeInbox(hasNewApprovals);
+        setHasUnreadMessages(hasUnreadEvents);
+        setHasPendingApprovals(currentIds.size > 0);
       } catch {
         // Keep previous state when polling fails.
       }
@@ -249,23 +261,60 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
     };
   }, []);
 
+  // ── Inbox badge dot: orange when approvals pending, green when only unread
+  // messages, hidden when nothing.
+  const hasInboxUnread = hasUnreadMessages || hasPendingApprovals;
+  const inboxDotColor = hasPendingApprovals
+    ? "#e04848"
+    : "rgba(255, 157, 77, 1)";
+
   // ── Adapter: convert MenuItem trees to antd, with inbox badge decoration.
+
+  /** Mark current approvals as "seen" so the wobble stops. */
+  const handleInboxHover = useCallback(() => {
+    seenApprovalIdsRef.current = new Set(currentApprovalIdsRef.current);
+    setShakeInbox(false);
+  }, []);
+
+  /**
+   * Bridge hover events from the antd Menu `<li>` to our handler.
+   * addEventListener de-duplicates the same function reference, so re-calling
+   * on the same element is harmless; old detached elements are GC'd naturally.
+   */
+  const inboxLiRefCallback = useCallback(
+    (node: HTMLSpanElement | null) => {
+      const li = node?.closest("li");
+      if (!li) return;
+      li.addEventListener("mouseenter", handleInboxHover);
+    },
+    [handleInboxHover],
+  );
 
   /** Wrap the inbox label with the unread-Badge while keeping all other labels intact. */
   const decorateLabel = (item: MenuItem, label: ReactNode): ReactNode => {
     if (item.id !== "core.inbox" || label == null) return label;
     return (
-      <Badge dot={hasInboxUnread} color="rgba(255, 157, 77, 1)" offset={[5, 7]}>
-        <span>{label}</span>
-      </Badge>
+      <span ref={inboxLiRefCallback}>
+        <Badge dot={hasInboxUnread} color={inboxDotColor} offset={[5, 7]}>
+          <span>{label}</span>
+        </Badge>
+      </span>
     );
   };
 
+  const getItemClassName = (item: MenuItem) => {
+    if (item.id === "core.inbox" && shakeInbox) {
+      return styles.inboxShake;
+    }
+    return undefined;
+  };
+
   const agentMenuItems = useMemo(
-    () => toAntdItems(agentMenu, { collapsed, decorateLabel }),
-    // hasInboxUnread closure inside decorateLabel — listed as dep explicitly.
+    () =>
+      toAntdItems(agentMenu, { collapsed, decorateLabel, getItemClassName }),
+    // hasUnreadMessages / hasPendingApprovals / shakeInbox closures — listed as deps explicitly.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agentMenu, collapsed, hasInboxUnread],
+    [agentMenu, collapsed, hasUnreadMessages, hasPendingApprovals, shakeInbox],
   );
 
   const settingsMenuItems = useMemo(
@@ -300,7 +349,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
               width: 6,
               height: 6,
               borderRadius: "50%",
-              background: "rgba(255, 157, 77, 1)",
+              background: inboxDotColor,
             }}
           />
         )}
@@ -316,7 +365,15 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
         ? { ...entry, icon: decorateInboxIcon(entry.icon) }
         : entry,
     );
-  }, [agentMenu, settingsMenu, routes, chatPath, t, hasInboxUnread]);
+  }, [
+    agentMenu,
+    settingsMenu,
+    routes,
+    chatPath,
+    t,
+    hasInboxUnread,
+    inboxDotColor,
+  ]);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -459,11 +516,18 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                 <button
                   className={`${styles.collapsedNavItem} ${
                     isActive ? styles.collapsedNavItemActive : ""
+                  }${
+                    item.key === "core.inbox" && shakeInbox
+                      ? ` ${styles.inboxShake}`
+                      : ""
                   }`}
                   onClick={() =>
                     item.href
                       ? window.open(item.href, "_blank", "noopener,noreferrer")
                       : navigate(item.path)
+                  }
+                  onMouseEnter={
+                    item.key === "core.inbox" ? handleInboxHover : undefined
                   }
                 >
                   {item.icon}
@@ -489,7 +553,8 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                     key={entry.key}
                     className={`${styles.simpleNavItem} ${
                       isActive ? styles.simpleNavItemActive : ""
-                    }`}
+                    }${isInbox && shakeInbox ? ` ${styles.inboxShake}` : ""}`}
+                    onMouseEnter={isInbox ? handleInboxHover : undefined}
                     onClick={() =>
                       entry.href
                         ? window.open(
@@ -517,7 +582,7 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
                               width: 6,
                               height: 6,
                               borderRadius: "50%",
-                              background: "rgba(255, 157, 77, 1)",
+                              background: inboxDotColor,
                             }}
                           />
                         )}

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -433,6 +433,64 @@
   margin-top: 4px;
 }
 
+// ─── Inbox wobble animation (new pending approvals) ──────────────────────────
+@keyframes inboxWobble {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  20% {
+    transform: rotate(3deg);
+  }
+  40% {
+    transform: rotate(-3deg);
+  }
+  60% {
+    transform: rotate(2.5deg);
+  }
+  80% {
+    transform: rotate(-2.5deg);
+  }
+}
+
+// Larger wobble for collapsed sidebar (small 40×40 icon button)
+@keyframes inboxWobbleLarge {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  20% {
+    transform: rotate(8deg);
+  }
+  40% {
+    transform: rotate(-8deg);
+  }
+  60% {
+    transform: rotate(6deg);
+  }
+  80% {
+    transform: rotate(-6deg);
+  }
+}
+
+.inboxShake {
+  animation: inboxWobble 0.6s ease-in-out infinite;
+  transform-origin: center center;
+  // Show a persistent hover-like background so the "rectangle" rotates
+  // together with the content.
+  background-color: rgba(0, 0, 0, 0.06) !important;
+
+  // Pause immediately on hover as a visual safety net (JS handler
+  // will permanently remove the class on the next React render).
+  &:hover {
+    animation-play-state: paused;
+  }
+}
+
+:global(.dark-mode) .inboxShake {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
 /* Collapse Toggle Button */
 .collapseToggleContainer {
   flex-shrink: 0;
@@ -671,6 +729,10 @@
   &:hover {
     background: rgba(0, 0, 0, 0.06);
     color: rgba(0, 0, 0, 0.88);
+  }
+
+  &.inboxShake {
+    animation-name: inboxWobbleLarge;
   }
 }
 

--- a/console/src/layouts/registry/adapter.tsx
+++ b/console/src/layouts/registry/adapter.tsx
@@ -69,6 +69,8 @@ interface ToAntdOpts {
   iconSize?: number;
   /** Optional Sidebar-local decoration. e.g. wrap inbox label with unread Badge. */
   decorateLabel?: (item: MenuItem, label: ReactNode) => ReactNode;
+  /** Optional per-item className (e.g. shake animation for inbox). */
+  getItemClassName?: (item: MenuItem) => string | undefined;
 }
 
 type ItemWithChildren = MenuItem & { __children?: MenuItem[] };
@@ -81,7 +83,7 @@ export function toAntdItems(
   items: MenuItem[],
   opts: ToAntdOpts,
 ): MenuProps["items"] {
-  const { collapsed, iconSize = 16, decorateLabel } = opts;
+  const { collapsed, iconSize = 16, decorateLabel, getItemClassName } = opts;
   return items
     .filter((i) => i.visible?.() !== false)
     .map((rawItem) => {
@@ -92,6 +94,7 @@ export function toAntdItems(
         key: i.id,
         label: decorated,
         icon: renderIcon(i.icon, iconSize),
+        className: getItemClassName?.(i),
       };
       if (i.__children && i.__children.length > 0) {
         // antd expects `children` on submenu / group items

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -221,6 +221,8 @@
     "createSuccess": "Harvest created successfully",
     "emptyApprovals": "No pending approvals",
     "emptyPush": "No push messages",
+    "wobbleEnable": "Enable approval wobble notification",
+    "wobbleDisable": "Disable approval wobble notification",
     "emptyHarvests": "No harvests yet",
     "statusReadyToHarvest": "Ready to Harvest",
     "statusGrowing": "Growing",

--- a/console/src/locales/id.json
+++ b/console/src/locales/id.json
@@ -1164,6 +1164,8 @@
     "createSuccess": "Panen berhasil dibuat",
     "emptyApprovals": "Tidak ada persetujuan yang tertunda",
     "emptyPush": "Tidak ada pesan push",
+    "wobbleEnable": "Aktifkan notifikasi getar persetujuan",
+    "wobbleDisable": "Nonaktifkan notifikasi getar persetujuan",
     "emptyHarvests": "Belum ada panen",
     "statusReadyToHarvest": "Siap Dipanen",
     "statusGrowing": "Sedang Tumbuh",

--- a/console/src/locales/ja.json
+++ b/console/src/locales/ja.json
@@ -2717,6 +2717,8 @@
     "createSuccess": "Harvest を作成しました",
     "emptyApprovals": "保留中の承認はありません",
     "emptyPush": "通知はありません",
+    "wobbleEnable": "承認の揺れ通知を有効にする",
+    "wobbleDisable": "承認の揺れ通知を無効にする",
     "emptyHarvests": "Harvest はまだありません",
     "statusReadyToHarvest": "実行可能",
     "statusGrowing": "実行中",

--- a/console/src/locales/pt-BR.json
+++ b/console/src/locales/pt-BR.json
@@ -2772,6 +2772,8 @@
     "createSuccess": "Colheita criada com sucesso",
     "emptyApprovals": "Nenhuma aprovação pendente",
     "emptyPush": "Nenhuma mensagem push",
+    "wobbleEnable": "Ativar notificação de aprovação por vibração",
+    "wobbleDisable": "Desativar notificação de aprovação por vibração",
     "emptyHarvests": "Ainda não há colheitas",
     "statusReadyToHarvest": "Pronto para colher",
     "statusGrowing": "Em crescimento",

--- a/console/src/locales/ru.json
+++ b/console/src/locales/ru.json
@@ -2732,6 +2732,8 @@
     "createSuccess": "Сбор успешно создан",
     "emptyApprovals": "Нет ожидающих подтверждений",
     "emptyPush": "Нет push-сообщений",
+    "wobbleEnable": "Включить уведомление о подтверждении",
+    "wobbleDisable": "Отключить уведомление о подтверждении",
     "emptyHarvests": "Сборов пока нет",
     "statusReadyToHarvest": "Готово к сбору",
     "statusGrowing": "Растёт",

--- a/console/src/locales/vi.json
+++ b/console/src/locales/vi.json
@@ -319,6 +319,8 @@
     "createSuccess": "Tạo thu hoạch thành công",
     "emptyApprovals": "Không có phê duyệt nào đang chờ",
     "emptyPush": "Không có tin nhắn đẩy",
+    "wobbleEnable": "Bật thông báo rung phê duyệt",
+    "wobbleDisable": "Tắt thông báo rung phê duyệt",
     "emptyHarvests": "Chưa có thu hoạch nào",
     "statusReadyToHarvest": "Sẵn sàng thu hoạch",
     "statusGrowing": "Đang phát triển",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -221,6 +221,8 @@
     "createSuccess": "Harvest 创建成功",
     "emptyApprovals": "暂无待审批项",
     "emptyPush": "暂无推送消息",
+    "wobbleEnable": "开启审批震动提醒",
+    "wobbleDisable": "关闭审批震动提醒",
     "emptyHarvests": "暂无 Harvest 任务",
     "statusReadyToHarvest": "可立即收获",
     "statusGrowing": "生成中",

--- a/console/src/pages/Inbox/index.module.less
+++ b/console/src/pages/Inbox/index.module.less
@@ -40,6 +40,10 @@
   font-size: 15px;
 }
 
+.wobbleToggleActive {
+  color: #ff7f16 !important;
+}
+
 .tabContent {
   padding-bottom: 8px;
 

--- a/console/src/pages/Inbox/index.tsx
+++ b/console/src/pages/Inbox/index.tsx
@@ -14,6 +14,7 @@ import {
   Tag,
   Spin,
   Select,
+  Tooltip,
 } from "antd";
 import {
   BulbOutlined,
@@ -21,7 +22,7 @@ import {
   DownOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
-import { PackageOpen, Bell } from "lucide-react";
+import { PackageOpen, Bell, BellRing } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useTranslation } from "react-i18next";
@@ -29,6 +30,7 @@ import { PageHeader } from "@/components/PageHeader";
 import { externalLinkMarkdownComponents } from "@/components/Markdown/externalLinkComponents";
 import { ApprovalCard as GlobalApprovalCard } from "../../components/ApprovalCard/ApprovalCard";
 import { useApprovalContext } from "../../contexts/ApprovalContext";
+import { useInboxWobble } from "../../hooks/useInboxWobble";
 import { commandsApi } from "../../api/modules/commands";
 import { chatApi } from "../../api/modules/chat";
 import sessionApi from "../Chat/sessionApi";
@@ -93,6 +95,7 @@ export default function InboxPage() {
   const [selectedMessageIds, setSelectedMessageIds] = useState<string[]>([]);
   const [batchMode, setBatchMode] = useState(false);
   const agents = useAgentStore((state) => state.agents);
+  const [wobbleEnabled, toggleWobble] = useInboxWobble();
   const { approvals: pendingApprovals, setApprovals } = useApprovalContext();
   const {
     summary,
@@ -513,6 +516,23 @@ export default function InboxPage() {
           onChange={(key) => setActiveTab(key as TabKey)}
           items={tabItems}
           className={styles.inboxTabs}
+          tabBarExtraContent={
+            <Tooltip
+              title={t(
+                wobbleEnabled ? "inbox.wobbleDisable" : "inbox.wobbleEnable",
+              )}
+            >
+              <Button
+                type="text"
+                size="small"
+                icon={<BellRing size={16} />}
+                onClick={toggleWobble}
+                className={
+                  wobbleEnabled ? styles.wobbleToggleActive : undefined
+                }
+              />
+            </Tooltip>
+          }
         />
       </div>
       <Modal


### PR DESCRIPTION

## Description

Enhance the inbox notification UX in the sidebar with two improvements:
**1. Wobble animation for new approvals**
When new pending approvals arrive, the inbox menu item wobbles continuously to draw the user's attention. The animation is a center-pivoted rotation (±3° for expanded mode, ±8° for the smaller collapsed icon), with a persistent background highlight so the "rectangle" visually rotates as a whole.
- Hovering over the inbox item is treated as an **acknowledgment** — the wobble stops permanently until a *new* approval arrives
- Uses `request_id` tracking (`seenApprovalIdsRef` vs `currentApprovalIdsRef`) to distinguish new vs. already-seen approvals
- Works across all three sidebar modes: expanded menu, collapsed icon-nav, and simple/mobile mode
- CSS `:hover { animation-play-state: paused }` provides instant visual feedback; the JS handler permanently removes the animation class on the next render

**2. Color-coded badge dot**
The inbox dot now conveys what type of unread content is pending:
| State | Dot |
|-------|-----|
| No unread content | Hidden |
| Unread push messages only | 🟠 Orange (`rgba(255,157,77,1)`) |
| Pending approvals (with or without messages) | 🔴 Red (`#e04848`) |
This lets users instantly judge whether the inbox needs urgent attention (approval) or is informational (push message).


**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
