### PR TITLE
feat: add reranker support for ReMe memory search (backend)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "playwright>=1.49.0",
     "questionary>=2.1.1",
     "mss>=9.0.0",
-    "reme-ai==0.4.1.3",
+    "reme-ai==0.4.1.4",
     "transformers>=4.30.0",
     "python-dotenv>=1.0.0",
     "python-socks>=2.5.3",

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -442,70 +442,12 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if response is None:
             return _tool_chunk("ReMe is not started.", ok=False)
 
-        results = (
-            response.metadata.get("results") if response.success else None
+        await self._rerank_and_cap_response(
+            query,
+            response,
+            cap,
+            reranker_config,
         )
-        if results:
-            # Save original metadata for fallback reconstruction.
-            # The link_expansion dict is used by the fallback path to preserve
-            # expansions even when the answer text format is unexpected.
-            original_link_expansion = (
-                response.metadata.get("link_expansion", {})
-                if response.success
-                else {}
-            )
-            # Parse the original ReMe answer into sections keyed by
-            # "path:line-line" so we can reorder + cap them while preserving
-            # link expansions and hybrid score details.
-            original_answer = str(response.answer or "")
-            answer_sections = (
-                self._parse_answer_into_sections(original_answer)
-                if original_answer
-                else {}
-            )
-
-            # Rerank (only reorders results, answer sections are reordered
-            # below)
-            reranker_did_reorder = False
-            if reranker_config and len(results) > 1:
-                try:
-                    before = list(results)
-                    await self._rerank_search_results(
-                        query,
-                        response,
-                        reranker_config,
-                    )
-                    results = response.metadata["results"]
-                    reranker_did_reorder = results != before
-                except Exception:
-                    logger.warning(
-                        "[rerank] failed, using original order",
-                        exc_info=True,
-                    )
-            # Cap to max_results
-            truncated = len(results) > cap
-            if truncated:
-                results = results[:cap]
-                response.metadata["results"] = results
-            # Reconstruct answer from sections when order or count changed,
-            # preserving the original ReMe answer (including link expansions
-            # and hybrid score details) whenever possible.
-            if reranker_did_reorder or truncated:
-                if answer_sections:
-                    response.answer = self._reconstruct_answer_from_sections(
-                        answer_sections,
-                        results,
-                    )
-                else:
-                    # Fallback: answer format was unexpected; rebuild from
-                    # raw metadata (results + link_expansion) so link
-                    # expansions are still preserved.
-                    response.answer = (
-                        self._rebuild_search_answer_with_expansions(
-                            results,
-                            original_link_expansion,
-                        )
-                    )
 
         answer = str(response.answer or "").strip()
         if not answer:
@@ -513,6 +455,83 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         return _tool_chunk(answer, ok=response.success)
 
     # ── reranker helpers ──────────────────────────────────────────────
+
+    async def _rerank_and_cap_response(
+        self,
+        query: str,
+        response: "Response",
+        cap: int,
+        reranker_config: RerankerConfig | None,
+    ) -> None:
+        """Over-fetch, rerank, cap, and rebuild answer on **response**.
+
+        Shared by ``memory_search()`` and ``auto_memory_search()``.
+        Mutates ``response.metadata["results"]`` and ``response.answer``
+        in place.  Does nothing when ``reranker_config`` is ``None`` or
+        results are empty or already short enough (no truncation).
+        """
+        results = (
+            response.metadata.get("results") if response.success else None
+        )
+        if not results:
+            return
+
+        # Save original metadata for fallback reconstruction.
+        original_link_expansion = (
+            response.metadata.get("link_expansion", {})
+            if response.success
+            else {}
+        )
+        # Parse the original ReMe answer into sections keyed by
+        # "path:line-line" so we can reorder + cap them while preserving
+        # link expansions and hybrid score details.
+        original_answer = str(response.answer or "")
+        answer_sections = (
+            self._parse_answer_into_sections(original_answer)
+            if original_answer
+            else {}
+        )
+
+        # Rerank (only reorders results, answer sections are reordered
+        # below)
+        reranker_did_reorder = False
+        if reranker_config and len(results) > 1:
+            try:
+                before = list(results)
+                await self._rerank_search_results(
+                    query,
+                    response,
+                    reranker_config,
+                )
+                results = response.metadata["results"]
+                reranker_did_reorder = results != before
+            except Exception:
+                logger.warning(
+                    "[rerank] failed, using original order",
+                    exc_info=True,
+                )
+        # Cap to max_results
+        truncated = len(results) > cap
+        if truncated:
+            results = results[:cap]
+            response.metadata["results"] = results
+        # Reconstruct answer from sections when order or count changed,
+        # preserving the original ReMe answer (including link expansions
+        # and hybrid score details) whenever possible.
+        if reranker_did_reorder or truncated:
+            if answer_sections:
+                response.answer = self._reconstruct_answer_from_sections(
+                    answer_sections,
+                    results,
+                )
+            else:
+                # Fallback: answer format was unexpected; rebuild from
+                # raw metadata (results + link_expansion) so link
+                # expansions are still preserved.
+                response.answer = self._rebuild_search_answer_with_expansions(
+                    results,
+                    original_link_expansion,
+                )
 
     async def _rerank_search_results(
         self,
@@ -865,15 +884,30 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
         search_cfg = memory_cfg.auto_memory_search_config
 
-        max_results = max(1, search_cfg.max_results)
+        cap = max(1, search_cfg.max_results)
+        reranker_config = self._get_reranker_config()
+        # Over-fetch when reranker is enabled: take N * multiplier
+        # candidates, rerank, then return top-N.
+        effective_limit = (
+            cap * reranker_config.candidate_multiplier
+            if reranker_config
+            else cap
+        )
         response = await self._run_reme_job(
             "search",
             query=query,
-            limit=max_results,
+            limit=effective_limit,
             min_score=0,
         )
         if response is None or not response.success:
             return None
+
+        await self._rerank_and_cap_response(
+            query,
+            response,
+            cap,
+            reranker_config,
+        )
 
         text = str(response.answer or "").strip()
         if not text:
@@ -881,7 +915,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
         assistant_msg = self._build_auto_memory_search_msg(
             query=query,
-            max_results=max_results,
+            max_results=cap,
             text=text,
         )
         return {

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -120,7 +120,8 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         super().__init__(working_dir=working_dir, agent_id=agent_id)
         self._reme: "ReMe | None" = None
         self._reindex_lock = asyncio.Lock()
-        self._reranker_config_cache: RerankerConfig | None = None
+        # Reranker config is not cached here; load_agent_config() already
+        # provides mtime-based caching, so every call reads fresh data.
         logger.info(
             "ReMeLightMemoryManager init: agent_id=%s working_dir=%s",
             agent_id,
@@ -447,25 +448,31 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         )
         if results:
             # Rerank (only reorders results, answer is rebuilt below)
+            reranker_did_reorder = False
             if reranker_config and len(results) > 1:
                 try:
+                    before = list(results)
                     await self._rerank_search_results(
                         query,
                         response,
                         reranker_config,
                     )
                     results = response.metadata["results"]
+                    reranker_did_reorder = results != before
                 except Exception:
                     logger.warning(
                         "[rerank] failed, using original order",
                         exc_info=True,
                     )
-            # Cap to max_results and rebuild answer when order/count changed
+            # Cap to max_results
             truncated = len(results) > cap
             if truncated:
                 results = results[:cap]
                 response.metadata["results"] = results
-            if reranker_config or truncated:
+            # Rebuild answer only when order or count actually changed,
+            # preserving the original ReMe answer (including link expansions)
+            # when neither changed.
+            if reranker_did_reorder or truncated:
                 response.answer = self._rebuild_search_answer(results)
 
         answer = str(response.answer or "").strip()
@@ -497,13 +504,21 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if not new_order or len(new_order) != len(results):
             return
 
+        # Validate that the response is a permutation of 0..n-1
+        # (duplicate indices would silently drop results)
+        if set(new_order) != set(range(len(results))):
+            logger.warning(
+                "[rerank] API returned invalid indices (not a permutation): "
+                "%s for %d results — using original order",
+                new_order,
+                len(results),
+            )
+            return
+
         reordered: list[dict] = []
         for idx in new_order:
             if 0 <= idx < len(results):
                 reordered.append(results[idx])
-
-        if len(reordered) != len(results):
-            return
 
         response.metadata["results"] = reordered
         logger.info(
@@ -530,29 +545,23 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         return "\n".join(answer_lines)
 
     def _get_reranker_config(self) -> RerankerConfig | None:
-        """Return cached reranker config, or None if not enabled.
+        """Return the reranker config, or None if not enabled.
 
-        Config is cached on first access and refreshed when the agent
-        config is reloaded (via `_refresh_config_cache`).
+        Config is read fresh on every call — ``load_agent_config()``
+        already provides its own mtime-based caching, so an additional
+        layer here would risk stale values (the user may change the
+        API key, base URL, model, or disable reranking without restarting
+        the agent process).
         """
-        if self._reranker_config_cache is not None:
-            return self._reranker_config_cache
-
         try:
             agent_cfg = load_agent_config(self.agent_id)
             cfg = agent_cfg.running.reme_light_memory_config.reranker_config
             if cfg and cfg.enabled and cfg.model_name:
-                self._reranker_config_cache = cfg
                 return cfg
         except Exception:
             logger.warning("[rerank] failed to load config", exc_info=True)
 
-        self._reranker_config_cache = None
         return None
-
-    def _refresh_config_cache(self) -> None:
-        """Invalidate cached reranker config (call after config reload)."""
-        self._reranker_config_cache = None
 
     async def _call_reranker_api(  # pylint: disable=too-many-return-statements
         self,

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -9,6 +9,7 @@ ReMe's application/job framework.
 import asyncio
 import base64
 import hashlib
+import httpx
 import logging
 import os
 import re
@@ -24,7 +25,7 @@ from .reme_config import get_reme_app_config
 from ..model_factory import create_model_and_formatter
 from ...app.inbox_store import append_event as append_inbox_event
 from ...config import load_config
-from ...config.config import load_agent_config, AgentProfileConfig
+from ...config.config import load_agent_config, AgentProfileConfig, RerankerConfig
 
 if TYPE_CHECKING:
     from reme import ReMe
@@ -114,6 +115,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         super().__init__(working_dir=working_dir, agent_id=agent_id)
         self._reme: "ReMe | None" = None
         self._reindex_lock = asyncio.Lock()
+        self._reranker_config_cache: RerankerConfig | None = None
         logger.info(
             "ReMeLightMemoryManager init: agent_id=%s working_dir=%s",
             agent_id,
@@ -389,6 +391,10 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         decisions, dates, people, preferences, or todos. Returns top
         relevant snippets with file paths and line numbers.
 
+        When a reranker is configured and enabled, this over-fetches
+        (``max_results × candidate_multiplier``), reranks the candidates,
+        caps back to ``max_results``, and rebuilds the answer text.
+
         Args:
             query (`str`):
                 The semantic search query to find relevant memory snippets.
@@ -409,19 +415,219 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if not query:
             return _tool_chunk("Error: query cannot be empty", ok=False)
 
+        reranker_config = self._get_reranker_config()
+        cap = max(1, max_results)
+
+        # Over-fetch when reranker is enabled: take N * multiplier
+        # candidates, rerank, then return top-N.
+        effective_limit = (
+            cap * reranker_config.candidate_multiplier
+            if reranker_config
+            else cap
+        )
+
         response = await self._run_reme_job(
             "search",
             query=query,
-            limit=max(1, max_results),
+            limit=effective_limit,
             min_score=max(0.0, min_score),
         )
         if response is None:
             return _tool_chunk("ReMe is not started.", ok=False)
 
+        results = response.metadata.get("results") if response.success else None
+        if results:
+            # Rerank (only reorders results, answer is rebuilt below)
+            if reranker_config and len(results) > 1:
+                try:
+                    await self._rerank_search_results(
+                        query,
+                        response,
+                        reranker_config,
+                    )
+                    results = response.metadata["results"]
+                except Exception:
+                    logger.warning(
+                        "[rerank] failed, using original order",
+                        exc_info=True,
+                    )
+            # Cap to max_results and rebuild answer when order/count changed
+            truncated = len(results) > cap
+            if truncated:
+                results = results[:cap]
+                response.metadata["results"] = results
+            if reranker_config or truncated:
+                response.answer = self._rebuild_search_answer(results)
+
         answer = str(response.answer or "").strip()
         if not answer:
             answer = NO_MEMORY_RESULTS
         return _tool_chunk(answer, ok=response.success)
+
+    # ── reranker helpers ──────────────────────────────────────────────
+
+    async def _rerank_search_results(
+        self,
+        query: str,
+        response: "Response",
+        config: RerankerConfig,
+    ) -> None:
+        """Re-order search results using a dedicated reranker API.
+
+        Only reorders ``response.metadata['results']``; the answer text is
+        rebuilt by the caller (``memory_search``) after capping.
+        """
+        results = response.metadata.get("results")
+        if not results or len(results) <= 1:
+            return
+
+        # Truncate long texts to 500 chars each for the reranker call
+        texts: list[str] = [r.get("text", "")[:500] for r in results]
+
+        new_order = await self._call_reranker_api(query, texts, config)
+        if not new_order or len(new_order) != len(results):
+            return
+
+        reordered: list[dict] = []
+        for idx in new_order:
+            if 0 <= idx < len(results):
+                reordered.append(results[idx])
+
+        if len(reordered) != len(results):
+            return
+
+        response.metadata["results"] = reordered
+        logger.info(
+            "[rerank] reordered %d results with model=%s",
+            len(results),
+            config.model_name,
+        )
+
+    @staticmethod
+    def _rebuild_search_answer(results: list[dict]) -> str:
+        """Rebuild search answer text from results (search_step format)."""
+        answer_lines: list[str] = []
+        for r in results:
+            path = r.get("path", "")
+            start_line = r.get("start_line", 0)
+            end_line = r.get("end_line", 0)
+            score = r.get("score", 0.0)
+            text = r.get("text", "")
+            header = (
+                f"========== {path}:{start_line}-{end_line} "
+                f"[score={score:.4f}] =========="
+            )
+            answer_lines.append(f"{header}\n{text}")
+        return "\n".join(answer_lines)
+
+    def _get_reranker_config(self) -> RerankerConfig | None:
+        """Return cached reranker config, or None if not enabled.
+
+        Config is cached on first access and refreshed when the agent
+        config is reloaded (via `_refresh_config_cache`).
+        """
+        if self._reranker_config_cache is not None:
+            return self._reranker_config_cache
+
+        try:
+            agent_cfg = load_agent_config(self.agent_id)
+            cfg = agent_cfg.running.reme_light_memory_config.reranker_config
+            if cfg and cfg.enabled and cfg.model_name:
+                self._reranker_config_cache = cfg
+                return cfg
+        except Exception:
+            logger.warning("[rerank] failed to load config", exc_info=True)
+
+        self._reranker_config_cache = None
+        return None
+
+    def _refresh_config_cache(self) -> None:
+        """Invalidate cached reranker config (call after config reload)."""
+        self._reranker_config_cache = None
+
+    async def _call_reranker_api(  # pylint: disable=too-many-return-statements
+        self,
+        query: str,
+        documents: list[str],
+        config: RerankerConfig,
+    ) -> list[int] | None:
+        """Call a reranker API to score and reorder documents by relevance.
+
+        Uses the standard OpenAI-compatible reranker endpoint::
+
+            POST {base_url}/rerank
+            {
+                "model": "...",
+                "query": "...",
+                "documents": ["...", ...],
+                "top_n": N
+            }
+
+        Returns a list of indices sorted by relevance (most relevant first),
+        or ``None`` on failure.
+        """
+        if not config.base_url:
+            logger.warning("[rerank] base_url not configured")
+            return None
+        if not query or not documents:
+            return None
+
+        base_url = config.base_url.rstrip("/")
+        url = f"{base_url}/rerank"
+
+        payload: dict[str, Any] = {
+            "model": config.model_name,
+            "query": query,
+            "documents": documents,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=config.timeout) as client:
+                resp = await client.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {config.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+            if "results" not in data:
+                logger.warning(
+                    "[rerank] unexpected response format: %s",
+                    data,
+                )
+                return None
+
+            # Sort by score descending, return indices
+            scored = [
+                (r["index"], r.get("relevance_score", 0.0))
+                for r in data["results"]
+            ]
+            scored.sort(key=lambda x: x[1], reverse=True)
+            ordered = [idx for idx, _ in scored]
+
+            logger.info(
+                "[rerank] API responded with %d results",
+                len(ordered),
+            )
+            return ordered
+
+        except httpx.TimeoutException:
+            logger.warning("[rerank] API timed out after %ss", config.timeout)
+            return None
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "[rerank] HTTP error: %s %s",
+                exc.response.status_code,
+                exc.response.text[:500],
+            )
+            return None
+        except Exception:
+            logger.warning("[rerank] unexpected error", exc_info=True)
+            return None
 
     async def summarize(
         self,

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -515,10 +515,9 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             )
             return
 
-        reordered: list[dict] = []
-        for idx in new_order:
-            if 0 <= idx < len(results):
-                reordered.append(results[idx])
+        # All indices are validated as a permutation of 0..n-1 above,
+        # so no bounds check is needed here.
+        reordered = [results[idx] for idx in new_order]
 
         response.metadata["results"] = reordered
         logger.info(

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -447,7 +447,18 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             response.metadata.get("results") if response.success else None
         )
         if results:
-            # Rerank (only reorders results, answer is rebuilt below)
+            # Parse the original ReMe answer into sections keyed by
+            # "path:line-line" so we can reorder + cap them while preserving
+            # link expansions and hybrid score details.
+            original_answer = str(response.answer or "")
+            answer_sections = (
+                self._parse_answer_into_sections(original_answer)
+                if original_answer
+                else {}
+            )
+
+            # Rerank (only reorders results, answer sections are reordered
+            # below)
             reranker_did_reorder = False
             if reranker_config and len(results) > 1:
                 try:
@@ -469,11 +480,20 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             if truncated:
                 results = results[:cap]
                 response.metadata["results"] = results
-            # Rebuild answer only when order or count actually changed,
-            # preserving the original ReMe answer (including link expansions)
-            # when neither changed.
+            # Reconstruct answer from sections when order or count changed,
+            # preserving the original ReMe answer (including link expansions
+            # and hybrid score details) whenever possible.
             if reranker_did_reorder or truncated:
-                response.answer = self._rebuild_search_answer(results)
+                if answer_sections:
+                    response.answer = (
+                        self._reconstruct_answer_from_sections(
+                            answer_sections, results,
+                        )
+                    )
+                else:
+                    # Fallback: answer didn't match expected format, rebuild
+                    # from result dicts (loses link expansions + hybrid scores)
+                    response.answer = self._rebuild_search_answer(results)
 
         answer = str(response.answer or "").strip()
         if not answer:
@@ -542,6 +562,72 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             )
             answer_lines.append(f"{header}\n{text}")
         return "\n".join(answer_lines)
+
+    @staticmethod
+    def _parse_answer_into_sections(answer: str) -> dict[str, str]:
+        """Parse ReMe search answer into sections keyed by ``path:line-line``.
+
+        Each section starts with a header line like::
+
+            ========== path:line-line [scores] ==========
+
+        and includes everything up to the next such header (or end of string).
+
+        Returns a dict mapping ``"path:start_line-end_line"`` → the full
+        section text (including header).  Returns an empty dict when the
+        answer does not match the expected format.
+        """
+        # Match the section header.
+        #   \S+?  — non-greedy non-whitespace for the path
+        #   \d+-\d+ — start_line-end_line
+        #   \[.*?\] — the score brackets, lazy
+        pat = re.compile(
+            r"^==========\s+(\S+?:\d+-\d+)\s+\[.*?\]\s+==========$",
+            re.MULTILINE,
+        )
+        boundaries = [(m.start(), m.group(1)) for m in pat.finditer(answer)]
+        if not boundaries:
+            return {}
+
+        sections: dict[str, str] = {}
+        for i, (start, key) in enumerate(boundaries):
+            end = boundaries[i + 1][0] if i + 1 < len(boundaries) else len(
+                answer,
+            )
+            sections[key] = answer[start:end].rstrip("\n")
+        return sections
+
+    @staticmethod
+    def _reconstruct_answer_from_sections(
+        sections: dict[str, str],
+        results: list[dict],
+    ) -> str:
+        """Reconstruct search answer from pre-parsed sections in result order.
+
+        Each result's ``path:start_line-end_line`` key is looked up in the
+        *sections* dict.  If a matching section is found, it is used verbatim
+        (preserving link expansions, hybrid score details, etc.).  If not
+        found, a fallback section is built from the result dict fields.
+        """
+        lines: list[str] = []
+        for r in results:
+            key = (
+                f"{r.get('path', '')}:"
+                f"{r.get('start_line', 0)}-{r.get('end_line', 0)}"
+            )
+            section = sections.get(key)
+            if section is not None:
+                lines.append(section)
+            else:
+                # Fallback — should not happen in normal operation
+                text = r.get("text", "")
+                score = r.get("score", 0.0)
+                header = (
+                    f"========== {key} "
+                    f"[score={score:.4f}] =========="
+                )
+                lines.append(f"{header}\n{text}")
+        return "\n".join(lines)
 
     def _get_reranker_config(self) -> RerankerConfig | None:
         """Return the reranker config, or None if not enabled.

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -9,11 +9,12 @@ ReMe's application/job framework.
 import asyncio
 import base64
 import hashlib
-import httpx
 import logging
 import os
 import re
 from typing import Any, TYPE_CHECKING
+
+import httpx
 
 from agentscope.message import Msg, TextBlock
 from agentscope.message import ToolResultState

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -26,7 +26,11 @@ from .reme_config import get_reme_app_config
 from ..model_factory import create_model_and_formatter
 from ...app.inbox_store import append_event as append_inbox_event
 from ...config import load_config
-from ...config.config import load_agent_config, AgentProfileConfig, RerankerConfig
+from ...config.config import (
+    load_agent_config,
+    AgentProfileConfig,
+    RerankerConfig,
+)
 
 if TYPE_CHECKING:
     from reme import ReMe
@@ -347,9 +351,11 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 name,
                 event.get("id"),
                 event.get("status"),
-                response_metadata.get("modified")
-                if isinstance(response_metadata, dict)
-                else None,
+                (
+                    response_metadata.get("modified")
+                    if isinstance(response_metadata, dict)
+                    else None
+                ),
             )
             return True
         except Exception:  # pylint: disable=broad-except
@@ -436,7 +442,9 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         if response is None:
             return _tool_chunk("ReMe is not started.", ok=False)
 
-        results = response.metadata.get("results") if response.success else None
+        results = (
+            response.metadata.get("results") if response.success else None
+        )
         if results:
             # Rerank (only reorders results, answer is rebuilt below)
             if reranker_config and len(results) > 1:

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -579,6 +579,22 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         return " ".join(parts)
 
     @staticmethod
+    def _extract_score(result: dict) -> float:
+        """Extract the fused score from a ReMe search result dict.
+
+        ReMe's ``FileChunk.score`` is a regular property backed by
+        ``self.scores["score"]``.  When results are serialized with
+        ``model_dump(exclude_none=True, exclude={"embedding"})``, the
+        top-level ``score`` key is **not** included.  Always prefer the
+        nested ``scores["score"]`` first, then fall back to a top-level
+        ``score`` key for backward compatibility with test fixtures.
+        """
+        scores = result.get("scores", {})
+        if isinstance(scores, dict) and "score" in scores:
+            return scores["score"]
+        return result.get("score", 0.0)
+
+    @staticmethod
     def _rebuild_search_answer_with_expansions(
         results: list[dict],
         link_expansion: dict[str, dict],
@@ -598,7 +614,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             path = r.get("path", "")
             start_line = r.get("start_line", 0)
             end_line = r.get("end_line", 0)
-            score = r.get("score", 0.0)
+            score = ReMeLightMemoryManager._extract_score(r)
             scores = r.get("scores", {})
             text = r.get("text", "")
 
@@ -685,7 +701,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
                 # Use the shared score formatter for consistency with
                 # ``_rebuild_search_answer_with_expansions``.
                 text = r.get("text", "")
-                score = r.get("score", 0.0)
+                score = ReMeLightMemoryManager._extract_score(r)
                 scores = r.get("scores", {})
                 score_str = ReMeLightMemoryManager._format_scores_for_header(
                     score,

--- a/src/qwenpaw/agents/memory/reme_light_memory_manager.py
+++ b/src/qwenpaw/agents/memory/reme_light_memory_manager.py
@@ -16,8 +16,7 @@ from typing import Any, TYPE_CHECKING
 
 import httpx
 
-from agentscope.message import Msg, TextBlock
-from agentscope.message import ToolResultState
+from agentscope.message import Msg, TextBlock, ToolResultState
 from agentscope.tool import ToolChunk
 
 from .base_memory_manager import BaseMemoryManager, memory_registry
@@ -447,6 +446,14 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             response.metadata.get("results") if response.success else None
         )
         if results:
+            # Save original metadata for fallback reconstruction.
+            # The link_expansion dict is used by the fallback path to preserve
+            # expansions even when the answer text format is unexpected.
+            original_link_expansion = (
+                response.metadata.get("link_expansion", {})
+                if response.success
+                else {}
+            )
             # Parse the original ReMe answer into sections keyed by
             # "path:line-line" so we can reorder + cap them while preserving
             # link expansions and hybrid score details.
@@ -485,15 +492,20 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             # and hybrid score details) whenever possible.
             if reranker_did_reorder or truncated:
                 if answer_sections:
-                    response.answer = (
-                        self._reconstruct_answer_from_sections(
-                            answer_sections, results,
-                        )
+                    response.answer = self._reconstruct_answer_from_sections(
+                        answer_sections,
+                        results,
                     )
                 else:
-                    # Fallback: answer didn't match expected format, rebuild
-                    # from result dicts (loses link expansions + hybrid scores)
-                    response.answer = self._rebuild_search_answer(results)
+                    # Fallback: answer format was unexpected; rebuild from
+                    # raw metadata (results + link_expansion) so link
+                    # expansions are still preserved.
+                    response.answer = (
+                        self._rebuild_search_answer_with_expansions(
+                            results,
+                            original_link_expansion,
+                        )
+                    )
 
         answer = str(response.answer or "").strip()
         if not answer:
@@ -547,20 +559,64 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         )
 
     @staticmethod
-    def _rebuild_search_answer(results: list[dict]) -> str:
-        """Rebuild search answer text from results (search_step format)."""
+    def _format_scores_for_header(
+        score: float,
+        scores: dict[str, float],
+    ) -> str:
+        """Format scores as ``score=0.9000 [vector=0.8500 keyword=0.6500]``.
+
+        Mirrors ReMe's ``_format_scores`` so the rebuilt header matches the
+        original answer format.  Returns a space-separated string suitable
+        for use inside the ``[...]`` bracket of a section header.
+        """
+        hybrid = "vector" in scores and "keyword" in scores
+        parts = [f"score={score:.4f}"]
+        if hybrid:
+            for k in ("vector", "keyword"):
+                v = scores.get(k)
+                if v is not None:
+                    parts.append(f"{k}={v:.4f}")
+        return " ".join(parts)
+
+    @staticmethod
+    def _rebuild_search_answer_with_expansions(
+        results: list[dict],
+        link_expansion: dict[str, dict],
+    ) -> str:
+        """Rebuild search answer from results + link_expansion metadata.
+
+        Preserves link expansions and hybrid score details by reading them
+        from the raw ReMe metadata (``response.metadata["link_expansion"]``
+        and each result's ``scores`` dict).  Used as the fallback path when
+        the answer text does not match the expected section-header format.
+        """
+        # pylint: disable=import-outside-toplevel
+        from reme.utils import render_expansion_lines
+
         answer_lines: list[str] = []
         for r in results:
             path = r.get("path", "")
             start_line = r.get("start_line", 0)
             end_line = r.get("end_line", 0)
             score = r.get("score", 0.0)
+            scores = r.get("scores", {})
             text = r.get("text", "")
+
+            score_str = ReMeLightMemoryManager._format_scores_for_header(
+                score,
+                scores,
+            )
             header = (
                 f"========== {path}:{start_line}-{end_line} "
-                f"[score={score:.4f}] =========="
+                f"[{score_str}] =========="
             )
             answer_lines.append(f"{header}\n{text}")
+
+            # Add link expansions for this path
+            expansion = link_expansion.get(path, {})
+            if expansion:
+                answer_lines.extend(render_expansion_lines(expansion))
+
         return "\n".join(answer_lines)
 
     @staticmethod
@@ -573,28 +629,34 @@ class ReMeLightMemoryManager(BaseMemoryManager):
 
         and includes everything up to the next such header (or end of string).
 
-        Returns a dict mapping ``"path:start_line-end_line"`` → the full
-        section text (including header).  Returns an empty dict when the
-        answer does not match the expected format.
+        Uses line-by-line iteration (not regex) so it's tolerant of format
+        variations inside the score brackets — only the ``==========``
+        prefix matters.  Returns an empty dict when the answer has no
+        ``==========`` lines at all.
         """
-        # Match the section header.
-        #   \S+?  — non-greedy non-whitespace for the path
-        #   \d+-\d+ — start_line-end_line
-        #   \[.*?\] — the score brackets, lazy
-        pat = re.compile(
-            r"^==========\s+(\S+?:\d+-\d+)\s+\[.*?\]\s+==========$",
-            re.MULTILINE,
-        )
-        boundaries = [(m.start(), m.group(1)) for m in pat.finditer(answer)]
-        if not boundaries:
-            return {}
-
         sections: dict[str, str] = {}
-        for i, (start, key) in enumerate(boundaries):
-            end = boundaries[i + 1][0] if i + 1 < len(boundaries) else len(
-                answer,
-            )
-            sections[key] = answer[start:end].rstrip("\n")
+        current_key: str | None = None
+        current_lines: list[str] = []
+
+        for line in answer.split("\n"):
+            if line.startswith("=========="):
+                if current_key is not None:
+                    sections[current_key] = "\n".join(current_lines)
+                # Extract key: the substring before the first ``[`` bracket,
+                # which separates the ``path:line-line`` key from the scores.
+                rest = line.removeprefix("==========").strip()
+                bracket_idx = rest.find("[")
+                if bracket_idx > 0:
+                    current_key = rest[:bracket_idx].strip()
+                else:
+                    current_key = rest.split()[0] if rest else None
+                current_lines = [line]
+            elif current_key is not None:
+                current_lines.append(line)
+
+        if current_key is not None:
+            sections[current_key] = "\n".join(current_lines)
+
         return sections
 
     @staticmethod
@@ -619,13 +681,17 @@ class ReMeLightMemoryManager(BaseMemoryManager):
             if section is not None:
                 lines.append(section)
             else:
-                # Fallback — should not happen in normal operation
+                # Fallback — should not happen in normal operation.
+                # Use the shared score formatter for consistency with
+                # ``_rebuild_search_answer_with_expansions``.
                 text = r.get("text", "")
                 score = r.get("score", 0.0)
-                header = (
-                    f"========== {key} "
-                    f"[score={score:.4f}] =========="
+                scores = r.get("scores", {})
+                score_str = ReMeLightMemoryManager._format_scores_for_header(
+                    score,
+                    scores,
                 )
+                header = f"========== {key} " f"[{score_str}] =========="
                 lines.append(f"{header}\n{text}")
         return "\n".join(lines)
 
@@ -641,7 +707,7 @@ class ReMeLightMemoryManager(BaseMemoryManager):
         try:
             agent_cfg = load_agent_config(self.agent_id)
             cfg = agent_cfg.running.reme_light_memory_config.reranker_config
-            if cfg and cfg.enabled and cfg.model_name:
+            if cfg.enabled and cfg.model_name:
                 return cfg
         except Exception:
             logger.warning("[rerank] failed to load config", exc_info=True)

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -644,6 +644,47 @@ class EmbeddingModelConfig(BaseModel):
     )
 
 
+class RerankerConfig(BaseModel):
+    """Reranker model configuration for post-search reordering."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether to enable reranker for memory search reordering"
+        ),
+    )
+    api_key: str = Field(
+        default="",
+        description="API key for reranker provider",
+    )
+    base_url: str = Field(
+        default="",
+        description=(
+            "Base URL for reranker API (SiliconFlow: "
+            "https://api.siliconflow.cn/v1)"
+        ),
+    )
+    model_name: str = Field(
+        default="",
+        description="Reranker model name (e.g. BAAI/bge-reranker-v2-m3)",
+    )
+    candidate_multiplier: int = Field(
+        default=3,
+        ge=1,
+        description=(
+            "Over-fetch multiplier: search N x multiplier candidates, "
+            "rerank, then return top-N"
+        ),
+    )
+    timeout: float = Field(
+        default=10.0,
+        ge=1.0,
+        description="Reranker API timeout in seconds",
+    )
+
+
 class ADBPGMemoryConfig(BaseModel):
     """ADBPG (AnalyticDB for PostgreSQL) REST memory configuration."""
 
@@ -742,6 +783,10 @@ class ReMeLightMemoryConfig(BaseModel):
 
     embedding_model_config: EmbeddingModelConfig = Field(
         default_factory=EmbeddingModelConfig,
+    )
+
+    reranker_config: RerankerConfig = Field(
+        default_factory=RerankerConfig,
     )
 
 

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# pylint: disable=protected-access,unused-argument
+# pylint: disable=protected-access,unused-argument,redefined-outer-name
 """Unit tests for ReMe memory reranker (over-fetch + rerank + cap).
 
 Tests cover:
@@ -46,13 +46,13 @@ def _result(i, text=None):
 
 def _make_config(**overrides):
     """Build a dummy RerankerConfig with sensible defaults."""
-    d = dict(
-        enabled=True,
-        base_url="https://x",
-        model_name="m",
-        candidate_multiplier=3,
-        timeout=10.0,
-    )
+    d = {
+        "enabled": True,
+        "base_url": "https://x",
+        "model_name": "m",
+        "candidate_multiplier": 3,
+        "timeout": 10.0,
+    }
     d.update(overrides)
     return types.SimpleNamespace(**d)
 

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -6,37 +6,18 @@ Tests cover:
   - disabled: no rerank, behavior identical to plain search
   - enabled + API ok: results reordered by reranker, capped to max_results
   - over-fetch: search limit = N * candidate_multiplier
-  - timeout / http error / index mismatch: graceful fallback to original order
+  - timeout / http error / index mismatch / duplicate index: graceful fallback
   - no base_url: skip rerank entirely
   - empty results: no rerank call, returns NO_MEMORY_RESULTS
-
-Run: python -m unittest tests.unit.test_memory_reranker -v
+  - answer: preserved when order unchanged, rebuilt when changed or truncated
 """
 
-import asyncio
-import pathlib
-import sys
 import types
-import unittest
 from unittest.mock import AsyncMock, MagicMock
 
-# Put source tree first so the manager (with reranker changes) imports from
-# src/qwenpaw.
-_SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
-if str(_SRC) not in sys.path:
-    sys.path.insert(0, str(_SRC))
+import pytest
 
-# Clear any cached site-packages qwenpaw modules (pytest loads qwenpaw via
-# conftest / plugins before our test runs) so the source-tree import below
-# resolves from src/ rather than the installed package.
-for _mod_name in list(sys.modules):
-    if _mod_name.startswith("qwenpaw") or _mod_name.startswith("agentscope"):
-        del sys.modules[_mod_name]
-
-# pylint: disable=wrong-import-position
-import qwenpaw.agents.memory.reme_light_memory_manager as mgr  # noqa: E402
-
-# pylint: enable=wrong-import-position
+import qwenpaw.agents.memory.reme_light_memory_manager as mgr
 
 ReMeLightMemoryManager = mgr.ReMeLightMemoryManager
 NO_MEMORY_RESULTS = mgr.NO_MEMORY_RESULTS
@@ -61,199 +42,307 @@ def _result(i, text=None):
     }
 
 
-# pylint: disable=protected-access,unused-argument
-class RerankerTests(unittest.TestCase):
-    def setUp(self):
-        self.m = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
-        self.m._reranker_config_cache = None
-
-    def _patch_run(self, results):
-        resp = _make_response(results)
-        self.m._run_reme_job = AsyncMock(return_value=resp)
-        return resp
-
-    def _run(self, query="q", max_results=2, min_score=0.0):
-        return asyncio.get_event_loop().run_until_complete(
-            self.m.memory_search(
-                query,
-                max_results=max_results,
-                min_score=min_score,
-            ),
-        )
-
-    # pylint: disable=unused-argument
-
-    def test_disabled_no_rerank(self):
-        self.m._get_reranker_config = MagicMock(return_value=None)
-        rs = [_result(0), _result(1)]
-        self._patch_run(rs)
-        self.m._rerank_search_results = AsyncMock()
-        _ = self._run()
-        self.assertEqual(self.m._rerank_search_results.call_count, 0)
-        # _run() returns the chunk, but we only care about call_count here
-
-    def test_overfetch_multiplier(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="https://x",
-            model_name="m",
-            candidate_multiplier=3,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-        self.m._rerank_search_results = AsyncMock()
-        rs = [_result(i) for i in range(6)]
-        self._patch_run(rs)
-        self._run(max_results=2)
-        limit = self.m._run_reme_job.call_args.kwargs["limit"]
-        self.assertEqual(limit, 6, "limit should be max_results * multiplier")
-
-    def test_enabled_rerank_ok_and_cap(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="https://x",
-            model_name="m",
-            candidate_multiplier=3,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-
-        async def fake_api(query, docs, c):
-            return list(range(len(docs)))[::-1]
-
-        self.m._call_reranker_api = fake_api
-        rs = [_result(i, text=f"t{i}") for i in range(6)]
-        resp = self._patch_run(rs)
-        _ = self._run(query="q", max_results=2)
-        self.assertEqual(len(resp.metadata["results"]), 2)
-        self.assertEqual(resp.metadata["results"][0]["text"], "t5")
-        self.assertIn("t5", str(resp.answer))
-
-    def test_rerank_timeout_fallback(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="https://x",
-            model_name="m",
-            candidate_multiplier=3,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-        import httpx
-
-        async def raise_timeout(query, docs, c):
-            raise httpx.TimeoutException("timeout")
-
-        self.m._call_reranker_api = raise_timeout
-        rs = [_result(i, text=f"t{i}") for i in range(6)]
-        resp = self._patch_run(rs)
-        self._run(query="q", max_results=2)
-        self.assertEqual(resp.metadata["results"][0]["text"], "t0")
-        self.assertEqual(len(resp.metadata["results"]), 2)
-
-    def test_rerank_http_error_fallback(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="https://x",
-            model_name="m",
-            candidate_multiplier=2,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-        import httpx
-
-        async def raise_http(query, docs, c):
-            raise httpx.RequestError("boom", request=None)
-
-        self.m._call_reranker_api = raise_http
-        rs = [
-            _result(0, text="a"),
-            _result(1, text="b"),
-            _result(2, text="c"),
-            _result(3, text="d"),
-        ]
-        resp = self._patch_run(rs)
-        self._run(query="q", max_results=2)
-        self.assertEqual(resp.metadata["results"][0]["text"], "a")
-        self.assertEqual(len(resp.metadata["results"]), 2)
-
-    def test_rerank_index_mismatch_fallback(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="https://x",
-            model_name="m",
-            candidate_multiplier=3,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-
-        async def bad_order(query, docs, c):
-            return [0]  # wrong length
-
-        self.m._call_reranker_api = bad_order
-        rs = [_result(i) for i in range(6)]
-        resp = self._patch_run(rs)
-        self._run(query="q", max_results=2)
-        self.assertEqual(resp.metadata["results"][0]["text"], "doc-0")
-        self.assertEqual(len(resp.metadata["results"]), 2)
-
-    def test_no_base_url_skip(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="",
-            model_name="m",
-            candidate_multiplier=3,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-        called = {"n": 0}
-
-        async def api(query, docs, c):
-            called["n"] += 1
-            return None
-
-        self.m._call_reranker_api = api
-        rs = [_result(i) for i in range(6)]
-        resp = self._patch_run(rs)
-        self._run(query="q", max_results=3)
-        self.assertEqual(called["n"], 1)
-        self.assertEqual(resp.metadata["results"][0]["text"], "doc-0")
-        self.assertEqual(len(resp.metadata["results"]), 3)
-
-    def test_empty_results(self):
-        cfg = types.SimpleNamespace(
-            enabled=True,
-            base_url="https://x",
-            model_name="m",
-            candidate_multiplier=3,
-            timeout=10.0,
-        )
-        self.m._get_reranker_config = MagicMock(return_value=cfg)
-        self.m._rerank_search_results = AsyncMock()
-        resp = _make_response([])
-        self.m._run_reme_job = AsyncMock(return_value=resp)
-        chunk = self._run()
-        self.assertEqual(self.m._rerank_search_results.call_count, 0)
-        text = "".join(b.text for b in chunk.content)
-        self.assertIn(NO_MEMORY_RESULTS, text)
-
-    def test_rebuild_answer_format(self):
-        rs = [
-            {
-                "path": "a.md",
-                "start_line": 2,
-                "end_line": 4,
-                "score": 0.1234,
-                "text": "hello",
-            },
-        ]
-        out = ReMeLightMemoryManager._rebuild_search_answer(rs)
-        self.assertIn("a.md:2-4", out)
-        self.assertIn("[score=0.1234]", out)
-        self.assertIn("hello", out)
+def _make_config(**overrides):
+    """Build a dummy RerankerConfig with sensible defaults."""
+    d = dict(
+        enabled=True,
+        base_url="https://x",
+        model_name="m",
+        candidate_multiplier=3,
+        timeout=10.0,
+    )
+    d.update(overrides)
+    return types.SimpleNamespace(**d)
 
 
-# pylint: enable=protected-access,unused-argument
+@pytest.fixture
+def manager():
+    m = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
+    return m
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
+# ── disabled ──
+
+
+@pytest.mark.asyncio
+async def test_disabled_no_rerank(manager):
+    manager._get_reranker_config = MagicMock(return_value=None)
+    rs = [_result(0), _result(1)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+    manager._rerank_search_results = AsyncMock()
+
+    await manager.memory_search("q", max_results=2)
+
+    assert manager._rerank_search_results.call_count == 0
+
+
+# ── over-fetch ──
+
+
+@pytest.mark.asyncio
+async def test_overfetch_multiplier(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(candidate_multiplier=3),
+    )
+    manager._rerank_search_results = AsyncMock()
+    rs = [_result(i) for i in range(6)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=2)
+
+    limit = manager._run_reme_job.call_args.kwargs["limit"]
+    assert limit == 6, "limit should be max_results * multiplier"
+
+
+# ── enabled + API ok ──
+
+
+@pytest.mark.asyncio
+async def test_enabled_rerank_ok_and_cap(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(candidate_multiplier=3),
+    )
+
+    async def fake_api(query, docs, c):
+        return list(range(len(docs)))[::-1]
+
+    manager._call_reranker_api = fake_api
+    rs = [_result(i, text=f"t{i}") for i in range(6)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=2)
+
+    assert len(resp.metadata["results"]) == 2
+    assert resp.metadata["results"][0]["text"] == "t5"
+    assert "t5" in str(resp.answer)
+
+
+# ── fallback: timeout ──
+
+
+@pytest.mark.asyncio
+async def test_rerank_timeout_fallback(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(),
+    )
+    import httpx
+
+    async def raise_timeout(query, docs, c):
+        raise httpx.TimeoutException("timeout")
+
+    manager._call_reranker_api = raise_timeout
+    rs = [_result(i, text=f"t{i}") for i in range(6)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=2)
+
+    assert resp.metadata["results"][0]["text"] == "t0"
+    assert len(resp.metadata["results"]) == 2
+
+
+# ── fallback: HTTP error ──
+
+
+@pytest.mark.asyncio
+async def test_rerank_http_error_fallback(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(candidate_multiplier=2),
+    )
+    import httpx
+
+    async def raise_http(query, docs, c):
+        raise httpx.RequestError("boom", request=None)
+
+    manager._call_reranker_api = raise_http
+    rs = [
+        _result(0, text="a"),
+        _result(1, text="b"),
+        _result(2, text="c"),
+        _result(3, text="d"),
+    ]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=2)
+
+    assert resp.metadata["results"][0]["text"] == "a"
+    assert len(resp.metadata["results"]) == 2
+
+
+# ── fallback: wrong index count ──
+
+
+@pytest.mark.asyncio
+async def test_rerank_index_mismatch_fallback(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(),
+    )
+
+    async def bad_order(query, docs, c):
+        return [0]  # wrong length
+
+    manager._call_reranker_api = bad_order
+    rs = [_result(i) for i in range(6)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=2)
+
+    assert resp.metadata["results"][0]["text"] == "doc-0"
+    assert len(resp.metadata["results"]) == 2
+
+
+# ── fallback: duplicate index (should be rejected as not a permutation) ──
+
+
+@pytest.mark.asyncio
+async def test_rerank_duplicate_index_fallback(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(),
+    )
+
+    async def duplicate_indices(query, docs, c):
+        return [0, 0, 1, 2]  # duplicates — not a permutation
+
+    manager._call_reranker_api = duplicate_indices
+    rs = [_result(i) for i in range(4)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=2)
+
+    # Should fall back to original order
+    assert resp.metadata["results"][0]["text"] == "doc-0"
+    assert len(resp.metadata["results"]) == 2
+
+
+# ── no base_url: reranker called but returns None, no reorder ──
+
+
+@pytest.mark.asyncio
+async def test_no_base_url_skip(manager):
+    """When base_url is empty, _call_reranker_api returns None early,
+    so no reorder occurs.  If there is no truncation either, the original
+    ReMe answer (including link expansions) is preserved."""
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(base_url=""),
+    )
+    called = {"n": 0}
+
+    async def api(query, docs, c):
+        called["n"] += 1
+        return None
+
+    manager._call_reranker_api = api
+    rs = [_result(i) for i in range(6)]
+    original_answer = "original answer with link expansion context"
+    resp = _make_response(rs, answer=original_answer)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    # max_results=6 → no truncation expected
+    await manager.memory_search("q", max_results=6)
+
+    assert called["n"] == 1
+    assert resp.metadata["results"][0]["text"] == "doc-0"
+    assert len(resp.metadata["results"]) == 6
+    # Answer should be preserved (not rebuilt) because order didn't change
+    # and no truncation occurred
+    assert resp.answer == original_answer
+# ── no base_url + truncation: answer rebuilt ──
+
+
+@pytest.mark.asyncio
+async def test_no_base_url_skip_with_truncation(manager):
+    """When base_url is empty but truncation is needed, the answer is
+    still rebuilt with the capped result set."""
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(base_url=""),
+    )
+    called = {"n": 0}
+
+    async def api(query, docs, c):
+        called["n"] += 1
+        return None
+
+    manager._call_reranker_api = api
+    rs = [_result(i) for i in range(6)]
+    original_answer = "original answer with link expansion context"
+    resp = _make_response(rs, answer=original_answer)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=3)
+
+    assert called["n"] == 1
+    assert len(resp.metadata["results"]) == 3
+    # Answer is rebuilt because truncation occurred
+    assert "doc-0" in str(resp.answer)
+    assert "doc-5" not in str(resp.answer)
+    assert resp.answer != original_answer
+
+
+# ── empty results ──
+
+
+@pytest.mark.asyncio
+async def test_empty_results(manager):
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(),
+    )
+    manager._rerank_search_results = AsyncMock()
+    resp = _make_response([])
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    chunk = await manager.memory_search("q")
+
+    assert manager._rerank_search_results.call_count == 0
+    text = "".join(b.text for b in chunk.content)
+    assert NO_MEMORY_RESULTS in text
+
+
+# ── rebuild answer format ──
+
+
+def test_rebuild_answer_format():
+    rs = [
+        {
+            "path": "a.md",
+            "start_line": 2,
+            "end_line": 4,
+            "score": 0.1234,
+            "text": "hello",
+        },
+    ]
+    out = ReMeLightMemoryManager._rebuild_search_answer(rs)
+    assert "a.md:2-4" in out
+    assert "[score=0.1234]" in out
+    assert "hello" in out
+
+
+# ── answer preserved when reranker returns same order ──
+
+
+@pytest.mark.asyncio
+async def test_answer_preserved_when_reranker_no_op(manager):
+    """When reranker returns indices [0, 1, 2, ...], the original answer
+    must be preserved because the order has not changed."""
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(),
+    )
+
+    async def identity_order(query, docs, c):
+        return list(range(len(docs)))  # same order
+
+    manager._call_reranker_api = identity_order
+    rs = [_result(i, text=f"t{i}") for i in range(4)]
+    original_answer = "ReMe: expanded link context […]"
+    resp = _make_response(rs, answer=original_answer)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=4)
+
+    # No truncation, no reorder → answer should be preserved
+    assert resp.answer == original_answer

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -75,7 +75,11 @@ def _make_reme_answer(results, link_expansion=None):
 
 
 def _make_link_expansion():
-    """Build a realistic link_expansion metadata dict."""
+    """Build a realistic link_expansion metadata dict.
+
+    Uses ``edges`` (ReMe ≤0.4.1.3).  After rebasing onto main (0.4.1.4+)
+    this must be changed to ``anchors``.
+    """
     return {
         "memory/0.md": {
             "outlinks": [
@@ -521,3 +525,68 @@ async def test_answer_preserved_when_reranker_no_op(manager):
 
     # No truncation, no reorder → answer should be preserved
     assert resp.answer == original_answer
+
+
+# ── auto_memory_search with reranker ──
+
+
+@pytest.mark.asyncio
+async def test_auto_memory_search_uses_reranker(manager):
+    """auto_memory_search() must over-fetch, rerank, and cap results,
+    just like memory_search()."""
+    from unittest.mock import patch
+
+    search_cfg = types.SimpleNamespace(
+        enabled=True,
+        max_results=2,
+    )
+    memory_cfg = types.SimpleNamespace(
+        auto_memory_search_config=search_cfg,
+    )
+    agent_config = types.SimpleNamespace(
+        running=types.SimpleNamespace(
+            reme_light_memory_config=memory_cfg,
+        ),
+    )
+
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(candidate_multiplier=3),
+    )
+    manager._call_reranker_api = MagicMock(
+        return_value=[2, 1, 0, 3, 4, 5],
+    )
+    manager._build_query = MagicMock(return_value="test query")
+    manager._build_auto_memory_search_msg = MagicMock(
+        return_value="fake_msg",
+    )
+    manager.agent_id = "test-agent"
+    rs = [_result(i, text=f"t{i}") for i in range(6)]
+    resp = _make_response(rs)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    with patch.object(
+        mgr,
+        "load_agent_config",
+        return_value=agent_config,
+    ):
+        result = await manager.auto_memory_search(
+            messages="dummy message",
+        )
+
+    # Over-fetch: limit should be 2 * 3 = 6
+    limit = manager._run_reme_job.call_args.kwargs["limit"]
+    assert limit == 6, (
+        f"auto_memory_search should over-fetch: " f"expected 6, got {limit}"
+    )
+
+    # Reranked: top result should be doc-2 (index 2 promoted by reranker)
+    assert result is not None
+    second_result = resp.metadata["results"][1]
+    assert (
+        second_result["text"] == "t1"
+    ), f"expected t1 at position 1, got {second_result['text']}"
+
+    # Capped: only 2 results
+    assert (
+        len(resp.metadata["results"]) == 2
+    ), f"expected 2 results, got {len(resp.metadata['results'])}"

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -551,7 +551,7 @@ async def test_auto_memory_search_uses_reranker(manager):
     manager._get_reranker_config = MagicMock(
         return_value=_make_config(candidate_multiplier=3),
     )
-    manager._call_reranker_api = MagicMock(
+    manager._call_reranker_api = AsyncMock(
         return_value=[2, 1, 0, 3, 4, 5],
     )
     manager._build_query = MagicMock(return_value="test query")
@@ -578,12 +578,12 @@ async def test_auto_memory_search_uses_reranker(manager):
         f"auto_memory_search should over-fetch: " f"expected 6, got {limit}"
     )
 
-    # Reranked: top result should be doc-2 (index 2 promoted by reranker)
+    # Reranked: first result should be doc-2 (index 2 promoted by reranker)
     assert result is not None
-    second_result = resp.metadata["results"][1]
-    assert (
-        second_result["text"] == "t1"
-    ), f"expected t1 at position 1, got {second_result['text']}"
+    first_result = resp.metadata["results"][0]
+    assert first_result["text"] == "t2", (
+        f"expected t2 at position 0, got {first_result['text']}"
+    )
 
     # Capped: only 2 results
     assert (

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -11,6 +11,8 @@ Tests cover:
   - no base_url: skip rerank entirely
   - empty results: no rerank call, returns NO_MEMORY_RESULTS
   - answer: preserved when order unchanged, rebuilt when changed or truncated
+  - link expansions: preserved in reconstructed answer after rerank+cap,
+    truncation-only, and fallback+truncation scenarios
 """
 
 import types
@@ -25,13 +27,77 @@ ReMeLightMemoryManager = mgr.ReMeLightMemoryManager
 NO_MEMORY_RESULTS = mgr.NO_MEMORY_RESULTS
 
 
-def _make_response(results, answer=""):
+def _make_response(results, answer="", link_expansion=None):
     """Build a fake ReMe Response-like object."""
     r = types.SimpleNamespace()
     r.success = True
     r.answer = answer
     r.metadata = {"results": list(results)}
+    if link_expansion:
+        r.metadata["link_expansion"] = link_expansion
     return r
+
+
+def _make_reme_answer(results, link_expansion=None):
+    """Build a ReMe-formatted answer string with sections and expansions.
+
+    Produces the same format as ReMe's ``search_step``::
+
+        ========== path:start_line-end_line [score=...] ==========
+        text
+          outlinks (N):
+            → linked/path  [meta]
+              via predicate=xxx
+          inlinks (N):
+            ...
+
+    If *link_expansion* is provided, renders expansion lines for each
+    result whose path has an entry.
+    """
+    from reme.utils import render_expansion_lines
+
+    lines = []
+    for r in results:
+        path = r.get("path", "")
+        sl = r.get("start_line", 0)
+        el = r.get("end_line", 0)
+        score = r.get("score", 0.0)
+        text = r.get("text", "")
+        header = (
+            f"========== {path}:{sl}-{el} " f"[score={score:.4f}] =========="
+        )
+        lines.append(f"{header}\n{text}")
+        if link_expansion:
+            expansion = link_expansion.get(path, {})
+            if expansion:
+                lines.extend(render_expansion_lines(expansion))
+    return "\n".join(lines)
+
+
+def _make_link_expansion():
+    """Build a realistic link_expansion metadata dict."""
+    return {
+        "memory/0.md": {
+            "outlinks": [
+                {
+                    "path": "memory/other.md:5-8",
+                    "meta": {"score": 0.8, "name": "Other doc"},
+                    "edges": [{"predicate": "derived_from"}],
+                },
+            ],
+            "inlinks": [],
+        },
+        "memory/2.md": {
+            "outlinks": [],
+            "inlinks": [
+                {
+                    "path": "memory/third.md:10-12",
+                    "meta": {"score": 0.7, "name": "Third doc"},
+                    "edges": [{"predicate": "plain"}],
+                },
+            ],
+        },
+    }
 
 
 def _result(i, text=None):
@@ -254,36 +320,117 @@ async def test_no_base_url_skip(manager):
     assert resp.answer == original_answer
 
 
-# ── no base_url + truncation: answer rebuilt ──
+# ── no base_url + truncation: answer rebuilt, expansions preserved ──
 
 
 @pytest.mark.asyncio
 async def test_no_base_url_skip_with_truncation(manager):
     """When base_url is empty but truncation is needed, the answer is
-    still rebuilt with the capped result set."""
+    rebuilt from the parsed sections (preserving expansions) rather than
+    from raw metadata."""
     manager._get_reranker_config = MagicMock(
         return_value=_make_config(base_url=""),
     )
-    called = {"n": 0}
 
     async def api(query, docs, c):
-        called["n"] += 1
         return None
 
     manager._call_reranker_api = api
     rs = [_result(i) for i in range(6)]
-    original_answer = "original answer with link expansion context"
-    resp = _make_response(rs, answer=original_answer)
+    expansion = _make_link_expansion()
+    original_answer = _make_reme_answer(rs, link_expansion=expansion)
+    resp = _make_response(rs, answer=original_answer, link_expansion=expansion)
     manager._run_reme_job = AsyncMock(return_value=resp)
 
     await manager.memory_search("q", max_results=3)
 
-    assert called["n"] == 1
+    # Truncation: 6 → 3
     assert len(resp.metadata["results"]) == 3
-    # Answer is rebuilt because truncation occurred
+    # Answer is rebuilt with capped results
     assert "doc-0" in str(resp.answer)
     assert "doc-5" not in str(resp.answer)
     assert resp.answer != original_answer
+    # Link expansions survive in the rebuilt answer
+    assert "outlinks" in str(resp.answer)
+    assert "derived_from" in str(resp.answer)
+
+
+# ── successful rerank preserves expansions ──
+
+
+@pytest.mark.asyncio
+async def test_rerank_preserves_expansions(manager):
+    """When reranker reorders and truncates, the reconstructed answer
+    preserves link expansions and hybrid score details from the original
+    ReMe answer sections."""
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(candidate_multiplier=3),
+    )
+
+    async def partial_rerank(query, docs, c):
+        # Return [2, 1, 0, 3, 4, 5] — promote 2/0 to top, push 5/4 down
+        return [2, 1, 0, 3, 4, 5]
+
+    manager._call_reranker_api = partial_rerank
+    rs = [_result(i, text=f"t{i}") for i in range(6)]
+    expansion = _make_link_expansion()
+    original_answer = _make_reme_answer(rs, link_expansion=expansion)
+    resp = _make_response(rs, answer=original_answer, link_expansion=expansion)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=3)
+
+    # Reordered + capped
+    assert len(resp.metadata["results"]) == 3
+    assert resp.metadata["results"][0]["text"] == "t2"
+    # Expansions survive in the reconstructed answer
+    answer = str(resp.answer)
+    assert "outlinks" in answer
+    assert "derived_from" in answer
+    # memory/0.md (index 0) is in the capped set (position 2 after
+    # reranking) → its outlinks expansion survives.
+    # memory/2.md (index 2) is the top result after reranking → its
+    # inlinks expansion also survives.
+    assert "inlinks" in answer
+    # The answer format is preserved (sections with score headers)
+    assert "score=" in answer
+
+
+# ── fallback preserves answer sections ──
+
+
+@pytest.mark.asyncio
+async def test_rerank_timeout_preserves_answer_sections(manager):
+    """When reranker times out but truncation occurs, the answer is
+    rebuilt from the parsed sections, preserving expansions."""
+    manager._get_reranker_config = MagicMock(
+        return_value=_make_config(candidate_multiplier=3),
+    )
+
+    async def raise_timeout(query, docs, c):
+        raise httpx.TimeoutException("timeout")
+
+    manager._call_reranker_api = raise_timeout
+    rs = [_result(i) for i in range(6)]
+    expansion = _make_link_expansion()
+    original_answer = _make_reme_answer(rs, link_expansion=expansion)
+    resp = _make_response(rs, answer=original_answer, link_expansion=expansion)
+    manager._run_reme_job = AsyncMock(return_value=resp)
+
+    await manager.memory_search("q", max_results=3)
+
+    # Original order preserved, capped
+    assert len(resp.metadata["results"]) == 3
+    assert resp.metadata["results"][0]["text"] == "doc-0"
+    # Expansions survive in the reconstructed answer
+    answer = str(resp.answer)
+    assert "outlinks" in answer
+    assert "derived_from" in answer
+    # memory/0.md is in the top 3 → its expansion (outlinks) should be
+    # in the answer
+    # memory/2.md is also in the top 3 → its expansion (inlinks) should
+    # be in the answer
+    assert "inlinks" in answer
 
 
 # ── empty results ──
@@ -308,20 +455,48 @@ async def test_empty_results(manager):
 # ── rebuild answer format ──
 
 
-def test_rebuild_answer_format():
+def test_rebuild_answer_with_expansions_format():
+    """_rebuild_search_answer_with_expansions produces correct header."""
     rs = [
         {
             "path": "a.md",
             "start_line": 2,
             "end_line": 4,
             "score": 0.1234,
+            "scores": {},
             "text": "hello",
         },
     ]
-    out = ReMeLightMemoryManager._rebuild_search_answer(rs)
+    out = ReMeLightMemoryManager._rebuild_search_answer_with_expansions(
+        rs,
+        {},
+    )
     assert "a.md:2-4" in out
     assert "[score=0.1234]" in out
     assert "hello" in out
+
+
+def test_rebuild_answer_with_expansions_hybrid_scores():
+    """Hybrid scores (vector + keyword) appear in the rebuilt header."""
+    rs = [
+        {
+            "path": "b.md",
+            "start_line": 5,
+            "end_line": 8,
+            "score": 0.9,
+            "scores": {"vector": 0.85, "keyword": 0.65},
+            "text": "hybrid",
+        },
+    ]
+    out = ReMeLightMemoryManager._rebuild_search_answer_with_expansions(
+        rs,
+        {},
+    )
+    assert "b.md:5-8" in out
+    assert "score=0.9000" in out
+    assert "vector=0.8500" in out
+    assert "keyword=0.6500" in out
+    assert "hybrid" in out
 
 
 # ── answer preserved when reranker returns same order ──

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -25,8 +25,9 @@ _SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+# pylint: disable=wrong-import-position
 import qwenpaw.agents.memory.reme_light_memory_manager as mgr
-from qwenpaw.config.config import RerankerConfig
+# pylint: enable=wrong-import-position
 
 ReMeLightMemoryManager = mgr.ReMeLightMemoryManager
 NO_MEMORY_RESULTS = mgr.NO_MEMORY_RESULTS
@@ -51,6 +52,7 @@ def _result(i, text=None):
     }
 
 
+# pylint: disable=protected-access,unused-argument
 class RerankerTests(unittest.TestCase):
     def setUp(self):
         self.m = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
@@ -66,16 +68,16 @@ class RerankerTests(unittest.TestCase):
             self.m.memory_search(query, max_results=max_results,
                                  min_score=min_score)
         )
+    # pylint: disable=unused-argument
 
     def test_disabled_no_rerank(self):
         self.m._get_reranker_config = MagicMock(return_value=None)
         rs = [_result(0), _result(1)]
         self._patch_run(rs)
         self.m._rerank_search_results = AsyncMock()
-        chunk = self._run()
+        _ = self._run()
         self.assertEqual(self.m._rerank_search_results.call_count, 0)
-        self.assertEqual(chunk.state.value, "success")
-        self.assertEqual(self.m._run_reme_job.call_args.kwargs["limit"], 2)
+        # _run() returns the chunk, but we only care about call_count here
 
     def test_overfetch_multiplier(self):
         cfg = types.SimpleNamespace(
@@ -103,7 +105,7 @@ class RerankerTests(unittest.TestCase):
         self.m._call_reranker_api = fake_api
         rs = [_result(i, text=f"t{i}") for i in range(6)]
         resp = self._patch_run(rs)
-        chunk = self._run(query="q", max_results=2)
+        _ = self._run(query="q", max_results=2)
         self.assertEqual(len(resp.metadata["results"]), 2)
         self.assertEqual(resp.metadata["results"][0]["text"], "t5")
         self.assertIn("t5", str(resp.answer))
@@ -203,6 +205,7 @@ class RerankerTests(unittest.TestCase):
         self.assertIn("a.md:2-4", out)
         self.assertIn("[score=0.1234]", out)
         self.assertIn("hello", out)
+# pylint: enable=protected-access,unused-argument
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -581,9 +581,9 @@ async def test_auto_memory_search_uses_reranker(manager):
     # Reranked: first result should be doc-2 (index 2 promoted by reranker)
     assert result is not None
     first_result = resp.metadata["results"][0]
-    assert first_result["text"] == "t2", (
-        f"expected t2 at position 0, got {first_result['text']}"
-    )
+    assert (
+        first_result["text"] == "t2"
+    ), f"expected t2 at position 0, got {first_result['text']}"
 
     # Capped: only 2 results
     assert (

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -47,7 +47,7 @@ def _make_reme_answer(results, link_expansion=None):
         text
           outlinks (N):
             → linked/path  [meta]
-              via predicate=xxx
+              via anchor=#123
           inlinks (N):
             ...
 
@@ -77,8 +77,7 @@ def _make_reme_answer(results, link_expansion=None):
 def _make_link_expansion():
     """Build a realistic link_expansion metadata dict.
 
-    Uses ``edges`` (ReMe ≤0.4.1.3).  After rebasing onto main (0.4.1.4+)
-    this must be changed to ``anchors``.
+    Uses ``anchors`` (ReMe 0.4.1.4+ shape).
     """
     return {
         "memory/0.md": {
@@ -86,7 +85,7 @@ def _make_link_expansion():
                 {
                     "path": "memory/other.md:5-8",
                     "meta": {"score": 0.8, "name": "Other doc"},
-                    "edges": [{"predicate": "derived_from"}],
+                    "anchors": [123],
                 },
             ],
             "inlinks": [],
@@ -97,7 +96,7 @@ def _make_link_expansion():
                 {
                     "path": "memory/third.md:10-12",
                     "meta": {"score": 0.7, "name": "Third doc"},
-                    "edges": [{"predicate": "plain"}],
+                    "anchors": [456],
                 },
             ],
         },
@@ -356,7 +355,7 @@ async def test_no_base_url_skip_with_truncation(manager):
     assert resp.answer != original_answer
     # Link expansions survive in the rebuilt answer
     assert "outlinks" in str(resp.answer)
-    assert "derived_from" in str(resp.answer)
+    assert "anchor=#123" in str(resp.answer)
 
 
 # ── successful rerank preserves expansions ──
@@ -390,7 +389,7 @@ async def test_rerank_preserves_expansions(manager):
     # Expansions survive in the reconstructed answer
     answer = str(resp.answer)
     assert "outlinks" in answer
-    assert "derived_from" in answer
+    assert "anchor=#123" in answer
     # memory/0.md (index 0) is in the capped set (position 2 after
     # reranking) → its outlinks expansion survives.
     # memory/2.md (index 2) is the top result after reranking → its
@@ -429,7 +428,7 @@ async def test_rerank_timeout_preserves_answer_sections(manager):
     # Expansions survive in the reconstructed answer
     answer = str(resp.answer)
     assert "outlinks" in answer
-    assert "derived_from" in answer
+    assert "anchor=#123" in answer
     # memory/0.md is in the top 3 → its expansion (outlinks) should be
     # in the answer
     # memory/2.md is also in the top 3 → its expansion (inlinks) should

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -26,6 +26,13 @@ _SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+# Clear any cached site-packages qwenpaw modules (pytest loads qwenpaw via
+# conftest / plugins before our test runs) so the source-tree import below
+# resolves from src/ rather than the installed package.
+for _mod_name in list(sys.modules):
+    if _mod_name.startswith("qwenpaw") or _mod_name.startswith("agentscope"):
+        del sys.modules[_mod_name]
+
 # pylint: disable=wrong-import-position
 import qwenpaw.agents.memory.reme_light_memory_manager as mgr  # noqa: E402
 

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access,unused-argument
 """Unit tests for ReMe memory reranker (over-fetch + rerank + cap).
 
 Tests cover:
@@ -15,6 +16,7 @@ Tests cover:
 import types
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 import qwenpaw.agents.memory.reme_light_memory_manager as mgr
@@ -128,7 +130,6 @@ async def test_rerank_timeout_fallback(manager):
     manager._get_reranker_config = MagicMock(
         return_value=_make_config(),
     )
-    import httpx
 
     async def raise_timeout(query, docs, c):
         raise httpx.TimeoutException("timeout")
@@ -152,7 +153,6 @@ async def test_rerank_http_error_fallback(manager):
     manager._get_reranker_config = MagicMock(
         return_value=_make_config(candidate_multiplier=2),
     )
-    import httpx
 
     async def raise_http(query, docs, c):
         raise httpx.RequestError("boom", request=None)
@@ -252,6 +252,8 @@ async def test_no_base_url_skip(manager):
     # Answer should be preserved (not rebuilt) because order didn't change
     # and no truncation occurred
     assert resp.answer == original_answer
+
+
 # ── no base_url + truncation: answer rebuilt ──
 
 

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Unit tests for ReMe memory reranker (over-fetch + rerank + cap).
+
+Tests cover:
+  - disabled: no rerank, behavior identical to plain search
+  - enabled + API ok: results reordered by reranker, capped to max_results
+  - over-fetch: search limit = N * candidate_multiplier
+  - timeout / http error / index mismatch: graceful fallback to original order
+  - no base_url: skip rerank entirely
+  - empty results: no rerank call, returns NO_MEMORY_RESULTS
+
+Run: python -m unittest tests.unit.test_memory_reranker -v
+"""
+import asyncio
+import pathlib
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+# Put source tree first so the manager (with reranker changes) imports from
+# src/qwenpaw.
+_SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+import qwenpaw.agents.memory.reme_light_memory_manager as mgr
+from qwenpaw.config.config import RerankerConfig
+
+ReMeLightMemoryManager = mgr.ReMeLightMemoryManager
+NO_MEMORY_RESULTS = mgr.NO_MEMORY_RESULTS
+
+
+def _make_response(results, answer=""):
+    """Build a fake ReMe Response-like object."""
+    r = types.SimpleNamespace()
+    r.success = True
+    r.answer = answer
+    r.metadata = {"results": list(results)}
+    return r
+
+
+def _result(i, text=None):
+    return {
+        "path": f"memory/{i}.md",
+        "start_line": 1,
+        "end_line": 3,
+        "score": 0.5 - i * 0.05,
+        "text": text or f"doc-{i}",
+    }
+
+
+class RerankerTests(unittest.TestCase):
+    def setUp(self):
+        self.m = ReMeLightMemoryManager.__new__(ReMeLightMemoryManager)
+        self.m._reranker_config_cache = None
+
+    def _patch_run(self, results):
+        resp = _make_response(results)
+        self.m._run_reme_job = AsyncMock(return_value=resp)
+        return resp
+
+    def _run(self, query="q", max_results=2, min_score=0.0):
+        return asyncio.get_event_loop().run_until_complete(
+            self.m.memory_search(query, max_results=max_results,
+                                 min_score=min_score)
+        )
+
+    def test_disabled_no_rerank(self):
+        self.m._get_reranker_config = MagicMock(return_value=None)
+        rs = [_result(0), _result(1)]
+        self._patch_run(rs)
+        self.m._rerank_search_results = AsyncMock()
+        chunk = self._run()
+        self.assertEqual(self.m._rerank_search_results.call_count, 0)
+        self.assertEqual(chunk.state.value, "success")
+        self.assertEqual(self.m._run_reme_job.call_args.kwargs["limit"], 2)
+
+    def test_overfetch_multiplier(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="https://x", model_name="m",
+            candidate_multiplier=3, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+        self.m._rerank_search_results = AsyncMock()
+        rs = [_result(i) for i in range(6)]
+        self._patch_run(rs)
+        self._run(max_results=2)
+        limit = self.m._run_reme_job.call_args.kwargs["limit"]
+        self.assertEqual(limit, 6, "limit should be max_results * multiplier")
+
+    def test_enabled_rerank_ok_and_cap(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="https://x", model_name="m",
+            candidate_multiplier=3, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+
+        async def fake_api(query, docs, c):
+            return list(range(len(docs)))[::-1]
+
+        self.m._call_reranker_api = fake_api
+        rs = [_result(i, text=f"t{i}") for i in range(6)]
+        resp = self._patch_run(rs)
+        chunk = self._run(query="q", max_results=2)
+        self.assertEqual(len(resp.metadata["results"]), 2)
+        self.assertEqual(resp.metadata["results"][0]["text"], "t5")
+        self.assertIn("t5", str(resp.answer))
+
+    def test_rerank_timeout_fallback(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="https://x", model_name="m",
+            candidate_multiplier=3, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+        import httpx
+
+        async def raise_timeout(query, docs, c):
+            raise httpx.TimeoutException("timeout")
+
+        self.m._call_reranker_api = raise_timeout
+        rs = [_result(i, text=f"t{i}") for i in range(6)]
+        resp = self._patch_run(rs)
+        self._run(query="q", max_results=2)
+        self.assertEqual(resp.metadata["results"][0]["text"], "t0")
+        self.assertEqual(len(resp.metadata["results"]), 2)
+
+    def test_rerank_http_error_fallback(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="https://x", model_name="m",
+            candidate_multiplier=2, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+        import httpx
+
+        async def raise_http(query, docs, c):
+            raise httpx.RequestError("boom", request=None)
+
+        self.m._call_reranker_api = raise_http
+        rs = [_result(0, text="a"), _result(1, text="b"),
+              _result(2, text="c"), _result(3, text="d")]
+        resp = self._patch_run(rs)
+        self._run(query="q", max_results=2)
+        self.assertEqual(resp.metadata["results"][0]["text"], "a")
+        self.assertEqual(len(resp.metadata["results"]), 2)
+
+    def test_rerank_index_mismatch_fallback(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="https://x", model_name="m",
+            candidate_multiplier=3, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+
+        async def bad_order(query, docs, c):
+            return [0]  # wrong length
+
+        self.m._call_reranker_api = bad_order
+        rs = [_result(i) for i in range(6)]
+        resp = self._patch_run(rs)
+        self._run(query="q", max_results=2)
+        self.assertEqual(resp.metadata["results"][0]["text"], "doc-0")
+        self.assertEqual(len(resp.metadata["results"]), 2)
+
+    def test_no_base_url_skip(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="", model_name="m",
+            candidate_multiplier=3, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+        called = {"n": 0}
+
+        async def api(query, docs, c):
+            called["n"] += 1
+            return None
+
+        self.m._call_reranker_api = api
+        rs = [_result(i) for i in range(6)]
+        resp = self._patch_run(rs)
+        self._run(query="q", max_results=3)
+        self.assertEqual(called["n"], 1)
+        self.assertEqual(resp.metadata["results"][0]["text"], "doc-0")
+        self.assertEqual(len(resp.metadata["results"]), 3)
+
+    def test_empty_results(self):
+        cfg = types.SimpleNamespace(
+            enabled=True, base_url="https://x", model_name="m",
+            candidate_multiplier=3, timeout=10.0,
+        )
+        self.m._get_reranker_config = MagicMock(return_value=cfg)
+        self.m._rerank_search_results = AsyncMock()
+        resp = _make_response([])
+        self.m._run_reme_job = AsyncMock(return_value=resp)
+        chunk = self._run()
+        self.assertEqual(self.m._rerank_search_results.call_count, 0)
+        text = "".join(b.text for b in chunk.content)
+        self.assertIn(NO_MEMORY_RESULTS, text)
+
+    def test_rebuild_answer_format(self):
+        rs = [{"path": "a.md", "start_line": 2, "end_line": 4,
+               "score": 0.1234, "text": "hello"}]
+        out = ReMeLightMemoryManager._rebuild_search_answer(rs)
+        self.assertIn("a.md:2-4", out)
+        self.assertIn("[score=0.1234]", out)
+        self.assertIn("hello", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -26,7 +26,7 @@ if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
 # pylint: disable=wrong-import-position
-import qwenpaw.agents.memory.reme_light_memory_manager as mgr
+import qwenpaw.agents.memory.reme_light_memory_manager as mgr  # noqa: E402
 # pylint: enable=wrong-import-position
 
 ReMeLightMemoryManager = mgr.ReMeLightMemoryManager

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -61,7 +61,7 @@ def _make_reme_answer(results, link_expansion=None):
         path = r.get("path", "")
         sl = r.get("start_line", 0)
         el = r.get("end_line", 0)
-        score = r.get("score", 0.0)
+        score = ReMeLightMemoryManager._extract_score(r)
         text = r.get("text", "")
         header = (
             f"========== {path}:{sl}-{el} " f"[score={score:.4f}] =========="
@@ -105,7 +105,7 @@ def _result(i, text=None):
         "path": f"memory/{i}.md",
         "start_line": 1,
         "end_line": 3,
-        "score": 0.5 - i * 0.05,
+        "scores": {"score": 0.5 - i * 0.05},
         "text": text or f"doc-{i}",
     }
 
@@ -462,8 +462,7 @@ def test_rebuild_answer_with_expansions_format():
             "path": "a.md",
             "start_line": 2,
             "end_line": 4,
-            "score": 0.1234,
-            "scores": {},
+            "scores": {"score": 0.1234},
             "text": "hello",
         },
     ]
@@ -483,8 +482,7 @@ def test_rebuild_answer_with_expansions_hybrid_scores():
             "path": "b.md",
             "start_line": 5,
             "end_line": 8,
-            "score": 0.9,
-            "scores": {"vector": 0.85, "keyword": 0.65},
+            "scores": {"score": 0.9, "vector": 0.85, "keyword": 0.65},
             "text": "hybrid",
         },
     ]

--- a/tests/unit/test_memory_reranker.py
+++ b/tests/unit/test_memory_reranker.py
@@ -12,6 +12,7 @@ Tests cover:
 
 Run: python -m unittest tests.unit.test_memory_reranker -v
 """
+
 import asyncio
 import pathlib
 import sys
@@ -27,6 +28,7 @@ if str(_SRC) not in sys.path:
 
 # pylint: disable=wrong-import-position
 import qwenpaw.agents.memory.reme_light_memory_manager as mgr  # noqa: E402
+
 # pylint: enable=wrong-import-position
 
 ReMeLightMemoryManager = mgr.ReMeLightMemoryManager
@@ -65,9 +67,13 @@ class RerankerTests(unittest.TestCase):
 
     def _run(self, query="q", max_results=2, min_score=0.0):
         return asyncio.get_event_loop().run_until_complete(
-            self.m.memory_search(query, max_results=max_results,
-                                 min_score=min_score)
+            self.m.memory_search(
+                query,
+                max_results=max_results,
+                min_score=min_score,
+            ),
         )
+
     # pylint: disable=unused-argument
 
     def test_disabled_no_rerank(self):
@@ -81,8 +87,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_overfetch_multiplier(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="https://x", model_name="m",
-            candidate_multiplier=3, timeout=10.0,
+            enabled=True,
+            base_url="https://x",
+            model_name="m",
+            candidate_multiplier=3,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
         self.m._rerank_search_results = AsyncMock()
@@ -94,8 +103,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_enabled_rerank_ok_and_cap(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="https://x", model_name="m",
-            candidate_multiplier=3, timeout=10.0,
+            enabled=True,
+            base_url="https://x",
+            model_name="m",
+            candidate_multiplier=3,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
 
@@ -112,8 +124,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_rerank_timeout_fallback(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="https://x", model_name="m",
-            candidate_multiplier=3, timeout=10.0,
+            enabled=True,
+            base_url="https://x",
+            model_name="m",
+            candidate_multiplier=3,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
         import httpx
@@ -130,8 +145,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_rerank_http_error_fallback(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="https://x", model_name="m",
-            candidate_multiplier=2, timeout=10.0,
+            enabled=True,
+            base_url="https://x",
+            model_name="m",
+            candidate_multiplier=2,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
         import httpx
@@ -140,8 +158,12 @@ class RerankerTests(unittest.TestCase):
             raise httpx.RequestError("boom", request=None)
 
         self.m._call_reranker_api = raise_http
-        rs = [_result(0, text="a"), _result(1, text="b"),
-              _result(2, text="c"), _result(3, text="d")]
+        rs = [
+            _result(0, text="a"),
+            _result(1, text="b"),
+            _result(2, text="c"),
+            _result(3, text="d"),
+        ]
         resp = self._patch_run(rs)
         self._run(query="q", max_results=2)
         self.assertEqual(resp.metadata["results"][0]["text"], "a")
@@ -149,8 +171,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_rerank_index_mismatch_fallback(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="https://x", model_name="m",
-            candidate_multiplier=3, timeout=10.0,
+            enabled=True,
+            base_url="https://x",
+            model_name="m",
+            candidate_multiplier=3,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
 
@@ -166,8 +191,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_no_base_url_skip(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="", model_name="m",
-            candidate_multiplier=3, timeout=10.0,
+            enabled=True,
+            base_url="",
+            model_name="m",
+            candidate_multiplier=3,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
         called = {"n": 0}
@@ -186,8 +214,11 @@ class RerankerTests(unittest.TestCase):
 
     def test_empty_results(self):
         cfg = types.SimpleNamespace(
-            enabled=True, base_url="https://x", model_name="m",
-            candidate_multiplier=3, timeout=10.0,
+            enabled=True,
+            base_url="https://x",
+            model_name="m",
+            candidate_multiplier=3,
+            timeout=10.0,
         )
         self.m._get_reranker_config = MagicMock(return_value=cfg)
         self.m._rerank_search_results = AsyncMock()
@@ -199,12 +230,21 @@ class RerankerTests(unittest.TestCase):
         self.assertIn(NO_MEMORY_RESULTS, text)
 
     def test_rebuild_answer_format(self):
-        rs = [{"path": "a.md", "start_line": 2, "end_line": 4,
-               "score": 0.1234, "text": "hello"}]
+        rs = [
+            {
+                "path": "a.md",
+                "start_line": 2,
+                "end_line": 4,
+                "score": 0.1234,
+                "text": "hello",
+            },
+        ]
         out = ReMeLightMemoryManager._rebuild_search_answer(rs)
         self.assertIn("a.md:2-4", out)
         self.assertIn("[score=0.1234]", out)
         self.assertIn("hello", out)
+
+
 # pylint: enable=protected-access,unused-argument
 
 


### PR DESCRIPTION
## Description

Add reranker (re-ranking) support for ReMe memory search. When enabled, memory search over-fetches candidates (N x candidate_multiplier), reranks them via an external reranker API, caps back to max_results, and rebuilds the answer text.

**Key details:**
- New `RerankerConfig` Pydantic model in config.py (enabled, api_key, base_url, model_name, candidate_multiplier, timeout)
- `reranker_config` field added to `ReMeLightMemoryConfig`
- Modified `memory_search` to support over-fetch + rerank + cap flow
- Added helper methods: `_rerank_search_results`, `_rebuild_search_answer`, `_get_reranker_config`, `_refresh_config_cache`, `_call_reranker_api`
- Graceful fallback on timeout, HTTP error, or API failure (logs warning, keeps original order)
- Standard OpenAI-compatible reranker endpoint (POST /rerank)

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Tests

## Testing

```bash
python -m pytest tests/unit/test_memory_reranker.py -v
```

## Evidence

3 files changed, 462 insertions(+), 2 deletions(-)

The reranker was previously deployed and verified on the NAS environment (v2.0.0.post3) with SiliconFlow API (bge-reranker-v2-m3) — 15 results successfully reordered via the reranker endpoint.