### PR TITLE
fix(local-models): ignore non-object tool call json

### DIFF
--- a/src/qwenpaw/local_models/tag_parser.py
+++ b/src/qwenpaw/local_models/tag_parser.py
@@ -234,6 +234,13 @@ def _parse_single_tool_call(raw_text: str) -> ParsedToolCall | None:
         data = None
 
     if data is not None:
+        if not isinstance(data, dict):
+            logger.warning(
+                "Tool call JSON must be an object: %s",
+                stripped[:200],
+            )
+            return None
+
         name = data.get("name", "")
         if not name:
             logger.warning(

--- a/tests/unit/local_models/test_tag_parser.py
+++ b/tests/unit/local_models/test_tag_parser.py
@@ -133,6 +133,12 @@ def test_parse_json_tool_call_missing_name() -> None:
     assert len(result.tool_calls) == 0
 
 
+def test_parse_json_tool_call_ignores_non_object_json() -> None:
+    text = "<tool_call>[1]</tool_call>"
+    result = parse_tool_calls_from_text(text)
+    assert len(result.tool_calls) == 0
+
+
 def test_parse_multiple_tool_calls() -> None:
     text = (
         'text<tool_call>{"name":"a","arguments":{}}</tool_call>'


### PR DESCRIPTION
## What Problem This Solves

Local model output can contain malformed `<tool_call>` blocks. When the JSON payload parses successfully but is not an object, such as `[1]`, the parser currently treats it like a mapping and can raise `AttributeError` while handling model text.

This change makes the parser ignore non-object JSON tool calls instead of crashing, matching the existing behavior for other malformed tool-call payloads.

## Evidence

- Added a unit test covering `<tool_call>[1]</tool_call>`.
- Verified the local parser test suite passes:

```bash
PYTHONPATH=src python -m pytest tests/unit/local_models/test_tag_parser.py -q
```

Result: `26 passed`.
