### PR TITLE
fix(providers): strip annotated null gemini schemas

### DIFF
--- a/src/qwenpaw/providers/gemini_provider.py
+++ b/src/qwenpaw/providers/gemini_provider.py
@@ -82,6 +82,10 @@ def _flatten_json_schema(schema: dict) -> dict:
     return _resolve_ref(schema)
 
 
+def _is_null_schema(schema: Any) -> bool:
+    return isinstance(schema, dict) and schema.get("type") == "null"
+
+
 # pylint: disable=too-many-branches
 def _sanitize_schema_for_gemini(schema: Any) -> Any:
     """Sanitize a JSON schema to be compatible with the Gemini API.
@@ -125,7 +129,7 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
 
     if "anyOf" in schema and isinstance(schema["anyOf"], list):
         any_of = schema["anyOf"]
-        non_null = [v for v in any_of if v != {"type": "null"}]
+        non_null = [v for v in any_of if not _is_null_schema(v)]
         if len(non_null) < len(any_of):
             if len(non_null) == 1:
                 merged = dict(_sanitize_schema_for_gemini(non_null[0]))

--- a/tests/unit/providers/test_gemini_provider.py
+++ b/tests/unit/providers/test_gemini_provider.py
@@ -333,6 +333,24 @@ def test_sanitize_handles_anyOf_with_null() -> None:
     assert result["properties"]["cwd"] == {"type": "string"}
 
 
+def test_sanitize_handles_anyOf_with_annotated_null() -> None:
+    from qwenpaw.providers.gemini_provider import _sanitize_schema_for_gemini
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "cwd": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "null", "title": "None"},
+                ],
+            },
+        },
+    }
+    result = _sanitize_schema_for_gemini(schema)
+    assert result["properties"]["cwd"] == {"type": "string"}
+
+
 def test_sanitize_nested_standalone_null() -> None:
     from qwenpaw.providers.gemini_provider import _sanitize_schema_for_gemini
 


### PR DESCRIPTION
## What Problem This Solves

Gemini schema sanitization strips nullable `anyOf` branches only when the branch is exactly `{"type": "null"}`. Pydantic-style schemas often annotate that null branch with metadata, for example `{"type": "null", "title": "None"}`, which leaves an unsupported nullable branch in the Gemini tool schema.

This change treats any schema object with `type == "null"` as a null schema, preserving the intended non-null branch while dropping the Gemini-incompatible nullable branch.

## Evidence

- Added a unit test for an `anyOf` schema containing `{"type": "null", "title": "None"}`.
- Verified the Gemini provider test suite passes:

```bash
PYTHONPATH=src python -m pytest tests/unit/providers/test_gemini_provider.py -q
```

Result: `21 passed`.
