### PR TITLE
fix(console): round heartbeat seconds up

### DIFF
--- a/console/src/pages/Control/Heartbeat/parseEvery.test.ts
+++ b/console/src/pages/Control/Heartbeat/parseEvery.test.ts
@@ -17,6 +17,12 @@ describe("parseEvery", () => {
   it("mixed 2h30m → total minutes 150 (not divisible by 60)", () => {
     expect(parseEvery("2h30m")).toEqual({ number: 150, unit: "m" });
   });
+
+  it("rounds seconds up to the nearest minute", () => {
+    expect(parseEvery("29s")).toEqual({ number: 1, unit: "m" });
+    expect(parseEvery("30s")).toEqual({ number: 1, unit: "m" });
+    expect(parseEvery("90s")).toEqual({ number: 2, unit: "m" });
+  });
 });
 
 describe("serializeEvery", () => {

--- a/console/src/pages/Control/Heartbeat/parseEvery.ts
+++ b/console/src/pages/Control/Heartbeat/parseEvery.ts
@@ -25,7 +25,7 @@ export function parseEvery(every: string): EveryParts {
   const hours = parseInt(m.groups.hours ?? "0", 10);
   const minutes = parseInt(m.groups.minutes ?? "0", 10);
   const seconds = parseInt(m.groups.seconds ?? "0", 10);
-  const totalMinutes = hours * 60 + minutes + Math.round(seconds / 60);
+  const totalMinutes = hours * 60 + minutes + Math.ceil(seconds / 60);
   if (totalMinutes <= 0) {
     return { number: 6, unit: "h" };
   }


### PR DESCRIPTION
## What Problem This Solves

The console heartbeat parser converts seconds with `Math.round(seconds / 60)`. Short non-zero values like `29s` round to `0` minutes, which then falls through to the default `6h` interval and silently displays a much longer heartbeat interval than configured.

This change rounds seconds up to the nearest minute so every non-zero seconds-only interval remains visible and does not collapse to the default.

## Evidence

- Added Vitest coverage for `29s`, `30s`, and `90s`.
- Verified the targeted console test passes:

```bash
npm test -- --run src/pages/Control/Heartbeat/parseEvery.test.ts
```

Result: `1 test file passed, 6 tests passed`.
