### PR TITLE
fix(shell): preserve multiline commands for Windows PowerShell

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -119,8 +119,11 @@ def _collapse_newlines_outside_quotes(cmd: str) -> str:
     return "".join(result)
 
 
-def _collapse_embedded_newlines(cmd: str) -> str:
-    r"""Replace embedded newline characters with spaces in a command string.
+def _collapse_embedded_newlines(
+    cmd: str,
+    shell_executable: str | None = None,
+) -> str:
+    r"""Normalize embedded newlines for the configured shell.
 
     LLMs produce tool-call arguments in JSON where ``\n`` is parsed as an
     actual newline character.  In the original shell command the user
@@ -129,21 +132,22 @@ def _collapse_embedded_newlines(cmd: str) -> str:
     break.  When passed to a shell:
 
     * **Windows** ``cmd.exe`` truncates the command at the first newline
-      regardless of quoting context — this is a hard limitation of the
-      Windows command processor.  All newlines must be collapsed.
+      regardless of quoting context, so all newlines must be collapsed.
+      PowerShell supports multiline scripts, so its newlines are preserved.
     * **Unix** ``sh -c`` treats an unquoted newline as a command separator,
       but correctly handles newlines inside quoted strings.
 
     On Unix/macOS, newlines inside quoted strings are preserved so that
     downstream commands receive the correct multi-line content (e.g.
-    ``--text "Hello\nWorld"``).  On Windows, all newlines are collapsed
-    to ensure the command at least executes successfully.
+    ``--text "Hello\nWorld"``).  On Windows, a missing or unrecognized shell
+    uses the conservative ``cmd.exe``-compatible behavior.
     """
     if "\n" not in cmd:
         return cmd
     if sys.platform == "win32":
-        # cmd.exe truncates at newlines regardless of quoting — must
-        # collapse all to ensure the command executes at all.
+        if shell_executable and _is_powershell(shell_executable):
+            return cmd
+        # cmd.exe (and unknown cmd-like Windows shells) truncate at newlines.
         return cmd.replace("\r\n", " ").replace("\n", " ")
     return _collapse_newlines_outside_quotes(cmd)
 
@@ -247,8 +251,9 @@ def _execute_subprocess_sync(
 
     Args:
         cmd (`str`):
-            The shell command to execute (must not contain embedded
-            newlines — see note above).
+            The shell command to execute. PowerShell commands may contain
+            embedded newlines; other Windows shell commands are normalized
+            by the caller as described above.
         cwd (`str`):
             The working directory for the command execution.
         timeout (`float`):
@@ -539,7 +544,15 @@ async def execute_shell_command(
             return code will be -1 and stderr will contain timeout information.
     """
 
-    cmd = _collapse_embedded_newlines((command or "").strip())
+    shell_executable = (
+        get_current_shell_command_executable()
+        or os.environ.get("SHELL")
+        or None
+    )
+    cmd = _collapse_embedded_newlines(
+        (command or "").strip(),
+        shell_executable=shell_executable,
+    )
 
     if _is_dangerous_self_kill(cmd):
         return ToolChunk(
@@ -584,12 +597,6 @@ async def execute_shell_command(
         env["PATH"] = python_bin_dir + os.pathsep + existing_path
     else:
         env["PATH"] = python_bin_dir
-
-    shell_executable = (
-        get_current_shell_command_executable()
-        or os.environ.get("SHELL")
-        or None
-    )
 
     if sandbox_config is not None:
         # Create a copy with resolved shell and timeout to avoid mutating

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -545,7 +545,9 @@ async def execute_shell_command(
     """
 
     shell_executable = (
-        get_current_shell_command_executable() or os.environ.get("SHELL") or None
+        get_current_shell_command_executable()
+        or os.environ.get("SHELL")
+        or None
     )
     cmd = _collapse_embedded_newlines(
         (command or "").strip(),

--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -545,9 +545,7 @@ async def execute_shell_command(
     """
 
     shell_executable = (
-        get_current_shell_command_executable()
-        or os.environ.get("SHELL")
-        or None
+        get_current_shell_command_executable() or os.environ.get("SHELL") or None
     )
     cmd = _collapse_embedded_newlines(
         (command or "").strip(),

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -118,9 +118,7 @@ class TestCollapseNewlinesOutsideQuotes:
         assert _collapse_newlines_outside_quotes("echo\nhello") == "echo hello"
 
     def test_crlf_to_space(self):
-        assert (
-            _collapse_newlines_outside_quotes("echo\r\nhello") == "echo hello"
-        )
+        assert _collapse_newlines_outside_quotes("echo\r\nhello") == "echo hello"
 
     def test_single_quoted_newline_preserved(self):
         result = _collapse_newlines_outside_quotes("echo 'hello\nworld'")
@@ -157,9 +155,7 @@ class TestCollapseEmbeddedNewlines:
 
     def test_no_newlines_unchanged(self):
         command = "echo hello"
-        assert (
-            _collapse_embedded_newlines(command, "powershell.exe") == command
-        )
+        assert _collapse_embedded_newlines(command, "powershell.exe") == command
 
     @patch("qwenpaw.agents.tools.shell.sys")
     def test_windows_cmd_collapses_all(self, mock_sys):
@@ -187,8 +183,7 @@ class TestCollapseEmbeddedNewlines:
     ):
         mock_sys.platform = "win32"
         command = (
-            f'$content = @"{newline}hello{newline}world'
-            f'{newline}"@{newline}$content'
+            f'$content = @"{newline}hello{newline}world{newline}"@{newline}$content'
         )
         assert _collapse_embedded_newlines(command, shell) == command
 
@@ -426,12 +421,15 @@ class TestExecuteShellCommand:
         mock_proc.returncode = 0
         mock_proc.pid = 12345
 
-        with patch(
-            "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
-            AsyncMock(return_value=mock_proc),
-        ), patch(
-            "qwenpaw.agents.tools.shell.asyncio.wait_for",
-            side_effect=fake_wait_for,
+        with (
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.wait_for",
+                side_effect=fake_wait_for,
+            ),
         ):
             from qwenpaw.agents.tools.shell import (
                 execute_shell_command,
@@ -466,12 +464,15 @@ class TestExecuteShellCommand:
         mock_proc.returncode = 1
         mock_proc.pid = 12345
 
-        with patch(
-            "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
-            AsyncMock(return_value=mock_proc),
-        ), patch(
-            "qwenpaw.agents.tools.shell.asyncio.wait_for",
-            side_effect=fake_wait_for,
+        with (
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.wait_for",
+                side_effect=fake_wait_for,
+            ),
         ):
             from qwenpaw.agents.tools.shell import (
                 execute_shell_command,
@@ -503,12 +504,15 @@ class TestExecuteShellCommand:
         mock_proc.returncode = 0
         mock_proc.pid = 12345
 
-        with patch(
-            "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
-            AsyncMock(return_value=mock_proc),
-        ), patch(
-            "qwenpaw.agents.tools.shell.asyncio.wait_for",
-            side_effect=fake_wait_for,
+        with (
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.wait_for",
+                side_effect=fake_wait_for,
+            ),
         ):
             from qwenpaw.agents.tools.shell import (
                 execute_shell_command,
@@ -540,12 +544,15 @@ class TestExecuteShellCommand:
         mock_proc.returncode = 0
         mock_proc.pid = 12345
 
-        with patch(
-            "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
-            AsyncMock(return_value=mock_proc),
-        ), patch(
-            "qwenpaw.agents.tools.shell.asyncio.wait_for",
-            side_effect=fake_wait_for,
+        with (
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.wait_for",
+                side_effect=fake_wait_for,
+            ),
         ):
             from qwenpaw.agents.tools.shell import (
                 execute_shell_command,
@@ -577,12 +584,15 @@ class TestExecuteShellCommand:
         mock_proc.returncode = 0
         mock_proc.pid = 12345
 
-        with patch(
-            "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
-            AsyncMock(return_value=mock_proc),
-        ), patch(
-            "qwenpaw.agents.tools.shell.asyncio.wait_for",
-            side_effect=fake_wait_for,
+        with (
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.create_subprocess_shell",
+                AsyncMock(return_value=mock_proc),
+            ),
+            patch(
+                "qwenpaw.agents.tools.shell.asyncio.wait_for",
+                side_effect=fake_wait_for,
+            ),
         ):
             from qwenpaw.agents.tools.shell import (
                 execute_shell_command,

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -156,19 +156,47 @@ class TestCollapseEmbeddedNewlines:
     """Tests for _collapse_embedded_newlines."""
 
     def test_no_newlines_unchanged(self):
-        assert _collapse_embedded_newlines("echo hello") == "echo hello"
+        command = "echo hello"
+        assert (
+            _collapse_embedded_newlines(command, "powershell.exe") == command
+        )
 
     @patch("qwenpaw.agents.tools.shell.sys")
-    def test_windows_collapses_all(self, mock_sys):
+    def test_windows_cmd_collapses_all(self, mock_sys):
+        mock_sys.platform = "win32"
+        result = _collapse_embedded_newlines(
+            'echo "hello\r\nworld"',
+            r"C:\Windows\System32\cmd.exe",
+        )
+        assert result == 'echo "hello world"'
+
+    @patch("qwenpaw.agents.tools.shell.sys")
+    def test_windows_default_shell_collapses_all(self, mock_sys):
         mock_sys.platform = "win32"
         result = _collapse_embedded_newlines('echo "hello\nworld"')
-        assert "\n" not in result
+        assert result == 'echo "hello world"'
+
+    @pytest.mark.parametrize("shell", ["powershell.exe", "pwsh.exe"])
+    @pytest.mark.parametrize("newline", ["\n", "\r\n"])
+    @patch("qwenpaw.agents.tools.shell.sys")
+    def test_windows_powershell_preserves_here_string(
+        self,
+        mock_sys,
+        newline,
+        shell,
+    ):
+        mock_sys.platform = "win32"
+        command = (
+            f'$content = @"{newline}hello{newline}world'
+            f'{newline}"@{newline}$content'
+        )
+        assert _collapse_embedded_newlines(command, shell) == command
 
     @patch("qwenpaw.agents.tools.shell.sys")
-    def test_unix_preserves_quoted(self, mock_sys):
+    def test_unix_preserves_quoted_newlines(self, mock_sys):
         mock_sys.platform = "linux"
-        result = _collapse_embedded_newlines('echo "hello\nworld"')
-        assert "\n" in result
+        command = 'echo "hello\nworld"'
+        assert _collapse_embedded_newlines(command, "/bin/bash") == command
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents/tools/test_shell.py
+++ b/tests/unit/agents/tools/test_shell.py
@@ -118,7 +118,9 @@ class TestCollapseNewlinesOutsideQuotes:
         assert _collapse_newlines_outside_quotes("echo\nhello") == "echo hello"
 
     def test_crlf_to_space(self):
-        assert _collapse_newlines_outside_quotes("echo\r\nhello") == "echo hello"
+        assert (
+            _collapse_newlines_outside_quotes("echo\r\nhello") == "echo hello"
+        )
 
     def test_single_quoted_newline_preserved(self):
         result = _collapse_newlines_outside_quotes("echo 'hello\nworld'")
@@ -155,7 +157,9 @@ class TestCollapseEmbeddedNewlines:
 
     def test_no_newlines_unchanged(self):
         command = "echo hello"
-        assert _collapse_embedded_newlines(command, "powershell.exe") == command
+        assert (
+            _collapse_embedded_newlines(command, "powershell.exe") == command
+        )
 
     @patch("qwenpaw.agents.tools.shell.sys")
     def test_windows_cmd_collapses_all(self, mock_sys):
@@ -183,7 +187,8 @@ class TestCollapseEmbeddedNewlines:
     ):
         mock_sys.platform = "win32"
         command = (
-            f'$content = @"{newline}hello{newline}world{newline}"@{newline}$content'
+            f'$content = @"{newline}hello{newline}'
+            f'world{newline}"@{newline}$content'
         )
         assert _collapse_embedded_newlines(command, shell) == command
 


### PR DESCRIPTION
## Description

On Windows, `execute_shell_command` always collapsed embedded newlines before launching the configured shell. That is needed for `cmd.exe`, which truncates at newlines, but it breaks valid multiline PowerShell scripts such as here-strings when the shell is `powershell.exe` or `pwsh.exe`.

This change makes newline normalization shell-aware:
- Windows + PowerShell / pwsh: preserve LF and CRLF
- Windows + cmd or unknown shell: keep collapsing newlines to spaces
- Unix/macOS: unchanged quote-aware collapsing

**Related Issue:** Fixes #6406

**Security Considerations:** No security-sensitive change. Command content is not rewritten for PowerShell beyond preserving the original line breaks; cmd behavior remains conservative.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --files` on the changed paths and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Unit coverage for `_collapse_embedded_newlines` was extended for:
- Windows cmd collapse
- Windows default/unknown shell collapse
- Windows PowerShell/pwsh here-string preserve (LF and CRLF)
- Unix quoted newline preserve
- no-newline path unchanged

Commands run after the pre-commit formatting fix:

```text
black --line-length=79 src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell.py
flake8 --extend-ignore=E203 src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell.py
pre-commit run --files src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell.py
python -m pytest tests/unit/agents/tools/test_shell.py -q
```

## Evidence

Local verification on the latest head after the pre-commit formatting fix:
- black line-length 79 passed on both changed files
- flake8 with extend-ignore=E203 passed on both changed files
- pre-commit on the changed paths passed black, flake8, mypy, pylint, and other applicable hooks
- full shell unit suite: 71 passed in about 0.80s
- no product-logic change in the formatting commit; only black/flake8 layout fixes

Transcript summary:

```text
pre-commit run --files src/qwenpaw/agents/tools/shell.py tests/unit/agents/tools/test_shell.py
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
mypy.....................................................................Passed

python -m pytest tests/unit/agents/tools/test_shell.py -q
.......................................................................  [100%]
71 passed in 0.80s
```

## Additional Notes

Related open work for Unix newline handling exists in #4673 and does not address Windows PowerShell preservation.
Addressed the pre-commit formatting request by applying black (line-length 79) and fixing flake8 E501 on the PowerShell here-string test.
