### PR TITLE
test(e2e): add skill auto-sync cases (#5639)

### DIFF
--- a/e2e/pages/skill_pool_page.py
+++ b/e2e/pages/skill_pool_page.py
@@ -2,12 +2,22 @@
 """
 QwenPaw Skill Pool page object.
 
-Wraps all interactions on the Skill Pool page and exposes business-level methods.
+Wraps interactions on the Skill Pool page (``/skill-pool``), including the
+skill auto-sync affordances added in upstream #5639:
+
+- the per-card sync status badge (colored dot + status label),
+- the hover-revealed auto-update quick-toggle button,
+- the edit-drawer Auto Sync switch + target-agent select (staged until Save).
+
+Selectors target the real post-#5639 DOM: antd ``prefixCls`` is ``qwenpaw``
+and component-local styles are CSS-Module hashed class names, matched via
+``[class*=basename]`` substrings (never the stale ``.qwenpaw-card`` stub).
 """
 from __future__ import annotations
 
 import logging
-from typing import Optional, List
+from typing import List, Optional
+
 from playwright.sync_api import Page, Locator
 
 from pages.base_page import BasePage
@@ -17,32 +27,50 @@ logger = logging.getLogger(__name__)
 
 
 class SkillPoolPage(BasePage):
-    """
-    Skill Pool page object.
-
-    Wraps all user actions on the Skill Pool page:
-    - Page navigation
-    - Get skill cards
-    - Search skills
-    - Upload and install skills
-    """
+    """Skill Pool page object (card grid + edit drawer + auto-sync)."""
 
     PAGE_TITLE = "Skill Pool"
     PAGE_URL = f"{config.base_url}/skill-pool"
 
-    # ========== Selector definitions ==========
+    # ========== Selectors ==========
+    # Page + card grid (SkillPool/index.module.less, PoolSkillCard.tsx)
+    PAGE_CONTAINER = '[class*="skillsPage"]'
+    SKILL_GRID = '[class*="skillsGrid"]'
+    SKILL_CARD = '[class*="skillCard"]'
+    SKILL_TITLE = '[class*="skillTitle"]'
+    # Sync status badge (rendered for every card) + its colored dot.
+    STATUS_BADGE = '[class*="statusBadge"]'
+    STATUS_DOT = '[class*="statusDot"]'
+    # "Auto Sync" chip in the title row — only when skill.auto_update === true.
+    AUTO_UPDATE_TAG = '[class*="autoUpdateTag"]'
+    BUILTIN_TAG = '[class*="builtinTag"]'
+    CUSTOM_TAG = '[class*="customTag"]'
+    # Card footer is only mounted on hover / batch / mobile; the auto-update
+    # quick-toggle button (SyncOutlined) lives inside it.
+    CARD_FOOTER = '[class*="cardFooter"]'
+    AUTO_UPDATE_BUTTON = '[class*="autoUpdateButton"]'
 
-    # Skill card
-    SKILL_CARD = ".qwenpaw-card"
-
-    # Search input
-    SEARCH_INPUT = 'input[placeholder*="搜索"], input[placeholder*="Search"]'
-
-    # Upload button
-    UPLOAD_BTN = 'button:has-text("上传"), button:has-text("Upload")'
-
-    # Install button
-    INSTALL_BTN = 'button:has-text("安装"), button:has-text("Install")'
+    # Edit drawer (PoolSkillDrawer.tsx)
+    DRAWER = '.qwenpaw-drawer'
+    DRAWER_TITLE = '.qwenpaw-drawer-title'
+    # The only Switch inside the drawer is the Auto Sync toggle.
+    AUTO_SYNC_SWITCH = '.qwenpaw-drawer button[role="switch"]'
+    # Target-agent multi-select is rendered ONLY after the switch is ON; anchor
+    # on its placeholder text (unique) so we don't match other selects.
+    TARGET_SELECT_PLACEHOLDER = (
+        '.qwenpaw-drawer [class*="select-selection-placeholder"]'
+        ':has-text("All agents that have this skill"), '
+        '.qwenpaw-drawer [class*="select-selection-placeholder"]'
+        ':has-text("所有已安装该技能的智能体")'
+    )
+    SAVE_BTN = (
+        '.qwenpaw-drawer button:has-text("Save"), '
+        '.qwenpaw-drawer button:has-text("保存")'
+    )
+    CANCEL_BTN = (
+        '.qwenpaw-drawer button:has-text("Cancel"), '
+        '.qwenpaw-drawer button:has-text("取消")'
+    )
 
     # ========== Initialization ==========
 
@@ -50,108 +78,112 @@ class SkillPoolPage(BasePage):
         super().__init__(page)
         logger.info("SkillPoolPage initialized")
 
-    # ========== Page navigation ==========
+    # ========== Navigation ==========
 
     def open(self) -> "SkillPoolPage":
-        """Open the Skill Pool page."""
+        """Open the Skill Pool page and wait for the card grid container."""
         logger.info("Opening Skill Pool page")
         self.goto()
-        self.wait_for_loading()
+        try:
+            self.page.locator(self.PAGE_CONTAINER).first.wait_for(
+                state="visible", timeout=self.timeout
+            )
+        except Exception:
+            logger.warning("skillsPage container not visible within timeout")
+        self.wait(500)
         return self
 
-    def wait_for_page_loaded(self) -> bool:
-        """
-        Wait for the page to finish loading.
-
-        Returns:
-            True if loaded, False otherwise.
-        """
-        try:
-            self.wait_for_element(self.SKILL_CARD, timeout=10000)
-            return True
-        except Exception as e:
-            logger.error(f"Page load failed: {e}")
-            return False
-
-    # ========== Skill card methods ==========
+    # ========== Card queries ==========
 
     def get_skill_cards(self) -> List[Locator]:
-        """
-        Return all skill cards.
+        """Return all skill cards currently rendered in the grid."""
+        return self.page.locator(self.SKILL_CARD).all()
 
-        Returns:
-            List of Locator instances.
-        """
-        logger.info("Getting skill cards")
-        return self.find_all(self.SKILL_CARD)
+    def find_card_by_name(self, name: str) -> Optional[Locator]:
+        """Return the skill card whose text contains ``name`` (or None)."""
+        card = self.page.locator(
+            f'{self.SKILL_CARD}:has-text("{name}")'
+        ).first
+        return card if card.count() > 0 else None
 
-    def get_skill_name(self, card: Locator) -> str:
-        """
-        Read the skill name from a card.
+    def hover_card(self, card: Locator) -> "SkillPoolPage":
+        """Hover a card so its footer (auto-update button) is mounted."""
+        card.scroll_into_view_if_needed(timeout=5000)
+        card.hover(timeout=5000)
+        self.wait(300)
+        return self
 
-        Args:
-            card: Skill card Locator.
+    def open_edit_drawer(self, name: str) -> "SkillPoolPage":
+        """Click a skill card (non-batch mode) to open its edit drawer."""
+        card = self.find_card_by_name(name)
+        if card is None:
+            raise ValueError(f"Skill card not found: {name}")
+        card.scroll_into_view_if_needed(timeout=5000)
+        card.click()
+        self.page.locator(self.DRAWER).first.wait_for(
+            state="visible", timeout=self.timeout
+        )
+        self.wait(400)
+        return self
 
-        Returns:
-            The skill name.
+    def toggle_auto_sync_switch(self) -> "SkillPoolPage":
+        """Click the Auto Sync switch inside the open edit drawer."""
+        switch = self.page.locator(self.AUTO_SYNC_SWITCH).first
+        switch.wait_for(state="visible", timeout=self.timeout)
+        switch.click()
+        self.wait(400)
+        return self
+
+    def save_drawer(self) -> "SkillPoolPage":
+        """Click the drawer's Save button."""
+        self.page.locator(self.SAVE_BTN).first.click()
+        self.wait(800)
+        return self
+
+    # ========== Seeding (API — pool endpoints in app/routers/skills.py) ==========
+
+    @staticmethod
+    def seed_pool_skill(api_context, name: str, content: str = "") -> bool:
+        """Create a pool skill via ``POST /api/skills/pool/create``.
+
+        A freshly-created pool skill has ``auto_update=false`` (the create
+        schema has no auto_update field). Returns True on success; a 4xx
+        (already exists) is treated as a soft success so re-runs don't break
+        setup.
         """
-        logger.info("Getting skill name from card")
+        body = content or (
+            f"---\nname: {name}\n"
+            "description: e2e seeded pool skill for auto-sync tests\n---\n"
+            f"# {name}\n\nSeeded by e2e; no LLM required.\n"
+        )
+        resp = api_context.post(
+            "/api/skills/pool/create",
+            data={"name": name, "content": body, "enable": True},
+        )
+        ok = resp.ok or resp.status in (400, 409)
+        logger.info("seed_pool_skill(%s) -> HTTP %s (ok=%s)", name, resp.status, ok)
+        return ok
+
+    @staticmethod
+    def set_pool_auto_update(
+        api_context, name: str, enabled: bool, targets=None
+    ) -> bool:
+        """Set a pool skill's auto-update via PUT .../auto-update."""
+        resp = api_context.put(
+            f"/api/skills/pool/{name}/auto-update",
+            data={"enabled": enabled, "targets": targets},
+        )
+        logger.info(
+            "set_pool_auto_update(%s, enabled=%s) -> HTTP %s",
+            name, enabled, resp.status,
+        )
+        return resp.ok
+
+    @staticmethod
+    def delete_pool_skill(api_context, name: str) -> None:
+        """Delete a pool skill (best-effort cleanup)."""
         try:
-            # Try to read the card title or its text content
-            return card.inner_text().strip().split('\n')[0]
-        except Exception as e:
-            logger.warning(f"Failed to get skill name: {e}")
-            return ""
-
-    # ========== Search ==========
-
-    def search_skills(self, keyword: str) -> "SkillPoolPage":
-        """
-        Search for skills.
-
-        Args:
-            keyword: Search keyword.
-
-        Returns:
-            self
-        """
-        logger.info(f"Searching skills with keyword: {keyword}")
-        search_input = self.find(self.SEARCH_INPUT)
-        search_input.fill(keyword)
-        self.wait(500)
-        return self
-
-    # ========== Upload and install ==========
-
-    def click_upload(self) -> "SkillPoolPage":
-        """
-        Click the Upload button.
-
-        Returns:
-            self
-        """
-        logger.info("Clicking upload button")
-        upload_btn = self.find(self.UPLOAD_BTN)
-        upload_btn.click()
-        self.wait(500)
-        return self
-
-    def click_install(self, card: Locator) -> "SkillPoolPage":
-        """
-        Click the Install button on a given skill card.
-
-        Args:
-            card: Skill card Locator.
-
-        Returns:
-            self
-        """
-        logger.info("Clicking install button on skill card")
-        # Find the install button inside the card
-        install_btn = card.locator(self.INSTALL_BTN).first
-        if install_btn.count() > 0:
-            install_btn.click()
-            self.wait(500)
-        else:
-            logger.warning("Install button not found in card")
-        return self
+            resp = api_context.delete(f"/api/skills/pool/{name}")
+            logger.info("delete_pool_skill(%s) -> HTTP %s", name, resp.status)
+        except Exception as exc:  # noqa: BLE001 - cleanup must never raise
+            logger.warning("delete_pool_skill(%s) failed: %s", name, exc)

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -43,6 +43,7 @@ markers =
     slash_commands: Slash commands module (typed in chat input, e.g. /model, /skills)
     skills: Skills module
     skill_pool: Skill Pool module
+    skill_sync: Skill auto-sync feature (Sprint 4, upstream #5639) — spans inbox + skill_pool
     tools: Tools module
     files: Files module
     mcp: MCP clients module

--- a/e2e/tests/test_inbox.py
+++ b/e2e/tests/test_inbox.py
@@ -12,10 +12,12 @@ Cases:
 - INBOX-004 P1  test_message_card_renders_and_modal_opens
 - INBOX-005 P1  test_batch_mode_select_and_delete
 - INBOX-006 P1  test_sidebar_unread_dot_appears_with_seeded_event
+- SYNC-003  P2  test_skill_autosync_notification_card
 """
 from __future__ import annotations
 
 import logging
+import re
 import time
 
 import pytest
@@ -307,6 +309,73 @@ class TestSidebarUnreadDot:
                 inbox_page.SIDEBAR_INBOX_BADGE
             ).first
             expect(badge).to_be_visible(timeout=18000)
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed")
+        finally:
+            inbox_page.clean_inbox()
+
+
+# ============================================================================
+# SYNC-003 P2  Skill auto-sync notification renders as an inbox card
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p2
+@pytest.mark.inbox
+@pytest.mark.skill_sync
+class TestSkillAutoSyncInbox:
+    """SYNC-003: a ``skill_autoupdate`` event renders a 'Skill auto-sync' card.
+
+    The auto-sync notification (upstream #5639) is emitted server-side with
+    ``source_type='skill_autoupdate'``; the frontend maps that source to a
+    fixed card title via i18n (``inbox.skillAutoUpdateTitle``), so the visible
+    title is 'Skill auto-sync' / '技能自动同步' regardless of the stored title.
+    """
+
+    @pytest.mark.test_id("SYNC-003")
+    def test_skill_autosync_notification_card(
+        self,
+        inbox_page: InboxPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        try:
+            log_test_step("1. Seed a skill_autoupdate inbox event")
+            inbox_page.clean_inbox()
+            inbox_page.seed_events([
+                inbox_page.make_event(
+                    event_id="evt-skillsync-1",
+                    source_type="skill_autoupdate",
+                    event_type="auto_update",
+                    status="success",
+                    severity="info",
+                    title="Auto-update: 1 skill updated",
+                    body="e2e_sync_skill -> default",
+                    payload={
+                        "synced": [
+                            {"skill": "e2e_sync_skill", "agents": ["default"]},
+                        ],
+                        "failed": [],
+                    },
+                    read=False,
+                    created_at=time.time(),
+                ),
+            ])
+
+            log_test_step("2. Open /inbox")
+            inbox_page.open()
+
+            log_test_step("3. A message card is rendered (poll window ~18s)")
+            cards = inbox_page.page.locator(inbox_page.MESSAGE_CARD)
+            expect(cards.first).to_be_visible(timeout=18000)
+
+            log_test_step("4. The card title reads 'Skill auto-sync'")
+            title = inbox_page.page.locator('[class*="messageTitle"]').filter(
+                has_text=re.compile(r"Skill auto-sync|技能自动同步")
+            )
+            expect(title.first).to_be_visible(timeout=inbox_page.timeout)
 
             log_test_result(test_name, True, 0)
             logger.info(f"Test {test_name} passed")

--- a/e2e/tests/test_skill_pool.py
+++ b/e2e/tests/test_skill_pool.py
@@ -14,6 +14,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from config.settings import config
+from pages.skill_pool_page import SkillPoolPage
 from utils.helpers import log_test_step, log_test_result
 
 logger = logging.getLogger(__name__)
@@ -644,3 +645,131 @@ class TestSkillPoolBuiltinImport:
                 logger.info("No dialog appeared after click, may be running in background")
 
         log_test_result(test_name, True, 0)
+
+
+# ============================================================================
+# SYNC-001 P1  Skill card shows sync-status badge + auto-update button
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.skill_pool
+@pytest.mark.skill_sync
+class TestSkillAutoSyncCard:
+    """SYNC-001: a pool skill card carries a sync-status badge and, on hover,
+    the auto-update quick-toggle button (upstream #5639)."""
+
+    SKILL_NAME = "e2e_sync_card_skill"
+
+    @pytest.mark.test_id("SYNC-001")
+    def test_skill_card_sync_badge_and_button(
+        self,
+        page: Page,
+        api_context,
+        request: pytest.FixtureRequest,
+    ):
+        test_name = request.node.name
+        pool = SkillPoolPage(page)
+        try:
+            log_test_step("1. Seed a pool skill via API (no LLM)")
+            SkillPoolPage.delete_pool_skill(api_context, self.SKILL_NAME)
+            assert SkillPoolPage.seed_pool_skill(
+                api_context, self.SKILL_NAME
+            ), "Failed to seed pool skill"
+
+            log_test_step("2. Open the Skill Pool page (card view is default)")
+            pool.open()
+
+            log_test_step("3. Locate the seeded skill card")
+            card = pool.find_card_by_name(self.SKILL_NAME)
+            assert card is not None, f"Seeded card not found: {self.SKILL_NAME}"
+            expect(card).to_be_visible(timeout=pool.timeout)
+
+            log_test_step("4. Card shows a sync-status badge with a colored dot")
+            expect(
+                card.locator(pool.STATUS_BADGE).first
+            ).to_be_visible(timeout=pool.timeout)
+            expect(
+                card.locator(pool.STATUS_DOT).first
+            ).to_be_visible(timeout=pool.timeout)
+
+            log_test_step("5. Hovering the card reveals the auto-update button")
+            pool.hover_card(card)
+            expect(
+                card.locator(pool.AUTO_UPDATE_BUTTON).first
+            ).to_be_visible(timeout=pool.timeout)
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed")
+        finally:
+            SkillPoolPage.delete_pool_skill(api_context, self.SKILL_NAME)
+
+
+# ============================================================================
+# SYNC-002 P1  Edit-drawer Auto Sync switch reveals targets + persists on Save
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.skill_pool
+@pytest.mark.skill_sync
+class TestSkillAutoSyncDrawer:
+    """SYNC-002: in the edit drawer, turning the Auto Sync switch ON reveals the
+    target-agent select; clicking Save persists it (card shows the Auto Sync
+    tag afterwards). The switch is staged — nothing persists until Save."""
+
+    SKILL_NAME = "e2e_sync_drawer_skill"
+
+    @pytest.mark.test_id("SYNC-002")
+    def test_auto_sync_switch_reveals_targets_and_persists(
+        self,
+        page: Page,
+        api_context,
+        request: pytest.FixtureRequest,
+    ):
+        test_name = request.node.name
+        pool = SkillPoolPage(page)
+        try:
+            log_test_step("1. Seed a pool skill (auto_update defaults off)")
+            SkillPoolPage.delete_pool_skill(api_context, self.SKILL_NAME)
+            assert SkillPoolPage.seed_pool_skill(
+                api_context, self.SKILL_NAME
+            ), "Failed to seed pool skill"
+
+            log_test_step("2. Open the Skill Pool page and the skill's edit drawer")
+            pool.open()
+            pool.open_edit_drawer(self.SKILL_NAME)
+
+            log_test_step("3. Auto Sync switch visible; target select hidden")
+            expect(
+                page.locator(pool.AUTO_SYNC_SWITCH).first
+            ).to_be_visible(timeout=pool.timeout)
+            target_before = page.locator(pool.TARGET_SELECT_PLACEHOLDER)
+            assert (
+                target_before.count() == 0
+                or not target_before.first.is_visible()
+            ), "Target-agent select should be hidden while Auto Sync is off"
+
+            log_test_step("4. Turn Auto Sync ON → target-agent select appears")
+            pool.toggle_auto_sync_switch()
+            expect(
+                page.locator(pool.TARGET_SELECT_PLACEHOLDER).first
+            ).to_be_visible(timeout=pool.timeout)
+
+            log_test_step("5. Save → the drawer closes")
+            pool.save_drawer()
+            expect(
+                page.locator(pool.DRAWER).first
+            ).to_be_hidden(timeout=pool.timeout)
+
+            log_test_step("6. The card now shows the Auto Sync tag (persisted)")
+            card = pool.find_card_by_name(self.SKILL_NAME)
+            assert card is not None, "Card missing after save"
+            expect(
+                card.locator(pool.AUTO_UPDATE_TAG).first
+            ).to_be_visible(timeout=pool.timeout)
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed")
+        finally:
+            SkillPoolPage.delete_pool_skill(api_context, self.SKILL_NAME)


### PR DESCRIPTION
## Summary
- Adds Sprint-4 regression coverage for **skill auto-sync** (upstream #5639), previously untested:
  - **SYNC-001** (p1): a pool skill card shows the sync-status badge + colored dot, and hovering the card reveals the auto-update quick-toggle button.
  - **SYNC-002** (p1): the edit-drawer Auto Sync switch reveals the target-agent select when turned ON, and Save persists it (the card shows the Auto Sync tag afterwards). The switch is staged — nothing persists until Save.
  - **SYNC-003** (p2): a `skill_autoupdate` inbox event renders a "Skill auto-sync" notification card.
- Rewrites `e2e/pages/skill_pool_page.py` to the real post-#5639 CSS-Module selectors (the old `.qwenpaw-card` stub matched every antd Card) and adds pool-skill seed/cleanup API helpers (`POST /api/skills/pool/create`, `PUT .../auto-update`, `DELETE`). Registers a `skill_sync` marker spanning inbox + skill_pool.

## Test plan
- [x] fork CI `-m skill_sync`: **3 passed** (SYNC-001/002/003)
- [x] fork CI full suite by priority tier: `-m p2` all green; within `-m p0` / `-m p1` the three SYNC cases pass on both runs (two independent green data points).
- [x] The only full-suite failures are **4 pre-existing** Agents / cross-module cases (`test_edit_agent_info`, `test_toggle_agent_status`, `test_agent_drag_reorder`, `test_skill_to_agent_to_chat`) broken by the #6198 Agents redesign — **unrelated to this PR** (this branch touches only skill_pool/inbox e2e) and fixed separately in #6333.
- [x] e2e-only, UI-driven (page.locator/expect primary; API only for seeding); no product code touched.