### PR TITLE
feat: allow renaming custom providers

### DIFF
--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -79,6 +79,7 @@ export interface BaseUrlOption {
 }
 
 export interface ProviderConfigRequest {
+  name?: string;
   api_key?: string;
   base_url?: string;
   chat_model?: string;

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -460,6 +460,7 @@ export function ProviderConfigModal({
   useEffect(() => {
     if (open) {
       form.setFieldsValue({
+        name: provider.name,
         api_key: undefined,
         base_url: provider.base_url || undefined,
         chat_model: provider.chat_model || "OpenAIChatModel",
@@ -522,6 +523,7 @@ export function ProviderConfigModal({
         }, {});
 
       await api.configureProvider(provider.id, {
+        name: provider.is_custom ? values.name?.trim() : undefined,
         api_key: values.api_key,
         base_url: values.base_url,
         chat_model: values.chat_model,
@@ -533,7 +535,11 @@ export function ProviderConfigModal({
       await onSaved();
       setFormDirty(false);
       onClose();
-      message.success(t("models.configurationSaved", { name: provider.name }));
+      message.success(
+        t("models.configurationSaved", {
+          name: values.name?.trim() || provider.name,
+        }),
+      );
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) return;
       const errMsg =
@@ -664,6 +670,7 @@ export function ProviderConfigModal({
         form={form}
         layout="vertical"
         initialValues={{
+          name: provider.name,
           base_url: provider.base_url || undefined,
           chat_model: provider.chat_model || "OpenAIChatModel",
           generate_kwargs_text:
@@ -674,6 +681,22 @@ export function ProviderConfigModal({
         }}
         onValuesChange={() => setFormDirty(true)}
       >
+        {provider.is_custom && (
+          <Form.Item
+            name="name"
+            label={t("models.providerNameLabel")}
+            rules={[
+              {
+                required: true,
+                whitespace: true,
+                message: t("models.providerNameLabel"),
+              },
+            ]}
+          >
+            <Input placeholder={t("models.providerNamePlaceholder")} />
+          </Form.Item>
+        )}
+
         {provider.is_custom && (
           <Form.Item
             name="chat_model"

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -14,7 +14,7 @@ from fastapi import (
     Query,
     Request,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from qwenpaw.exceptions import (
     AppBaseException,
@@ -76,6 +76,7 @@ def _active_models_info(
 
 
 class ProviderConfigRequest(BaseModel):
+    name: Optional[str] = Field(default=None)
     api_key: Optional[str] = Field(default=None)
     base_url: Optional[str] = Field(default=None)
     chat_model: Optional[ChatModelName] = Field(
@@ -101,6 +102,17 @@ class ProviderConfigRequest(BaseModel):
             "Only applies to Anthropic-compatible providers."
         ),
     )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize and validate an optional provider display name."""
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError(f"{'Provider name cannot be empty.'}")
+        return value
 
 
 class ModelSlotRequest(BaseModel):
@@ -236,9 +248,22 @@ async def configure_provider(
     provider_id: str = Path(...),
     body: ProviderConfigRequest = Body(...),
 ) -> ProviderInfo:
+    provider = manager.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Provider '{provider_id}' not found",
+        )
+    if body.name is not None and not provider.is_custom:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{'Only custom providers can be renamed.'}",
+        )
+
     ok = manager.update_provider(
         provider_id,
         {
+            "name": body.name,
             "api_key": body.api_key,
             "base_url": body.base_url,
             "chat_model": body.chat_model,

--- a/tests/unit/app/routers/test_provider_config_router.py
+++ b/tests/unit/app/routers/test_provider_config_router.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
 
 import pytest
 from fastapi import HTTPException
@@ -14,7 +15,7 @@ from qwenpaw.providers.provider_manager import ProviderManager
 
 
 @pytest.fixture
-def provider_manager(monkeypatch, tmp_path) -> ProviderManager:
+def configured_provider_manager(monkeypatch, tmp_path) -> ProviderManager:
     secret_dir = tmp_path / ".qwenpaw.secret"
     monkeypatch.setattr(provider_manager_module, "SECRET_DIR", secret_dir)
     return ProviderManager()
@@ -26,9 +27,9 @@ def test_provider_config_request_rejects_blank_name() -> None:
 
 
 async def test_configure_provider_renames_custom_provider(
-    provider_manager: ProviderManager,
+    configured_provider_manager: ProviderManager,
 ) -> None:
-    await provider_manager.add_custom_provider(
+    await configured_provider_manager.add_custom_provider(
         OpenAIProvider(
             id="custom-openai",
             name="Custom OpenAI",
@@ -36,7 +37,7 @@ async def test_configure_provider_renames_custom_provider(
     )
 
     updated = await configure_provider(
-        manager=provider_manager,
+        manager=configured_provider_manager,
         provider_id="custom-openai",
         body=ProviderConfigRequest(name="Renamed Provider"),
     )
@@ -50,16 +51,16 @@ async def test_configure_provider_renames_custom_provider(
 
 
 async def test_configure_provider_rejects_builtin_rename(
-    provider_manager: ProviderManager,
+    configured_provider_manager: ProviderManager,
 ) -> None:
     with pytest.raises(HTTPException) as exc_info:
         await configure_provider(
-            manager=provider_manager,
+            manager=configured_provider_manager,
             provider_id="openai",
             body=ProviderConfigRequest(name="Renamed OpenAI"),
         )
 
     assert exc_info.value.status_code == 400
-    provider = provider_manager.get_provider("openai")
+    provider = configured_provider_manager.get_provider("openai")
     assert provider is not None
     assert provider.name == "OpenAI"

--- a/tests/unit/app/routers/test_provider_config_router.py
+++ b/tests/unit/app/routers/test_provider_config_router.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+import qwenpaw.providers.provider_manager as provider_manager_module
+from qwenpaw.app.routers.providers import (
+    ProviderConfigRequest,
+    configure_provider,
+)
+from qwenpaw.providers.openai_provider import OpenAIProvider
+from qwenpaw.providers.provider_manager import ProviderManager
+
+
+@pytest.fixture
+def provider_manager(monkeypatch, tmp_path) -> ProviderManager:
+    secret_dir = tmp_path / ".qwenpaw.secret"
+    monkeypatch.setattr(provider_manager_module, "SECRET_DIR", secret_dir)
+    return ProviderManager()
+
+
+def test_provider_config_request_rejects_blank_name() -> None:
+    with pytest.raises(ValidationError):
+        ProviderConfigRequest(name="   ")
+
+
+async def test_configure_provider_renames_custom_provider(
+    provider_manager: ProviderManager,
+) -> None:
+    await provider_manager.add_custom_provider(
+        OpenAIProvider(
+            id="custom-openai",
+            name="Custom OpenAI",
+        ),
+    )
+
+    updated = await configure_provider(
+        manager=provider_manager,
+        provider_id="custom-openai",
+        body=ProviderConfigRequest(name="Renamed Provider"),
+    )
+
+    assert updated.id == "custom-openai"
+    assert updated.name == "Renamed Provider"
+    reloaded = ProviderManager()
+    provider = reloaded.get_provider("custom-openai")
+    assert provider is not None
+    assert provider.name == "Renamed Provider"
+
+
+async def test_configure_provider_rejects_builtin_rename(
+    provider_manager: ProviderManager,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await configure_provider(
+            manager=provider_manager,
+            provider_id="openai",
+            body=ProviderConfigRequest(name="Renamed OpenAI"),
+        )
+
+    assert exc_info.value.status_code == 400
+    provider = provider_manager.get_provider("openai")
+    assert provider is not None
+    assert provider.name == "OpenAI"

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -172,6 +172,29 @@ async def test_add_custom_provider_and_reload_from_storage(
     assert isinstance(loaded_duplicate, OpenAIProvider)
 
 
+async def test_update_custom_provider_name_persists(
+    isolated_secret_dir,
+) -> None:
+    manager = ProviderManager()
+    await manager.add_custom_provider(
+        OpenAIProvider(
+            id="custom-openai",
+            name="Custom OpenAI",
+        ),
+    )
+
+    ok = manager.update_provider(
+        "custom-openai",
+        {"name": "Renamed Provider"},
+    )
+
+    assert ok is True
+    reloaded = ProviderManager()
+    provider = reloaded.get_provider("custom-openai")
+    assert provider is not None
+    assert provider.name == "Renamed Provider"
+
+
 async def test_custom_provider_preserves_explicit_default_context_window(
     isolated_secret_dir,
 ) -> None:


### PR DESCRIPTION
# Summary

Adds a display-name editing entry for custom LLM providers.

Custom providers can now be renamed from their configuration dialog without
changing the stable provider ID, model bindings, or saved credentials.

Related Issue: #6414

## Changes

- Add an optional `name` field to the provider configuration API.
- Allow renaming custom providers only.
- Reject empty display names and attempts to rename built-in providers.
- Add a “Display Name” field to the custom-provider configuration dialog.
- Persist renamed provider display names across restarts.
- Add regression tests for successful rename, blank-name validation, and
  built-in-provider protection.