### PR TITLE
feat(models): allow renaming custom providers (#6414)

### DIFF
--- a/console/src/api/types/provider.ts
+++ b/console/src/api/types/provider.ts
@@ -81,6 +81,8 @@ export interface BaseUrlOption {
 export interface ProviderConfigRequest {
   api_key?: string;
   base_url?: string;
+  /** New display name. Only applied to custom providers. */
+  name?: string;
   chat_model?: string;
   generate_kwargs?: Record<string, unknown>;
   custom_headers?: Record<string, string>;

--- a/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/console/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -461,6 +461,7 @@ export function ProviderConfigModal({
     if (open) {
       form.setFieldsValue({
         api_key: undefined,
+        name: provider.name,
         base_url: provider.base_url || undefined,
         chat_model: provider.chat_model || "OpenAIChatModel",
         generate_kwargs_text:
@@ -523,6 +524,7 @@ export function ProviderConfigModal({
 
       await api.configureProvider(provider.id, {
         api_key: values.api_key,
+        name: provider.is_custom ? values.name?.trim() : undefined,
         base_url: values.base_url,
         chat_model: values.chat_model,
         generate_kwargs: hasGenerateConfigInput ? generateConfig : {},
@@ -533,7 +535,11 @@ export function ProviderConfigModal({
       await onSaved();
       setFormDirty(false);
       onClose();
-      message.success(t("models.configurationSaved", { name: provider.name }));
+      message.success(
+        t("models.configurationSaved", {
+          name: (provider.is_custom && values.name?.trim()) || provider.name,
+        }),
+      );
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) return;
       const errMsg =
@@ -664,6 +670,7 @@ export function ProviderConfigModal({
         form={form}
         layout="vertical"
         initialValues={{
+          name: provider.name,
           base_url: provider.base_url || undefined,
           chat_model: provider.chat_model || "OpenAIChatModel",
           generate_kwargs_text:
@@ -674,6 +681,22 @@ export function ProviderConfigModal({
         }}
         onValuesChange={() => setFormDirty(true)}
       >
+        {provider.is_custom && (
+          <Form.Item
+            name="name"
+            label={t("models.providerNameLabel")}
+            rules={[
+              {
+                required: true,
+                whitespace: true,
+                message: t("models.providerNameLabel"),
+              },
+            ]}
+          >
+            <Input placeholder={t("models.providerNamePlaceholder")} />
+          </Form.Item>
+        )}
+
         {provider.is_custom && (
           <Form.Item
             name="chat_model"

--- a/src/qwenpaw/app/routers/providers.py
+++ b/src/qwenpaw/app/routers/providers.py
@@ -78,6 +78,10 @@ def _active_models_info(
 class ProviderConfigRequest(BaseModel):
     api_key: Optional[str] = Field(default=None)
     base_url: Optional[str] = Field(default=None)
+    name: Optional[str] = Field(
+        default=None,
+        description=("New display name. Only applied to custom providers."),
+    )
     chat_model: Optional[ChatModelName] = Field(
         default=None,
         description="Chat model class name for protocol selection",
@@ -236,17 +240,22 @@ async def configure_provider(
     provider_id: str = Path(...),
     body: ProviderConfigRequest = Body(...),
 ) -> ProviderInfo:
-    ok = manager.update_provider(
-        provider_id,
-        {
-            "api_key": body.api_key,
-            "base_url": body.base_url,
-            "chat_model": body.chat_model,
-            "generate_kwargs": body.generate_kwargs,
-            "custom_headers": body.custom_headers,
-            "auth_mode": body.auth_mode,
-        },
-    )
+    config = {
+        "api_key": body.api_key,
+        "base_url": body.base_url,
+        "chat_model": body.chat_model,
+        "generate_kwargs": body.generate_kwargs,
+        "custom_headers": body.custom_headers,
+        "auth_mode": body.auth_mode,
+    }
+    # Renaming is restricted to custom providers so built-in
+    # provider names stay immutable.
+    name = body.name.strip() if body.name else None
+    if name:
+        provider = manager.get_provider(provider_id)
+        if provider is not None and provider.is_custom:
+            config["name"] = name
+    ok = manager.update_provider(provider_id, config)
     if not ok:
         raise HTTPException(
             status_code=404,

--- a/tests/unit/app/routers/test_provider_rename.py
+++ b/tests/unit/app/routers/test_provider_rename.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Tests for renaming custom providers via the config endpoint."""
+
+from types import SimpleNamespace
+
+from qwenpaw.app.routers.providers import (
+    ProviderConfigRequest,
+    configure_provider,
+)
+
+
+class FakeManager:
+    """Records update_provider calls for assertion."""
+
+    def __init__(self, is_custom: bool) -> None:
+        self._provider = SimpleNamespace(is_custom=is_custom)
+        self.last_config: dict | None = None
+
+    def get_provider(self, _provider_id: str):
+        return self._provider
+
+    def update_provider(self, _provider_id: str, config: dict) -> bool:
+        self.last_config = config
+        return True
+
+    async def get_provider_info(self, _provider_id: str):
+        return SimpleNamespace(id="fake")
+
+
+async def test_configure_custom_provider_applies_stripped_name():
+    manager = FakeManager(is_custom=True)
+    body = ProviderConfigRequest(name="  New Name  ")
+
+    await configure_provider(
+        manager=manager,
+        provider_id="my-custom",
+        body=body,
+    )
+
+    assert manager.last_config is not None
+    assert manager.last_config["name"] == "New Name"
+
+
+async def test_configure_builtin_provider_ignores_name():
+    manager = FakeManager(is_custom=False)
+    body = ProviderConfigRequest(name="Hacked Name")
+
+    await configure_provider(
+        manager=manager,
+        provider_id="openai",
+        body=body,
+    )
+
+    assert manager.last_config is not None
+    assert "name" not in manager.last_config
+
+
+async def test_configure_provider_ignores_blank_name():
+    manager = FakeManager(is_custom=True)
+    body = ProviderConfigRequest(name="   ")
+
+    await configure_provider(
+        manager=manager,
+        provider_id="my-custom",
+        body=body,
+    )
+
+    assert manager.last_config is not None
+    assert "name" not in manager.last_config


### PR DESCRIPTION
Backend
providers.py: Added an optional `name` field to `ProviderConfigRequest`; the `configure_provider` endpoint applies the name change only when `provider.is_custom` is true (and the name is non-empty after trimming), while built-in provider names remain immutable.
test_provider_rename.py: Added 3 unit tests—successful renaming of a custom provider (including trimming), ignored renaming of a built-in provider, and ignored blank names.
Frontend
provider.ts: Added `name?` to the `ProviderConfigRequest` type.
ProviderConfigModal.tsx: Added a "Provider Name" input field (required, initialized with the current name) to the top of the custom provider settings modal; the value is submitted with the configuration upon saving, and the success notification displays the new name. Reused existing i18n keys `models.providerNameLabel` and `providerNamePlaceholder`; no new entries were added.
<img width="1710" height="1228" alt="image" src="https://github.com/user-attachments/assets/85e47cb7-31bd-4dad-8a13-88c4e82f63e5" />
<img width="1711" height="1228" alt="image" src="https://github.com/user-attachments/assets/55dfa01d-d284-4fa2-ad3b-1ff3eaac90ae" />

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
