### PR TITLE
Remove '/new' command suggestion from Chat

### DIFF
--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2404,11 +2404,6 @@ export default function ChatPage() {
     const i18nConfig = getDefaultConfig(t);
     const commandSuggestions: CommandSuggestion[] = [
       {
-        command: "/new",
-        value: "new",
-        description: "",
-      },
-      {
         command: "/clear",
         value: "clear",
         description: t("chat.commands.clear.description"),


### PR DESCRIPTION
## Description

从控制台 `/` 快捷指令面板中移除 `/new` 条目。

Web 控制台侧边栏已有"新对话"入口，`/` 命令面板中再出现 `/new` 属于冗余展示，且该条目无 description 注释，与其他命令不统一。移除后 `/new` 命令本身不受影响。

**备注：** 同文件中 `skillSuggestions` 的 `description` 也被硬编码为 `""`，而 `SkillSpec` 类型包含 `description?: string`。考虑到技能描述通常较长，直接展示可能影响面板可用性，本次未修改。

**Related Issue:** N/A

**Security Considerations:** N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

改动仅删除硬编码的菜单条目，不涉及逻辑变更。`/new` 命令仍可通过输入 `/new` 回车触发。

## Evidence

仅删除了 `commandSuggestions` 数组中的一个 `/new` 条目（5 行），无运行时代码路径变动。前端 Vitest 单元测试和 Playwright E2E Smoke 测试均已通过，无需额外测试覆盖。

## Additional Notes
N/A