### PR TITLE
docs(sandbox): clarify native Windows sandbox support

### DIFF
--- a/src/qwenpaw/agents/context/__init__.py
+++ b/src/qwenpaw/agents/context/__init__.py
@@ -209,8 +209,8 @@ def build_scroll_components(
         )
         # Structured front door for the common recall ops (expand / search /
         # recall_tool): in-process bound queries, no sandbox, no approval —
-        # so fold stubs and the eviction index stay readable even where the
-        # sandboxed REPL can't run (e.g. Windows without WSL2).
+        # so fold stubs and the eviction index stay readable even when the
+        # sandboxed REPL is unavailable.
         recall = make_recall_history(
             history_db_path=str(history.path),
             session_id=session_id,

--- a/src/qwenpaw/agents/context/scroll/recall_tool.py
+++ b/src/qwenpaw/agents/context/scroll/recall_tool.py
@@ -11,8 +11,9 @@ model controls beyond scalar parameters, so there is nothing to isolate.
 
 ``recall_history_python`` remains the escape hatch for everything else
 (sessions listing, custom SQL aggregation, scratch tables) — but it executes
-model-authored Python and therefore requires the sandbox, which on platforms
-without one (e.g. Windows sans WSL2) means per-call approval or refusal.
+model-authored Python and therefore requires the sandbox. When no sandbox
+backend is available, it fails closed unless the explicit unsafe fallback is
+enabled.
 Fold stubs and the eviction index point at THIS tool first so the common
 re-read path works everywhere.
 """

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -842,11 +842,11 @@ class AgentBuilder:
         ``scroll_config.allow_unsandboxed``, via
         ``scroll_unsandboxed_allowed``).
 
-        When neither holds (e.g. Windows without WSL2), every call would fail
-        closed, and the guard layer misreads that ``DENIED`` as a sandbox
-        violation and escalates to a recurring approval prompt. So we omit the
-        REPL and let the model recall through the structured ``recall_history``
-        tool, which needs no sandbox. This is narrower than
+        When neither holds, every call would fail closed, and the guard layer
+        misreads that ``DENIED`` as a sandbox violation and escalates to a
+        recurring approval prompt. So we omit the REPL and let the model recall
+        through the structured ``recall_history`` tool, which needs no sandbox.
+        This is narrower than
         :meth:`_scroll_recall_runnable`, which gates whether scroll is wired at
         all; here scroll is already wired and structured recall is present.
 
@@ -895,11 +895,11 @@ class AgentBuilder:
 
         The sandboxed ``recall_history_python`` REPL is registered ONLY when
         it can actually run in a sandbox (or unsandboxed recall is explicitly
-        opted in). Where no sandbox exists — e.g. Windows without WSL2, or an
-        OFF-mode path that skips sandbox compilation — every call would fail
-        closed, and the guard layer misreads that ``DENIED`` as a sandbox
-        violation and turns it into a recurring approval prompt. Omitting it
-        removes that dead-end: the model recalls through the structured tool.
+        opted in). Where no sandbox exists, or an OFF-mode path skips sandbox
+        compilation, every call would fail closed, and the guard layer misreads
+        that ``DENIED`` as a sandbox violation and turns it into a recurring
+        approval prompt. Omitting it removes that dead-end: the model recalls
+        through the structured tool.
         """
         extra_tools.append(
             self._wrap_tool(

--- a/website/public/docs/context.en.md
+++ b/website/public/docs/context.en.md
@@ -225,7 +225,7 @@ A failed cell is unmistakable: the observation leads with a `RECALL FAILED — t
 
 Search (both `recall_history(op="search")` and `ms.search`) also never echoes the agent back at itself: the recall tool's own source/output rows are kept out of the results, and so is the current **active turn** (the latest user request and the reply being written) — otherwise a multi-round recall would top-k-match the previous round's quoted findings instead of the real history. Earlier evicted turns of the same session remain searchable, and `ms.expand` / `ms.recall_tool` stay unfiltered (verbatim replay is their point).
 
-Security note: `recall_history_python` runs model-authored Python. It normally requires sandbox injection from the governance layer. (`recall_history` is unaffected: it never executes model-authored code, so it runs everywhere — including on platforms without a sandbox, such as Windows without WSL2.) If no sandbox is available, the REPL fails closed unless both are true:
+Security note: `recall_history_python` runs model-authored Python. It normally requires sandbox injection from the governance layer. (`recall_history` is unaffected: it never executes model-authored code, so it still runs when no sandbox backend is available or sandboxing is disabled. QwenPaw supports native Windows sandbox backends; WSL2 itself is not a prerequisite for sandboxing.) If no sandbox is available, the REPL fails closed unless both are true:
 
 - environment variable `QWENPAW_ALLOW_UNSANDBOXED_RECALL` is truthy
 - `running.light_context_config.scroll_config.allow_unsandboxed = true`

--- a/website/public/docs/context.zh.md
+++ b/website/public/docs/context.zh.md
@@ -224,7 +224,7 @@ print(ms.agents())
 
 搜索（`recall_history(op="search")` 与 `ms.search` 皆然）也不会把 Agent 自己的回声搜回来：recall 工具自身的源码/输出行不会出现在结果里，当前**活动轮次**（最新的用户请求和正在写的回复）同样被排除——否则多轮 recall 时，top-k 会命中上一轮引用过的内容而不是真正的历史。本会话更早的已驱逐轮次仍然可搜；`ms.expand` / `ms.recall_tool` 不做过滤（逐字回放正是它们的用途）。
 
-安全说明：`recall_history_python` 会运行模型生成的 Python。正常情况下，它需要治理层注入 sandbox 配置；如果没有 sandbox，它会默认拒绝执行。（`recall_history` 不受影响：它从不执行模型生成的代码，所以在没有沙箱的平台——例如未装 WSL2 的 Windows——上也能正常运行。）只有同时满足以下条件时才允许 REPL 非沙箱运行：
+安全说明：`recall_history_python` 会运行模型生成的 Python。正常情况下，它需要治理层注入 sandbox 配置；如果没有 sandbox，它会默认拒绝执行。（`recall_history` 不受影响：它从不执行模型生成的代码，所以在没有可用沙箱后端或沙箱被禁用时仍能正常运行。QwenPaw 支持原生 Windows 沙箱后端，WSL2 本身不是启用沙箱的前提。）只有同时满足以下条件时才允许 REPL 非沙箱运行：
 
 - 环境变量 `QWENPAW_ALLOW_UNSANDBOXED_RECALL` 为 truthy
 - `running.light_context_config.scroll_config.allow_unsandboxed = true`


### PR DESCRIPTION
## Description

This PR corrects outdated references that describe Windows without WSL2 as an environment where QwenPaw has no sandbox support.

QwenPaw now provides native Windows sandbox backends, including AppContainer and restricted-token-based isolation. WSL2 itself is therefore not a prerequisite for sandboxing, although native sandbox availability still depends on platform requirements such as the Windows version, required system capabilities, configuration, and administrator privileges.

The changes:

- Update the English context documentation.
- Update the Chinese context documentation with equivalent wording.
- Remove the outdated Windows/WSL2 example from the structured recall module documentation.
- Align the context assembly and runtime builder comments with the current sandbox architecture.
- Preserve the distinction between the two recall tools:
  - `recall_history` uses structured, in-process, read-only queries and does not require a sandbox.
  - `recall_history_python` executes model-authored Python and requires an available sandbox unless the explicit unsafe fallback is enabled.

This is a documentation and source-comment-only change. No runtime behavior is modified.

**Related Issue:** N/A — documentation consistency correction

**Security Considerations:** No security behavior or sandbox policy is changed. The updated wording documents the existing native Windows sandbox support and fail-closed behavior more accurately. `recall_history_python` continues to refuse unsandboxed execution unless both explicit unsafe opt-ins are enabled.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

This PR changes only Markdown documentation, Python module documentation, and comments. No runtime code paths were modified.

The following focused checks were performed:

1. Checked the complete patch for whitespace errors:

```bash
git diff upstream/main...HEAD --check
```

Result: passed with exit code 0.

2. Parsed all three modified Python files with Python's `ast` module:

```text
AST parse: OK (3 files)
```

3. Searched the source and website documentation for the outdated expressions:

```text
Windows sans WSL2
Windows without WSL2
未装 WSL2 的 Windows
```

Result: no remaining matches in source files or website documentation.

4. Confirmed that the local branch and pushed fork branch point to the same commit:

```text
0d84cdc180cec31c8551ed07bf67a8f83ebf0abd
```

## Evidence

The evidence below confirms that this documentation-only patch passes whitespace and Python syntax checks and removes the outdated WSL2 references.

```text
$ git diff --shortstat upstream/main...HEAD
5 files changed, 17 insertions(+), 16 deletions(-)

$ git diff --name-only upstream/main...HEAD
src/qwenpaw/agents/context/__init__.py
src/qwenpaw/agents/context/scroll/recall_tool.py
src/qwenpaw/runtime/builder.py
website/public/docs/context.en.md
website/public/docs/context.zh.md

$ git log --oneline upstream/main..HEAD
0d84cdc1 docs(scroll): remove stale WSL2 sandbox references
14457689 docs(sandbox): clarify native Windows sandbox support

$ git diff upstream/main...HEAD --check
# Exit code: 0

AST parse: OK (3 files)

Outdated WSL2 reference search:
# No matches
```

## Additional Notes

- Channel-specific checks are not applicable because this PR does not modify channel behavior.
- `pytest` was not run because this change modifies documentation and comments only.
- `pre-commit` and the website formatter were not available in the existing local environment. No dependencies were installed solely for this documentation-only change; the full formatting and repository checks can run in CI.
- The PR intentionally does not change sandbox capability detection, sandbox policy, recall registration, or fail-closed execution behavior.