### PR TITLE
feat(ci): deploy the website from the release orchestrator (stable/post only)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -6,6 +6,18 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit SHA to build/deploy (empty = the triggering ref)"
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Stub the GitHub Pages push (fork verification)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -24,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -133,8 +147,14 @@ jobs:
         run: cp website/dist/index.html website/dist/404.html
 
       - name: Deploy to GitHub Pages
+        if: ${{ !inputs.dry_run }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/dist
           cname: qwenpaw.agentscope.io
+
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY-RUN: would deploy website/dist to GitHub Pages (cname qwenpaw.agentscope.io)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@
 #      products in parallel (wheel / web verify / desktop win+mac / plugins).
 #   3. Only if EVERY prepare job is green does the publish phase run: PyPI,
 #      Docker, desktop (GitHub assets + OSS), plugins. The draft is flipped to
-#      published LAST, then the Release Duty issue is created inline.
+#      published LAST. Post-publish (inline): promote the desktop latest/updater,
+#      deploy the website (stable/post only — skipped for betas), and open the
+#      Release Duty issue.
 #   4. If anything fails, nothing is published and the draft is left untouched
 #      (zero external trace; just fix and re-run).
 #
@@ -47,6 +49,7 @@ jobs:
     outputs:
       tag: ${{ steps.pick.outputs.tag }}
       sha: ${{ steps.pick.outputs.sha }}
+      is_prerelease: ${{ steps.pick.outputs.is_prerelease }}
     steps:
       - name: Resolve target draft release and commit
         id: pick
@@ -80,9 +83,16 @@ jobs:
           target="$(gh release view "$TAG" --repo "$REPO" --json targetCommitish --jq '.targetCommitish')"
           sha="$(gh api "repos/$REPO/commits/$target" --jq '.sha')"
           echo "Target commitish '$target' resolved to SHA $sha"
+          if [[ "$TAG" =~ (beta|alpha|rc|dev) ]]; then
+            is_prerelease=true
+          else
+            is_prerelease=false
+          fi
+          echo "Prerelease (tag-based): $is_prerelease"
           {
             echo "tag=$TAG"
             echo "sha=$sha"
+            echo "is_prerelease=$is_prerelease"
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout the resolved commit
@@ -299,11 +309,7 @@ jobs:
           VERSION: ${{ needs.resolve.outputs.tag }}
           QWENPAW_DISABLED_CHANNELS: "imessage"
         run: |
-          if [[ "$VERSION" =~ (beta|alpha|rc|dev) ]]; then
-            IS_PRERELEASE=true
-          else
-            IS_PRERELEASE=false
-          fi
+          IS_PRERELEASE="${{ needs.resolve.outputs.is_prerelease }}"
           TAGS="-t ${ACR_REGISTRY}/${IMAGE}:${VERSION} -t ${ACR_REGISTRY}/${IMAGE}:pre"
           TAGS="${TAGS} -t docker.io/${IMAGE}:${VERSION} -t docker.io/${IMAGE}:pre"
           if [ "${IS_PRERELEASE}" != "true" ]; then
@@ -459,4 +465,17 @@ jobs:
     uses: ./.github/workflows/release-duty.yml
     with:
       tag: ${{ needs.resolve.outputs.tag }}
+    secrets: inherit
+
+  # ── Post-publish: deploy the public website (stable + post only) ────────────
+  # Skipped for pre-releases (beta/alpha/rc/dev) so the site advertises only
+  # GA/post versions. Invoked inline because the finalize job flips the draft
+  # with GITHUB_TOKEN, which suppresses deploy-website.yml's own release trigger.
+  deploy-website:
+    needs: [resolve, finalize]
+    if: needs.resolve.outputs.is_prerelease == 'false'
+    uses: ./.github/workflows/deploy-website.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,8 +40,10 @@ with, e.g., a web release that has no matching desktop build.
    single failure above skips the entire publish phase. When all prepare jobs are
    green: publish to PyPI, push the multi-arch Docker image, attach the desktop
    installers to the release + upload them to OSS, publish plugins — then, as the
-   **last** step, flip the draft to *published* (pinned to the built SHA) and open
-   the Release Duty verification issue.
+   **last** step, flip the draft to *published* (pinned to the built SHA). After
+   publishing, it promotes the desktop `latest`/updater, deploys the website
+   (stable/post only — betas are skipped), and opens the Release Duty verification
+   issue.
 
 A full run is ~60–75 min, dominated by the desktop Tauri builds.
 
@@ -83,6 +85,9 @@ Notes:
 - Pre-release detection is **tag-based**: a tag containing `beta`/`alpha`/`rc`/`dev`
   is a pre-release (so use the `-beta.N` form); `stable` and `.postN` tags also
   update the Docker `latest` tag.
+- The **website** (GitHub Pages, `qwenpaw.agentscope.io`) is deployed only for
+  **stable** and `.postN` releases; pre-releases are skipped so the public site
+  advertises only GA versions.
 - The desktop OSS `latest` files and the Tauri auto-update manifest are currently
   updated for **every** release, including betas (this matches the previous
   `desktop-release.yml` behavior and is unchanged here). Making the desktop
@@ -100,6 +105,7 @@ jobs succeed. If anything fails, the release stays a draft.
 | `finalize` fails | All artifacts published but the release was not flipped | Re-run `finalize`, or manually `gh release edit <tag> --draft=false --target <sha>` (or click *Publish*). |
 | `duty-issue` fails | Release is published; only the tracking issue is missing | Re-run the job, or dispatch `release-duty.yml` with the `tag`. Non-blocking. |
 | `promote-desktop` fails | Release is published, but the desktop `latest` files / updater manifest / index were not refreshed (existing users' auto-updater does not see the new version yet; versioned downloads still work) | Re-run the job — it is idempotent (`ossutil cp --force`). Non-blocking for first-install users. |
+| `deploy-website` fails (stable/post only) | Release is published, but the public site (`qwenpaw.agentscope.io`) still shows the previous version | Re-run the job, or manually dispatch `deploy-website.yml` (workflow_dispatch). Idempotent, non-blocking. |
 | "Multiple draft releases found" | More than one draft exists | Re-run *Run workflow* with an explicit `tag`. |
 | "No draft release found" / "not a draft" | No draft, or wrong tag | Create the draft / fix the tag, then re-run. |
 | resolve rejects the tag (version mismatch) | The draft tag doesn't match `src/qwenpaw/__version__.py` | Align the tag with the version (packaging-normalized, e.g. `v2.0.1-beta.1` ↔ `2.0.1b1`), then re-run. |

--- a/RELEASING_zh.md
+++ b/RELEASING_zh.md
@@ -34,7 +34,8 @@ QwenPaw 一个版本会发布四种产物——**PyPI** wheel、**Docker** 镜�
 3. **Gate + Publish（门禁 + 发布）**——每个 publish job 都 `needs` **全部** prepare
    job，因此上面任一失败都会跳过整个发布阶段。全绿后：发布 PyPI、推多架构 Docker
    镜像、把桌面安装包挂到 release 并上传 OSS、发布插件——然后**最后一步**才把草稿翻成
-   *published*（tag 钉到构建用的 SHA），并创建 Release Duty 验收 issue。
+   *published*（tag 钉到构建用的 SHA）。发布后再：推桌面 `latest`/更新清单、部署官网
+   （仅正式版/post，beta 跳过）、创建 Release Duty 验收 issue。
 
 整体约 60–75 分钟，主要耗时在桌面 Tauri 构建。
 
@@ -71,6 +72,8 @@ QwenPaw 一个版本会发布四种产物——**PyPI** wheel、**Docker** 镜�
 
 - 预发布判定是**基于 tag** 的：tag 含 `beta`/`alpha`/`rc`/`dev` 即为预发布
   （所以用 `-beta.N` 写法）；`stable` 与 `.postN` 会更新 Docker 的 `latest` 标签。
+- **官网**（GitHub Pages，`qwenpaw.agentscope.io`）只在**正式版**与 `.postN` 部署；
+  预发布跳过，保证官网只展示 GA 版本。
 - ⚠️ 桌面 OSS 的 `latest` 文件与 Tauri 自动更新清单目前对**每个**版本（含 beta）
   都会更新（与之前 `desktop-release.yml` 行为一致，本次未改）。让桌面
   `latest`/自动更新只在正式版更新，可作为后续改进。
@@ -87,6 +90,7 @@ release 就仍是草稿。
 | `finalize` 失败 | 产物都发了但 release 没翻 | 重跑 `finalize`，或手动 `gh release edit <tag> --draft=false --target <sha>`（或 UI 点 *Publish*）。 |
 | `duty-issue` 失败 | release 已发布，只是缺验收 issue | 重跑该 job，或用 `tag` 手动 dispatch `release-duty.yml`。不阻塞发布。 |
 | `promote-desktop` 失败 | release 已发布，但桌面 `latest` 文件 / 更新清单 / index 未刷新（存量用户的自动更新暂时看不到新版；版本化下载仍可用） | 重跑该 job，幂等（`ossutil cp --force`）。对首装用户不阻塞。 |
+| `deploy-website` 失败（仅正式/post） | release 已发布，但官网（`qwenpaw.agentscope.io`）仍是旧版本 | 重跑该 job，或手动 dispatch `deploy-website.yml`（workflow_dispatch）。幂等、不阻塞。 |
 | "Multiple draft releases found" | 存在多个草稿 | 重跑 *Run workflow* 时显式填 `tag`。 |
 | "No draft release found" / "not a draft" | 没有草稿，或 tag 填错 | 先建草稿 / 改正 tag，再重跑。 |
 | resolve 拒绝该 tag（版本不匹配） | 草稿 tag 与 `src/qwenpaw/__version__.py` 不一致 | 让 tag 与版本对齐（`packaging` 归一化，如 `v2.0.1-beta.1` ↔ `2.0.1b1`），再重跑。 |


### PR DESCRIPTION
## Summary
- The unified release orchestrator (#6329) flips the draft to published with `GITHUB_TOKEN`, which suppresses `deploy-website.yml`'s own `release: published` trigger — so the public site (qwenpaw.agentscope.io) was never refreshed under the new flow. This wires website deployment into the orchestrator as a post-publish job.
- Gated to **stable** and **`.postN`** releases only; pre-releases (`beta`/`alpha`/`rc`/`dev`) are skipped, so the site advertises only GA versions. Gating is tag-based, reusing a new `is_prerelease` output from `resolve` (same rule as the Docker `latest` tag).
- Purely additive: `deploy-website.yml` keeps its existing `release`/`workflow_dispatch` triggers, so the legacy fallback path and manual deploys are unchanged.

## Changes
- `release.yml`: `resolve` exposes a tag-based `is_prerelease` output (single source of truth); `push-docker` consumes it instead of recomputing the regex; new post-publish `deploy-website` job (`needs: [resolve, finalize]`, `if: is_prerelease == 'false'`) calls the reusable workflow with the pinned SHA + `dry_run`.
- `deploy-website.yml`: gains a `workflow_call` trigger (`ref` + `dry_run` inputs); checks out the pinned `ref` (falls back to `github.ref` for existing triggers); the Pages push is stubbed on `dry_run`.
- `RELEASING.md` / `RELEASING_zh.md`: document the post-publish website step, the stable/post-only gating, and a troubleshooting row.

## Test plan
- [x] Unit-tested the `is_prerelease` tag regex: `v2.0.0`, `v2.0.0.post4`, `v1.2.3` → deploy; `-beta.N`/`-alpha.N`/`-rc.N`/`.devN` → skip.
- [x] actionlint (shellcheck disabled per repo convention) + pre-commit green.
- [x] Full fork dry-run with a stable draft tag (`v2.0.1`): all 22 jobs green — `resolve` computed `is_prerelease=false`, `finalize` flipped the draft, then `deploy-website / deploy` **ran** (site built; `Deploy to GitHub Pages` step skipped by the `dry_run` stub, dry-run notice printed). Evidence: https://github.com/yutai78786/QwenPaw/actions/runs/30112535490
- [x] Confirmed the `GITHUB_TOKEN` flip triggered **no** legacy `release: published` workflows on the fork (the inline invocation is required and does not double-fire).
- [ ] After merge: confirm on the next stable/post release that the site refreshes automatically (betas should show the `deploy-website` job as skipped).