### PR TITLE
docs(faq): align zh sub-section headings with en

### DIFF
--- a/website/public/docs/faq.zh.md
+++ b/website/public/docs/faq.zh.md
@@ -263,7 +263,7 @@ QwenPaw-Flash 模型目前已经在 [ModelScope](https://www.modelscope.cn/organ
 
 QwenPaw 内置的本地提供商均可接入 QwenPaw-Flash 模型：
 
-**QwenPaw Local (llama.cpp)**
+#### QwenPaw Local (llama.cpp)
 
 直接在 QwenPaw Local 的模型界面中选择下载 QwenPaw-Flash 模型并启动即可。
 
@@ -272,7 +272,7 @@ QwenPaw 内置的本地提供商均可接入 QwenPaw-Flash 模型：
 > QwenPaw Local 目前仍处于测试阶段，对不同设备的兼容性以及运行稳定性仍在持续优化中，如果你在使用过程中遇到任何问题，欢迎随时在 GitHub 上提 issue 反馈。
 > 如果无法正常使用 QwenPaw Local，建议先使用 Ollama 或 LM Studio 部署 QwenPaw-Flash 模型。
 
-**Ollama**:
+#### Ollama
 
 1. 从 [ModelScope](https://www.modelscope.cn/organization/AgentScope?tab=model) 或 [Hugging Face](https://huggingface.co/agentscope-ai/models) 下载 QwenPaw-Flash 量化版模型，这些模型后缀为 `Q8_0` 或 `Q4_K_M`，例如 [QwenPaw-Flash-4B-Q4_K_M](https://www.modelscope.cn/models/AgentScope/QwenPaw-Flash-4B-Q4_K_M)。
 
@@ -313,7 +313,7 @@ ollama create qwenpaw-flash -f qwenpaw-flash.txt
 
 4. 在 QwenPaw 的模型配置中选择 Ollama 提供商，并在模型页面中自动获取模型即可。
 
-**LM Studio**:
+#### LM Studio
 
 1. 参考 Ollama 的步骤 1 下载合适的 QwenPaw-Flash 量化版模型。
 


### PR DESCRIPTION
## Description

In `website/public/docs/faq.zh.md`, the three QwenPaw-Flash provider sub-sections — **QwenPaw Local (llama.cpp)**, **Ollama**, and **LM Studio** — were written as bold pseudo-headings (`**...**`), while `faq.en.md` uses real H4 headings (`####`). As a result, the three sub-sections were missing from the Chinese page's rendered table of contents and had no stable anchor links, and the zh page structure diverged from the en page.

This PR switches those three zh headings to `####` to match `faq.en.md`, so they render in the TOC and gain stable anchor links consistent with the English version. The body content of each sub-section is unchanged.

**Related Issue:** none (docs consistency fix found while reviewing the zh docs)

**Security Considerations:** none — markdown-only.

**Type of Change:** Documentation

**Component(s) Affected:** Documentation (website)

## Evidence

Docs-only change (3 markdown heading lines). Verified locally:

- `git diff --check` — clean (no whitespace / conflict markers), covering the pre-commit `trailing-whitespace` hook for this file.
- `prettier --check` on the edited file passes ("All matched files use Prettier code style!"). This matches the `npm-format` CI gate (`prettier --check .`), since `public/docs/` is not listed in `website/.prettierignore`.
- The diff is exactly 3 lines (bold → H4), with no collateral changes.

Local verification output:

```text
$ git diff --check
$ # (no output = clean)

$ npx --yes prettier@3.0.0 --check website/public/docs/faq.zh.md
Checking formatting...
All matched files use Prettier code style!
```

## Checklist

- [x] Documentation updated
- [x] Ready for review
- [ ] `pre-commit run --all-files` — not run locally (requires Python 3.11 + dev install); deferred to CI. For this markdown-only change, the applicable pre-commit hooks (trailing-whitespace, etc.) were verified locally via `git diff --check` (clean).
- [ ] `pytest` — n/a (no Python changed); CI runs it.
