### PR TITLE
fix(providers): sync MiniMax model baseline with current platform lineup

### DIFF
--- a/src/qwenpaw/providers/capability_baseline.py
+++ b/src/qwenpaw/providers/capability_baseline.py
@@ -96,7 +96,10 @@ class ExpectedCapabilityRegistry:
         """Register a single baseline entry."""
         self._data[(cap.provider_id, cap.model_id)] = cap
 
-    def _load_baseline(self) -> None:  # pylint: disable=too-many-statements
+    # pylint: disable=too-many-statements,too-many-branches
+    def _load_baseline(
+        self,
+    ) -> None:
         """Load baseline data for built-in providers."""
 
         # ---------------------------------------------------------------
@@ -219,7 +222,11 @@ class ExpectedCapabilityRegistry:
                 expected_image=False,
                 expected_video=False,
                 doc_url=_acp_doc,
-                note="MiniMax models are text-only",
+                note=(
+                    "MiniMax-M2.5 is text-only; on the official MiniMax "
+                    "platform it is now listed as a legacy model "
+                    "(current: M2.7 / M3)"
+                ),
             ),
         )
         self._register(
@@ -296,7 +303,11 @@ class ExpectedCapabilityRegistry:
                 expected_image=False,
                 expected_video=False,
                 doc_url=_atp_doc,
-                note="MiniMax models are text-only",
+                note=(
+                    "MiniMax-M2.5 is text-only; on the official MiniMax "
+                    "platform it is now listed as a legacy model "
+                    "(current: M2.7 / M3)"
+                ),
             ),
         )
         self._register(
@@ -646,11 +657,25 @@ class ExpectedCapabilityRegistry:
 
         # ---------------------------------------------------------------
         # 11. MiniMax (International)
+        #     https://platform.minimax.io/docs/guides/models-intro
         # ---------------------------------------------------------------
-        _mm_doc = "https://www.minimax.io/platform/document/announcement"
+        _mm_doc = "https://platform.minimax.io/docs/guides/models-intro"
+        # Current flagship — frontier multimodal coding model (1M context).
+        self._register(
+            ExpectedCapability(
+                provider_id="minimax",
+                model_id="MiniMax-M3",
+                expected_image=True,
+                expected_video=True,
+                doc_url=_mm_doc,
+                note=(
+                    "M3 is the frontier multimodal coding model "
+                    "(1M context window, supports image + video input)"
+                ),
+            ),
+        )
+        # Current generation — text-only.
         for mid in (
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
         ):
@@ -661,17 +686,52 @@ class ExpectedCapabilityRegistry:
                     expected_image=False,
                     expected_video=False,
                     doc_url=_mm_doc,
-                    note="MiniMax models are text-only",
+                    note="M2.7 series is text-only",
+                ),
+            )
+        # Legacy models — still served on the official docs page.
+        for mid in (
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.1",
+            "MiniMax-M2.1-highspeed",
+            "MiniMax-M2",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="minimax",
+                    model_id=mid,
+                    expected_image=False,
+                    expected_video=False,
+                    doc_url=_mm_doc,
+                    note=(
+                        "Legacy text-only model "
+                        "(superseded by M2.7 / M3 on MiniMax platform)"
+                    ),
                 ),
             )
 
         # ---------------------------------------------------------------
         # 12. MiniMax (China)
+        #     https://platform.minimaxi.com/docs/guides/models-intro
         # ---------------------------------------------------------------
-        _mm_cn_doc = "https://platform.minimaxi.com/document/announcement"
+        _mm_cn_doc = "https://platform.minimaxi.com/docs/guides/models-intro"
+        # Current flagship — frontier multimodal coding model (1M context).
+        self._register(
+            ExpectedCapability(
+                provider_id="minimax-cn",
+                model_id="MiniMax-M3",
+                expected_image=True,
+                expected_video=True,
+                doc_url=_mm_cn_doc,
+                note=(
+                    "M3 is the frontier multimodal coding model "
+                    "(1M context window, supports image + video input)"
+                ),
+            ),
+        )
+        # Current generation — text-only.
         for mid in (
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
             "MiniMax-M2.7",
             "MiniMax-M2.7-highspeed",
         ):
@@ -682,7 +742,28 @@ class ExpectedCapabilityRegistry:
                     expected_image=False,
                     expected_video=False,
                     doc_url=_mm_cn_doc,
-                    note="MiniMax models are text-only",
+                    note="M2.7 series is text-only",
+                ),
+            )
+        # Legacy models — still served on the official docs page.
+        for mid in (
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.1",
+            "MiniMax-M2.1-highspeed",
+            "MiniMax-M2",
+        ):
+            self._register(
+                ExpectedCapability(
+                    provider_id="minimax-cn",
+                    model_id=mid,
+                    expected_image=False,
+                    expected_video=False,
+                    doc_url=_mm_cn_doc,
+                    note=(
+                        "Legacy text-only model "
+                        "(superseded by M2.7 / M3 on MiniMax platform)"
+                    ),
                 ),
             )
         # ---------------------------------------------------------------

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -586,17 +586,10 @@ AZURE_OPENAI_MODELS: List[ModelInfo] = [
 
 MINIMAX_MODELS: List[ModelInfo] = [
     ModelInfo(
-        id="MiniMax-M2.5",
-        name="MiniMax M2.5",
-        supports_image=False,
-        supports_video=False,
-        probe_source="documentation",
-    ),
-    ModelInfo(
-        id="MiniMax-M2.5-highspeed",
-        name="MiniMax M2.5 Highspeed",
-        supports_image=False,
-        supports_video=False,
+        id="MiniMax-M3",
+        name="MiniMax M3",
+        supports_image=True,
+        supports_video=True,
         probe_source="documentation",
     ),
     ModelInfo(
@@ -609,6 +602,41 @@ MINIMAX_MODELS: List[ModelInfo] = [
     ModelInfo(
         id="MiniMax-M2.7-highspeed",
         name="MiniMax M2.7 Highspeed",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="MiniMax-M2.5",
+        name="MiniMax M2.5 (legacy)",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="MiniMax-M2.5-highspeed",
+        name="MiniMax M2.5 Highspeed (legacy)",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="MiniMax-M2.1",
+        name="MiniMax M2.1 (legacy)",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="MiniMax-M2.1-highspeed",
+        name="MiniMax M2.1 Highspeed (legacy)",
+        supports_image=False,
+        supports_video=False,
+        probe_source="documentation",
+    ),
+    ModelInfo(
+        id="MiniMax-M2",
+        name="MiniMax M2 (legacy)",
         supports_image=False,
         supports_video=False,
         probe_source="documentation",


### PR DESCRIPTION
# PR Description — fix(providers): sync MiniMax model baseline with current platform lineup

## Description

The hardcoded MiniMax model lists in this repo (both the capability baseline used by the multimodal prober and the built-in model picker in `provider_manager.py`) had drifted away from the official Models documentation at <https://platform.minimax.io/docs/guides/models-intro>.

Specifically:

1. The new flagship `MiniMax-M3` — listed on the docs page as a **frontier multimodal coding model with a 1M context window** (features: "Multimodal", "1M context window", "Frontier coding") — was not registered anywhere. Users who picked the MiniMax provider in the Console could not see or use M3 in the model picker.
2. The legacy models that are still listed on the docs page (M2.1, M2.1-highspeed, M2) were missing from the baseline. Only M2.5/M2.5-highspeed/M2.7/M2.7-highspeed were registered, so capability probing silently returned `None` for the missing ones instead of matching the docs.
3. The `doc_url` for both `minimax` and `minimax-cn` pointed to the legacy `/platform/document/announcement` page, which no longer lists the current model lineup.
4. The "MiniMax models are text-only" note was applied uniformly, which became misleading after M2.5 was moved to the **Legacy Models** accordion on the docs page (current generation is now M2.7 / M3).

This PR syncs both the capability baseline and the user-facing model list with the current state of the official documentation.

### Source of truth

Cross-checked against the [Models intro page](https://platform.minimax.io/docs/guides/models-intro) (also reachable via the `#legacy-models-3` anchor the user pointed to). The model catalog there splits into:

| Status      | Models                                                                       |
| ----------- | ---------------------------------------------------------------------------- |
| Current     | `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`                       |
| Legacy      | `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` |

Capability assumptions derived from the docs:

- **M3** → *Multimodal* + *1M context window* → `expected_image=True, expected_video=True`.
- **M2.7 / M2.7-highspeed** → listed as "Top real-world engineering" / "Polyglot code mastery", no Multimodal row → text-only.
- **M2.5 / M2.1 / M2** (all variants) → text-only (no Multimodal feature on the docs page).

### Changes

**`src/qwenpaw/providers/capability_baseline.py`**

- For both `minimax` and `minimax-cn`:
  - Register `MiniMax-M3` as the current flagship with `expected_image=True, expected_video=True` and a note that it is the frontier multimodal coding model (1M context window).
  - Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as the current text-only generation, with a dedicated "M2.7 series is text-only" note.
  - Register the legacy models `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` with an explicit "Legacy text-only model (superseded by M2.7 / M3 on MiniMax platform)" note.
  - Update `doc_url` from `https://www.minimax.io/platform/document/announcement` to `https://platform.minimax.io/docs/guides/models-intro` (and the `minimaxi.com` mirror for the China provider).
- For `aliyun-codingplan` and `aliyun-tokenplan`:
  - Keep the existing `MiniMax-M2.5` entry (Aliyun may still proxy it) but update the note to clarify that on the official MiniMax platform it is now listed as a legacy model and M2.7 / M3 are the current generation.

**`src/qwenpaw/providers/provider_manager.py`**

- `MINIMAX_MODELS` (the list shown in the Console / CLI model picker for both `minimax` and `minimax-cn`):
  - Add `MiniMax-M3` at the top with `supports_image=True, supports_video=True`.
  - Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as the current text-only generation.
  - Add the missing `MiniMax-M2.1`, `MiniMax-M2.1-highspeed`, `MiniMax-M2` and append `(legacy)` to the display name of the M2.5 entries so users can tell them apart in the picker.

### Out of scope (deliberately not touched)

- The `Aliyun Coding Plan` / `Aliyun Token Plan` model lists in `provider_manager.py` were left as-is for `MiniMax-M2.5`. The Aliyun plans are independent of the official MiniMax lineup and may keep offering M2.5 regardless of the MiniMax platform's legacy status. No authoritative source was checked to confirm whether they currently expose M3.
- `config.zh.md` / `config.en.md` — both already only list provider IDs and API base URLs; no per-model version information is hardcoded there, so no change needed.

**Related Issue:** Relates to the outdated model lineup discussed at <https://platform.minimax.io/docs/guides/models-intro#legacy-models-3> (no upstream issue was opened on the QwenPaw side; happy to file one if a maintainer prefers an issue-first flow per the [Contributing guide](https://github.com/agentscope-ai/QwenPaw/blob/main/CONTRIBUTING.md)).

**Security Considerations:** None. Only internal baseline/model-list data is changed; no auth, env, or external request paths are affected.

## Type of Change

- [x] Bug fix (the baseline was out of sync with the upstream model lineup)
- [x] Documentation (the `doc_url` references now point at the current Models intro page)

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes *(for the two files changed in this PR — see Evidence. The full-repo pre-commit run also surfaces **pre-existing** failures in `src/qwenpaw/cli/shutdown_cmd.py` and in `tests/unit/loop/test_handler_continuation_reset.py` / `tests/unit/providers/test_provider_class_identity.py` that are unrelated to this PR; details below.)*
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks *(the second iteration reformatted the `def _load_baseline` signature; one follow-up `git commit --amend` captured the final form)*
- [x] I ran tests locally (`pytest` or as relevant) and they pass *(48/48 across `test_capability_baseline.py` + `test_provider_manager.py` — see Evidence)*
- [x] Documentation updated (if needed) *(no user-facing doc change needed; only the internal `doc_url` pointer was updated)*
- [x] Ready for review

## Testing

- Compile-check the two changed files: `python -m py_compile src/qwenpaw/providers/capability_baseline.py src/qwenpaw/providers/provider_manager.py` (passes cleanly).
- Unit tests under `tests/unit/providers/test_capability_baseline.py` exercise the registry behaviour with synthetic models only — they do not assert on the specific model list, so adding new entries is safe and removing/renaming is not done.
- Manual smoke test on a dev install (re-run before pushing):
  ```bash
  pip install -e ".[dev,full,test]"
  pre-commit run --all-files
  pytest tests/unit/providers/test_capability_baseline.py tests/unit/providers/test_provider_manager.py -q
  ```
- Expected: existing tests pass; no lint complaints on the two changed files (see Evidence below for the exact hook output).
- Note about the `[test]` extra: `pytest` is in the `test` extras group, **not** in `[dev]`. The original `pip install -e ".[dev,full]"` does not pull in pytest.

## Evidence

### Local pre-commit on the changed files

```bash
$ pre-commit run --files src/qwenpaw/providers/capability_baseline.py src/qwenpaw/providers/provider_manager.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

### Local pytest

```bash
$ python -m pytest tests/unit/providers/test_capability_baseline.py tests/unit/providers/test_provider_manager.py -q
................................................                     [100%]
48 passed in 1.10s
```

### Final diff stat

```bash
$ git diff --stat main..HEAD
 src/qwenpaw/providers/capability_baseline.py | 102 ++++++++++++++++++++++++++---
 src/qwenpaw/providers/provider_manager.py    | 40 ++++++++++--
 2 files changed, 126 insertions(+), 17 deletions(-)
```

### Pre-existing failures observed during the full `pre-commit run --all-files` (NOT introduced by this PR)

The following lint failures were visible in the full-repo pre-commit run but live in files this PR does not touch. They are listed here only for transparency so a reviewer does not think this PR caused them:

- `mypy` → `src/qwenpaw/cli/shutdown_cmd.py:142`, `:144`, `:149` — `Argument 1 to "add" of "set" has incompatible type "int | None"; expected "int"`. Last touched in commit `bcaeb906` ("Refactor: CoPaw is Officially Rebranding to QwenPaw", #3285), well before this PR.
- `pylint` → `tests/unit/loop/test_handler_continuation_reset.py` — `W0613 Unused argument 'ctx'`.
- `pylint` → `tests/unit/providers/test_provider_class_identity.py` — `W0613 Unused argument 'timeout'` and `'model_id'`.

All three are pre-existing on `main` and are out of scope for this change. Happy to send a follow-up PR addressing them if a maintainer wants, but they are not regressions from this work.

## Additional Notes

- The user-facing list update (adding M3 to the picker) is the highest-impact change: today a QwenPaw user picking the MiniMax provider cannot select M3 from the Console at all. After this PR it appears as the top entry with multimodal capability correctly advertised.
- The legacy entries are kept on purpose. The official docs page still lists them under the "Legacy Models" accordion, so users on existing M2.x setups will still be able to load their saved model without surprise breakage. The `(legacy)` suffix in the display name surfaces the deprecation status in the UI without hiding the model.
- A follow-up issue worth considering (not done in this PR): the same drift likely exists in other providers whose docs were updated recently (e.g. `gemini` and `kimi` entries here vs. their respective current docs). This PR is scoped to MiniMax only because that is what was reported; happy to send separate PRs for the other providers if maintainers want a sweep.
