### PR TITLE
fix(crons): add keepalive task so cron jobs fire when event loop is idle

### DIFF
--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -45,6 +45,14 @@ DREAM_MISFIRE_GRACE_SECONDS = 600
 DREAM_JITTER_MAX_SECONDS = 60
 INTERNAL_JOB_IDS = frozenset({HEARTBEAT_JOB_ID, DREAM_JOB_ID})
 CRON_HISTORY_LIMIT = 50
+# Periodic self-contained keepalive so the asyncio event loop keeps ticking
+# even with no external traffic. APScheduler's AsyncIOScheduler processes
+# due jobs via loop call_later wakeups; on some platforms (e.g. WSL2) a
+# long-delay call_later does not reliably wake an otherwise-idle loop, so
+# cron jobs misfire until the next HTTP request arrives (see issue #6471).
+# A short, always-on keepalive task keeps loop._run_once sweeping due
+# timers regardless of the heartbeat config.
+CRON_KEEPALIVE_INTERVAL_SECONDS = 60
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +89,7 @@ class CronManager(ManagerBase):
         self._history: Dict[str, list[CronExecutionRecord]] = {}
         self._rt: Dict[str, _Runtime] = {}
         self._started = False
+        self._keepalive_task: Optional[asyncio.Task] = None
 
     async def start(self) -> None:
         async with self._lock:
@@ -164,13 +173,47 @@ class CronManager(ManagerBase):
                     )
 
             self._started = True
+            self._keepalive_task = asyncio.create_task(
+                self._keepalive_loop(),
+                name="cron-keepalive",
+            )
 
     async def stop(self) -> None:
         async with self._lock:
             if not self._started:
                 return
-            self._scheduler.shutdown(wait=False)
             self._started = False
+            keepalive = self._keepalive_task
+            self._keepalive_task = None
+            if keepalive is not None:
+                keepalive.cancel()
+                try:
+                    await asyncio.wait_for(keepalive, timeout=5)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    pass
+                except Exception as exc:  # pylint: disable=broad-except
+                    logger.debug(
+                        "Error cancelling cron keepalive task: %s",
+                        repr(exc),
+                    )
+            self._scheduler.shutdown(wait=False)
+
+    async def _keepalive_loop(self) -> None:
+        """Keep the asyncio event loop ticking while cron is running.
+
+        APScheduler's AsyncIOScheduler processes due jobs via loop
+        call_later wakeups. On platforms where a long-delay call_later
+        does not reliably wake an otherwise-idle event loop (e.g. WSL2,
+        see issue #6471), cron jobs misfire until external I/O wakes the
+        loop. This self-contained task sleeps for a short, reliable
+        interval so the loop keeps sweeping due timers regardless of
+        external traffic or the heartbeat config.
+        """
+        try:
+            while self._started:
+                await asyncio.sleep(CRON_KEEPALIVE_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            pass
 
     # ----- read/state -----
 

--- a/tests/unit/app/crons/test_manager.py
+++ b/tests/unit/app/crons/test_manager.py
@@ -55,6 +55,23 @@ async def test_start_is_idempotent(manager: CronManager):
 
 
 @pytest.mark.asyncio
+async def test_keepalive_task_lifecycle(manager: CronManager):
+    """A self-contained keepalive task runs while cron is started.
+
+    The keepalive keeps the asyncio event loop ticking so APScheduler's
+    AsyncIOScheduler keeps processing due jobs even when the loop is
+    otherwise idle (see issue #6471).
+    """
+    await manager.start()
+    task = manager._keepalive_task
+    assert task is not None
+    assert not task.done()
+    await manager.stop()
+    assert manager._keepalive_task is None
+    assert task.done()
+
+
+@pytest.mark.asyncio
 async def test_scheduled_dream_waits_for_random_delay(
     repo: InMemoryJobRepository,
 ):


### PR DESCRIPTION
## Description

Fixes #6471.

When the asyncio event loop has no external traffic for an extended period (no HTTP requests, WebSocket, or I/O), `AsyncIOScheduler`-based cron jobs misfire: they only fire when the next HTTP request wakes the loop, by which time APScheduler reports the run as missed/skipped (grace window exceeded). Reproduced and analyzed in #6471 (WSL2, uvicorn single worker, heartbeat disabled) — e.g. a job scheduled for 09:20 was detected at 09:41 (`late by 1282s, grace=600s`), exactly when a user opened the Web UI.

### Root cause

`AsyncIOScheduler` relies on `loop.call_later` wakeups to process due jobs. On some platforms (e.g. WSL2) a long-delay `call_later` does not reliably wake an otherwise-idle event loop, so due jobs sit until external I/O wakes the loop. The reporter confirmed that enabling the heartbeat (a short-interval scheduler job) works around it — because a short `call_later` keeps `loop._run_once` running, which sweeps all due timers including the long-delayed cron wakeups.

### Fix

Add a self-contained keepalive `asyncio.Task` to `CronManager` that sleeps for a short, reliable interval (`CRON_KEEPALIVE_INTERVAL_SECONDS = 60`) while the manager is running. This keeps the event loop's `_run_once` sweeping every 60s regardless of external traffic or the heartbeat config, so due cron jobs fire promptly even when the loop is otherwise idle. The task is created in `start()` and cancelled in `stop()`.

This mirrors the proven heartbeat workaround but is always-on and internal to the cron subsystem, so users no longer need to enable heartbeat purely for cron reliability.

**Type of Change:** Bug fix

**Component(s) Affected:** Core / Backend (app/crons)

**Security Considerations:** none.

## Evidence

- `pytest tests/unit/app/crons/test_manager.py` — 16 passed, including a new lifecycle test asserting the keepalive task is created on `start()` and cancelled on `stop()`. No existing tests regressed.

```text
============================= test session starts ==============================
tests/unit/app/crons/test_manager.py::test_start_is_idempotent PASSED
tests/unit/app/crons/test_manager.py::test_keepalive_task_lifecycle PASSED
... (14 more) ...
============================== 16 passed in 1.48s ==============================
```

### Honest limitation

The underlying misfire is environmental/timing-dependent: in a normal unit test the event loop is actively driven by pytest-asyncio, so `call_later` fires normally and the idle-loop misfire cannot be reproduced in-process. The added test therefore verifies the keepalive mechanism is wired correctly (task lifecycle on start/stop), not that the misfire itself is fixed. The fix rationale rests on the root-cause analysis and logs in #6471 (and the proven heartbeat workaround, which this generalizes). End-to-end verification requires the reporter's idle-loop scenario, so I'm also happy to help validate on their setup.

## Checklist

- [x] I ran tests locally (`pytest tests/unit/app/crons/test_manager.py`) and they pass (16 passed)
- [x] `pre-commit run --files` on the changed files passes locally (black/flake8/pylint/mypy/trailing-whitespace)
- [x] Documentation: n/a — internal runtime behavior, no user-facing API change (heartbeat docs already cover heartbeat; this makes heartbeat optional for cron reliability rather than required)
- [x] Ready for review
