### PR TITLE
test: cover streamable HTTP MCP transport

### DIFF
--- a/tests/unit/drivers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/test_mcp_stateful_client.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for HttpStatefulClient transport selection in _setup_transport.
+
+Verifies that:
+- transport="streamable_http" calls streamable_http_client
+- transport="sse" calls sse_client
+- Invalid transport raises ValueError in __init__
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import qwenpaw.drivers.handlers.mcp_stateful_client as mcp_mod
+from qwenpaw.drivers.handlers.mcp_stateful_client import HttpStatefulClient
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_calls_streamable_http_client() -> None:
+    """When transport='streamable_http', streamable_http_client is called
+    with the url and an httpx.AsyncClient, and sse_client is NOT called."""
+    with (
+        patch.object(mcp_mod, "streamable_http_client") as mock_streamable,
+        patch.object(mcp_mod, "sse_client") as mock_sse,
+    ):
+        mock_streamable.return_value = AsyncMock()
+
+        client = HttpStatefulClient(
+            name="jin10_mcp",
+            transport="streamable_http",
+            url="https://mcp.example.com/api/",
+            headers={"Authorization": "Bearer secret"},
+            timeout=20,
+            sse_read_timeout=200,
+        )
+        mock_stack = AsyncMock()
+        mock_stack.enter_async_context = AsyncMock(
+            return_value=(MagicMock(), MagicMock()),
+        )
+
+        read, write = await client._setup_transport(mock_stack)
+
+        # streamable_http_client was called exactly once
+        mock_streamable.assert_called_once()
+        call_kwargs = mock_streamable.call_args.kwargs
+        assert call_kwargs["url"] == "https://mcp.example.com/api/"
+        http_client: httpx.AsyncClient = call_kwargs["http_client"]
+        assert isinstance(http_client, httpx.AsyncClient)
+        assert http_client.headers["authorization"] == "Bearer secret"
+
+        # sse_client was NOT called
+        mock_sse.assert_not_called()
+
+        # enter_async_context called twice: httpx.AsyncClient + streamable_http_client
+        assert mock_stack.enter_async_context.call_count == 2
+
+        # _setup_transport returns the (read, write) tuple from enter_async_context
+        assert read is not None
+        assert write is not None
+
+
+@pytest.mark.asyncio
+async def test_sse_calls_sse_client() -> None:
+    """When transport='sse', sse_client is called with correct args."""
+    with (
+        patch.object(mcp_mod, "sse_client") as mock_sse,
+        patch.object(mcp_mod, "streamable_http_client") as mock_streamable,
+    ):
+        mock_sse.return_value = AsyncMock()
+
+        client = HttpStatefulClient(
+            name="sse_mcp",
+            transport="sse",
+            url="https://mcp.example.com/sse",
+            headers={"X-Custom": "value"},
+            timeout=15,
+            sse_read_timeout=120,
+            extra_arg="extra_val",
+        )
+        mock_stack = AsyncMock()
+        mock_stack.enter_async_context = AsyncMock(
+            return_value=(MagicMock(), MagicMock()),
+        )
+
+        await client._setup_transport(mock_stack)
+
+        # sse_client was called exactly once
+        mock_sse.assert_called_once()
+        call_kwargs = mock_sse.call_args.kwargs
+        assert call_kwargs["url"] == "https://mcp.example.com/sse"
+        assert call_kwargs["headers"] == {"X-Custom": "value"}
+        assert call_kwargs["timeout"] == 15
+        assert call_kwargs["sse_read_timeout"] == 120
+        assert call_kwargs.get("extra_arg") == "extra_val"
+
+        # streamable_http_client was NOT called
+        mock_streamable.assert_not_called()
+
+        # enter_async_context called once (sse_client only, no extra httpx.AsyncClient)
+        assert mock_stack.enter_async_context.call_count == 1
+
+
+def test_invalid_transport_raises_value_error() -> None:
+    """__init__ raises ValueError when transport is not 'streamable_http' or 'sse'."""
+    with pytest.raises(ValueError, match="transport must be"):
+        HttpStatefulClient(
+            name="bad",
+            transport="stdio",
+            url="http://localhost",
+        )
+
+
+def test_invalid_transport_raises_value_error_unknown() -> None:
+    """__init__ raises ValueError for any unrecognized transport string."""
+    with pytest.raises(ValueError, match="transport must be"):
+        HttpStatefulClient(
+            name="bad",
+            transport="websocket",
+            url="http://localhost",
+        )
+
+
+def test_transport_type_error_on_non_string() -> None:
+    """__init__ raises TypeError when transport is not a string."""
+    with pytest.raises(TypeError, match="transport must be str"):
+        HttpStatefulClient(
+            name="bad",
+            transport=123,  # type: ignore[arg-type]
+            url="http://localhost",
+        )
+
+
+def test_name_type_error_on_non_string() -> None:
+    """__init__ raises TypeError when name is not a string."""
+    with pytest.raises(TypeError, match="name must be str"):
+        HttpStatefulClient(
+            name=None,  # type: ignore[arg-type]
+            transport="sse",
+            url="http://localhost",
+        )
+
+
+def test_url_type_error_on_non_string() -> None:
+    """__init__ raises TypeError when url is not a string."""
+    with pytest.raises(TypeError, match="url must be str"):
+        HttpStatefulClient(
+            name="bad",
+            transport="sse",
+            url=42,  # type: ignore[arg-type]
+        )
+
+
+def test_valid_transports_accepted() -> None:
+    """Both 'streamable_http' and 'sse' are accepted as valid transports."""
+    for transport in ("streamable_http", "sse"):
+        client = HttpStatefulClient(
+            name="valid",
+            transport=transport,
+            url="http://localhost",
+        )
+        assert client.transport == transport
+        assert client.is_stateful is True
+
+
+@pytest.mark.asyncio
+async def test_sse_with_minimal_args() -> None:
+    """sse_client path works with only required args (no headers, no extra kwargs)."""
+    with patch.object(mcp_mod, "sse_client") as mock_sse:
+        mock_sse.return_value = AsyncMock()
+
+        client = HttpStatefulClient(
+            name="minimal",
+            transport="sse",
+            url="http://localhost:3000/sse",
+        )
+        mock_stack = AsyncMock()
+        mock_stack.enter_async_context = AsyncMock(
+            return_value=(MagicMock(), MagicMock()),
+        )
+
+        await client._setup_transport(mock_stack)
+
+        mock_sse.assert_called_once()
+        call_kwargs = mock_sse.call_args.kwargs
+        assert call_kwargs["url"] == "http://localhost:3000/sse"
+        assert call_kwargs["headers"] is None
+        assert call_kwargs["timeout"] == 30  # default
+        assert call_kwargs["sse_read_timeout"] == 300  # default (60*5)
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_with_minimal_args() -> None:
+    """streamable_http path works with only required args (no headers, no extra kwargs)."""
+    with patch.object(mcp_mod, "streamable_http_client") as mock_streamable:
+        mock_streamable.return_value = AsyncMock()
+
+        client = HttpStatefulClient(
+            name="minimal_http",
+            transport="streamable_http",
+            url="http://localhost:3000/mcp",
+        )
+        mock_stack = AsyncMock()
+        mock_stack.enter_async_context = AsyncMock(
+            return_value=(MagicMock(), MagicMock()),
+        )
+
+        await client._setup_transport(mock_stack)
+
+        mock_streamable.assert_called_once()
+        call_kwargs = mock_streamable.call_args.kwargs
+        assert call_kwargs["url"] == "http://localhost:3000/mcp"
+        http_client = call_kwargs["http_client"]
+        assert isinstance(http_client, httpx.AsyncClient)
+        # No custom headers should be supplied by the client configuration.
+        # httpx still installs its own standard default headers.
+        assert "authorization" not in http_client.headers


### PR DESCRIPTION
## Description

Adds focused regression coverage for the MCP stateful HTTP client's transport selection reported in #6470.

The current main implementation already branches on transport and creates an httpx.AsyncClient for streamable_http. This PR locks that behavior down so a future refactor cannot silently fall back to the legacy SSE client again.

**Related Issue:** Relates to #6470

**Security Considerations:** No runtime or credential-handling changes. Tests use synthetic URLs and placeholder headers.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [x] Tests

## Component(s) Affected

- [x] Core / Backend (drivers)
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## What Changed

- verifies transport="streamable_http" invokes streamable_http_client
- verifies headers and timeout configuration are applied to the HTTP client
- verifies transport="sse" continues to invoke sse_client
- covers minimal configuration and invalid constructor inputs

---

# AutoResearch Validation Report

## Goal

Analyze issue #6470, reproduce the reported Streamable HTTP transport-selection failure, and verify the proposed change.

## Reported Reproduction Environment

- QwenPaw: v2.0.1
- OS: Windows 10 AMD64
- Distribution: exe installer
- Python: bundled 3.11
- Reported MCP server: Jin10
- Reported symptom: the packaged client used SSE for a transport: streamable_http endpoint, received HTTP 400, and loaded no tools.

## Actual Validation Runtime

- Platform: macOS-26.3.2-arm64-arm-64bit
- Python: 3.11.15
- Process platform: darwin
- Live Jin10 credentials were not used.
- The Windows exe installer was not available on this host.

## Changed Files

- tests/unit/drivers/test_mcp_stateful_client.py

No runtime source file is changed by this PR.

## Baseline Reproduction

Baseline ref: v2.0.1

Resolved commit: ed5857b546e732174d601b0ea5ca1a081a900b98

Status: **not_reproduced**

Source inspection of src/qwenpaw/drivers/handlers/mcp_stateful_client.py at the approved baseline already shows an explicit streamable_http branch. It creates an httpx.AsyncClient and calls streamable_http_client; the fallback branch calls sse_client.

The candidate regression test was overlaid onto a detached v2.0.1 worktree and run against that worktree's src tree:

~~~text
Command: PYTHONPATH=<v2.0.1-worktree>/src python -m pytest tests/unit/drivers/test_mcp_stateful_client.py -q
Exit code: 0
Output:
..........                                                               [100%]
10 passed in 0.15s
~~~

Because the approved source baseline passes the same focused tests, the reported hardcoded-SSE behavior cannot be reproduced from the v2.0.1 tag source. The issue may involve Windows installer provenance, stale packaged code, configuration loading, or another packaged-runtime path not represented by the tag source.

## Candidate Verification

Candidate commit: 1ad6530b9f4289f740187eb0c92a533823b78dbf

Status: **passed**

~~~text
Command: PYTHONPATH=<candidate-worktree>/src python -m pytest tests/unit/drivers/test_mcp_stateful_client.py -q
Exit code: 0
Output:
..........                                                               [100%]
10 passed in 0.15s
~~~

Coverage verifies:

1. streamable_http selects streamable_http_client.
2. configured headers and timeouts reach the HTTP client.
3. sse remains backward compatible.
4. invalid transport and constructor inputs are rejected.
5. minimal SSE and Streamable HTTP configurations remain valid.

## Conclusion

The source-level reproduction gate did **not** reproduce issue #6470 on the upstream v2.0.1 tag. This PR therefore does not claim a runtime bug fix. It adds focused regression protection for transport selection that passes on both the approved baseline and candidate.

The remaining product-level validation is to reproduce with the affected Windows v2.0.1 exe and compare its embedded mcp_stateful_client.py or build provenance with commit ed5857b. If the packaged artifact contains stale code, the corrective action belongs in release packaging or artifact provenance, followed by a Windows installer smoke test against a Streamable HTTP MCP server.

## Isolation and Evidence Limits

- No production credentials were used or recorded.
- No live request was sent to Jin10.
- The reported Windows exe was not physically executed on this macOS host.
- Passing mocked transport-selection tests prove dispatch behavior in source; they do not prove a particular installer contains that source.
- The earlier repository-wide pre-push suite was stopped at approximately 5%; the focused regression file above completed successfully.

## Checklist

- [ ] Windows v2.0.1 exe reproduction completed
- [x] Upstream v2.0.1 source baseline inspected
- [x] Same focused tests executed on baseline and candidate
- [x] Validation result reported without claiming an unobserved fix
- [x] Complete AutoResearch report attached to this PR
