### PR TITLE
fix(console): keep sidebar settings gear visible when collapsed

### DIFF
--- a/console/src/layouts/Sidebar.tsx
+++ b/console/src/layouts/Sidebar.tsx
@@ -689,23 +689,24 @@ export default function Sidebar({ selectedKey }: SidebarProps) {
       )}
 
       <div className={styles.collapseToggleContainer}>
-        {!collapsed && (
-          <Popover
-            open={settingsOpen}
-            onOpenChange={setSettingsOpen}
-            placement="topRight"
-            trigger="click"
-            content={
-              <SidebarSettingsPanel onClose={() => setSettingsOpen(false)} />
-            }
-          >
-            <Button
-              type="text"
-              icon={<SparkSettingLine size={18} />}
-              className={styles.collapseToggle}
-            />
-          </Popover>
-        )}
+        {/* Gear stays visible in collapsed state too — otherwise users
+            (especially on mobile, where the sidebar starts collapsed)
+            cannot discover how to restore full mode. */}
+        <Popover
+          open={settingsOpen}
+          onOpenChange={setSettingsOpen}
+          placement={collapsed ? "rightBottom" : "topRight"}
+          trigger="click"
+          content={
+            <SidebarSettingsPanel onClose={() => setSettingsOpen(false)} />
+          }
+        >
+          <Button
+            type="text"
+            icon={<SparkSettingLine size={18} />}
+            className={styles.collapseToggle}
+          />
+        </Popover>
         <Button
           type="text"
           icon={

--- a/console/src/layouts/index.module.less
+++ b/console/src/layouts/index.module.less
@@ -183,6 +183,9 @@
     }
 
     .collapseToggleContainer {
+      // Gear + expand toggle stack vertically — the narrow rail
+      // (56/72px) cannot fit two buttons side by side.
+      flex-direction: column;
       justify-content: center;
       width: calc(100% + 16px);
       margin: 0 -8px;


### PR DESCRIPTION
The gear button (with the simple/full mode toggle) was only rendered when the sidebar was expanded. On mobile the sidebar starts collapsed, so users could not discover how to restore full mode without first expanding the sidebar. Render the gear in the collapsed rail too, stacked vertically above the expand toggle, with the popover opening to the right.

<img width="433" height="933" alt="image" src="https://github.com/user-attachments/assets/9ce8ecb1-fda6-4064-8276-3fd02a988edf" />
<img width="440" height="933" alt="image" src="https://github.com/user-attachments/assets/b29d0a9c-e653-4f2e-82e6-c8ed4b835a29" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
