### PR TITLE
fix(desktop): bundle PawApp SDK modules

### DIFF
--- a/scripts/pack-tauri/qwenpaw.spec
+++ b/scripts/pack-tauri/qwenpaw.spec
@@ -132,6 +132,8 @@ a = Analysis(
         *collect_submodules("qwenpaw.app.channels"),
         # ACP runner support is lazily imported by delegate_external_agent.
         *collect_submodules("qwenpaw.agents.acp"),
+        # PawApp SDK modules are imported by installed app plugins at runtime.
+        *collect_submodules("qwenpaw.pawapp"),
         # ASGI app entry points
         "qwenpaw.app._app",
         "qwenpaw.app.multi_agent_manager",

--- a/tests/unit/tauri/test_pyinstaller_spec.py
+++ b/tests/unit/tauri/test_pyinstaller_spec.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPEC_PATH = REPO_ROOT / "scripts" / "pack-tauri" / "qwenpaw.spec"
+
+
+def _collected_submodule_packages() -> set[str]:
+    tree = ast.parse(SPEC_PATH.read_text(encoding="utf-8"))
+    packages = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != "collect_submodules" or not node.args:
+            continue
+        package = node.args[0]
+        if isinstance(package, ast.Constant) and isinstance(
+            package.value,
+            str,
+        ):
+            packages.add(package.value)
+    return packages
+
+
+def test_desktop_spec_collects_pawapp_sdk_for_runtime_loaded_plugins():
+    assert "qwenpaw.pawapp" in _collected_submodule_packages()


### PR DESCRIPTION
## Description

PawApp backends are installed from the App Center after the desktop sidecar has
already been frozen. Their `qwenpaw.pawapp` imports therefore sit outside the
PyInstaller static analysis graph, even though the SDK is present in the source
and Python distribution.

This PR collects the shared PawApp SDK package in the macOS/Windows desktop
spec, following the existing pattern for channels, ACP, and backup modules. It
also adds a focused regression test that parses the spec and verifies the
runtime-loaded SDK remains declared.

This fixes the packaging contract for Agent Kanban and future PawApp plugins
instead of special-casing one plugin.

**Related Issue:** Fixes #6473

**Security Considerations:** None. This only changes first-party module
collection in the desktop bundle.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration changed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/tauri/ -q`
- `pre-commit run --files scripts/pack-tauri/qwenpaw.spec tests/unit/tauri/test_pyinstaller_spec.py`
- Built the complete PyInstaller sidecar from this branch with PyInstaller 6.21.0.
- Inspected the built executable recursively with `pyi-archive_viewer`.

Verification matrix:

| Surface | Result |
|---|---|
| Shared macOS/Windows PyInstaller spec | Covered |
| Agent Kanban runtime SDK import | Covered through shared PawApp collection |
| Future PawApp plugin SDK imports | Covered through shared PawApp collection |
| Wheel and Docker packaging | Unchanged |
| Channels/providers/streaming | Not applicable |

## Evidence

The focused regression suite and full sidecar build both passed. Recursive
archive inspection confirmed that the built executable contains the PawApp SDK
root package and every current submodule:

```bash
$ pytest tests/unit/tauri/ -q
..............                                                           [100%]
14 passed in 0.40s

$ pre-commit run --files scripts/pack-tauri/qwenpaw.spec tests/unit/tauri/test_pyinstaller_spec.py
check python ast.........................................................Passed
fix python encoding pragma...............................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

$ python -m PyInstaller scripts/pack-tauri/qwenpaw.spec \
    --distpath /tmp/qwenpaw-6473-build/dist \
    --workpath /tmp/qwenpaw-6473-build/work --clean --noconfirm
436888 INFO: Build complete! The results are available in: /tmp/qwenpaw-6473-build/dist

$ pyi-archive_viewer -r -b qwenpaw-backend | rg "qwenpaw\\.pawapp"
 qwenpaw.pawapp
 qwenpaw.pawapp.app
 qwenpaw.pawapp.context
 qwenpaw.pawapp.deps
 qwenpaw.pawapp.task
```

## Additional Notes

`pre-commit run --all-files` passed every hook except pylint, which reported
four existing `E1120` findings in
`src/qwenpaw/sandbox/windows_restricted_sandbox.py`. That file is identical to
`upstream/main` and is outside this PR. Running the complete hook set against
both changed files passes cleanly.

The full sidecar build was performed on Linux against the shared spec. The same
spec is consumed by both macOS and Windows desktop build scripts.
