### PR TITLE
fix(files): preserve uploaded filenames in hints

### DIFF
--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -7,10 +7,11 @@ This module handles:
 - Message validation
 """
 import asyncio
+import json
 import logging
 import os
 import urllib.parse
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional
 
 from agentscope.message import Msg, TextBlock, URLSource
@@ -21,6 +22,8 @@ from .file_handling import download_file_from_base64, download_file_from_url
 from .image_freezing import freeze_local_images_async
 
 logger = logging.getLogger(__name__)
+
+_MAX_PROMPT_FILENAME_LENGTH = 200
 
 
 def _audio_text_block(block, text: str):
@@ -92,6 +95,43 @@ def _extract_source_and_filename(block: dict, block_type: str):
             filename = os.path.basename(parsed.path) or None
 
     return source, filename
+
+
+def _quote_display_filename(filename: object) -> Optional[str]:
+    """Return a bounded, quoted basename with unsafe characters escaped."""
+    if not isinstance(filename, str):
+        return None
+
+    display_name = PureWindowsPath(filename).name.strip()
+    if not display_name or display_name in {".", ".."}:
+        return None
+
+    quoted = json.dumps(
+        display_name[:_MAX_PROMPT_FILENAME_LENGTH],
+        ensure_ascii=False,
+    )
+    # JSON escapes C0 controls, but leaves C1 controls and Unicode line
+    # separators literal when ensure_ascii=False. Keep readable Unicode while
+    # escaping every remaining non-printable character.
+    return "".join(
+        json.dumps(char, ensure_ascii=True)[1:-1]
+        if not char.isprintable()
+        else char
+        for char in quoted
+    )
+
+
+def _format_uploaded_file_hint(
+    local_path: str,
+    filename: object,
+    language: str,
+) -> str:
+    """Build a localized upload hint with optional filename metadata."""
+    display_name = _quote_display_filename(filename)
+    name_suffix = f" {display_name}" if display_name else ""
+    if language == "zh":
+        return f"用户上传文件{name_suffix}，已经下载到 {local_path}"
+    return f"User uploaded a file{name_suffix}, downloaded to {local_path}"
 
 
 def _media_type_from_path(path: str) -> str:
@@ -493,7 +533,7 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
         if not isinstance(message.content, list):
             continue
 
-        downloaded_files = []
+        downloaded_files: list[tuple[int, str, object]] = []
 
         for i, block in enumerate(message.content):
             # === 2.0 Pydantic DataBlock fast-path ===
@@ -508,7 +548,9 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
                     block,
                 )
                 if local_path:
-                    downloaded_files.append((i, local_path))
+                    downloaded_files.append(
+                        (i, local_path, getattr(block, "name", None)),
+                    )
                 # Remote URL or no URL on a Pydantic block: skip silently.
                 # Adding remote-download for Pydantic DataBlock is a
                 # separate feature (would need to also convert the dict
@@ -531,15 +573,18 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
                 block_dict,
             )
             if local_path:
-                downloaded_files.append((i, local_path))
+                # Legacy storage accepts raw filenames in its download path.
+                # Keep filename display propagation scoped to typed DataBlock
+                # uploads until that separate path is hardened.
+                downloaded_files.append((i, local_path, None))
 
         if downloaded_files:
             lang = load_config().agents.language
-            for i, local_path in reversed(downloaded_files):
-                text = (
-                    f"用户上传文件，已经下载到 {local_path}"
-                    if lang == "zh"
-                    else f"User uploaded a file, downloaded to {local_path}"
+            for i, local_path, filename in reversed(downloaded_files):
+                text = _format_uploaded_file_hint(
+                    local_path,
+                    filename,
+                    lang,
                 )
                 message.content.insert(
                     i + 1,

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -4,6 +4,7 @@
 Covers:
 - is_first_user_interaction
 - prepend_to_message_content
+- process_file_and_media_blocks_in_message
 """
 # pylint: disable=redefined-outer-name
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,6 +19,7 @@ from agentscope.message import (
 )
 from PIL import Image
 
+from qwenpaw.agents.utils import message_processing
 from qwenpaw.agents.utils.message_processing import (
     _process_audio_block,
     is_first_user_interaction,
@@ -65,6 +67,28 @@ def _audio_config():
         return_value=config,
     ):
         yield config
+
+
+def _set_language(monkeypatch, language: str) -> None:
+    config = MagicMock()
+    config.agents.language = language
+    monkeypatch.setattr(message_processing, "load_config", lambda: config)
+
+
+def _data_file_msg(local_path, name=None) -> Msg:
+    return Msg(
+        name="user",
+        role="user",
+        content=[
+            DataBlock(
+                source=URLSource(
+                    url=local_path.as_uri(),
+                    media_type="application/octet-stream",
+                ),
+                name=name,
+            ),
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -305,3 +329,78 @@ class TestProcessLocalImageDataBlock:
         assert isinstance(second_msg.content[0].source, Base64Source)
         assert first_msg.content[0].source.data == first_source.data
         assert second_msg.content[0].source.data != first_source.data
+
+
+class TestProcessFileAndMediaBlocks:
+    """Typed file blocks retain bounded, quoted display filenames."""
+
+    @pytest.mark.asyncio
+    async def test_data_block_hint_preserves_chinese_filename(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        local_path = tmp_path / "884ff39f590c4472f__.docx"
+        msg = _data_file_msg(local_path, "项目方案.docx")
+        _set_language(monkeypatch, "zh")
+
+        await process_file_and_media_blocks_in_message(msg)
+
+        assert msg.content[1].text == (
+            f'用户上传文件 "项目方案.docx"，已经下载到 {local_path}'
+        )
+
+    @pytest.mark.asyncio
+    async def test_data_block_hint_normalizes_and_escapes_filename(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        local_path = tmp_path / "stored.docx"
+        msg = _data_file_msg(
+            local_path,
+            "..\\..\\会议\n记\u0085录\u2028划\u2029.docx",
+        )
+        _set_language(monkeypatch, "en")
+
+        await process_file_and_media_blocks_in_message(msg)
+
+        assert msg.content[1].text == (
+            "User uploaded a file "
+            '"会议\\n记\\u0085录\\u2028划\\u2029.docx", '
+            f"downloaded to {local_path}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_data_block_hint_bounds_display_filename(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        local_path = tmp_path / "stored.bin"
+        msg = _data_file_msg(local_path, f"{'a' * 250}.txt")
+        _set_language(monkeypatch, "en")
+
+        await process_file_and_media_blocks_in_message(msg)
+
+        expected_name = "a" * 200
+        assert msg.content[1].text == (
+            f'User uploaded a file "{expected_name}", '
+            f"downloaded to {local_path}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_hint_without_name_keeps_existing_wording(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        local_path = tmp_path / "stored.bin"
+        msg = _data_file_msg(local_path)
+        _set_language(monkeypatch, "en")
+
+        await process_file_and_media_blocks_in_message(msg)
+
+        assert msg.content[1].text == (
+            f"User uploaded a file, downloaded to {local_path}"
+        )


### PR DESCRIPTION
## Description

Console uploads already carry the browser-provided original filename in
`DataBlock.name`, while the storage layer uses a UUID-prefixed local path. The
shared file-block processor discarded that display metadata and injected only
the generated path into the user message.

This PR propagates the display name through the current
`_process_local_data_block()` path and includes it in the localized upload
hint. It preserves the local-audio transcription/native-delivery behavior and
`file_url_to_local_path()` handling introduced by #6573.

The display name is reduced to a cross-platform basename, capped at 200 code
points, quoted, and escaped for C0/C1 controls and Unicode line separators.
Readable Unicode such as Chinese filenames remains intact. The real local path
is unchanged, and blocks without a display name keep the existing wording.

Scope is intentionally limited to AgentScope 2.0 typed `DataBlock` inputs,
which cover the reported Console flow. The legacy dict download path remains
behaviorally unchanged; its storage-filename hardening is a separate concern.

**Related Issue:** Fixes #6453

**Security Considerations:** Filename metadata is untrusted. Path components
are removed and the displayed value is bounded, quoted, and escaped before it
is added to the prompt. This does not treat the filename as trusted content or
change storage naming/file-access behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant tests locally and they pass
- [x] Documentation updated (not needed; no configuration or workflow changed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

- `pytest tests/unit/agents/utils/test_message_processing.py -q`
- `pytest tests/unit/agents/utils/test_message_processing.py tests/unit/runtime/test_message_convert.py -q`
- `pre-commit run --files src/qwenpaw/agents/utils/message_processing.py tests/unit/agents/utils/test_message_processing.py`

Verification matrix:

| Surface | Result |
|---|---|
| Console/local typed `DataBlock` | Chinese display filename preserved |
| C0/C1 and U+2028/U+2029 | Escaped in the quoted display value |
| Display name over 200 code points | Bounded before prompt insertion |
| Local audio transcription/native mode | Preserved and regression-tested |
| Missing display name | Existing generic wording preserved |
| Legacy dict download path | Unchanged; no filename propagation |
| UUID-prefixed storage path | Unchanged and still available to tools |
| Other typed callers carrying `DataBlock.name` | Covered by shared processor |

## Evidence

```bash
$ pytest tests/unit/agents/utils/test_message_processing.py -q
........................                                                 [100%]
24 passed in 0.35s

$ pytest tests/unit/agents/utils/test_message_processing.py tests/unit/runtime/test_message_convert.py -q
...........................                                              [100%]
27 passed in 0.57s

$ pre-commit run --files src/qwenpaw/agents/utils/message_processing.py tests/unit/agents/utils/test_message_processing.py
check python ast.........................................................Passed
fix python encoding pragma...............................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

A broader `tests/unit/agents/utils/` run reached 154 passed with one unrelated
environment-sensitive failure in `test_remote_download`: the sandbox umask
created mode `0664` while the existing test expects `0644`. Neither changed
file touches that download implementation.

## Additional Notes

No Console API or storage filename changes are required because the original
name already reaches `DataBlock.name`. Keeping the UUID-prefixed local path
preserves the existing storage and agent file-access contract.
