### PR TITLE
fix(video): deliver video data to models across OpenAI Response, Anthropic, and Chat Completions providers

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -178,21 +178,34 @@ def _anthropic_media_dedup_key(source: Any) -> str | None:
     return None
 
 
-def _video_oversize_placeholder(size: int) -> dict:
-    """Text placeholder substituted for a video that exceeds the inline cap.
+def _video_oversize_placeholder(
+    size: int,
+    *,
+    response_api: bool = False,
+) -> dict:
+    """Text placeholder substituted for a video that exceeds
+    the inline cap.
 
     Mirrors the wording used by ``capping_formatter``'s
-    ``CappingFormatterMixin._placeholder_text`` so oversized-video messages
-    are consistent across every provider path.  Tool-result videos inline
-    through these helpers bypass the capping formatters (which only see
-    ``_format_*_source``), so the cap is enforced here instead.
+    ``CappingFormatterMixin._placeholder_text`` so
+    oversized-video messages are consistent across every
+    provider path.  Tool-result videos inline through these
+    helpers bypass the capping formatters (which only see
+    ``_format_*_source``), so the cap is enforced here
+    instead.
+
+    When *response_api* is True the block uses
+    ``input_text`` instead of ``text``, matching the
+    Responses API content-type convention.
     """
+    txt_type = "input_text" if response_api else "text"
     return {
-        "type": "text",
+        "type": txt_type,
         "text": (
-            f"[video omitted from model context: local file is "
-            f"{size} bytes, exceeds inline limit of "
-            f"{MAX_INLINE_MEDIA_BYTES} bytes]"
+            "[video omitted from model context: "
+            f"local file is {size} bytes, exceeds "
+            f"inline limit of {MAX_INLINE_MEDIA_BYTES}"
+            " bytes]"
         ),
     }
 
@@ -272,43 +285,60 @@ def _format_anthropic_video_data_block(block: Any) -> dict | None:
     return None
 
 
-def _format_openai_video_block(video_block: dict) -> dict:
+def _format_openai_video_block(
+    video_block: dict,
+    response_api: bool = False,
+) -> dict:
     """Format a video block for OpenAI-compatible API.
 
     Local files are converted to base64 data URLs; web URLs are
     passed through directly.
 
+    When ``response_api`` is True the output uses the
+    ``input_video`` content type adopted by Volcengine Ark
+    and other providers that extend the OpenAI Responses API
+    with native video support.  Official OpenAI and DashScope
+    Responses APIs do **not** support video; callers should
+    fall back gracefully (the react-agent already retries
+    without media on 400 errors).
+
     Args:
-        video_block (`dict`):
-            The video block to format.
+        video_block: The video block to format.
+        response_api: When True, emit the Responses API
+            ``input_video`` shape instead of the Chat
+            Completions ``video_url`` shape.
 
     Returns:
-        `dict`:
-            ``{"type": "video_url", "video_url": {"url": ...}}``.
+        Wire-format dict for the provider.
 
     Raises:
-        `ValueError`:
+        ModelFormatterError:
             If the source type or video format is not supported.
     """
     source = video_block["source"]
     if source["type"] == "base64":
         media_type = source["media_type"]
-        # base64 length -> approximate raw byte count.
         size = len(source.get("data") or "") * 3 // 4
         if size > MAX_INLINE_MEDIA_BYTES:
-            return _video_oversize_placeholder(size)
+            return _video_oversize_placeholder(
+                size,
+                response_api=response_api,
+            )
         url = f"data:{media_type};base64,{source['data']}"
     elif source["type"] == "url":
         raw_url = _file_url_to_path(source["url"])
-        if os.path.exists(raw_url) and os.path.isfile(raw_url):
-            # Cap oversized local files before reading/encoding the whole
-            # thing into the request body (see ``capping_formatter``).
+        if os.path.exists(raw_url) and os.path.isfile(
+            raw_url,
+        ):
             try:
                 size = os.path.getsize(raw_url)
             except OSError:
                 size = 0
             if size > MAX_INLINE_MEDIA_BYTES:
-                return _video_oversize_placeholder(size)
+                return _video_oversize_placeholder(
+                    size,
+                    response_api=response_api,
+                )
             ext = os.path.splitext(raw_url)[1].lower()
             media_type = _SUPPORTED_VIDEO_EXTENSIONS.get(ext)
             if not media_type:
@@ -327,8 +357,9 @@ def _format_openai_video_block(video_block: dict) -> dict:
             else:
                 raise ModelFormatterError(
                     message=(
-                        f"Invalid video URL: {source['url']}. "
-                        "It should be a local file or a web URL."
+                        f"Invalid video URL: "
+                        f"{source['url']}. It should be"
+                        " a local file or a web URL."
                     ),
                 )
     else:
@@ -336,6 +367,8 @@ def _format_openai_video_block(video_block: dict) -> dict:
             message=f"Unsupported video source type: {source['type']}",
         )
 
+    if response_api:
+        return {"type": "input_video", "video_url": url}
     return {
         "type": "video_url",
         "video_url": {"url": url},
@@ -345,10 +378,22 @@ def _format_openai_video_block(video_block: dict) -> dict:
 def _replace_video_placeholders(
     messages: list[dict],
     video_subs: dict[str, dict],
+    *,
+    response_api: bool = False,
 ) -> None:
     """Replace video placeholder text blocks with formatted
-    video blocks in OpenAI-formatted messages."""
+    video blocks in OpenAI-formatted messages.
+
+    Only ``user``, ``tool``, and ``system`` messages are
+    processed; ``assistant`` messages keep placeholders
+    as-is because ``input_video`` / ``video_url`` blocks
+    are not valid in assistant content for most providers.
+    """
+    _TEXT_TYPES = ("text", "input_text")
+    _REPLACEABLE_ROLES = ("user", "tool", "system")
     for fmt_msg in messages:
+        if fmt_msg.get("role") not in _REPLACEABLE_ROLES:
+            continue
         content = fmt_msg.get("content")
         if not isinstance(content, list):
             continue
@@ -356,12 +401,13 @@ def _replace_video_placeholders(
         for item in content:
             if (
                 isinstance(item, dict)
-                and item.get("type") == "text"
+                and item.get("type") in _TEXT_TYPES
                 and item.get("text") in video_subs
             ):
                 new_content.append(
                     _format_openai_video_block(
                         video_subs[item["text"]],
+                        response_api=response_api,
                     ),
                 )
             else:
@@ -401,12 +447,17 @@ def _substitute_video_blocks(
 ) -> dict[str, dict]:
     """Replace video blocks in msgs with text placeholders.
 
-    Returns a mapping from placeholder text to the original video
-    block so they can be restored later.  Handles both dict blocks
-    (1.x) and Pydantic DataBlock objects (2.0).
+    Returns a mapping from placeholder text to the original
+    video block so they can be restored later.  Handles both
+    dict blocks (1.x) and Pydantic DataBlock objects (2.0).
+
+    Assistant messages are skipped because video blocks are
+    not valid in assistant content for most providers.
     """
     video_subs: dict[str, dict] = {}
     for msg in msgs:
+        if getattr(msg, "role", "") == "assistant":
+            continue
         if not isinstance(msg.content, list):
             continue
         for i, blk in enumerate(msg.content):
@@ -464,6 +515,8 @@ def _restore_video_blocks(
 def _promote_tool_result_videos(
     msgs: list,
     messages: list[dict],
+    *,
+    response_api: bool = False,
 ) -> list[dict]:
     """Inject promoted video user messages after tool result messages.
 
@@ -531,9 +584,10 @@ def _promote_tool_result_videos(
         if not isinstance(tcid, str) or tcid not in promotions:
             continue
         tool_name, videos = promotions[tcid]
+        txt_type = "input_text" if response_api else "text"
         promoted: list[dict] = [
             {
-                "type": "text",
+                "type": txt_type,
                 "text": "<system-info>The following are "
                 "the video contents from the tool "
                 f"result of '{tool_name}':",
@@ -542,15 +596,21 @@ def _promote_tool_result_videos(
         for url, vid_block in videos:
             promoted.append(
                 {
-                    "type": "text",
+                    "type": txt_type,
                     "text": f"\n- The video from '{url}': ",
                 },
             )
             promoted.append(
-                _format_openai_video_block(vid_block),
+                _format_openai_video_block(
+                    vid_block,
+                    response_api=response_api,
+                ),
             )
         promoted.append(
-            {"type": "text", "text": "</system-info>"},
+            {
+                "type": txt_type,
+                "text": "</system-info>",
+            },
         )
         new_messages.append(
             {"role": "user", "content": promoted},
@@ -1016,7 +1076,11 @@ def _create_file_block_support_formatter(
             messages = await super().format(normalized_msgs)
 
             if video_subs:
-                _replace_video_placeholders(messages, video_subs)
+                _replace_video_placeholders(
+                    messages,
+                    video_subs,
+                    response_api=_is_response_formatter,
+                )
                 _restore_video_blocks(normalized_msgs, video_subs)
 
             if _needs_video and getattr(
@@ -1027,6 +1091,7 @@ def _create_file_block_support_formatter(
                 messages = _promote_tool_result_videos(
                     normalized_msgs,
                     messages,
+                    response_api=_is_response_formatter,
                 )
 
             messages = _reorder_tool_and_promoted_messages(messages)

--- a/src/qwenpaw/providers/anthropic_provider.py
+++ b/src/qwenpaw/providers/anthropic_provider.py
@@ -17,9 +17,12 @@ from pydantic import Field
 from qwenpaw.providers.multimodal_prober import (
     ProbeResult,
     _PROBE_IMAGE_B64,
+    _PROBE_VIDEO_B64,
+    _PROBE_VIDEO_URL,
     _IMAGE_PROBE_PROMPT,
     _is_media_keyword_error,
     evaluate_image_probe_answer,
+    evaluate_video_probe_answer,
 )
 from qwenpaw.providers.provider import ModelInfo, Provider
 
@@ -305,24 +308,195 @@ class AnthropicProvider(Provider):
         self,
         model_id: str,
         timeout: float = 60,
-        image_only: bool = False,  # pylint: disable=unused-argument
+        image_only: bool = False,
     ) -> ProbeResult:
-        """Probe multimodal support using Anthropic messages API format.
+        """Probe multimodal support via Anthropic messages API.
 
-        Anthropic does not support video input, so supports_video is
-        always False.  Image support is probed by sending a minimal 1x1
-        PNG via the Anthropic base64 image source format.
+        Image support is probed by sending a solid-red PNG.
+        Video support is probed by sending a solid-blue MP4
+        to cover third-party Anthropic-compatible providers
+        that accept video input (official Anthropic does not).
         """
         img_ok, img_msg = await self._probe_image_support(
             model_id,
             timeout,
         )
+        if not img_ok:
+            return ProbeResult(
+                supports_image=False,
+                supports_video=False,
+                image_message=img_msg,
+                video_message="Skipped: image probe failed",
+            )
+        if image_only:
+            return ProbeResult(
+                supports_image=img_ok,
+                supports_video=False,
+                image_message=img_msg,
+                video_message="Skipped: image_only=True",
+            )
+        vid_ok, vid_msg = await self._probe_video_support(
+            model_id,
+            timeout,
+        )
         return ProbeResult(
             supports_image=img_ok,
-            supports_video=False,
+            supports_video=vid_ok,
             image_message=img_msg,
-            video_message="Video not supported by Anthropic",
+            video_message=vid_msg,
         )
+
+    async def _probe_video_support(
+        self,
+        model_id: str,
+        timeout: float = 30,
+    ) -> tuple[bool, str]:
+        """Probe video support via Anthropic messages API.
+
+        Tries a base64 probe video first; if the provider
+        rejects it (400) falls back to an HTTP URL probe.
+        Official Anthropic endpoints reject ``video`` blocks
+        entirely; third-party providers may accept them.
+        """
+        logger.info(
+            "Video probe start: model=%s url=%s",
+            model_id,
+            self.base_url,
+        )
+        start_time = time.monotonic()
+        sources = [
+            {
+                "type": "base64",
+                "media_type": "video/mp4",
+                "data": _PROBE_VIDEO_B64,
+            },
+            {
+                "type": "url",
+                "url": _PROBE_VIDEO_URL,
+            },
+        ]
+        last_err = ""
+        last_400: list[str] = []
+        for source in sources:
+            is_http = source.get("type") == "url"
+            result = await self._try_video_source(
+                model_id,
+                source,
+                timeout=(timeout * 3 if is_http else timeout),
+                start_time=start_time,
+                is_http=is_http,
+                last_400=last_400,
+            )
+            if result is not None:
+                return result
+            detail = last_400[-1] if last_400 else ""
+            last_err = (
+                f"format rejected ({source['type']})"
+                f"{f': {detail}' if detail else ''}"
+            )
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            "Video probe: model=%s ok=False %.2fs",
+            model_id,
+            elapsed,
+        )
+        return False, f"Video not supported: {last_err}"
+
+    async def _try_video_source(
+        self,
+        model_id: str,
+        source: dict,
+        timeout: float,
+        *,
+        start_time: float,
+        is_http: bool = False,
+        last_400: list[str] | None = None,
+    ) -> tuple[bool, str] | None:
+        """Try one video source format. Return None to try next.
+
+        If a 400 error occurs and *last_400* is provided, the
+        error summary is appended to help callers log the
+        actual rejection reason.
+        """
+        client = self._client(timeout=timeout)
+        try:
+            resp = await client.messages.create(
+                model=model_id,
+                max_tokens=200,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "video",
+                                "source": source,
+                            },
+                            {
+                                "type": "text",
+                                "text": (
+                                    "What is the single "
+                                    "dominant color shown "
+                                    "in this video? Reply "
+                                    "with ONLY the color "
+                                    "name, nothing else."
+                                ),
+                            },
+                        ],
+                    },
+                ],
+            )
+            answer = ""
+            thinking = ""
+            for block in resp.content:
+                btype = getattr(block, "type", "")
+                if btype == "thinking":
+                    thinking += getattr(
+                        block,
+                        "thinking",
+                        "",
+                    )
+                elif hasattr(block, "text"):
+                    answer += block.text
+            return evaluate_video_probe_answer(
+                answer,
+                model_id,
+                start_time,
+                reasoning=thinking,
+                is_http=is_http,
+            )
+        except anthropic.APIError as e:
+            status = getattr(e, "status_code", None)
+            if status == 400:
+                logger.debug(
+                    "Video probe format rejected (400): %s",
+                    e,
+                )
+                if last_400 is not None:
+                    last_400.append(str(e)[:200])
+                return None
+            elapsed = time.monotonic() - start_time
+            err_type = type(e).__name__
+            logger.warning(
+                "Video probe error: model=%s %s %s %.2fs",
+                model_id,
+                err_type,
+                e,
+                elapsed,
+            )
+            if _is_media_keyword_error(e):
+                return False, f"Video not supported: {e}"
+            return False, f"Probe inconclusive: {e}"
+        except Exception as e:
+            elapsed = time.monotonic() - start_time
+            err_type = type(e).__name__
+            logger.warning(
+                "Video probe error: model=%s %s %s %.2fs",
+                model_id,
+                err_type,
+                e,
+                elapsed,
+            )
+            return False, f"Probe failed: {e}"
 
     async def _probe_image_support(
         self,

--- a/src/qwenpaw/providers/multimodal_prober.py
+++ b/src/qwenpaw/providers/multimodal_prober.py
@@ -6,6 +6,7 @@ Provider-specific probe logic lives in each provider class
 """
 
 import logging
+import time
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -108,7 +109,25 @@ _IMAGE_PROBE_PROMPT = (
 )
 
 # Red-family keywords the probe image (solid red) should elicit.
-_RED_KW = ("red", "scarlet", "crimson", "vermilion", "maroon", "红")
+_RED_KW = (
+    "red",
+    "scarlet",
+    "crimson",
+    "vermilion",
+    "maroon",
+    "红",
+)
+
+# Blue-family keywords the probe video (solid blue) should elicit.
+_BLUE_KW = (
+    "blue",
+    "navy",
+    "azure",
+    "cobalt",
+    "cyan",
+    "indigo",
+    "蓝",
+)
 
 
 def evaluate_image_probe_answer(
@@ -129,13 +148,12 @@ def evaluate_image_probe_answer(
     Returns:
         ``(supported, message)`` tuple.
     """
-    import time as _time  # deferred to keep module-level imports light
 
     answer = answer.lower().strip()
     reasoning = reasoning.lower().strip()
 
     if any(kw in answer for kw in _RED_KW):
-        elapsed = _time.monotonic() - start_time
+        elapsed = time.monotonic() - start_time
         logger.info(
             "Image probe done: model=%s result=True %.2fs",
             model_id,
@@ -144,7 +162,7 @@ def evaluate_image_probe_answer(
         return True, f"Image supported (answer={answer!r})"
 
     if reasoning and any(kw in reasoning for kw in _RED_KW):
-        elapsed = _time.monotonic() - start_time
+        elapsed = time.monotonic() - start_time
         logger.info(
             "Image probe done: model=%s result=True %.2fs",
             model_id,
@@ -152,10 +170,90 @@ def evaluate_image_probe_answer(
         )
         return True, f"Image supported (reasoning, answer={answer!r})"
 
-    elapsed = _time.monotonic() - start_time
+    elapsed = time.monotonic() - start_time
     logger.info(
         "Image probe done: model=%s result=False %.2fs",
         model_id,
         elapsed,
     )
     return False, f"Model did not recognise image (answer={answer!r})"
+
+
+def evaluate_video_probe_answer(
+    answer: str,
+    model_id: str,
+    start_time: float,
+    reasoning: str = "",
+    *,
+    is_http: bool = False,
+) -> tuple[bool, str]:
+    """Shared evaluation for video color-probe answers.
+
+    Args:
+        answer: The model's primary text answer.
+        model_id: Model identifier (for logging).
+        start_time: ``time.monotonic()`` when the probe
+            started.
+        reasoning: Optional reasoning/thinking text for
+            models that put analysis in a separate field.
+        is_http: When True, accept any non-empty answer as
+            evidence of video support.  This relaxed check
+            is safe because ``probe_model_multimodal`` only
+            reaches the video probe after the image probe
+            has already passed, filtering out text-only
+            models that silently accept media payloads.
+
+    Returns:
+        ``(supported, message)`` tuple.
+    """
+
+    answer = answer.lower().strip()
+    reasoning = reasoning.lower().strip()
+
+    answer_match = any(kw in answer for kw in _BLUE_KW)
+    reasoning_match = reasoning and any(kw in reasoning for kw in _BLUE_KW)
+
+    if answer_match:
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            "Video probe done: model=%s ok=True(color) %.2fs",
+            model_id,
+            elapsed,
+        )
+        return True, f"Video supported ({answer!r})"
+
+    if reasoning_match:
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            "Video probe done: model=%s ok=True(reasoning) %.2fs",
+            model_id,
+            elapsed,
+        )
+        return (
+            True,
+            f"Video supported (reasoning, {answer!r})",
+        )
+
+    if is_http and answer:
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            "Video probe done: model=%s ok=True(http) %.2fs",
+            model_id,
+            elapsed,
+        )
+        return (
+            True,
+            f"Video supported (http, {answer!r})",
+        )
+
+    elapsed = time.monotonic() - start_time
+    logger.info(
+        "Video probe done: model=%s ok=False %r %.2fs",
+        model_id,
+        answer,
+        elapsed,
+    )
+    return (
+        False,
+        f"Model did not recognise video (answer={answer!r})",
+    )

--- a/src/qwenpaw/providers/openai_provider.py
+++ b/src/qwenpaw/providers/openai_provider.py
@@ -17,6 +17,7 @@ from pydantic import Field
 from qwenpaw.providers.provider import ModelInfo, Provider
 
 from .capping_formatter import MAX_INLINE_MEDIA_BYTES, _CappingOpenAIFormatter
+from .multimodal_prober import evaluate_video_probe_answer
 
 if TYPE_CHECKING:
     from qwenpaw.providers.multimodal_prober import ProbeResult
@@ -524,70 +525,22 @@ class OpenAIProvider(Provider):
     ) -> tuple[bool, str]:
         """Evaluate video probe response.
 
-        Detection criteria:
-            The probe video is a solid-blue 64×64 H.264 MP4.  We ask
-            "What is the single dominant color?" and check for "blue"
-            or "蓝" in the reply or reasoning_content.
-
-            Special case for HTTP URL probes: if the model returns any
-            non-empty answer (even without "blue"), we accept it as
-            supported.  The HTTP URL points to an external video whose
-            content we do not control (not the blue probe video), so
-            colour-matching is impossible.  This relaxed check is safe
-            because ``probe_model_multimodal`` only reaches the video
-            probe after the image probe has already passed, which
-            filters out text-only models that silently accept media
-            payloads (e.g. qwen3-max).
+        Delegates to the shared
+        ``evaluate_video_probe_answer`` in
+        ``multimodal_prober`` so all providers use the same
+        colour-keyword list and logging.
         """
-        answer = (res.choices[0].message.content or "").lower().strip()
-        # Primary check: answer contains a blue-family color keyword.
-        # Models may describe the solid-blue video as "blue", "navy",
-        # "azure", "cobalt", "cyan", "indigo", "蓝" etc.
-        _BLUE_KW = ("blue", "navy", "azure", "cobalt", "cyan", "indigo", "蓝")
-        if any(kw in answer for kw in _BLUE_KW):
-            elapsed = time.monotonic() - start_time
-            logger.info(
-                "Video probe done: model=%s result=True %.2fs",
-                model_id,
-                elapsed,
-            )
-            return True, f"Video supported (answer={answer!r})"
-        # Fallback: reasoning models may put analysis in reasoning_content.
+        answer = res.choices[0].message.content or ""
         reasoning = ""
         msg = res.choices[0].message
         if hasattr(msg, "reasoning_content") and msg.reasoning_content:
-            reasoning = msg.reasoning_content.lower()
-        if reasoning and any(kw in reasoning for kw in _BLUE_KW):
-            elapsed = time.monotonic() - start_time
-            logger.info(
-                "Video probe done: model=%s result=True %.2fs",
-                model_id,
-                elapsed,
-            )
-            return (
-                True,
-                f"Video supported (reasoning, answer={answer!r})",
-            )
-        # HTTP URL fallback: accept any non-empty response as evidence
-        # of video support (see docstring for safety rationale).
-        if is_http and answer:
-            elapsed = time.monotonic() - start_time
-            logger.info(
-                "Video probe done: model=%s result=True (http) %.2fs",
-                model_id,
-                elapsed,
-            )
-            return True, f"Video supported (http, answer={answer!r})"
-        elapsed = time.monotonic() - start_time
-        logger.info(
-            "Video probe done: model=%s result=False answer=%r %.2fs",
-            model_id,
+            reasoning = msg.reasoning_content
+        return evaluate_video_probe_answer(
             answer,
-            elapsed,
-        )
-        return (
-            False,
-            f"Model did not recognise video (answer={answer!r})",
+            model_id,
+            start_time,
+            reasoning=reasoning,
+            is_http=is_http,
         )
 
 

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from agentscope.model import ChatModelBase, OpenAIResponseModel
@@ -12,6 +13,45 @@ from .capping_formatter import _CappingOpenAIResponseFormatter
 from .openai_provider import OpenAIProvider
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_response_text(response: Any) -> str:
+    """Extract aggregated output text from a Responses API
+    response object.
+
+    Prefers the SDK's built-in ``output_text`` property when
+    available (concatenates all output_text parts); falls back
+    to manual traversal for plain-dict / SimpleNamespace mocks.
+    """
+    agg = getattr(response, "output_text", None)
+    if agg is not None:
+        return agg
+    for item in getattr(response, "output", []):
+        if getattr(item, "type", None) != "message":
+            continue
+        for part in getattr(item, "content", []):
+            if getattr(part, "type", None) == "output_text":
+                return getattr(part, "text", "") or ""
+    return ""
+
+
+def _extract_reasoning_text(response: Any) -> str:
+    """Extract concatenated reasoning summary text from a
+    Responses API response.
+
+    Reasoning items have ``type == "reasoning"`` with a
+    ``summary`` list whose elements carry a ``.text``
+    attribute.
+    """
+    parts: list[str] = []
+    for item in getattr(response, "output", []):
+        if getattr(item, "type", None) != "reasoning":
+            continue
+        for s in getattr(item, "summary", []):
+            text = getattr(s, "text", "")
+            if text:
+                parts.append(text)
+    return " ".join(parts)
 
 
 class OpenAIResponseModelCompat(OpenAIResponseModel):
@@ -71,17 +111,20 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
 
 
 class OpenAIResponseProvider(OpenAIProvider):
-    """Provider that uses the OpenAI Responses API instead of Chat Completions.
+    """Provider that uses the OpenAI Responses API instead of
+    Chat Completions.
 
-    Inherits connection/discovery logic from ``OpenAIProvider`` but
-    creates ``OpenAIResponseModel`` instances via ``get_chat_model_instance``.
-    The ``check_model_connection`` method uses the Responses API endpoint.
+    Inherits connection/discovery logic from ``OpenAIProvider``
+    but creates ``OpenAIResponseModel`` instances via
+    ``get_chat_model_instance``.
 
-    Multimodal probing (``_probe_image_support`` / ``_probe_video_support``)
-    is inherited from ``OpenAIProvider`` and uses the Chat Completions
-    endpoint.  This works for OpenAI (which supports both APIs) and fails
-    gracefully (returns "probe inconclusive") for third-party providers
-    that only expose the Response API.
+    Multimodal probing is overridden to use the Responses API
+    endpoint (``client.responses.create``) so the probe result
+    accurately reflects what the Responses API actually
+    supports.  This prevents false-positive ``supports_video``
+    results that occur when probing via Chat Completions on
+    providers where the Responses API does not support video
+    (e.g. DashScope).
     """
 
     async def check_model_connection(
@@ -115,6 +158,176 @@ class OpenAIResponseProvider(OpenAIProvider):
                 False,
                 f"Unknown exception when connecting to model '{model_id}'",
             )
+
+    # Responses API's max_output_tokens includes reasoning
+    # tokens, so reasoning models (o-series, gpt-5) can
+    # exhaust the budget on thinking alone.  1024 gives enough
+    # headroom for a one-word color answer after reasoning.
+    _PROBE_TOKEN_BUDGET = 1024
+
+    async def _probe_image_support(
+        self,
+        model_id: str,
+        timeout: float = 15,
+    ) -> tuple[bool, str]:
+        """Probe image support via the Responses API."""
+        from openai import APIError
+
+        from .multimodal_prober import (
+            _IMAGE_PROBE_PROMPT,
+            _PROBE_IMAGE_B64,
+            _is_media_keyword_error,
+            evaluate_image_probe_answer,
+        )
+
+        logger.info(
+            "Image probe (responses) start: model=%s url=%s",
+            model_id,
+            self.base_url,
+        )
+        start_time = time.monotonic()
+        client = self._client(timeout=timeout)
+        try:
+            res = await client.responses.create(
+                model=model_id,
+                input=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_image",
+                                "image_url": (
+                                    "data:image/png;base64,"
+                                    f"{_PROBE_IMAGE_B64}"
+                                ),
+                            },
+                            {
+                                "type": "input_text",
+                                "text": _IMAGE_PROBE_PROMPT,
+                            },
+                        ],
+                    },
+                ],
+                max_output_tokens=self._PROBE_TOKEN_BUDGET,
+                timeout=timeout,
+            )
+            answer = _extract_response_text(res).lower().strip()
+            reasoning = _extract_reasoning_text(res).lower().strip()
+            return evaluate_image_probe_answer(
+                answer,
+                model_id,
+                start_time,
+                reasoning,
+            )
+        except APIError as e:
+            elapsed = time.monotonic() - start_time
+            logger.warning(
+                "Image probe error: model=%s %s %.2fs",
+                model_id,
+                e,
+                elapsed,
+            )
+            status = getattr(e, "status_code", None)
+            if status == 400 or _is_media_keyword_error(e):
+                return False, f"Image not supported: {e}"
+            return False, f"Probe inconclusive: {e}"
+        except Exception as e:
+            elapsed = time.monotonic() - start_time
+            logger.warning(
+                "Image probe error: model=%s %s %.2fs",
+                model_id,
+                e,
+                elapsed,
+            )
+            return False, f"Probe failed: {e}"
+
+    async def _try_video_url(
+        self,
+        model_id: str,
+        video_url: str,
+        timeout: float,
+        *,
+        start_time: float,
+    ) -> tuple[bool, str] | None:
+        """Try a single video URL via the Responses API.
+
+        Returns None to signal the caller should try the next
+        format.
+        """
+        from openai import APIError
+
+        from .multimodal_prober import (
+            _PROBE_VIDEO_URL,
+            _is_media_keyword_error,
+            evaluate_video_probe_answer,
+        )
+
+        is_http = video_url == _PROBE_VIDEO_URL
+        req_timeout = timeout * 3 if is_http else timeout
+        client = self._client(timeout=req_timeout)
+        try:
+            res = await client.responses.create(
+                model=model_id,
+                input=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_video",
+                                "video_url": video_url,
+                            },
+                            {
+                                "type": "input_text",
+                                "text": (
+                                    "What is the single "
+                                    "dominant color shown in "
+                                    "this video? Reply with "
+                                    "ONLY the color name, "
+                                    "nothing else."
+                                ),
+                            },
+                        ],
+                    },
+                ],
+                max_output_tokens=self._PROBE_TOKEN_BUDGET,
+                timeout=req_timeout,
+            )
+            answer = _extract_response_text(res)
+            reasoning = _extract_reasoning_text(res)
+            return evaluate_video_probe_answer(
+                answer,
+                model_id,
+                start_time,
+                reasoning=reasoning,
+                is_http=is_http,
+            )
+        except APIError as e:
+            status = getattr(e, "status_code", None)
+            if status == 400:
+                logger.debug(
+                    "Video probe format rejected (400): %s",
+                    e,
+                )
+                return None
+            elapsed = time.monotonic() - start_time
+            is_kw = _is_media_keyword_error(e)
+            label = "not supported" if is_kw else "inconclusive"
+            logger.warning(
+                "Video probe error: model=%s %s %.2fs",
+                model_id,
+                e,
+                elapsed,
+            )
+            return False, f"Video {label}: {e}"
+        except Exception as e:
+            elapsed = time.monotonic() - start_time
+            logger.warning(
+                "Video probe error: model=%s %s %.2fs",
+                model_id,
+                e,
+                elapsed,
+            )
+            return False, f"Probe failed: {e}"
 
     def get_chat_model_instance(self, model_id: str) -> ChatModelBase:
         from agentscope.credential import OpenAICredential

--- a/tests/unit/agents/test_model_factory_video_capping.py
+++ b/tests/unit/agents/test_model_factory_video_capping.py
@@ -16,6 +16,7 @@ from qwenpaw.agents.model_factory import (
     MAX_INLINE_MEDIA_BYTES,
     _format_anthropic_video_data_block,
     _format_openai_video_block,
+    _replace_video_placeholders,
 )
 
 
@@ -142,3 +143,164 @@ def test_anthropic_missing_file_returns_none(tmp_path) -> None:
         ),
     )
     assert _format_anthropic_video_data_block(block) is None
+
+
+# --------------------------------- OpenAI Responses API (input_video)
+
+
+def test_openai_response_api_emits_input_video() -> None:
+    import base64
+
+    data = base64.b64encode(b"\x00" * 16).decode()
+    block = {
+        "source": {
+            "type": "base64",
+            "media_type": "video/mp4",
+            "data": data,
+        },
+    }
+    out = _format_openai_video_block(block, response_api=True)
+    assert out["type"] == "input_video"
+    assert out["video_url"].startswith("data:video/mp4;base64,")
+
+
+def test_openai_response_api_remote_url() -> None:
+    block = {
+        "source": {
+            "type": "url",
+            "url": "https://example.com/v.mp4",
+        },
+    }
+    out = _format_openai_video_block(block, response_api=True)
+    assert out["type"] == "input_video"
+    assert out["video_url"] == "https://example.com/v.mp4"
+
+
+def test_openai_response_api_local_file(tmp_path) -> None:
+    url = _write_video(tmp_path, "small.mp4", 64)
+    block = {"source": {"type": "url", "url": url}}
+    out = _format_openai_video_block(block, response_api=True)
+    assert out["type"] == "input_video"
+    assert out["video_url"].startswith("data:video/mp4;base64,")
+
+
+def test_openai_response_api_oversize_is_placeholder() -> None:
+    import base64
+
+    data = base64.b64encode(
+        b"\x00" * (MAX_INLINE_MEDIA_BYTES + 1),
+    ).decode()
+    block = {
+        "source": {
+            "type": "base64",
+            "media_type": "video/mp4",
+            "data": data,
+        },
+    }
+    out = _format_openai_video_block(block, response_api=True)
+    assert out["type"] == "input_text"
+    assert "video omitted" in out["text"]
+
+
+# ------------------------------------------- _replace_video_placeholders
+
+
+def _make_video_sub():
+    import base64
+
+    data = base64.b64encode(b"\x00" * 16).decode()
+    key = "__QWENPAW_VID_test__"
+    block = {
+        "source": {
+            "type": "base64",
+            "media_type": "video/mp4",
+            "data": data,
+        },
+    }
+    return key, block
+
+
+def _first_content_item(msgs: list[dict]) -> dict:
+    """Return the first content item of the first message."""
+    content = msgs[0]["content"]
+    assert isinstance(content, list)
+    return content[0]
+
+
+def test_replace_placeholders_text_type() -> None:
+    key, block = _make_video_sub()
+    msgs: list[dict] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": key},
+            ],
+        },
+    ]
+    _replace_video_placeholders(msgs, {key: block})
+    assert _first_content_item(msgs)["type"] == "video_url"
+
+
+def test_replace_placeholders_input_text_type() -> None:
+    key, block = _make_video_sub()
+    msgs: list[dict] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": key},
+            ],
+        },
+    ]
+    _replace_video_placeholders(msgs, {key: block})
+    assert _first_content_item(msgs)["type"] == "video_url"
+
+
+def test_replace_placeholders_skips_assistant_messages() -> None:
+    key, block = _make_video_sub()
+    msgs: list[dict] = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": key},
+            ],
+        },
+    ]
+    _replace_video_placeholders(msgs, {key: block})
+    item = _first_content_item(msgs)
+    assert item["type"] == "output_text"
+    assert item["text"] == key
+
+
+def test_replace_placeholders_response_api() -> None:
+    key, block = _make_video_sub()
+    msgs: list[dict] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": key},
+            ],
+        },
+    ]
+    _replace_video_placeholders(
+        msgs,
+        {key: block},
+        response_api=True,
+    )
+    item = _first_content_item(msgs)
+    assert item["type"] == "input_video"
+
+
+def test_replace_placeholders_non_match_untouched() -> None:
+    key, block = _make_video_sub()
+    msgs: list[dict] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "hello"},
+            ],
+        },
+    ]
+    _replace_video_placeholders(msgs, {key: block})
+    item = _first_content_item(msgs)
+    assert item["type"] == "input_text"
+    assert item["text"] == "hello"

--- a/tests/unit/providers/test_anthropic_provider.py
+++ b/tests/unit/providers/test_anthropic_provider.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=protected-access
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
 import qwenpaw.providers.anthropic_provider as anthropic_provider_module
@@ -270,3 +272,170 @@ async def test_update_config_updates_only_non_none_values() -> None:
     assert provider_info.api_key_prefix == "sk-ant-"
     assert provider_info.is_custom
     assert not provider_info.support_connection_check
+
+
+# ---------------------------------------- _try_video_source
+
+
+def _make_text_block(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _make_thinking_block(text: str):
+    return SimpleNamespace(type="thinking", thinking=text)
+
+
+def _make_response(*blocks):
+    return SimpleNamespace(content=list(blocks))
+
+
+async def test_try_video_source_color_match(monkeypatch) -> None:
+    provider = _make_provider()
+    resp = _make_response(_make_text_block("blue"))
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            _ = kwargs
+            return resp
+
+    fake_client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda timeout=30: fake_client,
+    )
+
+    result = await provider._try_video_source(
+        "test-model",
+        {"type": "base64", "media_type": "video/mp4", "data": "AA=="},
+        timeout=30,
+        start_time=time.monotonic(),
+    )
+    assert result is not None
+    ok, msg = result
+    assert ok is True
+    assert "Video supported" in msg
+
+
+async def test_try_video_source_thinking_block_match(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    resp = _make_response(
+        _make_thinking_block("The video shows a blue color"),
+        _make_text_block("unknown"),
+    )
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            _ = kwargs
+            return resp
+
+    fake_client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda timeout=30: fake_client,
+    )
+
+    result = await provider._try_video_source(
+        "test-model",
+        {"type": "base64", "media_type": "video/mp4", "data": "AA=="},
+        timeout=30,
+        start_time=time.monotonic(),
+    )
+    assert result is not None
+    ok, _ = result
+    assert ok is True
+
+
+async def test_try_video_source_no_match(monkeypatch) -> None:
+    provider = _make_provider()
+    resp = _make_response(_make_text_block("green"))
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            _ = kwargs
+            return resp
+
+    fake_client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda timeout=30: fake_client,
+    )
+
+    result = await provider._try_video_source(
+        "test-model",
+        {"type": "base64", "media_type": "video/mp4", "data": "AA=="},
+        timeout=30,
+        start_time=time.monotonic(),
+    )
+    assert result is not None
+    ok, msg = result
+    assert ok is False
+    assert "did not recognise" in msg
+
+
+async def test_try_video_source_400_returns_none(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+
+    class Fake400Error(
+        anthropic_provider_module.anthropic.APIError,
+    ):
+        def __init__(self):
+            self.status_code = 400
+            self.message = "bad"
+            self.body = {}
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            _ = kwargs
+            raise Fake400Error()
+
+    fake_client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda timeout=30: fake_client,
+    )
+
+    result = await provider._try_video_source(
+        "test-model",
+        {"type": "base64", "media_type": "video/mp4", "data": "AA=="},
+        timeout=30,
+        start_time=time.monotonic(),
+    )
+    assert result is None
+
+
+async def test_try_video_source_http_fallback_accepts_any_answer(
+    monkeypatch,
+) -> None:
+    provider = _make_provider()
+    resp = _make_response(_make_text_block("green"))
+
+    class FakeMessages:
+        async def create(self, **kwargs):
+            _ = kwargs
+            return resp
+
+    fake_client = SimpleNamespace(messages=FakeMessages())
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda timeout=30: fake_client,
+    )
+
+    result = await provider._try_video_source(
+        "test-model",
+        {"type": "url", "url": "https://example.com/v.mp4"},
+        timeout=30,
+        start_time=time.monotonic(),
+        is_http=True,
+    )
+    assert result is not None
+    ok, _ = result
+    assert ok is True

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -2,10 +2,14 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 
+import httpx
 from agentscope.model import OpenAIResponseModel
+from openai import BadRequestError
 
+from qwenpaw.providers.multimodal_prober import _PROBE_VIDEO_URL
 from qwenpaw.providers.openai_response_provider import (
     OpenAIResponseProvider,
     _extract_reasoning_text,
@@ -41,6 +45,17 @@ def _fake_response(text: str) -> SimpleNamespace:
     )
 
 
+def _bad_request(message: str) -> BadRequestError:
+    return BadRequestError(
+        message=message,
+        response=httpx.Response(
+            status_code=400,
+            request=httpx.Request("POST", "http://x"),
+        ),
+        body=None,
+    )
+
+
 # ------ _extract_response_text ----------------------------
 
 
@@ -54,9 +69,6 @@ def test_extract_response_text_prefers_output_text_attr() -> None:
     use it instead of manual traversal."""
     res = SimpleNamespace(output_text="aggregated text")
     assert _extract_response_text(res) == "aggregated text"
-
-
-# ------ _is_incomplete_due_to_tokens ---------------------
 
 
 def test_extract_reasoning_text() -> None:
@@ -115,20 +127,10 @@ async def test_image_probe_400_returns_not_supported(
     monkeypatch,
 ) -> None:
     """A 400 from responses.create means image not supported."""
-    import httpx
-    from openai import BadRequestError
-
     provider = _make_provider()
 
     async def fake_create(**_kwargs):
-        raise BadRequestError(
-            message="image not supported",
-            response=httpx.Response(
-                status_code=400,
-                request=httpx.Request("POST", "http://x"),
-            ),
-            body=None,
-        )
+        raise _bad_request("image not supported")
 
     mock_client = SimpleNamespace(
         responses=SimpleNamespace(create=fake_create),
@@ -187,8 +189,6 @@ async def test_video_probe_uses_responses_api(
 ) -> None:
     """Ensure video probe calls responses.create with
     input_video."""
-    import time
-
     captured: dict = {}
 
     async def fake_create(**kwargs):
@@ -228,22 +228,10 @@ async def test_video_probe_400_returns_none(
 ) -> None:
     """A 400 means this video format was rejected; return
     None so the caller tries the next format."""
-    import time
-
-    import httpx
-    from openai import BadRequestError
-
     provider = _make_provider()
 
     async def fake_create(**_kwargs):
-        raise BadRequestError(
-            message="video too short",
-            response=httpx.Response(
-                status_code=400,
-                request=httpx.Request("POST", "http://x"),
-            ),
-            body=None,
-        )
+        raise _bad_request("video too short")
 
     mock_client = SimpleNamespace(
         responses=SimpleNamespace(create=fake_create),
@@ -266,13 +254,9 @@ async def test_video_probe_400_returns_none(
 async def test_video_probe_no_color_match(
     monkeypatch,
 ) -> None:
-    """Model returns non-blue answer → not supported."""
-    import time
+    """Model returns non-blue answer -> not supported."""
 
-    captured: dict = {}
-
-    async def fake_create(**kwargs):
-        captured.update(kwargs)
+    async def fake_create(**_kwargs):
         return _fake_response("I cannot see any video")
 
     provider = _make_provider()
@@ -302,11 +286,6 @@ async def test_video_probe_http_fallback_accepts_any(
 ) -> None:
     """When using the HTTP probe URL, any non-empty answer
     is accepted as evidence of video support."""
-    import time
-
-    from qwenpaw.providers.multimodal_prober import (
-        _PROBE_VIDEO_URL,
-    )
 
     async def fake_create(**_kwargs):
         return _fake_response("something unrelated")
@@ -339,8 +318,6 @@ async def test_video_probe_reasoning_fallback(
 ) -> None:
     """When answer is empty but reasoning mentions 'blue',
     the evaluator still detects support."""
-    import time
-
     provider = _make_provider()
 
     async def fake_create(**_kwargs):

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -2,9 +2,401 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from agentscope.model import OpenAIResponseModel
 
-from qwenpaw.providers.openai_response_provider import OpenAIResponseProvider
+from qwenpaw.providers.openai_response_provider import (
+    OpenAIResponseProvider,
+    _extract_reasoning_text,
+    _extract_response_text,
+)
+
+
+def _make_provider() -> OpenAIResponseProvider:
+    return OpenAIResponseProvider(
+        id="openai-response",
+        name="OpenAI Responses",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+        chat_model="OpenAIResponseModel",
+    )
+
+
+def _fake_response(text: str) -> SimpleNamespace:
+    """Build a minimal Responses API result with one
+    output_text part."""
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[
+                    SimpleNamespace(
+                        type="output_text",
+                        text=text,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+# ------ _extract_response_text ----------------------------
+
+
+def test_extract_response_text_basic() -> None:
+    res = _fake_response("blue")
+    assert _extract_response_text(res) == "blue"
+
+
+def test_extract_response_text_empty_output() -> None:
+    res = SimpleNamespace(output=[])
+    assert _extract_response_text(res) == ""
+
+
+def test_extract_response_text_no_message_item() -> None:
+    res = SimpleNamespace(
+        output=[SimpleNamespace(type="function_call")],
+    )
+    assert _extract_response_text(res) == ""
+
+
+def test_extract_response_text_prefers_output_text_attr() -> None:
+    """When the SDK response has an output_text property,
+    use it instead of manual traversal."""
+    res = SimpleNamespace(output_text="aggregated text")
+    assert _extract_response_text(res) == "aggregated text"
+
+
+# ------ _is_incomplete_due_to_tokens ---------------------
+
+
+def test_extract_reasoning_text() -> None:
+    res = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                summary=[
+                    SimpleNamespace(text="thinking about"),
+                    SimpleNamespace(text="red color"),
+                ],
+            ),
+        ],
+    )
+    assert _extract_reasoning_text(res) == "thinking about red color"
+
+
+def test_extract_reasoning_text_empty() -> None:
+    res = SimpleNamespace(output=[])
+    assert _extract_reasoning_text(res) == ""
+
+
+# ------ _probe_image_support -----------------------------
+
+
+async def test_image_probe_uses_responses_api(
+    monkeypatch,
+) -> None:
+    """Ensure image probe calls responses.create with
+    input_image."""
+    captured: dict = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _fake_response("red")
+
+    provider = _make_provider()
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    ok, msg = await provider._probe_image_support("test-model")
+
+    assert ok is True
+    assert "red" in msg.lower()
+
+    inp = captured["input"]
+    assert inp[0]["role"] == "user"
+    types = [c["type"] for c in inp[0]["content"]]
+    assert "input_image" in types
+    assert "input_text" in types
+    assert "max_output_tokens" in captured
+
+
+async def test_image_probe_400_returns_not_supported(
+    monkeypatch,
+) -> None:
+    """A 400 from responses.create means image not supported."""
+    import httpx
+    from openai import BadRequestError
+
+    provider = _make_provider()
+
+    async def fake_create(**_kwargs):
+        raise BadRequestError(
+            message="image not supported",
+            response=httpx.Response(
+                status_code=400,
+                request=httpx.Request("POST", "http://x"),
+            ),
+            body=None,
+        )
+
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    ok, msg = await provider._probe_image_support("test-model")
+    assert ok is False
+    assert "not supported" in msg.lower()
+
+
+async def test_image_probe_reasoning_fallback(
+    monkeypatch,
+) -> None:
+    """When answer is empty but reasoning mentions 'red',
+    the evaluator still detects support."""
+    provider = _make_provider()
+
+    async def fake_create(**_kwargs):
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    summary=[
+                        SimpleNamespace(
+                            text="The image shows a red square",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    ok, msg = await provider._probe_image_support("test-model")
+    assert ok is True
+    assert "reasoning" in msg.lower()
+
+
+# ------ _try_video_url -----------------------------------
+
+
+async def test_video_probe_uses_responses_api(
+    monkeypatch,
+) -> None:
+    """Ensure video probe calls responses.create with
+    input_video."""
+    import time
+
+    captured: dict = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _fake_response("blue")
+
+    provider = _make_provider()
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    result = await provider._try_video_url(
+        "test-model",
+        "data:video/mp4;base64,AAAA",
+        timeout=10,
+        start_time=time.monotonic(),
+    )
+
+    assert result is not None
+    ok, msg = result
+    assert ok is True
+    assert "blue" in msg.lower()
+
+    inp = captured["input"]
+    types = [c["type"] for c in inp[0]["content"]]
+    assert "input_video" in types
+    assert "input_text" in types
+
+
+async def test_video_probe_400_returns_none(
+    monkeypatch,
+) -> None:
+    """A 400 means this video format was rejected; return
+    None so the caller tries the next format."""
+    import time
+
+    import httpx
+    from openai import BadRequestError
+
+    provider = _make_provider()
+
+    async def fake_create(**_kwargs):
+        raise BadRequestError(
+            message="video too short",
+            response=httpx.Response(
+                status_code=400,
+                request=httpx.Request("POST", "http://x"),
+            ),
+            body=None,
+        )
+
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    result = await provider._try_video_url(
+        "test-model",
+        "data:video/mp4;base64,AAAA",
+        timeout=10,
+        start_time=time.monotonic(),
+    )
+    assert result is None
+
+
+async def test_video_probe_no_color_match(
+    monkeypatch,
+) -> None:
+    """Model returns non-blue answer → not supported."""
+    import time
+
+    captured: dict = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _fake_response("I cannot see any video")
+
+    provider = _make_provider()
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    result = await provider._try_video_url(
+        "test-model",
+        "data:video/mp4;base64,AAAA",
+        timeout=10,
+        start_time=time.monotonic(),
+    )
+
+    assert result is not None
+    ok, _ = result
+    assert ok is False
+
+
+async def test_video_probe_http_fallback_accepts_any(
+    monkeypatch,
+) -> None:
+    """When using the HTTP probe URL, any non-empty answer
+    is accepted as evidence of video support."""
+    import time
+
+    from qwenpaw.providers.multimodal_prober import (
+        _PROBE_VIDEO_URL,
+    )
+
+    async def fake_create(**_kwargs):
+        return _fake_response("something unrelated")
+
+    provider = _make_provider()
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    result = await provider._try_video_url(
+        "test-model",
+        _PROBE_VIDEO_URL,
+        timeout=10,
+        start_time=time.monotonic(),
+    )
+
+    assert result is not None
+    ok, msg = result
+    assert ok is True
+    assert "http" in msg.lower()
+
+
+async def test_video_probe_reasoning_fallback(
+    monkeypatch,
+) -> None:
+    """When answer is empty but reasoning mentions 'blue',
+    the evaluator still detects support."""
+    import time
+
+    provider = _make_provider()
+
+    async def fake_create(**_kwargs):
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    summary=[
+                        SimpleNamespace(
+                            text="The video is blue",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    mock_client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create),
+    )
+    monkeypatch.setattr(
+        provider,
+        "_client",
+        lambda **_kw: mock_client,
+    )
+
+    result = await provider._try_video_url(
+        "test-model",
+        "data:video/mp4;base64,AAAA",
+        timeout=10,
+        start_time=time.monotonic(),
+    )
+
+    assert result is not None
+    ok, msg = result
+    assert ok is True
+    assert "reasoning" in msg.lower()
+
+
+# ------ existing test -----------------------------------
 
 
 async def test_summary_limit_is_adapted_for_responses_api(
@@ -17,14 +409,12 @@ async def test_summary_limit_is_adapted_for_responses_api(
         captured.update(kwargs)
         return "ok"
 
-    monkeypatch.setattr(OpenAIResponseModel, "_call_api", fake_call_api)
-    provider = OpenAIResponseProvider(
-        id="openai-response",
-        name="OpenAI Responses",
-        base_url="https://api.openai.com/v1",
-        api_key="sk-test",
-        chat_model="OpenAIResponseModel",
+    monkeypatch.setattr(
+        OpenAIResponseModel,
+        "_call_api",
+        fake_call_api,
     )
+    provider = _make_provider()
     model = provider.get_chat_model_instance("gpt-5")
 
     result = await model._call_api(

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -49,18 +49,6 @@ def test_extract_response_text_basic() -> None:
     assert _extract_response_text(res) == "blue"
 
 
-def test_extract_response_text_empty_output() -> None:
-    res = SimpleNamespace(output=[])
-    assert _extract_response_text(res) == ""
-
-
-def test_extract_response_text_no_message_item() -> None:
-    res = SimpleNamespace(
-        output=[SimpleNamespace(type="function_call")],
-    )
-    assert _extract_response_text(res) == ""
-
-
 def test_extract_response_text_prefers_output_text_attr() -> None:
     """When the SDK response has an output_text property,
     use it instead of manual traversal."""
@@ -84,11 +72,6 @@ def test_extract_reasoning_text() -> None:
         ],
     )
     assert _extract_reasoning_text(res) == "thinking about red color"
-
-
-def test_extract_reasoning_text_empty() -> None:
-    res = SimpleNamespace(output=[])
-    assert _extract_reasoning_text(res) == ""
 
 
 # ------ _probe_image_support -----------------------------


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
