### PR TITLE
fix(plugins): remove implicit max version derivation for legacy plugins

### DIFF
--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -2,8 +2,8 @@
 """Plugin–QwenPaw version compatibility check.
 
 Semantics: left-closed, right-open interval  ``>=min, <max``.
-When ``max`` is not specified, it is derived from ``min`` as
-``{major}.{minor+1}.0`` (all patch versions of the same minor).
+When ``max`` is not specified, no upper bound is enforced — the plugin
+is considered compatible with any QwenPaw version that satisfies ``>=min``.
 """
 
 from __future__ import annotations
@@ -51,16 +51,13 @@ def check_plugin_version_compat(
     qv = manifest.qwenpaw_version
     if qv is not None:
         min_v = Version(qv.min)
-        max_v = Version(qv.max) if qv.max else _derive_exclusive_max(qv.min)
+        max_v = Version(qv.max) if qv.max else None
     else:
         min_v = Version(manifest.min_version)
-        max_v = (
-            Version(manifest.max_version)
-            if manifest.max_version
-            else _derive_exclusive_max(manifest.min_version)
-        )
+        max_v = Version(manifest.max_version) if manifest.max_version else None
 
-    if current < min_v or current >= max_v:
-        msg = f"requires QwenPaw >={min_v}, <{max_v}, current is {current}"
+    if current < min_v or (max_v is not None and current >= max_v):
+        upper = f", <{max_v}" if max_v is not None else ""
+        msg = f"requires QwenPaw >={min_v}{upper}, current is {current}"
         return False, msg
     return True, ""

--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -4,6 +4,8 @@
 Semantics: left-closed, right-open interval  ``>=min, <max``.
 When ``max`` is not specified, no upper bound is enforced — the plugin
 is considered compatible with any QwenPaw version that satisfies ``>=min``.
+This follows the universal convention (pip, npm, cargo) where an
+unspecified upper bound means no upper bound.
 """
 
 from __future__ import annotations
@@ -23,6 +25,11 @@ def _derive_exclusive_max(min_str: str) -> Version:
     """Derive exclusive upper bound from a min version string.
 
     '1.1.6' -> Version('1.2.0')
+
+    .. deprecated::
+        This function is retained for backward compatibility but no longer
+        called by :func:`check_plugin_version_compat`.  An unspecified ``max``
+        now means *no upper bound* instead of a derived exclusive bound.
     """
     parts = min_str.split(".")
     major = int(parts[0])

--- a/tests/unit/plugins/test_download_catalog.py
+++ b/tests/unit/plugins/test_download_catalog.py
@@ -10,12 +10,14 @@ def test_entry_with_qwenpaw_version_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        "qwenpaw_version": {"min": "1.1.6", "max": "2.1.0"},
+        # Exclusive upper bound: current 2.1.0b1 is treated as 2.1.0.
+        "qwenpaw_version": {"min": "1.1.6", "max": "2.2.0"},
     }
     assert _is_entry_compatible(entry) is True
 
 
 def test_entry_with_qwenpaw_version_incompatible() -> None:
+    """Declared max excludes a newer running QwenPaw."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
@@ -28,7 +30,8 @@ def test_entry_with_only_min_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        "qwenpaw_version": {"min": "2.0.0"},
+        # No max specified: no upper bound enforced.
+        "qwenpaw_version": {"min": "2.1.0"},
     }
     assert _is_entry_compatible(entry) is True
 
@@ -57,7 +60,7 @@ def test_entry_with_malformed_qwenpaw_version_falls_to_legacy() -> None:
         "version": "1.0.0",
         "qwenpaw_version": "not-a-dict",
         "min_version": "1.0.0",
-        "max_version": "2.1.0",
+        "max_version": "2.2.0",
     }
     assert _is_entry_compatible(entry) is True
 
@@ -77,7 +80,7 @@ def test_legacy_min_version_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        "min_version": "2.0.0",
+        "min_version": "2.1.0",
     }
     assert _is_entry_compatible(entry) is True
 
@@ -98,7 +101,7 @@ def test_legacy_min_max_version_compatible() -> None:
         "id": "demo",
         "version": "1.0.0",
         "min_version": "1.0.0",
-        "max_version": "2.1.0",
+        "max_version": "2.2.0",
     }
     assert _is_entry_compatible(entry) is True
 


### PR DESCRIPTION
## Description

Removes the implicit upper-bound derivation in `_version_compat.py` that was silently disabling legacy plugins on QwenPaw 2.0+.

When a plugin's `plugin.json` does not specify `max_version` (or `qwenpaw_version.max`), the `_derive_exclusive_max()` function derived an upper bound from `min_version` (e.g. `"0.1.0" → "0.2.0"`). On QwenPaw 2.0.1, this caused `current(2.0.1) >= max_v(0.2.0)` → incompatible, silently setting `enabled=False` and skipping `register()`. The plugin's tools never entered `ToolRegistry`, so they were invisible to the LLM — with only a WARNING log.

**Fix:** When `max` is not specified, set `max_v = None` and skip the upper-bound check entirely. This follows the universal convention (pip, npm) that `>=min` without an explicit max means no upper bound.

**Related Issue:** Fixes #6496

**Security Considerations:** None. Only affects plugin version compatibility checking logic.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

N/A — no channel changes.

## Testing

All testing was performed locally with QwenPaw 2.0.1 on Python 3.12 using `uv` for environment management and editable installs.

### End-to-end test (CLI + HTTP API)

Two identical plugins differing only in version declaration:

| Plugin | min_version | max_version |
|--------|------------|-------------|
| `normal-echo` | `2.0.0` | `3.0.0` |
| `legacy-echo` | `0.1.0` (default) | not specified |

Flow: `qwenpaw init` → `qwenpaw plugin install` (both) → `qwenpaw app --port 18080` → `curl /api/plugins` + `curl /api/tools`

### Regression test

Verified that genuinely incompatible plugins are still correctly blocked:

| Case | Expected | Result |
|------|---------|--------|
| `min=0.1.0, max=None` | compatible | ✅ `True` |
| `min=2.0.0, max=3.0.0` | compatible | ✅ `True` |
| no version fields (default) | compatible | ✅ `True` |
| `min=3.0.0, max=None` | incompatible | ✅ `False` |
| `min=2.0.0, max=2.0.1` | incompatible | ✅ `False` |

## Evidence

The following terminal transcripts and API responses demonstrate the bug before the fix and the correct behavior after the fix. All evidence was collected from a local QwenPaw 2.0.1 instance with two test plugins (`legacy-echo` and `normal-echo`) that differ only in their version declaration.

### 1. `/api/plugins` — before fix

```json
{
    "id": "legacy-echo",
    "enabled": false,
    "loaded": false
}
```

### 2. `/api/plugins` — after fix

```json
{
    "id": "legacy-echo",
    "enabled": true,
    "loaded": true
}
```

### 3. `/api/tools` — after fix

```
总工具数: 28
echo 相关工具: 2
  - name=normal_echo, enabled=True
  - name=legacy_echo, enabled=True
```

### 4. Server log — before fix

```
WARNING Plugin 'legacy-echo' is incompatible: requires QwenPaw >=0.1.0, <0.2.0, current is 2.0.1
```

### 5. Server log — after fix

```
INFO ✓ Loaded plugin 'legacy-echo' successfully
INFO Registered tool function 'legacy_echo' to tools module
INFO Injected 'legacy_echo' into workspace 'default' ToolRegistry
```

### 6. Unit-level version compatibility check — after fix

```python
>>> check_plugin_version_compat(PluginManifest(id='legacy-echo', version='1.0.0', min_version='0.1.0'))
(True, '')

>>> check_plugin_version_compat(PluginManifest(id='future', version='1.0.0', min_version='3.0.0'))
(False, 'requires QwenPaw >=3.0.0, current is 2.0.1')

>>> check_plugin_version_compat(PluginManifest(id='tight', version='1.0.0', min_version='2.0.0', max_version='2.0.1'))
(False, 'requires QwenPaw >=2.0.0, <2.0.1, current is 2.0.1')
```

## Additional Notes

- The `_derive_exclusive_max()` function is retained but no longer called, to avoid breaking any external imports.
- All 10 built-in plugins use `qwenpaw_version` (new API). 9 specify explicit `max` (zero behavior change). 1 (`agent-kanban`) omits `max` — it is now compatible with future QwenPaw minor versions instead of being silently blocked at the next minor boundary.
