### PR TITLE
fix(browser): make unauthenticated local CDP exposure opt-in

### DIFF
--- a/src/qwenpaw/agents/skills/browser_cdp-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_cdp-en/SKILL.md
@@ -2,7 +2,7 @@
 name: browser_cdp
 description: "Use this skill when the user explicitly wants to connect to a running Chrome browser, scan local CDP ports, specify a `cdp_port`, or share a single browser across multiple agents/tools. By default browser_use opens no debugging port; pass an explicit `cdp_port` only when the user wants another local tool to attach."
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🔌"
     requires: {}
@@ -10,7 +10,7 @@ metadata:
 
 # Browser CDP Reference
 
-By default, **browser_use** launches and manages the local Chrome/Chromium via **managed CDP**, but this does not mean the CDP port should be exposed to the user or other tools every time.
+By default, **browser_use** opens no debugging port: the browser is managed directly by Playwright over a pipe. This skill covers the cases where a CDP port is wanted on purpose.
 
 This skill focuses on more "explicit" CDP usage:
 
@@ -21,12 +21,12 @@ This skill focuses on more "explicit" CDP usage:
 
 In other words:
 
-- The default `start` uses managed CDP under the hood, but users typically do not need to understand or be aware of CDP details
+- The default `start` opens no debugging port, so users typically do not need to understand or be aware of CDP details
 - Only enter the scope of this skill when the user explicitly mentions "connect to an existing browser / scan ports / specify a port / share a browser"
 
 > **Privacy Recommendation**
 >
-> If the user does not want to expose browser history, cookies, page content, or session data, recommend using `private_mode=true`, which switches to Playwright-managed mode.
+> The default `start` exposes nothing — no debugging port is opened. Only pass `cdp_port` when the user explicitly wants another local tool to attach, and warn about the exposure first.
 
 > **Warning: One browser instance per workspace**
 >
@@ -121,8 +121,8 @@ To also open a visible window:
 Current behavior:
 
 - If the explicitly specified `cdp_port` is already in use, an error is raised immediately — it will not forcefully reuse the port
-- If `cdp_port` is not specified, an available port is automatically selected, which usually avoids multi-workspace conflicts
-- Auto-selecting an available port still has a tiny race window: between "finding an available port" and "Chrome actually binding to the port", another process could theoretically claim it; on failure, cleanup occurs and an error is reported, but there is no automatic retry
+- If `cdp_port` is not specified, no port is opened and none is chosen automatically
+- An explicitly specified port still has a tiny race window: between "checking that the port is free" and "Chrome actually binding to it", another process could theoretically claim it; on failure, cleanup occurs and an error is reported, but there is no automatic retry
 
 Therefore:
 
@@ -136,11 +136,11 @@ Therefore:
 The current port strategy for multiple workspaces:
 
 - **Explicitly specified port**: checks whether `127.0.0.1:cdp_port` is already in use; if so, fails immediately and prompts the user to choose a different port or stop the old process
-- **No explicit port**: reduces conflict probability by automatically selecting an available port
+- **No explicit port**: no port is opened, so there is no conflict to begin with
 
 This means:
 
-- Multiple workspaces using the default launch can usually coexist
+- Multiple workspaces using the default launch always coexist, because no port is opened
 - If multiple workspaces all request the same fixed `cdp_port`, the later one will fail because the port is already in use
 
 ---
@@ -152,12 +152,6 @@ CDP-related stop behavior differs depending on the type:
 ### 1. Managed CDP launched by QwenPaw
 
 For example:
-
-```json
-{"action": "start"}
-```
-
-Or:
 
 ```json
 {"action": "start", "cdp_port": 9222}
@@ -197,7 +191,7 @@ In short:
 
 ## Notes
 
-- Although the default `start` uses managed CDP internally, this is the tool's default implementation detail and does not mean CDP concepts should be exposed to the user every time
+- The default `start` opens no debugging port; surface CDP concepts to the user only when they explicitly ask for them
 - Before using explicit CDP capabilities, warn the user about the risk of sensitive data exposure
 - Auto-stop for external CDP means "auto-disconnect," not "auto-close the user's browser"
 - Activity is currently refreshed primarily by tool operations; the user's manual interactions in the browser window typically do not reset the idle timer

--- a/src/qwenpaw/agents/skills/browser_cdp-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_cdp-en/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser_cdp
-description: "Use this skill when the user explicitly wants to connect to a running Chrome browser, scan local CDP ports, specify a `cdp_port`, or share a single browser across multiple agents/tools. By default, browser_use already launches the browser using managed CDP; if the user does not want to expose browser history, cookies, or other sensitive data, recommend using `private_mode=true` instead."
+description: "Use this skill when the user explicitly wants to connect to a running Chrome browser, scan local CDP ports, specify a `cdp_port`, or share a single browser across multiple agents/tools. By default browser_use opens no debugging port; pass an explicit `cdp_port` only when the user wants another local tool to attach."
 metadata:
   builtin_skill_version: "1.2"
   qwenpaw:

--- a/src/qwenpaw/agents/skills/browser_cdp-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_cdp-zh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser_cdp
-description: "当用户明确希望连接到已运行的 Chrome 浏览器、扫描本地 CDP 端口、显式指定 `cdp_port`，或让多个 agent / 工具共享同一个浏览器时，使用本 skill。当前 browser_use 默认已使用 managed CDP 启动浏览器；如果用户不希望暴露浏览器历史、Cookies 等敏感信息，推荐改用 `private_mode=true` 的隐私模式。"
+description: "当用户明确希望连接到已运行的 Chrome 浏览器、扫描本地 CDP 端口、显式指定 `cdp_port`，或让多个 agent / 工具共享同一个浏览器时，使用本 skill。browser_use 默认不开放调试端口；仅当用户明确希望其他本地工具附加时才显式传入 `cdp_port`。"
 metadata:
   builtin_skill_version: "1.2"
   qwenpaw:

--- a/src/qwenpaw/agents/skills/browser_cdp-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_cdp-zh/SKILL.md
@@ -2,7 +2,7 @@
 name: browser_cdp
 description: "当用户明确希望连接到已运行的 Chrome 浏览器、扫描本地 CDP 端口、显式指定 `cdp_port`，或让多个 agent / 工具共享同一个浏览器时，使用本 skill。browser_use 默认不开放调试端口；仅当用户明确希望其他本地工具附加时才显式传入 `cdp_port`。"
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🔌"
     requires: {}
@@ -10,7 +10,7 @@ metadata:
 
 # 浏览器 CDP 使用参考
 
-当前 **browser_use** 默认就是以 **managed CDP** 方式启动并接管本地 Chrome/Chromium，但这不等于每次都应该把 CDP 端口暴露给用户或其他工具。
+**browser_use** 默认不开放调试端口，浏览器由 Playwright 通过管道直接管理。本 skill 关注的是有意需要 CDP 端口的场景。
 
 本 skill 关注的是更“显式”的 CDP 用法：
 
@@ -21,12 +21,12 @@ metadata:
 
 也就是说：
 
-- 普通 `start` 默认会使用 managed CDP，但通常不需要用户理解或感知 CDP 细节
+- 普通 `start` 不开放调试端口，通常不需要用户理解或感知 CDP 细节
 - 只有在用户明确提出“连接现有浏览器 / 扫描端口 / 指定端口 / 共享浏览器”时，才应进入本 skill 的语义范围
 
 > **隐私建议**
 >
-> 如果用户不希望暴露浏览器历史、Cookies、页面内容或会话信息，推荐使用 `private_mode=true`，改走 Playwright 直接管理模式。
+> 默认 `start` 本身不暴露任何东西——不会开放调试端口。只有用户明确希望其他本地工具附加时才传 `cdp_port`，并应先提示暴露风险。
 
 > **⚠️ 单 workspace 单浏览器实例**
 >
@@ -121,8 +121,8 @@ metadata:
 当前行为说明：
 
 - 如果显式指定的 `cdp_port` 已被占用，会直接报错，不会强行复用
-- 如果不指定 `cdp_port`，默认会自动挑选空闲端口，通常可避免多 workspace 冲突
-- 自动挑空闲端口仍存在极小 race window：在“找到空闲端口”和“Chrome 真正绑定端口”之间理论上可能被别的进程抢占；当前失败时会清理并报错，但不会自动重试
+- 如果不指定 `cdp_port`，则完全不开放端口，也不会自动挑选端口
+- 显式指定端口时仍存在极小 race window：在“检测端口空闲”和“Chrome 真正绑定端口”之间理论上可能被别的进程抢占；当前失败时会清理并报错，但不会自动重试
 
 因此：
 
@@ -136,11 +136,11 @@ metadata:
 当前多 workspace 下的端口策略是：
 
 - **显式指定端口**：先检测 `127.0.0.1:cdp_port` 是否已占用；若已占用则直接失败，提示用户换端口或先停止旧进程
-- **未显式指定端口**：通过自动选空闲端口来降低冲突概率
+- **未显式指定端口**：不开放端口，因而不存在冲突
 
 这意味着：
 
-- 多个 workspace 同时使用默认启动，通常可以并存
+- 多个 workspace 同时使用默认启动一定可以并存，因为不开放端口
 - 如果多个 workspace 都要求同一个固定 `cdp_port`，后启动的那个会因为端口已占用而失败
 
 ---
@@ -152,12 +152,6 @@ CDP 相关 stop 需要区分两类：
 ### 1. QwenPaw 自己启动的 managed CDP
 
 例如：
-
-```json
-{"action": "start"}
-```
-
-或：
 
 ```json
 {"action": "start", "cdp_port": 9222}
@@ -197,7 +191,7 @@ CDP 相关 stop 需要区分两类：
 
 ## 注意
 
-- 默认 `start` 虽然底层使用 managed CDP，但这属于 tool 的内部默认实现，不代表每次都要把 CDP 概念暴露给用户
+- 默认 `start` 不开放调试端口；只有用户明确询问时才向其暴露 CDP 概念
 - 使用显式 CDP 能力前，应提醒用户存在敏感数据暴露风险
 - external CDP 的 auto-stop 是“自动断开”，不是“自动关闭用户浏览器”
 - 当前 activity 主要由 tool 操作刷新；用户手动在浏览器窗口中的本地交互，通常不会刷新 idle 计时

--- a/src/qwenpaw/agents/skills/browser_visible-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_visible-en/SKILL.md
@@ -2,7 +2,7 @@
 name: browser_visible
 description: "Use this skill when the user needs to control the browser launch mode for browser_use. By default browser_use is managed by Playwright over a pipe and opens no debugging port (pass an explicit `cdp_port` to let another local tool attach); `headed` controls whether the window is visible, and `private_mode` is kept for backward compatibility and no longer changes the default."
 metadata:
-  builtin_skill_version: "1.2"
+  builtin_skill_version: "1.3"
   qwenpaw:
     emoji: "🖥️"
     requires: {}
@@ -19,7 +19,7 @@ metadata:
 Parameter meanings:
 
 - `headed`: whether to display the browser window
-- `private_mode`: whether to disable CDP and use Playwright instead
+- `private_mode`: kept for backward compatibility; it no longer changes the launch mode
 
 The two parameters are independent and can be freely combined.
 
@@ -35,32 +35,17 @@ Open a visible window:
 {"action": "start", "headed": true}
 ```
 
-Without CDP:
-```json
-{"action": "start", "private_mode": true}
-```
+## `private_mode`
 
-Visible window + without CDP:
-```json
-{"action": "start", "headed": true, "private_mode": true}
-```
-
-## When to Use `private_mode`
-
-Only set `private_mode=true` when the user explicitly requests one of the following:
-
-- Does not want the browser managed via CDP
-- Wants to use Playwright instead
-- Wants to reduce the possibility of other local tools connecting via CDP
-
-Otherwise, just set `headed=true` as needed.
+Already the default behavior — do not set it. The parameter is kept only so
+that older calls keep working, and passing it together with `cdp_port` is
+rejected.
 
 ## Notes
 
 - The default is Playwright-managed with no debugging port
 - The launch mode is entirely determined by the call parameters
 - Managed CDP requires Chrome / Chromium / Edge to be installed locally
-- `private_mode=true` does not mean absolutely undetectable — it simply switches to Playwright management
 - When the user manually operates the visible browser, the idle timer may not be refreshed
 - `private_mode` is an explicit parameter for each `start` call and is not persisted
 - If a browser is already running, you must `stop` it and then `start` again to switch launch modes or window visibility

--- a/src/qwenpaw/agents/skills/browser_visible-en/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_visible-en/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser_visible
-description: "Use this skill when the user needs to control the browser launch mode for browser_use. By default, browser_use launches the local Chrome/Chromium using managed CDP; `headed` controls whether the window is visible, and `private_mode` controls whether CDP is disabled in favor of Playwright."
+description: "Use this skill when the user needs to control the browser launch mode for browser_use. By default browser_use is managed by Playwright over a pipe and opens no debugging port (pass an explicit `cdp_port` to let another local tool attach); `headed` controls whether the window is visible, and `private_mode` is kept for backward compatibility and no longer changes the default."
 metadata:
   builtin_skill_version: "1.2"
   qwenpaw:
@@ -10,10 +10,11 @@ metadata:
 
 # Browser Launch Modes
 
-`browser_use.start` has only two launch modes:
+`browser_use.start` launch modes:
 
-- Default: managed CDP
-- `private_mode=true`: Playwright-managed
+- Default: Playwright-managed, no debugging port
+- `cdp_port=N`: managed CDP, opens a local debugging port so other local tools can attach (see the browser_cdp skill)
+- `private_mode=true`: same as the default, kept for backward compatibility
 
 Parameter meanings:
 
@@ -56,7 +57,7 @@ Otherwise, just set `headed=true` as needed.
 
 ## Notes
 
-- The default is managed CDP
+- The default is Playwright-managed with no debugging port
 - The launch mode is entirely determined by the call parameters
 - Managed CDP requires Chrome / Chromium / Edge to be installed locally
 - `private_mode=true` does not mean absolutely undetectable — it simply switches to Playwright management

--- a/src/qwenpaw/agents/skills/browser_visible-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_visible-zh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser_visible
-description: "当用户需要控制 browser_use 的浏览器启动方式时，使用本 skill。当前 browser_use 默认使用 managed CDP 启动本地 Chrome/Chromium；`headed` 控制是否显示窗口，`private_mode` 控制是否禁用 CDP、改走 Playwright，`browser_args` 传入额外的 Chromium 启动参数，`executable_path` 指定自定义浏览器可执行文件路径。"
+description: "当用户需要控制 browser_use 的浏览器启动方式时，使用本 skill。browser_use 默认由 Playwright 通过管道直接管理、不开放调试端口（需让其他本地工具附加时显式传 `cdp_port`）；`headed` 控制是否显示窗口，`private_mode` 保留用于兼容、不再改变默认行为，`browser_args` 传入额外的 Chromium 启动参数，`executable_path` 指定自定义浏览器可执行文件路径。"
 metadata:
   builtin_skill_version: "1.3"
   qwenpaw:
@@ -10,10 +10,11 @@ metadata:
 
 # 浏览器启动模式
 
-`browser_use.start` 只有两种启动方式：
+`browser_use.start` 的启动方式：
 
-- 默认：managed CDP
-- `private_mode=true`：Playwright 直接管理
+- 默认：Playwright 直接管理，不开放调试端口
+- `cdp_port=N`：managed CDP，开放本地调试端口供其他本地工具附加（详见 browser_cdp skill）
+- `private_mode=true`：与默认相同，保留用于兼容
 
 参数含义：
 
@@ -90,7 +91,7 @@ metadata:
 
 ## 注意
 
-- 默认就是 managed CDP
+- 默认由 Playwright 直接管理，不开放调试端口
 - 启动方式完全由调用参数决定
 - managed CDP 依赖本机存在 Chrome / Chromium / Edge
 - `private_mode=true` 不等于绝对不可检测，只是改为 Playwright 管理

--- a/src/qwenpaw/agents/skills/browser_visible-zh/SKILL.md
+++ b/src/qwenpaw/agents/skills/browser_visible-zh/SKILL.md
@@ -2,7 +2,7 @@
 name: browser_visible
 description: "当用户需要控制 browser_use 的浏览器启动方式时，使用本 skill。browser_use 默认由 Playwright 通过管道直接管理、不开放调试端口（需让其他本地工具附加时显式传 `cdp_port`）；`headed` 控制是否显示窗口，`private_mode` 保留用于兼容、不再改变默认行为，`browser_args` 传入额外的 Chromium 启动参数，`executable_path` 指定自定义浏览器可执行文件路径。"
 metadata:
-  builtin_skill_version: "1.3"
+  builtin_skill_version: "1.4"
   qwenpaw:
     emoji: "🖥️"
     requires: {}
@@ -19,7 +19,7 @@ metadata:
 参数含义：
 
 - `headed`：是否显示浏览器窗口
-- `private_mode`：是否禁用 CDP，改走 Playwright
+- `private_mode`：保留用于兼容，不再改变启动方式
 - `browser_args`：额外的 Chromium 启动参数（字符串），多个参数用空格分隔。适用于所有启动路径（headless、headed、managed CDP）。例如 `"--incognito"` 启用隐身模式，`"--proxy-server=http://127.0.0.1:7890"` 设置代理。默认空字符串（无额外参数）。
 - `executable_path`：自定义浏览器可执行文件路径（字符串）。设置后覆盖系统默认浏览器检测，可指定任意基于 Chromium 的浏览器。例如 `"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"`。仅允许包含已知浏览器关键词（chrome、chromium、edge、firefox、brave 等）的可执行文件，且文件必须存在。默认空字符串（使用系统默认）。
 
@@ -37,16 +37,6 @@ metadata:
 {"action": "start", "headed": true}
 ```
 
-不走 CDP：
-```json
-{"action": "start", "private_mode": true}
-```
-
-可见窗口 + 不走 CDP：
-```json
-{"action": "start", "headed": true, "private_mode": true}
-```
-
 隐身模式：
 ```json
 {"action": "start", "headed": true, "browser_args": "--incognito"}
@@ -57,15 +47,9 @@ metadata:
 {"action": "start", "headed": true, "browser_args": "--proxy-server=http://127.0.0.1:7890", "executable_path": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"}
 ```
 
-## 什么时候用 `private_mode`
+## `private_mode`
 
-只有当用户明确要求以下之一时，再设置 `private_mode=true`：
-
-- 不想通过 CDP 管理浏览器
-- 想改走 Playwright
-- 想减少被其他本地工具通过 CDP 连接的可能性
-
-否则只按需设置 `headed=true` 即可。
+已是默认行为，无需设置。该参数仅为兼容旧调用而保留，与 `cdp_port` 同时传入会被拒绝。
 
 ## 什么时候用 `browser_args`
 
@@ -94,7 +78,6 @@ metadata:
 - 默认由 Playwright 直接管理，不开放调试端口
 - 启动方式完全由调用参数决定
 - managed CDP 依赖本机存在 Chrome / Chromium / Edge
-- `private_mode=true` 不等于绝对不可检测，只是改为 Playwright 管理
 - 用户手动操作可见浏览器时，不一定会刷新 idle 计时
 - `private_mode`、`browser_args`、`executable_path` 都是每次 `start` 的显式参数，不会持久保存
 - 若当前已有浏览器在运行，需要先 `stop` 再重新 `start`，才能切换启动方式、窗口可见性或启动参数。

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1708,6 +1708,20 @@ async def _action_start(
     executable_path: str = "",
 ) -> ToolChunk:
     _validate_executable_path(executable_path)
+    if cdp_port and private_mode:
+        return _tool_response(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": (
+                        "private_mode=true conflicts with cdp_port; "
+                        "drop one of them."
+                    ),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
     # Check browser state based on mode
     if _USE_SYNC_PLAYWRIGHT:
         browser_exists = (
@@ -1779,7 +1793,10 @@ async def _action_start(
     started_playwright = None
     cleanup_errors: list[str] = []
     try:
-        if not _USE_SYNC_PLAYWRIGHT and not bool(private_mode):
+        if not _USE_SYNC_PLAYWRIGHT and _should_use_managed_cdp(
+            private_mode,
+            cdp_port,
+        ):
             await _start_managed_cdp_browser(
                 state,
                 cdp_port=cdp_port,

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1801,6 +1801,12 @@ async def _action_start(
             )
     # Default: headless (background). Only headed=True (e.g. browser_visible skill) shows window.
     state["headless"] = not headed
+    # Record the exposure decision next to the other launch intent, before any
+    # preflight check can return early: _reset_browser_state keeps "_" prefixed
+    # keys, so a rejected start must not leave an earlier decision behind for
+    # _ensure_browser to replay.
+    state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
+    state["_cdp_port"] = cdp_port
 
     if cdp_port:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _s:
@@ -1823,11 +1829,6 @@ async def _action_start(
     started_playwright = None
     cleanup_errors: list[str] = []
     try:
-        # Record the exposure decision before launching, so that a failed
-        # start cannot leave a previous start's decision behind for
-        # _ensure_browser to replay (_reset_browser_state keeps "_" keys).
-        state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
-        state["_cdp_port"] = cdp_port
         if not _USE_SYNC_PLAYWRIGHT and _should_use_managed_cdp(
             private_mode,
             cdp_port,

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1189,7 +1189,7 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     executable_path: str = "",
 ) -> None:
     default_kind, exe = await asyncio.to_thread(
-        _resolve_chromium_launch_target
+        _resolve_chromium_launch_target,
     )
     explicit_exe = bool(executable_path)
     if executable_path:
@@ -1865,7 +1865,8 @@ async def _action_start(
                 json.dumps(result, ensure_ascii=False, indent=2),
             )
     if cdp_port and await asyncio.to_thread(
-        _probe_local_port_in_use, cdp_port
+        _probe_local_port_in_use,
+        cdp_port,
     ):
         return _tool_response(
             json.dumps(

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1054,9 +1054,14 @@ def _resolve_chromium_launch_target() -> tuple[Optional[str], Optional[str]]:
     return default_kind, _chromium_executable_path()
 
 
-_FORBIDDEN_BROWSER_ARGS = (
-    "--remote-debugging-port",
-    "--remote-debugging-address",
+# Chromium treats "--switch", "-switch" and (on Windows) "/switch" as
+# equivalent, so the guard below compares bare switch names.
+_SWITCH_PREFIXES = ("--", "-", "/") if sys.platform == "win32" else ("--", "-")
+_FORBIDDEN_SWITCH_NAMES = frozenset(
+    {
+        "remote-debugging-port",
+        "remote-debugging-address",
+    },
 )
 
 
@@ -1067,15 +1072,26 @@ def _should_use_managed_cdp(private_mode: bool, cdp_port: int) -> bool:
     return cdp_port > 0
 
 
+def _switch_name(part: str) -> str:
+    """Return the bare switch name, or "" when *part* is not a switch."""
+    for prefix in _SWITCH_PREFIXES:  # "--" is matched before "-"
+        if part.startswith(prefix):
+            return part[len(prefix) :].split("=", 1)[0].lower()
+    return ""
+
+
 def _reject_debug_surface_args(browser_args: str) -> None:
-    """Reject launch args that would re-open an unauthenticated CDP surface."""
+    """Reject launch args that would re-open an unauthenticated CDP surface.
+
+    This guards against accidental exposure; it is not a security boundary,
+    because browser_args carries full local command-line power by design.
+    """
     if not browser_args:
         return
     for part in shlex.split(browser_args, posix=sys.platform != "win32"):
-        flag = part.split("=", 1)[0]
-        if flag in _FORBIDDEN_BROWSER_ARGS:
+        if _switch_name(part) in _FORBIDDEN_SWITCH_NAMES:
             raise ValueError(
-                f"{flag} is not allowed in browser_args; "
+                f"{part.split('=', 1)[0]} is not allowed in browser_args; "
                 "use the cdp_port parameter instead.",
             )
 

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -12,7 +12,6 @@ wait_for, pdf, close. Uses refs from snapshot for ref-based actions.
 import asyncio
 import atexit
 from collections.abc import Iterable
-import contextlib
 from concurrent import futures
 import json
 import logging
@@ -1147,14 +1146,25 @@ def _fetch_cdp_version(url: str) -> dict[str, Any]:
 async def _wait_for_cdp_ready(
     port: int,
     proc: subprocess.Popen,
-    user_data_dir: str,
     timeout: float = 15.0,
 ) -> dict[str, Any]:
-    """Wait until our Chrome process owns the CDP endpoint on *port*."""
+    """Wait until the CDP endpoint of the Chrome we spawned answers on *port*.
+
+    Ownership model: _start_managed_cdp_browser() verified the port was free
+    immediately before spawning *proc* (fail-closed preflight), and this loop
+    fails closed as soon as *proc* exits -- including right after a probe
+    succeeded, so a foreign endpoint answering while our Chrome dies from a
+    bind conflict is still rejected. The remaining race -- a foreign process
+    binding the port in the milliseconds between preflight and Chrome's own
+    bind while our Chrome keeps running unbound -- is an accepted residual:
+    this guard targets accidental exposure, not a hostile local process.
+    DevToolsActivePort cannot serve as an ownership proof here: with a fixed
+    --remote-debugging-port, current Chrome (verified on 150) never writes
+    that file.
+    """
     deadline = time.monotonic() + timeout
     last_error: Optional[Exception] = None
     url = f"http://127.0.0.1:{port}/json/version"
-    port_file = Path(user_data_dir) / "DevToolsActivePort"
     while time.monotonic() < deadline:
         exit_code = proc.poll()
         if exit_code is not None:
@@ -1164,20 +1174,22 @@ async def _wait_for_cdp_ready(
                 "another process.",
             )
         try:
-            first_line = (
-                port_file.read_text(encoding="utf-8").splitlines()[0].strip()
-            )
-        except (OSError, IndexError):
-            first_line = ""
-        if first_line == str(port):
-            try:
-                return await asyncio.to_thread(_fetch_cdp_version, url)
-            except Exception as exc:
-                last_error = exc
+            version = await asyncio.to_thread(_fetch_cdp_version, url)
+        except Exception as exc:
+            last_error = exc
+        else:
+            exit_code = proc.poll()
+            if exit_code is not None:
+                raise RuntimeError(
+                    f"Chrome exited (code {exit_code}) right after the CDP "
+                    f"endpoint on port {port} answered; refusing to attach "
+                    "to an endpoint our process does not own.",
+                )
+            return version
         await asyncio.sleep(0.2)
     raise RuntimeError(
         f"Timed out waiting for Chrome CDP endpoint on port {port}: "
-        f"{last_error or 'DevToolsActivePort not written by our process'}",
+        f"{last_error or 'no response from endpoint'}",
     )
 
 
@@ -1228,7 +1240,7 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     )
     pw = None
     try:
-        await _wait_for_cdp_ready(chosen_cdp_port, proc, user_data_dir)
+        await _wait_for_cdp_ready(chosen_cdp_port, proc)
         async_playwright = _ensure_playwright_async()
         pw = await async_playwright().start()
         browser = await pw.chromium.connect_over_cdp(
@@ -1282,8 +1294,6 @@ def _start_managed_chromium_process(
     browser_args: str = "",
 ) -> subprocess.Popen:
     _secure_profile_directory(user_data_dir)
-    with contextlib.suppress(OSError):
-        (Path(user_data_dir) / "DevToolsActivePort").unlink()
     args = [
         executable_path,
         f"--remote-debugging-port={cdp_port}",
@@ -1854,6 +1864,14 @@ async def _action_start(
                 await _action_stop(state)
             except Exception:
                 pass
+            # The old session is being destroyed to satisfy this new request,
+            # so its recorded launch config no longer describes a live
+            # session. On success the block below records the new config; on
+            # failure _ensure_browser must not replay the dead session.
+            state.pop("_expose_cdp", None)
+            state.pop("_cdp_port", None)
+            state.pop("_browser_args", None)
+            state.pop("_executable_path", None)
         else:
             result: dict[str, Any] = {
                 "ok": True,

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -959,6 +959,12 @@ def _sync_browser_launch(  # pylint: disable=too-many-branches,too-many-statemen
     executable_path: str = "",
 ):
     """Launch browser using sync Playwright (for hybrid mode)."""
+    if cdp_port and _probe_local_port_in_use(cdp_port):
+        raise RuntimeError(
+            f"Port {cdp_port} is already in use; refusing to "
+            "attach to an existing CDP endpoint. Choose a different "
+            "cdp_port or stop the process using it.",
+        )
     sync_playwright = _ensure_playwright_sync()
     pw = sync_playwright().start()  # Start without context manager
     browser = None
@@ -997,7 +1003,7 @@ def _sync_browser_launch(  # pylint: disable=too-many-branches,too-many-statemen
             )
             state["user_data_dir"] = user_data_dir
             if user_data_dir:
-                Path(user_data_dir).mkdir(parents=True, exist_ok=True)
+                _secure_profile_directory(user_data_dir)
                 context = pw.chromium.launch_persistent_context(
                     user_data_dir=user_data_dir,
                     headless=state["headless"],
@@ -1054,6 +1060,29 @@ def _resolve_chromium_launch_target() -> tuple[Optional[str], Optional[str]]:
     return default_kind, _chromium_executable_path()
 
 
+def _secure_profile_directory(user_data_dir: str) -> None:
+    """Create the browser profile dir and tighten it to 0700 on POSIX.
+
+    Windows note: POSIX mode bits do not express Windows directory ACLs,
+    so this helper only creates the directory there and makes no
+    owner-only claim. Real DACL hardening is tracked as a follow-up.
+    """
+    if not user_data_dir:
+        return
+    path = Path(user_data_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "win32":
+        return
+    try:
+        path.chmod(0o700)
+    except (OSError, NotImplementedError):
+        logger.warning(
+            "Failed to set 0700 permissions on browser profile dir %s",
+            user_data_dir,
+            exc_info=True,
+        )
+
+
 # Chromium treats "--switch", "-switch" and (on Windows) "/switch" as
 # equivalent, so the guard below compares bare switch names.
 _SWITCH_PREFIXES = ("--", "-", "/") if sys.platform == "win32" else ("--", "-")
@@ -1103,22 +1132,52 @@ def _find_free_local_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _probe_local_port_in_use(port: int) -> bool:
+    """Return True when 127.0.0.1:*port* already accepts connections."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _fetch_cdp_version(url: str) -> dict[str, Any]:
+    """Blocking fetch of /json/version; callers run this off-loop."""
+    with urllib_request.urlopen(url, timeout=1.0) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
 async def _wait_for_cdp_ready(
     port: int,
+    proc: subprocess.Popen,
+    user_data_dir: str,
     timeout: float = 15.0,
 ) -> dict[str, Any]:
+    """Wait until our Chrome process owns the CDP endpoint on *port*."""
     deadline = time.monotonic() + timeout
     last_error: Optional[Exception] = None
     url = f"http://127.0.0.1:{port}/json/version"
+    port_file = Path(user_data_dir) / "DevToolsActivePort"
     while time.monotonic() < deadline:
+        exit_code = proc.poll()
+        if exit_code is not None:
+            raise RuntimeError(
+                f"Chrome exited (code {exit_code}) before its CDP endpoint "
+                f"on port {port} became ready; the port may be held by "
+                "another process.",
+            )
         try:
-            with urllib_request.urlopen(url, timeout=1.0) as resp:
-                return json.loads(resp.read().decode("utf-8"))
-        except Exception as exc:
-            last_error = exc
-            await asyncio.sleep(0.2)
+            first_line = port_file.read_text(encoding="utf-8").splitlines()[
+                0
+            ].strip()
+        except (OSError, IndexError):
+            first_line = ""
+        if first_line == str(port):
+            try:
+                return await asyncio.to_thread(_fetch_cdp_version, url)
+            except Exception as exc:
+                last_error = exc
+        await asyncio.sleep(0.2)
     raise RuntimeError(
-        f"Timed out waiting for Chrome CDP endpoint on port {port}: {last_error}",
+        f"Timed out waiting for Chrome CDP endpoint on port {port}: "
+        f"{last_error or 'DevToolsActivePort not written by our process'}",
     )
 
 
@@ -1129,7 +1188,7 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     browser_args: str = "",
     executable_path: str = "",
 ) -> None:
-    default_kind, exe = _resolve_chromium_launch_target()
+    default_kind, exe = await asyncio.to_thread(_resolve_chromium_launch_target)
     explicit_exe = bool(executable_path)
     if executable_path:
         exe = executable_path
@@ -1150,16 +1209,24 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     state["user_data_dir"] = user_data_dir
 
     chosen_cdp_port = cdp_port or _find_free_local_port()
-    proc = _start_managed_chromium_process(
-        executable_path=exe,
-        user_data_dir=user_data_dir,
-        headless=state["headless"],
-        cdp_port=chosen_cdp_port,
-        browser_args=browser_args,
+    if await asyncio.to_thread(_probe_local_port_in_use, chosen_cdp_port):
+        raise RuntimeError(
+            f"Port {chosen_cdp_port} is already in use; refusing to "
+            "attach to an existing CDP endpoint. Choose a different "
+            "cdp_port or stop the process using it.",
+        )
+    proc = await asyncio.to_thread(
+        lambda: _start_managed_chromium_process(
+            executable_path=exe,
+            user_data_dir=user_data_dir,
+            headless=state["headless"],
+            cdp_port=chosen_cdp_port,
+            browser_args=browser_args,
+        ),
     )
     pw = None
     try:
-        await _wait_for_cdp_ready(chosen_cdp_port)
+        await _wait_for_cdp_ready(chosen_cdp_port, proc, user_data_dir)
         async_playwright = _ensure_playwright_async()
         pw = await async_playwright().start()
         browser = await pw.chromium.connect_over_cdp(
@@ -1212,9 +1279,9 @@ def _start_managed_chromium_process(
     cdp_port: int,
     browser_args: str = "",
 ) -> subprocess.Popen:
-    Path(user_data_dir).mkdir(parents=True, exist_ok=True)
-    with contextlib.suppress(OSError, NotImplementedError):
-        Path(user_data_dir).chmod(0o700)
+    _secure_profile_directory(user_data_dir)
+    with contextlib.suppress(OSError):
+        (Path(user_data_dir) / "DevToolsActivePort").unlink()
     args = [
         executable_path,
         f"--remote-debugging-port={cdp_port}",
@@ -1228,6 +1295,7 @@ def _start_managed_chromium_process(
         "--disable-session-crashed-bubble",
         "--hide-crash-restore-bubble",
         "--password-store=basic",
+        "--use-mock-keychain",
     ]
     args.extend(_chromium_launch_args())
     if browser_args:
@@ -1651,11 +1719,12 @@ async def _ensure_browser(
     try:
         if _USE_SYNC_PLAYWRIGHT:
             # Hybrid mode: use sync Playwright in thread pool
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             pw, browser, context = await loop.run_in_executor(
                 _get_executor(),
                 lambda: _sync_browser_launch(
                     state,
+                    cdp_port=state.get("_cdp_port", 0),
                     browser_args=state.get("_browser_args", ""),
                     executable_path=state.get("_executable_path", ""),
                 ),
@@ -1671,22 +1740,16 @@ async def _ensure_browser(
             state["launch_mode"] = "playwright"
         else:
             if state.get("_expose_cdp"):
-                try:
-                    await _start_managed_cdp_browser(
-                        state,
-                        cdp_port=state.get("_cdp_port", 0),
-                        ensure_pages=True,
-                        browser_args=state.get("_browser_args", ""),
-                        executable_path=state.get("_executable_path", ""),
-                    )
-                except Exception:
-                    await _action_start(
-                        state,
-                        headed=not state["headless"],
-                        private_mode=True,
-                        browser_args=state.get("_browser_args", ""),
-                        executable_path=state.get("_executable_path", ""),
-                    )
+                # The user explicitly opted into CDP sharing; a recovery
+                # failure must fail closed rather than silently downgrading
+                # to pipe mode and dropping the shared endpoint.
+                await _start_managed_cdp_browser(
+                    state,
+                    cdp_port=state.get("_cdp_port", 0),
+                    ensure_pages=True,
+                    browser_args=state.get("_browser_args", ""),
+                    executable_path=state.get("_executable_path", ""),
+                )
             else:
                 await _action_start(
                     state,
@@ -1799,32 +1862,23 @@ async def _action_start(
             return _tool_response(
                 json.dumps(result, ensure_ascii=False, indent=2),
             )
+    if cdp_port and await asyncio.to_thread(_probe_local_port_in_use, cdp_port):
+        return _tool_response(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": (
+                        f"Port {cdp_port} is already in use. "
+                        "Another browser may be running on this port. "
+                        "Choose a different cdp_port or stop the existing process first."
+                    ),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
     # Default: headless (background). Only headed=True (e.g. browser_visible skill) shows window.
     state["headless"] = not headed
-    # Record the exposure decision next to the other launch intent, before any
-    # preflight check can return early: _reset_browser_state keeps "_" prefixed
-    # keys, so a rejected start must not leave an earlier decision behind for
-    # _ensure_browser to replay.
-    state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
-    state["_cdp_port"] = cdp_port
-
-    if cdp_port:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _s:
-            if _s.connect_ex(("127.0.0.1", cdp_port)) == 0:
-                return _tool_response(
-                    json.dumps(
-                        {
-                            "ok": False,
-                            "error": (
-                                f"Port {cdp_port} is already in use. "
-                                "Another browser may be running on this port. "
-                                "Choose a different cdp_port or stop the existing process first."
-                            ),
-                        },
-                        ensure_ascii=False,
-                        indent=2,
-                    ),
-                )
 
     started_playwright = None
     cleanup_errors: list[str] = []
@@ -1841,7 +1895,7 @@ async def _action_start(
                 executable_path=executable_path,
             )
         elif _USE_SYNC_PLAYWRIGHT:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             pw, browser, context = await loop.run_in_executor(
                 _get_executor(),
                 lambda: _sync_browser_launch(
@@ -1865,7 +1919,9 @@ async def _action_start(
             async_playwright = _ensure_playwright_async()
             pw = await async_playwright().start()
             started_playwright = pw
-            default_kind, exe = _resolve_chromium_launch_target()
+            default_kind, exe = await asyncio.to_thread(
+                _resolve_chromium_launch_target,
+            )
             if executable_path:
                 exe = executable_path
             extra_args = list(_chromium_launch_args())
@@ -1880,9 +1936,10 @@ async def _action_start(
                 # Use persistent context so cookies/storage survive browser restarts
                 user_data_dir = state["user_data_dir"]
                 if user_data_dir:
-                    Path(user_data_dir).mkdir(parents=True, exist_ok=True)
-                    with contextlib.suppress(OSError, NotImplementedError):
-                        Path(user_data_dir).chmod(0o700)
+                    await asyncio.to_thread(
+                        _secure_profile_directory,
+                        user_data_dir,
+                    )
                     context = await pw.chromium.launch_persistent_context(
                         user_data_dir=user_data_dir,
                         headless=state["headless"],
@@ -1938,9 +1995,13 @@ async def _action_start(
         _touch_activity(state)
         _start_idle_watchdog(state)
         await _configure_download_behavior(state)
-        # Store launch config for _ensure_browser fallback restarts
+        # Store launch config for _ensure_browser restarts. These keys mean
+        # "last successfully started configuration": a rejected or failed
+        # start never reaches this point, so it can never be replayed.
         state["_browser_args"] = browser_args
         state["_executable_path"] = executable_path
+        state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
+        state["_cdp_port"] = cdp_port
         msg = (
             "Browser started (visible window)"
             if not state["headless"]

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1807,6 +1807,11 @@ async def _action_start(
     started_playwright = None
     cleanup_errors: list[str] = []
     try:
+        # Record the exposure decision before launching, so that a failed
+        # start cannot leave a previous start's decision behind for
+        # _ensure_browser to replay (_reset_browser_state keeps "_" keys).
+        state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
+        state["_cdp_port"] = cdp_port
         if not _USE_SYNC_PLAYWRIGHT and _should_use_managed_cdp(
             private_mode,
             cdp_port,
@@ -1917,8 +1922,6 @@ async def _action_start(
         _start_idle_watchdog(state)
         await _configure_download_behavior(state)
         # Store launch config for _ensure_browser fallback restarts
-        state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
-        state["_cdp_port"] = cdp_port
         state["_browser_args"] = browser_args
         state["_executable_path"] = executable_path
         msg = (

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1196,6 +1196,8 @@ def _start_managed_chromium_process(
     browser_args: str = "",
 ) -> subprocess.Popen:
     Path(user_data_dir).mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError, NotImplementedError):
+        Path(user_data_dir).chmod(0o700)
     args = [
         executable_path,
         f"--remote-debugging-port={cdp_port}",
@@ -1856,6 +1858,8 @@ async def _action_start(
                 user_data_dir = state["user_data_dir"]
                 if user_data_dir:
                     Path(user_data_dir).mkdir(parents=True, exist_ok=True)
+                    with contextlib.suppress(OSError, NotImplementedError):
+                        Path(user_data_dir).chmod(0o700)
                     context = await pw.chromium.launch_persistent_context(
                         user_data_dir=user_data_dir,
                         headless=state["headless"],

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -5165,6 +5165,10 @@ async def browser_use(  # pylint: disable=R0911,R0912
             "--proxy-server=http://127.0.0.1:7890". Multiple args separated by
             space. Applied to all launch paths (headless, headed, managed CDP).
             Default empty string (no extra args).
+            `--remote-debugging-port` and `--remote-debugging-address` are
+            rejected in any prefix form; use the cdp_port parameter instead.
+            All other arguments pass through as-is, so this parameter carries
+            full local command-line power and is not a security boundary.
         executable_path (str):
             Custom browser executable path, e.g.
             "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe".
@@ -5229,6 +5233,11 @@ async def browser_use(  # pylint: disable=R0911,R0912
                 executable_path=executable_path,
             )
         if action == "stop":
+            # An explicit stop ends the session, so the recorded launch intent
+            # must not survive it: a later _ensure_browser has to fall back to
+            # the no-debug-port default instead of replaying an old cdp_port.
+            state.pop("_expose_cdp", None)
+            state.pop("_cdp_port", None)
             return await _action_stop(state)
         if action == "connect_cdp":
             return await _action_connect_cdp(state, cdp_url)

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1718,6 +1718,7 @@ async def _action_start(
     executable_path: str = "",
 ) -> ToolChunk:
     _validate_executable_path(executable_path)
+    _reject_debug_surface_args(browser_args)
     if cdp_port and private_mode:
         return _tool_response(
             json.dumps(

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1053,6 +1053,32 @@ def _resolve_chromium_launch_target() -> tuple[Optional[str], Optional[str]]:
     return default_kind, _chromium_executable_path()
 
 
+_FORBIDDEN_BROWSER_ARGS = (
+    "--remote-debugging-port",
+    "--remote-debugging-address",
+)
+
+
+def _should_use_managed_cdp(private_mode: bool, cdp_port: int) -> bool:
+    """Return whether this start explicitly opts in to managed CDP."""
+    if private_mode:
+        return False
+    return cdp_port > 0
+
+
+def _reject_debug_surface_args(browser_args: str) -> None:
+    """Reject launch args that would re-open an unauthenticated CDP surface."""
+    if not browser_args:
+        return
+    for part in shlex.split(browser_args, posix=sys.platform != "win32"):
+        flag = part.split("=", 1)[0]
+        if flag in _FORBIDDEN_BROWSER_ARGS:
+            raise ValueError(
+                f"{flag} is not allowed in browser_args; "
+                "use the cdp_port parameter instead.",
+            )
+
+
 def _find_free_local_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -12,6 +12,7 @@ wait_for, pdf, close. Uses refs from snapshot for ref-based actions.
 import asyncio
 import atexit
 from collections.abc import Iterable
+import contextlib
 from concurrent import futures
 import json
 import logging

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1651,14 +1651,24 @@ async def _ensure_browser(
             state["browser_process"] = None
             state["launch_mode"] = "playwright"
         else:
-            try:
-                await _start_managed_cdp_browser(
-                    state,
-                    ensure_pages=True,
-                    browser_args=state.get("_browser_args", ""),
-                    executable_path=state.get("_executable_path", ""),
-                )
-            except Exception:
+            if state.get("_expose_cdp"):
+                try:
+                    await _start_managed_cdp_browser(
+                        state,
+                        cdp_port=state.get("_cdp_port", 0),
+                        ensure_pages=True,
+                        browser_args=state.get("_browser_args", ""),
+                        executable_path=state.get("_executable_path", ""),
+                    )
+                except Exception:
+                    await _action_start(
+                        state,
+                        headed=not state["headless"],
+                        private_mode=True,
+                        browser_args=state.get("_browser_args", ""),
+                        executable_path=state.get("_executable_path", ""),
+                    )
+            else:
                 await _action_start(
                     state,
                     headed=not state["headless"],
@@ -1901,6 +1911,8 @@ async def _action_start(
         _start_idle_watchdog(state)
         await _configure_download_behavior(state)
         # Store launch config for _ensure_browser fallback restarts
+        state["_expose_cdp"] = _should_use_managed_cdp(private_mode, cdp_port)
+        state["_cdp_port"] = cdp_port
         state["_browser_args"] = browser_args
         state["_executable_path"] = executable_path
         msg = (

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -1164,9 +1164,9 @@ async def _wait_for_cdp_ready(
                 "another process.",
             )
         try:
-            first_line = port_file.read_text(encoding="utf-8").splitlines()[
-                0
-            ].strip()
+            first_line = (
+                port_file.read_text(encoding="utf-8").splitlines()[0].strip()
+            )
         except (OSError, IndexError):
             first_line = ""
         if first_line == str(port):
@@ -1188,7 +1188,9 @@ async def _start_managed_cdp_browser(  # pylint: disable=too-many-statements
     browser_args: str = "",
     executable_path: str = "",
 ) -> None:
-    default_kind, exe = await asyncio.to_thread(_resolve_chromium_launch_target)
+    default_kind, exe = await asyncio.to_thread(
+        _resolve_chromium_launch_target
+    )
     explicit_exe = bool(executable_path)
     if executable_path:
         exe = executable_path
@@ -1862,7 +1864,9 @@ async def _action_start(
             return _tool_response(
                 json.dumps(result, ensure_ascii=False, indent=2),
             )
-    if cdp_port and await asyncio.to_thread(_probe_local_port_in_use, cdp_port):
+    if cdp_port and await asyncio.to_thread(
+        _probe_local_port_in_use, cdp_port
+    ):
         return _tool_response(
             json.dumps(
                 {

--- a/src/qwenpaw/agents/tools/browser_control.py
+++ b/src/qwenpaw/agents/tools/browser_control.py
@@ -5132,14 +5132,13 @@ async def browser_use(  # pylint: disable=R0911,R0912
             When True with action=start, launch a visible browser window
             (non-headless). User can see the real browser. Default False.
         cdp_port (int):
-            When > 0 with action=start, use the specified CDP port. When 0,
-            QwenPaw chooses a free local port automatically for managed CDP.
+            When > 0 with action=start, launch the browser with a local CDP
+            port so other local tools can attach. When 0 (default), no
+            debugging port is opened and no port is chosen automatically.
         private_mode (bool):
-            When True with action=start, force direct Playwright management
-            instead of managed CDP. Use this when the user explicitly does not
-            want the browser to be connectable by other local tools/workspaces
-            via CDP. Default False. By default, QwenPaw prefers managed CDP for
-            both headless and headed starts.
+            Deprecated and now the default behavior: the browser is managed
+            directly by Playwright over a pipe with no debugging port.
+            Passing private_mode=true together with cdp_port is rejected.
         browser_args (str):
             Extra Chromium launch arguments, e.g. "--incognito" or
             "--proxy-server=http://127.0.0.1:7890". Multiple args separated by


### PR DESCRIPTION
## Description

`browser_use(action="start")` previously launched Chrome with an unauthenticated local DevTools TCP port by default. Any local process able to reach that port could attach to the browser session, inspect logged-in pages and cookies, and execute browser actions.

This PR makes managed CDP an explicit opt-in: the default uses Playwright's pipe transport and opens no TCP debugging port; passing a positive `cdp_port` remains the intentional way to share the browser with another local tool.

The review-fix round closes the remaining bypass and state-lifecycle gaps:

1. **No-debug-port default** — managed CDP is selected only for an explicit positive `cdp_port`.
2. **No prefix-form bypass** — the `browser_args` guard now rejects `--remote-debugging-port` and `--remote-debugging-address` in Chromium's `--x`, `-x`, and Windows `/x` forms, case-insensitively. This is an accident guard, not a security boundary: `browser_args` intentionally retains full local command-line power for all other arguments.
3. **Launch intent is current and explicit stops clear it** — `_expose_cdp` / `_cdp_port` are recorded after already-running returns but before every preflight check. An explicit `action="stop"` clears both keys, so a later auto-start returns to the no-debug-port default. Crash recovery retains its original async launch mode when the session was not explicitly stopped.
4. **Conflicting arguments are rejected** — `private_mode=true` plus `cdp_port` returns `ok: false` instead of silently selecting a mode.
5. **Profile directories are owner-only** — managed-CDP and async persistent-profile directories are set to `0700`.
6. **Agent-facing documentation matches shipped behavior** — the `browser_cdp` bodies now describe the no-port default, managed-CDP examples carry an explicit `cdp_port`, and both `browser_visible` bodies remove obsolete `private_mode` decision rules. All four edited skills bump `builtin_skill_version`, which is required because pool skills are version-compared snapshots; content-only edits would not update existing user copies.

Scope stays intentionally narrow: `connect_cdp`, `list_cdp_targets`, `_chromium_launch_args()`, and the Windows sync launch path are unchanged. No new configuration surface is added.

**Related Issue:** N/A (external security report, no issue filed)

**Security Considerations:** The default unauthenticated TCP DevTools surface is removed. Explicit `cdp_port`, external CDP attachment, and port scanning remain available only when deliberately requested.

## Breaking Changes / Migration

- Sharing the agent browser with another local tool now requires an explicit positive `cdp_port`; `cdp_port=0` opens no port and does not auto-select one.
- `browser_args` containing either blocked remote-debugging switch now fails with guidance to use `cdp_port`.
- On macOS, **every switch between the default pipe path and an explicit `cdp_port` can drop login state**. Both paths share the profile directory but use different cookie-encryption backends, so users may need to sign in after each mode switch.

## Known Limitations

- The Windows sync-Playwright recovery path calls `_sync_browser_launch` without `cdp_port`, so recovery fails closed by not re-exposing that port. It is outside this PR; the recovery-inheritance claim applies to the async path.
- On Windows, `shlex.split(posix=False)` preserves quotes, so a quoted `"-remote-debugging-port=9222"` does not match a switch prefix. Chrome also receives the leading quote and does not treat it as a switch, so this is not a bypass.

## Not Adopted

The real-browser smoke probe is deliberately not added to the automated suite: it requires CI-side Chrome, process spawning, and listening-port inspection. Manual probe evidence is included below.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [x] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran relevant focused tests locally and they pass
- [x] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable.

## Testing

- Focused launch-security regression suite: **17 passed** after the implementation.
- Reverse verification against the pre-fix source: **7 failed, 10 passed**; failures covered the single-dash, uppercase, and Windows-slash guard forms plus stale port intent.
- `.venv/bin/pre-commit run --all-files` passed before every review-fix commit.
- Real Chrome probe: `browser_use(action="start", browser_args="-remote-debugging-port=9411")` was rejected with `cdp_port` guidance, and `lsof` confirmed 0 listeners on 9411. A normal start used Playwright pipe transport and had 0 `--remote-debugging-port` processes.
- The prescribed `tests/unit/agents` regression reached 37% without a test failure, then blocked for more than six minutes waiting for unrelated `mini_mcp_server.py` and `stdio_echo_server.py` fixture processes. The stalled run was stopped and is documented rather than reported as passing.

## Evidence

```text
pre-fix reverse verification
7 failed, 10 passed in 0.86s

post-fix focused suite
17 passed in 0.22s

manual single-dash probe
browser_use(start, browser_args="-remote-debugging-port=9411")
{ "ok": false, "error": "-remote-debugging-port is not allowed in browser_args; use the cdp_port parameter instead." }
PORT_9411_LISTEN_LINES=0
DEFAULT launch_mode=playwright
PIPE_PROCESS_COUNT=3
TCP_DEBUG_PORT_PROCESS_COUNT=0

original reviewer reproduction before this fix
-remote-debugging-port=9411 opened 127.0.0.1:9411 and /json/list returned an unauthenticated webSocketDebuggerUrl.
```

## Additional Notes

- The focused regression suite lives in the repository's intentionally untracked `tests/local` path, so it is not included in the PR diff.
- The macOS authenticated-session probe confirmed the encryption-backend migration behavior described above.
