### PR TITLE
fix(dev): include test extra in setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ docs(skills): document Skills Hub import
 
 - **Required local gate (must pass before push/PR):**
   ```bash
-  pip install -e ".[dev,full]"
+  pip install -e ".[dev,test,full]"
   pre-commit install
   pre-commit run --all-files
   pytest

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -69,7 +69,7 @@ docs(skills): document Skills Hub import
 
 - **本地必跑门禁（push/提 PR 前必须通过）：**
   ```bash
-  pip install -e ".[dev,full]"
+  pip install -e ".[dev,test,full]"
   pre-commit install
   pre-commit run --all-files
   pytest

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ cp -R console/dist/. src/qwenpaw/console/
 pip install -e .
 ```
 
-- **Dev** (tests, formatting): `pip install -e ".[dev,full]"`
+- **Dev** (tests, formatting): `pip install -e ".[dev,test,full]"`
 - **Then**: Run `qwenpaw init --defaults`, then `qwenpaw app`.
 
 > **Note for updates:** When updating to a new major version after `git pull`, please also rebuild the frontend, reinstall the package (`pip install -e .`), restart `qwenpaw app`, and clear your browser cache with `Ctrl+Shift+R` (or `Cmd+Shift+R` on macOS).

--- a/README_ja.md
+++ b/README_ja.md
@@ -485,7 +485,7 @@ cp -R console/dist/. src/qwenpaw/console/
 pip install -e .
 ```
 
-- **開発**（テスト、フォーマット）: `pip install -e ".[dev,full]"`
+- **開発**（テスト、フォーマット）: `pip install -e ".[dev,test,full]"`
 - **その後**: `qwenpaw init --defaults` を実行し、次に `qwenpaw app`。
 
 > **アップデート時の注意:** `git pull` 後に新しいメジャーバージョンにアップデートする場合は、フロントエンドの再ビルド、パッケージの再インストール（`pip install -e .`）、`qwenpaw app` の再起動、およびブラウザキャッシュの削除（`Ctrl+Shift+R` または macOS では `Cmd+Shift+R`）も行ってください。

--- a/README_ru.md
+++ b/README_ru.md
@@ -487,7 +487,7 @@ cp -R console/dist/. src/qwenpaw/console/
 pip install -e .
 ```
 
-- **Разработка** (тесты, форматирование): `pip install -e ".[dev,full]"`
+- **Разработка** (тесты, форматирование): `pip install -e ".[dev,test,full]"`
 - **Затем**: Выполните `qwenpaw init --defaults`, затем `qwenpaw app`.
 
 > **Примечание при обновлении:** При обновлении до новой мажорной версии после `git pull` пересоберите frontend, переустановите пакет (`pip install -e .`), перезапустите `qwenpaw app` и очистите кэш браузера (`Ctrl+Shift+R` или `Cmd+Shift+R` на macOS).

--- a/README_vi.md
+++ b/README_vi.md
@@ -485,7 +485,7 @@ cp -R console/dist/. src/qwenpaw/console/
 pip install -e .
 ```
 
-- **Dev** (kiểm thử, định dạng): `pip install -e ".[dev,full]"`
+- **Dev** (kiểm thử, định dạng): `pip install -e ".[dev,test,full]"`
 - **Sau đó**: Chạy `qwenpaw init --defaults`, rồi `qwenpaw app`.
 
 > **Lưu ý khi cập nhật:** Khi cập nhật lên phiên bản chính mới sau `git pull`, vui lòng xây dựng lại frontend, cài đặt lại gói (`pip install -e .`), khởi động lại `qwenpaw app`, và xóa bộ nhớ đệm trình duyệt với `Ctrl+Shift+R` (hoặc `Cmd+Shift+R` trên macOS).

--- a/README_zh.md
+++ b/README_zh.md
@@ -487,7 +487,7 @@ cp -R console/dist/. src/qwenpaw/console/
 pip install -e .
 ```
 
-- **开发**（测试、格式化）：`pip install -e ".[dev,full]"`
+- **开发**（测试、格式化）：`pip install -e ".[dev,test,full]"`
 - **然后**：运行 `qwenpaw init --defaults`，再运行 `qwenpaw app`。
 
 > **版本更新提示：** 当执行 `git pull` 更新到大版本后，请重新构建前端、重新安装 Python 包（`pip install -e .`）、重启 `qwenpaw app`，并清除浏览器缓存（`Ctrl+Shift+R` 或 macOS 上 `Cmd+Shift+R`）。

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -223,7 +223,7 @@ def main() -> int:
         print_error(
             "pytest is not installed. Please install dev dependencies:",
         )
-        print('  pip install -e ".[dev,full]"')
+        print('  pip install -e ".[dev,test,full]"')
         return 1
 
     # Determine what to run


### PR DESCRIPTION
## Description

Fix the clean contributor setup so the documented development install actually provides the test runner and plugins that the next steps require.

This updates every contributor-facing `.[dev,full]` command to `.[dev,test,full]` in:

- the English and Chinese contribution guides;
- all five translated README development sections;
- the missing-`pytest` recovery hint in `scripts/run_tests.py`.

The runtime dependency model is unchanged; this only aligns setup guidance with the existing `test` extra and the command already used by CI.

**Related Issue:** Fixes #6501

**Security Considerations:** None. No runtime, credential, or network behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and recorded the upstream baseline result below
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks (no files were modified)
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; no channel code changed.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Resolve `.[dev,test,full]` in a clean Python 3.11 environment and confirm the declared test packages are present.
2. Run all configured hooks against the eight changed files.
3. Run the complete pytest suite with an isolated QwenPaw working directory.
4. Run all-files pre-commit on both this branch and a clean clone of the exact upstream base to classify the unrelated baseline lint result.

## Evidence

Corrected clean dependency resolution:

```text
Resolved 263 packages
Would install 263 packages
 + hypothesis==6.161.6
 + pre-commit==4.6.1
 + pytest==9.1.1
 + pytest-asyncio==1.4.0
 + pytest-cov==7.1.0
 + pytest-timeout==2.4.0
 + pytest-xdist==3.8.0
```

Changed-file pre-commit result:

```text
check python ast.........................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

Complete test suite:

```text
6207 passed, 12 skipped, 4 xpassed, 56 warnings in 798.91s (0:13:18)
```

All-files pre-commit was also run. Its only failure is four existing `pylint E1120` findings in `src/qwenpaw/sandbox/windows_restricted_sandbox.py` (lines 1822, 1824, 2244, and 2316), a file this PR does not modify. The same four findings reproduce on a clean clone of `origin/main@b0553ff4`; every other hook passes on both trees.

## Additional Notes

The branch and PR are based on `main@b0553ff4`; pushed head is `8ed1e5fe792c4bd0168ca49da942480a9b55b19c`.
