### PR TITLE
fix(agents): inherit session approval_level in spawn_subagent

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -784,6 +784,8 @@ def _build_spawn_request_context(current_agent_id: str) -> dict[str, Any]:
     safe_meta = _json_safe_channel_meta(inherited.get("channel_meta") or {})
     if isinstance(safe_meta, dict) and safe_meta:
         context["channel_meta"] = safe_meta
+    if inherited.get("approval_level"):
+        context["approval_level"] = inherited["approval_level"]
     return context
 
 

--- a/src/qwenpaw/hooks/request_setup/contextvars_hook.py
+++ b/src/qwenpaw/hooks/request_setup/contextvars_hook.py
@@ -69,6 +69,12 @@ class ContextVarsSetupHook(LifecycleHook):
                 "channel": getattr(ctx.request, "channel", None) or "",
                 "channel_meta": getattr(ctx.request, "channel_meta", None),
             }
+        if isinstance(request_context, dict) and request_context.get(
+            "approval_level",
+        ):
+            approval_route["approval_level"] = request_context.get(
+                "approval_level",
+            )
         set_current_approval_route(approval_route)
 
         coding_project_dir = None

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -447,6 +447,41 @@ async def test_spawn_subagent_inherits_root_channel_context(monkeypatch):
     assert "done" in response.content[0].text
 
 
+async def test_spawn_subagent_inherits_approval_level(monkeypatch):
+    captured = {}
+
+    def fake_collect(_base_url, request_payload, _to_agent, _timeout):
+        captured["payload"] = request_payload
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: {"approval_level": "off"},
+    )
+
+    await agent_management.spawn_subagent("do work")
+
+    context = captured["payload"]["request_context"]
+    assert context["approval_level"] == "off"
+
+
 def test_normalize_str_list_accepts_json_array_string():
     assert agent_management._normalize_str_list(
         '["read_file", "write_file"]',


### PR DESCRIPTION
## Description

Session-level `approval_level` overrides (for example OFF from the console chat) were applied only on the parent request path. Child sessions created by `spawn_subagent` rebuilt request context from `approval_route`, which did not carry `approval_level`, so workers fell back to the agent.json default and still prompted for guarded tools such as Bash.

This PR stores truthy `approval_level` on `approval_route` in the request setup hook and copies it into the spawn child request context. Nested spawns keep the override when it is already present on the child request context.

**Related Issue:** Fixes #6506

**Security Considerations:** Does not lower security below the level the user already set for the parent session. It only propagates that same session override to descendants.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Set an agent profile approval_level to AUTO or SMART.
2. In a console chat, set tool execution level to OFF for that session.
3. Run a task that calls `spawn_subagent` with a Bash tool in the child.
4. Confirm the child no longer creates approval prompts solely because it lost the session OFF override.

## Evidence

Local checks on the changed files:

```bash
black --line-length=79 --check \
  src/qwenpaw/agents/tools/agent_management.py \
  src/qwenpaw/hooks/request_setup/contextvars_hook.py \
  tests/unit/agents/tools/test_agent_management.py
# 3 files would be left unchanged

flake8 --extend-ignore=E203 \
  src/qwenpaw/agents/tools/agent_management.py \
  src/qwenpaw/hooks/request_setup/contextvars_hook.py \
  tests/unit/agents/tools/test_agent_management.py
# exit 0
```

Targeted inheritance proof for `_build_spawn_request_context` (full package pytest blocked in this sparse environment by optional provider deps such as google.genai):

```text
UNIT_PROOF_PASS off
UNIT_PROOF_ABSENT_PASS
```

Added unit test: `test_spawn_subagent_inherits_approval_level`.

## Additional Notes

Draft while CI and review run.
