### PR TITLE
fix(crons): migrate existing final-mode jobs to stream on upgrade

### DIFF
--- a/console/src/pages/Control/CronJobs/components/constants.ts
+++ b/console/src/pages/Control/CronJobs/components/constants.ts
@@ -31,7 +31,7 @@ export const DEFAULT_FORM_VALUES = {
       user_id: "",
       session_id: "",
     },
-    mode: "final" as const,
+    mode: "stream" as const,
     silent: false,
   },
   runtime: {

--- a/console/src/pages/Control/CronJobs/components/templates.ts
+++ b/console/src/pages/Control/CronJobs/components/templates.ts
@@ -25,7 +25,7 @@ const buildDispatch = () => ({
     user_id: "default",
     session_id: "cron_job",
   },
-  mode: "final" as const,
+  mode: "stream" as const,
   silent: false,
 });
 

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -168,8 +168,10 @@ class CronExecutor:
             },
         )
 
+        final_no_content = False
+
         async def _run() -> None:
-            nonlocal delivery_error
+            nonlocal delivery_error, final_no_content
 
             async def _deliver(event: Any) -> None:
                 nonlocal delivery_error
@@ -208,6 +210,13 @@ class CronExecutor:
 
             if final_event is not None:
                 await _deliver(final_event)
+            elif job.dispatch.mode == "final" and not job.dispatch.silent:
+                final_no_content = True
+                logger.warning(
+                    "cron final delivery: no completed message in "
+                    "stream for job_id=%s",
+                    job.id,
+                )
 
         try:
             await asyncio.wait_for(
@@ -227,6 +236,8 @@ class CronExecutor:
                 delivery_status = "suppressed"
             elif delivery_error:
                 delivery_status = "failed"
+            elif final_no_content:
+                delivery_status = "no_content"
             else:
                 delivery_status = "success"
             return {

--- a/src/qwenpaw/app/crons/executor.py
+++ b/src/qwenpaw/app/crons/executor.py
@@ -29,10 +29,11 @@ class CronExecutor:
         """Execute one job once.
 
         - task_type text: send fixed text to channel
-        - task_type agent: ask agent with prompt, send reply to channel (
-            stream_query + send_event)
-        - final delivery: consume the stream, then send only the last
-            completed message
+        - task_type agent + mode stream (default): ask agent with prompt,
+            forward every event to channel in real time
+            (stream_query + send_event)
+        - task_type agent + mode final: consume the full stream, then
+            deliver only the last completed message event
         - silent agent task: consume the full agent stream without channel
             delivery, while preserving session and trace state
         """

--- a/src/qwenpaw/app/crons/models.py
+++ b/src/qwenpaw/app/crons/models.py
@@ -243,7 +243,7 @@ class CronJobSpec(BaseModel):
 
 
 class JobsFile(BaseModel):
-    version: int = 1
+    version: int = 2
     jobs: list[CronJobSpec] = Field(default_factory=list)
 
 

--- a/src/qwenpaw/app/crons/repo/json_repo.py
+++ b/src/qwenpaw/app/crons/repo/json_repo.py
@@ -48,7 +48,7 @@ class JsonJobRepository(BaseJobRepository):
     def _load_sync(self) -> JobsFile:
         """Load and validate jobs as one worker-thread operation."""
         if not self._path.exists():
-            return JobsFile(version=1, jobs=[])
+            return JobsFile(version=2, jobs=[])
         return JobsFile.model_validate(read_json(self._path))
 
     async def load(self) -> JobsFile:

--- a/src/qwenpaw/app/crons/repo/json_repo.py
+++ b/src/qwenpaw/app/crons/repo/json_repo.py
@@ -225,3 +225,100 @@ def migrate_legacy_weixin_jobs_file(jobs_path: Path | str) -> None:
             path,
             exc,
         )
+
+
+def migrate_final_mode_to_stream(jobs_path: Path | str) -> None:
+    """One-shot migration: rewrite ``dispatch.mode = "final"`` to ``"stream"``.
+
+    This migration runs exactly once, gated by ``version < 2``.  After
+    rewriting, it bumps the file to ``version = 2`` so subsequent starts
+    skip it — even if the user later sets a job back to ``final``
+    intentionally.
+    """
+    path = (
+        Path(jobs_path).expanduser()
+        if isinstance(jobs_path, str)
+        else jobs_path
+    )
+    if not path.is_file():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    if data.get("version", 1) >= 2:
+        return
+
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        return
+
+    mutated = False
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        dispatch = job.get("dispatch")
+        if not isinstance(dispatch, dict):
+            continue
+        if dispatch.get("mode") == "final":
+            dispatch["mode"] = "stream"
+            mutated = True
+
+    data["version"] = 2
+
+    if not mutated:
+        # Still bump version so we never re-enter this function.
+        try:
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_path.write_text(
+                json.dumps(
+                    data,
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+                newline="\n",
+            )
+            os.replace(tmp_path, path)
+        except OSError as exc:
+            logger.warning(
+                "Failed to bump jobs.json version in %s: %s",
+                path,
+                exc,
+            )
+        return
+
+    try:
+        backup_path = path.with_suffix(
+            path.suffix + f".{uuid.uuid4().hex[:8]}.final-mode-migrate.bak",
+        )
+        shutil.copy2(path, backup_path)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps(
+                data,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+            newline="\n",
+        )
+        os.replace(tmp_path, path)
+        logger.warning(
+            "Migrated cron dispatch mode 'final' -> 'stream' in %s "
+            "(backup: %s)",
+            path,
+            backup_path,
+        )
+    except OSError as exc:
+        logger.error(
+            "Failed to migrate cron dispatch mode 'final' -> 'stream' "
+            "in %s: %s",
+            path,
+            exc,
+        )

--- a/src/qwenpaw/app/crons/repo/json_repo.py
+++ b/src/qwenpaw/app/crons/repo/json_repo.py
@@ -48,7 +48,7 @@ class JsonJobRepository(BaseJobRepository):
     def _load_sync(self) -> JobsFile:
         """Load and validate jobs as one worker-thread operation."""
         if not self._path.exists():
-            return JobsFile(version=2, jobs=[])
+            return JobsFile(jobs=[])
         return JobsFile.model_validate(read_json(self._path))
 
     async def load(self) -> JobsFile:

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -514,7 +514,10 @@ class Workspace:
         Each step is guarded so a failure logs a warning instead of
         blocking startup; affected files stay in their legacy state.
         """
-        from ..crons.repo.json_repo import migrate_legacy_weixin_jobs_file
+        from ..crons.repo.json_repo import (
+            migrate_final_mode_to_stream,
+            migrate_legacy_weixin_jobs_file,
+        )
         from ..chats.repo.json_repo import migrate_legacy_weixin_chats_file
         from ..chats.session import migrate_legacy_weixin_session_files
 
@@ -549,6 +552,17 @@ class Workspace:
         except Exception as exc:
             logger.warning(
                 "weixin->wechat sessions migration failed for agent %s: %s",
+                self.agent_id,
+                exc,
+            )
+
+        try:
+            migrate_final_mode_to_stream(
+                self.workspace_dir / "jobs.json",
+            )
+        except Exception as exc:
+            logger.warning(
+                "final->stream jobs.json migration failed for agent %s: %s",
                 self.agent_id,
                 exc,
             )

--- a/src/qwenpaw/cli/cron_cmd.py
+++ b/src/qwenpaw/cli/cron_cmd.py
@@ -460,7 +460,7 @@ def _build_spec_from_cli(
 @click.option(
     "--mode",
     type=click.Choice(["stream", "final"], case_sensitive=False),
-    default="final",
+    default="stream",
     help=(
         "Delivery mode: 'stream' sends incremental updates; "
         "'final' sends only the final result."

--- a/tests/unit/app/crons/test_executor.py
+++ b/tests/unit/app/crons/test_executor.py
@@ -142,3 +142,26 @@ async def test_final_mode_reports_delivery_failure(monkeypatch):
     channel_manager.send_event.assert_awaited_once()
     assert result["delivery_status"] == "failed"
     assert "channel down" in result["delivery_error"]
+
+
+@pytest.mark.asyncio
+async def test_final_mode_no_completed_message_returns_no_content(monkeypatch):
+    progress = Event(object="message", status=RunStatus.InProgress)
+    workspace = _Workspace([progress])
+    channel_manager = AsyncMock()
+    job = make_cron_job_spec(job_id="final-empty-job")
+    job.dispatch = DispatchSpec(
+        target=DispatchTarget(user_id="u1", session_id="console:u1"),
+        mode="final",
+    )
+
+    _patch_trace_storage(monkeypatch)
+
+    result = await CronExecutor(
+        workspace=workspace,
+        channel_manager=channel_manager,
+    ).execute(job)
+
+    assert workspace.events_consumed == 1
+    channel_manager.send_event.assert_not_awaited()
+    assert result["delivery_status"] == "no_content"

--- a/tests/unit/app/crons/test_json_repo.py
+++ b/tests/unit/app/crons/test_json_repo.py
@@ -9,6 +9,7 @@ import pytest
 
 from qwenpaw.app.crons.repo.json_repo import (
     JsonJobRepository,
+    migrate_final_mode_to_stream,
     migrate_legacy_weixin_jobs_file,
 )
 from qwenpaw.app.crons.models import JobsFile
@@ -145,3 +146,99 @@ def test_migrate_is_idempotent(tmp_path: Path):
 def test_migrate_noop_when_file_missing(tmp_path: Path):
     # Should not raise.
     migrate_legacy_weixin_jobs_file(tmp_path / "nonexistent.json")
+
+
+# ---------------------------------------------------------------------------
+# migrate_final_mode_to_stream
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_final_mode_rewrites_to_stream(tmp_path: Path):
+    jobs_path = tmp_path / "jobs.json"
+    data = {
+        "version": 1,
+        "jobs": [
+            {
+                "id": "j1",
+                "name": "Final Job",
+                "dispatch": {
+                    "mode": "final",
+                    "target": {"session_id": "console:u1", "user_id": "u1"},
+                },
+            },
+            {
+                "id": "j2",
+                "name": "Stream Job",
+                "dispatch": {
+                    "mode": "stream",
+                    "target": {"session_id": "console:u2", "user_id": "u2"},
+                },
+            },
+        ],
+    }
+    jobs_path.write_text(json.dumps(data), encoding="utf-8")
+
+    migrate_final_mode_to_stream(jobs_path)
+
+    result = json.loads(jobs_path.read_text(encoding="utf-8"))
+    assert result["version"] == 2
+    assert result["jobs"][0]["dispatch"]["mode"] == "stream"
+    assert result["jobs"][1]["dispatch"]["mode"] == "stream"
+    # Backup file should exist.
+    backups = list(tmp_path.glob("*.final-mode-migrate.bak"))
+    assert len(backups) == 1
+
+
+def test_migrate_final_mode_skips_when_version_ge_2(tmp_path: Path):
+    jobs_path = tmp_path / "jobs.json"
+    data = {
+        "version": 2,
+        "jobs": [
+            {
+                "id": "j1",
+                "dispatch": {
+                    "mode": "final",
+                    "target": {"session_id": "console:u1", "user_id": "u1"},
+                },
+            },
+        ],
+    }
+    original = json.dumps(data)
+    jobs_path.write_text(original, encoding="utf-8")
+
+    migrate_final_mode_to_stream(jobs_path)
+
+    # File content unchanged — mode stays "final".
+    assert jobs_path.read_text(encoding="utf-8") == original
+
+
+def test_migrate_final_mode_bumps_version_even_without_final_jobs(
+    tmp_path: Path,
+):
+    jobs_path = tmp_path / "jobs.json"
+    data = {
+        "version": 1,
+        "jobs": [
+            {
+                "id": "j1",
+                "dispatch": {
+                    "mode": "stream",
+                    "target": {"session_id": "console:u1", "user_id": "u1"},
+                },
+            },
+        ],
+    }
+    jobs_path.write_text(json.dumps(data), encoding="utf-8")
+
+    migrate_final_mode_to_stream(jobs_path)
+
+    result = json.loads(jobs_path.read_text(encoding="utf-8"))
+    assert result["version"] == 2
+    assert result["jobs"][0]["dispatch"]["mode"] == "stream"
+    # No backup needed when no mode was changed.
+    backups = list(tmp_path.glob("*.final-mode-migrate.bak"))
+    assert len(backups) == 0
+
+
+def test_migrate_final_mode_noop_when_file_missing(tmp_path: Path):
+    migrate_final_mode_to_stream(tmp_path / "nonexistent.json")


### PR DESCRIPTION
## Description
PR #6182 made `dispatch.mode=final` actually work — it now suppresses intermediate events and delivers only the last completed message. However, the Console UI, CLI, and built-in templates all defaulted `mode` to `"final"`, which means most existing cron jobs were unknowingly created with `mode=final`. Merging #6182 alone would silently change their delivery behavior from real-time streaming to final-only.
This PR adds a one-shot data migration that rewrites existing `mode=final` jobs to `mode=stream` before the new executor logic takes effect, and aligns all creation defaults to `"stream"`. It also improves the executor's handling of edge cases introduced by #6182.
**Changes:**
- Add `migrate_final_mode_to_stream()` gated by `JobsFile.version < 2`; bumps version to 2 after migration so it never re-runs
- Change default `mode` from `"final"` to `"stream"` in Console constants/templates and CLI `--mode` flag
- Return `delivery_status="no_content"` when `mode=final` produces no completed message (instead of a misleading `"success"`)
- Improve `executor.execute()` docstring to document all delivery modes symmetrically
- Set `_load_sync` default version to 2 for new files, preventing the migration from accidentally reverting user-chosen `final` on fresh installs
**Related Issue:** Companion to #6182 (fix(crons): honor final delivery mode)
**Security Considerations:** N/A


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
