### PR TITLE
feat(console): add RobotFramework syntax highlighting in Coding Mode …

### DIFF
--- a/console/src/monaco/robotframework.test.ts
+++ b/console/src/monaco/robotframework.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the RobotFramework Monaco language module:
+ *   • registerRobotFramework wiring + double-registration guard
+ *   • Monarch grammar smoke tests via a minimal rule-matching harness
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  ROBOT_LANGUAGE_ID,
+  conf,
+  language,
+  registerRobotFramework,
+} from "./robotframework";
+
+// ---------------------------------------------------------------------------
+// Mock Monaco instance
+// ---------------------------------------------------------------------------
+
+function createMonacoMock(existingIds: string[] = []) {
+  return {
+    languages: {
+      getLanguages: vi.fn(() => existingIds.map((id) => ({ id }))),
+      register: vi.fn(),
+      setLanguageConfiguration: vi.fn(),
+      setMonarchTokensProvider: vi.fn(),
+    },
+  };
+}
+
+describe("registerRobotFramework", () => {
+  it("registers language with .robot and .resource extensions", () => {
+    const monaco = createMonacoMock();
+    registerRobotFramework(monaco as never);
+
+    expect(monaco.languages.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: ROBOT_LANGUAGE_ID,
+        extensions: [".robot", ".resource"],
+      }),
+    );
+    expect(monaco.languages.setLanguageConfiguration).toHaveBeenCalledWith(
+      ROBOT_LANGUAGE_ID,
+      conf,
+    );
+    expect(monaco.languages.setMonarchTokensProvider).toHaveBeenCalledWith(
+      ROBOT_LANGUAGE_ID,
+      language,
+    );
+  });
+
+  it("skips registration when language already exists", () => {
+    const monaco = createMonacoMock([ROBOT_LANGUAGE_ID]);
+    registerRobotFramework(monaco as never);
+
+    expect(monaco.languages.register).not.toHaveBeenCalled();
+    expect(monaco.languages.setMonarchTokensProvider).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grammar smoke tests
+//
+// Minimal emulation of Monarch's first-match-wins scanning over the `root`
+// state (state transitions are not followed — enough for rule-level checks).
+// ---------------------------------------------------------------------------
+
+type MonarchAction = string | { token: string };
+type MonarchRule = [RegExp, MonarchAction];
+
+const rootRules = (language.tokenizer as Record<string, MonarchRule[]>).root;
+
+function tokenOf(action: MonarchAction): string {
+  return typeof action === "string" ? action : action.token;
+}
+
+function tokenize(line: string): { token: string; text: string }[] {
+  const out: { token: string; text: string }[] = [];
+  let pos = 0;
+  while (pos < line.length) {
+    let matched = false;
+    for (const [pattern, action] of rootRules) {
+      const re = new RegExp(pattern.source, "iy");
+      re.lastIndex = pos;
+      const m = re.exec(line);
+      if (m && m[0].length > 0) {
+        out.push({ token: tokenOf(action), text: m[0] });
+        pos += m[0].length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      out.push({ token: "", text: line[pos] });
+      pos += 1;
+    }
+  }
+  return out;
+}
+
+function tokensIn(line: string): string[] {
+  return tokenize(line).map((t) => t.token);
+}
+
+describe("robotframework Monarch grammar", () => {
+  it("highlights section headers case-insensitively", () => {
+    expect(tokensIn("*** Test Cases ***")[0]).toBe("keyword.section");
+    expect(tokensIn("*** settings ***")[0]).toBe("keyword.section");
+    expect(tokensIn("*** Keywords ***")[0]).toBe("keyword.section");
+    expect(tokensIn("*** Variables ***")[0]).toBe("keyword.section");
+  });
+
+  it("highlights comments", () => {
+    expect(tokensIn("# top-level comment")[0]).toBe("comment");
+    expect(tokensIn("    Log    hi    # trailing")).toContain("comment");
+  });
+
+  it("does not treat escaped hash as comment", () => {
+    const tokens = tokenize("    Log    \\# not a comment");
+    const escape = tokens.find((t) => t.text === "\\#");
+    expect(escape?.token).toBe("string.escape");
+  });
+
+  it("highlights scalar / list / dict / env variables", () => {
+    expect(tokensIn("${VAR}    value")).toContain("variable");
+    expect(tokensIn("@{LIST}    a    b")).toContain("variable");
+    expect(tokensIn("&{DICT}    k=v")).toContain("variable");
+    expect(tokensIn("    Log    %{HOME}")).toContain("variable");
+  });
+
+  it("highlights bracket settings like [Tags] and [Arguments]", () => {
+    const tags = tokenize("    [Tags]    smoke");
+    expect(tags.find((t) => t.text === "[Tags]")?.token).toBe("tag");
+    const args = tokenize("    [Arguments]    ${a}");
+    expect(args.find((t) => t.text === "[Arguments]")?.token).toBe("tag");
+  });
+
+  it("highlights control-flow structures and FOR separators", () => {
+    const forLine = tokenize("    FOR    ${i}    IN RANGE    10");
+    const controls = forLine.filter((t) => t.token === "keyword.control");
+    expect(controls.map((t) => t.text.trim())).toEqual(["FOR", "IN RANGE"]);
+    expect(forLine.find((t) => t.text === "10")?.token).toBe("number");
+    expect(tokensIn("    END")).toContain("keyword.control");
+  });
+
+  it("highlights settings-section directives at column 0", () => {
+    expect(tokensIn("Library    Collections")[0]).toBe("keyword");
+    expect(tokensIn("Suite Setup    Open Browser")[0]).toBe("keyword");
+    expect(tokensIn("Resource    common.resource")[0]).toBe("keyword");
+  });
+
+  it("highlights test case / keyword names at column 0", () => {
+    expect(tokensIn("My First Test")[0]).toBe("type");
+    // A name merely starting with a directive word is still a name
+    expect(tokensIn("Library helpers should load")[0]).toBe("type");
+  });
+
+  it("leaves indented keyword calls as plain text", () => {
+    const tokens = tokenize("    Open Browser    https://example.org");
+    expect(tokens.find((t) => t.text.includes("Open"))?.token).toBe("");
+  });
+});

--- a/console/src/monaco/robotframework.test.ts
+++ b/console/src/monaco/robotframework.test.ts
@@ -60,14 +60,14 @@ describe("registerRobotFramework", () => {
 // ---------------------------------------------------------------------------
 // Grammar smoke tests
 //
-// Minimal emulation of Monarch's first-match-wins scanning over the `root`
-// state (state transitions are not followed — enough for rule-level checks).
+// Minimal emulation of Monarch's first-match-wins scanning, including the
+// state transitions used by the variable rules.
 // ---------------------------------------------------------------------------
 
-type MonarchAction = string | { token: string };
+type MonarchAction = string | { token: string; next?: string };
 type MonarchRule = [RegExp, MonarchAction];
 
-const rootRules = (language.tokenizer as Record<string, MonarchRule[]>).root;
+const tokenizer = language.tokenizer as Record<string, MonarchRule[]>;
 
 function tokenOf(action: MonarchAction): string {
   return typeof action === "string" ? action : action.token;
@@ -75,16 +75,27 @@ function tokenOf(action: MonarchAction): string {
 
 function tokenize(line: string): { token: string; text: string }[] {
   const out: { token: string; text: string }[] = [];
+  const stateStack = ["root"];
   let pos = 0;
   while (pos < line.length) {
     let matched = false;
-    for (const [pattern, action] of rootRules) {
+    const state = stateStack[stateStack.length - 1];
+    for (const [pattern, action] of tokenizer[state]) {
       const re = new RegExp(pattern.source, "iy");
       re.lastIndex = pos;
       const m = re.exec(line);
       if (m && m[0].length > 0) {
         out.push({ token: tokenOf(action), text: m[0] });
         pos += m[0].length;
+        if (typeof action !== "string" && action.next) {
+          if (action.next === "@push") {
+            stateStack.push(state);
+          } else if (action.next === "@pop") {
+            stateStack.pop();
+          } else {
+            stateStack.push(action.next.replace(/^@/, ""));
+          }
+        }
         matched = true;
         break;
       }
@@ -114,6 +125,14 @@ describe("robotframework Monarch grammar", () => {
     expect(tokensIn("    Log    hi    # trailing")).toContain("comment");
   });
 
+  it("only treats hashes at cell boundaries as comments", () => {
+    expect(tokensIn("    Log    https://example.org/#section")).not.toContain(
+      "comment",
+    );
+    expect(tokensIn("    Log    value#literal")).not.toContain("comment");
+    expect(tokensIn("    Log    value\t# trailing")).toContain("comment");
+  });
+
   it("does not treat escaped hash as comment", () => {
     const tokens = tokenize("    Log    \\# not a comment");
     const escape = tokens.find((t) => t.text === "\\#");
@@ -125,6 +144,17 @@ describe("robotframework Monarch grammar", () => {
     expect(tokensIn("@{LIST}    a    b")).toContain("variable");
     expect(tokensIn("&{DICT}    k=v")).toContain("variable");
     expect(tokensIn("    Log    %{HOME}")).toContain("variable");
+  });
+
+  it("follows variable states and supports nested variables", () => {
+    const tokens = tokenize("${outer_${inner}}    tail");
+    const variableText = tokens
+      .filter((token) => token.token === "variable")
+      .map((token) => token.text)
+      .join("");
+
+    expect(variableText).toBe("${outer_${inner}}");
+    expect(tokens.find((token) => token.text === "tail")?.token).toBe("");
   });
 
   it("highlights bracket settings like [Tags] and [Arguments]", () => {
@@ -140,6 +170,14 @@ describe("robotframework Monarch grammar", () => {
     expect(controls.map((t) => t.text.trim())).toEqual(["FOR", "IN RANGE"]);
     expect(forLine.find((t) => t.text === "10")?.token).toBe("number");
     expect(tokensIn("    END")).toContain("keyword.control");
+  });
+
+  it("accepts a single tab as a cell separator", () => {
+    const forLine = tokenize("\tFOR\t${i}\tIN RANGE\t10");
+    const controls = forLine.filter((t) => t.token === "keyword.control");
+
+    expect(controls.map((t) => t.text.trim())).toEqual(["FOR", "IN RANGE"]);
+    expect(tokensIn("Library\tCollections")[0]).toBe("keyword");
   });
 
   it("highlights settings-section directives at column 0", () => {

--- a/console/src/monaco/robotframework.ts
+++ b/console/src/monaco/robotframework.ts
@@ -36,8 +36,8 @@ export const conf: Monaco.languages.LanguageConfiguration = {
 /**
  * Monarch grammar.
  *
- * RobotFramework separates cells with 2+ spaces (or tabs), so most
- * keyword rules assert a cell boundary via `(?=[ \t]{2,}|[ \t]*$)`.
+ * RobotFramework separates cells with 2+ spaces or 1+ tabs, so keyword
+ * rules assert a cell boundary via `(?= {2,}|\t+|[ \t]*$)`.
  * Token names reuse Monaco's built-in theme colors (keyword, comment,
  * variable, tag, type, number) so both `vs` and `vs-dark` work.
  */
@@ -55,14 +55,14 @@ export const language: Monaco.languages.IMonarchLanguage = {
       [/^[ \t]*\.\.\.(?=[ \t]|$)/, "delimiter"],
       // Control-flow structures at cell start (FOR / IF / TRY …)
       [
-        /^[ \t]*(FOR|END|IF|ELSE IF|ELSE|WHILE|TRY|EXCEPT|FINALLY|RETURN|BREAK|CONTINUE|VAR|GROUP)(?=[ \t]{2,}|[ \t]*$)/,
+        /^[ \t]*(FOR|END|IF|ELSE IF|ELSE|WHILE|TRY|EXCEPT|FINALLY|RETURN|BREAK|CONTINUE|VAR|GROUP)(?= {2,}|\t+|[ \t]*$)/,
         "keyword.control",
       ],
       // Gherkin-style prefixes in keyword calls
       [/^[ \t]+(given|when|then|and|but)(?=[ \t])/, "keyword.control"],
       // Settings-section directives at column 0
       [
-        /^(library|resource|variables|documentation|metadata|name|suite setup|suite teardown|test setup|test teardown|test template|test timeout|test tags|task setup|task teardown|task template|task timeout|task tags|force tags|default tags|keyword tags)(?=[ \t]{2,}|[ \t]*$)/,
+        /^(library|resource|variables|documentation|metadata|name|suite setup|suite teardown|test setup|test teardown|test template|test timeout|test tags|task setup|task teardown|task template|task timeout|task tags|force tags|default tags|keyword tags)(?= {2,}|\t+|[ \t]*$)/,
         "keyword",
       ],
       // Test case / task / keyword definition name at column 0
@@ -74,13 +74,14 @@ export const language: Monaco.languages.IMonarchLanguage = {
       ],
       // Escaped characters (\# is not a comment, \${ not a variable)
       [/\\./, "string.escape"],
-      // Comments
-      [/#.*$/, "comment"],
+      // Comments in the first cell or after a cell separator
+      [/^[ \t]*#.*$/, "comment"],
+      [/(?: {2,}|\t+)[ \t]*#.*$/, "comment"],
       // Variables: ${scalar} @{list} &{dict} %{env}
       [/[$@&%]\{/, { token: "variable", next: "@variable" }],
       // FOR loop separators as standalone cells
       [
-        /\b(IN RANGE|IN ENUMERATE|IN ZIP|IN)(?=[ \t]{2,}|[ \t]*$)/,
+        /\b(IN RANGE|IN ENUMERATE|IN ZIP|IN)(?= {2,}|\t+|[ \t]*$)/,
         "keyword.control",
       ],
       // Numbers

--- a/console/src/monaco/robotframework.ts
+++ b/console/src/monaco/robotframework.ts
@@ -1,0 +1,120 @@
+/**
+ * RobotFramework language support for Monaco.
+ *
+ * Monaco does not ship a RobotFramework definition, so `.robot` and
+ * `.resource` files fell back to plaintext in the Coding Mode editor.
+ * This module registers a Monarch tokenizer covering section headers,
+ * settings, control-flow keywords, variables, tags and comments.
+ *
+ * Registered once from `monacoSetup.ts` (side-effect free by itself;
+ * call `registerRobotFramework` with a Monaco instance).
+ */
+
+import type * as Monaco from "monaco-editor";
+
+export const ROBOT_LANGUAGE_ID = "robotframework";
+
+export const conf: Monaco.languages.LanguageConfiguration = {
+  comments: { lineComment: "#" },
+  brackets: [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+  ],
+  autoClosingPairs: [
+    { open: "{", close: "}" },
+    { open: "[", close: "]" },
+    { open: "(", close: ")" },
+  ],
+  surroundingPairs: [
+    { open: "{", close: "}" },
+    { open: "[", close: "]" },
+    { open: "(", close: ")" },
+  ],
+};
+
+/**
+ * Monarch grammar.
+ *
+ * RobotFramework separates cells with 2+ spaces (or tabs), so most
+ * keyword rules assert a cell boundary via `(?=[ \t]{2,}|[ \t]*$)`.
+ * Token names reuse Monaco's built-in theme colors (keyword, comment,
+ * variable, tag, type, number) so both `vs` and `vs-dark` work.
+ */
+export const language: Monaco.languages.IMonarchLanguage = {
+  defaultToken: "",
+  ignoreCase: true,
+  tokenizer: {
+    root: [
+      // Section headers: *** Settings ***, *** Test Cases *** …
+      [
+        /^\*+[ \t]*(settings?|variables?|test cases?|tasks?|keywords?|comments?)\b[ \t*]*$/,
+        "keyword.section",
+      ],
+      // Line continuation marker
+      [/^[ \t]*\.\.\.(?=[ \t]|$)/, "delimiter"],
+      // Control-flow structures at cell start (FOR / IF / TRY …)
+      [
+        /^[ \t]*(FOR|END|IF|ELSE IF|ELSE|WHILE|TRY|EXCEPT|FINALLY|RETURN|BREAK|CONTINUE|VAR|GROUP)(?=[ \t]{2,}|[ \t]*$)/,
+        "keyword.control",
+      ],
+      // Gherkin-style prefixes in keyword calls
+      [/^[ \t]+(given|when|then|and|but)(?=[ \t])/, "keyword.control"],
+      // Settings-section directives at column 0
+      [
+        /^(library|resource|variables|documentation|metadata|name|suite setup|suite teardown|test setup|test teardown|test template|test timeout|test tags|task setup|task teardown|task template|task timeout|task tags|force tags|default tags|keyword tags)(?=[ \t]{2,}|[ \t]*$)/,
+        "keyword",
+      ],
+      // Test case / task / keyword definition name at column 0
+      [/^[^ \t#*$@&%\\[].*$/, "type"],
+      // [Tags] / [Arguments] … bracket settings
+      [
+        /\[(documentation|tags|arguments|setup|teardown|template|timeout|return|precondition|postcondition)\]/,
+        "tag",
+      ],
+      // Escaped characters (\# is not a comment, \${ not a variable)
+      [/\\./, "string.escape"],
+      // Comments
+      [/#.*$/, "comment"],
+      // Variables: ${scalar} @{list} &{dict} %{env}
+      [/[$@&%]\{/, { token: "variable", next: "@variable" }],
+      // FOR loop separators as standalone cells
+      [
+        /\b(IN RANGE|IN ENUMERATE|IN ZIP|IN)(?=[ \t]{2,}|[ \t]*$)/,
+        "keyword.control",
+      ],
+      // Numbers
+      [/\b\d+(\.\d+)?\b/, "number"],
+      // Cell separators & plain text
+      [/[ \t]+/, "white"],
+      [/[^ \t$@&%#\\]+/, ""],
+      [/./, ""],
+    ],
+    // Inside ${ … } — supports nesting like ${outer_${inner}}
+    variable: [
+      [/[$@&%]\{/, { token: "variable", next: "@push" }],
+      [/\}/, { token: "variable", next: "@pop" }],
+      [/[^$@&%{}]+/, "variable"],
+      [/./, "variable"],
+    ],
+  },
+};
+
+/**
+ * Register RobotFramework with the given Monaco instance.
+ * Safe to call multiple times — skips if already registered.
+ */
+export function registerRobotFramework(monaco: typeof Monaco): void {
+  const alreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((lang) => lang.id === ROBOT_LANGUAGE_ID);
+  if (alreadyRegistered) return;
+
+  monaco.languages.register({
+    id: ROBOT_LANGUAGE_ID,
+    extensions: [".robot", ".resource"],
+    aliases: ["RobotFramework", "robotframework", "Robot Framework"],
+  });
+  monaco.languages.setLanguageConfiguration(ROBOT_LANGUAGE_ID, conf);
+  monaco.languages.setMonarchTokensProvider(ROBOT_LANGUAGE_ID, language);
+}

--- a/console/src/monacoSetup.ts
+++ b/console/src/monacoSetup.ts
@@ -17,6 +17,7 @@
 
 import * as monaco from "monaco-editor";
 import { loader } from "@monaco-editor/react";
+import { registerRobotFramework } from "./monaco/robotframework";
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
@@ -47,6 +48,9 @@ self.MonacoEnvironment = {
     }
   },
 };
+
+// Register languages Monaco does not ship built-in.
+registerRobotFramework(monaco);
 
 // Use the locally bundled monaco instance instead of loading it from the CDN.
 loader.config({ monaco });

--- a/console/src/pages/Coding/TabbedEditor.tsx
+++ b/console/src/pages/Coding/TabbedEditor.tsx
@@ -36,6 +36,7 @@ import { useWorkspaceWatch } from "../../hooks/useWorkspaceWatch";
 import { useTheme } from "../../contexts/ThemeContext";
 import { setTextareaValue } from "../Chat/utils";
 import { clearLastEditorCopy, setLastEditorCopy } from "./lastEditorCopy";
+import { getLanguage } from "./getLanguage";
 import {
   useCurrentDiffs,
   useCodingTabsStore,
@@ -63,38 +64,6 @@ interface TabbedEditorProps {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function getLanguage(path: string): string {
-  const ext = path.split(".").pop()?.toLowerCase() ?? "";
-  const map: Record<string, string> = {
-    py: "python",
-    ts: "typescript",
-    tsx: "typescript",
-    js: "javascript",
-    jsx: "javascript",
-    json: "json",
-    yaml: "yaml",
-    yml: "yaml",
-    md: "markdown",
-    sh: "shell",
-    bash: "shell",
-    html: "html",
-    css: "css",
-    less: "less",
-    scss: "scss",
-    sql: "sql",
-    toml: "ini",
-    rs: "rust",
-    go: "go",
-    java: "java",
-    cpp: "cpp",
-    c: "c",
-    h: "c",
-    kt: "kotlin",
-    rb: "ruby",
-  };
-  return map[ext] ?? "plaintext";
-}
 
 function appendToChat(text: string): void {
   const senderEl = document.querySelector('[class*="sender"]');

--- a/console/src/pages/Coding/getLanguage.test.ts
+++ b/console/src/pages/Coding/getLanguage.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Tests for the Coding editor's extension → Monaco language mapping.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { getLanguage } from "./getLanguage";
+
+describe("getLanguage", () => {
+  it("maps RobotFramework extensions", () => {
+    expect(getLanguage("tests/login.robot")).toBe("robotframework");
+    expect(getLanguage("resources/common.resource")).toBe("robotframework");
+    expect(getLanguage("SUITE.ROBOT")).toBe("robotframework");
+  });
+
+  it("keeps existing mappings intact", () => {
+    expect(getLanguage("main.py")).toBe("python");
+    expect(getLanguage("app.tsx")).toBe("typescript");
+    expect(getLanguage("unknown.xyz")).toBe("plaintext");
+  });
+});

--- a/console/src/pages/Coding/getLanguage.ts
+++ b/console/src/pages/Coding/getLanguage.ts
@@ -1,0 +1,38 @@
+/**
+ * Extension → Monaco language id mapping for the Coding editor.
+ * Shared by the normal editor and the DiffEditor in TabbedEditor.
+ */
+
+export function getLanguage(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    py: "python",
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    json: "json",
+    yaml: "yaml",
+    yml: "yaml",
+    md: "markdown",
+    sh: "shell",
+    bash: "shell",
+    html: "html",
+    css: "css",
+    less: "less",
+    scss: "scss",
+    sql: "sql",
+    toml: "ini",
+    rs: "rust",
+    go: "go",
+    java: "java",
+    cpp: "cpp",
+    c: "c",
+    h: "c",
+    kt: "kotlin",
+    rb: "ruby",
+    robot: "robotframework",
+    resource: "robotframework",
+  };
+  return map[ext] ?? "plaintext";
+}


### PR DESCRIPTION
Cloes #6403

<img width="2560" height="1231" alt="image" src="https://github.com/user-attachments/assets/0562b493-f1fd-4454-b440-2bc1cbd420f7" />
<img width="2551" height="1235" alt="image" src="https://github.com/user-attachments/assets/26cc9831-fac6-4975-99f4-3bd9b195e0f1" />


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
