### PR TITLE
fix(console): surface OMP loop modes in slash menu with i18n and inline Markdown

### DIFF
--- a/console/src/components/LoopInput/LoopModeSelector.test.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.test.tsx
@@ -11,7 +11,10 @@ import {
 import { LoopModeSelector } from "./LoopModeSelector";
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "zh" },
+  }),
 }));
 
 const goal: LoopModeInfo = {
@@ -36,6 +39,14 @@ const ompUltraqa: LoopModeInfo = {
     "**UltraQA** — automated QA cycle engine\n\n" +
     "Usage:\n" +
     '  `/ultraqa [--tests|--build|--lint|--typecheck|--custom "cmd"]`\n',
+  name_i18n: {
+    en: "UltraQA",
+    "zh-CN": "UltraQA",
+  },
+  description_i18n: {
+    en: "**UltraQA** — automated QA cycle engine",
+    "zh-CN": "**UltraQA** — 自动化 QA 循环引擎",
+  },
   source: "plugin",
 };
 
@@ -68,9 +79,13 @@ describe("LoopModeSelector", () => {
     expect(
       screen.queryByText("Backend goal description"),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("UltraQA")).toBeInTheDocument();
-    expect(screen.getByText("UltraQA").tagName).toBe("STRONG");
-    expect(screen.getByText(/automated QA cycle engine/)).toBeInTheDocument();
+    const ultraqaLabels = screen.getAllByText("UltraQA");
+    expect(ultraqaLabels.length).toBeGreaterThanOrEqual(2);
+    expect(ultraqaLabels.some((node) => node.tagName === "STRONG")).toBe(true);
+    expect(screen.getByText(/自动化 QA 循环引擎/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/automated QA cycle engine/),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/\*\*UltraQA\*\*/)).not.toBeInTheDocument();
     expect(screen.queryByText(/`\/ultraqa/)).not.toBeInTheDocument();
   });

--- a/console/src/components/LoopInput/LoopModeSelector.test.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.test.tsx
@@ -28,12 +28,22 @@ const custom: LoopModeInfo = {
   description: "Keep the user's original description.",
   source: "custom",
 };
+const ompUltraqa: LoopModeInfo = {
+  id: "plugin:ultraqa",
+  name: "ultraqa",
+  slash_command: "ultraqa",
+  description:
+    "**UltraQA** — automated QA cycle engine\n\n" +
+    "Usage:\n" +
+    '  `/ultraqa [--tests|--build|--lint|--typecheck|--custom "cmd"]`\n',
+  source: "plugin",
+};
 
 describe("LoopModeSelector", () => {
   beforeEach(() => {
     useLoopStore.setState({
       selectedModeId: "default",
-      availableModes: [DEFAULT_LOOP_MODE, goal, custom],
+      availableModes: [DEFAULT_LOOP_MODE, goal, custom, ompUltraqa],
       sessionState: "idle",
       activeMode: null,
       catalogLoading: false,
@@ -58,6 +68,11 @@ describe("LoopModeSelector", () => {
     expect(
       screen.queryByText("Backend goal description"),
     ).not.toBeInTheDocument();
+    expect(screen.getByText("UltraQA")).toBeInTheDocument();
+    expect(screen.getByText("UltraQA").tagName).toBe("STRONG");
+    expect(screen.getByText(/automated QA cycle engine/)).toBeInTheDocument();
+    expect(screen.queryByText(/\*\*UltraQA\*\*/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/`\/ultraqa/)).not.toBeInTheDocument();
   });
 
   it("selects a custom mode from the compact menu", async () => {

--- a/console/src/components/LoopInput/LoopModeSelector.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.tsx
@@ -21,13 +21,11 @@ import {
   useLoopStore,
 } from "../../stores/loopStore";
 import { InlineMarkdown } from "../Markdown/InlineMarkdown";
-import { resolveLoopModeDescriptionMarkdown } from "../../utils/loopModeDescription";
+import {
+  resolveLoopModeDescriptionMarkdown,
+  resolveLoopModeName,
+} from "../../utils/loopModeDescription";
 import styles from "./index.module.less";
-
-function modeName(mode: LoopModeInfo, t: (key: string) => string): string {
-  if (mode.source !== "builtin") return mode.name;
-  return t(`loop.modes.${mode.id}.name`);
-}
 
 function ModeIcon({ mode, size = 14 }: { mode: LoopModeInfo; size?: number }) {
   if (mode.id === "goal") return <Target size={size} />;
@@ -38,7 +36,8 @@ function ModeIcon({ mode, size = 14 }: { mode: LoopModeInfo; size?: number }) {
 }
 
 export function LoopModeSelector() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language || "en";
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const availableModes = useLoopStore((state) => state.availableModes);
@@ -80,7 +79,7 @@ export function LoopModeSelector() {
           {sessionState === "awaiting_user" && (
             <MessageCircleQuestion size={14} />
           )}
-          <span>{modeName(activeMode, t)}</span>
+          <span>{resolveLoopModeName(activeMode, t, lang)}</span>
           <span className={styles.activeState}>
             {t(`loop.${sessionState}`)}
           </span>
@@ -114,10 +113,12 @@ export function LoopModeSelector() {
                 <ModeIcon mode={mode} size={16} />
               </span>
               <span className={styles.optionCopy}>
-                <span className={styles.optionName}>{modeName(mode, t)}</span>
+                <span className={styles.optionName}>
+                  {resolveLoopModeName(mode, t, lang)}
+                </span>
                 <span className={styles.optionDescription}>
                   <InlineMarkdown
-                    markdown={resolveLoopModeDescriptionMarkdown(mode, t)}
+                    markdown={resolveLoopModeDescriptionMarkdown(mode, t, lang)}
                   />
                 </span>
               </span>
@@ -186,7 +187,7 @@ export function LoopModeSelector() {
         ) : (
           <ModeIcon mode={selectedMode} />
         )}
-        <span>{modeName(selectedMode, t)}</span>
+        <span>{resolveLoopModeName(selectedMode, t, lang)}</span>
         <ChevronDown size={13} />
       </button>
     </Popover>

--- a/console/src/components/LoopInput/LoopModeSelector.tsx
+++ b/console/src/components/LoopInput/LoopModeSelector.tsx
@@ -20,19 +20,13 @@ import {
   type LoopModeInfo,
   useLoopStore,
 } from "../../stores/loopStore";
+import { InlineMarkdown } from "../Markdown/InlineMarkdown";
+import { resolveLoopModeDescriptionMarkdown } from "../../utils/loopModeDescription";
 import styles from "./index.module.less";
 
 function modeName(mode: LoopModeInfo, t: (key: string) => string): string {
   if (mode.source !== "builtin") return mode.name;
   return t(`loop.modes.${mode.id}.name`);
-}
-
-function modeDescription(
-  mode: LoopModeInfo,
-  t: (key: string) => string,
-): string {
-  if (mode.source !== "builtin") return mode.description;
-  return t(`loop.modes.${mode.id}.description`);
 }
 
 function ModeIcon({ mode, size = 14 }: { mode: LoopModeInfo; size?: number }) {
@@ -122,7 +116,9 @@ export function LoopModeSelector() {
               <span className={styles.optionCopy}>
                 <span className={styles.optionName}>{modeName(mode, t)}</span>
                 <span className={styles.optionDescription}>
-                  {modeDescription(mode, t)}
+                  <InlineMarkdown
+                    markdown={resolveLoopModeDescriptionMarkdown(mode, t)}
+                  />
                 </span>
               </span>
               {selected ? <CircleDot size={15} /> : null}

--- a/console/src/components/Markdown/InlineMarkdown.module.less
+++ b/console/src/components/Markdown/InlineMarkdown.module.less
@@ -1,0 +1,21 @@
+.root {
+  display: inline;
+  min-width: 0;
+
+  :global(strong) {
+    font-weight: 600;
+  }
+
+  :global(code) {
+    padding: 0 3px;
+    border-radius: 3px;
+    font-size: 0.95em;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
+    background: var(--ant-color-fill-secondary, rgba(0, 0, 0, 0.06));
+  }
+
+  :global(em) {
+    font-style: italic;
+  }
+}

--- a/console/src/components/Markdown/InlineMarkdown.test.tsx
+++ b/console/src/components/Markdown/InlineMarkdown.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { InlineMarkdown } from "./InlineMarkdown";
+
+describe("InlineMarkdown", () => {
+  it("renders nothing for empty markdown", () => {
+    const { container } = render(<InlineMarkdown markdown="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders strong and inline code without exposing raw markers", () => {
+    render(
+      <InlineMarkdown markdown="**UltraQA** — use `/ultraqa` for QA cycles" />,
+    );
+
+    expect(screen.getByText("UltraQA")).toBeInTheDocument();
+    expect(screen.getByText("/ultraqa")).toBeInTheDocument();
+    expect(screen.queryByText(/\*\*UltraQA\*\*/)).not.toBeInTheDocument();
+    expect(screen.getByText("UltraQA").tagName).toBe("STRONG");
+    expect(screen.getByText("/ultraqa").tagName).toBe("CODE");
+  });
+
+  it("does not render block constructs from disallowed markup", () => {
+    render(<InlineMarkdown markdown={"# Title\n\n**ok**"} />);
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(screen.getByText("ok").tagName).toBe("STRONG");
+  });
+});

--- a/console/src/components/Markdown/InlineMarkdown.tsx
+++ b/console/src/components/Markdown/InlineMarkdown.tsx
@@ -1,0 +1,34 @@
+import ReactMarkdown from "react-markdown";
+
+import styles from "./InlineMarkdown.module.less";
+
+/** Inline-only tags safe for compact menu / suggestion rows. */
+const INLINE_ELEMENTS = ["p", "strong", "em", "code", "del"] as const;
+
+/**
+ * Render a short Markdown snippet as inline content (no block layout).
+ * Disallowed nodes are unwrapped so surrounding text still appears.
+ */
+export function InlineMarkdown({
+  markdown,
+  className,
+}: {
+  markdown: string;
+  className?: string;
+}) {
+  if (!markdown) return null;
+
+  return (
+    <span className={[styles.root, className].filter(Boolean).join(" ")}>
+      <ReactMarkdown
+        allowedElements={[...INLINE_ELEMENTS]}
+        unwrapDisallowed
+        components={{
+          p: ({ children }) => <>{children}</>,
+        }}
+      >
+        {markdown}
+      </ReactMarkdown>
+    </span>
+  );
+}

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -34,6 +34,8 @@ import {
   prepareLoopModeMessage,
   useLoopStore,
 } from "../../stores/loopStore";
+import { buildLoopSlashSuggestions } from "./loopSlashSuggestions";
+import { InlineMarkdown } from "../../components/Markdown/InlineMarkdown";
 import { LoopModeSelector } from "../../components/LoopInput";
 import { useChatAnywhereInput } from "@agentscope-ai/chat";
 import styles from "./index.module.less";
@@ -549,21 +551,12 @@ function renderSuggestionLabel(command: string, description?: string) {
     >
       <span className={styles.suggestionCommand}>{command}</span>
       {description ? (
-        <span className={styles.suggestionDescription}>{description}</span>
+        <span className={styles.suggestionDescription}>
+          <InlineMarkdown markdown={description} />
+        </span>
       ) : null}
     </div>
   );
-}
-
-/** First-line, plain-text blurb for loop slash suggestions (OMP help is multi-line MD). */
-function shortLoopSuggestionDescription(description?: string): string {
-  if (!description) return "";
-  const firstLine = description
-    .split(/\r?\n/, 1)[0]
-    .replace(/\*\*/g, "")
-    .trim();
-  if (firstLine.length <= 80) return firstLine;
-  return `${firstLine.slice(0, 77)}...`;
 }
 
 // ---------------------------------------------------------------------------
@@ -2498,17 +2491,7 @@ export default function ChatPage() {
     // LoopModeSelector; include them in the slash menu when the QwenPaw
     // backend is active. Empty slash_command (default mode) is skipped.
     const loopSuggestions: CommandSuggestion[] = usesQwenPawBackend
-      ? loopAvailableModes
-          .filter(
-            (mode) =>
-              Boolean(mode.slash_command) &&
-              !reservedCommands.has(mode.slash_command),
-          )
-          .map((mode) => ({
-            command: `/${mode.slash_command}`,
-            value: mode.slash_command,
-            description: shortLoopSuggestionDescription(mode.description),
-          }))
+      ? buildLoopSlashSuggestions(loopAvailableModes, reservedCommands, t)
       : [];
     const skillSuggestions: CommandSuggestion[] = consoleSkills
       .filter(

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2491,7 +2491,12 @@ export default function ChatPage() {
     // LoopModeSelector; include them in the slash menu when the QwenPaw
     // backend is active. Empty slash_command (default mode) is skipped.
     const loopSuggestions: CommandSuggestion[] = usesQwenPawBackend
-      ? buildLoopSlashSuggestions(loopAvailableModes, reservedCommands, t)
+      ? buildLoopSlashSuggestions(
+          loopAvailableModes,
+          reservedCommands,
+          t,
+          i18n.language,
+        )
       : [];
     const skillSuggestions: CommandSuggestion[] = consoleSkills
       .filter(

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -555,6 +555,17 @@ function renderSuggestionLabel(command: string, description?: string) {
   );
 }
 
+/** First-line, plain-text blurb for loop slash suggestions (OMP help is multi-line MD). */
+function shortLoopSuggestionDescription(description?: string): string {
+  if (!description) return "";
+  const firstLine = description
+    .split(/\r?\n/, 1)[0]
+    .replace(/\*\*/g, "")
+    .trim();
+  if (firstLine.length <= 80) return firstLine;
+  return `${firstLine.slice(0, 77)}...`;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -2483,6 +2494,22 @@ export default function ChatPage() {
     const loopCommandNames = new Set(
       loopAvailableModes.map((mode) => mode.slash_command).filter(Boolean),
     );
+    // Loop/plugin modes (goal, mission, OMP, custom) share GET /loops with
+    // LoopModeSelector; include them in the slash menu when the QwenPaw
+    // backend is active. Empty slash_command (default mode) is skipped.
+    const loopSuggestions: CommandSuggestion[] = usesQwenPawBackend
+      ? loopAvailableModes
+          .filter(
+            (mode) =>
+              Boolean(mode.slash_command) &&
+              !reservedCommands.has(mode.slash_command),
+          )
+          .map((mode) => ({
+            command: `/${mode.slash_command}`,
+            value: mode.slash_command,
+            description: shortLoopSuggestionDescription(mode.description),
+          }))
+      : [];
     const skillSuggestions: CommandSuggestion[] = consoleSkills
       .filter(
         (skill) =>
@@ -2719,12 +2746,14 @@ export default function ChatPage() {
       );
     }
 
-    const baseSuggestions = [...commandSuggestions, ...skillSuggestions].map(
-      (item) => ({
-        label: renderSuggestionLabel(item.command, item.description),
-        value: item.value,
-      }),
-    );
+    const baseSuggestions = [
+      ...commandSuggestions,
+      ...loopSuggestions,
+      ...skillSuggestions,
+    ].map((item) => ({
+      label: renderSuggestionLabel(item.command, item.description),
+      value: item.value,
+    }));
     const userMessageAnchorsConfig = {
       ...defaultConfig.theme.bubbleList.userMessageAnchors,
       variant: "navigator" as const,

--- a/console/src/pages/Chat/loopSlashSuggestions.test.ts
+++ b/console/src/pages/Chat/loopSlashSuggestions.test.ts
@@ -13,13 +13,6 @@ const t = (key: string) => {
 describe("buildLoopSlashSuggestions", () => {
   const modes: LoopModeInfo[] = [
     {
-      id: "default",
-      name: "default",
-      slash_command: "",
-      description: "default",
-      source: "builtin",
-    },
-    {
       id: "goal",
       name: "goal",
       slash_command: "goal",
@@ -30,20 +23,17 @@ describe("buildLoopSlashSuggestions", () => {
       id: "plugin:ultrawork",
       name: "ultrawork",
       slash_command: "ultrawork",
-      description: "**Ultrawork** — parallel\n\nUsage: `/ultrawork`",
+      description: "**Ultrawork** — parallel\n\nUsage",
       source: "plugin",
-    },
-    {
-      id: "mission",
-      name: "mission",
-      slash_command: "clear",
-      description: "should be reserved",
-      source: "builtin",
+      description_i18n: {
+        en: "**Ultrawork** — parallel",
+        "zh-CN": "**Ultrawork** — 并行",
+      },
     },
   ];
 
-  it("skips empty/reserved commands and keeps first-line Markdown", () => {
-    expect(buildLoopSlashSuggestions(modes, new Set(["clear"]), t)).toEqual([
+  it("resolves plugin descriptions for the active language", () => {
+    expect(buildLoopSlashSuggestions(modes, new Set(), t, "zh")).toEqual([
       {
         command: "/goal",
         value: "goal",
@@ -52,7 +42,7 @@ describe("buildLoopSlashSuggestions", () => {
       {
         command: "/ultrawork",
         value: "ultrawork",
-        description: "**Ultrawork** — parallel",
+        description: "**Ultrawork** — 并行",
       },
     ]);
   });

--- a/console/src/pages/Chat/loopSlashSuggestions.test.ts
+++ b/console/src/pages/Chat/loopSlashSuggestions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { LoopModeInfo } from "../../stores/loopStore";
+import { buildLoopSlashSuggestions } from "./loopSlashSuggestions";
+
+const t = (key: string) => {
+  if (key === "loop.modes.goal.description") {
+    return "设定目标并持续推进直到完成。";
+  }
+  return key;
+};
+
+describe("buildLoopSlashSuggestions", () => {
+  const modes: LoopModeInfo[] = [
+    {
+      id: "default",
+      name: "default",
+      slash_command: "",
+      description: "default",
+      source: "builtin",
+    },
+    {
+      id: "goal",
+      name: "goal",
+      slash_command: "goal",
+      description: "Set a goal and work until it is done.",
+      source: "builtin",
+    },
+    {
+      id: "plugin:ultrawork",
+      name: "ultrawork",
+      slash_command: "ultrawork",
+      description: "**Ultrawork** — parallel\n\nUsage: `/ultrawork`",
+      source: "plugin",
+    },
+    {
+      id: "mission",
+      name: "mission",
+      slash_command: "clear",
+      description: "should be reserved",
+      source: "builtin",
+    },
+  ];
+
+  it("skips empty/reserved commands and keeps first-line Markdown", () => {
+    expect(buildLoopSlashSuggestions(modes, new Set(["clear"]), t)).toEqual([
+      {
+        command: "/goal",
+        value: "goal",
+        description: "设定目标并持续推进直到完成。",
+      },
+      {
+        command: "/ultrawork",
+        value: "ultrawork",
+        description: "**Ultrawork** — parallel",
+      },
+    ]);
+  });
+});

--- a/console/src/pages/Chat/loopSlashSuggestions.ts
+++ b/console/src/pages/Chat/loopSlashSuggestions.ts
@@ -12,6 +12,7 @@ export function buildLoopSlashSuggestions(
   modes: LoopModeInfo[],
   reservedCommands: ReadonlySet<string>,
   t: (key: string) => string,
+  lang: string = "en",
 ): LoopSlashSuggestion[] {
   return modes
     .filter(
@@ -22,6 +23,6 @@ export function buildLoopSlashSuggestions(
     .map((mode) => ({
       command: `/${mode.slash_command}`,
       value: mode.slash_command,
-      description: resolveLoopModeDescriptionMarkdown(mode, t),
+      description: resolveLoopModeDescriptionMarkdown(mode, t, lang),
     }));
 }

--- a/console/src/pages/Chat/loopSlashSuggestions.ts
+++ b/console/src/pages/Chat/loopSlashSuggestions.ts
@@ -1,0 +1,27 @@
+import type { LoopModeInfo } from "../../stores/loopStore";
+import { resolveLoopModeDescriptionMarkdown } from "../../utils/loopModeDescription";
+
+export interface LoopSlashSuggestion {
+  command: string;
+  value: string;
+  /** First-line Markdown; render with InlineMarkdown in the suggestion label. */
+  description: string;
+}
+
+export function buildLoopSlashSuggestions(
+  modes: LoopModeInfo[],
+  reservedCommands: ReadonlySet<string>,
+  t: (key: string) => string,
+): LoopSlashSuggestion[] {
+  return modes
+    .filter(
+      (mode) =>
+        Boolean(mode.slash_command) &&
+        !reservedCommands.has(mode.slash_command),
+    )
+    .map((mode) => ({
+      command: `/${mode.slash_command}`,
+      value: mode.slash_command,
+      description: resolveLoopModeDescriptionMarkdown(mode, t),
+    }));
+}

--- a/console/src/stores/loopStore.ts
+++ b/console/src/stores/loopStore.ts
@@ -14,6 +14,10 @@ export interface LoopModeInfo {
   slash_command: string;
   description: string;
   source: LoopModeSource;
+  /** Plugin-owned display names keyed by locale (e.g. en, zh-CN). */
+  name_i18n?: Record<string, string> | null;
+  /** Plugin-owned menu summaries keyed by locale. */
+  description_i18n?: Record<string, string> | null;
 }
 
 interface LoopModeStatusResponse {

--- a/console/src/utils/loopModeDescription.test.ts
+++ b/console/src/utils/loopModeDescription.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { LoopModeInfo } from "../stores/loopStore";
+import {
+  firstLoopDescriptionMarkdown,
+  resolveLoopModeDescriptionMarkdown,
+} from "./loopModeDescription";
+
+const t = (key: string) => {
+  if (key === "loop.modes.goal.description") {
+    return "设定目标并持续推进直到完成。";
+  }
+  return key;
+};
+
+describe("firstLoopDescriptionMarkdown", () => {
+  it("returns empty for missing input", () => {
+    expect(firstLoopDescriptionMarkdown()).toBe("");
+    expect(firstLoopDescriptionMarkdown("")).toBe("");
+  });
+
+  it("keeps the first non-empty line including Markdown markers", () => {
+    expect(
+      firstLoopDescriptionMarkdown(
+        "**UltraQA** — automated QA cycle engine\n\n" +
+          "Usage:\n" +
+          "  `/ultraqa [--tests|--build]`\n",
+      ),
+    ).toBe("**UltraQA** — automated QA cycle engine");
+  });
+
+  it("skips blank lines before the summary", () => {
+    expect(
+      firstLoopDescriptionMarkdown(
+        "\n\n**Team** — multi-agent collaboration\n\nUsage",
+      ),
+    ).toBe("**Team** — multi-agent collaboration");
+  });
+});
+
+describe("resolveLoopModeDescriptionMarkdown", () => {
+  it("uses i18n for builtin modes", () => {
+    const goal: Pick<LoopModeInfo, "id" | "source" | "description"> = {
+      id: "goal",
+      source: "builtin",
+      description: "Set a goal and work until it is done.",
+    };
+    expect(resolveLoopModeDescriptionMarkdown(goal, t)).toBe(
+      "设定目标并持续推进直到完成。",
+    );
+  });
+
+  it("keeps Markdown on plugin/custom API descriptions", () => {
+    const omp: Pick<LoopModeInfo, "id" | "source" | "description"> = {
+      id: "plugin:ultrawork",
+      source: "plugin",
+      description:
+        "**Ultrawork** — parallel task execution engine\n\n" +
+        "Usage: `/ultrawork <task description>`",
+    };
+    expect(resolveLoopModeDescriptionMarkdown(omp, t)).toBe(
+      "**Ultrawork** — parallel task execution engine",
+    );
+  });
+});

--- a/console/src/utils/loopModeDescription.test.ts
+++ b/console/src/utils/loopModeDescription.test.ts
@@ -4,62 +4,103 @@ import type { LoopModeInfo } from "../stores/loopStore";
 import {
   firstLoopDescriptionMarkdown,
   resolveLoopModeDescriptionMarkdown,
+  resolveLoopModeName,
 } from "./loopModeDescription";
 
 const t = (key: string) => {
   if (key === "loop.modes.goal.description") {
     return "设定目标并持续推进直到完成。";
   }
+  if (key === "loop.modes.goal.name") {
+    return "目标";
+  }
   return key;
 };
 
 describe("firstLoopDescriptionMarkdown", () => {
-  it("returns empty for missing input", () => {
-    expect(firstLoopDescriptionMarkdown()).toBe("");
-    expect(firstLoopDescriptionMarkdown("")).toBe("");
-  });
-
   it("keeps the first non-empty line including Markdown markers", () => {
     expect(
       firstLoopDescriptionMarkdown(
-        "**UltraQA** — automated QA cycle engine\n\n" +
-          "Usage:\n" +
-          "  `/ultraqa [--tests|--build]`\n",
+        "**UltraQA** — automated QA cycle engine\n\nUsage:\n",
       ),
     ).toBe("**UltraQA** — automated QA cycle engine");
-  });
-
-  it("skips blank lines before the summary", () => {
-    expect(
-      firstLoopDescriptionMarkdown(
-        "\n\n**Team** — multi-agent collaboration\n\nUsage",
-      ),
-    ).toBe("**Team** — multi-agent collaboration");
   });
 });
 
 describe("resolveLoopModeDescriptionMarkdown", () => {
-  it("uses i18n for builtin modes", () => {
-    const goal: Pick<LoopModeInfo, "id" | "source" | "description"> = {
+  it("uses Console i18n for builtin modes", () => {
+    const goal: Pick<
+      LoopModeInfo,
+      "id" | "source" | "description" | "description_i18n"
+    > = {
       id: "goal",
       source: "builtin",
       description: "Set a goal and work until it is done.",
     };
-    expect(resolveLoopModeDescriptionMarkdown(goal, t)).toBe(
+    expect(resolveLoopModeDescriptionMarkdown(goal, t, "zh")).toBe(
       "设定目标并持续推进直到完成。",
     );
   });
 
-  it("keeps Markdown on plugin/custom API descriptions", () => {
-    const omp: Pick<LoopModeInfo, "id" | "source" | "description"> = {
+  it("uses description_i18n for plugins when present", () => {
+    const omp: Pick<
+      LoopModeInfo,
+      "id" | "source" | "description" | "description_i18n"
+    > = {
       id: "plugin:ultrawork",
       source: "plugin",
-      description:
-        "**Ultrawork** — parallel task execution engine\n\n" +
-        "Usage: `/ultrawork <task description>`",
+      description: "**Ultrawork** — parallel task execution engine\n\nUsage",
+      description_i18n: {
+        en: "**Ultrawork** — parallel task execution engine",
+        "zh-CN": "**Ultrawork** — 并行任务执行引擎",
+      },
     };
-    expect(resolveLoopModeDescriptionMarkdown(omp, t)).toBe(
+    expect(resolveLoopModeDescriptionMarkdown(omp, t, "zh")).toBe(
+      "**Ultrawork** — 并行任务执行引擎",
+    );
+    expect(resolveLoopModeDescriptionMarkdown(omp, t, "en")).toBe(
       "**Ultrawork** — parallel task execution engine",
     );
+  });
+
+  it("falls back to API description when plugin has no i18n map", () => {
+    const other: Pick<
+      LoopModeInfo,
+      "id" | "source" | "description" | "description_i18n"
+    > = {
+      id: "plugin:a2a",
+      source: "plugin",
+      description: "List or call remote A2A agents",
+    };
+    expect(resolveLoopModeDescriptionMarkdown(other, t, "zh")).toBe(
+      "List or call remote A2A agents",
+    );
+  });
+});
+
+describe("resolveLoopModeName", () => {
+  it("uses Console i18n for builtin names", () => {
+    expect(
+      resolveLoopModeName(
+        { id: "goal", name: "goal", source: "builtin" },
+        t,
+        "zh",
+      ),
+    ).toBe("目标");
+  });
+
+  it("uses name_i18n for plugins", () => {
+    expect(
+      resolveLoopModeName(
+        {
+          id: "plugin:ralph",
+          name: "ralph",
+          source: "plugin",
+          name_i18n: { en: "Ralph", "zh-CN": "Ralph" },
+        },
+        t,
+        "zh",
+      ),
+    ).toBe("Ralph");
   });
 });

--- a/console/src/utils/loopModeDescription.ts
+++ b/console/src/utils/loopModeDescription.ts
@@ -1,0 +1,29 @@
+import type { LoopModeInfo } from "../stores/loopStore";
+
+/**
+ * First non-empty line of loop/plugin help text, Markdown markers preserved.
+ *
+ * OMP CommandSpec.help_text is a multi-line Markdown doc; menus only need the
+ * summary line, which is then rendered with restricted inline Markdown.
+ */
+export function firstLoopDescriptionMarkdown(description?: string): string {
+  if (!description) return "";
+  return (
+    description
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? ""
+  );
+}
+
+/** Builtin modes use i18n; plugin/custom use API text — keep Markdown. */
+export function resolveLoopModeDescriptionMarkdown(
+  mode: Pick<LoopModeInfo, "id" | "source" | "description">,
+  t: (key: string) => string,
+): string {
+  const raw =
+    mode.source === "builtin"
+      ? t(`loop.modes.${mode.id}.description`)
+      : mode.description;
+  return firstLoopDescriptionMarkdown(raw);
+}

--- a/console/src/utils/loopModeDescription.ts
+++ b/console/src/utils/loopModeDescription.ts
@@ -1,4 +1,5 @@
 import type { LoopModeInfo } from "../stores/loopStore";
+import { resolveLocalizedText } from "./resolveLocalizedText";
 
 /**
  * First non-empty line of loop/plugin help text, Markdown markers preserved.
@@ -16,14 +17,33 @@ export function firstLoopDescriptionMarkdown(description?: string): string {
   );
 }
 
-/** Builtin modes use i18n; plugin/custom use API text — keep Markdown. */
+/**
+ * Builtin modes use Console i18n; plugins prefer description_i18n + lang,
+ * then fall back to API description.
+ */
 export function resolveLoopModeDescriptionMarkdown(
-  mode: Pick<LoopModeInfo, "id" | "source" | "description">,
+  mode: Pick<
+    LoopModeInfo,
+    "id" | "source" | "description" | "description_i18n"
+  >,
   t: (key: string) => string,
+  lang: string = "en",
 ): string {
-  const raw =
-    mode.source === "builtin"
-      ? t(`loop.modes.${mode.id}.description`)
-      : mode.description;
-  return firstLoopDescriptionMarkdown(raw);
+  if (mode.source === "builtin") {
+    return firstLoopDescriptionMarkdown(t(`loop.modes.${mode.id}.description`));
+  }
+  const fromI18n = resolveLocalizedText(mode.description_i18n, lang);
+  return firstLoopDescriptionMarkdown(fromI18n || mode.description);
+}
+
+/** Plugin name_i18n when present; otherwise API / builtin name via t. */
+export function resolveLoopModeName(
+  mode: Pick<LoopModeInfo, "id" | "name" | "source" | "name_i18n">,
+  t: (key: string) => string,
+  lang: string = "en",
+): string {
+  if (mode.source === "builtin") {
+    return t(`loop.modes.${mode.id}.name`);
+  }
+  return resolveLocalizedText(mode.name_i18n, lang) || mode.name;
 }

--- a/console/src/utils/resolveLocalizedText.test.ts
+++ b/console/src/utils/resolveLocalizedText.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveLocalizedText } from "./resolveLocalizedText";
+
+describe("resolveLocalizedText", () => {
+  const dict = {
+    en: "English",
+    "zh-CN": "中文",
+  };
+
+  it("returns empty for nullish", () => {
+    expect(resolveLocalizedText(null, "zh")).toBe("");
+    expect(resolveLocalizedText(undefined, "en")).toBe("");
+  });
+
+  it("returns plain strings as-is", () => {
+    expect(resolveLocalizedText("plain", "zh")).toBe("plain");
+  });
+
+  it("matches short UI lang to long dict key", () => {
+    expect(resolveLocalizedText(dict, "zh")).toBe("中文");
+  });
+
+  it("matches exact locale", () => {
+    expect(resolveLocalizedText(dict, "zh-CN")).toBe("中文");
+    expect(resolveLocalizedText(dict, "en")).toBe("English");
+  });
+
+  it("falls back to English when locale missing", () => {
+    expect(resolveLocalizedText(dict, "ja")).toBe("English");
+  });
+});

--- a/console/src/utils/resolveLocalizedText.ts
+++ b/console/src/utils/resolveLocalizedText.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve a plain string or locale→string map against the UI language.
+ *
+ * Priority: exact locale → short code → prefix match (zh ↔ zh-CN) →
+ * English → Chinese → first non-empty value.
+ * Matches ChannelDrawer.resolveLocalized behavior.
+ */
+export function resolveLocalizedText(value: unknown, lang: string): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value !== "object") return String(value);
+
+  const dict = value as Record<string, string>;
+  const locale = lang || "en";
+  const short = locale.split("-")[0].toLowerCase();
+  const prefixKey = Object.keys(dict).find(
+    (k) => k.split("-")[0].toLowerCase() === short && !!dict[k],
+  );
+
+  const exactMatch = dict[locale];
+  const shortMatch = dict[short];
+  const prefixMatch = prefixKey ? dict[prefixKey] : undefined;
+  const englishFallback = dict["en-US"] || dict["en"];
+  const chineseFallback = dict["zh-CN"] || dict["zh"];
+  const anyNonEmpty = Object.values(dict).find((v) => !!v);
+
+  return (
+    exactMatch ||
+    shortMatch ||
+    prefixMatch ||
+    englishFallback ||
+    chineseFallback ||
+    anyNonEmpty ||
+    ""
+  );
+}

--- a/plugins/bundle/omp_workflows/autopilot/mode.py
+++ b/plugins/bundle/omp_workflows/autopilot/mode.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from qwenpaw.runtime.slash_command_registry import CommandSpec
 
 from ..shared.args import split_args
+from ..shared.loop_ui_i18n import loop_command_metadata, loop_help_text
 from ..shared.mode_base import OMPModeBase, info_msg, rewrite_user_msg
 from .gate import AutopilotGate
 
@@ -21,14 +22,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_HELP = (
-    "**Autopilot** — full lifecycle pipeline\n\n"
-    "Usage: `/autopilot [--skip-qa] [--skip-validation] <task>`\n\n"
-    "Phases: expansion -> planning -> execution "
-    "-> qa -> validation -> cleanup -> completed\n"
-    "Validation uses 3 parallel reviewers "
-    "(architect + security + code)."
-)
+_HELP = loop_help_text("autopilot")
 
 
 class AutopilotMode(OMPModeBase):
@@ -47,7 +41,7 @@ class AutopilotMode(OMPModeBase):
                 handler=self._handler,
                 category="builtin",
                 help_text=_HELP,
-                metadata={"builtin": True},
+                metadata=loop_command_metadata("autopilot"),
             ),
         ]
 

--- a/plugins/bundle/omp_workflows/plugin.json
+++ b/plugins/bundle/omp_workflows/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "omp-workflows",
   "name": "OMP Workflows",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "bundle",
   "description": "Oh My Paw workflow modes: Autopilot, Ralph, UltraQA, Ultrawork, Team",
   "author": "QwenPaw Team",

--- a/plugins/bundle/omp_workflows/ralph/mode.py
+++ b/plugins/bundle/omp_workflows/ralph/mode.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from qwenpaw.runtime.slash_command_registry import CommandSpec
 
 from ..shared.args import split_args
+from ..shared.loop_ui_i18n import loop_command_metadata, loop_help_text
 from ..shared.mode_base import OMPModeBase, info_msg, rewrite_user_msg
 from .gate import RalphGate
 
@@ -21,13 +22,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_HELP = (
-    "**Ralph** — PRD-driven continuous implementation loop\n\n"
-    "Usage: `/ralph [--no-deslop] "
-    "[--critic=architect|critic|codex] <task>`\n\n"
-    "Creates a PRD with user stories, implements each one,\n"
-    "verifies acceptance criteria, and runs reviewer verification."
-)
+_HELP = loop_help_text("ralph")
 
 
 class RalphMode(OMPModeBase):
@@ -46,7 +41,7 @@ class RalphMode(OMPModeBase):
                 handler=self._handler,
                 category="builtin",
                 help_text=_HELP,
-                metadata={"builtin": True},
+                metadata=loop_command_metadata("ralph"),
             ),
         ]
 

--- a/plugins/bundle/omp_workflows/shared/loop_ui_i18n.py
+++ b/plugins/bundle/omp_workflows/shared/loop_ui_i18n.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""OMP loop UI copy: names, menu summaries, and full help texts.
+
+Menu short copy is bilingual (en / zh-CN). Full ``help`` is English for now;
+zh-CN can be added later without changing call sites.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+LOOP_UI_I18N: dict[str, dict[str, Any]] = {
+    "ultrawork": {
+        "name": {
+            "en": "Ultrawork",
+            "zh-CN": "Ultrawork",
+        },
+        "description": {
+            "en": "**Ultrawork** — parallel task execution engine",
+            "zh-CN": "**Ultrawork** — 并行任务执行引擎",
+        },
+        "help": {
+            "en": (
+                "**Ultrawork** — parallel task execution engine\n\n"
+                "Usage: `/ultrawork <task description>`\n\n"
+                "Decomposes the task into independent sub-tasks and executes\n"
+                "them in parallel via spawn_subagent batch mode."
+            ),
+        },
+    },
+    "ralph": {
+        "name": {
+            "en": "Ralph",
+            "zh-CN": "Ralph",
+        },
+        "description": {
+            "en": ("**Ralph** — PRD-driven continuous implementation loop"),
+            "zh-CN": "**Ralph** — PRD 驱动的持续实现循环",
+        },
+        "help": {
+            "en": (
+                "**Ralph** — PRD-driven continuous implementation loop\n\n"
+                "Usage: `/ralph [--no-deslop] "
+                "[--critic=architect|critic|codex] <task>`\n\n"
+                "Creates a PRD with user stories, implements each one,\n"
+                "verifies acceptance criteria, and runs reviewer verification."
+            ),
+        },
+    },
+    "autopilot": {
+        "name": {
+            "en": "Autopilot",
+            "zh-CN": "Autopilot",
+        },
+        "description": {
+            "en": "**Autopilot** — full lifecycle pipeline",
+            "zh-CN": "**Autopilot** — 全生命周期流水线",
+        },
+        "help": {
+            "en": (
+                "**Autopilot** — full lifecycle pipeline\n\n"
+                "Usage: `/autopilot [--skip-qa] "
+                "[--skip-validation] <task>`\n\n"
+                "Phases: expansion -> planning -> execution "
+                "-> qa -> validation -> cleanup -> completed\n"
+                "Validation uses 3 parallel reviewers "
+                "(architect + security + code)."
+            ),
+        },
+    },
+    "ultraqa": {
+        "name": {
+            "en": "UltraQA",
+            "zh-CN": "UltraQA",
+        },
+        "description": {
+            "en": "**UltraQA** — automated QA cycle engine",
+            "zh-CN": "**UltraQA** — 自动化 QA 循环引擎",
+        },
+        "help": {
+            "en": (
+                "**UltraQA** — automated QA cycle engine\n\n"
+                "Usage:\n"
+                "  `/ultraqa [--tests|--build|--lint|"
+                '--typecheck|--custom "cmd"]'
+                " [--interactive]`\n\n"
+                "Runs repeated QA cycles: check → diagnose → fix → re-check.\n"
+                "Stops when all checks pass or max cycles reached."
+            ),
+        },
+    },
+    "team": {
+        "name": {
+            "en": "Team",
+            "zh-CN": "Team",
+        },
+        "description": {
+            "en": "**Team** — multi-agent collaboration pipeline",
+            "zh-CN": "**Team** — 多智能体协作流水线",
+        },
+        "help": {
+            "en": (
+                "**Team** — multi-agent collaboration pipeline\n\n"
+                "Usage: `/team [N:role] <task>`\n\n"
+                "Examples:\n"
+                "  `/team 3:executor Implement authentication`\n"
+                "  `/team ralph Build the REST API`\n\n"
+                "Phases: plan -> prd -> exec -> verify -> fix (retry)"
+            ),
+        },
+    },
+}
+
+
+def loop_ui(mode_key: str) -> dict[str, Any]:
+    """Return the UI copy bundle for one OMP mode."""
+    try:
+        return LOOP_UI_I18N[mode_key]
+    except KeyError as exc:
+        raise KeyError(f"Unknown OMP loop UI key: {mode_key}") from exc
+
+
+def _pick_locale(mapping: dict[str, str], lang: str = "en") -> str:
+    if not mapping:
+        return ""
+    if lang in mapping and mapping[lang]:
+        return mapping[lang]
+    short = lang.split("-", 1)[0].lower()
+    for key, value in mapping.items():
+        if key.split("-", 1)[0].lower() == short and value:
+            return value
+    for key in ("en", "en-US", "zh-CN", "zh"):
+        if mapping.get(key):
+            return mapping[key]
+    for value in mapping.values():
+        if value:
+            return value
+    return ""
+
+
+def loop_help_text(mode_key: str, lang: str = "en") -> str:
+    """Full help text for CommandSpec / slash help handlers."""
+    help_map = loop_ui(mode_key).get("help") or {}
+    if not isinstance(help_map, dict):
+        return ""
+    return _pick_locale(help_map, lang)
+
+
+def loop_command_metadata(mode_key: str) -> dict[str, Any]:
+    """Metadata for CommandSpec: loop_name + i18n maps for GET /loops."""
+    ui = loop_ui(mode_key)
+    name_map = ui.get("name") or {}
+    desc_map = ui.get("description") or {}
+    return {
+        "builtin": True,
+        "loop_name": _pick_locale(name_map, "en") or mode_key,
+        "name_i18n": dict(name_map) if isinstance(name_map, dict) else {},
+        "description_i18n": dict(desc_map)
+        if isinstance(desc_map, dict)
+        else {},
+    }

--- a/plugins/bundle/omp_workflows/team/mode.py
+++ b/plugins/bundle/omp_workflows/team/mode.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Optional
 from qwenpaw.runtime.slash_command_registry import CommandSpec
 
 from ..shared.args import split_args
+from ..shared.loop_ui_i18n import loop_command_metadata, loop_help_text
 from ..shared.mode_base import OMPModeBase, info_msg, rewrite_user_msg
 from ..shared.role_prompts import resolve_role
 from .gate import TeamPipelineGate
@@ -23,14 +24,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_HELP = (
-    "**Team** — multi-agent collaboration pipeline\n\n"
-    "Usage: `/team [N:role] <task>`\n\n"
-    "Examples:\n"
-    "  `/team 3:executor Implement authentication`\n"
-    "  `/team ralph Build the REST API`\n\n"
-    "Phases: plan -> prd -> exec -> verify -> fix (retry)"
-)
+_HELP = loop_help_text("team")
 
 
 class TeamMode(OMPModeBase):
@@ -49,7 +43,7 @@ class TeamMode(OMPModeBase):
                 handler=self._handler,
                 category="builtin",
                 help_text=_HELP,
-                metadata={"builtin": True},
+                metadata=loop_command_metadata("team"),
             ),
         ]
 

--- a/plugins/bundle/omp_workflows/ultraqa/mode.py
+++ b/plugins/bundle/omp_workflows/ultraqa/mode.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Optional
 from qwenpaw.runtime.slash_command_registry import CommandSpec
 
 from ..shared.args import split_args
+from ..shared.loop_ui_i18n import loop_command_metadata, loop_help_text
 from ..shared.mode_base import OMPModeBase, info_msg, rewrite_user_msg
 from .gate import UltraQAGate
 
@@ -21,14 +22,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_HELP = (
-    "**UltraQA** — automated QA cycle engine\n\n"
-    "Usage:\n"
-    '  `/ultraqa [--tests|--build|--lint|--typecheck|--custom "cmd"]'
-    " [--interactive]`\n\n"
-    "Runs repeated QA cycles: check → diagnose → fix → re-check.\n"
-    "Stops when all checks pass or max cycles reached."
-)
+_HELP = loop_help_text("ultraqa")
 
 
 class UltraQAMode(OMPModeBase):
@@ -47,7 +41,7 @@ class UltraQAMode(OMPModeBase):
                 handler=self._handler,
                 category="builtin",
                 help_text=_HELP,
-                metadata={"builtin": True},
+                metadata=loop_command_metadata("ultraqa"),
             ),
         ]
 

--- a/plugins/bundle/omp_workflows/ultrawork/mode.py
+++ b/plugins/bundle/omp_workflows/ultrawork/mode.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Optional
 
 from qwenpaw.runtime.slash_command_registry import CommandSpec
 
+from ..shared.loop_ui_i18n import loop_command_metadata, loop_help_text
 from ..shared.mode_base import OMPModeBase, info_msg, rewrite_user_msg
 from .gate import UltraworkGate
 
@@ -20,12 +21,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_HELP = (
-    "**Ultrawork** — parallel task execution engine\n\n"
-    "Usage: `/ultrawork <task description>`\n\n"
-    "Decomposes the task into independent sub-tasks and executes\n"
-    "them in parallel via spawn_subagent batch mode."
-)
+_HELP = loop_help_text("ultrawork")
 
 
 class UltraworkMode(OMPModeBase):
@@ -44,7 +40,7 @@ class UltraworkMode(OMPModeBase):
                 handler=self._handler,
                 category="builtin",
                 help_text=_HELP,
-                metadata={"builtin": True},
+                metadata=loop_command_metadata("ultrawork"),
             ),
         ]
 

--- a/src/qwenpaw/app/routers/loops.py
+++ b/src/qwenpaw/app/routers/loops.py
@@ -35,6 +35,8 @@ class LoopModeInfo(BaseModel):
     slash_command: str
     description: str
     source: Literal["builtin", "custom", "plugin"]
+    name_i18n: dict[str, str] | None = None
+    description_i18n: dict[str, str] | None = None
 
 
 class LoopModeStatus(BaseModel):
@@ -380,6 +382,8 @@ def _build_loop_catalog(
         command = commands[0]
         metadata = command.metadata or {}
         descriptor_id = f"plugin:{runtime_name}"
+        name_i18n = _as_str_dict(metadata.get("name_i18n"))
+        description_i18n = _as_str_dict(metadata.get("description_i18n"))
         result.append(
             LoopModeInfo(
                 id=descriptor_id,
@@ -387,10 +391,26 @@ def _build_loop_catalog(
                 slash_command=command.name,
                 description=command.help_text,
                 source="plugin",
+                name_i18n=name_i18n or None,
+                description_i18n=description_i18n or None,
             ),
         )
         runtime_modes[runtime_name] = descriptor_id
     return _deduplicate(result), runtime_modes
+
+
+def _as_str_dict(value: Any) -> dict[str, str]:
+    """Normalize metadata i18n maps to ``dict[str, str]``."""
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key, item in value.items():
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            result[str(key)] = text
+    return result
 
 
 __all__ = ["LoopModeInfo", "LoopModeStatus", "router"]

--- a/tests/unit/app/routers/test_loops_router.py
+++ b/tests/unit/app/routers/test_loops_router.py
@@ -94,7 +94,17 @@ def test_loop_catalog_includes_enabled_custom_and_plugin_modes(
                     name="review",
                     handler=handler,
                     help_text="Review the current work.",
-                    metadata={"loop_name": "Review"},
+                    metadata={
+                        "loop_name": "Review",
+                        "name_i18n": {
+                            "en": "Review",
+                            "zh-CN": "评审",
+                        },
+                        "description_i18n": {
+                            "en": "**Review** — code review",
+                            "zh-CN": "**评审** — 代码评审",
+                        },
+                    },
                 ),
             ]
 
@@ -114,7 +124,13 @@ def test_loop_catalog_includes_enabled_custom_and_plugin_modes(
         "custom:quality",
         "plugin:review",
     ]
-    assert response.json()[-1]["name"] == "Review"
+    plugin = response.json()[-1]
+    assert plugin["name"] == "Review"
+    assert plugin["name_i18n"] == {"en": "Review", "zh-CN": "评审"}
+    assert plugin["description_i18n"] == {
+        "en": "**Review** — code review",
+        "zh-CN": "**评审** — 代码评审",
+    }
 
 
 def test_loop_status_reports_active_mode_and_restores_context(
@@ -293,6 +309,8 @@ def test_loop_status_reports_custom_mode(client, workspace) -> None:
         "slash_command": "quality",
         "description": "",
         "source": "custom",
+        "name_i18n": None,
+        "description_i18n": None,
     }
 
 

--- a/tests/unit/plugins/test_omp_loop_ui_i18n.py
+++ b/tests/unit/plugins/test_omp_loop_ui_i18n.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""OMP loop UI i18n catalog and CommandSpec metadata wiring."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_I18N_PATH = (
+    _REPO
+    / "plugins"
+    / "bundle"
+    / "omp_workflows"
+    / "shared"
+    / "loop_ui_i18n.py"
+)
+
+
+@lru_cache(maxsize=1)
+def _omp_loop_ui_i18n():
+    spec = importlib.util.spec_from_file_location(
+        "omp_loop_ui_i18n",
+        _I18N_PATH,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "mode_key",
+    ["ultrawork", "ralph", "autopilot", "ultraqa", "team"],
+)
+def test_loop_ui_has_en_and_zh_description(mode_key: str):
+    mod = _omp_loop_ui_i18n()
+    ui = mod.loop_ui(mode_key)
+    assert ui["description"]["en"]
+    assert ui["description"]["zh-CN"]
+    assert ui["name"]["en"]
+    assert mod.loop_help_text(mode_key).startswith("**")
+
+
+def test_loop_command_metadata_exposes_i18n_maps():
+    meta = _omp_loop_ui_i18n().loop_command_metadata("ultrawork")
+    assert meta["loop_name"] == "Ultrawork"
+    assert "zh-CN" in meta["description_i18n"]
+    assert "en" in meta["name_i18n"]
+
+
+def test_as_str_dict_and_catalog_fields():
+    from qwenpaw.app.routers.loops import LoopModeInfo, _as_str_dict
+
+    assert _as_str_dict({"en": "Hi", "zh-CN": "你好"}) == {
+        "en": "Hi",
+        "zh-CN": "你好",
+    }
+    assert not _as_str_dict("nope")
+
+    info = LoopModeInfo(
+        id="plugin:ultrawork",
+        name="Ultrawork",
+        slash_command="ultrawork",
+        description="help",
+        source="plugin",
+        name_i18n={"en": "Ultrawork"},
+        description_i18n={"zh-CN": "**Ultrawork** — 并行"},
+    )
+    desc_i18n = info.description_i18n or {}
+    assert desc_i18n["zh-CN"].startswith("**Ultrawork**")


### PR DESCRIPTION
## Description

Console chat slash autocomplete previously assembled suggestions from hardcoded commands (`/new`, `/clear`, `/compact`, `/skills`), enabled skills, and frontend-plugin `sender.suggestions` only. Loop / plugin modes already available via `GET /loops` (including OMP's `/ultrawork`, `/ralph`, `/autopilot`, `/ultraqa`, `/team`, plus builtin `/goal` and `/mission`) were loaded into `loopAvailableModes` but only used to exclude colliding skill names — they never appeared in the `/` menu.

This PR fixes that discovery gap and improves how loop/OMP blurbs are shown:

1. **Slash autocomplete** — Map `loopAvailableModes` with a non-empty `slash_command` into `loopSuggestions` and merge them into `baseSuggestions` (QwenPaw backend only), so installed OMP and other loop modes appear when typing `/`.
2. **Inline Markdown blurbs** — Loop dropdown and slash labels use a first-line summary rendered via restricted `InlineMarkdown` (`strong` / `em` / `code` / `del`), so OMP `**...**` / backticks display correctly instead of raw markers. Builtin modes keep Console i18n (`t('loop.modes.*')`); custom modes keep user-authored copy.
3. **Plugin-owned i18n** — OMP ships `name` / `description` / `help` in `plugins/bundle/omp_workflows/shared/loop_ui_i18n.py`. Modes attach `metadata.name_i18n` / `description_i18n` and `CommandSpec.help_text`. `GET /loops` forwards the optional i18n maps; Console resolves them with `i18n.language` (prefix / `en` fallback). Full `/xxx help` stays English for now (structure ready for later `zh-CN` help).

**Security Considerations:** N/A — suggestion/catalog display and plugin copy packaging only; no auth, channel, or config changes. Command execution still goes through the existing slash / loop dispatch path.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Ensure `omp-workflows` is installed from this branch's bundle (or reinstall with `--force`), then restart / hot-reload as needed so `GET /loops` includes `description_i18n`.
2. Start backend + Console with this branch's frontend (e.g. `qwenpaw app` on `:8088` and `cd console && npm run dev` on `:5173`, or rebuild `console/dist`).
3. Open a QwenPaw-backend agent chat, type `/`:
   - Expect `/goal`, `/mission`, and (if OMP installed) `/ultrawork`, `/ralph`, `/autopilot`, `/ultraqa`, `/team`.
4. Type `/ult` — list narrows to `ultrawork`; Tab/click inserts `/ultrawork `.
5. In Loop mode selector and slash menu: OMP blurbs show bold/code as formatted text (no raw `**`); only the short summary line is shown.
6. Switch Console language zh ↔ en: OMP menu name/description follow the language; builtin modes still use Console locales; custom modes stay verbatim.
7. `/ultrawork help` (and peers) still return the full English help text.
8. Plugins without `*_i18n` metadata fall back to `name` / `description` as before.

## Evidence

```bash
.venv/bin/pre-commit run --files \
  console/src/pages/Chat/index.tsx \
  console/src/utils/resolveLocalizedText.ts \
  plugins/bundle/omp_workflows/shared/loop_ui_i18n.py \
  src/qwenpaw/app/routers/loops.py
# ... hooks Passed (prettier skips console/ by config)

cd console && npm run test:run -- \
  src/utils/resolveLocalizedText.test.ts \
  src/utils/loopModeDescription.test.ts \
  src/pages/Chat/loopSlashSuggestions.test.ts \
  src/components/LoopInput/LoopModeSelector.test.tsx

.venv/bin/python -m pytest \
  tests/unit/app/routers/test_loops_router.py \
  tests/unit/plugins/test_omp_loop_ui_i18n.py -q
```

## Additional Notes

- Shared Loop UI path (`GET /loops` → `loopStore` → selector / slash menu); copy source differs by mode: builtin → Console i18n, plugin → API `*_i18n` maps, custom → user string.
- OMP copy is **not** added to `console/src/locales`; plugin owns the dictionaries.
- After pulling this PR, local installs under `~/.qwenpaw/plugins/omp-workflows` must be reinstalled from `plugins/bundle/omp_workflows` to pick up i18n metadata.