### PR TITLE
fix: retain dirty flag on token usage flush failure

### DIFF
--- a/src/qwenpaw/token_usage/buffer.py
+++ b/src/qwenpaw/token_usage/buffer.py
@@ -146,19 +146,25 @@ class TokenUsageBuffer:
                     break
 
     async def _flush_once(self, force: bool = False) -> None:
-        """Write ``_disk_cache`` to disk if dirty."""
+        """Write ``_disk_cache`` to disk if dirty.
+
+        The dirty flag is cleared **only** after a successful write so that
+        transient I/O failures are retried by the next periodic flush.
+        """
         if not self._cache_loaded:
-            # The cache was never seeded, so no event can have reached
-            # ``_disk_cache`` and it still holds the initial empty dict.
-            # Writing it out would replace the stored history with ``{}``.
             return
         if not self._dirty and not force:
             return
-        self._dirty = False
 
         snapshot = copy.deepcopy(self._disk_cache)
-        await asyncio.to_thread(save_data_sync, self._path, snapshot)
-        logger.debug("token_usage: flushed cache to disk")
+        ok = await asyncio.to_thread(save_data_sync, self._path, snapshot)
+        if ok:
+            self._dirty = False
+            logger.debug("token_usage: flushed cache to disk")
+        else:
+            logger.warning(
+                "token_usage: flush failed, retaining dirty flag for retry",
+            )
 
     async def _flush_loop(self) -> None:
         """Periodically flush the cache to disk."""

--- a/src/qwenpaw/token_usage/storage.py
+++ b/src/qwenpaw/token_usage/storage.py
@@ -32,11 +32,11 @@ async def load_data(path: Path) -> dict:
     return data
 
 
-def save_data_sync(path: Path, data: dict) -> None:
+def save_data_sync(path: Path, data: dict) -> bool:
     """Persist *data* to *path* using an atomic write (tmp → replace).
 
-    This is intentionally synchronous so it can be called from the buffer
-    flush task without blocking the event loop via ``asyncio.to_thread``.
+    Returns ``True`` on success, ``False`` on failure.  The caller is
+    responsible for deciding whether to retry on transient errors.
     """
     tmp_path = path.with_suffix(".tmp")
     try:
@@ -45,18 +45,19 @@ def save_data_sync(path: Path, data: dict) -> None:
         with open(tmp_path, mode="w", encoding="utf-8") as f:
             f.write(payload)
         os.replace(tmp_path, path)
+        return True
     except OSError as exc:
         logger.warning(
             "token_usage: failed to write %s: %s",
             path,
             exc,
         )
-        # Clean up orphaned tmp file if it was created.
         try:
             if tmp_path.exists():
                 tmp_path.unlink()
         except OSError:
             pass
+        return False
 
 
 __all__ = [

--- a/tests/unit/token_usage/test_token_usage.py
+++ b/tests/unit/token_usage/test_token_usage.py
@@ -283,6 +283,82 @@ class TestTokenUsageBuffer:
         assert written["2026-04-23"]["openai:gpt-4"]["prompt_tokens"] == 7
         assert written["2026-04-24"]["openai:gpt-4"]["prompt_tokens"] == 100
 
+    @pytest.mark.asyncio
+    async def test_flush_once_retains_dirty_flag_on_failure(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A failed flush must leave _dirty=True so a later flush retries."""
+        path = tmp_path / "test.json"
+        path.write_text("{}", encoding="utf-8")
+
+        buffer = TokenUsageBuffer(path, flush_interval=3600)
+        buffer.start()
+        buffer.enqueue(
+            _UsageEvent(
+                provider_id="openai",
+                model_name="gpt-4",
+                prompt_tokens=100,
+                completion_tokens=50,
+                date_str="2026-04-24",
+                now_iso="2026-04-24T10:00:00+00:00",
+            ),
+        )
+
+        await asyncio.sleep(0.2)
+
+        assert buffer._dirty is True
+
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.buffer.save_data_sync",
+            lambda _p, _d: False,
+        )
+
+        await buffer._flush_once()
+
+        assert buffer._dirty is True
+
+        monkeypatch.setattr(
+            "qwenpaw.token_usage.buffer.save_data_sync",
+            lambda _p, _d: True,
+        )
+
+        await buffer._flush_once()
+
+        assert buffer._dirty is False
+
+        await buffer.stop()
+
+    @pytest.mark.asyncio
+    async def test_flush_once_success_clears_dirty_flag(self, tmp_path):
+        """A successful flush must clear the dirty flag."""
+        path = tmp_path / "test.json"
+        path.write_text("{}", encoding="utf-8")
+
+        buffer = TokenUsageBuffer(path, flush_interval=3600)
+        buffer.start()
+        buffer.enqueue(
+            _UsageEvent(
+                provider_id="openai",
+                model_name="gpt-4",
+                prompt_tokens=100,
+                completion_tokens=50,
+                date_str="2026-04-24",
+                now_iso="2026-04-24T10:00:00+00:00",
+            ),
+        )
+
+        await asyncio.sleep(0.2)
+
+        assert buffer._dirty is True
+
+        await buffer._flush_once()
+
+        assert buffer._dirty is False
+
+        await buffer.stop()
+
 
 # =============================================================================
 # Test Pydantic Models


### PR DESCRIPTION
## Summary

This PR fixes #6374 by ensuring that failed token usage persistence flushes do not silently lose data.

## Problem

In `TokenUsageBuffer._flush_once()`, the `_dirty` flag was cleared **before** calling `save_data_sync()`. When a transient I/O failure occurred:
1. `_dirty` was already set to `False`
2. `save_data_sync()` caught the `OSError`, logged it, and returned without signaling failure
3. Subsequent periodic flushes saw `_dirty=False` and skipped the write
4. Token usage data was lost until a new event happened

## Changes

- **`storage.py`**: `save_data_sync()` now returns `bool` — `True` on success, `False` on failure
- **`buffer.py`**: `_flush_once()` only clears `_dirty` after a successful write. Failed writes retain the dirty flag so the next periodic flush retries automatically.
- **`test_token_usage.py`**: Added two regression tests:
  - `test_flush_once_retains_dirty_flag_on_failure` — verifies dirty flag persists after failed flush and clears after retry
  - `test_flush_once_success_clears_dirty_flag` — verifies normal successful flush still works

## Testing

- [x] Manual async test verified: dirty=True after failed flush, dirty=False after retry
- [x] Existing token usage tests still pass (tested via import and direct execution)
- [x] No public API changes — `save_data_sync()` return type changed from `None` to `bool`, but it was not used as a return value anywhere else

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes