### PR TITLE
fix(mission): preserve quoted verify commands

### DIFF
--- a/src/qwenpaw/modes/mission/handler.py
+++ b/src/qwenpaw/modes/mission/handler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,10 @@ def parse_mission_args(
 
     Unlike the old ``_parse_mission_args`` this receives
     the text *after* ``/mission`` (no command prefix).
+
+    Uses :func:`shlex.split` for quote-aware tokenization so that
+    ``--verify "pytest -q"`` is parsed correctly.  Falls back to plain
+    whitespace splitting when the input contains malformed quotes.
     """
     args: dict[str, Any] = {
         "task_text": "",
@@ -53,7 +58,11 @@ def parse_mission_args(
         "max_iterations": default_max_iterations,
     }
 
-    tokens = raw_args.split()
+    try:
+        tokens = shlex.split(raw_args)
+    except ValueError:
+        tokens = raw_args.split()
+
     task_parts: list[str] = []
     i = 0
     while i < len(tokens):

--- a/src/qwenpaw/modes/mission/handler.py
+++ b/src/qwenpaw/modes/mission/handler.py
@@ -4,6 +4,7 @@
 Called by ``MissionMode._mission_handler`` (registered via
 ``SlashCommandRegistry``) to process ``/mission`` sub-commands.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -29,8 +30,7 @@ from .state import (
 logger = logging.getLogger(__name__)
 
 MISSION_HELP_TEXT = (
-    "Launch mission mode \u2014 decompose, implement, "
-    "and verify complex tasks"
+    "Launch mission mode — decompose, implement, and verify complex tasks"
 )
 
 _DEFAULT_MAX_ITERATIONS = 20

--- a/tests/unit/loop/test_mission_settings.py
+++ b/tests/unit/loop/test_mission_settings.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for user-editable Mission defaults."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
@@ -61,9 +62,11 @@ def test_mission_args_handles_quoted_verify_command() -> None:
 
 def test_mission_args_handles_single_quoted_verify_command() -> None:
     """Single-quoted verify commands must also be parsed correctly."""
-    result = parse_mission_args(
-        "Implement the feature --verify 'npm test --coverage' --max-iterations 5",
+    cmd = (
+        "Implement the feature --verify 'npm test --coverage' "
+        + "--max-iterations 5"
     )
+    result = parse_mission_args(cmd)
 
     assert result["task_text"] == "Implement the feature"
     assert result["verify_commands"] == "npm test --coverage"

--- a/tests/unit/loop/test_mission_settings.py
+++ b/tests/unit/loop/test_mission_settings.py
@@ -48,6 +48,38 @@ def test_mission_args_use_defaults_and_allow_command_override() -> None:
     assert override["verify_commands"] == "pytest"
 
 
+def test_mission_args_handles_quoted_verify_command() -> None:
+    """Quoted multi-word verify commands must be parsed as a single token."""
+    result = parse_mission_args(
+        'Implement the feature --verify "pytest -q" --max-iterations 7',
+    )
+
+    assert result["task_text"] == "Implement the feature"
+    assert result["verify_commands"] == "pytest -q"
+    assert result["max_iterations"] == 7
+
+
+def test_mission_args_handles_single_quoted_verify_command() -> None:
+    """Single-quoted verify commands must also be parsed correctly."""
+    result = parse_mission_args(
+        "Implement the feature --verify 'npm test --coverage' --max-iterations 5",
+    )
+
+    assert result["task_text"] == "Implement the feature"
+    assert result["verify_commands"] == "npm test --coverage"
+    assert result["max_iterations"] == 5
+
+
+def test_mission_args_falls_back_on_malformed_quotes() -> None:
+    """Malformed quotes should not crash — falls back to whitespace split."""
+    result = parse_mission_args(
+        'Implement the feature --verify "unclosed quote',
+    )
+
+    assert result["verify_commands"] == '"unclosed'
+    assert result["task_text"] == "Implement the feature quote"
+
+
 def test_master_prompt_uses_configured_story_retry_limit() -> None:
     """Retry configuration replaces the previous hard-coded prompt value."""
     prompt = build_master_prompt(


### PR DESCRIPTION
## Description

Fixes #6355.

`parse_mission_args()` used whitespace splitting, so a quoted multi-word
verification command was broken into separate tokens. For example,
`--verify "pytest -q"` produced an invalid verifier command and leaked `-q"`
into the mission task.

This PR uses standard-library quote-aware tokenization for valid input. If
quotes are malformed, it preserves the existing whitespace-splitting fallback
so command parsing remains fail-open instead of crashing.

**Related Issue:** Fixes #6355

**Security Considerations:** None. The parser only tokenizes an existing
operator-provided command string.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Applicable pre-commit hooks pass
- [x] Relevant tests pass
- [x] Documentation updated (not needed; parser correctness fix)
- [x] Ready for review

## Testing

The focused suite covers double-quoted and single-quoted verifier commands,
malformed quote fallback, existing unquoted options, and default behavior.

## Evidence

Before the fix:

```text
parse_mission_args('Implement the feature --verify "pytest -q" --max-iterations 7')
task_text='Implement the feature -q"'
verify_commands='"pytest'
```

After rebasing onto current `main`:

```bash
.venv/bin/pytest tests/unit/loop/test_mission_settings.py -q
# 8 passed in 0.71s

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/modes/mission/handler.py \
  tests/unit/loop/test_mission_settings.py
# Python AST, encoding, private-key detection, whitespace, trailing commas,
# mypy, black, flake8, and pylint: Passed
```

`actionlint` is not applicable to the changed Python files.

## Additional Notes

The implementation was AI-assisted and personally verified against current
`main`, Issue #6355, the focused regression suite, and the changed-file lint
checks above.
