### PR TITLE
Fix editable per-tool call limit names

### DIFF
--- a/console/src/pages/Agent/Config/components/AgentLoopCard.render.test.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.render.test.tsx
@@ -6,7 +6,7 @@ import { Form } from "@agentscope-ai/design";
 import type { FormInstance } from "antd";
 import type { CustomLoopModeConfig } from "@/api/types";
 import { renderWithProviders } from "@/test/common_setup";
-import { AgentLoopCard } from "./AgentLoopCard";
+import { AgentLoopCard, buildCustomLoopMode } from "./AgentLoopCard";
 
 vi.mock("@agentscope-ai/design", async () =>
   vi.importActual<typeof import("antd")>("antd"),
@@ -116,5 +116,38 @@ describe("AgentLoopCard custom mode rendering", () => {
     expect(
       mission.getByText("Default test command (optional)"),
     ).toBeInTheDocument();
+  }, 15_000);
+
+  it("updates a per-tool call limit name", async () => {
+    let form: FormInstance | undefined;
+    const mode = buildCustomLoopMode([], "Research", "research", "research", 1);
+    const budget = mode.gates.find((gate) => gate.type === "tool_call_budget");
+    if (!budget) throw new Error("Research mode must include a tool budget");
+    budget.params.per_tool = { "tool-name": 3 };
+
+    renderWithProviders(
+      <LoopForm modes={[mode]} onForm={(next) => (form = next)} />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Research" }));
+    fireEvent.click(await screen.findByText("Tool-call budget"));
+    const toolName = screen.getByLabelText("Tool name");
+    fireEvent.change(toolName, { target: { value: "search" } });
+
+    expect(toolName).toHaveValue("search");
+
+    fireEvent.blur(toolName);
+
+    expect(
+      form?.getFieldValue([
+        "loop",
+        "custom_modes",
+        0,
+        "gates",
+        2,
+        "params",
+        "per_tool",
+      ]),
+    ).toEqual({ search: 3 });
   }, 15_000);
 });

--- a/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
+++ b/console/src/pages/Agent/Config/components/AgentLoopCard.tsx
@@ -651,12 +651,16 @@ function PerToolLimits({
   const entries = Object.entries(value);
   const updateName = (oldName: string, nextName: string) => {
     const normalized = nextName.trim();
-    if (!normalized || (normalized !== oldName && normalized in value)) return;
+    if (!normalized || (normalized !== oldName && normalized in value)) {
+      return false;
+    }
+    if (normalized === oldName) return true;
     const next = { ...value };
     const limit = next[oldName];
     delete next[oldName];
     next[normalized] = limit;
     onChange?.(next);
+    return true;
   };
   const updateLimit = (name: string, limit: number | null) =>
     onChange?.({ ...value, [name]: limit || 1 });
@@ -675,12 +679,14 @@ function PerToolLimits({
       {entries.map(([name, limit]) => (
         <div className={loopStyles.toolLimitRow} key={name}>
           <Input
-            value={name}
+            defaultValue={name}
             aria-label={t("agentConfig.loopMode.toolName", "Tool name")}
-            onBlur={(event) => updateName(name, event.target.value)}
-            onPressEnter={(event) =>
-              updateName(name, event.currentTarget.value)
-            }
+            onBlur={(event) => {
+              if (!updateName(name, event.target.value)) {
+                event.target.value = name;
+              }
+            }}
+            onPressEnter={(event) => event.currentTarget.blur()}
           />
           <InputNumber
             min={1}


### PR DESCRIPTION
## Summary

- allow per-tool call limit names to be edited before committing on blur
- preserve trimming and reject empty or duplicate tool names
- add a regression test that verifies the renamed key is written back to the form

## Root cause

The tool-name input was controlled by the existing object key but had no
`onChange` handler. React therefore restored the old key after every keystroke,
making the field appear read-only.

## User impact

Users can now replace the generated `tool-name` placeholder with the actual
tool name when configuring a tool-call budget.

## Validation

- `npm run test:run -- src/pages/Agent/Config/components/AgentLoopCard.render.test.tsx src/pages/Agent/Config/components/AgentLoopCard.test.ts`
- `npx tsc -b --noEmit`
- targeted Prettier and ESLint checks
