### PR TITLE
fix(acp): add models field to new_session response

### DIFF
--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -48,6 +48,7 @@ from acp.schema import (
     Implementation,
     ListSessionsResponse,
     McpServerStdio,
+    ModelInfo as ACPModelInfo,
     PermissionOption,
     ResourceContentBlock,
     ResumeSessionResponse,
@@ -57,6 +58,7 @@ from acp.schema import (
     SessionConfigSelectOption,
     SessionInfo,
     SessionListCapabilities,
+    SessionModelState,
     SessionResumeCapabilities,
     SetSessionConfigOptionResponse,
     SseMcpServer,
@@ -73,7 +75,7 @@ from qwenpaw.schemas import (
 
 from ...__version__ import __version__
 from ...constant import WORKING_DIR
-from ...config.config import ModelSlotConfig
+from ...config.config import ModelSlotConfig, load_agent_config
 from ...exceptions import AppBaseException
 from ...providers.provider_manager import ProviderManager
 from .meta import (
@@ -465,6 +467,7 @@ class QwenPawACPAgent(Agent):
         return NewSessionResponse(
             session_id=session_id,
             config_options=self._build_config_options(session_id),
+            models=await self._build_model_state(),
             field_meta=self._session_meta(),
         )
 
@@ -1078,6 +1081,49 @@ class QwenPawACPAgent(Agent):
             logger.exception("ACP: failed to resolve agent id for _meta")
             return None
         return {ACP_AGENT_META_KEY: agent_id} if agent_id else None
+
+    async def _build_model_state(self) -> SessionModelState | None:
+        """Build the ACP ``SessionModelState`` from the provider manager.
+
+        Collects all available models across all providers and determines
+        the current active model so ACP clients can present a model
+        selector to users.
+        """
+        try:
+            manager = ProviderManager.get_instance()
+            provider_infos = await manager.list_provider_info()
+
+            available_models: list[ACPModelInfo] = []
+            for pinfo in provider_infos:
+                for model in pinfo.models + pinfo.extra_models:
+                    available_models.append(
+                        ACPModelInfo(
+                            model_id=f"{pinfo.id}:{model.id}",
+                            name=model.name,
+                        ),
+                    )
+
+            agent_id = self._resolve_agent_id()
+            agent_config = load_agent_config(agent_id)
+            active = agent_config.active_model
+            if active and active.provider_id and active.model:
+                current_model_id = f"{active.provider_id}:{active.model}"
+            else:
+                current_model_id = ""
+                logger.warning(
+                    "ACP: no active model configured for agent %s",
+                    agent_id,
+                )
+
+            return SessionModelState(
+                available_models=available_models,
+                current_model_id=current_model_id,
+            )
+        except Exception:
+            logger.exception(
+                "ACP: failed to build model state",
+            )
+            return None
 
     def _build_available_commands(
         self,

--- a/src/qwenpaw/agents/acp/server.py
+++ b/src/qwenpaw/agents/acp/server.py
@@ -1305,7 +1305,6 @@ class QwenPawACPAgent(Agent):
                 )
 
         from ...config.config import (
-            load_agent_config,
             save_agent_config,
         )
 


### PR DESCRIPTION
## What Problem This Solves

When QwenPaw's ACP server is used by external agent clients (e.g. Multica daemon, OpenCode, Zed), the `new_session` response did **not** include a `models` field (type `SessionModelState`). This meant the client could not discover what models the agent has available, and could not present a model selector to the user.

This is a regression/omission from the ACP protocol specification which defines `models` as an optional but important field in `NewSessionResponse`.

## Evidence

**Local verification** — ran the modified ACP server against a real ACP client (new_session request):

**Request:**
```json
{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/tmp","mcpServers":[]}}
```

**Response (abbreviated — models array trimmed for readability):**
```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": {
    "_meta": {"qwenpaw.agent": "default"},
    "models": {
      "availableModels": [
        {"modelId": "github-models:openai/gpt-4o-mini", "name": "GPT-4o Mini"},
        {"modelId": "github-models:openai/gpt-4o", "name": "GPT-4o"},
        {"modelId": "dashscope:deepseek-v4-pro", "name": "DeepSeek-V4 Pro"},
        {"modelId": "openai:gpt-5.2", "name": "GPT-5.2"},
        {"modelId": "gemini:gemini-2.5-pro", "name": "Gemini 2.5 Pro"},
        {"modelId": "deepseek:deepseek-v4-flash", "name": "DeepSeek V4 Flash"},
        {"modelId": "sensenova:deepseek-v4-flash", "name": "deepseek-v4-flash"}
      ],
      "currentModelId": "sensenova:deepseek-v4-flash"
    },
    "sessionId": "432985b1790a41248883cf3dd5b68304"
  }
}
```

**Key observations:**
1. The `models` field is present in the response with proper `SessionModelState` structure
2. `availableModels` lists all models from all providers (185 total)
3. `currentModelId` correctly reflects the currently active model
4. The response also includes a `session/update` notification with available commands, confirming the session is fully functional

**Code change:** Only `src/qwenpaw/agents/acp/server.py` was modified — 47 lines added, 1 removed. The `_build_model_state()` method collects available models from `ProviderManager` and builds the ACP `SessionModelState`.

## Changes

- Added `_build_model_state()` method that collects all available models from `ProviderManager` and identifies the current active model
- Modified `new_session()` to include the `models` field in the `NewSessionResponse`
- Added `ACPModelInfo` and `SessionModelState` to `acp.schema` imports
- Added `load_agent_config` to config imports

## Related Issue

Closes #6529

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-reviewed the code
- [x] The commit message follows Conventional Commits