### PR TITLE
fix(plugins): temporarily disable max version check in plugin compat

### DIFF
--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -4,6 +4,10 @@
 Semantics: left-closed, right-open interval  ``>=min, <max``.
 When ``max`` is not specified, it is derived from ``min`` as
 ``{major}.{minor+1}.0`` (all patch versions of the same minor).
+
+NOTE: Upper-bound (``max``) enforcement is temporarily disabled.
+Restore the commented check in ``check_plugin_version_compat`` when
+re-enabling full range checks.
 """
 
 from __future__ import annotations
@@ -60,7 +64,15 @@ def check_plugin_version_compat(
             else _derive_exclusive_max(manifest.min_version)
         )
 
-    if current < min_v or current >= max_v:
-        msg = f"requires QwenPaw >={min_v}, <{max_v}, current is {current}"
+    # Temporary: only enforce >= min.  Original full-range check:
+    # if current < min_v or current >= max_v:
+    #     msg = (
+    #         f"requires QwenPaw >={min_v}, <{max_v}, current is {current}"
+    #     )
+    #     return False, msg
+    # return True, ""
+    if current < min_v:
+        msg = f"requires QwenPaw >={min_v}, current is {current}"
         return False, msg
+    _ = max_v  # retained for restoring the upper-bound check above
     return True, ""

--- a/tests/unit/plugins/test_download_catalog.py
+++ b/tests/unit/plugins/test_download_catalog.py
@@ -15,13 +15,14 @@ def test_entry_with_qwenpaw_version_compatible() -> None:
     assert _is_entry_compatible(entry) is True
 
 
-def test_entry_with_qwenpaw_version_incompatible() -> None:
+def test_entry_with_qwenpaw_version_max_ignored() -> None:
+    """Declared max must not exclude a newer running QwenPaw."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
         "qwenpaw_version": {"min": "0.1.0", "max": "1.1.0"},
     }
-    assert _is_entry_compatible(entry) is False
+    assert _is_entry_compatible(entry) is True
 
 
 def test_entry_with_only_min_compatible() -> None:
@@ -93,7 +94,7 @@ def test_legacy_min_version_incompatible() -> None:
 
 
 def test_legacy_min_max_version_compatible() -> None:
-    """Legacy min+max range covering current QwenPaw is compatible."""
+    """Legacy min+max still loads when min is satisfied (max ignored)."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
@@ -103,15 +104,15 @@ def test_legacy_min_max_version_compatible() -> None:
     assert _is_entry_compatible(entry) is True
 
 
-def test_legacy_min_max_version_incompatible() -> None:
-    """Legacy min+max range not covering current QwenPaw."""
+def test_legacy_max_version_ignored() -> None:
+    """Legacy max_version alone must not make an entry incompatible."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
         "min_version": "0.1.0",
         "max_version": "1.0.0",
     }
-    assert _is_entry_compatible(entry) is False
+    assert _is_entry_compatible(entry) is True
 
 
 def test_entry_with_empty_dict_qwenpaw_version() -> None:


### PR DESCRIPTION
## Description

Temporarily disable the upper-bound (`max`) check in plugin–QwenPaw version compatibility after the bump to `2.1.0b1`.

Compatibility previously used a left-closed / right-open range (`>=min, <max`), and pre-releases are normalized to their base version (`2.1.0b1` → `2.1.0`). Many plugins still declare `max: "2.1.0"` (or omit `max`, which derived `max` as the next minor), so they were treated as incompatible on the current build and failed to load.

This change keeps computing `max` / derived upper bounds, but only enforces `>= min` for now. The original full-range check is left commented in place so it can be restored later without rewriting the logic. Catalog unit tests are updated to reflect that a declared `max` no longer excludes a newer running QwenPaw. Integration plugin-type fixtures keep their original `max: "2.1.0"` values.

No per-plugin `plugin.json` updates are required for this temporary workaround.

**Related Issue:** Relates to #6518

**Security Considerations:** N/A — compatibility gating only; no auth, env, or config handling changes. Plugins that are below the required minimum version are still rejected.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```bash
# from repo root, with .venv active
.venv/bin/pre-commit run --files \
  src/qwenpaw/_version_compat.py \
  tests/unit/plugins/test_download_catalog.py \
  tests/integration/test_plugin_types.py

.venv/bin/python -m pytest \
  tests/unit/plugins/test_download_catalog.py \
  tests/integration/test_plugin_types.py -q
```

## Evidence

```bash
.venv/bin/pre-commit run --files \
  src/qwenpaw/_version_compat.py \
  tests/unit/plugins/test_download_catalog.py \
  tests/integration/test_plugin_types.py
# check python ast.........................................................Passed
# fix python encoding pragma...............................................Passed
# detect private key.......................................................Passed
# trim trailing whitespace.................................................Passed
# Add trailing commas......................................................Passed
# mypy.....................................................................Passed
# black....................................................................Passed
# flake8...................................................................Passed
# pylint...................................................................Passed

.venv/bin/python -m pytest \
  tests/unit/plugins/test_download_catalog.py \
  tests/integration/test_plugin_types.py -q
# 28 passed
```

Smoke check on `2.1.0b1` (normalized to `2.1.0`):
- `qwenpaw_version={"min":"1.1.6","max":"2.1.0"}` → compatible
- `qwenpaw_version={"min":"2.0.0"}` (derived max previously blocked) → compatible
- `qwenpaw_version={"min":"3.0.0"}` → still incompatible

## Additional Notes

This is an intentional temporary workaround. To restore full `>=min, <max` enforcement later, uncomment the original check block in `src/qwenpaw/_version_compat.py` and adjust the catalog unit tests that currently assert `max` is ignored.