### PR TITLE
fix(cloudpaw): accept mission verification kwargs

### DIFF
--- a/plugins/bundle/cloudpaw/hooks.py
+++ b/plugins/bundle/cloudpaw/hooks.py
@@ -621,6 +621,8 @@ def _patch_mission_master_prompt() -> None:
         agent_id: str,
         max_iterations: int = 20,
         verify_commands: str = "",
+        verification_instructions: str = "",
+        max_retries_per_story: int = 3,
         prd_path: str = "",
         progress_path: str = "",
         git_context: dict | None = None,
@@ -637,6 +639,8 @@ def _patch_mission_master_prompt() -> None:
                 agent_id=agent_id,
                 max_iterations=max_iterations,
                 verify_commands=verify_commands,
+                verification_instructions=verification_instructions,
+                max_retries_per_story=max_retries_per_story,
                 prd_path=prd_path,
                 progress_path=progress_path,
                 git_context=git_context,
@@ -670,6 +674,7 @@ def _patch_mission_master_prompt() -> None:
         verifier_tpl = build_verifier_prompt(
             loop_dir=loop_dir,
             verify_commands=verify_commands,
+            verification_instructions=verification_instructions,
         )
 
         prompt = CLOUDPAW_MASTER_PROMPT.format(

--- a/tests/unit/plugins/test_cloudpaw_mission_prompt_patch.py
+++ b/tests/unit/plugins/test_cloudpaw_mission_prompt_patch.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""Tests for the CloudPaw mission prompt patch."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_mission_prompts(monkeypatch):
+    """Load mission prompts without importing the full qwenpaw package."""
+    for package_name in (
+        "qwenpaw",
+        "qwenpaw.modes",
+        "qwenpaw.modes.mission",
+    ):
+        package = types.ModuleType(package_name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, package_name, package)
+
+    prompts_path = (
+        Path(__file__).parents[3]
+        / "src"
+        / "qwenpaw"
+        / "modes"
+        / "mission"
+        / "prompts.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "qwenpaw.modes.mission.prompts",
+        prompts_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    mission_prompts = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(
+        sys.modules,
+        "qwenpaw.modes.mission.prompts",
+        mission_prompts,
+    )
+    spec.loader.exec_module(mission_prompts)
+
+    mission_handler = types.ModuleType("qwenpaw.modes.mission.handler")
+    mission_handler.build_master_prompt = mission_prompts.build_master_prompt
+    monkeypatch.setitem(
+        sys.modules,
+        "qwenpaw.modes.mission.handler",
+        mission_handler,
+    )
+    return mission_prompts, mission_handler
+
+
+def test_mission_patch_accepts_upstream_prompt_kwargs(monkeypatch):
+    """Both patched prompt paths accept the upstream mission kwargs."""
+    mission_prompts, mission_handler = _load_mission_prompts(monkeypatch)
+
+    from plugins.bundle.cloudpaw.hooks import _patch_mission_master_prompt
+
+    _patch_mission_master_prompt()
+
+    prompt_kwargs = {
+        "loop_dir": "/tmp/mission-loop",
+        "verification_instructions": "Check the regression scenario.",
+        "max_retries_per_story": 7,
+    }
+    default_prompt = mission_prompts.build_master_prompt(
+        agent_id="default",
+        **prompt_kwargs,
+    )
+    cloudpaw_prompt = mission_handler.build_master_prompt(
+        agent_id="cloud-orchestrator",
+        **prompt_kwargs,
+    )
+
+    assert "Check the regression scenario." in default_prompt
+    assert "Max 7 retries per story" in default_prompt
+    assert "Check the regression scenario." in cloudpaw_prompt
+    assert cloudpaw_prompt


### PR DESCRIPTION
## Description

CloudPaw's mission-mode monkey-patch of `build_master_prompt` was missing the newer upstream keyword arguments `verification_instructions` and `max_retries_per_story`. Because the patch also replaces `mission.handler.build_master_prompt`, any `/mission` call raised:

```text
TypeError: _patched_build_master_prompt() got an unexpected keyword argument 'verification_instructions'
```

This change updates the patched signature, forwards both kwargs on the non-CloudPaw path, and passes `verification_instructions` into `build_verifier_prompt` on the CloudPaw path.

**Related Issue:** Fixes #6533

**Security Considerations:** None. Prompt-builder signature alignment only; no auth, channel, or permission changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Testing

Focused regression for the CloudPaw mission prompt patch. Also ran black (line-length 79) and flake8 (`--extend-ignore=E203`) on the touched files.

1. Call the patched builder with `verification_instructions` and `max_retries_per_story`.
2. Confirm the CloudPaw path no longer raises TypeError on those kwargs.
3. Confirm `verification_instructions` is forwarded into the verifier prompt path.

## Evidence

Local unit proof for the CloudPaw mission prompt patch:

- test file: `tests/unit/plugins/test_cloudpaw_mission_prompt_patch.py`
- result: 1 passed in 0.30s
- black on touched files: 2 files left unchanged
- flake8 on touched files: clean

Commands used:

```bash
PYTHONPATH=. python3 -m pytest tests/unit/plugins/test_cloudpaw_mission_prompt_patch.py -q -o addopts= --noconftest
# 1 passed in 0.30s

python3 -m black --line-length=79 plugins/bundle/cloudpaw/hooks.py tests/unit/plugins/test_cloudpaw_mission_prompt_patch.py
# 2 files left unchanged

python3 -m flake8 --extend-ignore=E203 plugins/bundle/cloudpaw/hooks.py tests/unit/plugins/test_cloudpaw_mission_prompt_patch.py
# clean
```

## Additional Notes

`max_retries_per_story` is accepted and forwarded on the default path. The CloudPaw master prompt template does not currently interpolate that field, so the CloudPaw path accepts it to avoid the TypeError without rewriting the prompt template.
