### PR TITLE
fix(deps): pin Codex and Qoder SDK versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ test = [
     "pytest-timeout>=2.3.0",
     "pytest-xdist>=3.5.0",
     "hypothesis>=6.0.0",
-    "qoder-agent-sdk>=1.0.9,<2",
+    "qoder-agent-sdk==1.0.9",
 ]
 dev = [
     "pre-commit>=4.2.0",
@@ -136,10 +136,10 @@ whisper = [
     "openai-whisper>=20231117",
 ]
 codex = [
-    "openai-codex>=0.144.4,<1",
+    "openai-codex==0.144.4",
 ]
 qoder = [
-    "qoder-agent-sdk>=1.0.9,<2",
+    "qoder-agent-sdk==1.0.9",
 ]
 full = [
     "qwenpaw[local,whisper,codex,qoder]",

--- a/tests/unit/harnesses/test_optional_dependencies.py
+++ b/tests/unit/harnesses/test_optional_dependencies.py
@@ -20,6 +20,7 @@ def test_codex_and_qoder_sdks_are_optional_and_in_full() -> None:
     dependencies = project["dependencies"]
     extras = project["optional-dependencies"]
 
+    assert not any("openai-codex" in item for item in dependencies)
     assert not any("qoder-agent-sdk" in item for item in dependencies)
     assert extras["codex"] == ["openai-codex==0.144.4"]
     assert extras["qoder"] == ["qoder-agent-sdk==1.0.9"]

--- a/tests/unit/harnesses/test_optional_dependencies.py
+++ b/tests/unit/harnesses/test_optional_dependencies.py
@@ -21,8 +21,8 @@ def test_codex_and_qoder_sdks_are_optional_and_in_full() -> None:
     extras = project["optional-dependencies"]
 
     assert not any("qoder-agent-sdk" in item for item in dependencies)
-    assert extras["codex"] == ["openai-codex>=0.144.4,<1"]
-    assert extras["qoder"] == ["qoder-agent-sdk>=1.0.9,<2"]
+    assert extras["codex"] == ["openai-codex==0.144.4"]
+    assert extras["qoder"] == ["qoder-agent-sdk==1.0.9"]
     assert extras["full"] == ["qwenpaw[local,whisper,codex,qoder]"]
 
 


### PR DESCRIPTION
## Summary

- pin `openai-codex` to `0.144.4`
- pin `qoder-agent-sdk` to `1.0.9`
- update the optional dependency assertions

## Why

The unbounded SDK ranges allowed patch releases with breaking API changes to
enter CI. In particular, `qoder-agent-sdk` 1.0.10 removed the
`ToolProgressMessage` export used by the Qoder harness, causing unit-test
collection to fail.

Pinning both third-party agent SDKs keeps installs reproducible and prevents
unreviewed SDK API changes from breaking the test suite.

## Validation

- `22 passed` for the Qoder adapter, event mapper, and optional dependency tests
- pre-commit checks passed for all changed files
- `git diff --check` passed
