### PR TITLE
Fix/agent switch stale chat restore

### DIFF
--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -81,6 +81,9 @@ vi.mock("../../sessionApi", () => ({
     finishSessionSwitch: vi.fn(),
     lastNavigatedChatId: null,
     getEffectiveSessionId: mockGetEffectiveSessionId,
+    // Ownership epoch helpers: tests run under a single stable owner.
+    getActiveOwner: vi.fn(() => ({ agentId: "default", generation: 0 })),
+    isActiveOwner: vi.fn(() => true),
   },
 }));
 

--- a/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/ChatSessionDrawer.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "@/test/common_setup";
 import ChatSessionDrawer from "./index";
 import { useChatAnywhereSessionsState } from "@agentscope-ai/chat";
+import { useAgentStore } from "../../../../stores/agentStore";
 
 // Mock react-window's VariableSizeList to render all items directly
 // (jsdom has no layout, so the virtual list never renders rows).
@@ -211,6 +212,10 @@ function withSession(overrides: Record<string, unknown> = {}) {
 }
 
 describe("ChatSessionDrawer", () => {
+  beforeEach(() => {
+    useAgentStore.setState({ selectedAgent: "default" });
+  });
+
   afterEach(() => vi.clearAllMocks());
 
   it("renders nothing when open=false", () => {
@@ -346,6 +351,50 @@ describe("ChatSessionDrawer", () => {
   it("on open=true triggers session list refresh", async () => {
     renderWithProviders(<ChatSessionDrawer {...defaultProps} />);
     await vi.waitFor(() => expect(mockGetSessionList).toHaveBeenCalled());
+  });
+
+  it("clears stale sessions and reloads when the selected agent changes", async () => {
+    let resolveAgentB!: (sessions: Array<Record<string, unknown>>) => void;
+    const agentBList = new Promise<Array<Record<string, unknown>>>(
+      (resolve) => {
+        resolveAgentB = resolve;
+      },
+    );
+
+    mockGetSessionList
+      .mockResolvedValueOnce([
+        {
+          id: "agent-a-chat",
+          name: "Agent A Chat",
+          updatedAt: new Date().toISOString(),
+        },
+      ])
+      .mockReturnValueOnce(agentBList);
+
+    renderWithProviders(<ChatSessionDrawer {...defaultProps} />);
+    await screen.findByText("Agent A Chat");
+
+    act(() => {
+      useAgentStore.setState({ selectedAgent: "agent-b" });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Agent A Chat")).not.toBeInTheDocument();
+      expect(mockGetSessionList).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      resolveAgentB([
+        {
+          id: "agent-b-chat",
+          name: "Agent B Chat",
+          updatedAt: new Date().toISOString(),
+        },
+      ]);
+      await agentBList;
+    });
+
+    expect(await screen.findByText("Agent B Chat")).toBeInTheDocument();
   });
 
   it("pinned sessions sort before unpinned", async () => {

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -334,7 +334,10 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
 
   /** Re-fetch session list from the backend and sync to context state */
   const refreshSessions = useCallback(async () => {
+    const owner = sessionApi.getActiveOwner();
     const list = await sessionApi.getSessionList();
+    // Never publish a list that finished loading under a previous agent.
+    if (!sessionApi.isActiveOwner(owner)) return;
     setSessions(list);
   }, [setSessions]);
 
@@ -343,12 +346,13 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     if (!props.open) return;
 
     let isCancelled = false;
+    const owner = sessionApi.getActiveOwner();
 
     const fetchSessions = async () => {
       setListLoading(true);
       try {
         const list = await sessionApi.getSessionList();
-        if (!isCancelled) {
+        if (!isCancelled && sessionApi.isActiveOwner(owner)) {
           // sessionApi already returns the previous array reference when the
           // list hasn't changed, so a reference check is enough to skip no-op
           // state updates and avoid a full re-render cascade.
@@ -373,7 +377,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       if (sessionApi.isSessionSwitching) return;
       try {
         const list = await sessionApi.getSessionList();
-        if (!isCancelled) {
+        if (!isCancelled && sessionApi.isActiveOwner(owner)) {
           // sessionApi already returns the previous array reference when the
           // list hasn't changed, so a reference check is enough to skip no-op
           // state updates and avoid a full re-render cascade.
@@ -441,6 +445,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Delete a session: call deleteChat API then refresh the list */
   const handleDelete = useCallback(
     async (sessionId: string) => {
+      const owner = sessionApi.getActiveOwner();
       const session = sessions.find((s) => s.id === sessionId) as
         | ExtendedChatSession
         | undefined;
@@ -450,20 +455,27 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
         await chatApi.deleteChat(backendId);
       }
 
+      // Per-session cleanup is safe regardless of the active agent: it is
+      // keyed to the deleted conversation only.
       localStorage.removeItem(`approval_level-${sessionId}`);
 
       // Clear the message queue for the deleted session so stale items don't
       // linger in storage or get sent after deletion. The queue may be keyed
-      // by the local id or the resolved backend id, so clear both. Also notify
-      // the chat page (when mounted) to abort any in-flight background send.
+      // by the local id or the resolved backend id, so clear both.
       const mq = useMessageQueueStore.getState();
       mq.clear(sessionId);
       if (backendId && backendId !== sessionId) mq.clear(backendId);
+
+      // Everything below mutates the CURRENT view (callbacks, shared list,
+      // navigation). A delete that finished after an agent switch must not
+      // touch the new agent's state.
+      if (!sessionApi.isActiveOwner(owner)) return;
       sessionApi.onSessionRemoved?.(backendId ?? sessionId);
 
       // Fetch the updated session list after deletion
       const freshList =
         (await sessionApi.getSessionList()) as ExtendedChatSession[];
+      if (!sessionApi.isActiveOwner(owner)) return;
       setSessions(freshList);
       syncSessionsGlobal(freshList as unknown as ExtendedSession[]);
 
@@ -503,6 +515,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Submit rename */
   const handleEditSubmit = useCallback(async () => {
     if (!editingSessionId) return;
+    const owner = sessionApi.getActiveOwner();
 
     const session = sessions.find((s) => s.id === editingSessionId) as
       | ExtendedChatSession
@@ -518,6 +531,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
 
     setEditingSessionId(null);
     setEditValue("");
+    if (!sessionApi.isActiveOwner(owner)) return;
     await refreshSessions();
   }, [editingSessionId, editValue, sessions, refreshSessions]);
 
@@ -530,6 +544,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Toggle pin status for a session */
   const handlePinToggle = useCallback(
     async (sessionId: string) => {
+      const owner = sessionApi.getActiveOwner();
       const session = sessions.find((s) => s.id === sessionId) as
         | ExtendedChatSession
         | undefined;
@@ -541,6 +556,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
           await chatApi.updateChat(backendId, {
             pinned: newPinnedState,
           });
+          if (!sessionApi.isActiveOwner(owner)) return;
           await refreshSessions();
         } catch (error) {
           console.error("Failed to toggle pin status:", error);
@@ -553,6 +569,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Toggle archive status for a session */
   const handleArchiveToggle = useCallback(
     async (sessionId: string) => {
+      const owner = sessionApi.getActiveOwner();
       const session = sessions.find((s) => s.id === sessionId) as
         | ExtendedChatSession
         | undefined;
@@ -562,13 +579,15 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       try {
         if (wasArchived) {
           await chatApi.unarchiveChat(backendId);
-          message.success(
-            t("sessions.archive.unarchiveSuccess", "Chat unarchived"),
-          );
         } else {
           await chatApi.archiveChat(backendId);
-          message.success(t("sessions.archive.successHint"));
         }
+        if (!sessionApi.isActiveOwner(owner)) return;
+        message.success(
+          wasArchived
+            ? t("sessions.archive.unarchiveSuccess", "Chat unarchived")
+            : t("sessions.archive.successHint"),
+        );
         await refreshSessions();
 
         if (!wasArchived) {

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -36,6 +36,7 @@ import {
   syncSessionsGlobal,
   type ExtendedSession,
 } from "../../../../stores/sessionListStore";
+import { useAgentStore } from "../../../../stores/agentStore";
 import {
   type DateGroup,
   groupSessions,
@@ -232,6 +233,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   const location = useLocation();
   const sdkState = useChatAnywhereSessionsState();
   const { codingMode } = useCodingMode();
+  const selectedAgent = useAgentStore((state) => state.selectedAgent);
 
   const createNewSession = useCreateNewSession();
 
@@ -348,6 +350,11 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     let isCancelled = false;
     const owner = sessionApi.getActiveOwner();
 
+    // The drawer owns a local list outside the SDK context. Clear the
+    // previous agent's entries before loading the newly selected agent.
+    lastPolledSessionsRef.current = [];
+    setSessions([]);
+
     const fetchSessions = async () => {
       setListLoading(true);
       try {
@@ -395,7 +402,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       isCancelled = true;
       clearInterval(timer);
     };
-  }, [props.open, setSessions]);
+  }, [props.open, selectedAgent, setSessions]);
 
   /** Whether a session switch is in progress (issue #4557) */
   const [switchingSessionId, setSwitchingSessionId] = useState<string | null>(

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.test.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for cross-agent ownership in the shared session-list CRUD
+ * handlers: a delete started under agent A must not mutate the view after the
+ * user switches to agent B, while same-agent CRUD keeps working.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import React from "react";
+import { App } from "antd";
+import { MemoryRouter } from "react-router-dom";
+import type { ChatSpec } from "../../../../api";
+import api from "../../../../api";
+import { chatApi } from "../../../../api/modules/chat";
+import sessionApi from "../../sessionApi";
+import { useAgentStore } from "../../../../stores/agentStore";
+import { useSessionListStore } from "../../../../stores/sessionListStore";
+import {
+  useSessionListData,
+  type ExtendedChatSession,
+} from "./useSessionListData";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const A_CHAT = "33333333-aaaa-4aaa-8aaa-333333333333";
+
+const makeSession = (id: string): ExtendedChatSession =>
+  ({ id, name: id, messages: [] }) as unknown as ExtendedChatSession;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return React.createElement(
+    App,
+    null,
+    React.createElement(MemoryRouter, null, children),
+  );
+}
+
+function renderListData(sessions: ExtendedChatSession[]) {
+  const setSessions = vi.fn();
+  const hook = renderHook(
+    () =>
+      useSessionListData(sessions, setSessions, {
+        active: false,
+        currentSessionId: A_CHAT,
+        onSessionClick: vi.fn(),
+      }),
+    { wrapper },
+  );
+  return { hook, setSessions };
+}
+
+beforeEach(() => {
+  sessionApi.resetForTests();
+  useAgentStore.setState({ selectedAgent: "agent-a", lastChatIdByAgent: {} });
+  useSessionListStore.setState({
+    sessions: [],
+    lastUpdated: 0,
+    _setLibrarySessions: null,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  sessionApi.resetForTests();
+});
+
+describe("useSessionListData cross-agent ownership", () => {
+  it("a delete finishing after an agent switch does not mutate the new view", async () => {
+    sessionApi.setActiveAgent("agent-a");
+    const onSessionRemoved = vi.fn();
+    sessionApi.onSessionRemoved = onSessionRemoved;
+    const newChatListener = vi.fn();
+    window.addEventListener("qwenpaw:sidebar-new-chat", newChatListener);
+
+    const dDelete = deferred<Awaited<ReturnType<typeof chatApi.deleteChat>>>();
+    vi.spyOn(chatApi, "deleteChat").mockReturnValue(dDelete.promise);
+    const listSpy = vi.spyOn(api, "listChats").mockResolvedValue([]);
+
+    const { hook, setSessions } = renderListData([makeSession(A_CHAT)]);
+
+    act(() => {
+      hook.result.current.handleDelete(A_CHAT);
+    });
+
+    // The user switches to agent B while the backend delete is in flight.
+    sessionApi.setActiveAgent("agent-b");
+    useSessionListStore.setState({ sessions: [makeSession("chat-b")] });
+
+    dDelete.resolve({} as Awaited<ReturnType<typeof chatApi.deleteChat>>);
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 0));
+    });
+
+    // The late completion must not touch B's view or callbacks.
+    expect(onSessionRemoved).not.toHaveBeenCalled();
+    expect(setSessions).not.toHaveBeenCalled();
+    expect(useSessionListStore.getState().sessions.map((s) => s.id)).toEqual([
+      "chat-b",
+    ]);
+    expect(newChatListener).not.toHaveBeenCalled();
+    expect(listSpy).not.toHaveBeenCalled();
+
+    window.removeEventListener("qwenpaw:sidebar-new-chat", newChatListener);
+  });
+
+  it("a same-agent delete still refreshes the list and fires callbacks", async () => {
+    sessionApi.setActiveAgent("agent-a");
+    const onSessionRemoved = vi.fn();
+    sessionApi.onSessionRemoved = onSessionRemoved;
+
+    vi.spyOn(chatApi, "deleteChat").mockResolvedValue(
+      {} as Awaited<ReturnType<typeof chatApi.deleteChat>>,
+    );
+    vi.spyOn(api, "listChats").mockResolvedValue([] as ChatSpec[]);
+
+    const { hook, setSessions } = renderListData([makeSession(A_CHAT)]);
+
+    await act(async () => {
+      hook.result.current.handleDelete(A_CHAT);
+      await new Promise((res) => setTimeout(res, 0));
+    });
+
+    expect(onSessionRemoved).toHaveBeenCalledWith(A_CHAT);
+    expect(setSessions).toHaveBeenCalled();
+  });
+
+  it("refetches the list immediately when the selected agent changes", async () => {
+    sessionApi.setActiveAgent("agent-a");
+    const listSpy = vi.spyOn(api, "listChats").mockResolvedValue([]);
+    const setSessions = vi.fn();
+
+    renderHook(
+      () =>
+        useSessionListData([], setSessions, {
+          active: true,
+          currentSessionId: undefined,
+          onSessionClick: vi.fn(),
+        }),
+      { wrapper },
+    );
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useAgentStore.setState({ selectedAgent: "agent-b" });
+    });
+
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+  });
+});

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../components/ContextMenu";
 import { getChannelLabel } from "../../../Control/Channels/components";
 import { syncSessionsGlobal } from "../../../../stores/sessionListStore";
+import { useAgentStore } from "../../../../stores/agentStore";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
 
 export { ContextMenu, useContextMenu, type ContextMenuItem, getChannelLabel };
@@ -131,6 +132,10 @@ export function useSessionListData(
   const { t } = useTranslation();
   const { message } = useAppMessage();
   const { active, currentSessionId, onSessionClick } = opts;
+  // Re-fetch immediately when the selected agent changes — the shared store
+  // is cleared synchronously on the switch and must be repopulated for the
+  // new agent without waiting for the next poll tick.
+  const selectedAgent = useAgentStore((s) => s.selectedAgent);
 
   const [loading, setLoading] = useState(true);
   const [switchingSessionId, setSwitchingSessionId] = useState<string | null>(
@@ -148,8 +153,11 @@ export function useSessionListData(
   const lastSessionsRef = useRef<ExtendedChatSession[]>([]);
 
   const refreshSessions = useCallback(async () => {
+    const owner = sessionApi.getActiveOwner();
     try {
       const list = await sessionApi.getSessionList();
+      // Never publish a list that finished loading under a previous agent.
+      if (!sessionApi.isActiveOwner(owner)) return;
       const extended = list as ExtendedChatSession[];
       setSessions(extended);
       syncSessionsGlobal(extended);
@@ -161,12 +169,13 @@ export function useSessionListData(
   useEffect(() => {
     if (!active) return;
     let cancelled = false;
+    const owner = sessionApi.getActiveOwner();
 
     const fetchSessions = async () => {
       setLoading(true);
       try {
         const list = await sessionApi.getSessionList();
-        if (!cancelled) {
+        if (!cancelled && sessionApi.isActiveOwner(owner)) {
           const extended = list as ExtendedChatSession[];
           if (!sessionsEqual(lastSessionsRef.current, extended)) {
             lastSessionsRef.current = extended;
@@ -188,7 +197,7 @@ export function useSessionListData(
       if (sessionApi.isSessionSwitching) return;
       try {
         const list = await sessionApi.getSessionList();
-        if (!cancelled) {
+        if (!cancelled && sessionApi.isActiveOwner(owner)) {
           const extended = list as ExtendedChatSession[];
           if (!sessionsEqual(lastSessionsRef.current, extended)) {
             lastSessionsRef.current = extended;
@@ -205,7 +214,7 @@ export function useSessionListData(
       cancelled = true;
       clearInterval(timer);
     };
-  }, [active, setSessions]);
+  }, [active, setSessions, selectedAgent]);
 
   const resolvedSessions = useMemo(() => {
     return sessions.filter((s) => {
@@ -255,24 +264,32 @@ export function useSessionListData(
 
   const handleDelete = useCallback(
     async (sessionId: string) => {
+      const owner = sessionApi.getActiveOwner();
       const session = sessions.find((s) => s.id === sessionId);
       const backendId = session ? getBackendId(session) : null;
       if (backendId) await chatApi.deleteChat(backendId);
 
+      // Per-session cleanup is safe regardless of the active agent: it is
+      // keyed to the deleted conversation only.
       localStorage.removeItem(`approval_level-${sessionId}`);
 
       // Clear the message queue for the deleted session so stale items don't
       // linger in storage or get sent after deletion. The queue may be keyed
-      // by the local id or the resolved backend id, so clear both. Also notify
-      // the chat page (when mounted) to abort any in-flight background send.
+      // by the local id or the resolved backend id, so clear both.
       const mq = useMessageQueueStore.getState();
       mq.clear(sessionId);
       if (backendId && backendId !== sessionId) mq.clear(backendId);
+
+      // Everything below mutates the CURRENT view (callbacks, shared list,
+      // navigation). A delete that finished after an agent switch must not
+      // touch the new agent's state.
+      if (!sessionApi.isActiveOwner(owner)) return;
       sessionApi.onSessionRemoved?.(backendId ?? sessionId);
 
       // Fetch fresh session list after deletion
       const freshList =
         (await sessionApi.getSessionList()) as ExtendedChatSession[];
+      if (!sessionApi.isActiveOwner(owner)) return;
       setSessions(freshList);
       syncSessionsGlobal(freshList);
 
@@ -308,6 +325,7 @@ export function useSessionListData(
 
   const handleEditSubmit = useCallback(async () => {
     if (!editingSessionId) return;
+    const owner = sessionApi.getActiveOwner();
     const session = sessions.find((s) => s.id === editingSessionId);
     const backendId = session ? getBackendId(session) : null;
     const newName = editValue.trim();
@@ -316,6 +334,7 @@ export function useSessionListData(
     }
     setEditingSessionId(null);
     setEditValue("");
+    if (!sessionApi.isActiveOwner(owner)) return;
     await refreshSessions();
   }, [editingSessionId, editValue, sessions, refreshSessions]);
 
@@ -326,11 +345,13 @@ export function useSessionListData(
 
   const handlePinToggle = useCallback(
     async (sessionId: string) => {
+      const owner = sessionApi.getActiveOwner();
       const session = sessions.find((s) => s.id === sessionId);
       const backendId = session ? getBackendId(session) : null;
       if (backendId && session) {
         try {
           await chatApi.updateChat(backendId, { pinned: !session.pinned });
+          if (!sessionApi.isActiveOwner(owner)) return;
           await refreshSessions();
         } catch (err) {
           console.error("Failed to toggle pin status:", err);
@@ -342,6 +363,7 @@ export function useSessionListData(
 
   const handleArchiveToggle = useCallback(
     async (sessionId: string) => {
+      const owner = sessionApi.getActiveOwner();
       const session = sessions.find((s) => s.id === sessionId);
       const backendId = session ? getBackendId(session) : null;
       if (!backendId) return;
@@ -349,13 +371,15 @@ export function useSessionListData(
       try {
         if (wasArchived) {
           await chatApi.unarchiveChat(backendId);
-          message.success(
-            t("sessions.archive.unarchiveSuccess", "Chat unarchived"),
-          );
         } else {
           await chatApi.archiveChat(backendId);
-          message.success(t("sessions.archive.successHint"));
         }
+        if (!sessionApi.isActiveOwner(owner)) return;
+        message.success(
+          wasArchived
+            ? t("sessions.archive.unarchiveSuccess", "Chat unarchived")
+            : t("sessions.archive.successHint"),
+        );
         await refreshSessions();
 
         if (!wasArchived && currentSessionId) {

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -210,8 +210,15 @@ const ChatSessionInitializer: React.FC = () => {
 
     return () => {
       // Abort any in-flight embedded switch so a late preload result cannot
-      // navigate after this initializer (and its chat view) is gone.
-      switchControllerRef.current?.abort();
+      // navigate after this initializer (and its chat view) is gone. The
+      // aborted promise's finally skips finishSessionSwitch, and the ref
+      // always points at the newest switch started by this instance, so
+      // releasing the lock here cannot unlock someone else's switch.
+      const controller = switchControllerRef.current;
+      if (controller && !controller.signal.aborted) {
+        controller.abort();
+        sessionApi.finishSessionSwitch();
+      }
       switchControllerRef.current = null;
       window.removeEventListener(
         "qwenpaw:sidebar-select-session",

--- a/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionInitializer/index.tsx
@@ -209,6 +209,10 @@ const ChatSessionInitializer: React.FC = () => {
     }
 
     return () => {
+      // Abort any in-flight embedded switch so a late preload result cannot
+      // navigate after this initializer (and its chat view) is gone.
+      switchControllerRef.current?.abort();
+      switchControllerRef.current = null;
       window.removeEventListener(
         "qwenpaw:sidebar-select-session",
         handleSelectSession,

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -1140,6 +1140,14 @@ function SessionQueuePanel({ sessionId, ...handlers }: SessionQueuePanelProps) {
 
 const HISTORY_PANEL_STORAGE_KEY = "qwenpaw_history_panel_open";
 
+/**
+ * Temporary local session ids (created before the first message is sent) are
+ * not real backend sessions and must never be used for URL restore, session
+ * preference, or persistence.
+ */
+const isLocalTimestampId = (id: string | null | undefined): boolean =>
+  !!id && /^\d+-[a-z0-9]+$/.test(id);
+
 export default function ChatPage() {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -1676,9 +1684,13 @@ export default function ChatPage() {
     usesQwenPawBackend,
   );
 
-  const { setLastChatId, getLastChatId } = useAgentStore();
+  const { setLastChatId, getLastChatId, removeLastChatId } = useAgentStore();
   const setLastChatIdRef = useRef(setLastChatId);
   setLastChatIdRef.current = setLastChatId;
+  const getLastChatIdRef = useRef(getLastChatId);
+  getLastChatIdRef.current = getLastChatId;
+  const removeLastChatIdRef = useRef(removeLastChatId);
+  removeLastChatIdRef.current = removeLastChatId;
   const selectedAgentRef = useRef(selectedAgent);
   selectedAgentRef.current = selectedAgent;
 
@@ -2056,8 +2068,15 @@ export default function ChatPage() {
   // useMount auto-selects the correct session without an extra getSession round-trip.
   // When URL has no chatId (e.g. navigating back from /settings), fall back to the
   // last actively selected session to avoid jumping to the first session on re-mount.
-  const effectiveChatId =
-    chatId || sessionApi.lastActiveChatId || getLastChatId(selectedAgent);
+  // Never use a temporary local timestamp id here: it would be passed to the SDK
+  // as preferredChatId and could be navigated to as a bogus URL.
+  const safeLastActive = isLocalTimestampId(sessionApi.lastActiveChatId)
+    ? null
+    : sessionApi.lastActiveChatId;
+  const safeLastStored = isLocalTimestampId(getLastChatId(selectedAgent))
+    ? null
+    : getLastChatId(selectedAgent);
+  const effectiveChatId = chatId || safeLastActive || safeLastStored;
   if (effectiveChatId && sessionApi.preferredChatId !== effectiveChatId) {
     sessionApi.preferredChatId = effectiveChatId;
   }
@@ -2090,6 +2109,24 @@ export default function ChatPage() {
     };
 
     sessionApi.onSessionRemoved = (removedId) => {
+      // Drop the persisted last-chat id for the current agent when it points
+      // at the removed session, so agent-switch restore doesn't resurrect a
+      // deleted conversation.
+      const agentId = selectedAgentRef.current;
+      if (getLastChatIdRef.current(agentId) === removedId) {
+        removeLastChatIdRef.current(agentId);
+      }
+      // Same for the in-memory re-mount fallback used when the URL has no
+      // chatId (e.g. navigating back from /settings).
+      const lastActive = sessionApi.lastActiveChatId;
+      if (
+        lastActive &&
+        (lastActive === removedId ||
+          sessionApi.getRealIdForSession(lastActive) === removedId)
+      ) {
+        sessionApi.lastActiveChatId = null;
+      }
+
       // Clean up the queue and abort any in-flight background send for the
       // removed session so stale items don't linger in storage or get sent
       // after the conversation is deleted. Navigation to a fresh chat is
@@ -2155,6 +2192,12 @@ export default function ChatPage() {
 
       const resolvedTarget = sessionApi.getEffectiveSessionId(targetId, null);
 
+      // Never navigate to a temporary local timestamp id. The SDK may
+      // auto-select an unresolved local session after an agent switch;
+      // ignoring it keeps the URL stable until the user sends a message or
+      // selects a real backend session.
+      if (isLocalTimestampId(resolvedTarget)) return;
+
       if (
         resolvedTarget !== lastSessionIdRef.current &&
         targetId !== lastSessionIdRef.current
@@ -2180,7 +2223,15 @@ export default function ChatPage() {
       }
       lastSessionIdRef.current = sessionId;
       sessionApi.lastActiveChatId = sessionId;
-      setLastChatIdRef.current(selectedAgentRef.current, sessionId);
+      // Do not persist a temporary local timestamp id. It would otherwise be
+      // restored on agent switch and appear as an unknown id in the URL. The
+      // real backend UUID is persisted by onSessionIdResolved after the first
+      // message is sent.
+      if (isLocalTimestampId(sessionId)) {
+        removeLastChatIdRef.current(selectedAgentRef.current);
+      } else {
+        setLastChatIdRef.current(selectedAgentRef.current, sessionId);
+      }
       navigateRef.current(buildCurrentBasePath(), { replace: true });
     };
 
@@ -2212,16 +2263,20 @@ export default function ChatPage() {
       // and the first message of a fresh chat would carry it.
       sessionApi.resetWindowIdentity();
 
-      // Save current chat ID for the agent we're leaving
+      // Save current chat ID for the agent we're leaving.
+      // Skip temporary local timestamp ids — they are not real backend
+      // sessions and should not be restored later.
       const currentChatId =
         chatIdRef.current || lastSessionIdRef.current || undefined;
-      if (currentChatId && prevAgent) {
+      if (currentChatId && prevAgent && !isLocalTimestampId(currentChatId)) {
         setLastChatId(prevAgent, currentChatId);
       }
 
-      // Restore last chat ID for the agent we're switching to
+      // Restore last chat ID for the agent we're switching to.
+      // Ignore temporary local timestamp ids that may have been persisted
+      // before this guard was added.
       const restored = getLastChatId(selectedAgent);
-      if (restored) {
+      if (restored && !isLocalTimestampId(restored)) {
         navigateRef.current(buildSessionPath("chat", restored), {
           replace: true,
         });

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2064,6 +2064,12 @@ export default function ChatPage() {
     chatRef.current?.input.submit({ query: "/new" });
   }, []);
 
+  // Claim session ownership for the selected agent before any session work
+  // (SDK mount, list polling, temp-id resolution) can start. Render runs
+  // before child effects, so async results from a previous agent are already
+  // stale by the time the new agent's UI mounts.
+  sessionApi.setActiveAgent(selectedAgent);
+
   // Tell sessionApi which session to put first in getSessionList, so the library's
   // useMount auto-selects the correct session without an extra getSession round-trip.
   // When URL has no chatId (e.g. navigating back from /settings), fall back to the
@@ -2250,6 +2256,11 @@ export default function ChatPage() {
   useEffect(() => {
     const prevAgent = prevSelectedAgentRef.current;
     if (prevAgent !== selectedAgent && prevAgent !== undefined) {
+      // Advance the session ownership epoch before starting any new-agent
+      // work (idempotent when render already claimed it): in-flight session
+      // list/resolve results owned by the previous agent become stale.
+      sessionApi.setActiveAgent(selectedAgent);
+
       // Immediately block the queue sender. window.currentSessionId is a
       // global that still holds the PREVIOUS agent's session_id until the
       // SDK finishes reloading. Without this guard, scheduleNextSend could

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -2064,12 +2064,6 @@ export default function ChatPage() {
     chatRef.current?.input.submit({ query: "/new" });
   }, []);
 
-  // Claim session ownership for the selected agent before any session work
-  // (SDK mount, list polling, temp-id resolution) can start. Render runs
-  // before child effects, so async results from a previous agent are already
-  // stale by the time the new agent's UI mounts.
-  sessionApi.setActiveAgent(selectedAgent);
-
   // Tell sessionApi which session to put first in getSessionList, so the library's
   // useMount auto-selects the correct session without an extra getSession round-trip.
   // When URL has no chatId (e.g. navigating back from /settings), fall back to the
@@ -2256,10 +2250,9 @@ export default function ChatPage() {
   useEffect(() => {
     const prevAgent = prevSelectedAgentRef.current;
     if (prevAgent !== selectedAgent && prevAgent !== undefined) {
-      // Advance the session ownership epoch before starting any new-agent
-      // work (idempotent when render already claimed it): in-flight session
-      // list/resolve results owned by the previous agent become stale.
-      sessionApi.setActiveAgent(selectedAgent);
+      // Session ownership has already advanced: sessionApi subscribes to the
+      // agent store and claims the new epoch synchronously with the change,
+      // so in-flight results owned by the previous agent are stale by now.
 
       // Immediately block the queue sender. window.currentSessionId is a
       // global that still holds the PREVIOUS agent's session_id until the

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -10,6 +10,7 @@ import api, {
   type Message,
 } from "../../../api";
 import { toDisplayUrl } from "../utils";
+import { useAgentStore } from "../../../stores/agentStore";
 import {
   extractTurnUsageFromOutputMessages,
   extractLatestSnapshotFromCards,
@@ -524,9 +525,13 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
   /** Short-lived result cache so the library's subsequent getSession call
    *  (triggered by setCurrentSessionId → useAsyncEffect) can reuse the
-   *  already-fetched session without making another network request. */
-  private sessionResultCache: Map<string, IAgentScopeRuntimeWebUISession> =
-    new Map();
+   *  already-fetched session without making another network request. Each
+   *  entry carries the owner epoch it was produced under and is only served
+   *  within that epoch. */
+  private sessionResultCache: Map<
+    string,
+    { session: IAgentScopeRuntimeWebUISession; owner: SessionOwnerToken }
+  > = new Map();
 
   // ---------------------------------------------------------------------------
   // LRU cache for fully-converted sessions (avoids re-fetching on switch-back)
@@ -605,21 +610,33 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     session: IAgentScopeRuntimeWebUISession;
     realId: string | null;
   }> {
+    const owner = this.getActiveOwner();
     try {
       const session = await this.getSession(sessionId, signal);
       const extendedSession = session as ExtendedSession;
       const realId = extendedSession.realId || null;
 
-      // Cache the result so subsequent getSession calls return immediately.
-      this.sessionResultCache.set(sessionId, session);
-      if (realId) {
-        this.sessionResultCache.set(realId, session);
+      // Cache the result so subsequent getSession calls return immediately —
+      // but never publish a result that arrived after an agent switch into
+      // the new epoch's cache.
+      if (this.isActiveOwner(owner)) {
+        const entry = { session, owner };
+        this.sessionResultCache.set(sessionId, entry);
+        if (realId) {
+          this.sessionResultCache.set(realId, entry);
+        }
+        // Clear after 3s (enough for the library's useAsyncEffect to fire).
+        // Delete by entry identity so a late timer cannot remove a newer
+        // entry cached under the same key.
+        setTimeout(() => {
+          if (this.sessionResultCache.get(sessionId) === entry) {
+            this.sessionResultCache.delete(sessionId);
+          }
+          if (realId && this.sessionResultCache.get(realId) === entry) {
+            this.sessionResultCache.delete(realId);
+          }
+        }, 3000);
       }
-      // Clear cache after 3s (enough for the library's useAsyncEffect to fire).
-      setTimeout(() => {
-        this.sessionResultCache.delete(sessionId);
-        if (realId) this.sessionResultCache.delete(realId);
-      }, 3000);
 
       return { session, realId };
     } catch (error) {
@@ -645,30 +662,29 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   // singleton state or notify the current view.
   // ---------------------------------------------------------------------------
 
-  /** Current ownership epoch. agentId "" = not yet claimed (initial mount). */
+  /** Current ownership epoch. agentId "" = not yet claimed (tests only —
+   *  at runtime the module claims the selected agent on load, below). */
   private activeOwner: SessionOwnerToken = { agentId: "", generation: 0 };
 
   /**
    * Claims session ownership for an agent. Advances the generation whenever
    * the agent actually changes so that A -> B -> A creates a fresh epoch.
-   * The very first claim keeps the initial generation so that work started
-   * during initial mount (before ChatPage renders) is not spuriously
-   * invalidated.
+   * Driven by the agent-store subscription at the bottom of this module, so
+   * the claim happens synchronously with the agent change — before any React
+   * re-render or effect can start new-agent session work.
    */
   setActiveAgent(agentId: string): SessionOwnerToken {
     if (this.activeOwner.agentId === agentId) return this.activeOwner;
-    const generation =
-      this.activeOwner.agentId === ""
-        ? this.activeOwner.generation
-        : this.activeOwner.generation + 1;
-    this.activeOwner = { agentId, generation };
-    if (generation !== 0) {
-      // Drop shared in-flight work from the previous epoch so the new agent
-      // never awaits or reuses it. The underlying promises keep running but
-      // their results are rejected by the owner checks at the apply sites.
-      this.sessionListRequest = null;
-      this.resolvePromise = null;
-    }
+    this.activeOwner = { agentId, generation: this.activeOwner.generation + 1 };
+    // Drop shared in-flight work and short-lived caches from the previous
+    // epoch so the new agent never awaits or reuses them. The underlying
+    // promises keep running but their results are rejected by the owner
+    // checks at the apply sites.
+    this.sessionListRequest = null;
+    this.resolvePromise = null;
+    this.sessionRequests.clear();
+    this.sessionResultCache.clear();
+    this.convertedSessionCache.clear();
     return this.activeOwner;
   }
 
@@ -676,13 +692,27 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     return this.activeOwner;
   }
 
-  /**
-   * The generation alone identifies an epoch (it advances on every agent
-   * change), so comparing it is sufficient — and it lets initial-mount work
-   * captured under the unclaimed owner survive the first explicit claim.
-   */
+  /** A token is active only when both the agent and its epoch still match. */
   isActiveOwner(token: SessionOwnerToken): boolean {
-    return token.generation === this.activeOwner.generation;
+    return (
+      token.agentId === this.activeOwner.agentId &&
+      token.generation === this.activeOwner.generation
+    );
+  }
+
+  /**
+   * Applies the view-facing side effects of a loaded session (window identity
+   * globals and the turn-usage store) only while the owner epoch that started
+   * the load is still active. A stale load must never rewrite the current
+   * agent's identity or usage view.
+   */
+  private applySessionView(
+    session: ExtendedSession,
+    owner: SessionOwnerToken,
+  ): void {
+    if (!this.isActiveOwner(owner)) return;
+    this.updateWindowVariables(session);
+    hydrateTurnUsageFromMessages(session.messages ?? []);
   }
 
   /**
@@ -752,11 +782,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
   /**
    * Deduplicates concurrent getSession calls for the same sessionId.
-   * Key: sessionId, Value: in-flight promise for getSession.
+   * Each in-flight promise carries the owner epoch it was started under and
+   * is never reused across an agent switch.
    */
   private sessionRequests: Map<
     string,
-    Promise<IAgentScopeRuntimeWebUISession>
+    { promise: Promise<IAgentScopeRuntimeWebUISession>; owner: SessionOwnerToken }
   > = new Map();
 
   /**
@@ -840,11 +871,16 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     }
   }
 
-  private createEmptySession(sessionId: string): ExtendedSession {
-    window.currentSessionId = sessionId;
-    window.currentUserId = DEFAULT_USER_ID;
-    window.currentChannel = DEFAULT_CHANNEL;
-    useTurnUsageStore.getState().setSnapshot(null);
+  private createEmptySession(
+    sessionId: string,
+    owner: SessionOwnerToken,
+  ): ExtendedSession {
+    if (this.isActiveOwner(owner)) {
+      window.currentSessionId = sessionId;
+      window.currentUserId = DEFAULT_USER_ID;
+      window.currentChannel = DEFAULT_CHANNEL;
+      useTurnUsageStore.getState().setSnapshot(null);
+    }
     return {
       id: sessionId,
       name: DEFAULT_SESSION_NAME,
@@ -1156,16 +1192,24 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   private lastSelectedIds: Set<string> = new Set();
 
   async getSession(sessionId: string, signal?: AbortSignal) {
-    // Check short-lived result cache first (populated by preloadSession).
-    const cached = this.sessionResultCache.get(sessionId);
-    if (cached) return cached;
-
-    const existingRequest = this.sessionRequests.get(sessionId);
-    if (existingRequest) return existingRequest;
-
     const owner = this.getActiveOwner();
-    const requestPromise = this._doGetSession(sessionId, signal);
-    this.sessionRequests.set(sessionId, requestPromise);
+
+    // Check short-lived result cache first (populated by preloadSession).
+    // Entries from a previous ownership epoch are never served.
+    const cached = this.sessionResultCache.get(sessionId);
+    if (cached && this.isActiveOwner(cached.owner)) return cached.session;
+
+    // Reuse an in-flight request only within the same ownership epoch, so a
+    // new agent never adopts a request (and its captured owner) started by a
+    // previous agent.
+    const existingRequest = this.sessionRequests.get(sessionId);
+    if (existingRequest && this.isActiveOwner(existingRequest.owner)) {
+      return existingRequest.promise;
+    }
+
+    const requestPromise = this._doGetSession(sessionId, signal, owner);
+    const entry = { promise: requestPromise, owner };
+    this.sessionRequests.set(sessionId, entry);
 
     try {
       const session = await requestPromise;
@@ -1184,20 +1228,27 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       }
       return session;
     } finally {
-      this.sessionRequests.delete(sessionId);
+      // Delete by entry identity so a stale request cannot remove a newer
+      // epoch's in-flight entry stored under the same key.
+      if (this.sessionRequests.get(sessionId) === entry) {
+        this.sessionRequests.delete(sessionId);
+      }
     }
   }
 
   /**
    * Fetch chat history from backend and build an ExtendedSession.
    * Centralises the repeated fetch-convert-patch-build pattern used by
-   * _doGetSession in multiple branches.
+   * _doGetSession in multiple branches. Construction is applied to shared
+   * state (window identity, turn-usage store, converted cache) only while
+   * the caller's owner epoch is still active.
    */
   private async fetchAndBuildSession(
     displayId: string,
     backendId: string,
     listEntry: ExtendedSession | undefined,
-    signal?: AbortSignal,
+    signal: AbortSignal | undefined,
+    owner: SessionOwnerToken,
   ): Promise<ExtendedSession> {
     // Check LRU cache for non-generating sessions
     const isIdle = !listEntry?.generating;
@@ -1210,8 +1261,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         // Update mutable fields that may differ
         cached.id = displayId;
         if (listEntry?.name) cached.name = listEntry.name;
-        this.updateWindowVariables(cached);
-        hydrateTurnUsageFromMessages(cached.messages ?? []);
+        this.applySessionView(cached, owner);
         return cached;
       }
     }
@@ -1233,10 +1283,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       realId: listEntry?.realId,
       generating,
     };
-    this.updateWindowVariables(session);
 
-    // Cache non-generating sessions
-    if (!generating) {
+    // Cache non-generating sessions — only within the epoch that fetched
+    // them, so a stale load cannot write into the new agent's cache.
+    if (!generating && this.isActiveOwner(owner)) {
       this.setCachedConvertedSession(
         backendId,
         session,
@@ -1244,17 +1294,20 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       );
     }
 
-    hydrateTurnUsageFromMessages(session.messages ?? []);
+    this.applySessionView(session, owner);
     return session;
   }
 
   private async _doGetSession(
     sessionId: string,
-    signal?: AbortSignal,
+    signal: AbortSignal | undefined,
+    owner: SessionOwnerToken,
   ): Promise<IAgentScopeRuntimeWebUISession> {
     // --- No session selected (library bug: createSession sets undefined) ---
     if (!sessionId || sessionId === "undefined" || sessionId === "null") {
-      useTurnUsageStore.getState().setSnapshot(null);
+      if (this.isActiveOwner(owner)) {
+        useTurnUsageStore.getState().setSnapshot(null);
+      }
       return {
         id: sessionId || "",
         name: "",
@@ -1276,12 +1329,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
             fromList.realId,
             fromList,
             signal,
+            owner,
           );
         } catch (error) {
           // If fetching with realId fails, return the local session without messages
           // This handles cases where the backend has an inconsistency
-          this.updateWindowVariables(fromList);
-          hydrateTurnUsageFromMessages(fromList.messages ?? []);
+          this.applySessionView(fromList, owner);
           return fromList;
         }
       }
@@ -1299,20 +1352,19 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
               resolved.realId,
               resolved,
               signal,
+              owner,
             );
           } catch {
-            this.updateWindowVariables(resolved);
-            hydrateTurnUsageFromMessages(resolved.messages ?? []);
+            this.applySessionView(resolved, owner);
             return resolved;
           }
         }
       }
       if (fromList) {
-        this.updateWindowVariables(fromList);
-        hydrateTurnUsageFromMessages(fromList.messages ?? []);
+        this.applySessionView(fromList, owner);
         return fromList;
       }
-      return this.createEmptySession(sessionId);
+      return this.createEmptySession(sessionId, owner);
     }
 
     // --- Regular backend UUID ---
@@ -1322,6 +1374,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         sessionId,
         this.findSession(sessionId),
         signal,
+        owner,
       );
     } catch (error: any) {
       // If the backend session doesn't exist (e.g. invalid UUID or expired session)
@@ -1329,7 +1382,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       // Note: the request layer throws Error(message) without attaching .status,
       // so only message-based detection is reliable here.
       if (error.message?.includes("Chat not found")) {
-        const emptySession = this.createEmptySession(sessionId);
+        const emptySession = this.createEmptySession(sessionId, owner);
         emptySession.id = sessionId;
         return emptySession;
       }
@@ -1450,7 +1503,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     const localId = `${Date.now()}-${Math.random()
       .toString(36)
       .substring(2, 9)}`;
-    const extended = this.createEmptySession(localId);
+    const extended = this.createEmptySession(localId, this.getActiveOwner());
     extended.name = session.name || DEFAULT_SESSION_NAME;
     this.sessionList.unshift(extended);
     session.id = localId;
@@ -1486,7 +1539,19 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   }
 }
 
-export default new SessionApi();
+const sessionApi = new SessionApi();
+
+// Ownership follows the selected agent from the agent store. Claiming here —
+// at module load and synchronously inside every store update — guarantees a
+// single lifecycle location and that the epoch advances before any React
+// re-render or effect can start new-agent session work, regardless of which
+// page (chat, settings, sidebar preload) triggers the change.
+sessionApi.setActiveAgent(useAgentStore.getState().selectedAgent);
+useAgentStore.subscribe((state) => {
+  sessionApi.setActiveAgent(state.selectedAgent);
+});
+
+export default sessionApi;
 
 // ---------------------------------------------------------------------------
 // Test-only exports (used by ./tests/testLargeSession.test.tsx — PR-F3 / #5479)

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -811,7 +811,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    */
   private sessionRequests: Map<
     string,
-    { promise: Promise<IAgentScopeRuntimeWebUISession>; owner: SessionOwnerToken }
+    {
+      promise: Promise<IAgentScopeRuntimeWebUISession>;
+      owner: SessionOwnerToken;
+    }
   > = new Map();
 
   /**

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -613,30 +613,34 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     const owner = this.getActiveOwner();
     try {
       const session = await this.getSession(sessionId, signal);
+
+      // A preload that completes after an agent switch must fail like an
+      // aborted request: resolving normally would let the caller navigate
+      // the new agent to the stale session and mark it as preferred.
+      if (!this.isActiveOwner(owner)) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
       const extendedSession = session as ExtendedSession;
       const realId = extendedSession.realId || null;
 
-      // Cache the result so subsequent getSession calls return immediately —
-      // but never publish a result that arrived after an agent switch into
-      // the new epoch's cache.
-      if (this.isActiveOwner(owner)) {
-        const entry = { session, owner };
-        this.sessionResultCache.set(sessionId, entry);
-        if (realId) {
-          this.sessionResultCache.set(realId, entry);
-        }
-        // Clear after 3s (enough for the library's useAsyncEffect to fire).
-        // Delete by entry identity so a late timer cannot remove a newer
-        // entry cached under the same key.
-        setTimeout(() => {
-          if (this.sessionResultCache.get(sessionId) === entry) {
-            this.sessionResultCache.delete(sessionId);
-          }
-          if (realId && this.sessionResultCache.get(realId) === entry) {
-            this.sessionResultCache.delete(realId);
-          }
-        }, 3000);
+      // Cache the result so subsequent getSession calls return immediately.
+      const entry = { session, owner };
+      this.sessionResultCache.set(sessionId, entry);
+      if (realId) {
+        this.sessionResultCache.set(realId, entry);
       }
+      // Clear after 3s (enough for the library's useAsyncEffect to fire).
+      // Delete by entry identity so a late timer cannot remove a newer
+      // entry cached under the same key.
+      setTimeout(() => {
+        if (this.sessionResultCache.get(sessionId) === entry) {
+          this.sessionResultCache.delete(sessionId);
+        }
+        if (realId && this.sessionResultCache.get(realId) === entry) {
+          this.sessionResultCache.delete(realId);
+        }
+      }, 3000);
 
       return { session, realId };
     } catch (error) {
@@ -685,6 +689,13 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.sessionRequests.clear();
     this.sessionResultCache.clear();
     this.convertedSessionCache.clear();
+    // Reset the session list and its comparison state as well: the next
+    // agent's chats can share a session_id (channel:user_id) with the old
+    // list, and merging against leftover entries would transfer the previous
+    // agent's local id / backend UUID onto a different chat.
+    this.sessionList = [];
+    this._prevReturnedList = null;
+    this.lastSelectedIds.clear();
     return this.activeOwner;
   }
 

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -454,6 +454,20 @@ function clearPendingUserMessage(sessionId: string): void {
 // SessionApi
 // ---------------------------------------------------------------------------
 
+/**
+ * Ownership token for asynchronous session work. Captured when an operation
+ * starts; a result whose token no longer matches the active epoch must not
+ * mutate singleton state or notify the current view.
+ *
+ * The generation is required in addition to the agent id: switching
+ * A -> B -> A would otherwise let work from the first A epoch pass an
+ * agent-id-only comparison.
+ */
+export interface SessionOwnerToken {
+  agentId: string;
+  generation: number;
+}
+
 class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   private sessionList: IAgentScopeRuntimeWebUISession[] = [];
 
@@ -624,6 +638,79 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.switchAbortController = null;
   }
 
+  // ---------------------------------------------------------------------------
+  // Agent ownership epochs
+  // Async session operations capture the active owner token before awaiting;
+  // late results from a previous epoch are rejected before they can mutate
+  // singleton state or notify the current view.
+  // ---------------------------------------------------------------------------
+
+  /** Current ownership epoch. agentId "" = not yet claimed (initial mount). */
+  private activeOwner: SessionOwnerToken = { agentId: "", generation: 0 };
+
+  /**
+   * Claims session ownership for an agent. Advances the generation whenever
+   * the agent actually changes so that A -> B -> A creates a fresh epoch.
+   * The very first claim keeps the initial generation so that work started
+   * during initial mount (before ChatPage renders) is not spuriously
+   * invalidated.
+   */
+  setActiveAgent(agentId: string): SessionOwnerToken {
+    if (this.activeOwner.agentId === agentId) return this.activeOwner;
+    const generation =
+      this.activeOwner.agentId === ""
+        ? this.activeOwner.generation
+        : this.activeOwner.generation + 1;
+    this.activeOwner = { agentId, generation };
+    if (generation !== 0) {
+      // Drop shared in-flight work from the previous epoch so the new agent
+      // never awaits or reuses it. The underlying promises keep running but
+      // their results are rejected by the owner checks at the apply sites.
+      this.sessionListRequest = null;
+      this.resolvePromise = null;
+    }
+    return this.activeOwner;
+  }
+
+  getActiveOwner(): SessionOwnerToken {
+    return this.activeOwner;
+  }
+
+  /**
+   * The generation alone identifies an epoch (it advances on every agent
+   * change), so comparing it is sufficient — and it lets initial-mount work
+   * captured under the unclaimed owner survive the first explicit claim.
+   */
+  isActiveOwner(token: SessionOwnerToken): boolean {
+    return token.generation === this.activeOwner.generation;
+  }
+
+  /**
+   * Test-only: restores ownership, in-flight work, caches, and callbacks to a
+   * pristine page-load state so tests cannot leak state into each other.
+   */
+  resetForTests(): void {
+    this.activeOwner = { agentId: "", generation: 0 };
+    this.sessionListRequest = null;
+    this.resolvePromise = null;
+    this.sessionRequests.clear();
+    this.sessionResultCache.clear();
+    this.convertedSessionCache.clear();
+    this.sessionList = [];
+    this._prevReturnedList = null;
+    this.lastSelectedIds.clear();
+    this.preferredChatId = null;
+    this.lastActiveChatId = null;
+    this.lastNavigatedChatId = null;
+    this.isSessionSwitching = false;
+    this.switchAbortController = null;
+    this.userInitiatedCreate = false;
+    this.onSessionIdResolved = null;
+    this.onSessionRemoved = null;
+    this.onSessionSelected = null;
+    this.onSessionCreated = null;
+  }
+
   /**
    * Cache the latest user message for a chat so it can be patched into
    * history during reconnect (the backend only persists it after generation
@@ -652,9 +739,13 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    * Deduplicates concurrent getSessionList calls so that two parallel
    * invocations share one network request and write sessionList only once,
    * preserving any realId mappings that were already resolved.
+   * The in-flight request carries the owner token it was started under so it
+   * is never reused — nor applied — across an agent switch.
    */
-  private sessionListRequest: Promise<IAgentScopeRuntimeWebUISession[]> | null =
-    null;
+  private sessionListRequest: {
+    owner: SessionOwnerToken;
+    promise: Promise<IAgentScopeRuntimeWebUISession[]>;
+  } | null = null;
 
   /** Pending resolve promise so getSession can await it before returning. */
   private resolvePromise: Promise<void> | null = null;
@@ -1025,18 +1116,36 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   }
 
   async getSessionList() {
-    if (this.sessionListRequest) return this.sessionListRequest;
+    // Reuse an in-flight request only within the same ownership epoch, so a
+    // new agent never awaits a list request started by a previous agent.
+    if (
+      this.sessionListRequest &&
+      this.isActiveOwner(this.sessionListRequest.owner)
+    ) {
+      return this.sessionListRequest.promise;
+    }
 
-    this.sessionListRequest = (async () => {
+    const owner = this.getActiveOwner();
+    const entry = { owner } as {
+      owner: SessionOwnerToken;
+      promise: Promise<IAgentScopeRuntimeWebUISession[]>;
+    };
+    entry.promise = (async () => {
       try {
         const chats = await api.listChats({ archived: false });
+        // A result from a stale epoch must not replace the current agent's
+        // session list; hand back the current list without mutation.
+        if (!this.isActiveOwner(owner)) {
+          return this._prevReturnedList ?? [...this.sessionList];
+        }
         return this.applyChatsToSessionList(chats);
       } finally {
-        this.sessionListRequest = null;
+        if (this.sessionListRequest === entry) this.sessionListRequest = null;
       }
     })();
+    this.sessionListRequest = entry;
 
-    return this.sessionListRequest;
+    return entry.promise;
   }
 
   /**
@@ -1054,6 +1163,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     const existingRequest = this.sessionRequests.get(sessionId);
     if (existingRequest) return existingRequest;
 
+    const owner = this.getActiveOwner();
     const requestPromise = this._doGetSession(sessionId, signal);
     this.sessionRequests.set(sessionId, requestPromise);
 
@@ -1062,10 +1172,11 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       const extendedSession = session as ExtendedSession;
       const realId = extendedSession.realId || null;
 
-      // Only trigger onSessionSelected if neither the displayId nor the
-      // realId has already been selected. This prevents the infinite loop
-      // where displayId and realId alternate triggering onSessionSelected.
-      if (!this.lastSelectedIds.has(sessionId)) {
+      // Only trigger onSessionSelected if the result still belongs to the
+      // active ownership epoch and neither the displayId nor the realId has
+      // already been selected. The latter prevents the infinite loop where
+      // displayId and realId alternate triggering onSessionSelected.
+      if (this.isActiveOwner(owner) && !this.lastSelectedIds.has(sessionId)) {
         this.lastSelectedIds.clear();
         this.lastSelectedIds.add(sessionId);
         if (realId) this.lastSelectedIds.add(realId);
@@ -1228,9 +1339,13 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
   /**
    * After fetching the latest session list, try to resolve a local timestamp
-   * session to its real backend UUID and notify listeners.
+   * session to its real backend UUID and notify listeners. Skipped entirely
+   * when the ownership epoch the resolution was started under is no longer
+   * active: a late resolution from a previous agent must neither rewrite the
+   * current agent's session list nor fire onSessionIdResolved into its view.
    */
-  private resolveAndNotify(tempId: string): void {
+  private resolveAndNotify(tempId: string, owner: SessionOwnerToken): void {
+    if (!this.isActiveOwner(owner)) return;
     const { list, realId } = resolveRealId(this.sessionList, tempId);
     this.sessionList = list;
     if (realId) {
@@ -1256,6 +1371,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     if (!isLocalTimestamp(tempId)) return;
     const existing = this.findSession(tempId);
     if (!existing || existing.realId) return; // already resolved
+    const owner = this.getActiveOwner();
     // Force a fresh listChats request: if a stale in-flight getSessionList
     // (started before the POST) is still pending, its response won't contain
     // the new backend session yet. Sharing that stale promise would cause
@@ -1263,7 +1379,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     // leaving the URL at /chat instead of /chat/<uuid>.
     this.sessionListRequest = null;
     const promise = this.getSessionList()
-      .then(() => this.resolveAndNotify(tempId))
+      .then(() => this.resolveAndNotify(tempId, owner))
       .finally(() => {
         if (this.resolvePromise === promise) this.resolvePromise = null;
       });

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -812,7 +812,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
   ): void {
     this.lastActiveChatId = effectiveId;
     this.lastNavigatedChatId = effectiveId;
-    if (persistFn && agentId) {
+    // Never persist a temporary local timestamp id. These ids only exist in
+    // memory for brand-new chats before the first message is sent; persisting
+    // them causes an unknown id to be restored on agent switch.
+    if (persistFn && agentId && !isLocalTimestamp(effectiveId)) {
       persistFn(agentId, effectiveId);
     }
   }

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -127,8 +127,21 @@ interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
 // Message conversion helpers: backend flat messages → card-based UI format
 // ---------------------------------------------------------------------------
 
+/**
+ * Cryptographically random base36 suffix for locally generated ids.
+ * The ids are not secrets, but sourcing them from the CSPRNG avoids any
+ * predictability concern and keeps static analysis clean.
+ */
+function randomBase36(length: number): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (const byte of bytes) out += (byte % 36).toString(36);
+  return out;
+}
+
 function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  return `${Date.now()}-${randomBase36(9)}`;
 }
 
 /** Parse metadata.timestamp string (e.g. "2026-05-27 10:44:53.362") to unix seconds. */
@@ -1527,9 +1540,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
       return [...this.sessionList];
     }
 
-    const localId = `${Date.now()}-${Math.random()
-      .toString(36)
-      .substring(2, 9)}`;
+    const localId = `${Date.now()}-${randomBase36(7)}`;
     const extended = this.createEmptySession(localId, this.getActiveOwner());
     extended.name = session.name || DEFAULT_SESSION_NAME;
     this.sessionList.unshift(extended);

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -644,6 +644,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
       return { session, realId };
     } catch (error) {
+      // A stale completion must look like an abort on the error path too:
+      // a plain network/backend rejection would otherwise be handled as a
+      // failure of the CURRENT switch and select the old agent's session.
+      if (!this.isActiveOwner(owner)) {
+        throw new DOMException("Aborted", "AbortError");
+      }
       // Don't reset switching state on abort — the new switch owns the lock
       if (error instanceof DOMException && error.name === "AbortError") {
         throw error;
@@ -696,6 +702,13 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     this.sessionList = [];
     this._prevReturnedList = null;
     this.lastSelectedIds.clear();
+    // Release the switch lock: the switch it belonged to is owned by the
+    // previous epoch and its completion handler may never run (e.g. the
+    // initializer aborted on unmount). Leaving it set would make the new
+    // agent permanently skip URL sync, session selection, and list polling.
+    this.isSessionSwitching = false;
+    this.switchAbortController?.abort();
+    this.switchAbortController = null;
     return this.activeOwner;
   }
 

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -256,12 +256,38 @@ describe("agent session ownership epochs", () => {
     await sessionApi.getSession(A_CHAT);
     expect(getChatSpy).toHaveBeenCalledTimes(2);
 
-    // A's preload completes late: its result must not be published into the
-    // short-lived result cache, so a follow-up getSession never serves it.
+    // A's preload completes late: it must fail like an aborted request so
+    // the caller's navigation path never runs, and its result must not be
+    // served from the short-lived result cache.
     dA.resolve(makeHistory());
-    const { session: staleSession } = await preloadPromise;
-    const after = await sessionApi.getSession(A_CHAT);
-    expect(after).not.toBe(staleSession);
+    await expect(preloadPromise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+
+  it("the previous agent's list entries cannot leak ids into the new agent's list", async () => {
+    const listSpy = vi.spyOn(api, "listChats");
+
+    // Agent A resolves a blank local session to its backend UUID, leaving a
+    // list entry with a local id and realId mapping.
+    sessionApi.setActiveAgent("agent-a");
+    const spec: { id?: string } = {};
+    await sessionApi.createSession(spec);
+    const tempId = spec.id!;
+    listSpy.mockResolvedValueOnce([makeChatSpec(A_CHAT, tempId)]);
+    sessionApi.triggerResolve(tempId);
+    await flush();
+
+    // Agent B's backend chat shares the same session_id (channel:user_id).
+    // Merging against A's leftover entry would transfer A's local id and
+    // UUID onto B's chat.
+    sessionApi.setActiveAgent("agent-b");
+    listSpy.mockResolvedValueOnce([makeChatSpec(B_CHAT, tempId)]);
+    const list = await sessionApi.getSessionList();
+
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(B_CHAT);
+    expect((list[0] as { realId?: string }).realId).toBeUndefined();
   });
 
   it("work started before the first ownership claim is rejected after it", async () => {

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -265,6 +265,39 @@ describe("agent session ownership epochs", () => {
     });
   });
 
+  it("a stale preload that fails with a normal error still rejects as AbortError", async () => {
+    vi.spyOn(api, "listChats").mockResolvedValue([
+      makeChatSpec(A_CHAT, "console:a"),
+    ]);
+    const dChat = deferred<ChatHistory>();
+    vi.spyOn(api, "getChat").mockReturnValueOnce(dChat.promise);
+
+    // Agent A starts a preload whose fetch is still pending at switch time.
+    sessionApi.setActiveAgent("agent-a");
+    await sessionApi.getSessionList();
+    const preloadPromise = sessionApi.preloadSession(A_CHAT);
+
+    // After the switch the old request fails with a plain backend error.
+    // The caller must see an abort — a normal rejection would be handled as
+    // a current-switch failure and select the stale session.
+    sessionApi.setActiveAgent("agent-b");
+    dChat.reject(new Error("backend unavailable"));
+
+    await expect(preloadPromise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  });
+
+  it("switching agents releases a stuck session-switch lock", () => {
+    sessionApi.setActiveAgent("agent-a");
+    // Simulate an embedded switch whose finally never ran (unmount abort).
+    sessionApi.isSessionSwitching = true;
+
+    sessionApi.setActiveAgent("agent-b");
+
+    expect(sessionApi.isSessionSwitching).toBe(false);
+  });
+
   it("the previous agent's list entries cannot leak ids into the new agent's list", async () => {
     const listSpy = vi.spyOn(api, "listChats");
 

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression tests for cross-agent session ownership.
+ *
+ * SessionApi is a page-global singleton: its session list, in-flight list
+ * request, and temporary-ID resolution are not naturally scoped to an agent.
+ * Without ownership tracking, an asynchronous operation started under agent A
+ * could finish after the user switched to agent B and then replace B's
+ * session list, navigate B's view, or persist A's chat id for B.
+ *
+ * These tests drive the public sessionApi surface with deferred `api`
+ * promises to prove that late results from a stale ownership epoch are
+ * rejected, while same-epoch results keep working.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ChatSpec, ChatHistory } from "../../../api";
+import api from "../../../api";
+import sessionApi from "../sessionApi";
+import { useAgentStore } from "../../../stores/agentStore";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Flush pending microtasks so `.then` chains after a resolve can settle. */
+async function flush(): Promise<void> {
+  await new Promise((res) => setTimeout(res, 0));
+}
+
+function makeChatSpec(
+  id: string,
+  sessionId: string,
+  name = "chat",
+): ChatSpec {
+  return {
+    id,
+    name,
+    session_id: sessionId,
+    user_id: "default",
+    channel: "console",
+    created_at: "2026-07-27T10:00:00.000000+00:00",
+    updated_at: "2026-07-27T10:00:00.000000+00:00",
+    meta: {},
+    status: "idle",
+    pinned: false,
+    archived: false,
+    archived_at: null,
+  } as unknown as ChatSpec;
+}
+
+function makeHistory(): ChatHistory {
+  return { messages: [], status: "idle" } as unknown as ChatHistory;
+}
+
+const A_CHAT = "11111111-aaaa-4aaa-8aaa-111111111111";
+const B_CHAT = "22222222-bbbb-4bbb-8bbb-222222222222";
+
+beforeEach(() => {
+  sessionApi.resetForTests();
+  useAgentStore.setState({ lastChatIdByAgent: {} });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  sessionApi.resetForTests();
+});
+
+describe("agent session ownership epochs", () => {
+  it("Test A: an old agent's list request cannot replace the new agent's list", async () => {
+    const listSpy = vi.spyOn(api, "listChats");
+    const onSessionSelected = vi.fn();
+    sessionApi.onSessionSelected = onSessionSelected;
+
+    // Agent A starts a list request that stays pending.
+    sessionApi.setActiveAgent("agent-a");
+    const dA = deferred<ChatSpec[]>();
+    listSpy.mockReturnValueOnce(dA.promise);
+    const pA = sessionApi.getSessionList();
+
+    // The user switches to agent B, whose own request resolves first.
+    sessionApi.setActiveAgent("agent-b");
+    const dB = deferred<ChatSpec[]>();
+    listSpy.mockReturnValueOnce(dB.promise);
+    const pB = sessionApi.getSessionList();
+
+    // B must not have reused A's in-flight promise.
+    expect(pB).not.toBe(pA);
+    expect(listSpy).toHaveBeenCalledTimes(2);
+
+    dB.resolve([makeChatSpec(B_CHAT, "console:b")]);
+    const listB = await pB;
+    expect(listB.map((s) => s.id)).toEqual([B_CHAT]);
+
+    // A's request finishes late: its data must not be applied.
+    dA.resolve([makeChatSpec(A_CHAT, "console:a")]);
+    const staleResult = await pA;
+    expect(staleResult.map((s) => s.id)).toEqual([B_CHAT]);
+
+    // A fresh call still sees B's list, not A's.
+    listSpy.mockResolvedValueOnce([makeChatSpec(B_CHAT, "console:b")]);
+    const current = await sessionApi.getSessionList();
+    expect(current.map((s) => s.id)).toEqual([B_CHAT]);
+    expect(onSessionSelected).not.toHaveBeenCalled();
+  });
+
+  it("Test B: an old temp-id resolution cannot notify or persist for the new agent", async () => {
+    const listSpy = vi.spyOn(api, "listChats");
+    const onSessionIdResolved = vi.fn();
+    sessionApi.onSessionIdResolved = onSessionIdResolved;
+    useAgentStore.setState({ lastChatIdByAgent: { "agent-b": B_CHAT } });
+
+    // Agent A creates a blank local session (temp timestamp id).
+    sessionApi.setActiveAgent("agent-a");
+    const spec: { id?: string } = {};
+    await sessionApi.createSession(spec);
+    const tempId = spec.id!;
+    expect(tempId).toMatch(/^\d+-[a-z0-9]+$/);
+
+    // First message sent: resolution starts but the list stays pending.
+    const dResolve = deferred<ChatSpec[]>();
+    listSpy.mockReturnValueOnce(dResolve.promise);
+    sessionApi.triggerResolve(tempId);
+
+    // The user switches to agent B before A's resolution completes.
+    sessionApi.setActiveAgent("agent-b");
+
+    // A's backend answer arrives with the matching chat (session_id equals
+    // the temp id, which would resolve successfully in the same epoch).
+    dResolve.resolve([makeChatSpec(A_CHAT, tempId)]);
+    await flush();
+
+    // No notification reaches B's view and B's persisted chat is untouched.
+    expect(onSessionIdResolved).not.toHaveBeenCalled();
+    expect(useAgentStore.getState().getLastChatId("agent-b")).toBe(B_CHAT);
+  });
+
+  it("Test C: A -> B -> A rejects results from the first A epoch", async () => {
+    const listSpy = vi.spyOn(api, "listChats");
+
+    // Work starts under the first A epoch.
+    sessionApi.setActiveAgent("agent-a");
+    const dOld = deferred<ChatSpec[]>();
+    listSpy.mockReturnValueOnce(dOld.promise);
+    const pOld = sessionApi.getSessionList();
+
+    // Switch away and back: the agent id matches again but the epoch differs.
+    sessionApi.setActiveAgent("agent-b");
+    sessionApi.setActiveAgent("agent-a");
+    const dNew = deferred<ChatSpec[]>();
+    listSpy.mockReturnValueOnce(dNew.promise);
+    const pNew = sessionApi.getSessionList();
+    dNew.resolve([makeChatSpec(B_CHAT, "console:new-a")]);
+    await pNew;
+
+    // The generation-1 work resolves last and must still be rejected.
+    dOld.resolve([makeChatSpec(A_CHAT, "console:old-a")]);
+    const staleResult = await pOld;
+    expect(staleResult.map((s) => s.id)).toEqual([B_CHAT]);
+  });
+
+  it("Test D: same-owner list, selection, and temp-id resolution still work", async () => {
+    const listSpy = vi.spyOn(api, "listChats");
+    vi.spyOn(api, "getChat").mockResolvedValue(makeHistory());
+    const onSessionSelected = vi.fn();
+    const onSessionIdResolved = vi.fn();
+    sessionApi.onSessionSelected = onSessionSelected;
+    sessionApi.onSessionIdResolved = onSessionIdResolved;
+
+    sessionApi.setActiveAgent("agent-a");
+
+    // List loading applies normally.
+    listSpy.mockResolvedValueOnce([makeChatSpec(A_CHAT, "console:a")]);
+    const list = await sessionApi.getSessionList();
+    expect(list.map((s) => s.id)).toEqual([A_CHAT]);
+
+    // Session loading notifies selection normally.
+    await sessionApi.getSession(A_CHAT);
+    expect(onSessionSelected).toHaveBeenCalledWith(A_CHAT, null);
+
+    // Temp-id resolution completes normally within the same epoch. The
+    // backend reports the new chat with session_id equal to the temp id.
+    const spec: { id?: string } = {};
+    await sessionApi.createSession(spec);
+    const tempId = spec.id!;
+    listSpy.mockResolvedValueOnce([
+      makeChatSpec(B_CHAT, tempId),
+      makeChatSpec(A_CHAT, "console:a"),
+    ]);
+    sessionApi.triggerResolve(tempId);
+    await flush();
+    expect(onSessionIdResolved).toHaveBeenCalledWith(tempId, B_CHAT);
+  });
+});

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -16,9 +16,7 @@ import type { ChatSpec, ChatHistory } from "../../../api";
 import api from "../../../api";
 import sessionApi from "../sessionApi";
 import { useAgentStore } from "../../../stores/agentStore";
-import {
-  useTurnUsageStore,
-} from "../turnUsageStore";
+import { useTurnUsageStore } from "../turnUsageStore";
 import type { TurnUsageSnapshot } from "../turnUsage";
 
 function deferred<T>() {
@@ -36,11 +34,7 @@ async function flush(): Promise<void> {
   await new Promise((res) => setTimeout(res, 0));
 }
 
-function makeChatSpec(
-  id: string,
-  sessionId: string,
-  name = "chat",
-): ChatSpec {
+function makeChatSpec(id: string, sessionId: string, name = "chat"): ChatSpec {
   return {
     id,
     name,
@@ -227,9 +221,9 @@ describe("agent session ownership epochs", () => {
     dChat.resolve(makeHistory());
     await pending;
 
-    expect(
-      (window as { currentSessionId?: string }).currentSessionId,
-    ).toBe("sentinel-session");
+    expect((window as { currentSessionId?: string }).currentSessionId).toBe(
+      "sentinel-session",
+    );
     expect(useTurnUsageStore.getState().snapshot).toBe(sentinelSnapshot);
     expect(onSessionSelected).not.toHaveBeenCalled();
   });

--- a/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
+++ b/console/src/pages/Chat/tests/agentSessionOwnership.test.ts
@@ -16,6 +16,10 @@ import type { ChatSpec, ChatHistory } from "../../../api";
 import api from "../../../api";
 import sessionApi from "../sessionApi";
 import { useAgentStore } from "../../../stores/agentStore";
+import {
+  useTurnUsageStore,
+} from "../turnUsageStore";
+import type { TurnUsageSnapshot } from "../turnUsage";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -194,5 +198,93 @@ describe("agent session ownership epochs", () => {
     sessionApi.triggerResolve(tempId);
     await flush();
     expect(onSessionIdResolved).toHaveBeenCalledWith(tempId, B_CHAT);
+  });
+
+  it("a stale getSession cannot rewrite window identity, turn usage, or fire selection", async () => {
+    vi.spyOn(api, "listChats").mockResolvedValue([
+      makeChatSpec(A_CHAT, "console:a"),
+    ]);
+    const dChat = deferred<ChatHistory>();
+    vi.spyOn(api, "getChat").mockReturnValueOnce(dChat.promise);
+    const onSessionSelected = vi.fn();
+    sessionApi.onSessionSelected = onSessionSelected;
+
+    sessionApi.setActiveAgent("agent-a");
+    await sessionApi.getSessionList();
+    const pending = sessionApi.getSession(A_CHAT);
+
+    // Switch to B and mark B's current view state with sentinels.
+    sessionApi.setActiveAgent("agent-b");
+    (window as { currentSessionId?: string }).currentSessionId =
+      "sentinel-session";
+    const sentinelSnapshot = {
+      usage: null,
+      context_usage: null,
+    } as unknown as TurnUsageSnapshot;
+    useTurnUsageStore.getState().setSnapshot(sentinelSnapshot);
+
+    // A's fetch completes late: B's view state must stay untouched.
+    dChat.resolve(makeHistory());
+    await pending;
+
+    expect(
+      (window as { currentSessionId?: string }).currentSessionId,
+    ).toBe("sentinel-session");
+    expect(useTurnUsageStore.getState().snapshot).toBe(sentinelSnapshot);
+    expect(onSessionSelected).not.toHaveBeenCalled();
+  });
+
+  it("in-flight session requests and preload results are not reused across epochs", async () => {
+    vi.spyOn(api, "listChats").mockResolvedValue([
+      makeChatSpec(A_CHAT, "console:a"),
+    ]);
+    const dA = deferred<ChatHistory>();
+    const getChatSpy = vi
+      .spyOn(api, "getChat")
+      .mockReturnValueOnce(dA.promise)
+      .mockResolvedValue(makeHistory());
+
+    // A preloads; the fetch is still pending when the agent switches.
+    sessionApi.setActiveAgent("agent-a");
+    await sessionApi.getSessionList();
+    const preloadPromise = sessionApi.preloadSession(A_CHAT);
+
+    // B requests the same id: it must start its own fetch instead of
+    // adopting A's in-flight request (and A's captured owner).
+    sessionApi.setActiveAgent("agent-b");
+    await sessionApi.getSessionList();
+    await sessionApi.getSession(A_CHAT);
+    expect(getChatSpy).toHaveBeenCalledTimes(2);
+
+    // A's preload completes late: its result must not be published into the
+    // short-lived result cache, so a follow-up getSession never serves it.
+    dA.resolve(makeHistory());
+    const { session: staleSession } = await preloadPromise;
+    const after = await sessionApi.getSession(A_CHAT);
+    expect(after).not.toBe(staleSession);
+  });
+
+  it("work started before the first ownership claim is rejected after it", async () => {
+    // Return to the pristine unclaimed state (the store subscription claims
+    // the persisted agent as soon as beforeEach touches the agent store).
+    sessionApi.resetForTests();
+
+    // A sidebar-style preload starts while ownership is still unclaimed.
+    const dList = deferred<ChatSpec[]>();
+    const listSpy = vi.spyOn(api, "listChats");
+    listSpy.mockReturnValueOnce(dList.promise);
+    const pUnclaimed = sessionApi.getSessionList();
+
+    // The first claim arrives (e.g. the app resolves the selected agent).
+    sessionApi.setActiveAgent("agent-a");
+
+    dList.resolve([makeChatSpec(A_CHAT, "console:a")]);
+    const stale = await pUnclaimed;
+    expect(stale).toEqual([]);
+
+    // The claimed epoch loads its own list normally.
+    listSpy.mockResolvedValueOnce([makeChatSpec(B_CHAT, "console:b")]);
+    const fresh = await sessionApi.getSessionList();
+    expect(fresh.map((s) => s.id)).toEqual([B_CHAT]);
   });
 });

--- a/console/src/stores/agentStore.test.ts
+++ b/console/src/stores/agentStore.test.ts
@@ -22,6 +22,7 @@ describe("agentStore", () => {
     useAgentStore.setState({
       selectedAgent: "default",
       agents: [],
+      lastChatIdByAgent: {},
     });
   });
 
@@ -162,5 +163,42 @@ describe("agentStore", () => {
       useAgentStore.getState().updateAgent("999", { name: "Ghost" }),
     ).not.toThrow();
     expect(useAgentStore.getState().agents).toHaveLength(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // lastChatIdByAgent
+  // ---------------------------------------------------------------------------
+
+  it("setLastChatId stores chat id per agent", () => {
+    useAgentStore.getState().setLastChatId("agent-1", "chat-1");
+    expect(useAgentStore.getState().getLastChatId("agent-1")).toBe("chat-1");
+  });
+
+  it("removeLastChatId removes the stored chat id for an agent", () => {
+    useAgentStore.getState().setLastChatId("agent-1", "chat-1");
+    useAgentStore.getState().setLastChatId("agent-2", "chat-2");
+    useAgentStore.getState().removeLastChatId("agent-1");
+    expect(useAgentStore.getState().getLastChatId("agent-1")).toBeUndefined();
+    expect(useAgentStore.getState().getLastChatId("agent-2")).toBe("chat-2");
+  });
+
+  it("removeLastChatId with non-existent id does not throw and leaves others", () => {
+    useAgentStore.getState().setLastChatId("agent-1", "chat-1");
+    expect(() =>
+      useAgentStore.getState().removeLastChatId("agent-999"),
+    ).not.toThrow();
+    expect(useAgentStore.getState().getLastChatId("agent-1")).toBe("chat-1");
+  });
+
+  it("setLastChatId does not persist temporary local timestamp ids", () => {
+    useAgentStore.getState().setLastChatId("agent-1", "1785114733908-0l0jmai");
+    expect(useAgentStore.getState().getLastChatId("agent-1")).toBeUndefined();
+  });
+
+  it("setLastChatId removes existing entry when given a temporary local id", () => {
+    useAgentStore.getState().setLastChatId("agent-1", "chat-1");
+    useAgentStore.getState().setLastChatId("agent-1", "1785114733908-0l0jmai");
+    expect(useAgentStore.getState().getLastChatId("agent-1")).toBeUndefined();
+    expect(useAgentStore.getState().getLastChatId("agent-2")).toBeUndefined();
   });
 });

--- a/console/src/stores/agentStore.ts
+++ b/console/src/stores/agentStore.ts
@@ -16,6 +16,9 @@ const STORAGE_KEY = "qwenpaw-agent-storage";
  */
 const LAST_USED_AGENT_KEY = "qwenpaw-last-used-agent";
 
+/** Returns true for temporary local session ids like 1785114733908-0l0jmai. */
+const isLocalTimestamp = (id: string): boolean => /^\d+-[a-z0-9]+$/.test(id);
+
 let agentRefreshPromise: Promise<void> | null = null;
 
 interface AgentStore {
@@ -30,6 +33,7 @@ interface AgentStore {
   removeAgent: (agentId: string) => void;
   updateAgent: (agentId: string, updates: Partial<AgentSummary>) => void;
   setLastChatId: (agentId: string, chatId: string) => void;
+  removeLastChatId: (agentId: string) => void;
   getLastChatId: (agentId: string) => string | undefined;
 }
 
@@ -137,10 +141,29 @@ export const useAgentStore = create<AgentStore>()(
           ),
         })),
 
-      setLastChatId: (agentId, chatId) =>
+      setLastChatId: (agentId, chatId) => {
+        // Never persist a temporary local timestamp id. These ids only exist
+        // in memory before the first message is sent and should not be
+        // restored on agent switch.
+        if (isLocalTimestamp(chatId)) {
+          set((state) => {
+            const remainingChatIds = { ...state.lastChatIdByAgent };
+            delete remainingChatIds[agentId];
+            return { lastChatIdByAgent: remainingChatIds };
+          });
+          return;
+        }
         set((state) => ({
           lastChatIdByAgent: { ...state.lastChatIdByAgent, [agentId]: chatId },
-        })),
+        }));
+      },
+
+      removeLastChatId: (agentId) =>
+        set((state) => {
+          const remainingChatIds = { ...state.lastChatIdByAgent };
+          delete remainingChatIds[agentId];
+          return { lastChatIdByAgent: remainingChatIds };
+        }),
 
       getLastChatId: (agentId) => get().lastChatIdByAgent[agentId],
     }),

--- a/console/src/stores/sessionListStore.test.ts
+++ b/console/src/stores/sessionListStore.test.ts
@@ -4,6 +4,7 @@ import {
   syncSessionsGlobal,
   type ExtendedSession,
 } from "./sessionListStore";
+import { useAgentStore } from "./agentStore";
 
 function makeSession(
   id: string,
@@ -130,5 +131,28 @@ describe("sessionListStore", () => {
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledWith([expect.objectContaining({ id: "x" })]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Agent scoping — the shared list must not survive an agent switch
+  // ---------------------------------------------------------------------------
+
+  it("clears the shared list when the selected agent changes", () => {
+    useAgentStore.setState({ selectedAgent: "agent-a" });
+    syncSessionsGlobal([makeSession("chat-a")]);
+    expect(useSessionListStore.getState().sessions).toHaveLength(1);
+
+    useAgentStore.setState({ selectedAgent: "agent-b" });
+
+    expect(useSessionListStore.getState().sessions).toEqual([]);
+  });
+
+  it("keeps the list on unrelated agent-store updates", () => {
+    useAgentStore.setState({ selectedAgent: "agent-a" });
+    syncSessionsGlobal([makeSession("chat-a")]);
+
+    useAgentStore.setState({ agents: [] });
+
+    expect(useSessionListStore.getState().sessions).toHaveLength(1);
   });
 });

--- a/console/src/stores/sessionListStore.ts
+++ b/console/src/stores/sessionListStore.ts
@@ -11,6 +11,7 @@
  */
 import { create } from "zustand";
 import type { IAgentScopeRuntimeWebUISession } from "@agentscope-ai/chat";
+import { useAgentStore } from "./agentStore";
 
 export interface ExtendedSession extends IAgentScopeRuntimeWebUISession {
   realId?: string;
@@ -75,3 +76,14 @@ export const useSessionListStore = create<SessionListStore>((set, get) => ({
 export function syncSessionsGlobal(sessions: ExtendedSession[]) {
   useSessionListStore.getState().syncSessions(sessions);
 }
+
+// The shared list belongs to one agent at a time. Clear it synchronously on
+// every agent change so consumers (e.g. the simple-mode sidebar) never keep
+// rendering — and navigating to — the previous agent's sessions while the
+// new agent's list is still loading. The library setter stays registered:
+// it belongs to the mounted initializer, which re-syncs after the switch.
+useAgentStore.subscribe((state, prevState) => {
+  if (state.selectedAgent !== prevState.selectedAgent) {
+    useSessionListStore.setState({ sessions: [], lastUpdated: Date.now() });
+  }
+});


### PR DESCRIPTION
Fixes #6482

## Root Cause
Temporary local IDs for newly created chats were incorrectly persisted; upon an agent switch, the system restored a session that did not exist on the backend, causing the UI panel to become stuck and unable to switch views.
The `sessionApi` was a global singleton not isolated by agent; asynchronous requests from an old agent arriving late would pollute the session list, routing, and cache of the new agent.
## Fix
Filter out temporary IDs across the entire data flow—eliminating persistence and restoration—and synchronously clean up records when a session is deleted.
Introduce an ownership epoch (agent ID + generation counter): switching agents invalidates the old epoch, and asynchronous results are validated for ownership before application (stale lists, loads, preloads, and cache entries are discarded).
Expired preloads now terminate with an `AbortError` and no longer trigger navigation; fixed an issue where the switching lock could cause a permanent hang.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
