### PR TITLE
feat(ai review): enhance rview bot

### DIFF
--- a/scripts/review-bot/prompts.py
+++ b/scripts/review-bot/prompts.py
@@ -1,23 +1,234 @@
 # -*- coding: utf-8 -*-
-"""Review prompt templates for QwenPaw AI Review Bot.
+"""Review prompt templates for QwenPaw AI Review Bot (enhanced).
 
 The review methodology, coding standards, and anti-pattern checklist
 live in the workspace persona files (SOUL.md, AGENTS.md) written by
-setup_review_workspace.py.  This module only builds the *task* prompt
-that tells the agent which PR to review and what output format to use.
+setup_review_workspace.py.  This module builds the *task* prompt that
+tells the agent which PR to review and what output format to use.
+
+Enhancement over the base bot: the runner pre-computes a per-file
+**change map** (each changed file's diff with adaptive context — at
+least a floor of context lines, widened toward the whole file when the
+per-file budget allows) and embeds it in the prompt. The change map is
+the agent's starting point; the prompt also gives ONE full-file fetch
+command (the "Full-file fetch" in Step 2) that the agent uses whenever a
+file was truncated or it needs more context than the map shows. That
+single command is the only place the fetch is spelled out — the change
+map's truncation markers merely point back to it, never repeating it.
+
+If no change map is available (the runner couldn't build one), we fall
+back to the original self-fetch prompt so the bot still works.
 """
 
 
-def build_review_prompt(pr_number: int, repo: str) -> str:
+def build_review_prompt(
+    pr_number: int,
+    repo: str,
+    change_map: str = "",
+    head_sha: str = "",
+) -> str:
     """Build a task-oriented review prompt.
-
-    Instead of embedding the full diff in the prompt, we tell QwenPaw
-    to fetch the PR data itself using ``gh`` CLI commands.
 
     Args:
         pr_number: The pull request number to review.
         repo: The full repository name (owner/repo).
+        change_map: Optional pre-computed per-file change map (adaptive-
+            context diffs, capped per file). When present, the prompt
+            embeds it and switches to the enhanced workflow.
+        head_sha: The PR head commit SHA, used in the full-file fetch
+            command so the agent reads the exact reviewed revision.
     """
+    if change_map.strip():
+        return _build_enhanced_prompt(pr_number, repo, change_map, head_sha)
+    return _build_fallback_prompt(pr_number, repo)
+
+
+# ----------------------------------------------------------------------
+# Enhanced prompt: change map is provided up front
+# ----------------------------------------------------------------------
+def _build_enhanced_prompt(
+    pr_number: int,
+    repo: str,
+    change_map: str,
+    head_sha: str,
+) -> str:
+    # The contents API needs a concrete ref. Prefer the pinned head SHA;
+    # if the runner couldn't resolve it, tell the agent to look it up.
+    ref = head_sha or "<HEAD_SHA>"
+    ref_hint = (
+        ""
+        if head_sha
+        else (
+            " (first resolve <HEAD_SHA> once with "
+            f"`gh pr view {pr_number} --repo {repo} "
+            "--json headRefOid --jq .headRefOid`)"
+        )
+    )
+    return f"""\
+Please perform a thorough yet precise code review for \
+**PR #{pr_number}** in the **{repo}** repository.
+
+## Step 1: PR Metadata and the Change Map
+
+First, fetch the PR's intent (title, description, author, related issue):
+   `gh pr view {pr_number} --repo {repo} --json \
+number,title,body,author,baseRefName,headRefName,additions,deletions,files`
+
+Below is a **per-file change map** for this PR: for each changed file it \
+shows its diff with surrounding context. Most files include generous \
+context; very large files are truncated, and a marker inside the diff \
+tells you where and points you at the Full-file fetch (Step 2). Treat \
+this as your starting point — it tells you WHICH files changed and \
+WHERE, but a truncated file is not the whole story.
+
+<change_map>
+{change_map}
+</change_map>
+
+## Step 2: Read Before You Conclude
+
+The change map shows the touched regions (and, for large files, only \
+part of them). Before you assert that something is a bug — or that a \
+change is safe — you MUST read the surrounding code, not just the hunk.
+
+**Full-file fetch** — to read the COMPLETE source of any file at this \
+PR's revision, run{ref_hint}:
+   `gh api -H "Accept: application/vnd.github.raw" \
+"repos/{repo}/contents/<PATH>?ref={ref}"`
+   (replace `<PATH>` with the repo-relative file path, e.g. \
+`src/cache.py`). Use this whenever a file is marked truncated/omitted or \
+you need more context than the change map shows.
+
+Rules you must follow:
+- **Read the full file for any non-trivial finding.** If a hunk calls a \
+function, mutates shared state, or changes a signature, use the Full-file \
+fetch to confirm the surrounding logic actually behaves the way you claim.
+- **Trace cross-file impact.** When a changed symbol (function, class, \
+constant, config key) is used elsewhere, find its other call sites with \
+`gh search code --repo {repo} "<symbol>"` (or read the importing files) \
+and check whether the change breaks or requires updating them.
+- **Cite evidence.** Every issue must quote the exact offending code and \
+give a `path:line` reference. If you did not read the code, do not raise \
+the issue.
+- **Do not speculate.** If you cannot verify a concern from the actual \
+source, phrase it as "consider verifying" rather than asserting a defect.
+
+**Security & concurrency blocker checklist** — for EVERY changed file, \
+actively scan for the high-severity classes below, even when the diff looks \
+benign. These are the defects that are easiest to miss by reading only the \
+hunk. An existing guard is NOT proof it is correct: when a hunk matches a \
+class, read the full file and verify the actual comparison/logic before \
+concluding the code is safe.
+
+- **Path traversal / Zip Slip**: archive extraction (zip/tar), file writes or \
+paths built from user- or plugin-supplied names/IDs, joins involving `..`. \
+Confirm the guard uses a real boundary test (`Path.is_relative_to`, a \
+resolved-prefix check that includes the path separator) — a bare `startswith` \
+or `in`-substring match is bypassable.
+- **TLS / certificate verification disabled**: `verify=False`, \
+`rejectUnauthorized: false`, `InsecureSkipVerify`, a custom \
+TrustManager, or disabled hostname checks → MITM.
+- **SSRF / unbounded fetch**: server-side requests to user-controlled URLs; \
+missing size, redirect, or timeout limits; reachability of internal IPs.
+- **Missing origin / auth checks**: `postMessage` handlers that don't validate \
+`event.origin` (or send with target origin `'*'`); endpoints missing \
+authorization; fail-open on 401/error (reporting "ready"/"connected" without \
+raising).
+- **Unsafe deserialization / injection**: `pickle`/`yaml.load`, `eval`/`Function`, \
+SQL or shell command string concatenation, template injection.
+- **Concurrency / TOCTOU races**: shared mutable state read-then-written across \
+concurrent requests or callbacks; check-then-act without atomicity; a \
+"success" path that resets state an in-flight request still depends on. Reason \
+through 2–3 interleaved requests — do not stop at "is there a lock".
+- **Refactor fallout**: constants/handlers left unreferenced after a rewrite \
+(dead code / linter breakage); a validator or helper whose logic has drifted \
+from the runtime loader/consumer it is meant to mirror (read BOTH and compare).
+
+## Step 3: Output the Review Report
+
+Please strictly follow this structure:
+
+### 1. Overview
+
+| Item | Details |
+|------|---------|
+| PR Number | (from gh) |
+| Author | @username format, e.g. @lalaliat |
+| Changes | (from gh) |
+| Merge Target | (from gh) |
+| Related Issue | (extract from PR body, if any) |
+
+### 2. Background
+
+Describe the problem this PR solves and the motivation.
+
+### 3. Core Changes
+
+Summarize what this PR does (in list form), grouped by file/area using \
+the change map.
+
+### 4. Strengths
+
+List what was done well, with specific file and code details.
+
+### 5. Issues and Suggestions
+
+Output by severity:
+
+#### High
+#### Medium
+#### Low
+
+Each issue should include:
+- **Code reference**: The problematic code snippet + `path:line`
+- **Explanation**: Why this is an issue (grounded in code you read)
+
+If no issues at a given level, write "None".
+
+### 5.5 Cross-file Impact Analysis
+
+For each changed public symbol / signature / config key, state whether \
+its other usages were checked and whether they need updating. If the PR \
+is fully self-contained, say so explicitly (e.g. "No external call sites \
+affected — symbol X is only used within the changed file"). Do NOT invent \
+impacts you did not verify.
+
+### 6. Summary
+
+- One-sentence qualitative assessment
+- N items that must be addressed before merge (if any)
+- Items that can be followed up later
+
+Finally, output a JSON code block with the conclusion \
+(include issue counts per severity):
+
+```json
+{{
+  "verdict": "APPROVE or REQUEST_CHANGES",
+  "high_count": 0,
+  "medium_count": 0,
+  "low_count": 0,
+  "summary": "One-sentence summary of the review conclusion"
+}}
+```
+
+## Key Principles
+
+- **Focus on changes**: Only review code in the diff; use the full files \
+only as context to judge those changes.
+- **Verify before flagging**: Read the real code behind every finding.
+- **Distinguish blockers from suggestions**: Be clear about what must \
+change vs. what can be improved later.
+- **Provide concrete fixes**: Include improvement code examples for each \
+issue.
+- **Acknowledge strengths**: Explicitly praise good design decisions.
+"""
+
+
+# ----------------------------------------------------------------------
+# Fallback prompt: no change map (identical intent to the base bot)
+# ----------------------------------------------------------------------
+def _build_fallback_prompt(pr_number: int, repo: str) -> str:
     return f"""\
 Please perform a thorough yet precise code review for \
 **PR #{pr_number}** in the **{repo}** repository.
@@ -37,7 +248,13 @@ additions,deletions,files`
 ## Step 2: Analyze and Review
 
 Follow the review methodology in AGENTS.md to perform a \
-dimension-based analysis of the diff.
+dimension-based analysis of the diff. Before flagging any non-trivial \
+issue, read the surrounding source: resolve the head commit with \
+`gh pr view {pr_number} --repo {repo} --json headRefOid --jq .headRefOid`, \
+then read the full file via `gh api -H "Accept: \
+application/vnd.github.raw" "repos/{repo}/contents/<PATH>?ref=<HEAD_SHA>"` \
+so every finding is grounded in the actual code, and check other call \
+sites of any changed symbol with `gh search code --repo {repo} "<symbol>"`.
 
 ## Step 3: Output the Review Report
 

--- a/scripts/review-bot/prompts.py
+++ b/scripts/review-bot/prompts.py
@@ -26,6 +26,7 @@ def build_review_prompt(
     repo: str,
     change_map: str = "",
     head_sha: str = "",
+    base_sha: str = "",
 ) -> str:
     """Build a task-oriented review prompt.
 
@@ -37,9 +38,18 @@ def build_review_prompt(
             embeds it and switches to the enhanced workflow.
         head_sha: The PR head commit SHA, used in the full-file fetch
             command so the agent reads the exact reviewed revision.
+        base_sha: The merge-base SHA. Required for files the change map
+            marks DELETED: they are absent from the head revision, so
+            fetching them there can only 404.
     """
     if change_map.strip():
-        return _build_enhanced_prompt(pr_number, repo, change_map, head_sha)
+        return _build_enhanced_prompt(
+            pr_number,
+            repo,
+            change_map,
+            head_sha,
+            base_sha,
+        )
     return _build_fallback_prompt(pr_number, repo)
 
 
@@ -51,6 +61,7 @@ def _build_enhanced_prompt(
     repo: str,
     change_map: str,
     head_sha: str,
+    base_sha: str = "",
 ) -> str:
     # The contents API needs a concrete ref. Prefer the pinned head SHA;
     # if the runner couldn't resolve it, tell the agent to look it up.
@@ -63,6 +74,29 @@ def _build_enhanced_prompt(
             f"`gh pr view {pr_number} --repo {repo} "
             "--json headRefOid --jq .headRefOid`)"
         )
+    )
+    base_ref = base_sha or f"{repo.split('/')[-1]}-base"
+    # A deleted file is absent from the head revision, so it can only be
+    # read at the merge-base. Without this the change map's truncation
+    # marker points at a fetch that is guaranteed to 404, while the rules
+    # below still require reading the full file before raising anything.
+    deleted_rule = (
+        f"""
+**Deleted files** — any file the change map marks `DELETED in this PR` \
+(and any binary file whose fetch below returns 404) no longer exists at \
+`{ref}`. Read its PRE-DELETION source from the base revision instead:
+   `gh api -H "Accept: application/vnd.github.raw" \
+"repos/{repo}/contents/<PATH>?ref={base_ref}"`
+   Judge a deletion by whether the removed code is still referenced \
+elsewhere — use `gh search code` to check before approving it.
+"""
+        if base_sha
+        else """
+**Deleted files** — a file the change map marks `DELETED in this PR` is \
+absent from the revision above, so that fetch will 404. Read its \
+pre-deletion source with \
+`gh pr diff <PR> --repo <REPO>` or at the PR's base branch instead.
+"""
     )
     return f"""\
 Please perform a thorough yet precise code review for \
@@ -98,7 +132,7 @@ PR's revision, run{ref_hint}:
    (replace `<PATH>` with the repo-relative file path, e.g. \
 `src/cache.py`). Use this whenever a file is marked truncated/omitted or \
 you need more context than the change map shows.
-
+{deleted_rule}
 Rules you must follow:
 - **Read the full file for any non-trivial finding.** If a hunk calls a \
 function, mutates shared state, or changes a signature, use the Full-file \

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -15,7 +15,10 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+import threading
 import time
+from collections.abc import Sequence
 
 try:  # ``fcntl`` is Unix-only; without it the repo lock is a no-op.
     import fcntl
@@ -39,6 +42,44 @@ CHAT_ENDPOINT = f"{QWENPAW_URL}/api/console/chat"
 MAX_RETRIES = 5
 TIMEOUT_SECONDS = 300
 
+# ---- global time budget ----
+# The workflow job is capped at 20 min (pr-ai-review.yml `timeout-minutes`).
+# Worst-case setup before this script runs (checkout, pip install, qwenpaw
+# init, waiting up to 90s for the server) plus posting the comment and
+# tearing down afterwards costs roughly 7.5 min of that, so the runner has
+# to finish within ~11 min. Every timeout below is clamped to whatever is
+# left of this budget, which is what keeps the *worst* path -- 5 model
+# retries, a cold clone, a very wide diff -- from being killed by Actions
+# before it can publish a result or fall back.
+REVIEW_BUDGET_SECONDS = float(
+    os.environ.get("REVIEW_BUDGET_SECONDS", "660"),
+)
+# A fresh model attempt with less than this left cannot plausibly finish,
+# so retrying would only burn the time needed to publish the fallback.
+MODEL_MIN_ATTEMPT_SECONDS = float(
+    os.environ.get("MODEL_MIN_ATTEMPT_SECONDS", "120"),
+)
+RETRY_SLEEP_SECONDS = 5.0
+
+_RUN_DEADLINE = time.monotonic() + REVIEW_BUDGET_SECONDS
+
+
+def _time_left() -> float:
+    """Seconds left in the global budget; never negative.
+
+    Every blocking operation clamps its own timeout to this, so the
+    process cannot outlive the budget no matter which path it takes. A
+    clamped timeout of 0 makes the operation fail immediately, which the
+    callers already treat as "degrade gracefully".
+    """
+    return max(0.0, _RUN_DEADLINE - time.monotonic())
+
+
+def _budgeted_sleep(seconds: float = RETRY_SLEEP_SECONDS) -> None:
+    """Back off between retries without sleeping past the budget."""
+    time.sleep(min(seconds, _time_left()))
+
+
 # ---- change-map (per-file diff) configuration ----
 # The runner pre-computes a compact per-file diff ("change map") from an
 # internal blobless clone and embeds it in the prompt. The clone is an
@@ -53,6 +94,10 @@ QWENPAW_ENH_WORK_DIR = os.environ.get(
 MAP_CONTEXT = int(os.environ.get("MAP_CONTEXT", "20"))
 # Max lines kept per file in the change map.
 MAP_PER_FILE_LINES = int(os.environ.get("MAP_PER_FILE_LINES", "500"))
+# Max characters kept per *line*. A minified or single-line generated file
+# puts its whole diff on one line, where a line budget alone caps nothing,
+# so the streaming reader needs a width cap as well as a height cap.
+MAP_MAX_LINE_CHARS = int(os.environ.get("MAP_MAX_LINE_CHARS", "2000"))
 # Overall cap on the whole change map (safety valve for huge PRs).
 MAP_MAX_LINES = int(os.environ.get("MAP_MAX_LINES", "6000"))
 # Context ladder tried (ascending) when a file fits at MAP_CONTEXT and
@@ -118,7 +163,7 @@ def fetch_base_branch(pr_number: int, repo: str) -> str:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=60,
+            timeout=min(60, _time_left()),
             check=True,
         )
         return result.stdout.strip()
@@ -150,6 +195,10 @@ def _git(
     ``errors`` defaults to ``"replace"``, which is right for diff *text*.
     Callers reading **paths** must pass ``"surrogateescape"`` instead, so
     the value round-trips back into a later argv unchanged.
+
+    Only for commands with small, bounded output (rev-parse, merge-base,
+    fetch). Diffs must go through :func:`_git_bounded`, which caps how
+    much is read into memory.
     """
     result = subprocess.run(
         ["git", "-C", repo_dir, *args],
@@ -157,10 +206,97 @@ def _git(
         text=True,
         encoding="utf-8",
         errors=errors,
-        timeout=timeout,
+        timeout=min(timeout, _time_left()),
         check=True,
     )
     return result.stdout.strip()
+
+
+def _git_bounded(
+    repo_dir: str,
+    args: Sequence[str],
+    *,
+    max_chars: int,
+    timeout: float,
+    errors: str = "replace",
+) -> tuple[str, bool]:
+    """Run git and read at most ``max_chars`` of stdout, then stop it.
+
+    Returns ``(text, truncated)``. Unlike :func:`_git`, peak memory is
+    bounded by ``max_chars`` no matter how large the real output is: the
+    cap is applied *while* reading rather than to an already-buffered
+    string. That distinction is the whole point here -- a diff taken at
+    near-whole-file context can be tens of megabytes, and decoding it in
+    full just to throw most of it away is what spiked memory before.
+
+    stderr is spooled to a temp file rather than a second pipe, because
+    draining only stdout would deadlock as soon as stderr filled its own
+    64 KiB buffer.
+    """
+    argv = ["git", "-C", repo_dir, *args]
+    budget = min(timeout, _time_left())
+    expired = threading.Event()
+
+    with tempfile.TemporaryFile("w+b") as err_file:
+        watchdog: threading.Timer | None = None
+        try:
+            with subprocess.Popen(
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=err_file,
+                text=True,
+                encoding="utf-8",
+                errors=errors,
+            ) as proc:
+
+                def _expire() -> None:
+                    # git can also stall while producing *nothing* -- a
+                    # blobless clone fetching this file's blob over the
+                    # network -- where the read below blocks
+                    # indefinitely. Killing the child is what makes the
+                    # timeout real.
+                    expired.set()
+                    proc.kill()
+
+                watchdog = threading.Timer(budget, _expire)
+                watchdog.start()
+                # A single bounded read: ``TextIOWrapper.read(n)`` returns
+                # exactly n characters or everything up to EOF, so this is
+                # already the streaming cap -- no chunk loop needed. The
+                # one extra character is how we tell "output happens to
+                # end exactly at the cap" from "there is more to come".
+                text = proc.stdout.read(max_chars + 1)
+
+                truncated = len(text) > max_chars
+                if truncated:
+                    text = text[:max_chars]
+                    # Kill before the context manager waits: git is
+                    # blocked writing into a pipe nobody will drain.
+                    proc.kill()
+            # The timer stays armed across ``Popen.__exit__``, whose
+            # ``wait()`` takes no timeout of its own.
+        finally:
+            if watchdog is not None:
+                watchdog.cancel()
+
+        if proc.returncode == 0 or truncated:
+            # Either a clean read, or we stopped git ourselves -- a
+            # non-zero code from our own kill is not a failure. Checked
+            # before ``expired`` so a watchdog that fires in the moment
+            # between a completed read and ``cancel()`` cannot discard
+            # output we already hold.
+            return text, truncated
+
+        err_file.seek(0)
+        stderr_text = err_file.read().decode("utf-8", "replace").strip()
+
+    if expired.is_set():
+        raise subprocess.TimeoutExpired(argv, budget, stderr=stderr_text)
+    raise subprocess.CalledProcessError(
+        proc.returncode,
+        argv,
+        stderr=stderr_text,
+    )
 
 
 @contextlib.contextmanager
@@ -170,12 +306,27 @@ def _repo_lock(lock_path: str):
     Degrades to a no-op where ``fcntl`` is unavailable (Windows), which
     assumes a single process — acceptable because the shared clone only
     exists to help concurrent CI workers.
+
+    Acquisition polls instead of blocking: a plain ``LOCK_EX`` waits
+    without a deadline, and since a peer can hold this lock for a whole
+    clone it is the one place that could still spend the entire budget
+    doing nothing. Giving up raises, which
+    :func:`resolve_change_map` turns into the self-fetch fallback.
     """
     if fcntl is None:
         yield
         return
     with open(lock_path, "w", encoding="utf-8") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if _time_left() <= 0:
+                    raise TimeoutError(
+                        "timed out waiting for the repo lock",
+                    ) from e
+                time.sleep(min(0.5, _time_left()))
         try:
             yield
         finally:
@@ -239,7 +390,7 @@ def prepare_repo(
                     text=True,
                     encoding="utf-8",
                     errors="replace",
-                    timeout=GIT_TIMEOUT,
+                    timeout=min(GIT_TIMEOUT, _time_left()),
                     check=True,
                 )
                 # Safe under the lock: we know there is no .git here.
@@ -336,19 +487,41 @@ def _file_diff(
     to_sha: str,
     pathspecs: list[str],
     context: int,
-) -> list[str]:
-    """Return the diff lines for one file at a given context width."""
-    diff = _git(
+    max_lines: int = MAP_PER_FILE_LINES,
+) -> tuple[list[str], bool]:
+    """Return ``(diff_lines, overflowed)`` for one file at a context width.
+
+    ``overflowed`` means git had more to give than the budget allowed --
+    more than ``max_lines`` lines, or more characters than the streaming
+    cap. Callers treat the two identically: the file does not fit at this
+    context width.
+
+    Because the read itself is capped, ``-U{MAP_FULL_CONTEXT}`` is now
+    safe to probe: git is stopped as soon as it exceeds the budget
+    instead of being allowed to hand us a whole large file first.
+    """
+    text, char_truncated = _git_bounded(
         repo_dir,
-        "diff",
-        f"-U{context}",
-        from_sha,
-        to_sha,
-        "--",
-        *pathspecs,
+        [
+            "diff",
+            f"-U{context}",
+            from_sha,
+            to_sha,
+            "--",
+            *pathspecs,
+        ],
+        max_chars=max_lines * MAP_MAX_LINE_CHARS,
         timeout=DIFF_TIMEOUT,
     )
-    return diff.splitlines()
+    lines = text.splitlines()
+    overflowed = char_truncated or len(lines) > max_lines
+    # Every line is capped to the same width, so a line the character cap
+    # happened to slice is no more misleading than a legitimately long one
+    # -- and keeping it preserves the start of the change. The caller
+    # appends a truncation marker whenever ``overflowed`` is set, so a
+    # partial tail is never presented as the whole story.
+    kept = [line[:MAP_MAX_LINE_CHARS] for line in lines[:max_lines]]
+    return kept, overflowed
 
 
 def _diff_with_adaptive_context(
@@ -367,29 +540,39 @@ def _diff_with_adaptive_context(
 
     Returns ``(diff_lines, truncated)``. When truncated, the caller
     appends a marker pointing at the full-file fetch instruction.
-    """
-    floor = _file_diff(repo_dir, from_sha, to_sha, pathspecs, MAP_CONTEXT)
 
-    # Case 1: even minimum context overflows -> truncate the floor diff.
-    if len(floor) > MAP_PER_FILE_LINES:
-        total = len(floor)
-        kept = floor[:MAP_PER_FILE_LINES]
-        kept.append(
-            f"... (diff truncated: {total} lines at {MAP_CONTEXT}-line "
-            f"context, showing the first {MAP_PER_FILE_LINES} — read the "
-            f'complete file with the "Full-file fetch" command in Step 2) ...',
+    Each probe below re-clamps its timeout to the remaining global budget
+    (via :func:`_file_diff` -> :func:`_git_bounded`), so a file needing
+    several widening probes cannot overrun the budget between the
+    per-file deadline checks in :func:`build_change_map`.
+    """
+    floor, overflowed = _file_diff(
+        repo_dir,
+        from_sha,
+        to_sha,
+        pathspecs,
+        MAP_CONTEXT,
+    )
+
+    # Case 1: even minimum context overflows -> keep the truncated floor.
+    if overflowed:
+        floor.append(
+            f"... (diff truncated: showing the first {MAP_PER_FILE_LINES} "
+            f"lines at {MAP_CONTEXT}-line context; more changes follow — "
+            f'read the complete file with the "Full-file fetch" command '
+            f"in Step 2) ...",
         )
-        return kept, True
+        return floor, True
 
     # Case 2: room to spare -> prefer whole-file context if it fits.
-    full = _file_diff(
+    full, full_overflowed = _file_diff(
         repo_dir,
         from_sha,
         to_sha,
         pathspecs,
         MAP_FULL_CONTEXT,
     )
-    if len(full) <= MAP_PER_FILE_LINES:
+    if not full_overflowed:
         return full, False
 
     # Case 3: whole file too big -> climb the ladder, keep the widest fit.
@@ -397,11 +580,16 @@ def _diff_with_adaptive_context(
     for ctx in MAP_CONTEXT_LADDER:
         if ctx <= MAP_CONTEXT:
             continue
-        widened = _file_diff(repo_dir, from_sha, to_sha, pathspecs, ctx)
-        if len(widened) <= MAP_PER_FILE_LINES:
-            best = widened
-        else:
+        widened, widened_overflowed = _file_diff(
+            repo_dir,
+            from_sha,
+            to_sha,
+            pathspecs,
+            ctx,
+        )
+        if widened_overflowed:
             break  # context is monotonic; nothing larger will fit
+        best = widened
     return best, False
 
 
@@ -460,7 +648,10 @@ def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
     truncated_files: list[str] = []
     skipped_files: list[str] = []
     deadline_hit = False
-    deadline = time.monotonic() + MAP_BUILD_DEADLINE
+    # Never spend more than MAP_BUILD_DEADLINE on the map, and never more
+    # than the run has left -- whichever is smaller. Leaving the model no
+    # time at all is worse than shipping a partial map.
+    deadline = time.monotonic() + min(MAP_BUILD_DEADLINE, _time_left())
 
     for entry in entries:
         display = entry[0]
@@ -532,11 +723,21 @@ def _extract_stream_text(evt: dict) -> str:
     return fallback if isinstance(fallback, str) else ""
 
 
-def _collect_sse(resp) -> tuple[dict | None, list]:
-    """Read an SSE stream, returning ``(final_event, stream_errors)``."""
+def _collect_sse(resp, deadline: float) -> tuple[dict | None, list, bool]:
+    """Read an SSE stream, bounded by a wall-clock ``deadline``.
+
+    Returns ``(final_event, stream_errors, timed_out)``.
+
+    The deadline is not redundant with the client timeout: httpx applies
+    its read timeout per read, not to the stream as a whole, so a stream
+    that keeps trickling events stays under that timeout forever. Only a
+    wall-clock stop bounds the attempt.
+    """
     final_event = None
     stream_errors: list = []
     for line in resp.iter_lines():
+        if time.monotonic() > deadline:
+            return final_event, stream_errors, True
         if not line or not line.startswith("data: "):
             continue
         if line[6:] == "[DONE]":
@@ -550,7 +751,7 @@ def _collect_sse(resp) -> tuple[dict | None, list]:
         if parsed.get("type") == "turn_usage":
             continue
         final_event = parsed
-    return final_event, stream_errors
+    return final_event, stream_errors, False
 
 
 def call_qwenpaw(prompt: str, session_id: str) -> str:
@@ -560,6 +761,15 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
     iteration-limit stub / too-short output). Each attempt uses a FRESH session --
     resuming a session that already hit its iteration cap would just continue the
     stuck run instead of starting over.
+
+    Retries are bounded by the global budget, not just by ``MAX_RETRIES``:
+    each attempt gets whatever is left (capped at ``TIMEOUT_SECONDS``) and
+    the loop stops once there is too little left for another attempt to
+    finish. ``MAX_RETRIES`` * ``TIMEOUT_SECONDS`` on its own exceeds the
+    job timeout, which would let Actions kill the job before it could
+    publish either a review or the fallback comment. Attempts that fail
+    fast (HTTP error, empty reply) cost seconds, so in practice this only
+    bites when the model genuinely hangs -- exactly when it should.
     """
     base_payload = {
         "channel": "console",
@@ -568,13 +778,28 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
     }
 
     for attempt in range(1, MAX_RETRIES + 1):
+        left = _time_left()
+        if left < MODEL_MIN_ATTEMPT_SECONDS:
+            print(
+                f"  Time budget nearly exhausted ({left:.0f}s left, an "
+                f"attempt needs {MODEL_MIN_ATTEMPT_SECONDS:.0f}s); "
+                f"giving up after {attempt - 1} attempt(s)",
+            )
+            break
+
+        attempt_timeout = min(TIMEOUT_SECONDS, left)
         payload = {**base_payload, "session_id": f"{session_id}-try{attempt}"}
         try:
-            print(f"[attempt {attempt}/{MAX_RETRIES}] Calling QwenPaw...")
+            print(
+                f"[attempt {attempt}/{MAX_RETRIES}] Calling QwenPaw "
+                f"(timeout {attempt_timeout:.0f}s, "
+                f"budget {left:.0f}s left)...",
+            )
             final_event = None
             stream_errors = []
+            timed_out = False
 
-            with httpx.Client(timeout=TIMEOUT_SECONDS) as client:
+            with httpx.Client(timeout=attempt_timeout) as client:
                 with client.stream(
                     "POST",
                     CHAT_ENDPOINT,
@@ -582,13 +807,21 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
                 ) as resp:
                     if resp.status_code != 200:
                         print(f"  HTTP {resp.status_code}, retrying...")
-                        time.sleep(5)
+                        _budgeted_sleep()
                         continue
 
-                    final_event, stream_errors = _collect_sse(resp)
+                    final_event, stream_errors, timed_out = _collect_sse(
+                        resp,
+                        time.monotonic() + attempt_timeout,
+                    )
 
             if stream_errors:
                 print(f"  Stream errors: {'; '.join(stream_errors)}")
+            if timed_out:
+                print(
+                    f"  Attempt exceeded its {attempt_timeout:.0f}s slice "
+                    f"of the budget",
+                )
 
             response = _extract_stream_text(final_event or {})
             if response.strip() and not _is_degenerate_review(response):
@@ -601,11 +834,11 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
                     "  Degenerate response (iteration-limit stub / too short), "
                     "retrying with a fresh session...",
                 )
-            time.sleep(5)
+            _budgeted_sleep()
 
         except (httpx.TimeoutException, httpx.ConnectError) as e:
             print(f"  Error: {e}, retrying...")
-            time.sleep(5)
+            _budgeted_sleep()
 
     return ""
 
@@ -911,6 +1144,7 @@ def main():
 
     pr_number = int(pr_number)
     print(f"\nTarget: {repo} PR #{pr_number}")
+    print(f"Time budget: {REVIEW_BUDGET_SECONDS:.0f}s")
 
     change_map, head_sha = resolve_change_map(pr_number, repo)
 
@@ -925,6 +1159,12 @@ def main():
 
     if not response.strip():
         print("\n❌ ERROR: Got empty response from QwenPaw")
+        if _time_left() < MODEL_MIN_ATTEMPT_SECONDS:
+            print(
+                f"  Cause: the {REVIEW_BUDGET_SECONDS:.0f}s time budget ran "
+                f"out. Raise REVIEW_BUDGET_SECONDS (and the job's "
+                f"timeout-minutes with it) if this recurs.",
+            )
         sys.exit(1)
 
     warnings = validate_response(response, pr_number)
@@ -942,7 +1182,10 @@ def main():
     print(f"Response length: {len(response)} chars")
 
     write_outputs(verdict_info, response)
-    print("\n✅ Done! Results written to /tmp/review_result.md")
+    print(
+        f"\n✅ Done! Results written to /tmp/review_result.md "
+        f"({_time_left():.0f}s of budget unused)",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -73,7 +73,10 @@ def _is_degenerate_review(text: str) -> bool:
     if any(m in low for m in ITERATION_LIMIT_MARKERS):
         return True
     body = re.sub(
-        r"^\s*#.*\n", "", text, count=1
+        r"^\s*#.*\n",
+        "",
+        text,
+        count=1,
     ).strip()  # drop a leading title line
     return len(body) < MIN_REVIEW_CHARS
 
@@ -281,6 +284,38 @@ def _diff_with_adaptive_context(
     return best, False
 
 
+def _render_file_chunk(
+    repo_dir: str,
+    from_sha: str,
+    to_sha: str,
+    path: str,
+    stat: str,
+) -> tuple[str, int, bool]:
+    """Render one file's change-map chunk.
+
+    Returns ``(chunk_text, line_count, truncated)`` where ``truncated``
+    marks that the diff was cut to the per-file budget.
+    """
+    header = f"### {path} ({stat})"
+    if stat == "binary":
+        return f"{header}\n(binary file — diff omitted)\n", 2, False
+    try:
+        diff_lines, truncated = _diff_with_adaptive_context(
+            repo_dir,
+            from_sha,
+            to_sha,
+            path,
+        )
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as e:
+        return f"{header}\n(could not read diff: {e})\n", 0, False
+
+    block = "\n".join(diff_lines)
+    return f"{header}\n```diff\n{block}\n```\n", len(diff_lines) + 3, truncated
+
+
 def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
     """Build a compact per-file change map for the diff range.
 
@@ -306,32 +341,17 @@ def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
             skipped_files.append(path)
             continue
 
-        header = f"### {path} ({stat})"
-        if stat == "binary":
-            chunks.append(f"{header}\n(binary file — diff omitted)\n")
-            total_lines += 2
-            continue
-
-        try:
-            diff_lines, truncated = _diff_with_adaptive_context(
-                repo_dir,
-                from_sha,
-                to_sha,
-                path,
-            )
-        except (
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-        ) as e:
-            chunks.append(f"{header}\n(could not read diff: {e})\n")
-            continue
-
+        chunk, n_lines, truncated = _render_file_chunk(
+            repo_dir,
+            from_sha,
+            to_sha,
+            path,
+            stat,
+        )
         if truncated:
             truncated_files.append(path)
-
-        block = "\n".join(diff_lines)
-        chunks.append(f"{header}\n```diff\n{block}\n```\n")
-        total_lines += len(diff_lines) + 3
+        chunks.append(chunk)
+        total_lines += n_lines
 
     if skipped_files:
         chunks.append(
@@ -376,6 +396,27 @@ def _extract_stream_text(evt: dict) -> str:
     return fallback if isinstance(fallback, str) else ""
 
 
+def _collect_sse(resp) -> tuple[dict | None, list]:
+    """Read an SSE stream, returning ``(final_event, stream_errors)``."""
+    final_event = None
+    stream_errors: list = []
+    for line in resp.iter_lines():
+        if not line or not line.startswith("data: "):
+            continue
+        if line[6:] == "[DONE]":
+            break
+
+        parsed = parse_agent_sse_line(line)
+        if not parsed:
+            continue
+        if parsed.get("error"):
+            stream_errors.append(str(parsed["error"]))
+        if parsed.get("type") == "turn_usage":
+            continue
+        final_event = parsed
+    return final_event, stream_errors
+
+
 def call_qwenpaw(prompt: str, session_id: str) -> str:
     """Send prompt to QwenPaw console chat API and collect SSE response.
 
@@ -408,20 +449,7 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
                         time.sleep(5)
                         continue
 
-                    for line in resp.iter_lines():
-                        if not line or not line.startswith("data: "):
-                            continue
-                        if line[6:] == "[DONE]":
-                            break
-
-                        parsed = parse_agent_sse_line(line)
-                        if not parsed:
-                            continue
-                        if parsed.get("error"):
-                            stream_errors.append(str(parsed["error"]))
-                        if parsed.get("type") == "turn_usage":
-                            continue
-                        final_event = parsed
+                    final_event, stream_errors = _collect_sse(resp)
 
             if stream_errors:
                 print(f"  Stream errors: {'; '.join(stream_errors)}")
@@ -686,31 +714,16 @@ def write_outputs(verdict_info: dict, review_text: str):
         f.write(clean_text)
 
 
-def main():
-    print("=" * 60)
-    print("QwenPaw AI Review Bot")
-    print("=" * 60)
+def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str]:
+    """Resolve the PR's change map + head SHA, degrading gracefully.
 
-    pr_number = os.environ.get("PR_NUMBER")
-    repo = os.environ.get("PR_REPO")
-
-    if not pr_number or not repo:
-        print(
-            "ERROR: PR_NUMBER and PR_REPO environment variables "
-            "are required.",
-        )
-        sys.exit(1)
-
-    pr_number = int(pr_number)
-    print(f"\nTarget: {repo} PR #{pr_number}")
-
-    # Pre-compute a per-file change map from an internal blobless clone.
-    # This is an implementation detail — the clone is never surfaced to the
-    # model; only the resulting diff text (and the head SHA, used in the
-    # full-file fetch instruction) go into the prompt. Any failure here
-    # degrades gracefully to the self-fetch (gh pr diff) prompt.
-    change_map = ""
-    head_sha = ""
+    Pre-computes a per-file change map from an internal blobless clone. The
+    clone is an implementation detail — it is never surfaced to the model;
+    only the resulting diff text (and the head SHA, used in the full-file
+    fetch instruction) go into the prompt. Returns ``(change_map, head_sha)``,
+    both ``""`` on any failure so the caller falls back to the self-fetch
+    prompt.
+    """
     try:
         base_ref = fetch_base_branch(pr_number, repo)
         if not base_ref:
@@ -729,6 +742,7 @@ def main():
             )
         else:
             print("  change map empty; using self-fetch prompt")
+        return change_map, head_sha
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
@@ -737,10 +751,30 @@ def main():
     ) as e:
         print(
             f"  ⚠️  Could not build change map ({e}); "
-            f"falling back to self-fetch prompt"
+            f"falling back to self-fetch prompt",
         )
-        change_map = ""
-        head_sha = ""
+        return "", ""
+
+
+def main():
+    print("=" * 60)
+    print("QwenPaw AI Review Bot")
+    print("=" * 60)
+
+    pr_number = os.environ.get("PR_NUMBER")
+    repo = os.environ.get("PR_REPO")
+
+    if not pr_number or not repo:
+        print(
+            "ERROR: PR_NUMBER and PR_REPO environment variables "
+            "are required.",
+        )
+        sys.exit(1)
+
+    pr_number = int(pr_number)
+    print(f"\nTarget: {repo} PR #{pr_number}")
+
+    change_map, head_sha = resolve_change_map(pr_number, repo)
 
     prompt = build_review_prompt(pr_number, repo, change_map, head_sha)
     print(f"Prompt size: {len(prompt)} chars")

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -8,13 +8,19 @@ This script runs inside GitHub Actions to:
 3. QwenPaw autonomously fetches PR data via `gh` CLI
 4. Parse the response and output verdict + review text
 """
-import fcntl
+import contextlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
+
+try:  # ``fcntl`` is Unix-only; without it the repo lock is a no-op.
+    import fcntl
+except ImportError:  # pragma: no cover - non-Unix platforms
+    fcntl = None
 
 import httpx
 
@@ -56,6 +62,13 @@ MAP_CONTEXT_LADDER = (40, 80, 160, 320, 640)
 MAP_FULL_CONTEXT = 100000
 # Wall-clock ceiling for git clone/fetch operations (seconds).
 GIT_TIMEOUT = int(os.environ.get("GIT_TIMEOUT", "600"))
+# Per-call ceiling for the many small `git diff` reads used to build the
+# map. Far below GIT_TIMEOUT (these are local) but generous enough for a
+# file's first diff, which lazily fetches its blobs from the remote.
+DIFF_TIMEOUT = int(os.environ.get("DIFF_TIMEOUT", "120"))
+# Overall ceiling for building the whole map. On expiry the remaining
+# files are reported as omitted, exactly as when the size cap is hit.
+MAP_BUILD_DEADLINE = int(os.environ.get("MAP_BUILD_DEADLINE", "300"))
 
 # A "degenerate" reply is non-empty text that is NOT a real review: the agent
 # hit its internal iteration cap and emitted a warning stub, or returned almost
@@ -103,6 +116,8 @@ def fetch_base_branch(pr_number: int, repo: str) -> str:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
             check=True,
         )
@@ -119,16 +134,52 @@ def fetch_base_branch(pr_number: int, repo: str) -> str:
 # ----------------------------------------------------------------------
 # Change map: pre-computed per-file diff embedded in the prompt
 # ----------------------------------------------------------------------
-def _git(repo_dir: str, *args: str, timeout: int = GIT_TIMEOUT) -> str:
-    """Run a git command in ``repo_dir`` and return trimmed stdout."""
+def _git(
+    repo_dir: str,
+    *args: str,
+    timeout: int = GIT_TIMEOUT,
+    errors: str = "replace",
+) -> str:
+    """Run a git command in ``repo_dir`` and return trimmed stdout.
+
+    The encoding is pinned rather than inherited from the locale, and
+    decoding never raises: a diff may legitimately contain bytes that are
+    not valid UTF-8 (git treats a NUL-free latin-1 file as text), and a
+    ``UnicodeDecodeError`` here would abort the whole run.
+
+    ``errors`` defaults to ``"replace"``, which is right for diff *text*.
+    Callers reading **paths** must pass ``"surrogateescape"`` instead, so
+    the value round-trips back into a later argv unchanged.
+    """
     result = subprocess.run(
         ["git", "-C", repo_dir, *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors=errors,
         timeout=timeout,
         check=True,
     )
     return result.stdout.strip()
+
+
+@contextlib.contextmanager
+def _repo_lock(lock_path: str):
+    """Serialize clone/fetch between workers sharing one clone.
+
+    Degrades to a no-op where ``fcntl`` is unavailable (Windows), which
+    assumes a single process — acceptable because the shared clone only
+    exists to help concurrent CI workers.
+    """
+    if fcntl is None:
+        yield
+        return
+    with open(lock_path, "w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 
 def prepare_repo(
@@ -140,9 +191,16 @@ def prepare_repo(
 
     Clones are shared per repo under ``QWENPAW_ENH_WORK_DIR/repos`` and
     guarded by a file lock, so parallel workers reviewing PRs from the
-    *same* repo do not corrupt the clone or race on ``FETCH_HEAD``. The
-    lock is held only for the clone/fetch/resolve phase; the returned
-    SHAs are immutable, so building the change map runs lock-free.
+    *same* repo do not corrupt the clone. The lock is held only for the
+    clone/fetch/resolve phase; the returned SHAs are immutable, so
+    building the change map runs lock-free.
+
+    Both endpoints are fetched into local refs under
+    ``refs/qwenpaw-review/`` rather than read back from ``FETCH_HEAD``.
+    That keeps the commits *reachable*: with a bare ``FETCH_HEAD`` fetch
+    the objects belong to no ref, so a concurrent worker's fetch could
+    trigger an auto-gc that prunes them mid-review. The refs are named
+    per PR so concurrent reviews of the same repo cannot clobber them.
 
     Returns ``(repo_dir, from_sha, to_sha)`` where ``from_sha`` is the
     merge-base of the base branch and PR head (matching ``gh pr diff``)
@@ -153,13 +211,19 @@ def prepare_repo(
     slug = repo.replace("/", "__")
     repo_dir = os.path.join(repos_root, slug)
     clone_url = f"https://github.com/{repo}.git"
+    base_local = f"refs/qwenpaw-review/base/{pr_number}"
+    head_local = f"refs/qwenpaw-review/head/{pr_number}"
 
-    lock_path = os.path.join(repos_root, f".{slug}.lock")
-    with open(lock_path, "w", encoding="utf-8") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
-        try:
-            if not os.path.isdir(os.path.join(repo_dir, ".git")):
-                print(f"  Cloning {repo} (blobless) ...")
+    with _repo_lock(os.path.join(repos_root, f".{slug}.lock")):
+        if not os.path.isdir(os.path.join(repo_dir, ".git")):
+            print(f"  Cloning {repo} (blobless) ...")
+            # Clone into a scratch dir and move it into place only on
+            # success. A clone killed by the timeout leaves a .git behind
+            # but no usable repo, which would otherwise be mistaken for a
+            # good cache on every later run and poison it permanently.
+            tmp_dir = f"{repo_dir}.tmp"
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            try:
                 # Blobless partial clone: full commit graph (needed for
                 # merge-base) but blobs fetched on demand.
                 subprocess.run(
@@ -169,58 +233,108 @@ def prepare_repo(
                         "--filter=blob:none",
                         "--no-checkout",
                         clone_url,
-                        repo_dir,
+                        tmp_dir,
                     ],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=GIT_TIMEOUT,
                     check=True,
                 )
+                # Safe under the lock: we know there is no .git here.
+                shutil.rmtree(repo_dir, ignore_errors=True)
+                os.replace(tmp_dir, repo_dir)
+            finally:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
 
-            # Fetch the base branch tip and the PR head. The PR head is
-            # exposed on the base repo at refs/pull/<n>/head even for
-            # forks, so this works without knowing the fork remote.
-            _git(repo_dir, "fetch", "--no-tags", "origin", base_ref)
-            base_tip = _git(repo_dir, "rev-parse", "FETCH_HEAD")
+        # Fetch the base branch tip and the PR head. The PR head is
+        # exposed on the base repo at refs/pull/<n>/head even for
+        # forks, so this works without knowing the fork remote.
+        _git(
+            repo_dir,
+            "fetch",
+            "--no-tags",
+            "--force",
+            "origin",
+            f"{base_ref}:{base_local}",
+        )
+        base_tip = _git(repo_dir, "rev-parse", base_local)
 
-            _git(
-                repo_dir,
-                "fetch",
-                "--no-tags",
-                "origin",
-                f"refs/pull/{pr_number}/head",
-            )
-            head_sha = _git(repo_dir, "rev-parse", "FETCH_HEAD")
+        _git(
+            repo_dir,
+            "fetch",
+            "--no-tags",
+            "--force",
+            "origin",
+            f"refs/pull/{pr_number}/head:{head_local}",
+        )
+        head_sha = _git(repo_dir, "rev-parse", head_local)
 
-            merge_base = _git(repo_dir, "merge-base", base_tip, head_sha)
-        finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
+        merge_base = _git(repo_dir, "merge-base", base_tip, head_sha)
 
     return repo_dir, merge_base, head_sha
 
 
-def _numstat(repo_dir: str, from_sha: str, to_sha: str) -> dict[str, str]:
-    """Return ``{path: "+add -del"}`` for each changed file."""
-    raw = _git(repo_dir, "diff", "--numstat", from_sha, to_sha)
-    stats: dict[str, str] = {}
-    for line in raw.splitlines():
-        parts = line.split("\t")
+def _numstat(
+    repo_dir: str,
+    from_sha: str,
+    to_sha: str,
+) -> list[tuple[str, str, list[str]]]:
+    """Return ``[(display, "+add -del", pathspecs)]`` per changed file.
+
+    ``-z`` is required, not a nicety: the default format is *not*
+    round-trippable into a pathspec. It C-quotes any path holding
+    non-ASCII bytes (``"caf\\303\\251.py"``) and collapses a detected
+    rename into one ``old => new`` field. Feeding either back to
+    ``git diff -- <path>`` matches nothing, and git reports that by
+    printing nothing and exiting 0 — so the file would silently render
+    as an empty diff with no truncation marker to flag it.
+
+    With ``-z`` each record is ``add TAB del TAB path NUL``; for a
+    rename/copy the path field is empty and two more NUL-separated
+    fields follow with the real old and new paths. Renames carry both as
+    pathspecs, which is what makes git emit the rename diff rather than
+    treating the new path as a wholly new file.
+    """
+    raw = _git(
+        repo_dir,
+        "diff",
+        "--numstat",
+        "-z",
+        from_sha,
+        to_sha,
+        errors="surrogateescape",
+    )
+    fields = raw.split("\0")
+    entries: list[tuple[str, str, list[str]]] = []
+    i = 0
+    while i < len(fields):
+        parts = fields[i].split("\t")
         if len(parts) != 3:
+            i += 1
             continue
         add, dele, path = parts
-        # Binary files show "-" for counts; keep them but mark n/a.
-        if add == "-" or dele == "-":
-            stats[path] = "binary"
+        if path:
+            display, pathspecs = path, [path]
+            i += 1
         else:
-            stats[path] = f"+{add} -{dele}"
-    return stats
+            if i + 2 >= len(fields):
+                break
+            old, new = fields[i + 1], fields[i + 2]
+            display, pathspecs = f"{old} => {new}", [old, new]
+            i += 3
+        # Binary files show "-" for counts; keep them but mark n/a.
+        stat = "binary" if add == "-" or dele == "-" else f"+{add} -{dele}"
+        entries.append((display, stat, pathspecs))
+    return entries
 
 
 def _file_diff(
     repo_dir: str,
     from_sha: str,
     to_sha: str,
-    path: str,
+    pathspecs: list[str],
     context: int,
 ) -> list[str]:
     """Return the diff lines for one file at a given context width."""
@@ -231,7 +345,8 @@ def _file_diff(
         from_sha,
         to_sha,
         "--",
-        path,
+        *pathspecs,
+        timeout=DIFF_TIMEOUT,
     )
     return diff.splitlines()
 
@@ -240,7 +355,7 @@ def _diff_with_adaptive_context(
     repo_dir: str,
     from_sha: str,
     to_sha: str,
-    path: str,
+    pathspecs: list[str],
 ) -> tuple[list[str], bool]:
     """Pick the widest diff context that fits the per-file line budget.
 
@@ -253,7 +368,7 @@ def _diff_with_adaptive_context(
     Returns ``(diff_lines, truncated)``. When truncated, the caller
     appends a marker pointing at the full-file fetch instruction.
     """
-    floor = _file_diff(repo_dir, from_sha, to_sha, path, MAP_CONTEXT)
+    floor = _file_diff(repo_dir, from_sha, to_sha, pathspecs, MAP_CONTEXT)
 
     # Case 1: even minimum context overflows -> truncate the floor diff.
     if len(floor) > MAP_PER_FILE_LINES:
@@ -267,7 +382,13 @@ def _diff_with_adaptive_context(
         return kept, True
 
     # Case 2: room to spare -> prefer whole-file context if it fits.
-    full = _file_diff(repo_dir, from_sha, to_sha, path, MAP_FULL_CONTEXT)
+    full = _file_diff(
+        repo_dir,
+        from_sha,
+        to_sha,
+        pathspecs,
+        MAP_FULL_CONTEXT,
+    )
     if len(full) <= MAP_PER_FILE_LINES:
         return full, False
 
@@ -276,7 +397,7 @@ def _diff_with_adaptive_context(
     for ctx in MAP_CONTEXT_LADDER:
         if ctx <= MAP_CONTEXT:
             continue
-        widened = _file_diff(repo_dir, from_sha, to_sha, path, ctx)
+        widened = _file_diff(repo_dir, from_sha, to_sha, pathspecs, ctx)
         if len(widened) <= MAP_PER_FILE_LINES:
             best = widened
         else:
@@ -288,15 +409,18 @@ def _render_file_chunk(
     repo_dir: str,
     from_sha: str,
     to_sha: str,
-    path: str,
-    stat: str,
+    entry: tuple[str, str, list[str]],
 ) -> tuple[str, int, bool]:
     """Render one file's change-map chunk.
+
+    ``entry`` is one ``(display, stat, pathspecs)`` record from
+    :func:`_numstat`.
 
     Returns ``(chunk_text, line_count, truncated)`` where ``truncated``
     marks that the diff was cut to the per-file budget.
     """
-    header = f"### {path} ({stat})"
+    display, stat, pathspecs = entry
+    header = f"### {display} ({stat})"
     if stat == "binary":
         return f"{header}\n(binary file — diff omitted)\n", 2, False
     try:
@@ -304,7 +428,7 @@ def _render_file_chunk(
             repo_dir,
             from_sha,
             to_sha,
-            path,
+            pathspecs,
         )
     except (
         subprocess.CalledProcessError,
@@ -327,29 +451,37 @@ def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
     overflows the budget even at minimum context. The whole map is
     capped at ``MAP_MAX_LINES``. Returns "" if there are no changes.
     """
-    stats = _numstat(repo_dir, from_sha, to_sha)
-    if not stats:
+    entries = _numstat(repo_dir, from_sha, to_sha)
+    if not entries:
         return ""
 
     chunks: list[str] = []
     total_lines = 0
     truncated_files: list[str] = []
     skipped_files: list[str] = []
+    deadline_hit = False
+    deadline = time.monotonic() + MAP_BUILD_DEADLINE
 
-    for path, stat in stats.items():
-        if total_lines >= MAP_MAX_LINES:
-            skipped_files.append(path)
+    for entry in entries:
+        display = entry[0]
+        # Widening context costs several `git diff` calls per file, so a
+        # very wide PR can run long even though each call is cheap. Stop
+        # at the deadline and let the remaining files fall through to the
+        # existing "omitted" notice, which already points at Step 2.
+        if total_lines < MAP_MAX_LINES and time.monotonic() > deadline:
+            deadline_hit = True
+        if total_lines >= MAP_MAX_LINES or deadline_hit:
+            skipped_files.append(display)
             continue
 
         chunk, n_lines, truncated = _render_file_chunk(
             repo_dir,
             from_sha,
             to_sha,
-            path,
-            stat,
+            entry,
         )
         if truncated:
-            truncated_files.append(path)
+            truncated_files.append(display)
         chunks.append(chunk)
         total_lines += n_lines
 
@@ -366,9 +498,13 @@ def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
             f"{', '.join(truncated_files)}",
         )
     if skipped_files:
+        reason = (
+            f"after the {MAP_BUILD_DEADLINE}s build deadline"
+            if deadline_hit
+            else f"over the {MAP_MAX_LINES}-line total cap"
+        )
         print(
-            f"  change map: omitted {len(skipped_files)} file(s) over the "
-            f"{MAP_MAX_LINES}-line total cap",
+            f"  change map: omitted {len(skipped_files)} file(s) {reason}",
         )
 
     return "\n".join(chunks)
@@ -743,14 +879,16 @@ def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str]:
         else:
             print("  change map empty; using self-fetch prompt")
         return change_map, head_sha
-    except (
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        RuntimeError,
-        OSError,
-    ) as e:
+    # Deliberately broad: the change map is an optimisation, and this is
+    # the single point where its failure must never fail the CI job. An
+    # allow-list of exception types silently made that promise
+    # conditional -- e.g. a UnicodeDecodeError (a ValueError, so not
+    # covered) aborted the whole run instead of degrading. The type name
+    # is logged so a real defect is still visible rather than swallowed.
+    except Exception as e:
         print(
-            f"  ⚠️  Could not build change map ({e}); "
+            f"  ⚠️  Could not build change map "
+            f"({type(e).__name__}: {e}); "
             f"falling back to self-fetch prompt",
         )
         return "", ""

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -80,25 +80,34 @@ MAP_BUILD_DEADLINE = int(os.environ.get("MAP_BUILD_DEADLINE", "300"))
 # A "degenerate" reply is non-empty text that is NOT a real review: the agent
 # hit its internal iteration cap and emitted a warning stub, or returned almost
 # nothing. These are treated as failures and retried (see call_qwenpaw).
-ITERATION_LIMIT_MARKERS = (
-    "maximum number of iterations",
-    "reached the maximum",
-)
 MIN_REVIEW_CHARS = 200
+# Stubs run 1-3 lines and the shortest complete 6-section report seen is
+# ~16, so this sits in the gap between them rather than at either edge.
+MIN_REVIEW_LINES = 10
 
 
 def _is_degenerate_review(text: str) -> bool:
-    """True if the response is an iteration-limit stub or too short to be a review."""
-    low = text.lower()
-    if any(m in low for m in ITERATION_LIMIT_MARKERS):
-        return True
+    """True if the reply is too small to be a review.
+
+    Judged purely on size. An earlier version also searched the text for
+    the agent's iteration-limit phrasing, which discarded *valid* reviews
+    that merely quoted it -- a review of a PR adding "maximum number of
+    iterations" handling describes the phrase in its own prose. Since
+    call_qwenpaw retries on a degenerate reply, such a review was thrown
+    away up to MAX_RETRIES times and the job reported "Review Failed"
+    while holding five usable reports. Size alone loses nothing: a real
+    stub is one to three lines, so it fails both checks below anyway.
+    """
     body = re.sub(
         r"^\s*#.*\n",
         "",
         text,
         count=1,
     ).strip()  # drop a leading title line
-    return len(body) < MIN_REVIEW_CHARS
+    return (
+        len(body) < MIN_REVIEW_CHARS
+        or len(body.splitlines()) < MIN_REVIEW_LINES
+    )
 
 
 def fetch_base_branch(pr_number: int, repo: str) -> str:

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -373,6 +373,29 @@ def prepare_repo(
     return repo_dir, merge_base, head_sha
 
 
+def _safe_display(path: str) -> str:
+    """Render a git path for the prompt with no lone surrogates.
+
+    Git paths are bytes and need not be valid UTF-8, so :func:`_numstat`
+    reads them with ``surrogateescape`` to keep them round-trippable into
+    a later argv. Those surrogates must never reach the prompt: httpx
+    encodes the JSON body with ``ensure_ascii=False`` and then UTF-8, so a
+    single one raises ``UnicodeEncodeError`` from inside the HTTP call --
+    long after :func:`resolve_change_map` returned, with its fallback
+    already skipped and only ``TimeoutException``/``ConnectError`` caught
+    around the request.
+
+    Undecodable bytes become ``\\xNN`` text: valid UTF-8, unambiguous, and
+    still legible to the agent. Genuine UTF-8 paths (``café.py``) are
+    passed through untouched. The display value is therefore NOT a usable
+    pathspec -- that is what the separate ``pathspecs`` field is for.
+    """
+    return path.encode("utf-8", "surrogateescape").decode(
+        "utf-8",
+        "backslashreplace",
+    )
+
+
 def _numstat(
     repo_dir: str,
     from_sha: str,
@@ -412,14 +435,17 @@ def _numstat(
             i += 1
             continue
         add, dele, path = parts
+        # ``pathspecs`` keeps the raw surrogate form so it can go back
+        # into git's argv; ``display`` is sanitised for the prompt.
         if path:
-            display, pathspecs = path, [path]
+            display, pathspecs = _safe_display(path), [path]
             i += 1
         else:
             if i + 2 >= len(fields):
                 break
             old, new = fields[i + 1], fields[i + 2]
-            display, pathspecs = f"{old} => {new}", [old, new]
+            display = f"{_safe_display(old)} => {_safe_display(new)}"
+            pathspecs = [old, new]
             i += 3
         # Binary files show "-" for counts; keep them but mark n/a.
         stat = "binary" if add == "-" or dele == "-" else f"+{add} -{dele}"
@@ -545,13 +571,25 @@ def _render_file_chunk(
     ``entry`` is one ``(display, stat, pathspecs)`` record from
     :func:`_numstat`.
 
+    Deleted files are flagged in the header. Without that flag a truncated
+    deletion is a dead end: the marker sends the agent to the full-file
+    fetch, but the file does not exist at the PR head, so the fetch can
+    only 404 -- while the prompt still demands it read the full file
+    before asserting anything. The flag tells it to use the base revision
+    instead (spelled out once in the prompt's Step 2).
+
     Returns ``(chunk_text, line_count, truncated)`` where ``truncated``
     marks that the diff was cut to the per-file budget.
     """
     display, stat, pathspecs = entry
-    header = f"### {display} ({stat})"
     if stat == "binary":
-        return f"{header}\n(binary file — diff omitted)\n", 2, False
+        # No diff body to inspect, so the change type is unknown here; the
+        # prompt's Step 2 covers the 404-means-deleted case.
+        return (
+            f"### {display} ({stat})\n(binary file — diff omitted)\n",
+            2,
+            False,
+        )
     try:
         diff_lines, truncated = _diff_with_adaptive_context(
             repo_dir,
@@ -563,7 +601,19 @@ def _render_file_chunk(
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
     ) as e:
-        return f"{header}\n(could not read diff: {e})\n", 0, False
+        return (
+            f"### {display} ({stat})\n(could not read diff: {e})\n",
+            0,
+            False,
+        )
+
+    # git puts "deleted file mode <mode>" right after the "diff --git"
+    # line, so this is reliable even when the body was truncated.
+    deleted = any(
+        line.startswith("deleted file mode") for line in diff_lines[:5]
+    )
+    note = f"{stat} · DELETED in this PR" if deleted else stat
+    header = f"### {display} ({note})"
 
     block = "\n".join(diff_lines)
     return f"{header}\n```diff\n{block}\n```\n", len(diff_lines) + 3, truncated
@@ -979,15 +1029,19 @@ def write_outputs(verdict_info: dict, review_text: str):
         f.write(clean_text)
 
 
-def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str]:
-    """Resolve the PR's change map + head SHA, degrading gracefully.
+def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str, str]:
+    """Resolve the PR's change map + both SHAs, degrading gracefully.
 
     Pre-computes a per-file change map from an internal blobless clone. The
     clone is an implementation detail — it is never surfaced to the model;
-    only the resulting diff text (and the head SHA, used in the full-file
-    fetch instruction) go into the prompt. Returns ``(change_map, head_sha)``,
-    both ``""`` on any failure so the caller falls back to the self-fetch
-    prompt.
+    only the resulting diff text and the two SHAs used in the full-file
+    fetch instructions go into the prompt. Returns
+    ``(change_map, head_sha, base_sha)``, all ``""`` on any failure so the
+    caller falls back to the self-fetch prompt.
+
+    ``base_sha`` (the merge-base) is needed as well as the head: a deleted
+    file does not exist at the head, so fetching its full source there
+    always 404s.
     """
     try:
         base_ref = fetch_base_branch(pr_number, repo)
@@ -1000,6 +1054,13 @@ def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str]:
             base_ref=base_ref,
         )
         change_map = build_change_map(repo_dir, from_sha, head_sha)
+        # The prompt travels as a JSON body that httpx encodes as UTF-8.
+        # Verifying that here means a stray surrogate costs us only the
+        # map (this except clause) instead of raising deep inside
+        # call_qwenpaw's request, which catches only timeout/connect
+        # errors. _safe_display already sanitises paths; this is the
+        # backstop for any future source of undecodable text.
+        change_map.encode("utf-8")
         if change_map:
             print(
                 f"  change map: {len(change_map)} chars "
@@ -1007,7 +1068,7 @@ def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str]:
             )
         else:
             print("  change map empty; using self-fetch prompt")
-        return change_map, head_sha
+        return change_map, head_sha, from_sha
     # Deliberately broad: the change map is an optimisation, and this is
     # the single point where its failure must never fail the CI job. An
     # allow-list of exception types silently made that promise
@@ -1020,7 +1081,7 @@ def resolve_change_map(pr_number: int, repo: str) -> tuple[str, str]:
             f"({type(e).__name__}: {e}); "
             f"falling back to self-fetch prompt",
         )
-        return "", ""
+        return "", "", ""
 
 
 def main():
@@ -1041,9 +1102,15 @@ def main():
     pr_number = int(pr_number)
     print(f"\nTarget: {repo} PR #{pr_number}")
 
-    change_map, head_sha = resolve_change_map(pr_number, repo)
+    change_map, head_sha, base_sha = resolve_change_map(pr_number, repo)
 
-    prompt = build_review_prompt(pr_number, repo, change_map, head_sha)
+    prompt = build_review_prompt(
+        pr_number,
+        repo,
+        change_map,
+        head_sha,
+        base_sha,
+    )
     print(f"Prompt size: {len(prompt)} chars")
 
     session_id = f"pr-review-{pr_number}-{int(time.time())}"

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -8,9 +8,11 @@ This script runs inside GitHub Actions to:
 3. QwenPaw autonomously fetches PR data via `gh` CLI
 4. Parse the response and output verdict + review text
 """
+import fcntl
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 
@@ -26,10 +28,330 @@ from qwenpaw.agents.tools.agent_management import (  # noqa: E402
 
 # pylint: enable=wrong-import-position
 
-QWENPAW_URL = "http://localhost:8088"
+QWENPAW_URL = os.environ.get("QWENPAW_URL", "http://localhost:8088")
 CHAT_ENDPOINT = f"{QWENPAW_URL}/api/console/chat"
-MAX_RETRIES = 3
+MAX_RETRIES = 5
 TIMEOUT_SECONDS = 300
+
+# ---- change-map (per-file diff) configuration ----
+# The runner pre-computes a compact per-file diff ("change map") from an
+# internal blobless clone and embeds it in the prompt. The clone is an
+# implementation detail — it is NOT exposed to the model. Any failure
+# building the map degrades gracefully to the self-fetch prompt.
+QWENPAW_ENH_WORK_DIR = os.environ.get(
+    "QWENPAW_ENH_WORK_DIR",
+    os.path.join(os.path.expanduser("~"), ".qwenpaw-review-bot-cache"),
+)
+# MINIMUM lines of context around each hunk. The map starts here and
+# widens toward full-file context whenever the per-file budget allows.
+MAP_CONTEXT = int(os.environ.get("MAP_CONTEXT", "20"))
+# Max lines kept per file in the change map.
+MAP_PER_FILE_LINES = int(os.environ.get("MAP_PER_FILE_LINES", "500"))
+# Overall cap on the whole change map (safety valve for huge PRs).
+MAP_MAX_LINES = int(os.environ.get("MAP_MAX_LINES", "6000"))
+# Context ladder tried (ascending) when a file fits at MAP_CONTEXT and
+# there is spare per-file budget to show more surrounding code.
+MAP_CONTEXT_LADDER = (40, 80, 160, 320, 640)
+# "-U<this>" ~ whole-file context (git caps at the file length).
+MAP_FULL_CONTEXT = 100000
+# Wall-clock ceiling for git clone/fetch operations (seconds).
+GIT_TIMEOUT = int(os.environ.get("GIT_TIMEOUT", "600"))
+
+# A "degenerate" reply is non-empty text that is NOT a real review: the agent
+# hit its internal iteration cap and emitted a warning stub, or returned almost
+# nothing. These are treated as failures and retried (see call_qwenpaw).
+ITERATION_LIMIT_MARKERS = (
+    "maximum number of iterations",
+    "reached the maximum",
+)
+MIN_REVIEW_CHARS = 200
+
+
+def _is_degenerate_review(text: str) -> bool:
+    """True if the response is an iteration-limit stub or too short to be a review."""
+    low = text.lower()
+    if any(m in low for m in ITERATION_LIMIT_MARKERS):
+        return True
+    body = re.sub(
+        r"^\s*#.*\n", "", text, count=1
+    ).strip()  # drop a leading title line
+    return len(body) < MIN_REVIEW_CHARS
+
+
+def fetch_base_branch(pr_number: int, repo: str) -> str:
+    """Fetch the PR's target (base) branch name via `gh` (read-only).
+
+    Needed to compute the merge-base for the change map. Returns an
+    empty string on failure so the caller can degrade gracefully.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--json",
+                "baseRefName",
+                "--jq",
+                ".baseRefName",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+    ) as e:
+        print(f"  ⚠️  Could not fetch base branch via gh: {e}")
+        return ""
+
+
+# ----------------------------------------------------------------------
+# Change map: pre-computed per-file diff embedded in the prompt
+# ----------------------------------------------------------------------
+def _git(repo_dir: str, *args: str, timeout: int = GIT_TIMEOUT) -> str:
+    """Run a git command in ``repo_dir`` and return trimmed stdout."""
+    result = subprocess.run(
+        ["git", "-C", repo_dir, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def prepare_repo(
+    repo: str,
+    pr_number: int,
+    base_ref: str,
+) -> tuple[str, str, str]:
+    """Clone/refresh the repo and resolve the diff range for the PR.
+
+    Clones are shared per repo under ``QWENPAW_ENH_WORK_DIR/repos`` and
+    guarded by a file lock, so parallel workers reviewing PRs from the
+    *same* repo do not corrupt the clone or race on ``FETCH_HEAD``. The
+    lock is held only for the clone/fetch/resolve phase; the returned
+    SHAs are immutable, so building the change map runs lock-free.
+
+    Returns ``(repo_dir, from_sha, to_sha)`` where ``from_sha`` is the
+    merge-base of the base branch and PR head (matching ``gh pr diff``)
+    and ``to_sha`` is the PR head commit.
+    """
+    repos_root = os.path.join(QWENPAW_ENH_WORK_DIR, "repos")
+    os.makedirs(repos_root, exist_ok=True)
+    slug = repo.replace("/", "__")
+    repo_dir = os.path.join(repos_root, slug)
+    clone_url = f"https://github.com/{repo}.git"
+
+    lock_path = os.path.join(repos_root, f".{slug}.lock")
+    with open(lock_path, "w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            if not os.path.isdir(os.path.join(repo_dir, ".git")):
+                print(f"  Cloning {repo} (blobless) ...")
+                # Blobless partial clone: full commit graph (needed for
+                # merge-base) but blobs fetched on demand.
+                subprocess.run(
+                    [
+                        "git",
+                        "clone",
+                        "--filter=blob:none",
+                        "--no-checkout",
+                        clone_url,
+                        repo_dir,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=GIT_TIMEOUT,
+                    check=True,
+                )
+
+            # Fetch the base branch tip and the PR head. The PR head is
+            # exposed on the base repo at refs/pull/<n>/head even for
+            # forks, so this works without knowing the fork remote.
+            _git(repo_dir, "fetch", "--no-tags", "origin", base_ref)
+            base_tip = _git(repo_dir, "rev-parse", "FETCH_HEAD")
+
+            _git(
+                repo_dir,
+                "fetch",
+                "--no-tags",
+                "origin",
+                f"refs/pull/{pr_number}/head",
+            )
+            head_sha = _git(repo_dir, "rev-parse", "FETCH_HEAD")
+
+            merge_base = _git(repo_dir, "merge-base", base_tip, head_sha)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+    return repo_dir, merge_base, head_sha
+
+
+def _numstat(repo_dir: str, from_sha: str, to_sha: str) -> dict[str, str]:
+    """Return ``{path: "+add -del"}`` for each changed file."""
+    raw = _git(repo_dir, "diff", "--numstat", from_sha, to_sha)
+    stats: dict[str, str] = {}
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        add, dele, path = parts
+        # Binary files show "-" for counts; keep them but mark n/a.
+        if add == "-" or dele == "-":
+            stats[path] = "binary"
+        else:
+            stats[path] = f"+{add} -{dele}"
+    return stats
+
+
+def _file_diff(
+    repo_dir: str,
+    from_sha: str,
+    to_sha: str,
+    path: str,
+    context: int,
+) -> list[str]:
+    """Return the diff lines for one file at a given context width."""
+    diff = _git(
+        repo_dir,
+        "diff",
+        f"-U{context}",
+        from_sha,
+        to_sha,
+        "--",
+        path,
+    )
+    return diff.splitlines()
+
+
+def _diff_with_adaptive_context(
+    repo_dir: str,
+    from_sha: str,
+    to_sha: str,
+    path: str,
+) -> tuple[list[str], bool]:
+    """Pick the widest diff context that fits the per-file line budget.
+
+    Strategy: always show at least ``MAP_CONTEXT`` lines of context. If
+    the diff at that floor already fits ``MAP_PER_FILE_LINES``, try to
+    widen — first to whole-file context, else climbing ``MAP_CONTEXT_LADDER``
+    and keeping the largest width that still fits. If even the floor
+    overflows the budget, the diff is truncated to the budget.
+
+    Returns ``(diff_lines, truncated)``. When truncated, the caller
+    appends a marker pointing at the full-file fetch instruction.
+    """
+    floor = _file_diff(repo_dir, from_sha, to_sha, path, MAP_CONTEXT)
+
+    # Case 1: even minimum context overflows -> truncate the floor diff.
+    if len(floor) > MAP_PER_FILE_LINES:
+        total = len(floor)
+        kept = floor[:MAP_PER_FILE_LINES]
+        kept.append(
+            f"... (diff truncated: {total} lines at {MAP_CONTEXT}-line "
+            f"context, showing the first {MAP_PER_FILE_LINES} — read the "
+            f'complete file with the "Full-file fetch" command in Step 2) ...',
+        )
+        return kept, True
+
+    # Case 2: room to spare -> prefer whole-file context if it fits.
+    full = _file_diff(repo_dir, from_sha, to_sha, path, MAP_FULL_CONTEXT)
+    if len(full) <= MAP_PER_FILE_LINES:
+        return full, False
+
+    # Case 3: whole file too big -> climb the ladder, keep the widest fit.
+    best = floor
+    for ctx in MAP_CONTEXT_LADDER:
+        if ctx <= MAP_CONTEXT:
+            continue
+        widened = _file_diff(repo_dir, from_sha, to_sha, path, ctx)
+        if len(widened) <= MAP_PER_FILE_LINES:
+            best = widened
+        else:
+            break  # context is monotonic; nothing larger will fit
+    return best, False
+
+
+def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
+    """Build a compact per-file change map for the diff range.
+
+    For each changed file, emit a header (``path (+add -del)``) followed
+    by a fenced ```diff block. Context is adaptive: at least
+    ``MAP_CONTEXT`` lines, widened toward the whole file when the
+    per-file budget (``MAP_PER_FILE_LINES``) allows, and truncated (with
+    a marker pointing to the Step 2 full-file fetch) only when the file
+    overflows the budget even at minimum context. The whole map is
+    capped at ``MAP_MAX_LINES``. Returns "" if there are no changes.
+    """
+    stats = _numstat(repo_dir, from_sha, to_sha)
+    if not stats:
+        return ""
+
+    chunks: list[str] = []
+    total_lines = 0
+    truncated_files: list[str] = []
+    skipped_files: list[str] = []
+
+    for path, stat in stats.items():
+        if total_lines >= MAP_MAX_LINES:
+            skipped_files.append(path)
+            continue
+
+        header = f"### {path} ({stat})"
+        if stat == "binary":
+            chunks.append(f"{header}\n(binary file — diff omitted)\n")
+            total_lines += 2
+            continue
+
+        try:
+            diff_lines, truncated = _diff_with_adaptive_context(
+                repo_dir,
+                from_sha,
+                to_sha,
+                path,
+            )
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as e:
+            chunks.append(f"{header}\n(could not read diff: {e})\n")
+            continue
+
+        if truncated:
+            truncated_files.append(path)
+
+        block = "\n".join(diff_lines)
+        chunks.append(f"{header}\n```diff\n{block}\n```\n")
+        total_lines += len(diff_lines) + 3
+
+    if skipped_files:
+        chunks.append(
+            "### (change map truncated)\n"
+            f"{len(skipped_files)} more changed file(s) omitted to stay "
+            f"within the size limit; read them with the Step 2 full-file "
+            f"fetch: {', '.join(skipped_files)}\n",
+        )
+    if truncated_files:
+        print(
+            f"  change map: truncated {len(truncated_files)} large file(s): "
+            f"{', '.join(truncated_files)}",
+        )
+    if skipped_files:
+        print(
+            f"  change map: omitted {len(skipped_files)} file(s) over the "
+            f"{MAP_MAX_LINES}-line total cap",
+        )
+
+    return "\n".join(chunks)
 
 
 def _extract_stream_text(evt: dict) -> str:
@@ -55,15 +377,21 @@ def _extract_stream_text(evt: dict) -> str:
 
 
 def call_qwenpaw(prompt: str, session_id: str) -> str:
-    """Send prompt to QwenPaw console chat API and collect SSE response."""
-    payload = {
+    """Send prompt to QwenPaw console chat API and collect SSE response.
+
+    Retries on HTTP errors, empty replies, AND degenerate replies (the agent's
+    iteration-limit stub / too-short output). Each attempt uses a FRESH session --
+    resuming a session that already hit its iteration cap would just continue the
+    stuck run instead of starting over.
+    """
+    base_payload = {
         "channel": "console",
         "user_id": "review-bot",
-        "session_id": session_id,
         "input": [{"content": [{"type": "text", "text": prompt}]}],
     }
 
     for attempt in range(1, MAX_RETRIES + 1):
+        payload = {**base_payload, "session_id": f"{session_id}-try{attempt}"}
         try:
             print(f"[attempt {attempt}/{MAX_RETRIES}] Calling QwenPaw...")
             final_event = None
@@ -99,10 +427,16 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
                 print(f"  Stream errors: {'; '.join(stream_errors)}")
 
             response = _extract_stream_text(final_event or {})
-            if response.strip():
+            if response.strip() and not _is_degenerate_review(response):
                 return response
 
-            print("  Empty response, retrying...")
+            if not response.strip():
+                print("  Empty response, retrying...")
+            else:
+                print(
+                    "  Degenerate response (iteration-limit stub / too short), "
+                    "retrying with a fresh session...",
+                )
             time.sleep(5)
 
         except (httpx.TimeoutException, httpx.ConnectError) as e:
@@ -370,7 +704,45 @@ def main():
     pr_number = int(pr_number)
     print(f"\nTarget: {repo} PR #{pr_number}")
 
-    prompt = build_review_prompt(pr_number, repo)
+    # Pre-compute a per-file change map from an internal blobless clone.
+    # This is an implementation detail — the clone is never surfaced to the
+    # model; only the resulting diff text (and the head SHA, used in the
+    # full-file fetch instruction) go into the prompt. Any failure here
+    # degrades gracefully to the self-fetch (gh pr diff) prompt.
+    change_map = ""
+    head_sha = ""
+    try:
+        base_ref = fetch_base_branch(pr_number, repo)
+        if not base_ref:
+            raise RuntimeError("could not resolve PR base branch")
+        print("Preparing local clone + change map ...")
+        repo_dir, from_sha, head_sha = prepare_repo(
+            pr_number=pr_number,
+            repo=repo,
+            base_ref=base_ref,
+        )
+        change_map = build_change_map(repo_dir, from_sha, head_sha)
+        if change_map:
+            print(
+                f"  change map: {len(change_map)} chars "
+                f"({change_map.count(chr(10)) + 1} lines)",
+            )
+        else:
+            print("  change map empty; using self-fetch prompt")
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        RuntimeError,
+        OSError,
+    ) as e:
+        print(
+            f"  ⚠️  Could not build change map ({e}); "
+            f"falling back to self-fetch prompt"
+        )
+        change_map = ""
+        head_sha = ""
+
+    prompt = build_review_prompt(pr_number, repo, change_map, head_sha)
     print(f"Prompt size: {len(prompt)} chars")
 
     session_id = f"pr-review-{pr_number}-{int(time.time())}"

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -15,7 +15,10 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+import threading
 import time
+from collections.abc import Sequence
 
 try:  # ``fcntl`` is Unix-only; without it the repo lock is a no-op.
     import fcntl
@@ -53,6 +56,10 @@ QWENPAW_ENH_WORK_DIR = os.environ.get(
 MAP_CONTEXT = int(os.environ.get("MAP_CONTEXT", "20"))
 # Max lines kept per file in the change map.
 MAP_PER_FILE_LINES = int(os.environ.get("MAP_PER_FILE_LINES", "500"))
+# Max characters kept per *line*. A minified or single-line generated file
+# puts its whole diff on one line, where a line budget alone caps nothing,
+# so the streaming reader needs a width cap as well as a height cap.
+MAP_MAX_LINE_CHARS = int(os.environ.get("MAP_MAX_LINE_CHARS", "2000"))
 # Overall cap on the whole change map (safety valve for huge PRs).
 MAP_MAX_LINES = int(os.environ.get("MAP_MAX_LINES", "6000"))
 # Context ladder tried (ascending) when a file fits at MAP_CONTEXT and
@@ -150,6 +157,10 @@ def _git(
     ``errors`` defaults to ``"replace"``, which is right for diff *text*.
     Callers reading **paths** must pass ``"surrogateescape"`` instead, so
     the value round-trips back into a later argv unchanged.
+
+    Only for commands with small, bounded output (rev-parse, merge-base,
+    fetch). Diffs must go through :func:`_git_bounded`, which caps how
+    much is read into memory.
     """
     result = subprocess.run(
         ["git", "-C", repo_dir, *args],
@@ -161,6 +172,92 @@ def _git(
         check=True,
     )
     return result.stdout.strip()
+
+
+def _git_bounded(
+    repo_dir: str,
+    args: Sequence[str],
+    *,
+    max_chars: int,
+    timeout: float,
+    errors: str = "replace",
+) -> tuple[str, bool]:
+    """Run git and read at most ``max_chars`` of stdout, then stop it.
+
+    Returns ``(text, truncated)``. Unlike :func:`_git`, peak memory is
+    bounded by ``max_chars`` no matter how large the real output is: the
+    cap is applied *while* reading rather than to an already-buffered
+    string. That distinction is the whole point here -- a diff taken at
+    near-whole-file context can be tens of megabytes, and decoding it in
+    full just to throw most of it away is what spiked memory before.
+
+    stderr is spooled to a temp file rather than a second pipe, because
+    draining only stdout would deadlock as soon as stderr filled its own
+    64 KiB buffer.
+    """
+    argv = ["git", "-C", repo_dir, *args]
+    expired = threading.Event()
+
+    with tempfile.TemporaryFile("w+b") as err_file:
+        watchdog: threading.Timer | None = None
+        try:
+            with subprocess.Popen(
+                argv,
+                stdout=subprocess.PIPE,
+                stderr=err_file,
+                text=True,
+                encoding="utf-8",
+                errors=errors,
+            ) as proc:
+
+                def _expire() -> None:
+                    # git can also stall while producing *nothing* -- a
+                    # blobless clone fetching this file's blob over the
+                    # network -- where the read below blocks
+                    # indefinitely. Killing the child is what makes the
+                    # timeout real.
+                    expired.set()
+                    proc.kill()
+
+                watchdog = threading.Timer(timeout, _expire)
+                watchdog.start()
+                # A single bounded read: ``TextIOWrapper.read(n)`` returns
+                # exactly n characters or everything up to EOF, so this is
+                # already the streaming cap -- no chunk loop needed. The
+                # one extra character is how we tell "output happens to
+                # end exactly at the cap" from "there is more to come".
+                text = proc.stdout.read(max_chars + 1)
+
+                truncated = len(text) > max_chars
+                if truncated:
+                    text = text[:max_chars]
+                    # Kill before the context manager waits: git is
+                    # blocked writing into a pipe nobody will drain.
+                    proc.kill()
+            # The timer stays armed across ``Popen.__exit__``, whose
+            # ``wait()`` takes no timeout of its own.
+        finally:
+            if watchdog is not None:
+                watchdog.cancel()
+
+        if proc.returncode == 0 or truncated:
+            # Either a clean read, or we stopped git ourselves -- a
+            # non-zero code from our own kill is not a failure. Checked
+            # before ``expired`` so a watchdog that fires in the moment
+            # between a completed read and ``cancel()`` cannot discard
+            # output we already hold.
+            return text, truncated
+
+        err_file.seek(0)
+        stderr_text = err_file.read().decode("utf-8", "replace").strip()
+
+    if expired.is_set():
+        raise subprocess.TimeoutExpired(argv, timeout, stderr=stderr_text)
+    raise subprocess.CalledProcessError(
+        proc.returncode,
+        argv,
+        stderr=stderr_text,
+    )
 
 
 @contextlib.contextmanager
@@ -336,19 +433,41 @@ def _file_diff(
     to_sha: str,
     pathspecs: list[str],
     context: int,
-) -> list[str]:
-    """Return the diff lines for one file at a given context width."""
-    diff = _git(
+    max_lines: int = MAP_PER_FILE_LINES,
+) -> tuple[list[str], bool]:
+    """Return ``(diff_lines, overflowed)`` for one file at a context width.
+
+    ``overflowed`` means git had more to give than the budget allowed --
+    more than ``max_lines`` lines, or more characters than the streaming
+    cap. Callers treat the two identically: the file does not fit at this
+    context width.
+
+    Because the read itself is capped, ``-U{MAP_FULL_CONTEXT}`` is now
+    safe to probe: git is stopped as soon as it exceeds the budget
+    instead of being allowed to hand us a whole large file first.
+    """
+    text, char_truncated = _git_bounded(
         repo_dir,
-        "diff",
-        f"-U{context}",
-        from_sha,
-        to_sha,
-        "--",
-        *pathspecs,
+        [
+            "diff",
+            f"-U{context}",
+            from_sha,
+            to_sha,
+            "--",
+            *pathspecs,
+        ],
+        max_chars=max_lines * MAP_MAX_LINE_CHARS,
         timeout=DIFF_TIMEOUT,
     )
-    return diff.splitlines()
+    lines = text.splitlines()
+    overflowed = char_truncated or len(lines) > max_lines
+    # Every line is capped to the same width, so a line the character cap
+    # happened to slice is no more misleading than a legitimately long one
+    # -- and keeping it preserves the start of the change. The caller
+    # appends a truncation marker whenever ``overflowed`` is set, so a
+    # partial tail is never presented as the whole story.
+    kept = [line[:MAP_MAX_LINE_CHARS] for line in lines[:max_lines]]
+    return kept, overflowed
 
 
 def _diff_with_adaptive_context(
@@ -368,28 +487,33 @@ def _diff_with_adaptive_context(
     Returns ``(diff_lines, truncated)``. When truncated, the caller
     appends a marker pointing at the full-file fetch instruction.
     """
-    floor = _file_diff(repo_dir, from_sha, to_sha, pathspecs, MAP_CONTEXT)
+    floor, overflowed = _file_diff(
+        repo_dir,
+        from_sha,
+        to_sha,
+        pathspecs,
+        MAP_CONTEXT,
+    )
 
-    # Case 1: even minimum context overflows -> truncate the floor diff.
-    if len(floor) > MAP_PER_FILE_LINES:
-        total = len(floor)
-        kept = floor[:MAP_PER_FILE_LINES]
-        kept.append(
-            f"... (diff truncated: {total} lines at {MAP_CONTEXT}-line "
-            f"context, showing the first {MAP_PER_FILE_LINES} — read the "
-            f'complete file with the "Full-file fetch" command in Step 2) ...',
+    # Case 1: even minimum context overflows -> keep the truncated floor.
+    if overflowed:
+        floor.append(
+            f"... (diff truncated: showing the first {MAP_PER_FILE_LINES} "
+            f"lines at {MAP_CONTEXT}-line context; more changes follow — "
+            f'read the complete file with the "Full-file fetch" command '
+            f"in Step 2) ...",
         )
-        return kept, True
+        return floor, True
 
     # Case 2: room to spare -> prefer whole-file context if it fits.
-    full = _file_diff(
+    full, full_overflowed = _file_diff(
         repo_dir,
         from_sha,
         to_sha,
         pathspecs,
         MAP_FULL_CONTEXT,
     )
-    if len(full) <= MAP_PER_FILE_LINES:
+    if not full_overflowed:
         return full, False
 
     # Case 3: whole file too big -> climb the ladder, keep the widest fit.
@@ -397,11 +521,16 @@ def _diff_with_adaptive_context(
     for ctx in MAP_CONTEXT_LADDER:
         if ctx <= MAP_CONTEXT:
             continue
-        widened = _file_diff(repo_dir, from_sha, to_sha, pathspecs, ctx)
-        if len(widened) <= MAP_PER_FILE_LINES:
-            best = widened
-        else:
+        widened, widened_overflowed = _file_diff(
+            repo_dir,
+            from_sha,
+            to_sha,
+            pathspecs,
+            ctx,
+        )
+        if widened_overflowed:
             break  # context is monotonic; nothing larger will fit
+        best = widened
     return best, False
 
 

--- a/scripts/review-bot/review_runner.py
+++ b/scripts/review-bot/review_runner.py
@@ -15,10 +15,7 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
-import threading
 import time
-from collections.abc import Sequence
 
 try:  # ``fcntl`` is Unix-only; without it the repo lock is a no-op.
     import fcntl
@@ -42,44 +39,6 @@ CHAT_ENDPOINT = f"{QWENPAW_URL}/api/console/chat"
 MAX_RETRIES = 5
 TIMEOUT_SECONDS = 300
 
-# ---- global time budget ----
-# The workflow job is capped at 20 min (pr-ai-review.yml `timeout-minutes`).
-# Worst-case setup before this script runs (checkout, pip install, qwenpaw
-# init, waiting up to 90s for the server) plus posting the comment and
-# tearing down afterwards costs roughly 7.5 min of that, so the runner has
-# to finish within ~11 min. Every timeout below is clamped to whatever is
-# left of this budget, which is what keeps the *worst* path -- 5 model
-# retries, a cold clone, a very wide diff -- from being killed by Actions
-# before it can publish a result or fall back.
-REVIEW_BUDGET_SECONDS = float(
-    os.environ.get("REVIEW_BUDGET_SECONDS", "660"),
-)
-# A fresh model attempt with less than this left cannot plausibly finish,
-# so retrying would only burn the time needed to publish the fallback.
-MODEL_MIN_ATTEMPT_SECONDS = float(
-    os.environ.get("MODEL_MIN_ATTEMPT_SECONDS", "120"),
-)
-RETRY_SLEEP_SECONDS = 5.0
-
-_RUN_DEADLINE = time.monotonic() + REVIEW_BUDGET_SECONDS
-
-
-def _time_left() -> float:
-    """Seconds left in the global budget; never negative.
-
-    Every blocking operation clamps its own timeout to this, so the
-    process cannot outlive the budget no matter which path it takes. A
-    clamped timeout of 0 makes the operation fail immediately, which the
-    callers already treat as "degrade gracefully".
-    """
-    return max(0.0, _RUN_DEADLINE - time.monotonic())
-
-
-def _budgeted_sleep(seconds: float = RETRY_SLEEP_SECONDS) -> None:
-    """Back off between retries without sleeping past the budget."""
-    time.sleep(min(seconds, _time_left()))
-
-
 # ---- change-map (per-file diff) configuration ----
 # The runner pre-computes a compact per-file diff ("change map") from an
 # internal blobless clone and embeds it in the prompt. The clone is an
@@ -94,10 +53,6 @@ QWENPAW_ENH_WORK_DIR = os.environ.get(
 MAP_CONTEXT = int(os.environ.get("MAP_CONTEXT", "20"))
 # Max lines kept per file in the change map.
 MAP_PER_FILE_LINES = int(os.environ.get("MAP_PER_FILE_LINES", "500"))
-# Max characters kept per *line*. A minified or single-line generated file
-# puts its whole diff on one line, where a line budget alone caps nothing,
-# so the streaming reader needs a width cap as well as a height cap.
-MAP_MAX_LINE_CHARS = int(os.environ.get("MAP_MAX_LINE_CHARS", "2000"))
 # Overall cap on the whole change map (safety valve for huge PRs).
 MAP_MAX_LINES = int(os.environ.get("MAP_MAX_LINES", "6000"))
 # Context ladder tried (ascending) when a file fits at MAP_CONTEXT and
@@ -163,7 +118,7 @@ def fetch_base_branch(pr_number: int, repo: str) -> str:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=min(60, _time_left()),
+            timeout=60,
             check=True,
         )
         return result.stdout.strip()
@@ -195,10 +150,6 @@ def _git(
     ``errors`` defaults to ``"replace"``, which is right for diff *text*.
     Callers reading **paths** must pass ``"surrogateescape"`` instead, so
     the value round-trips back into a later argv unchanged.
-
-    Only for commands with small, bounded output (rev-parse, merge-base,
-    fetch). Diffs must go through :func:`_git_bounded`, which caps how
-    much is read into memory.
     """
     result = subprocess.run(
         ["git", "-C", repo_dir, *args],
@@ -206,97 +157,10 @@ def _git(
         text=True,
         encoding="utf-8",
         errors=errors,
-        timeout=min(timeout, _time_left()),
+        timeout=timeout,
         check=True,
     )
     return result.stdout.strip()
-
-
-def _git_bounded(
-    repo_dir: str,
-    args: Sequence[str],
-    *,
-    max_chars: int,
-    timeout: float,
-    errors: str = "replace",
-) -> tuple[str, bool]:
-    """Run git and read at most ``max_chars`` of stdout, then stop it.
-
-    Returns ``(text, truncated)``. Unlike :func:`_git`, peak memory is
-    bounded by ``max_chars`` no matter how large the real output is: the
-    cap is applied *while* reading rather than to an already-buffered
-    string. That distinction is the whole point here -- a diff taken at
-    near-whole-file context can be tens of megabytes, and decoding it in
-    full just to throw most of it away is what spiked memory before.
-
-    stderr is spooled to a temp file rather than a second pipe, because
-    draining only stdout would deadlock as soon as stderr filled its own
-    64 KiB buffer.
-    """
-    argv = ["git", "-C", repo_dir, *args]
-    budget = min(timeout, _time_left())
-    expired = threading.Event()
-
-    with tempfile.TemporaryFile("w+b") as err_file:
-        watchdog: threading.Timer | None = None
-        try:
-            with subprocess.Popen(
-                argv,
-                stdout=subprocess.PIPE,
-                stderr=err_file,
-                text=True,
-                encoding="utf-8",
-                errors=errors,
-            ) as proc:
-
-                def _expire() -> None:
-                    # git can also stall while producing *nothing* -- a
-                    # blobless clone fetching this file's blob over the
-                    # network -- where the read below blocks
-                    # indefinitely. Killing the child is what makes the
-                    # timeout real.
-                    expired.set()
-                    proc.kill()
-
-                watchdog = threading.Timer(budget, _expire)
-                watchdog.start()
-                # A single bounded read: ``TextIOWrapper.read(n)`` returns
-                # exactly n characters or everything up to EOF, so this is
-                # already the streaming cap -- no chunk loop needed. The
-                # one extra character is how we tell "output happens to
-                # end exactly at the cap" from "there is more to come".
-                text = proc.stdout.read(max_chars + 1)
-
-                truncated = len(text) > max_chars
-                if truncated:
-                    text = text[:max_chars]
-                    # Kill before the context manager waits: git is
-                    # blocked writing into a pipe nobody will drain.
-                    proc.kill()
-            # The timer stays armed across ``Popen.__exit__``, whose
-            # ``wait()`` takes no timeout of its own.
-        finally:
-            if watchdog is not None:
-                watchdog.cancel()
-
-        if proc.returncode == 0 or truncated:
-            # Either a clean read, or we stopped git ourselves -- a
-            # non-zero code from our own kill is not a failure. Checked
-            # before ``expired`` so a watchdog that fires in the moment
-            # between a completed read and ``cancel()`` cannot discard
-            # output we already hold.
-            return text, truncated
-
-        err_file.seek(0)
-        stderr_text = err_file.read().decode("utf-8", "replace").strip()
-
-    if expired.is_set():
-        raise subprocess.TimeoutExpired(argv, budget, stderr=stderr_text)
-    raise subprocess.CalledProcessError(
-        proc.returncode,
-        argv,
-        stderr=stderr_text,
-    )
 
 
 @contextlib.contextmanager
@@ -306,27 +170,12 @@ def _repo_lock(lock_path: str):
     Degrades to a no-op where ``fcntl`` is unavailable (Windows), which
     assumes a single process — acceptable because the shared clone only
     exists to help concurrent CI workers.
-
-    Acquisition polls instead of blocking: a plain ``LOCK_EX`` waits
-    without a deadline, and since a peer can hold this lock for a whole
-    clone it is the one place that could still spend the entire budget
-    doing nothing. Giving up raises, which
-    :func:`resolve_change_map` turns into the self-fetch fallback.
     """
     if fcntl is None:
         yield
         return
     with open(lock_path, "w", encoding="utf-8") as lock_file:
-        while True:
-            try:
-                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except OSError as e:
-                if _time_left() <= 0:
-                    raise TimeoutError(
-                        "timed out waiting for the repo lock",
-                    ) from e
-                time.sleep(min(0.5, _time_left()))
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
             yield
         finally:
@@ -390,7 +239,7 @@ def prepare_repo(
                     text=True,
                     encoding="utf-8",
                     errors="replace",
-                    timeout=min(GIT_TIMEOUT, _time_left()),
+                    timeout=GIT_TIMEOUT,
                     check=True,
                 )
                 # Safe under the lock: we know there is no .git here.
@@ -487,41 +336,19 @@ def _file_diff(
     to_sha: str,
     pathspecs: list[str],
     context: int,
-    max_lines: int = MAP_PER_FILE_LINES,
-) -> tuple[list[str], bool]:
-    """Return ``(diff_lines, overflowed)`` for one file at a context width.
-
-    ``overflowed`` means git had more to give than the budget allowed --
-    more than ``max_lines`` lines, or more characters than the streaming
-    cap. Callers treat the two identically: the file does not fit at this
-    context width.
-
-    Because the read itself is capped, ``-U{MAP_FULL_CONTEXT}`` is now
-    safe to probe: git is stopped as soon as it exceeds the budget
-    instead of being allowed to hand us a whole large file first.
-    """
-    text, char_truncated = _git_bounded(
+) -> list[str]:
+    """Return the diff lines for one file at a given context width."""
+    diff = _git(
         repo_dir,
-        [
-            "diff",
-            f"-U{context}",
-            from_sha,
-            to_sha,
-            "--",
-            *pathspecs,
-        ],
-        max_chars=max_lines * MAP_MAX_LINE_CHARS,
+        "diff",
+        f"-U{context}",
+        from_sha,
+        to_sha,
+        "--",
+        *pathspecs,
         timeout=DIFF_TIMEOUT,
     )
-    lines = text.splitlines()
-    overflowed = char_truncated or len(lines) > max_lines
-    # Every line is capped to the same width, so a line the character cap
-    # happened to slice is no more misleading than a legitimately long one
-    # -- and keeping it preserves the start of the change. The caller
-    # appends a truncation marker whenever ``overflowed`` is set, so a
-    # partial tail is never presented as the whole story.
-    kept = [line[:MAP_MAX_LINE_CHARS] for line in lines[:max_lines]]
-    return kept, overflowed
+    return diff.splitlines()
 
 
 def _diff_with_adaptive_context(
@@ -540,39 +367,29 @@ def _diff_with_adaptive_context(
 
     Returns ``(diff_lines, truncated)``. When truncated, the caller
     appends a marker pointing at the full-file fetch instruction.
-
-    Each probe below re-clamps its timeout to the remaining global budget
-    (via :func:`_file_diff` -> :func:`_git_bounded`), so a file needing
-    several widening probes cannot overrun the budget between the
-    per-file deadline checks in :func:`build_change_map`.
     """
-    floor, overflowed = _file_diff(
-        repo_dir,
-        from_sha,
-        to_sha,
-        pathspecs,
-        MAP_CONTEXT,
-    )
+    floor = _file_diff(repo_dir, from_sha, to_sha, pathspecs, MAP_CONTEXT)
 
-    # Case 1: even minimum context overflows -> keep the truncated floor.
-    if overflowed:
-        floor.append(
-            f"... (diff truncated: showing the first {MAP_PER_FILE_LINES} "
-            f"lines at {MAP_CONTEXT}-line context; more changes follow — "
-            f'read the complete file with the "Full-file fetch" command '
-            f"in Step 2) ...",
+    # Case 1: even minimum context overflows -> truncate the floor diff.
+    if len(floor) > MAP_PER_FILE_LINES:
+        total = len(floor)
+        kept = floor[:MAP_PER_FILE_LINES]
+        kept.append(
+            f"... (diff truncated: {total} lines at {MAP_CONTEXT}-line "
+            f"context, showing the first {MAP_PER_FILE_LINES} — read the "
+            f'complete file with the "Full-file fetch" command in Step 2) ...',
         )
-        return floor, True
+        return kept, True
 
     # Case 2: room to spare -> prefer whole-file context if it fits.
-    full, full_overflowed = _file_diff(
+    full = _file_diff(
         repo_dir,
         from_sha,
         to_sha,
         pathspecs,
         MAP_FULL_CONTEXT,
     )
-    if not full_overflowed:
+    if len(full) <= MAP_PER_FILE_LINES:
         return full, False
 
     # Case 3: whole file too big -> climb the ladder, keep the widest fit.
@@ -580,16 +397,11 @@ def _diff_with_adaptive_context(
     for ctx in MAP_CONTEXT_LADDER:
         if ctx <= MAP_CONTEXT:
             continue
-        widened, widened_overflowed = _file_diff(
-            repo_dir,
-            from_sha,
-            to_sha,
-            pathspecs,
-            ctx,
-        )
-        if widened_overflowed:
+        widened = _file_diff(repo_dir, from_sha, to_sha, pathspecs, ctx)
+        if len(widened) <= MAP_PER_FILE_LINES:
+            best = widened
+        else:
             break  # context is monotonic; nothing larger will fit
-        best = widened
     return best, False
 
 
@@ -648,10 +460,7 @@ def build_change_map(repo_dir: str, from_sha: str, to_sha: str) -> str:
     truncated_files: list[str] = []
     skipped_files: list[str] = []
     deadline_hit = False
-    # Never spend more than MAP_BUILD_DEADLINE on the map, and never more
-    # than the run has left -- whichever is smaller. Leaving the model no
-    # time at all is worse than shipping a partial map.
-    deadline = time.monotonic() + min(MAP_BUILD_DEADLINE, _time_left())
+    deadline = time.monotonic() + MAP_BUILD_DEADLINE
 
     for entry in entries:
         display = entry[0]
@@ -723,21 +532,11 @@ def _extract_stream_text(evt: dict) -> str:
     return fallback if isinstance(fallback, str) else ""
 
 
-def _collect_sse(resp, deadline: float) -> tuple[dict | None, list, bool]:
-    """Read an SSE stream, bounded by a wall-clock ``deadline``.
-
-    Returns ``(final_event, stream_errors, timed_out)``.
-
-    The deadline is not redundant with the client timeout: httpx applies
-    its read timeout per read, not to the stream as a whole, so a stream
-    that keeps trickling events stays under that timeout forever. Only a
-    wall-clock stop bounds the attempt.
-    """
+def _collect_sse(resp) -> tuple[dict | None, list]:
+    """Read an SSE stream, returning ``(final_event, stream_errors)``."""
     final_event = None
     stream_errors: list = []
     for line in resp.iter_lines():
-        if time.monotonic() > deadline:
-            return final_event, stream_errors, True
         if not line or not line.startswith("data: "):
             continue
         if line[6:] == "[DONE]":
@@ -751,7 +550,7 @@ def _collect_sse(resp, deadline: float) -> tuple[dict | None, list, bool]:
         if parsed.get("type") == "turn_usage":
             continue
         final_event = parsed
-    return final_event, stream_errors, False
+    return final_event, stream_errors
 
 
 def call_qwenpaw(prompt: str, session_id: str) -> str:
@@ -761,15 +560,6 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
     iteration-limit stub / too-short output). Each attempt uses a FRESH session --
     resuming a session that already hit its iteration cap would just continue the
     stuck run instead of starting over.
-
-    Retries are bounded by the global budget, not just by ``MAX_RETRIES``:
-    each attempt gets whatever is left (capped at ``TIMEOUT_SECONDS``) and
-    the loop stops once there is too little left for another attempt to
-    finish. ``MAX_RETRIES`` * ``TIMEOUT_SECONDS`` on its own exceeds the
-    job timeout, which would let Actions kill the job before it could
-    publish either a review or the fallback comment. Attempts that fail
-    fast (HTTP error, empty reply) cost seconds, so in practice this only
-    bites when the model genuinely hangs -- exactly when it should.
     """
     base_payload = {
         "channel": "console",
@@ -778,28 +568,13 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
     }
 
     for attempt in range(1, MAX_RETRIES + 1):
-        left = _time_left()
-        if left < MODEL_MIN_ATTEMPT_SECONDS:
-            print(
-                f"  Time budget nearly exhausted ({left:.0f}s left, an "
-                f"attempt needs {MODEL_MIN_ATTEMPT_SECONDS:.0f}s); "
-                f"giving up after {attempt - 1} attempt(s)",
-            )
-            break
-
-        attempt_timeout = min(TIMEOUT_SECONDS, left)
         payload = {**base_payload, "session_id": f"{session_id}-try{attempt}"}
         try:
-            print(
-                f"[attempt {attempt}/{MAX_RETRIES}] Calling QwenPaw "
-                f"(timeout {attempt_timeout:.0f}s, "
-                f"budget {left:.0f}s left)...",
-            )
+            print(f"[attempt {attempt}/{MAX_RETRIES}] Calling QwenPaw...")
             final_event = None
             stream_errors = []
-            timed_out = False
 
-            with httpx.Client(timeout=attempt_timeout) as client:
+            with httpx.Client(timeout=TIMEOUT_SECONDS) as client:
                 with client.stream(
                     "POST",
                     CHAT_ENDPOINT,
@@ -807,21 +582,13 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
                 ) as resp:
                     if resp.status_code != 200:
                         print(f"  HTTP {resp.status_code}, retrying...")
-                        _budgeted_sleep()
+                        time.sleep(5)
                         continue
 
-                    final_event, stream_errors, timed_out = _collect_sse(
-                        resp,
-                        time.monotonic() + attempt_timeout,
-                    )
+                    final_event, stream_errors = _collect_sse(resp)
 
             if stream_errors:
                 print(f"  Stream errors: {'; '.join(stream_errors)}")
-            if timed_out:
-                print(
-                    f"  Attempt exceeded its {attempt_timeout:.0f}s slice "
-                    f"of the budget",
-                )
 
             response = _extract_stream_text(final_event or {})
             if response.strip() and not _is_degenerate_review(response):
@@ -834,11 +601,11 @@ def call_qwenpaw(prompt: str, session_id: str) -> str:
                     "  Degenerate response (iteration-limit stub / too short), "
                     "retrying with a fresh session...",
                 )
-            _budgeted_sleep()
+            time.sleep(5)
 
         except (httpx.TimeoutException, httpx.ConnectError) as e:
             print(f"  Error: {e}, retrying...")
-            _budgeted_sleep()
+            time.sleep(5)
 
     return ""
 
@@ -1144,7 +911,6 @@ def main():
 
     pr_number = int(pr_number)
     print(f"\nTarget: {repo} PR #{pr_number}")
-    print(f"Time budget: {REVIEW_BUDGET_SECONDS:.0f}s")
 
     change_map, head_sha = resolve_change_map(pr_number, repo)
 
@@ -1159,12 +925,6 @@ def main():
 
     if not response.strip():
         print("\n❌ ERROR: Got empty response from QwenPaw")
-        if _time_left() < MODEL_MIN_ATTEMPT_SECONDS:
-            print(
-                f"  Cause: the {REVIEW_BUDGET_SECONDS:.0f}s time budget ran "
-                f"out. Raise REVIEW_BUDGET_SECONDS (and the job's "
-                f"timeout-minutes with it) if this recurs.",
-            )
         sys.exit(1)
 
     warnings = validate_response(response, pr_number)
@@ -1182,10 +942,7 @@ def main():
     print(f"Response length: {len(response)} chars")
 
     write_outputs(verdict_info, response)
-    print(
-        f"\n✅ Done! Results written to /tmp/review_result.md "
-        f"({_time_left():.0f}s of budget unused)",
-    )
+    print("\n✅ Done! Results written to /tmp/review_result.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Enhance the CI AI review bot (`scripts/review-bot/`) so it catches more real
merge-blockers while raising fewer false alarms on clean PRs. Two changes, no
change to the CI contract:

1. **Pre-computed per-file change map.** Before prompting the model, the runner
   builds a compact per-file diff (adaptive context: ≥20 lines, widened toward
   the whole file when the per-file budget allows, truncated with a pointer to a
   full-file fetch for huge files) from an internal **blobless clone**, and
   embeds it in the prompt. The agent now starts from the exact changed regions
   instead of self-fetching a raw `gh pr diff`. The clone is an implementation
   detail and is **never surfaced to the model** — only the diff text and the
   head SHA go into the prompt.

2. **Richer task prompt.** Adds a "read-before-you-conclude" step (full-file
   fetch + cross-file call-site tracing + `path:line` evidence requirement) and a
   **security / concurrency blocker checklist** (path traversal / Zip Slip, TLS
   verification disabled, SSRF, missing origin/auth, unsafe deserialization,
   TOCTOU races, refactor fallout).

Supporting hardening in `review_runner.py`: `call_qwenpaw` now retries up to 5×,
uses a fresh session per attempt, and rejects degenerate/iteration-limit stubs.
**If the change map can't be built for any reason, the bot degrades gracefully to
the original self-fetch prompt** — it never hard-fails. The CI I/O contract
(`PR_NUMBER`/`PR_REPO` env in, `GITHUB_OUTPUT` verdict/high_count/medium_count +
`/tmp/review_result.md` out) is unchanged, so `pr-ai-review.yml` needs no edits.

**Related Issue:** Fixes #

**Security Considerations:** The bot clones the target repo locally to build the
diff; the clone is read-only and is never exposed to the model. Existing secret
scanning / redaction on the review output is retained.

## Benchmarking / Data

Evaluated on the **QwenPaw-test** PR benchmark
(https://github.com/x1n95c/QwenPaw-test) — 35 negative (bug-injected) + 35
positive (clean) PR variants, judged by `qwen3.7-max`. Comparing the current bot
(`qwenpaw-bot`) against the enhanced bot (`qwenpaw-bot-enhanced`) on the four key
metrics:

| bot / model | neg_blocker_recall ↑ | neg_verdict_acc ↑ | pos_verdict_acc ↑ | pos_false_blocker ↓ |
|---|---|---|---|---|
| qwenpaw-bot / qwen3.7-max          | 0.398 | 0.829 | 0.371 | 1.143 |
| **qwenpaw-bot-enhanced / qwen3.7-max（this pr)** | **0.417** | 0.714 | **0.571** | **0.771** |

Highlights (enhanced vs. its own baseline):

- **neg_blocker_recall improves on both models** — the primary goal: catching the
  injected merge-blocker (qwen3.7-max 0.398 → 0.417, qwen3.7-plus 0.385 → 0.401).
- **qwen3.7-max is rebalanced substantially**: pos_verdict_acc 0.371 → **0.571**
  (+0.20) and pos_false_blocker 1.143 → **0.771** (far fewer false blockers on
  clean PRs), i.e. it stops over-flagging good PRs while still catching more real
  bugs. Its `discrimination` rises 0.514 → 0.629 and positive-PR review quality
  `rq_b` rises 7.514 → 8.114.

Trade-off (called out honestly): on qwen3.7-max, neg_verdict_acc dips 0.829 →
0.714 — the change map + read-before-conclude makes the model more precise about
what actually blocks a merge, which recovers a lot of positive-side accuracy at a
modest cost to negative-verdict accuracy. `fail_rate` stays 0.0 across all runs.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [x] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

**1. Benchmark (QwenPaw-test).** Ran the full 70-PR eval described above on
https://github.com/x1n95c/QwenPaw-test; results in the table.

**2. Live end-to-end sanity check** against a real PR
(`agentscope-ai/QwenPaw#6531`), mimicking the CI steps
(`setup_review_workspace.py` → start server → `review_runner.py` with
`PR_NUMBER`/`PR_REPO`):

- **Enhanced path**: built a change map (10,299 chars / 324 lines), produced a
  complete §1–6 report grounded in the actual source (read `server.py`, verified
  cross-file consistency with `_switch_model()`), verdict `APPROVE`, and wrote
  `/tmp/review_result.md` + `GITHUB_OUTPUT`.
- **Fallback path**: forced the change-map build to fail (tiny git timeout) and
  confirmed the bot logged the fallback and **still produced a full review** via
  the self-fetch prompt — no hard failure.

## Local Verification Evidence

```bash
python -m py_compile scripts/review-bot/prompts.py scripts/review-bot/review_runner.py
# OK

# pylint with the repo's pre-commit disable set:
pylint scripts/review-bot/review_runner.py --disable=<repo pre-commit set>
# Your code has been rated at 10.00/10

# Prompt regression: no-map prompt keeps the exact §1–6 + JSON verdict structure;
# with-map prompt contains <change_map>, the full-file fetch, and the checklist.
```

## Additional Notes

Key design decisions:
- **Backward compatible dispatcher**: `build_review_prompt(pr, repo, change_map="",
  head_sha="")` falls back to the original prompt when no map is supplied, so the
  behavior is unchanged whenever the change map is unavailable.
- **Graceful degradation everywhere**: any clone/fetch/diff failure is caught and
  downgrades to the self-fetch prompt; the review is never blocked by change-map
  problems.
- **CI contract untouched**: no workflow changes; the runner's env inputs and
  `GITHUB_OUTPUT` / `/tmp/review_result.md` outputs are identical to before.
- Change-map budgets (`MAP_CONTEXT`, `MAP_PER_FILE_LINES`, `MAP_MAX_LINES`,
  `GIT_TIMEOUT`, cache dir) are all env-overridable.
