### PR TITLE
fix(skills): preserve plugin-sourced skill tags across pool reconcile

### DIFF
--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -1022,6 +1022,14 @@ def reconcile_pool_manifest() -> dict[str, Any]:
 
         for skill_name in list(skills):
             if skill_name not in discovered:
+                # Plugin-sourced skills have no on-disk directory by design
+                # (registered as lightweight stubs); preserve them across
+                # reconcile so user-assigned tags survive restart. See #6537.
+                existing = normalize_skill_manifest_entry(
+                    skills.get(skill_name),
+                )
+                if str(existing.get("source") or "").startswith("plugin:"):
+                    continue
                 skills.pop(skill_name, None)
 
         return payload
@@ -1132,6 +1140,14 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
 
         for skill_name in list(skills):
             if skill_name not in discovered:
+                # Plugin-sourced skills have no on-disk directory by design
+                # (registered as lightweight stubs); preserve them across
+                # reconcile so user-assigned tags survive restart. See #6537.
+                existing = normalize_skill_manifest_entry(
+                    skills.get(skill_name),
+                )
+                if str(existing.get("source") or "").startswith("plugin:"):
+                    continue
                 skills.pop(skill_name, None)
 
         return payload

--- a/tests/unit/agents/test_reconcile_pool_manifest.py
+++ b/tests/unit/agents/test_reconcile_pool_manifest.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for pool manifest reconciliation.
+
+Regression coverage for #6537: plugin-sourced skills have no on-disk
+directory in the pool, so ``reconcile_pool_manifest()`` must NOT drop them
+(and their user-assigned tags) during the "remove skills no longer on
+disk" pass.
+"""
+from __future__ import annotations
+
+import json
+
+from qwenpaw.agents.skill_system import registry as skill_registry
+from qwenpaw.agents.skill_system.registry import reconcile_pool_manifest
+
+
+def _patch_pool(monkeypatch, pool_dir, manifest_path):
+    """Redirect the registry's pool-path lookups at a temp pool."""
+    monkeypatch.setattr(skill_registry, "get_skill_pool_dir", lambda: pool_dir)
+    monkeypatch.setattr(
+        skill_registry,
+        "get_pool_skill_manifest_path",
+        lambda: manifest_path,
+    )
+    monkeypatch.setattr(
+        skill_registry,
+        "get_skill_pool_dirs",
+        lambda: [pool_dir],
+    )
+
+
+def test_reconcile_preserves_plugin_sourced_skill_tags(
+    tmp_path,
+    monkeypatch,
+):
+    """A plugin-sourced skill (no on-disk dir) keeps its tags across reconcile.
+
+    Fails on the pre-fix code: the removal loop dropped any skill absent
+    from the discovered on-disk set, which deleted plugin stubs along with
+    their tags (#6537).
+    """
+    pool_dir = tmp_path / "skill_pool"
+    pool_dir.mkdir()
+    manifest = pool_dir / "skill.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "skills": {
+                    "plugin-skill": {
+                        "source": "plugin:superpowers",
+                        "protected": False,
+                        "tags": ["favorite", "experimental"],
+                    },
+                },
+                "builtin_skill_names": [],
+            },
+        ),
+    )
+    _patch_pool(monkeypatch, pool_dir, manifest)
+
+    reconcile_pool_manifest()
+
+    on_disk = json.loads(manifest.read_text())
+    entry = on_disk["skills"].get("plugin-skill")
+    assert (
+        entry is not None
+    ), "plugin-sourced skill was dropped by reconcile (regression of #6537)"
+    assert entry.get("tags") == ["favorite", "experimental"]
+
+
+def test_reconcile_still_removes_genuinely_deleted_customized_skill(
+    tmp_path,
+    monkeypatch,
+):
+    """A deleted customized skill is still dropped (not over-preserved).
+
+    Guards that the plugin-preservation fix only retains plugin-sourced
+    stubs, not every non-disk entry.
+    """
+    pool_dir = tmp_path / "skill_pool"
+    pool_dir.mkdir()
+    manifest = pool_dir / "skill.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "skills": {
+                    "gone-customized": {
+                        "source": "customized",
+                        "protected": False,
+                        "tags": ["stale"],
+                    },
+                },
+                "builtin_skill_names": [],
+            },
+        ),
+    )
+    _patch_pool(monkeypatch, pool_dir, manifest)
+
+    reconcile_pool_manifest()
+
+    on_disk = json.loads(manifest.read_text())
+    assert (
+        "gone-customized" not in on_disk["skills"]
+    ), "customized skill with no on-disk dir should be removed by reconcile"


### PR DESCRIPTION
## Description

Fixes #6537.

Skill tags set in the Skill Pool UI disappear after restart for plugin-sourced skills. Plugin skills are registered as lightweight manifest stubs with `source: "plugin:<id>"` and **no on-disk directory** in the pool. During startup reconcile, `reconcile_pool_manifest()` / `reconcile_workspace_manifest()` scan the pool directory for on-disk `SKILL.md` and drop any manifest entry not found on disk — which deletes plugin stubs along with their user-assigned tags. When the plugin re-registers on the next startup, a fresh tag-less stub is created.

This is a regression of #3270 (item 3): #3362 added tag preservation to the **build** path (`_build_reconciled_pool_entry` copies `tags` from the previous entry), but the **removal pass** in `reconcile_pool_manifest` / `reconcile_workspace_manifest` still drops non-disk entries unconditionally — so plugin stubs (and their tags) are deleted before the build path ever runs.

### Fix

In the removal pass of both `reconcile_pool_manifest()` and `reconcile_workspace_manifest()`, preserve entries whose `source` starts with `"plugin:"` (they have no on-disk dir by design). Genuinely-deleted customized/builtin skills (no disk dir, non-plugin source) are still dropped.

**Type of Change:** Bug fix

**Component(s) Affected:** Core / Backend (agents/skill_system)

**Security Considerations:** none — manifest bookkeeping.

## Evidence

- TDD: `test_reconcile_preserves_plugin_sourced_skill_tags` **fails on the old code** (the removal loop drops the plugin stub → `entry is None`) and **passes after the fix** (plugin stub preserved, tags intact). A second test confirms a genuinely-deleted customized skill is still removed (guards against over-preservation).
- `pre-commit run --files` on both changed files: black / mypy / flake8 / pylint / add-trailing-comma / trailing-whitespace all Passed.
- `pytest tests/integration/test_skills_pool.py tests/integration/test_skills_global.py` — 27 passed (no regression in the skill pool CRUD flow).

```text
$ pytest tests/unit/agents/test_reconcile_pool_manifest.py -v
test_reconcile_preserves_plugin_sourced_skill_tags PASSED   # failed before the fix
test_reconcile_still_removes_genuinely_deleted_customized_skill PASSED
2 passed

$ pytest tests/integration/test_skills_pool.py tests/integration/test_skills_global.py -q
27 passed
```

### Scope

This fixes the removal-pass plugin-drop in both pool and workspace reconcile (the primary reported regression). The reporter's separate "workspace tags lost when rebuilt from scratch" (no previous entry to copy tags from) is a different, larger change (would need a tag store independent of the manifest) and is out of scope here — happy to follow up if maintainers want.

## Checklist

- [x] I ran tests locally (unit + integration skill tests, all pass)
- [x] `pre-commit run --files` on changed files passes
- [x] Documentation: n/a — internal manifest reconcile, no user-facing API
- [x] Ready for review
