### PR TITLE
fix(providers): add MiniMax context windows to the static catalog

### DIFF
--- a/src/qwenpaw/providers/context_windows.py
+++ b/src/qwenpaw/providers/context_windows.py
@@ -70,6 +70,10 @@ _KNOWN_CONTEXT_WINDOWS: tuple[tuple[str, int], ...] = (
     # --- Google (1.5-pro is 2M; the rest of the family is 1M) --------------
     ("gemini-1.5-pro", 2_097_152),
     ("gemini", 1_048_576),
+    # --- MiniMax (M3 is a 1M-context multimodal flagship; the M2.7 series
+    #     is 204.8k. Legacy M2.5/M2.1/M2 keep the conservative default.) -----
+    ("minimax-m3", 1_000_000),
+    ("minimax-m2.7", 204_800),
     # --- Others -------------------------------------------------------------
     ("kimi-k2", 262_144),
     ("glm-5.2", 1_000_000),

--- a/tests/unit/providers/test_context_windows.py
+++ b/tests/unit/providers/test_context_windows.py
@@ -55,6 +55,10 @@ from qwenpaw.providers.provider import ModelInfo, Provider
         ("glm-5.2", 1_000_000),
         ("GLM-5.2[1m]", 1_000_000),
         ("zhipu/glm-5.2", 1_000_000),
+        # MiniMax: M3 is a 1M-context flagship; the M2.7 series is 204.8k.
+        ("MiniMax-M3", 1_000_000),
+        ("MiniMax-M2.7", 204_800),
+        ("MiniMax-M2.7-highspeed", 204_800),
     ],
 )
 def test_known_windows(model_id: str, expected: int):


### PR DESCRIPTION
Reason: The built-in MiniMax model catalog omitted context-window metadata, so the 1,000,000-token MiniMax-M3 fell back to the 128k default and triggered context compaction far too early.

## What changed

`MiniMax-M3` and the `MiniMax-M2.7` series are already registered in the built-in model list, but the static context-window catalog in `src/qwenpaw/providers/context_windows.py` had no MiniMax entries. As a result `resolve_context_window` returned the 128k default for every MiniMax model. Because the compaction trigger scales with this window, a 1,000,000-token model was being compacted as if it only had a 128k window.

This adds the documented input windows:

- `MiniMax-M3` -> 1,000,000 tokens (the 1M-context flagship)
- `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` -> 204,800 tokens

The entries use the existing case-insensitive, word-boundary substring matching, and the longest pattern still wins, so `MiniMax-M2.7` does not collide with `MiniMax-M3`. Legacy variants that are not listed keep the conservative default window.

## Checks

- `python -m py_compile src/qwenpaw/providers/context_windows.py tests/unit/providers/test_context_windows.py` - passes.
- `python -m pylint src/qwenpaw/providers/context_windows.py --disable=all --enable=E` - rated 10.00/10.
- Focused resolution check: `known_context_size` / `resolve_context_window` return 1,000,000 for `MiniMax-M3` and 204,800 for the `MiniMax-M2.7` series, while unlisted legacy variants stay on the 128k default. The same cases were added to `tests/unit/providers/test_context_windows.py::test_known_windows`.
