### PR TITLE
Fix Bug #6533, #6506, and #60

### DIFF
--- a/plugins/bundle/cloudpaw/hooks.py
+++ b/plugins/bundle/cloudpaw/hooks.py
@@ -621,6 +621,8 @@ def _patch_mission_master_prompt() -> None:
         agent_id: str,
         max_iterations: int = 20,
         verify_commands: str = "",
+        verification_instructions: str = "",
+        max_retries_per_story: int = 3,
         prd_path: str = "",
         progress_path: str = "",
         git_context: dict | None = None,
@@ -637,6 +639,8 @@ def _patch_mission_master_prompt() -> None:
                 agent_id=agent_id,
                 max_iterations=max_iterations,
                 verify_commands=verify_commands,
+                verification_instructions=verification_instructions,
+                max_retries_per_story=max_retries_per_story,
                 prd_path=prd_path,
                 progress_path=progress_path,
                 git_context=git_context,
@@ -670,6 +674,7 @@ def _patch_mission_master_prompt() -> None:
         verifier_tpl = build_verifier_prompt(
             loop_dir=loop_dir,
             verify_commands=verify_commands,
+            verification_instructions=verification_instructions,
         )
 
         prompt = CLOUDPAW_MASTER_PROMPT.format(

--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -839,6 +839,7 @@ def _build_spawn_request_context(current_agent_id: str) -> dict[str, Any]:
         "user_id": inherited.get("user_id") or get_current_user_id() or "",
         "channel": inherited.get("channel") or get_current_channel() or "",
         "_spawn_subagent": True,
+        "approval_level": inherited.get("approval_level"),
     }
     safe_meta = _json_safe_channel_meta(inherited.get("channel_meta") or {})
     if isinstance(safe_meta, dict) and safe_meta:

--- a/src/qwenpaw/hooks/request_setup/contextvars_hook.py
+++ b/src/qwenpaw/hooks/request_setup/contextvars_hook.py
@@ -60,6 +60,7 @@ class ContextVarsSetupHook(LifecycleHook):
                     "user_id",
                     "channel",
                     "channel_meta",
+                    "approval_level",
                 )
             }
         else:
@@ -68,6 +69,9 @@ class ContextVarsSetupHook(LifecycleHook):
                 "user_id": getattr(ctx.request, "user_id", None) or "",
                 "channel": getattr(ctx.request, "channel", None) or "",
                 "channel_meta": getattr(ctx.request, "channel_meta", None),
+                "approval_level": request_context.get("approval_level")
+                if isinstance(request_context, dict)
+                else None,
             }
         set_current_approval_route(approval_route)
 

--- a/src/qwenpaw/local_models/tag_parser.py
+++ b/src/qwenpaw/local_models/tag_parser.py
@@ -153,7 +153,12 @@ def _parse_xml_tool_call(raw_text: str) -> ParsedToolCall | None:
     if func_match:
         name = func_match.group(1).strip()
         if not name:
-            return None
+            logger.warning(
+                "XML tool call has empty function name; using fallback 'unknown'. "
+                "Raw: %s",
+                raw_text[:200],
+            )
+            name = "unknown"
         body = func_match.group(2)
         arguments: dict = {}
         for param_match in _XML_PARAM_RE.finditer(body):
@@ -181,7 +186,12 @@ def _parse_xml_tool_call(raw_text: str) -> ParsedToolCall | None:
 
     name = func_match_lenient.group(1).strip()
     if not name:
-        return None
+        logger.warning(
+            "Lenient XML tool call has empty function name; using fallback 'unknown'. "
+            "Raw: %s",
+            raw_text[:200],
+        )
+        name = "unknown"
 
     body = func_match_lenient.group(2)
     arguments = _extract_params_lenient(body)
@@ -244,10 +254,11 @@ def _parse_single_tool_call(raw_text: str) -> ParsedToolCall | None:
         name = data.get("name", "")
         if not name:
             logger.warning(
-                "Tool call missing 'name' field: %s",
+                "Tool call has empty 'name' field; using fallback name 'unknown'. "
+                "Raw: %s",
                 stripped[:200],
             )
-            return None
+            name = "unknown"
 
         arguments = data.get("arguments", {})
         if isinstance(arguments, str):


### PR DESCRIPTION
﻿This PR fixes three bugs identified in the QwenPaw repository:

**Bug #6533** — `/mission` command TypeError
- CloudPaw's `_patched_build_master_prompt` was missing `verification_instructions` and `max_retries_per_story` params that the original function accepts.
- Fixed by adding both params to the patched function signature and passing them through.

**Bug #6506** — approval_level not inherited by spawn_subagent children
- `approval_route` ContextVar didn't include `approval_level`, and `_build_spawn_request_context` didn't copy it to child sessions.
- Fixed by adding `approval_level` to both the approval_route dict and the spawn request context.

**Bug #60** — Tool call with empty `name` causes silent failure
- When a model outputs a tool call with an empty or missing `name` field, the `tag_parser` silently discarded it (returned `None`), causing the tool call to vanish with no trace.
- Fixed by falling back to `name="unknown"` so the tool call still flows through the pipeline. The downstream tool registry will reject it with a clear error instead of silently discarding it.

---

### Type of Change
- Bug fix

### Component(s) Affected
- Core (backend)

### Changes
| File | Change |
|---|---|
| `plugins/bundle/cloudpaw/hooks.py` | Added `verification_instructions` and `max_retries_per_story` to `_patched_build_master_prompt` |
| `src/qwenpaw/hooks/request_setup/contextvars_hook.py` | Added `approval_level` to `approval_route` dict |
| `src/qwenpaw/agents/tools/agent_management.py` | Added `approval_level` to spawn request context |
| `src/qwenpaw/local_models/tag_parser.py` | Empty `name` in tool calls now falls back to `"unknown"` instead of silent discard |

### Testing
- Verified JSON path: empty/missing `name` in `{"name": "", ...}` and `{"arguments": {...}}` now returns `ParsedToolCall(name="unknown")` instead of `None`
- Verified valid names still work: `{"name": "bash", ...}` continues to parse correctly
- XML paths follow the same pattern — both strict and lenient XML parsers updated

Closes #6533, #6506