### PR TITLE
fix(memory): flush pending turns before compression (#6555)

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -174,12 +174,12 @@ class MemoryMiddleware(MiddlewareBase):
             return
 
         try:
-            cfg = self._memory_config()
+            # Auto-Memory durability is independent of whether compression
+            # also produces a human-readable continuation summary.
             pending_markers = self._auto_memory_turn_state(agent)["pending"]
-            if (
-                getattr(cfg, "summarize_when_compact", False)
-                and pending_markers
-                and await self._will_compress_context(agent, input_kwargs)
+            if pending_markers and await self._will_compress_context(
+                agent,
+                input_kwargs,
             ):
                 await self._flush_auto_memory(agent)
         except Exception:

--- a/tests/unit/agents/test_memory_middleware.py
+++ b/tests/unit/agents/test_memory_middleware.py
@@ -400,16 +400,9 @@ class TestOnCompressContextAutomationSkip:
 
         with patch.object(
             MemoryMiddleware,
-            "_memory_config",
-        ) as mock_cfg, patch.object(
-            MemoryMiddleware,
             "_will_compress_context",
             return_value=True,
         ) as mock_wc:
-            cfg = MagicMock()
-            cfg.summarize_when_compact = True
-            mock_cfg.return_value = cfg
-
             agent.state.context = [_user_msg()]
 
             await mw.on_compress_context(agent, {}, next_handler)
@@ -421,7 +414,6 @@ class TestOnCompressContextAutomationSkip:
     @pytest.mark.parametrize(
         "failing_step",
         [
-            "memory_config",
             "turn_state",
             "will_compress",
             "flush",
@@ -437,12 +429,7 @@ class TestOnCompressContextAutomationSkip:
         agent = _make_agent(source="user")
         next_handler = AsyncMock()
 
-        if failing_step == "memory_config":
-            mm.get_memory_config.side_effect = RuntimeError(
-                "memory config unavailable",
-            )
-        else:
-            _auto_memory_turn_state(mm)["pending"] = ["m1"]
+        _auto_memory_turn_state(mm)["pending"] = ["m1"]
 
         if failing_step == "turn_state":
             mm.get_auto_memory_turn_state.side_effect = RuntimeError(
@@ -553,3 +540,87 @@ class TestFlushAutoMemoryDefensiveGuard:
         await mw._flush_auto_memory(agent)
 
         mm.auto_memory.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Issue #6555: always flush pending before compress, independent of
+# summarize_when_compact.
+# ---------------------------------------------------------------------------
+
+
+class TestPreCompressFlushNotGatedBySummaryFlag:
+    """Issue #6555 regression tests: pending markers always flush pre-compress.
+
+    ``summarize_when_compact`` controls whether a HUMAN SUMMARY of the
+    evicted content is generated, not whether the turns are durably
+    persisted to the daily memory note. Previously they were coupled, which
+    caused early-session turns to be lost whenever the default
+    ``summarize_when_compact=False`` was in effect and scroll compaction
+    evicted those messages before the auto-memory cadence fired.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("summary_enabled", [False, True])
+    async def test_summary_setting_does_not_gate_flush(
+        self,
+        summary_enabled,
+    ):
+        mm = _make_memory_manager()
+        mm.get_memory_config.return_value = SimpleNamespace(
+            summarize_when_compact=summary_enabled,
+        )
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        _auto_memory_turn_state(mm)["pending"] = ["turn-1"]
+        agent.state.context = [_user_msg()]
+        next_handler = AsyncMock()
+
+        with patch.object(
+            MemoryMiddleware,
+            "_will_compress_context",
+            return_value=True,
+        ):
+            await mw.on_compress_context(agent, {}, next_handler)
+
+        next_handler.assert_awaited_once()
+        mm.auto_memory.assert_awaited_once()
+        assert not _auto_memory_turn_state(mm)["pending"]
+        mm.get_memory_config.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_pending_no_flush_even_above_trigger(self):
+        """No pending markers → no work done, still invokes compress."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        next_handler = AsyncMock()
+
+        with patch.object(
+            MemoryMiddleware,
+            "_will_compress_context",
+            return_value=True,
+        ):
+            await mw.on_compress_context(agent, {}, next_handler)
+
+        next_handler.assert_awaited_once()
+        mm.auto_memory.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_below_trigger_no_flush(self):
+        """Under the token threshold → no flush; compress still runs."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        _auto_memory_turn_state(mm)["pending"] = ["turn-1"]
+        agent.state.context = [_user_msg()]
+        next_handler = AsyncMock()
+
+        with patch.object(
+            MemoryMiddleware,
+            "_will_compress_context",
+            return_value=False,
+        ):
+            await mw.on_compress_context(agent, {}, next_handler)
+
+        next_handler.assert_awaited_once()
+        mm.auto_memory.assert_not_awaited()


### PR DESCRIPTION
## Description

Fixes #6555.

PR #6592 fixed the main Scroll lifecycle gap by routing automatic Scroll
compression through the AgentScope middleware chain. One independent gap
remains: `MemoryMiddleware.on_compress_context()` still gates pending
Auto-Memory persistence on `summarize_when_compact`.

That setting controls whether compression produces a human-readable
continuation summary. It should not control whether pending user turns are
persisted before they are evicted from the live context window.

This revision is rebased onto current `main` and narrowed to that remaining
behavior:

- Flush pending Auto-Memory turns whenever compression will actually run.
- Keep the existing automation skip and fail-open compression behavior.
- Remove the previous speculative stranded-marker fallback.
- Remove `.pr-tracker/` from the PR.

**Related Issue:** Fixes #6555

**Security Considerations:** None. This changes only when already-pending
Auto-Memory turns are persisted.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Applicable pre-commit hooks pass
- [x] Relevant tests pass
- [x] Documentation updated (not needed; internal lifecycle fix)
- [x] Ready for review

## Testing

The regression suite verifies:

- both `summarize_when_compact=False` and `True` flush pending turns;
- the memory config is no longer consulted for persistence;
- no pending markers produces no flush;
- below-threshold compression produces no flush;
- existing memory failure behavior remains fail-open.

## Evidence

```bash
.venv/bin/pytest tests/unit/agents/test_memory_middleware.py -q
# 34 passed in 0.68s

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/agents/middlewares.py \
  tests/unit/agents/test_memory_middleware.py
# Python AST, encoding, secret detection, trailing commas,
# mypy, black, flake8, pylint: Passed
```

`actionlint` is not applicable to the changed Python files and cannot be
initialized locally because the host Go version is 1.17.13 while its
dependencies require Go 1.19+.

## Additional Notes

The implementation was AI-assisted and reviewed against current `main`,
maintainer feedback on this PR, #6592, and the focused regression suite.
