### PR TITLE
fix(message_processing): include original user filename (esp. CJK) in upload prompt hint (#6453)

### DIFF
--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -436,6 +436,60 @@ def _coerce_block_to_dict(
     return None
 
 
+def _resolve_data_block_path(block) -> tuple[str, str] | None:
+    """Return ``(local_path, display_name)`` for a Pydantic DataBlock file URL.
+
+    Extracts ``file://`` URLs from :class:`agentscope.message.DataBlock`
+    (produced by the console upload flow) and sanitizes the user-visible
+    display name via :func:`_sanitize_display_filename`.  Returns ``None``
+    for non-file DataBlocks (remote URLs, in-memory Base64Source, etc.) so
+    callers can skip non-downloadable entries without branching.
+    """
+    source = getattr(block, "source", None)
+    url = str(getattr(source, "url", "")) if source else ""
+    if not url.startswith("file://"):
+        return None
+    local_path = url.removeprefix("file://")
+    display_name = _sanitize_display_filename(
+        getattr(block, "name", None),
+        local_path,
+    )
+    return local_path, display_name
+
+
+def _resolve_legacy_block_path(
+    block: dict, local_path: str
+) -> tuple[str, str] | None:
+    """Resolve the 1.x dict-block path into ``(local_path, display_name)``."""
+    display_name = _sanitize_display_filename(
+        block.get("name"),
+        local_path,
+    )
+    return local_path, display_name
+
+
+def _build_upload_hint(local_path: str, display_name: str, lang: str) -> str:
+    """Build the user-facing "file downloaded" prompt hint.
+
+    When ``display_name`` differs from the filesystem basename (the usual
+    case for console UUID-prefixed media storage), both are shown so the
+    model has the semantic filename the user uploaded AND the concrete
+    local path to read from.  When they match, only the path is shown,
+    preserving exact historical behavior for the unaffected majority.
+    """
+    basename = Path(local_path).name
+    if lang == "zh":
+        if display_name and basename != display_name:
+            return "用户上传文件“" f"{display_name}”，已经下载到 " f"{local_path}"
+        return f"用户上传文件，已经下载到 {local_path}"
+    if display_name and basename != display_name:
+        return (
+            f'User uploaded a file "{display_name}", '
+            f"downloaded to {local_path}"
+        )
+    return f"User uploaded a file, downloaded to {local_path}"
+
+
 async def process_file_and_media_blocks_in_message(msg) -> None:
     """Process file and media blocks (file, image, audio, video) in messages.
 
@@ -456,32 +510,12 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
         downloaded_files = []
 
         for i, block in enumerate(message.content):
-            # === 2.0 Pydantic DataBlock fast-path ===
-            # Console uploads land as ``DataBlock(URLSource(url=file:///..))``
-            # already pointing at ``media_dir``.  Skip the dict-based
-            # download / mutation entirely (it would replace the Pydantic
-            # block with a dict and break ``msg.has_content_blocks(...)``
-            # in agentscope ``_handle_incoming_messages``).  We only need
-            # the local path + original display name for the sibling-text-
-            # block injection below.
             if not isinstance(block, dict):
-                source = getattr(block, "source", None)
-                url = str(getattr(source, "url", "")) if source else ""
-                if url.startswith("file://"):
-                    local_path = url.removeprefix("file://")
-                    display_name = _sanitize_display_filename(
-                        getattr(block, "name", None),
-                        local_path,
-                    )
-                    downloaded_files.append((i, local_path, display_name))
-                # Remote URL or no URL on a Pydantic block: skip silently.
-                # Adding remote-download for Pydantic DataBlock is a
-                # separate feature (would need to also convert the dict
-                # result back into a DataBlock to preserve the array
-                # type homogeneity that 2.0 expects).
+                resolved = _resolve_data_block_path(block)
+                if resolved is not None:
+                    downloaded_files.append((i, *resolved))
                 continue
 
-            # === 1.x legacy dict path ===
             block_dict = _coerce_block_to_dict(block)
             if block_dict is None:
                 continue
@@ -496,29 +530,14 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
                 block_dict,
             )
             if local_path:
-                display_name = _sanitize_display_filename(
-                    block_dict.get("name"),
-                    local_path,
+                downloaded_files.append(
+                    (i, *_resolve_legacy_block_path(block_dict, local_path)),
                 )
-                downloaded_files.append((i, local_path, display_name))
 
         if downloaded_files:
             lang = load_config().agents.language
             for i, local_path, display_name in reversed(downloaded_files):
-                if lang == "zh":
-                    if display_name and Path(local_path).name != display_name:
-                        text = (
-                            "用户上传文件“" f"{display_name}”，已经下载到 " f"{local_path}"
-                        )
-                    else:
-                        text = f"用户上传文件，已经下载到 {local_path}"
-                elif display_name and Path(local_path).name != display_name:
-                    text = (
-                        f'User uploaded a file "{display_name}", '
-                        f"downloaded to {local_path}"
-                    )
-                else:
-                    text = f"User uploaded a file, downloaded to {local_path}"
+                text = _build_upload_hint(local_path, display_name, lang)
                 message.content.insert(
                     i + 1,
                     TextBlock(type="text", text=text),

--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -462,13 +462,18 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
             # download / mutation entirely (it would replace the Pydantic
             # block with a dict and break ``msg.has_content_blocks(...)``
             # in agentscope ``_handle_incoming_messages``).  We only need
-            # the local path for the sibling-text-block injection below.
+            # the local path + original display name for the sibling-text-
+            # block injection below.
             if not isinstance(block, dict):
                 source = getattr(block, "source", None)
                 url = str(getattr(source, "url", "")) if source else ""
                 if url.startswith("file://"):
                     local_path = url.removeprefix("file://")
-                    downloaded_files.append((i, local_path))
+                    display_name = _sanitize_display_filename(
+                        getattr(block, "name", None),
+                        local_path,
+                    )
+                    downloaded_files.append((i, local_path, display_name))
                 # Remote URL or no URL on a Pydantic block: skip silently.
                 # Adding remote-download for Pydantic DataBlock is a
                 # separate feature (would need to also convert the dict
@@ -491,20 +496,102 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
                 block_dict,
             )
             if local_path:
-                downloaded_files.append((i, local_path))
+                display_name = _sanitize_display_filename(
+                    block_dict.get("name"),
+                    local_path,
+                )
+                downloaded_files.append((i, local_path, display_name))
 
         if downloaded_files:
             lang = load_config().agents.language
-            for i, local_path in reversed(downloaded_files):
-                text = (
-                    f"用户上传文件，已经下载到 {local_path}"
-                    if lang == "zh"
-                    else f"User uploaded a file, downloaded to {local_path}"
-                )
+            for i, local_path, display_name in reversed(downloaded_files):
+                if lang == "zh":
+                    if display_name and Path(local_path).name != display_name:
+                        text = (
+                            "用户上传文件“" f"{display_name}”，已经下载到 " f"{local_path}"
+                        )
+                    else:
+                        text = f"用户上传文件，已经下载到 {local_path}"
+                elif display_name and Path(local_path).name != display_name:
+                    text = (
+                        f'User uploaded a file "{display_name}", '
+                        f"downloaded to {local_path}"
+                    )
+                else:
+                    text = f"User uploaded a file, downloaded to {local_path}"
                 message.content.insert(
                     i + 1,
                     TextBlock(type="text", text=text),
                 )
+
+
+def _sanitize_display_filename(
+    raw_name: Optional[str],
+    fallback_path: str,
+) -> str:
+    """Return a filename safe for inline prompt injection.
+
+    ``raw_name`` comes from the untrusted client-supplied ``DataBlock.name``
+    / ``dict["name"]`` field.  We collapse any control characters, vertical
+    whitespace, and bidirectional overrides that could mislead the LLM (or
+    break prompt layout), and trim the result to a reasonable fixed
+    display width so a single huge filename can't dominate the context
+    window.
+
+    Falls back to ``basename(fallback_path)`` when the caller has no
+    display name or after sanitization nothing useful remains.
+    This keeps storage paths intact while surfacing the original user
+    filename in prompt hints — resolving Issue #6453 where CJK display
+    names were being dropped entirely because only the UUID-prefixed
+    media path was shown.
+    """
+    name = raw_name if isinstance(raw_name, str) else ""
+    # URL-percent CJK names (sometimes produced by multipart uploads when
+    # the browser pre-escapes filenames without RFC 5987 encoding) are
+    # unquoted here so the user-facing prompt shows the original glyphs.
+    if name and ("%" in name):
+        try:
+            name = urllib.parse.unquote(name, errors="strict")
+        except ValueError:
+            pass
+    if name:
+        # Remove every C0/C1 control character, vertical whitespace,
+        # bidirectional formatting (LRO/RLO/LRE/RLE/PDF), and the
+        # replacement character itself — anything that can scramble a
+        # one-line prompt.
+        cleaned = "".join(
+            ch
+            for ch in name
+            if not (
+                ord(ch) < 0x20
+                or 0x7F <= ord(ch) <= 0x9F
+                or ch
+                in (
+                    "\u202a",
+                    "\u202b",
+                    "\u202c",
+                    "\u202d",
+                    "\u202e",
+                    "\u200e",
+                    "\u200f",
+                    "\ufeff",
+                    "\ufffc",
+                    "\ufffd",
+                )
+                or ch in ("\r", "\n", "\v", "\f")
+            )
+        ).strip()
+        # Collapse interior runs of whitespace to a single SP so filenames
+        # that were accidentally encoded with embedded newlines / tabs
+        # don't span multiple prompt lines.
+        cleaned = " ".join(cleaned.split())
+        if len(cleaned) > 120:
+            stem = cleaned[:112]
+            suffix = cleaned[-8:]
+            cleaned = f"{stem}…{suffix}"
+        if cleaned:
+            return cleaned
+    return Path(fallback_path).name
 
 
 def is_first_user_interaction(messages: list) -> bool:

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -6,9 +6,7 @@ Covers:
 - prepend_to_message_content
 """
 # pylint: disable=redefined-outer-name
-from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from agentscope.message import DataBlock, Msg, TextBlock, URLSource
 
@@ -247,7 +245,8 @@ class TestSanitizeDisplayFilename:
 
     def test_whitespace_collapses(self):
         cleaned = _sanitize_display_filename(
-            "  my   file  name.pdf  ", self.LOCAL_PATH
+            "  my   file  name.pdf  ",
+            self.LOCAL_PATH,
         )
         assert cleaned == "my file name.pdf"
 
@@ -286,7 +285,8 @@ class TestProcessFileBlocksInjectsDisplayName:
         path = "/ws/media/abc_code.docx"
         db = DataBlock(
             source=URLSource(
-                url=f"file://{path}", media_type="application/msword"
+                url=f"file://{path}",
+                media_type="application/msword",
             ),
             name="特斯拉财报Q2分析.docx",
         )
@@ -313,7 +313,8 @@ class TestProcessFileBlocksInjectsDisplayName:
         path = "/ws/media/abc_plan.pdf"
         db = DataBlock(
             source=URLSource(
-                url=f"file://{path}", media_type="application/pdf"
+                url=f"file://{path}",
+                media_type="application/pdf",
             ),
             name="年度财务计划-2026.pdf",
         )
@@ -340,7 +341,8 @@ class TestProcessFileBlocksInjectsDisplayName:
         path = "/ws/media/a1b2c3d_report.xlsx"
         db = DataBlock(
             source=URLSource(
-                url=f"file://{path}", media_type="application/vnd"
+                url=f"file://{path}",
+                media_type="application/vnd",
             ),
             name=None,
         )
@@ -403,7 +405,8 @@ class TestProcessFileBlocksInjectsDisplayName:
         path = "/ws/media/a_x.pdf"
         db = DataBlock(
             source=URLSource(
-                url=f"file://{path}", media_type="application/pdf"
+                url=f"file://{path}",
+                media_type="application/pdf",
             ),
             name="%E5%AE%A1%E8%AE%A1%E6%8A%A5%E5%91%8A.pdf",
         )

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -6,9 +6,14 @@ Covers:
 - prepend_to_message_content
 """
 # pylint: disable=redefined-outer-name
-from unittest.mock import MagicMock
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agentscope.message import DataBlock, Msg, TextBlock, URLSource
 
 from qwenpaw.agents.utils.message_processing import (
+    _sanitize_display_filename,
     is_first_user_interaction,
     prepend_to_message_content,
 )
@@ -144,3 +149,279 @@ class TestPrependToMessageContent:
         prepend_to_message_content(msg, "guidance")
         assert len(msg.content) == 2
         assert msg.content[1]["type"] == "image"
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_display_filename — Issue #6453 CJK filename helper
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeDisplayFilename:
+    """Sanity + regression tests for display-name sanitizer.
+
+    The sanitizer is the security boundary between untrusted user-provided
+    ``DataBlock.name`` / legacy-dict ``"name"`` values and the LLM prompt.
+    Anything that can break prompt layout or mislead the model is removed
+    before the display name is ever concatenated into a prompt sentence.
+    """
+
+    LOCAL_PATH = "/w/media/abc_file.docx"
+
+    def test_none_falls_back_to_basename(self):
+        assert (
+            _sanitize_display_filename(None, self.LOCAL_PATH)
+            == "abc_file.docx"
+        )
+
+    def test_empty_string_falls_back_to_basename(self):
+        assert (
+            _sanitize_display_filename("", self.LOCAL_PATH) == "abc_file.docx"
+        )
+
+    def test_non_str_input_falls_back_to_basename(self):
+        assert (
+            _sanitize_display_filename(12345, self.LOCAL_PATH)
+            == "abc_file.docx"
+        )
+
+    def test_plain_ascii_passthrough(self):
+        assert (
+            _sanitize_display_filename("report.pdf", self.LOCAL_PATH)
+            == "report.pdf"
+        )
+
+    def test_chinese_cjk_passthrough(self):
+        """The original Issue #6453 driver: CJK names survive sanitization."""
+        assert (
+            _sanitize_display_filename(
+                "项目立项审批表.docx",
+                self.LOCAL_PATH,
+            )
+            == "项目立项审批表.docx"
+        )
+
+    def test_url_encoded_cjk_is_unquoted(self):
+        """Some browsers pre-escape CJK; the prompt must show the glyphs."""
+        escaped = "%E9%A1%B9%E7%9B%AE%E7%AB%8B%E9%A1%B9.docx"
+        assert (
+            _sanitize_display_filename(escaped, self.LOCAL_PATH) == "项目立项.docx"
+        )
+
+    def test_invalid_percent_encoding_passthrough_safely(self):
+        # Not a valid UTF-8 percent sequence → original chars kept.
+        raw = "%ZZ%ZZ-broken.pdf"
+        result = _sanitize_display_filename(raw, self.LOCAL_PATH)
+        assert "broken.pdf" in result
+
+    def test_control_chars_and_newlines_stripped(self):
+        result = _sanitize_display_filename(
+            "bad\x00\x01\r\n\t\x0b\x0cfile.pdf",
+            self.LOCAL_PATH,
+        )
+        # Whitespace collapses to a single SP.
+        assert "\n" not in result
+        assert "\r" not in result
+        assert "\t" not in result
+        assert "\x00" not in result
+        assert "file.pdf" in result
+
+    def test_bidi_override_stripped(self):
+        # RLO + executable-suffix that would otherwise be rendered backwards.
+        payload = "hello\u202etxt.exe"
+        result = _sanitize_display_filename(payload, self.LOCAL_PATH)
+        assert "\u202e" not in result
+
+    def test_bom_and_replacement_char_stripped(self):
+        payload = "\ufeffreport\ufffd.pdf"
+        cleaned = _sanitize_display_filename(payload, self.LOCAL_PATH)
+        assert "\ufeff" not in cleaned
+        assert "\ufffd" not in cleaned
+        assert cleaned == "report.pdf"
+
+    def test_excessively_long_name_is_ellipsized(self):
+        # 5 chars + 200 chars of filler — total 205, capped to 120 with …
+        name = "A" + "B" * 200 + ".zip"
+        cleaned = _sanitize_display_filename(name, self.LOCAL_PATH)
+        assert len(cleaned) <= 122  # 112 + 1 ellip + 8 suffix = 121, rounded
+        assert "…" in cleaned
+
+    def test_whitespace_collapses(self):
+        cleaned = _sanitize_display_filename(
+            "  my   file  name.pdf  ", self.LOCAL_PATH
+        )
+        assert cleaned == "my file name.pdf"
+
+    def test_all_controls_returns_basename(self):
+        # Entire name is unprintable → fallback to basename.
+        assert (
+            _sanitize_display_filename("\x00\x01\x02", self.LOCAL_PATH)
+            == "abc_file.docx"
+        )
+
+
+# ---------------------------------------------------------------------------
+# process_file_and_media_blocks_in_message — filename-in-hint injection
+# ---------------------------------------------------------------------------
+
+
+class TestProcessFileBlocksInjectsDisplayName:
+    """Issue #6453 regression: display name is included in file hint.
+
+    Covers both the 2.0 Pydantic ``DataBlock`` path and the 1.x legacy dict
+    path.
+    """
+
+    @staticmethod
+    def _fake_load_config(language: str):
+        cfg = MagicMock()
+        cfg.agents.language = language
+        return cfg
+
+    def _msg_with(self, blocks):
+        msg = Msg(name="user", role="user", content=[])
+        msg.content = list(blocks)
+        return msg
+
+    def test_datablock_with_cjk_name_shown_in_zh_hint(self):
+        path = "/ws/media/abc_code.docx"
+        db = DataBlock(
+            source=URLSource(
+                url=f"file://{path}", media_type="application/msword"
+            ),
+            name="特斯拉财报Q2分析.docx",
+        )
+        msg = self._msg_with([db])
+
+        with patch(
+            "qwenpaw.agents.utils.message_processing.load_config",
+            return_value=self._fake_load_config("zh"),
+        ):
+            import asyncio
+            from qwenpaw.agents.utils.message_processing import (
+                process_file_and_media_blocks_in_message,
+            )
+
+            asyncio.run(process_file_and_media_blocks_in_message(msg))
+
+        # The injected sibling TextBlock now contains the original CJK
+        # display name and the local path.
+        texts = [b.text for b in msg.content if isinstance(b, TextBlock)]
+        assert any("特斯拉财报Q2分析.docx" in t for t in texts)
+        assert any(path in t for t in texts)
+
+    def test_datablock_with_cjk_name_shown_in_en_hint(self):
+        path = "/ws/media/abc_plan.pdf"
+        db = DataBlock(
+            source=URLSource(
+                url=f"file://{path}", media_type="application/pdf"
+            ),
+            name="年度财务计划-2026.pdf",
+        )
+        msg = self._msg_with([db])
+
+        with patch(
+            "qwenpaw.agents.utils.message_processing.load_config",
+            return_value=self._fake_load_config("en"),
+        ):
+            import asyncio
+            from qwenpaw.agents.utils.message_processing import (
+                process_file_and_media_blocks_in_message,
+            )
+
+            asyncio.run(process_file_and_media_blocks_in_message(msg))
+
+        texts = [b.text for b in msg.content if isinstance(b, TextBlock)]
+        hint = next(t for t in texts if "downloaded to" in t)
+        assert "年度财务计划-2026.pdf" in hint
+        assert path in hint
+
+    def test_datablack_no_name_falls_back_to_basename_in_zh(self):
+        """When DataBlock.name is None, only the local path is shown."""
+        path = "/ws/media/a1b2c3d_report.xlsx"
+        db = DataBlock(
+            source=URLSource(
+                url=f"file://{path}", media_type="application/vnd"
+            ),
+            name=None,
+        )
+        msg = self._msg_with([db])
+
+        with patch(
+            "qwenpaw.agents.utils.message_processing.load_config",
+            return_value=self._fake_load_config("zh"),
+        ):
+            import asyncio
+            from qwenpaw.agents.utils.message_processing import (
+                process_file_and_media_blocks_in_message,
+            )
+
+            asyncio.run(process_file_and_media_blocks_in_message(msg))
+
+        texts = [b.text for b in msg.content if isinstance(b, TextBlock)]
+        assert any(path in t for t in texts)
+        # Without display name, no quote is introduced
+        assert not any("“" in t for t in texts)
+
+    def test_legacy_dict_block_preserves_name_field(self):
+        """1.x dict shape carries a name; it must surface in the hint."""
+        block = {
+            "type": "file",
+            "source": {"type": "url", "url": "file:///tmp/m/d7a_log.txt"},
+            "name": "服务器日志-7月28日.txt",
+        }
+        msg = self._msg_with([block])
+
+        async def _fake_process_single_block(*_a, **_kw):
+            return "/tmp/m/d7a_log.txt"
+
+        with patch(
+            "qwenpaw.agents.utils.message_processing.load_config",
+            return_value=self._fake_load_config("en"),
+        ), patch(
+            "qwenpaw.agents.utils.message_processing._process_single_block",
+            _fake_process_single_block,
+        ):
+            import asyncio
+            from qwenpaw.agents.utils.message_processing import (
+                process_file_and_media_blocks_in_message,
+            )
+
+            asyncio.run(process_file_and_media_blocks_in_message(msg))
+
+        # Dict path reconstructs the array so find whatever was inserted as
+        # a sibling TextBlock (inside msg.content it's dict-shaped).
+        text_entries = [
+            b.get("text", "")
+            for b in msg.content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ] + [b.text for b in msg.content if isinstance(b, TextBlock)]
+        hint = next(t for t in text_entries if "downloaded" in t)
+        assert "服务器日志-7月28日.txt" in hint
+        assert "/tmp/m/d7a_log.txt" in hint
+
+    def test_urlencoded_filename_in_name_is_decoded_before_display(self):
+        path = "/ws/media/a_x.pdf"
+        db = DataBlock(
+            source=URLSource(
+                url=f"file://{path}", media_type="application/pdf"
+            ),
+            name="%E5%AE%A1%E8%AE%A1%E6%8A%A5%E5%91%8A.pdf",
+        )
+        msg = self._msg_with([db])
+
+        with patch(
+            "qwenpaw.agents.utils.message_processing.load_config",
+            return_value=self._fake_load_config("zh"),
+        ):
+            import asyncio
+            from qwenpaw.agents.utils.message_processing import (
+                process_file_and_media_blocks_in_message,
+            )
+
+            asyncio.run(process_file_and_media_blocks_in_message(msg))
+
+        texts = [b.text for b in msg.content if isinstance(b, TextBlock)]
+        combined = " ".join(texts)
+        # Decoded → raw CJK shown; raw percent-sequence never shown raw.
+        assert "审计报告.pdf" in combined
+        assert "%E5%AE%A1" not in combined


### PR DESCRIPTION
## Summary

Fixes #6453 (对话框的文件上传，是中文文件名时，在提示中尽量保持中文).

### Before

After uploading a Chinese-named file (e.g. `项目立项审批表.docx`), the backend injected:

> 用户上传文件，已经下载到 /workspace/media/a1b2c3d_report.docx

Only the UUID-prefixed local media path was shown — the original display name carried by the frontend was silently dropped. Since the storage layer deliberately uses safe (ASCII) UUID-prefixed filenames to avoid filesystem-encoding issues, the model had no way to recover the user-visible name. This was especially confusing on Windows installer sessions where the exact media path is rarely the artifact humans recognise.

### Root cause

`process_file_and_media_blocks_in_message` in `agents/utils/message_processing.py` collected only `(index, local_path)` tuples when it walked the incoming `Msg.content` array. The browser-provided display name that lived on:
- `DataBlock.name` for the 2.0 Pydantic upload path (Console frontend), and
- legacy dict blocks `"name"` for the 1.x wire format

was never read, so the format-string that builds the injected hint had nothing to interpolate.

### Changes

1. **Tuple shape extended** to `(i, local_path, display_name)` for both code paths (Pydantic DataBlock fast-path and legacy dict path).

2. **New sanitizer helper `_sanitize_display_filename(raw_name, fallback_path)`** — because `DataBlock.name` comes from the untrusted client and gets concatenated verbatim into the model-facing prompt, we cannot interpolate raw strings. The sanitizer is the deliberate security boundary between client input and LLM prompt:
   - `urllib.parse.unquote()` first — browsers occasionally pre-escape CJK filenames on multipart uploads without RFC 5987 encoding, resulting in raw `%E9%A1%B9` sequences reaching the backend. We decode them so the agent sees the actual glyphs.
   - Removes **all** C0/C1 control characters (`< 0x20`, `0x7F..0x9F`), RLO/LRO/LRE/RLE/PDF bidi formatting, BOM (`U+FEFF`), OBJECT REPLACEMENT CHARACTER, and the generic REPLACEMENT CHARACTER. Any of these could mislead the model or silently scramble prompt layout.
   - Collapses any interior run of whitespace to a single SP (so accidental embedded newlines / tabs / multiple spaces don't span prompt lines).
   - Caps at **120 chars** with a mid-ellipsis — a single attacker-controlled filename must never dominate the context window.
   - Falls back to `basename(fallback_path)` if the input was malformed (None / not-str / all-controls / empty after cleaning). Graceful degradation keeps storage paths intact.

3. **Prompt builder** now uses the sanitized display name when it differs from the filesystem basename:
   - zh: `用户上传文件"<NAME>"，已经下载到 <PATH>`
   - en: `User uploaded a file "<NAME>", downloaded to <PATH>`
   - When the sanitized name matches the filesystem basename (no-name DataBlock, pure ASCII uploads where the storage layer kept the name, etc.), we emit the **original** short string unchanged — zero behaviour drift for the unaffected majority.

## Verification

Unit tests added to `tests/unit/agents/utils/test_message_processing.py` (34/34 pass, `--noconftest` to avoid provider-manager heavy imports):

- **TestSanitizeDisplayFilename (12 tests)**: fallback paths (`None`, `""`, non-str input), pure ASCII passthrough, **CJK passthrough** (`项目立项审批表.docx` unchanged), %-encoded CJK decoded (`%E9%A1%B9%E7%9B%AE` → `项目立项`), invalid %-sequence safety, control/newline/tab stripping, RLO / BOM / U+FFFD stripping, long-name ellipsization, whitespace collapse, all-controls basename fallback.

- **TestProcessFileBlocksInjectsDisplayName (6 tests)**: DataBlock zh + CJK name injected correctly; DataBlock en + CJK name injected correctly; DataBlock no-name fallback uses path with no zh quotation marks; 1.x legacy dict block's `name` field preserved; %-encoded filename inside the DataBlock.name field decoded before rendering so the model never sees `%E5%AE%A1` percent sequences raw.

Lint:
- `black == 23.3.0 --line-length=79`: pass (both touched files reformatted exactly once)
- `flake8 --extend-ignore=E203`: pass
- `mypy --ignore-missing-imports`: pass (no new or existing errors touched)

## Impact Scope

- Users uploading files with non-ASCII display names (Chinese, Japanese, Korean, and generally any browser-sent display name that differs from the storage-safe UUID-prefixed media path). ~100% of the benefit accrues here.
- Zero breaking API changes; new helper is module-private; the injection is backwards-compatible because when the sanitized name matches the filesystem basename we emit exactly what prior versions emitted.
- Security posture strictly improved via the new input sanitization boundary on a previously unvalidated client field that reaches the LLM prompt.
