### PR TITLE
fix(console): suppress EIO/EPIPE print errors after detached TTY

### DIFF
--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import errno
 import json as _json
 import logging
 import os
@@ -116,6 +117,11 @@ class ConsoleChannel(BaseChannel):
         else:
             self._media_dir = DEFAULT_MEDIA_DIR
         self._media_dir.mkdir(parents=True, exist_ok=True)
+
+        # When the controlling TTY/pipe is gone (e.g. daemon after terminal
+        # close), further print() calls raise EIO/EPIPE; skip them after
+        # one warning so daemon logs are not flooded.
+        self._stdout_broken = False
 
         # Windows stdout encoding fix
         if sys.platform == "win32":
@@ -531,15 +537,34 @@ class ConsoleChannel(BaseChannel):
 
     # ── pretty-print helpers ────────────────────────────────────────
 
+    def _mark_stdout_broken(self, exc: OSError) -> None:
+        """Disable further console prints after stdout becomes unusable."""
+        if self._stdout_broken:
+            return
+        self._stdout_broken = True
+        logger.warning(
+            "Console stdout is unavailable (%s); "
+            "suppressing further console prints",
+            exc,
+        )
+
     def _safe_print(self, text: str) -> None:
         """Safely print text, handling Windows encoding and pipe issues.
 
         On Windows, print() can raise OSError [Errno 22] when output is
         piped or contains unsupported characters. This wrapper handles
         such cases gracefully.
+
+        When stdout is detached/closed (common for ``qwenpaw app`` after
+        the launching terminal exits), print() raises EIO/EPIPE. Log once
+        and suppress further prints instead of flooding ERROR logs.
         """
+        if self._stdout_broken:
+            return
         try:
             print(text)
+        except BrokenPipeError as e:
+            self._mark_stdout_broken(e)
         except OSError as e:
             if e.errno == 22:
                 logger.warning(
@@ -557,6 +582,8 @@ class ConsoleChannel(BaseChannel):
                         "Failed to print even with fallback: %s",
                         fallback_err,
                     )
+            elif e.errno in (errno.EIO, errno.EPIPE):
+                self._mark_stdout_broken(e)
             else:
                 logger.error("Print failed with OSError: %s", e)
 

--- a/tests/unit/channels/test_console.py
+++ b/tests/unit/channels/test_console.py
@@ -12,6 +12,7 @@ Key patterns demonstrated:
 3. Lifecycle testing (start/stop)
 4. Simple mocking (no external dependencies)
 """
+
 # pylint: disable=redefined-outer-name,reimported,protected-access
 # pylint: disable=unused-argument
 from __future__ import annotations
@@ -455,6 +456,67 @@ class TestConsolePrinting:
 
         captured = capsys.readouterr()
         assert "Hello World" in captured.out
+
+    def test_safe_print_suppresses_eio_after_one_warning(
+        self,
+        channel_for_print,
+        monkeypatch,
+        caplog,
+    ):
+        """Broken TTY (EIO) should warn once, then suppress prints."""
+        import errno
+        import logging
+
+        def _raise_eio(_text):
+            raise OSError(errno.EIO, "Input/output error")
+
+        monkeypatch.setattr(
+            "builtins.print",
+            _raise_eio,
+        )
+        with caplog.at_level(logging.WARNING):
+            channel_for_print._safe_print("first")
+            channel_for_print._safe_print("second")
+            channel_for_print._safe_print("third")
+
+        assert channel_for_print._stdout_broken is True
+        warnings = [
+            r
+            for r in caplog.records
+            if "Console stdout is unavailable" in r.getMessage()
+        ]
+        errors = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Print failed" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert errors == []
+
+    def test_safe_print_suppresses_broken_pipe(
+        self,
+        channel_for_print,
+        monkeypatch,
+        caplog,
+    ):
+        """BrokenPipeError should also disable further console prints."""
+        import logging
+
+        def _raise_broken_pipe(_text):
+            raise BrokenPipeError()
+
+        monkeypatch.setattr("builtins.print", _raise_broken_pipe)
+        with caplog.at_level(logging.WARNING):
+            channel_for_print._safe_print("first")
+            channel_for_print._safe_print("second")
+
+        assert channel_for_print._stdout_broken is True
+        warnings = [
+            r
+            for r in caplog.records
+            if "Console stdout is unavailable" in r.getMessage()
+        ]
+        assert len(warnings) == 1
 
     def test_print_parts_formats_text_content(
         self,


### PR DESCRIPTION
## Description

Root cause: when `qwenpaw app` keeps running after its launching terminal closes, stdout still points at a deleted TTY (`/proc/<pid>/fd/1 -> /dev/pts/N (deleted)`). Console channel is enabled by default and pretty-prints every agent reply with `print()`. Writing to that broken fd raises `OSError: [Errno 5] Input/output error` (also BrokenPipeError / EPIPE). Before this change, `_safe_print` logged every failure at ERROR, flooding `~/.qwenpaw/qwenpaw.log` with false-alarm lines while Web/API chat still worked. Other long-running services avoid this by redirecting stdout at startup or never printing business output to a terminal from the request path; console mixes interactive terminal UX with server mode, so a detached TTY becomes log noise instead of a handled I/O condition.

Approach: track `_stdout_broken` on ConsoleChannel; on BrokenPipeError or OSError with errno EIO/EPIPE, log a single WARNING and flip the flag; subsequent `_safe_print` calls return immediately (no ERROR spam); keep the existing Windows Errno 22 encoding fallback unchanged. This is defensive daemon behavior, not a disable of the console channel.

Related Issue: Relates to operational log spam when running `qwenpaw app` as a long-lived process after terminal detach.

Security Considerations: None. Changes only console stdout error handling; no auth or config surface changes.
<img width="1638" height="655" alt="image" src="https://github.com/user-attachments/assets/8dd8b7b7-122e-45dc-9197-0f598a73da0a" />

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [x] **Contract test** exists in `tests/contract/channels/test_console_contract.py` (REQUIRED)
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [x] **Optional**: Unit tests in `tests/unit/channels/test_console.py` for complex internal logic

## Testing

Unit coverage added for EIO and BrokenPipeError suppression (warn once, then silent). Existing safe-print and print-parts tests remain green. Manual check: run qwenpaw app, close the launching TTY, send chat via Web/API, confirm at most one warning and no repeated Errno 5 ERROR lines.

## Evidence

Local verification on branch fix/console-stdout-eio: targeted unit tests passed (11 passed for TestConsolePrinting including the two new EIO/BrokenPipe cases). Pre-commit hooks for the touched Python files passed after black auto-format (black, flake8, pylint, mypy). Observed production symptom before fix: repeated log lines Print failed with OSError Errno 5 Input/output error from console channel while /proc/pid/fd/1 pointed at a deleted pts device.

```bash
PYTHONPATH=src pytest tests/unit/channels/test_console.py::TestConsolePrinting -q
# 11 passed

SKIP=actionlint pre-commit run --files \
  src/qwenpaw/app/channels/console/channel.py \
  tests/unit/channels/test_console.py
# black/flake8/pylint/mypy Passed
```

## Additional Notes

This is a defensive fix for daemon/detached-TTY operation. Users who still want terminal output should keep the launching session alive (tmux/systemd with redirected stdout) or reattach a valid stdout.
