### PR TITLE
fix(ci): skip label operations for fork PRs in real-behavior-proof

### DIFF
--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -44,7 +44,12 @@ jobs:
         run: python scripts/github/real_behavior_proof_check.py
 
       - name: Add needs-context label on failure
-        if: failure()
+        # Fork PRs do not have permission to write labels on the target
+        # repository, so label manipulation is restricted to same-repo PRs.
+        # The proof check itself still runs for fork PRs.
+        if: |
+          failure() &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
@@ -65,7 +70,11 @@ jobs:
             }
 
       - name: Remove needs-context label on success
-        if: success()
+        # Same restriction as the add-label step above: fork PRs cannot
+        # write labels on the target repository.
+        if: |
+          success() &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
## Description

The `real-behavior-proof.yml` workflow fails on fork PRs whose body is missing the required sections. The workflow runs with `pull_request_target` and calls `github.rest.issues.addLabels` using the default `GITHUB_TOKEN`. Fork PRs do not get a token with write access to the target repo's labels, so the API returns 403 and the whole workflow fails with a confusing error.

This is **confirmed real**: PR #6562 (external fork PR) CI log shows

```
→ MISSING sections: ['What Problem This Solves']
await github.rest.issues.addLabels({...})
HttpError: Resource not accessible by integration  (status: 403)
```

This change restricts the two label-manipulation steps to same-repository PRs only:

```yaml
if: |
  failure() &&
  github.event.pull_request.head.repo.full_name == github.repository
```

For a fork PR, `head.repo.full_name` (e.g. `someone/CoPaw`) != `github.repository` (`agentscope-ai/QwenPaw`), so the label steps are skipped. The proof check itself still runs for fork PRs, so the quality gate is preserved; only the optional label automation is skipped when write access is unavailable.

**Related Issue:** Fixes #6563

**Security Considerations:** No new surface area — the change only restricts label writes to same-repo PRs where the token already has permissions. The read-only proof check continues to run for all PRs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks — n/a
- [x] I ran tests locally — no runtime code changed
- [ ] Documentation updated (if needed) — n/a
- [x] Ready for review

### For Channel Changes

*n/a*

## Testing

- `pre-commit run --files .github/workflows/real-behavior-proof.yml` passes (check yaml, actionlint, trim trailing whitespace).
- The condition evaluates to `true` for same-repo PRs (label steps run) and `false` for fork PRs (label steps skipped).

## Evidence

The fix was verified end-to-end on real CI by deploying the patched workflow to a fork acting as the target repo and opening a fork PR with a missing-evidence body. The patched workflow skips the label step for fork PRs; the old workflow raises 403. A/B comparison below.

### A/B verification (real CI runs)

Because `pull_request_target` runs the **base-branch workflow**, the patched file cannot be exercised on a PR to `agentscope-ai/QwenPaw` before merge. To verify the patched workflow end-to-end, the patched `real-behavior-proof.yml` was deployed to a fork acting as the target repo (`kun6696/CoPaw`), and a fork PR with a missing-evidence body was opened from another fork (`hanson-hex/CoPaw`).

| Scenario | Workflow | `Add needs-context label on failure` | Result |
|---|---|---|---|
| **Before fix** — PR #6562 / PR #6576 (external fork PRs, `agentscope-ai/QwenPaw`, old workflow) | unpatched | executed → `addLabels` → **403** | job fails with `Resource not accessible by integration` |
| **After fix** — fork PR to patched target ([kun6696/CoPaw#1](https://github.com/kun6696/CoPaw/pull/1), from `hanson-hex/CoPaw`; [run log](https://github.com/kun6696/CoPaw/actions/runs/30514671466)) | **patched** | **skipped** | job fails only on `Check` (MISSING), **no 403** |

**Before fix — 403 reproduced in two independent CI runs (identical `addLabels` → 403):**

- [PR #6562](https://github.com/agentscope-ai/QwenPaw/pull/6562) — reported by `@BlackBox-Labs` (the issue author)
- [PR #6576](https://github.com/agentscope-ai/QwenPaw/pull/6576) — reproduced by this PR's author (`hanson-hex`, `CONTRIBUTOR` association); [run log](https://github.com/agentscope-ai/QwenPaw/actions/runs/30519675117)

Both runs show the same failure:
```
→ MISSING sections: ['What Problem This Solves']
await github.rest.issues.addLabels({...})
RequestError [HttpError]: Resource not accessible by integration
  status: 403
```

**After fix (patched-target run, fork PR):**
```
Check real behavior proof	→ MISSING sections: ['What Problem This Solves', 'Evidence']
Check real behavior proof	##[error]Process completed with exit code 1.   ← quality gate fails as designed
Add needs-context label on failure	(skipped — `head.repo.full_name != github.repository`)
```
No `addLabels` call, no 403. The `Check` step still fails because the body lacks required sections (this is the intended quality gate).

The verification is independent of repository naming — the condition compares the PR's `head.repo.full_name` against the target `github.repository`, so any external fork (regardless of name) triggers the skip, while same-repo PRs keep the automatic label behavior.

### pre-commit

```bash
$ pre-commit run --files .github/workflows/real-behavior-proof.yml
check yaml...............................................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
```

## Additional Notes

- The `Check real behavior proof` step is intentionally left unchanged so external contributors still see the Evidence / Description requirement.
- Same-repo PRs (including maintainer PRs) keep the automatic `triage: needs-pr-context` label behavior.
