### PR TITLE
fix(ci): skip label operations for fork PRs in real-behavior-proof

### DIFF
--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -44,7 +44,12 @@ jobs:
         run: python scripts/github/real_behavior_proof_check.py
 
       - name: Add needs-context label on failure
-        if: failure()
+        # Fork PRs do not have permission to write labels on the target
+        # repository, so label manipulation is restricted to same-repo PRs.
+        # The proof check itself still runs for fork PRs.
+        if: |
+          failure() &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}
@@ -65,7 +70,11 @@ jobs:
             }
 
       - name: Remove needs-context label on success
-        if: success()
+        # Same restriction as the add-label step above: fork PRs cannot
+        # write labels on the target repository.
+        if: |
+          success() &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
## Description

The `real-behavior-proof.yml` workflow fails on every pull request from a fork with:

```
Unhandled error: HttpError: Resource not accessible by integration
```

This happens because the workflow runs with `pull_request_target` and then calls `github.rest.issues.addLabels` / `removeLabel` using the default `GITHUB_TOKEN`. Fork PRs do not receive a token with write access to the target repository's labels, so the API returns 403 and the whole workflow fails.

This change restricts the two label-manipulation steps to same-repository PRs only by checking:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

The actual proof check (`python scripts/github/real_behavior_proof_check.py`) still runs for fork PRs, so the quality gate is preserved; only the optional label automation is skipped when write access is not available.

**Related Issue:** Fixes #6563

**Security Considerations:** No new surface area. This change makes the workflow more restrictive, not less: label write operations are now limited to same-repo PRs where the token already has the required permissions. The proof check itself (which only reads the PR body) continues to run for all PRs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [x] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass — no runtime code changed
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes

*n/a*

## Testing

- `pre-commit run --files .github/workflows/real-behavior-proof.yml` passes.
- `actionlint` (via pre-commit `Lint GitHub Actions workflow files`) passes.
- YAML syntax validated by pre-commit `check yaml`.
- The condition `github.event.pull_request.head.repo.full_name == github.repository` evaluates to:
  - `true` for same-repo PRs (label steps run)
  - `false` for fork PRs (label steps skipped)

## Evidence

```bash
$ pre-commit run --files .github/workflows/real-behavior-proof.yml
check yaml...............................................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Lint GitHub Actions workflow files.......................................Passed
```

Workflow diff (the two label steps now include the same-repo guard):

```yaml
      - name: Add needs-context label on failure
        if: |
          failure() &&
          github.event.pull_request.head.repo.full_name == github.repository
        uses: actions/github-script@v7
        ...

      - name: Remove needs-context label on success
        if: |
          success() &&
          github.event.pull_request.head.repo.full_name == github.repository
        uses: actions/github-script@v7
        ...
```

This PR is itself opened from a fork, so the updated `Real behavior proof` check running here is direct evidence that the workflow no longer fails with `Resource not accessible by integration`.

## Additional Notes

- The `Check real behavior proof` step is intentionally left unchanged so external contributors still see the Evidence / Description requirement.
- Same-repo PRs (including maintainer PRs) keep the automatic `triage: needs-pr-context` label behavior.
