### PR TITLE
fix(audio): restore transcription for channel audio messages

### DIFF
--- a/src/qwenpaw/agents/utils/message_processing.py
+++ b/src/qwenpaw/agents/utils/message_processing.py
@@ -13,12 +13,20 @@ import urllib.parse
 from pathlib import Path
 from typing import Optional
 
-from agentscope.message import Msg, TextBlock
+from agentscope.message import Msg, TextBlock, URLSource
 
+from ...app.channels.utils import file_url_to_local_path
 from ...config import load_config
 from .file_handling import download_file_from_base64, download_file_from_url
 
 logger = logging.getLogger(__name__)
+
+
+def _audio_text_block(block, text: str):
+    """Build a text replacement matching the input block representation."""
+    if isinstance(block, dict):
+        return {"type": "text", "text": text}
+    return TextBlock(type="text", text=text)
 
 
 async def _process_single_file_block(
@@ -230,7 +238,7 @@ async def _process_audio_block(
     message_content: list,
     index: int,
     local_path: str,
-    block: dict,
+    block,
 ) -> bool:
     """Handle an audio block according to the configured audio_mode.
 
@@ -269,36 +277,67 @@ async def _process_audio_block(
         else:
             # Unsupported format and conversion failed — show placeholder
             # instead of sending an unsupported audio block to the model.
-            message_content[index] = {
-                "type": "text",
-                "text": (
+            message_content[index] = _audio_text_block(
+                block,
+                (
                     "[Voice message]: (audio conversion failed, "
                     "install ffmpeg to enable native audio)"
                 ),
-            }
+            )
             return True
-        block["source"] = {
+        source = {
             "type": "url",
             "url": _local_file_url(audio_path),
             "media_type": _media_type_from_path(audio_path),
         }
+        if isinstance(block, dict):
+            block["source"] = source
+        else:
+            block.source = URLSource(**source)
         return True
 
     # "auto": attempt transcription.
     text = await transcribe_audio(local_path)
     if text:
-        message_content[index] = {
-            "type": "text",
-            "text": f"[Voice message]: {text}",
-        }
+        message_content[index] = _audio_text_block(
+            block,
+            f"[Voice message]: {text}",
+        )
         return True
 
     # Transcription failed — show file-uploaded placeholder.
-    message_content[index] = {
-        "type": "text",
-        "text": "[Voice message]: (audio file received)",
-    }
+    message_content[index] = _audio_text_block(
+        block,
+        "[Voice message]: (audio file received)",
+    )
     return False
+
+
+async def _process_local_data_block(
+    message_content: list,
+    index: int,
+    block,
+) -> Optional[str]:
+    """Process a local AgentScope DataBlock and return its file path."""
+    source = getattr(block, "source", None)
+    url = str(getattr(source, "url", "")) if source else ""
+    if not url.startswith("file://"):
+        return None
+
+    local_path = file_url_to_local_path(url)
+    if not local_path:
+        return None
+    media_type = getattr(source, "media_type", "") or ""
+    if media_type.startswith("audio/"):
+        handled = await _process_audio_block(
+            message_content,
+            index,
+            local_path,
+            block,
+        )
+        if handled:
+            return None
+    return local_path
 
 
 async def _process_single_block(
@@ -458,16 +497,16 @@ async def process_file_and_media_blocks_in_message(msg) -> None:
         for i, block in enumerate(message.content):
             # === 2.0 Pydantic DataBlock fast-path ===
             # Console uploads land as ``DataBlock(URLSource(url=file:///..))``
-            # already pointing at ``media_dir``.  Skip the dict-based
-            # download / mutation entirely (it would replace the Pydantic
-            # block with a dict and break ``msg.has_content_blocks(...)``
-            # in agentscope ``_handle_incoming_messages``).  We only need
-            # the local path for the sibling-text-block injection below.
+            # already pointing at ``media_dir``.  Preserve the Pydantic block
+            # type; local audio is handled in-place for transcription/native
+            # delivery, while other media only needs a path hint.
             if not isinstance(block, dict):
-                source = getattr(block, "source", None)
-                url = str(getattr(source, "url", "")) if source else ""
-                if url.startswith("file://"):
-                    local_path = url.removeprefix("file://")
+                local_path = await _process_local_data_block(
+                    message.content,
+                    i,
+                    block,
+                )
+                if local_path:
                     downloaded_files.append((i, local_path))
                 # Remote URL or no URL on a Pydantic block: skip silently.
                 # Adding remote-download for Pydantic DataBlock is a

--- a/src/qwenpaw/runtime/message_convert.py
+++ b/src/qwenpaw/runtime/message_convert.py
@@ -125,6 +125,7 @@ def _request_input_to_msgs(
                     getattr(c, "image_url", None)
                     or getattr(c, "audio_url", None)
                     or getattr(c, "video_url", None)
+                    or (getattr(c, "data", None) if ctype == "audio" else None)
                     or getattr(c, "url", None)
                 )
                 if url:

--- a/tests/unit/agents/utils/test_message_processing.py
+++ b/tests/unit/agents/utils/test_message_processing.py
@@ -6,11 +6,16 @@ Covers:
 - prepend_to_message_content
 """
 # pylint: disable=redefined-outer-name
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agentscope.message import DataBlock, Msg, TextBlock, URLSource
 
 from qwenpaw.agents.utils.message_processing import (
+    _process_audio_block,
     is_first_user_interaction,
     prepend_to_message_content,
+    process_file_and_media_blocks_in_message,
 )
 
 
@@ -24,6 +29,35 @@ def _msg(role: str, content="content"):
     m.role = role
     m.content = content
     return m
+
+
+def _audio_message(audio_path, media_type="audio/opus"):
+    block = DataBlock(
+        source=URLSource(
+            url=audio_path.resolve().as_uri(),
+            media_type=media_type,
+        ),
+    )
+    return Msg(name="user", role="user", content=[block]), block
+
+
+def _mock_transcription(result=None):
+    return patch(
+        "qwenpaw.agents.utils.audio_transcription.transcribe_audio",
+        new=AsyncMock(return_value=result),
+    )
+
+
+@pytest.fixture
+def _audio_config():
+    config = MagicMock()
+    config.agents.audio_mode = "auto"
+    config.agents.language = "en"
+    with patch(
+        "qwenpaw.agents.utils.message_processing.load_config",
+        return_value=config,
+    ):
+        yield config
 
 
 # ---------------------------------------------------------------------------
@@ -144,3 +178,89 @@ class TestPrependToMessageContent:
         prepend_to_message_content(msg, "guidance")
         assert len(msg.content) == 2
         assert msg.content[1]["type"] == "image"
+
+
+class TestProcessAudioDataBlock:
+    """P0: local AgentScope audio blocks reach transcription."""
+
+    @pytest.mark.asyncio
+    async def test_local_audio_is_replaced_with_transcription(
+        self,
+        tmp_path,
+        _audio_config,
+    ):
+        audio_path = tmp_path / "voice note.opus"
+        msg, _ = _audio_message(audio_path)
+
+        with _mock_transcription("hello from voice") as transcribe:
+            await process_file_and_media_blocks_in_message(msg)
+
+        transcribe.assert_awaited_once_with(str(audio_path.resolve()))
+        assert len(msg.content) == 1
+        assert isinstance(msg.content[0], TextBlock)
+        assert msg.content[0].text == "[Voice message]: hello from voice"
+
+    @pytest.mark.asyncio
+    async def test_failed_transcription_keeps_local_path_hint(
+        self,
+        tmp_path,
+        _audio_config,
+    ):
+        audio_path = tmp_path / "voice.opus"
+        msg, _ = _audio_message(audio_path)
+
+        with _mock_transcription():
+            await process_file_and_media_blocks_in_message(msg)
+
+        assert len(msg.content) == 2
+        assert isinstance(msg.content[0], TextBlock)
+        assert msg.content[0].text == "[Voice message]: (audio file received)"
+        assert isinstance(msg.content[1], TextBlock)
+        assert str(audio_path.resolve()) in msg.content[1].text
+
+    @pytest.mark.asyncio
+    async def test_native_audio_remains_data_block(
+        self,
+        tmp_path,
+        _audio_config,
+    ):
+        audio_path = tmp_path / "voice.wav"
+        msg, block = _audio_message(audio_path, "audio/wav")
+        _audio_config.agents.audio_mode = "native"
+
+        with _mock_transcription() as transcribe:
+            await process_file_and_media_blocks_in_message(msg)
+
+        transcribe.assert_not_awaited()
+        assert msg.content == [block]
+        assert block.source.media_type == "audio/wav"
+
+    @pytest.mark.asyncio
+    async def test_legacy_audio_replacement_remains_dict(
+        self,
+        tmp_path,
+        _audio_config,
+    ):
+        audio_path = tmp_path / "voice.opus"
+        block = {
+            "type": "audio",
+            "source": {
+                "type": "url",
+                "url": audio_path.resolve().as_uri(),
+                "media_type": "audio/opus",
+            },
+        }
+        content = [block]
+
+        with _mock_transcription("legacy voice"):
+            handled = await _process_audio_block(
+                content,
+                0,
+                str(audio_path),
+                block,
+            )
+
+        assert handled is True
+        assert content == [
+            {"type": "text", "text": "[Voice message]: legacy voice"},
+        ]

--- a/tests/unit/runtime/test_message_convert.py
+++ b/tests/unit/runtime/test_message_convert.py
@@ -7,7 +7,7 @@ from qwenpaw.constant import (
     QWENPAW_MESSAGE_TAG_KEY,
 )
 from qwenpaw.runtime.message_convert import _request_input_to_msgs
-from qwenpaw.schemas import Message, Role, TextContent
+from qwenpaw.schemas import AudioContent, Message, Role, TextContent
 
 
 def test_only_external_user_input_gets_query_tag():
@@ -46,3 +46,24 @@ def test_user_message_client_id_survives_conversion():
     assert messages[0].metadata[QWENPAW_MESSAGE_TAG_KEY] == (
         EXTERNAL_USER_QUERY_MESSAGE_TAG
     )
+
+
+def test_audio_content_data_becomes_audio_data_block(tmp_path):
+    audio_path = tmp_path / "voice.opus"
+
+    messages = _request_input_to_msgs(
+        [
+            Message(
+                role=Role.USER,
+                content=[AudioContent(data=str(audio_path))],
+            ),
+        ],
+    )
+
+    assert len(messages) == 1
+    assert len(messages[0].content) == 1
+    block = messages[0].content[0]
+    assert block.type == "data"
+    assert block.source.type == "url"
+    assert str(block.source.url) == audio_path.resolve().as_uri()
+    assert block.source.media_type.startswith("audio/")


### PR DESCRIPTION
## Summary

Fix audio transcription silently failing for channel messages after the
AgentScope 2.0 migration.

## Root Cause

Channel implementations such as Feishu create audio messages as
`AudioContent(data=...)`.

Two gaps prevented these messages from reaching transcription:

1. The request conversion layer did not read `AudioContent.data`, causing
   audio-only messages to be dropped.
2. Local AgentScope 2.0 `DataBlock` audio was skipped by the media processing
   hook, so transcription was never invoked.

## Changes

- Read `AudioContent.data` when converting audio content into an AgentScope
  `DataBlock`.
- Process local `audio/*` `DataBlock` instances through the existing audio
  handling pipeline.
- Preserve the existing `audio_mode` behavior:
  - `auto`: transcribe audio and replace it with a `TextBlock`.
  - `native`: keep audio as a `DataBlock` and skip transcription.
- Preserve legacy dictionary block representation for existing 1.x paths.
- Reuse the existing cross-platform file URL conversion utility.
- Keep a visible fallback and local path hint when transcription fails.

## Compatibility

The fix applies to the shared channel audio path without changing individual
channel implementations.

It preserves existing behavior for:

- Legacy dictionary audio blocks
- Native audio mode
- Non-audio media blocks
- Remote media URLs
- Existing Whisper API and local Whisper backends

**Related Issue:** Fixes #6544 

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
