### PR TITLE
fix(plugins): permanent max-version semantics — no implicit derivation, honor explicit max

### DIFF
--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -2,8 +2,10 @@
 """Plugin–QwenPaw version compatibility check.
 
 Semantics: left-closed, right-open interval  ``>=min, <max``.
-When ``max`` is not specified, it is derived from ``min`` as
-``{major}.{minor+1}.0`` (all patch versions of the same minor).
+When ``max`` is not specified, no upper bound is enforced — the plugin
+is considered compatible with any QwenPaw version that satisfies ``>=min``.
+This follows the universal convention (pip, npm, cargo) where an
+unspecified upper bound means no upper bound.
 """
 
 from __future__ import annotations
@@ -23,6 +25,11 @@ def _derive_exclusive_max(min_str: str) -> Version:
     """Derive exclusive upper bound from a min version string.
 
     '1.1.6' -> Version('1.2.0')
+
+    .. deprecated::
+        This function is retained for backward compatibility but no longer
+        called by :func:`check_plugin_version_compat`.  An unspecified ``max``
+        now means *no upper bound* instead of a derived exclusive bound.
     """
     parts = min_str.split(".")
     major = int(parts[0])
@@ -51,16 +58,13 @@ def check_plugin_version_compat(
     qv = manifest.qwenpaw_version
     if qv is not None:
         min_v = Version(qv.min)
-        max_v = Version(qv.max) if qv.max else _derive_exclusive_max(qv.min)
+        max_v = Version(qv.max) if qv.max else None
     else:
         min_v = Version(manifest.min_version)
-        max_v = (
-            Version(manifest.max_version)
-            if manifest.max_version
-            else _derive_exclusive_max(manifest.min_version)
-        )
+        max_v = Version(manifest.max_version) if manifest.max_version else None
 
-    if current < min_v or current >= max_v:
-        msg = f"requires QwenPaw >={min_v}, <{max_v}, current is {current}"
+    if current < min_v or (max_v is not None and current >= max_v):
+        upper = f", <{max_v}" if max_v is not None else ""
+        msg = f"requires QwenPaw >={min_v}{upper}, current is {current}"
         return False, msg
     return True, ""

--- a/tests/unit/plugins/test_download_catalog.py
+++ b/tests/unit/plugins/test_download_catalog.py
@@ -10,12 +10,14 @@ def test_entry_with_qwenpaw_version_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        "qwenpaw_version": {"min": "1.1.6", "max": "2.1.0"},
+        # Exclusive upper bound: current 2.1.0b1 is treated as 2.1.0.
+        "qwenpaw_version": {"min": "1.1.6", "max": "2.2.0"},
     }
     assert _is_entry_compatible(entry) is True
 
 
 def test_entry_with_qwenpaw_version_incompatible() -> None:
+    """Declared max excludes a newer running QwenPaw."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
@@ -28,7 +30,8 @@ def test_entry_with_only_min_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        "qwenpaw_version": {"min": "2.0.0"},
+        # No max specified: no upper bound enforced.
+        "qwenpaw_version": {"min": "2.1.0"},
     }
     assert _is_entry_compatible(entry) is True
 
@@ -57,7 +60,7 @@ def test_entry_with_malformed_qwenpaw_version_falls_to_legacy() -> None:
         "version": "1.0.0",
         "qwenpaw_version": "not-a-dict",
         "min_version": "1.0.0",
-        "max_version": "2.1.0",
+        "max_version": "2.2.0",
     }
     assert _is_entry_compatible(entry) is True
 
@@ -77,7 +80,7 @@ def test_legacy_min_version_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        "min_version": "2.0.0",
+        "min_version": "2.1.0",
     }
     assert _is_entry_compatible(entry) is True
 
@@ -98,7 +101,7 @@ def test_legacy_min_max_version_compatible() -> None:
         "id": "demo",
         "version": "1.0.0",
         "min_version": "1.0.0",
-        "max_version": "2.1.0",
+        "max_version": "2.2.0",
     }
     assert _is_entry_compatible(entry) is True
 


### PR DESCRIPTION
## Description

This PR proposes a **permanent** max-version compatibility semantics for plugins, as a follow-up to the temporary fix in #6532.

### Background

Issue #6496 reported that legacy plugins with only `min_version` (or the default `0.1.0`) were silently disabled because `_derive_exclusive_max()` implicitly derived an upper bound that rejected the current QwenPaw version.

#6532 fixed this by **temporarily disabling all upper-bound (`max`) checks** — including both the implicit derivation and explicit `max` values. Only `>= min` is enforced.

### This PR (permanent semantics)

Instead of disabling all max checks, this PR:

1. **Removes the implicit `_derive_exclusive_max()` derivation** — when no `max` is specified, there is no upper bound (consistent with pip/npm/cargo conventions).
2. **Still honors an explicit `max`** — if a plugin declares `max: "2.1.0"`, that upper bound is enforced.

### Comparison

| Case | This PR | #6532 (current `main`) |
|------|---------|------------------------|
| no `max` (legacy plugins) | ✅ compatible | ✅ compatible |
| explicit `max` below current version | ❌ incompatible (max enforced) | ✅ compatible (max ignored) |

### Why keep this PR open?

When the team is ready to restore full `>=min, <max` enforcement, this PR provides the correct long-term semantics: "no max ⇒ no upper bound", while still respecting explicit max declarations. It is a strict improvement over the temporary "ignore max entirely" approach in #6532.

## Type of Change

- [x] Bug fix (non-breaking)

## Component(s) Affected

- [x] Core
- [x] Tests

## Checklist

- [x] `black` passes
- [x] `flake8` passes
- [x] `pytest` passes (12 tests in relevant module)

## Testing

```bash
black src/qwenpaw/_version_compat.py tests/unit/plugins/test_download_catalog.py
# All done ✅

flake8 src/qwenpaw/_version_compat.py tests/unit/plugins/test_download_catalog.py
# No issues ✅

pytest tests/unit/plugins/test_download_catalog.py -v
# 12 passed ✅
```

### End-to-end verification

- Legacy plugin with only `min_version`: `enabled: true, loaded: true` ✅
- Tool count increased by 1 (28 → 29) ✅
- No WARNING about version incompatibility ✅
