### PR TITLE
fix(plugin-version): remove implicit max version derivation; keep explicit max check

### DIFF
--- a/src/qwenpaw/_version_compat.py
+++ b/src/qwenpaw/_version_compat.py
@@ -2,12 +2,10 @@
 """Plugin–QwenPaw version compatibility check.
 
 Semantics: left-closed, right-open interval  ``>=min, <max``.
-When ``max`` is not specified, it is derived from ``min`` as
-``{major}.{minor+1}.0`` (all patch versions of the same minor).
-
-NOTE: Upper-bound (``max``) enforcement is temporarily disabled.
-Restore the commented check in ``check_plugin_version_compat`` when
-re-enabling full range checks.
+When ``max`` is not specified, no upper bound is enforced — the plugin
+is considered compatible with any QwenPaw version that satisfies ``>=min``.
+This follows the universal convention (pip, npm, cargo) where an
+unspecified upper bound means no upper bound.
 """
 
 from __future__ import annotations
@@ -27,6 +25,11 @@ def _derive_exclusive_max(min_str: str) -> Version:
     """Derive exclusive upper bound from a min version string.
 
     '1.1.6' -> Version('1.2.0')
+
+    .. deprecated::
+        This function is retained for backward compatibility but no longer
+        called by :func:`check_plugin_version_compat`.  An unspecified ``max``
+        now means *no upper bound* instead of a derived exclusive bound.
     """
     parts = min_str.split(".")
     major = int(parts[0])
@@ -55,24 +58,13 @@ def check_plugin_version_compat(
     qv = manifest.qwenpaw_version
     if qv is not None:
         min_v = Version(qv.min)
-        max_v = Version(qv.max) if qv.max else _derive_exclusive_max(qv.min)
+        max_v = Version(qv.max) if qv.max else None
     else:
         min_v = Version(manifest.min_version)
-        max_v = (
-            Version(manifest.max_version)
-            if manifest.max_version
-            else _derive_exclusive_max(manifest.min_version)
-        )
+        max_v = Version(manifest.max_version) if manifest.max_version else None
 
-    # Temporary: only enforce >= min.  Original full-range check:
-    # if current < min_v or current >= max_v:
-    #     msg = (
-    #         f"requires QwenPaw >={min_v}, <{max_v}, current is {current}"
-    #     )
-    #     return False, msg
-    # return True, ""
-    if current < min_v:
-        msg = f"requires QwenPaw >={min_v}, current is {current}"
+    if current < min_v or (max_v is not None and current >= max_v):
+        upper = f", <{max_v}" if max_v is not None else ""
+        msg = f"requires QwenPaw >={min_v}{upper}, current is {current}"
         return False, msg
-    _ = max_v  # retained for restoring the upper-bound check above
     return True, ""

--- a/tests/unit/plugins/test_download_catalog.py
+++ b/tests/unit/plugins/test_download_catalog.py
@@ -16,21 +16,21 @@ def test_entry_with_qwenpaw_version_compatible() -> None:
     assert _is_entry_compatible(entry) is True
 
 
-def test_entry_with_qwenpaw_version_max_ignored() -> None:
-    """Declared max must not exclude a newer running QwenPaw."""
+def test_entry_with_qwenpaw_version_incompatible() -> None:
+    """Declared max excludes a newer running QwenPaw."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
         "qwenpaw_version": {"min": "0.1.0", "max": "1.1.0"},
     }
-    assert _is_entry_compatible(entry) is True
+    assert _is_entry_compatible(entry) is False
 
 
 def test_entry_with_only_min_compatible() -> None:
     entry = {
         "id": "demo",
         "version": "1.0.0",
-        # Derived exclusive max is 2.2.0 for min 2.1.0.
+        # No max specified: no upper bound enforced.
         "qwenpaw_version": {"min": "2.1.0"},
     }
     assert _is_entry_compatible(entry) is True
@@ -96,7 +96,7 @@ def test_legacy_min_version_incompatible() -> None:
 
 
 def test_legacy_min_max_version_compatible() -> None:
-    """Legacy min+max still loads when min is satisfied (max ignored)."""
+    """Legacy min+max range covering current QwenPaw is compatible."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
@@ -106,15 +106,15 @@ def test_legacy_min_max_version_compatible() -> None:
     assert _is_entry_compatible(entry) is True
 
 
-def test_legacy_max_version_ignored() -> None:
-    """Legacy max_version alone must not make an entry incompatible."""
+def test_legacy_min_max_version_incompatible() -> None:
+    """Legacy min+max range not covering current QwenPaw."""
     entry = {
         "id": "demo",
         "version": "1.0.0",
         "min_version": "0.1.0",
         "max_version": "1.0.0",
     }
-    assert _is_entry_compatible(entry) is True
+    assert _is_entry_compatible(entry) is False
 
 
 def test_entry_with_empty_dict_qwenpaw_version() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #6532 (temporary fix) — permanent max-version semantics.

When a plugin does not specify `max_version`, no upper bound should be **implicitly derived**. This matches the convention used by `pip`, `npm`, and `cargo`. Explicit `max_version` is still enforced when provided.

## What Problem This Solves

`_derive_exclusive_max()` was called even when the plugin author did not specify `max_version`, producing a spurious upper bound that caused compatible plugins to be silently disabled (issue #6496).

## Fix

- **New API path** (`qwenpaw_version`): if `max_version` is `None`, skip the upper-bound check entirely.
- **Legacy path** (`min_version`/`max_version`): if `max_version` is `None`, do not call `_derive_exclusive_max()`.
- `_derive_exclusive_max()` is retained but no longer called.
- Explicit `max_version` is still checked when provided.

## Comparison with #6532

| | #6532 (merged, temporary) | This PR (permanent) |
|---|---|---|
| Implicit max derivation | ❌ disabled | ❌ disabled |
| **Explicit max check** | ❌ **disabled** | ✅ **enforced** |

#6532 disabled **all** max-version checks (including explicit ones) as an emergency fix. This PR restores the explicit `max_version` check while keeping the implicit derivation removed.

## Testing

- `black` ✅
- `flake8` ✅
- `pytest` ✅ (all existing tests pass)
- End-to-end: legacy plugin with no `max_version` → `enabled: true, loaded: true`; tool count increased by 1; no WARNING.

Supersedes #6497 and #6574.