### PR TITLE
test(e2e): add sprint4/5 coverage - sidebar, memory, inbox, plugins, slash commands (15 cases)

### DIFF
--- a/e2e/mocks/plugin_market.py
+++ b/e2e/mocks/plugin_market.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Targeted route mocks for the Plugin Market compatibility feature.
+
+Unlike the ``register_all`` smoke mocks, these are meant to be layered on
+top of a *real* backend inside integration tests: only the market catalog,
+version probe and install endpoints are intercepted, because the market
+catalog is fetched from the network (platform.agentscope.io proxy) and is
+not seedable locally.
+
+Response shapes mirror ``console/src/api/modules/pluginMarket.ts``
+(``MarketPluginListResponse`` / ``MarketPluginEntry``) and
+``useMarketPlugins.ts`` (``/api/version`` -> ``{"version": ...}``).
+"""
+from __future__ import annotations
+
+import json
+
+from playwright.sync_api import Page
+
+# Names are matched by the tests — keep them unique enough to locate rows.
+COMPATIBLE_PLUGIN_NAME = "E2E Compat Plugin"
+INCOMPATIBLE_PLUGIN_NAME = "E2E Legacy Plugin"
+
+# Backend version reported to the frontend; deriveCompatLabel() turns it
+# into the "2.x" label used for the includes() check.
+MOCK_QWENPAW_VERSION = "2.0.0"
+
+_MARKET_PLUGINS = [
+    {
+        "id": "e2e-compat-plugin",
+        "display_name": COMPATIBLE_PLUGIN_NAME,
+        "developer": "e2e",
+        "owner": "e2e",
+        "version": "1.0.0",
+        "logo_url": None,
+        "downloads": 42,
+        "view_count": 100,
+        "details_url": None,
+        "locales": {
+            "en": {"description": "Compatible test plugin", "category": "tools"},
+            "zh": {"description": "兼容性测试插件", "category": "tools"},
+        },
+        "qwenpaw_compat_labels": ["2.x"],
+        "is_featured": False,
+    },
+    {
+        "id": "e2e-legacy-plugin",
+        "display_name": INCOMPATIBLE_PLUGIN_NAME,
+        "developer": "e2e",
+        "owner": "e2e",
+        "version": "0.9.0",
+        "logo_url": None,
+        "downloads": 7,
+        "view_count": 10,
+        "details_url": None,
+        "locales": {
+            "en": {"description": "Incompatible test plugin", "category": "tools"},
+            "zh": {"description": "不兼容测试插件", "category": "tools"},
+        },
+        "qwenpaw_compat_labels": ["1.x"],
+        "is_featured": False,
+    },
+]
+
+
+def register(page: Page) -> None:
+    """Intercept market search / version / install for one page."""
+
+    def _handle_search(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "success": True,
+                    "message": "",
+                    "data": {
+                        "total": len(_MARKET_PLUGINS),
+                        "plugins": _MARKET_PLUGINS,
+                    },
+                }
+            ),
+        )
+
+    def _handle_version(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"version": MOCK_QWENPAW_VERSION}),
+        )
+
+    def _handle_install(route):
+        # Never let a mocked install reach the real CDN / plugin loader.
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "id": "e2e-legacy-plugin",
+                    "name": INCOMPATIBLE_PLUGIN_NAME,
+                    "version": "0.9.0",
+                    "description": "mocked install",
+                    "loaded": True,
+                    "message": "",
+                }
+            ),
+        )
+
+    page.route("**/api/plugins/market/search*", _handle_search)
+    page.route("**/api/version", _handle_version)
+    page.route("**/api/plugins/install", _handle_install)

--- a/e2e/mocks/sidebar_sessions.py
+++ b/e2e/mocks/sidebar_sessions.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Targeted route mock for the sidebar session-list date grouping.
+
+The backend cannot backfill ``created_at`` / ``updated_at`` (patch forces
+"now"), so date-group buckets (Today / Within 7 days / Within 30 days /
+Earlier / Pinned) can only be exercised by intercepting the sidebar list
+request ``GET /api/chats?archived=false`` and returning sessions with
+crafted timestamps.
+
+Only the exact list GET is intercepted; every other ``/api/chats``
+request (POST create, per-chat GET/DELETE, messages, ...) falls through
+to the real backend via ``route.fallback()``.
+
+Shape mirrors ``console/src/api/types/chat.ts`` (``ChatSpec[]``, plain
+array, snake_case fields). Grouping uses ``updated_at ?? created_at``
+per ``console/src/utils/sessionGrouping.ts``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from playwright.sync_api import Page
+
+# Session names asserted by SIDEBAR-001.
+TODAY_NAME = "E2E Group Today"
+WEEK_NAME = "E2E Group Week"
+MONTH_NAME = "E2E Group Month"
+OLDER_NAME = "E2E Group Older"
+PINNED_NAME = "E2E Group Pinned"
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _build_sessions() -> list:
+    now = datetime.now(timezone.utc)
+    entries = [
+        # (id, name, age, pinned)
+        ("e2e-group-today", TODAY_NAME, timedelta(hours=1), False),
+        ("e2e-group-week", WEEK_NAME, timedelta(days=3), False),
+        ("e2e-group-month", MONTH_NAME, timedelta(days=10), False),
+        ("e2e-group-older", OLDER_NAME, timedelta(days=60), False),
+        ("e2e-group-pinned", PINNED_NAME, timedelta(days=2), True),
+    ]
+    sessions = []
+    for sid, name, age, pinned in entries:
+        ts = _iso(now - age)
+        sessions.append(
+            {
+                "id": sid,
+                "session_id": f"console:{sid}",
+                "user_id": "admin",
+                "channel": "console",
+                "name": name,
+                "created_at": ts,
+                "updated_at": ts,
+                "meta": {},
+                "status": "idle",
+                "pinned": pinned,
+                "archived_at": None,
+                "archived": False,
+            }
+        )
+    return sessions
+
+
+def register(page: Page) -> None:
+    """Intercept the sidebar session-list GET for one page.
+
+    The sidebar polls every ~3s; the mock stays registered and serves
+    identical data on every poll so groups never flap mid-test.
+    """
+    sessions = _build_sessions()
+
+    def _handle(route):
+        request = route.request
+        path = request.url.split("?")[0].rstrip("/")
+        if request.method == "GET" and path.endswith("/api/chats"):
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(sessions),
+            )
+        else:
+            route.fallback()
+
+    page.route("**/api/chats*", _handle)

--- a/e2e/pages/agents_page.py
+++ b/e2e/pages/agents_page.py
@@ -60,16 +60,19 @@ class AgentsPage(BasePage):
 
     # Action buttons
     CREATE_AGENT_BTN = 'button:has-text("创建智能体"), button:has-text("Create Agent"), .qwenpaw-btn-primary'
-    # Inline action buttons in a table row. Post-redesign (upstream #6198) the
-    # actions are 4 icon buttons in order: Pin | Edit | Toggle | Delete. Anchor
-    # on the icon (not Space position) so the added Pin button can't shift us:
+    # Inline action buttons in a table row. Post v2.0.1 (#6262 added a Copy
+    # button at position 3) the actions are 5 icon buttons in order:
+    # Pin | Edit | Copy | Toggle | Delete. Anchor on icon semantics only —
+    # positional fallbacks like :nth-child(N) go stale whenever upstream
+    # inserts a button (exactly what broke AGENT-005 on v2.0.1):
     #   Edit   = antd EditOutlined    -> .anticon-edit
+    #   Copy   = antd CopyOutlined    -> .anticon-copy   (do not match)
     #   Toggle = lucide Eye/EyeOff    -> svg.lucide-eye / svg.lucide-eye-off
     #   Delete = antd DeleteOutlined  -> .anticon-delete (danger button)
     EDIT_BTN = 'button:has(.anticon-edit)'
-    TOGGLE_BTN = 'button:has(svg.lucide-eye-off), button:has(svg.lucide-eye), .qwenpaw-space-item:nth-child(3) button'
+    TOGGLE_BTN = 'button:has(svg.lucide-eye-off), button:has(svg.lucide-eye)'
     DELETE_BTN = 'button.qwenpaw-btn-dangerous, button:has(.anticon-delete)'
-    ENABLE_TOGGLE = 'button:has(svg.lucide-eye-off), button:has(svg.lucide-eye), .qwenpaw-space-item:nth-child(3) button'
+    ENABLE_TOGGLE = 'button:has(svg.lucide-eye-off), button:has(svg.lucide-eye)'
     REFRESH_BTN = 'button:has(.anticon-reload), button:has(.spark-icon-spark-refresh-line)'
 
     # Create/edit form

--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -144,7 +144,12 @@ class ChatPage(BasePage):
 
     # --- Slash-command suggestion popup (@ant-design/x Suggestion) ---
     # Opens while the input starts with "/" and has no whitespace yet.
-    SUGGESTION_POPUP = '.qwenpaw-suggestion'
+    # Two nodes carry .qwenpaw-suggestion (inline content + the cascader
+    # dropdown); anchor on the dropdown, excluding its hidden state.
+    SUGGESTION_POPUP = (
+        '.qwenpaw-suggestion.qwenpaw-select-dropdown'
+        ':not(.qwenpaw-select-dropdown-hidden)'
+    )
     SUGGESTION_ITEM = '.qwenpaw-suggestion-item'
 
     # --- Sidebar session date groups — upstream #5643 ---

--- a/e2e/pages/chat_page.py
+++ b/e2e/pages/chat_page.py
@@ -130,6 +130,46 @@ class ChatPage(BasePage):
     MODEL_OPTION = '.qwenpaw-dropdown-menu-item'
     AGENT_SELECTOR = '.qwenpaw-select-selector'
 
+    # --- Sidebar agent switcher (components/AgentSelector) ---
+    # The antd Select sits inside a CSS-module wrapper whose hashed class
+    # keeps the "agentSelector" basename; scoping avoids other Selects.
+    AGENT_SWITCHER = '[class*="agentSelector"] .qwenpaw-select-selector'
+    AGENT_SWITCHER_VALUE = (
+        '[class*="agentSelector"] .qwenpaw-select-selection-item'
+    )
+    AGENT_SWITCHER_OPTION = (
+        '.qwenpaw-select-dropdown:not(.qwenpaw-select-dropdown-hidden) '
+        '.qwenpaw-select-item-option'
+    )
+
+    # --- Slash-command suggestion popup (@ant-design/x Suggestion) ---
+    # Opens while the input starts with "/" and has no whitespace yet.
+    SUGGESTION_POPUP = '.qwenpaw-suggestion'
+    SUGGESTION_ITEM = '.qwenpaw-suggestion-item'
+
+    # --- Sidebar session date groups — upstream #5643 ---
+    # SidebarSessionList renders one <button class={styles.groupLabel}> per
+    # non-empty bucket (Pinned / Today / Within 7 days / Within 30 days /
+    # Earlier); clicking toggles collapse. "month" + "older" start collapsed.
+    SIDEBAR_GROUP_LABEL = 'button[class*="groupLabel"]'
+    SIDEBAR_GROUP_CHEVRON = 'span[class*="groupChevron"]'
+    SIDEBAR_GROUP_TEXTS = {
+        "pinned": ("Pinned", "置顶"),
+        "today": ("Today", "今天"),
+        "week": ("Within 7 days", "7天内"),
+        "month": ("Within 30 days", "30天内"),
+        "older": ("Earlier", "更早"),
+    }
+
+    # --- Non-owner tab banner — upstream #5664 ---
+    # antd <Alert type="info" banner> injected into the sender beforeUI slot
+    # when this tab lost the qwenpaw:queue-owner:<sessionId> Web Lock. Appears
+    # only after a 300ms ownershipResolved fallback timer.
+    QUEUE_BANNER = '.qwenpaw-alert-banner'
+    _QUEUE_BANNER_RE = re.compile(
+        r"This tab queues only|当前标签页仅入队"
+    )
+
     # Action buttons
     COPY_BTN = 'span[title="复制"]'
 
@@ -1131,6 +1171,45 @@ class ChatPage(BasePage):
                 return out;
             }"""
         )
+
+    # ========== Sidebar date groups (upstream #5643) ==========
+
+    def get_sidebar_group_header(self, group: str) -> Locator:
+        """Locator for one sidebar date-group header button.
+
+        Args:
+            group: bucket key — pinned / today / week / month / older.
+        """
+        en, zh = self.SIDEBAR_GROUP_TEXTS[group]
+        return self.page.locator(
+            f'{self.SIDEBAR_GROUP_LABEL}:has-text("{en}"), '
+            f'{self.SIDEBAR_GROUP_LABEL}:has-text("{zh}")'
+        ).first
+
+    def toggle_sidebar_group(self, group: str) -> "ChatPage":
+        """Click a sidebar group header to collapse / expand it."""
+        logger.info(f"Toggling sidebar group '{group}'")
+        self.get_sidebar_group_header(group).click()
+        self.wait(300)
+        return self
+
+    def get_sidebar_session_by_name(self, name: str) -> Locator:
+        """Sidebar session row matched by its display name.
+
+        Scoped away from the All-Chats drawer by requiring the row to sit
+        under the sidebar group list (sibling of ``groupLabel`` buttons).
+        """
+        return self.page.locator(
+            f'div[role="button"][class*="item"]:has-text("{name}")'
+        ).first
+
+    # ========== Non-owner tab banner (upstream #5664) ==========
+
+    def get_queue_banner(self) -> Locator:
+        """The queue-only info banner in the sender area (non-owner tab)."""
+        return self.page.locator(self.QUEUE_BANNER).filter(
+            has_text=self._QUEUE_BANNER_RE
+        ).first
 
     # ========== Model and Agent switching ==========
     

--- a/e2e/pages/inbox_page.py
+++ b/e2e/pages/inbox_page.py
@@ -102,6 +102,15 @@ class InboxPage(BasePage):
         'text=/(No push messages|暂无推送消息)/'
     )
 
+    # Per-card delete (Trash icon, antd Button danger => -dangerous class)
+    CARD_DELETE_BTN = 'button.qwenpaw-btn-dangerous'
+
+    # Toolbar "Mark all read" button
+    MARK_ALL_READ_BTN = (
+        'button:has-text("Mark all read"), '
+        'button:has-text("全部标记已读")'
+    )
+
     # ========== Workspace path helpers ==========
 
     @staticmethod

--- a/e2e/pages/memory_page.py
+++ b/e2e/pages/memory_page.py
@@ -77,6 +77,12 @@ class MemoryPage(BasePage):
     REME_MEMORY_TAB = '[data-node-key="remeLightMemory"]'
     ADBPG_MEMORY_TAB = '[data-node-key="adbpgMemory"]'
     BACKEND_SELECT = '#memory_manager_backend'
+    # antd Select: the inner input is readonly; clicks must land on the
+    # surrounding selector box, not on #memory_manager_backend itself.
+    BACKEND_SELECT_TRIGGER = (
+        '.qwenpaw-select:has(#memory_manager_backend) '
+        '.qwenpaw-select-selector'
+    )
     BACKEND_OPTION = (
         '.qwenpaw-select-dropdown:not(.qwenpaw-select-dropdown-hidden) '
         '.qwenpaw-select-item-option'

--- a/e2e/pages/memory_page.py
+++ b/e2e/pages/memory_page.py
@@ -7,12 +7,13 @@ config (which holds ``reme_light_memory_config``), plus locator
 anchors for the Long-term Memory card on /agent-config.
 
 Cases covered:
-- MEM-001 P0  test_daily_memory_crud
-- MEM-002 P1  test_running_config_persistence
+- MEM-001 P1  test_auto_memory_interval_persistence
+- MEM-002 P1  test_dream_cron_persistence
 - MEM-003 P1  test_memory_card_ui_renders
 - MEM-004 P1  test_workspace_memory_md_expand
 - MEM-005 P2  test_memory_search_recall_seeded         (xfail, requires_llm)
-- MEM-006 P2  test_daily_memory_path_traversal_blocked
+- MEM-006 P2  test_memory_backend_select_switches_tabs
+- MEM-007 P2  test_auto_memory_search_toggle_and_max_results
 """
 from __future__ import annotations
 
@@ -50,6 +51,43 @@ class MemoryPage(BasePage):
     SUMMARIZE_SWITCH = (
         'button[role="switch"][id$="reme_light_memory_config_summarize_when_compact"]'
     )
+    # --- Long-term Memory card fields (ReMeLightMemoryCard.tsx) ---
+    AUTO_MEMORY_INTERVAL_INPUT = (
+        'input[id$="reme_light_memory_config_auto_memory_interval"]'
+    )
+    DREAM_CRON_ENABLED_SWITCH = (
+        'button[role="switch"]'
+        '[id$="reme_light_memory_config_dream_cron_enabled"]'
+    )
+    # Auto Memory Search collapse (forceRender: children always in DOM,
+    # visible only once the panel is expanded).
+    AUTO_SEARCH_COLLAPSE_HEADER = (
+        '.qwenpaw-collapse-header:has-text("Auto Memory Search"), '
+        '.qwenpaw-collapse-header:has-text("自动记忆搜索")'
+    )
+    AUTO_SEARCH_SWITCH = (
+        'button[role="switch"]'
+        '[id$="auto_memory_search_config_enabled"]'
+    )
+    AUTO_SEARCH_MAX_RESULTS_INPUT = (
+        'input[id$="auto_memory_search_config_max_results"]'
+    )
+    # --- ReAct Agent tab: memory backend select (ReactAgentCard.tsx) ---
+    REACT_TAB = '[data-node-key="reactAgent"] .qwenpaw-tabs-tab-btn'
+    REME_MEMORY_TAB = '[data-node-key="remeLightMemory"]'
+    ADBPG_MEMORY_TAB = '[data-node-key="adbpgMemory"]'
+    BACKEND_SELECT = '#memory_manager_backend'
+    BACKEND_OPTION = (
+        '.qwenpaw-select-dropdown:not(.qwenpaw-select-dropdown-hidden) '
+        '.qwenpaw-select-item-option'
+    )
+    # --- Save footer + toast ---
+    SAVE_BTN = (
+        'button.qwenpaw-btn-primary:has-text("Save"), '
+        'button.qwenpaw-btn-primary:has-text("保存"), '
+        'button.qwenpaw-btn-primary:has-text("保 存")'
+    )
+    SUCCESS_TOAST = '.qwenpaw-message-success'
 
     # localStorage agent storage — see CodingPage for the rationale.
     AGENT_ID_DEFAULT = "default"
@@ -116,6 +154,17 @@ class MemoryPage(BasePage):
     def click_memory_tab(self) -> None:
         self.page.locator(self.MEMORY_TAB).first.click(timeout=self.timeout)
 
+    def click_react_tab(self) -> None:
+        self.page.locator(self.REACT_TAB).first.click(timeout=self.timeout)
+        self.page.wait_for_timeout(800)
+
+    def click_save(self) -> None:
+        """Click the footer Save button and wait for the request."""
+        save_btn = self.page.locator(self.SAVE_BTN).first
+        expect(save_btn).to_be_visible(timeout=self.timeout)
+        save_btn.click()
+        self.page.wait_for_timeout(1500)
+
     # ========== API helpers (UI test setup only) ==========
     #
     # Pure API contract tests for /api/workspace/memory live in
@@ -138,3 +187,35 @@ class MemoryPage(BasePage):
             f"Write memory failed [{resp.status}]: {resp.text()}"
         )
         return resp.json()
+
+    def api_get_running_config(self, api_context) -> dict:
+        """GET /api/workspace/running-config — snapshot for restore."""
+        resp = api_context.get(
+            "/api/workspace/running-config",
+            headers=self._agent_headers(),
+        )
+        assert resp.ok, (
+            f"Get running config failed [{resp.status}]: {resp.text()}"
+        )
+        return resp.json()
+
+    def api_put_running_config(self, api_context, cfg: dict) -> None:
+        """PUT /api/workspace/running-config — restore snapshot.
+
+        Best-effort teardown helper: partial PUTs are unsupported, so
+        callers must pass the full config object captured beforehand.
+        """
+        try:
+            resp = api_context.put(
+                "/api/workspace/running-config",
+                data=cfg,
+                headers=self._agent_headers(),
+            )
+            if not resp.ok:
+                logger.warning(
+                    "Restore running config failed [%s]: %s",
+                    resp.status,
+                    resp.text(),
+                )
+        except Exception as exc:  # pragma: no cover — teardown only
+            logger.warning("Restore running config errored: %s", exc)

--- a/e2e/pages/plugin_page.py
+++ b/e2e/pages/plugin_page.py
@@ -12,6 +12,8 @@ UI-driven helpers.
 
 Cases covered:
 - PLUGIN-001 P0  test_plugin_manager_page_loads
+- COMPAT-001 P1  test_market_compat_tags_render
+- COMPAT-002 P1  test_incompatible_install_warning_modal
 """
 from __future__ import annotations
 
@@ -53,6 +55,32 @@ class PluginPage(BasePage):
     TAB_OFFICIAL = (
         '.qwenpaw-tabs-tab:has-text("Official"), '
         '.qwenpaw-tabs-tab:has-text("官方")'
+    )
+    TAB_MARKET = (
+        '.qwenpaw-tabs-tab:has-text("Plugin Market"), '
+        '.qwenpaw-tabs-tab:has-text("插件市场")'
+    )
+
+    # ----- Plugin Market compatibility (upstream #5661) -----
+    # Catalog rows share CSS-module classes with the Official list
+    # (OfficialPluginList.module.less), matched by basename substring.
+    MARKET_ROW = '[class*="catalogRow"]'
+    # antd Tag with prefixCls=qwenpaw; text is "QwenPaw <labels>"
+    COMPAT_TAG_GREEN = '.qwenpaw-tag-green:has-text("QwenPaw")'
+    COMPAT_TAG_ORANGE = '.qwenpaw-tag-orange:has-text("QwenPaw")'
+    MARKET_INSTALL_BTN = (
+        '[class*="catalogActions"] button:has-text("Install"), '
+        '[class*="catalogActions"] button:has-text("安装")'
+    )
+    # Modal.confirm for incompatible installs
+    COMPAT_MODAL = '.qwenpaw-modal-confirm'
+    COMPAT_MODAL_TITLE = (
+        '.qwenpaw-modal-confirm-title:has-text("Compatibility Warning"), '
+        '.qwenpaw-modal-confirm-title:has-text("兼容性警告")'
+    )
+    COMPAT_MODAL_OK = (
+        '.qwenpaw-modal-confirm-btns button:has-text("Install anyway"), '
+        '.qwenpaw-modal-confirm-btns button:has-text("仍然安装")'
     )
 
     # Empty-state text inside the installed table

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -31,6 +31,7 @@ markers =
     # ----- Modules (mapped to tests/test_*.py) -----
     chat: Chat module
     chat_core: Chat core scenarios (legacy alias, new tests should use chat)
+    chat_sidebar: Chat sidebar date groups + multi-tab banner (Sprint 4, upstream #5643/#5664)
     tool_approval: Chat tool approval level toggle (Sprint 4, upstream #5685)
     channels: Channels module
     coding: Coding Mode module

--- a/e2e/tests/test_chat_sidebar.py
+++ b/e2e/tests/test_chat_sidebar.py
@@ -51,6 +51,13 @@ class TestSidebarDateGroups:
 
         log_test_step("1. Mock the sidebar list with 5 crafted-timestamp sessions")
         sidebar_sessions.register(page)
+        # SidebarSessionList only mounts in the sidebar's *simple* mode
+        # (Sidebar.tsx: isSimpleExpanded branch); the default is "full"
+        # nav mode, so pin simple mode before the app boots.
+        page.add_init_script(
+            "try { localStorage.setItem('qwenpaw_sidebar_mode', 'simple'); }"
+            " catch (e) {}"
+        )
         chat = ChatPage(page)
         chat.open()
 

--- a/e2e/tests/test_chat_sidebar.py
+++ b/e2e/tests/test_chat_sidebar.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""
+QwenPaw Chat sidebar & multi-tab end-to-end tests (Sprint 4).
+
+Cases:
+- SIDEBAR-001  P1  test_sidebar_date_groups_and_collapse   (upstream #5643)
+- MULTITAB-001 P2  test_non_owner_tab_shows_queue_banner   (upstream #5664)
+
+SIDEBAR-001 mocks ``GET /api/chats?archived=false`` via page.route because
+the backend cannot backfill timestamps (patch forces "now"), so date
+buckets are otherwise impossible to construct. All assertions stay UI-side.
+
+MULTITAB-001 uses two real pages in the SAME browser context (Web Locks
+are shared per origin per context): the first page grabs the
+``qwenpaw:queue-owner:<sessionId>`` lock, the second becomes queue-only
+and must render the info banner in the sender area.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from playwright.sync_api import expect
+
+from pages.chat_page import ChatPage
+from mocks import sidebar_sessions
+from config.settings import config
+from utils.helpers import log_test_step, log_test_result
+
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# SIDEBAR-001 P1 — sidebar session date grouping (upstream #5643)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.chat_sidebar
+class TestSidebarDateGroups:
+    """Sidebar buckets: Pinned/Today/7d/30d/Earlier + collapse toggling."""
+
+    @pytest.mark.test_id("SIDEBAR-001")
+    def test_sidebar_date_groups_and_collapse(
+        self,
+        page,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        log_test_step("1. Mock the sidebar list with 5 crafted-timestamp sessions")
+        sidebar_sessions.register(page)
+        chat = ChatPage(page)
+        chat.open()
+
+        log_test_step("2. All five group headers render")
+        for group in ("pinned", "today", "week", "month", "older"):
+            expect(chat.get_sidebar_group_header(group)).to_be_visible(
+                timeout=chat.timeout
+            )
+
+        log_test_step("3. Expanded groups show their sessions")
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.PINNED_NAME)
+        ).to_be_visible(timeout=chat.timeout)
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.TODAY_NAME)
+        ).to_be_visible(timeout=chat.timeout)
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.WEEK_NAME)
+        ).to_be_visible(timeout=chat.timeout)
+
+        log_test_step("4. 'Within 30 days' and 'Earlier' start collapsed")
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.MONTH_NAME)
+        ).not_to_be_visible(timeout=5000)
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.OLDER_NAME)
+        ).not_to_be_visible(timeout=5000)
+
+        log_test_step("5. Clicking 'Earlier' header expands its sessions")
+        chat.toggle_sidebar_group("older")
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.OLDER_NAME)
+        ).to_be_visible(timeout=chat.timeout)
+
+        log_test_step("6. Clicking again collapses it back")
+        chat.toggle_sidebar_group("older")
+        expect(
+            chat.get_sidebar_session_by_name(sidebar_sessions.OLDER_NAME)
+        ).not_to_be_visible(timeout=5000)
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+# ============================================================================
+# MULTITAB-001 P2 — non-owner tab queue banner (upstream #5664)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p2
+@pytest.mark.chat_sidebar
+class TestMultiTabQueueBanner:
+    """Second tab on the same session becomes queue-only and shows a banner."""
+
+    @pytest.mark.test_id("MULTITAB-001")
+    def test_non_owner_tab_shows_queue_banner(
+        self,
+        page,
+        api_context,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        log_test_step("1. Seed a chat via API so both tabs share one session id")
+        seed = api_context.post(
+            "/api/chats",
+            data={
+                "name": "E2E MultiTab Banner",
+                "user_id": config.test.user_id,
+                "channel": config.test.channel,
+                "session_id": f"{config.test.channel}:{config.test.user_id}",
+            },
+        )
+        if not seed.ok:
+            pytest.skip(f"chat seed failed ({seed.status}); cannot test banner")
+        chat_id = (seed.json() or {}).get("id")
+        if not chat_id:
+            pytest.skip("chat seed returned no id; cannot test banner")
+
+        session_url = f"{config.base_url}/chat/{chat_id}"
+        page2 = None
+        try:
+            log_test_step("2. Tab 1 opens the session and becomes lock owner")
+            chat1 = ChatPage(page)
+            page.goto(session_url, wait_until="commit", timeout=chat1.timeout)
+            expect(page.locator(chat1.CHAT_INPUT).first).to_be_visible(
+                timeout=chat1.timeout
+            )
+            # Give tab 1 time to win the ownership Web Lock (300ms resolve
+            # timer + lock acquisition).
+            page.wait_for_timeout(1500)
+
+            log_test_step("3. Tab 2 (same context) opens the same session URL")
+            page2 = page.context.new_page()
+            chat2 = ChatPage(page2)
+            page2.goto(session_url, wait_until="commit", timeout=chat2.timeout)
+            expect(page2.locator(chat2.CHAT_INPUT).first).to_be_visible(
+                timeout=chat2.timeout
+            )
+
+            log_test_step("4. Tab 2 shows the queue-only info banner")
+            expect(chat2.get_queue_banner()).to_be_visible(timeout=15000)
+
+            log_test_step("5. Tab 1 (owner) shows no banner")
+            expect(chat1.get_queue_banner()).not_to_be_visible(timeout=3000)
+
+            log_test_step("6. Closing tab 2 releases nothing it owned; owner keeps clean")
+            page2.close()
+            page2 = None
+            expect(chat1.get_queue_banner()).not_to_be_visible(timeout=3000)
+        finally:
+            if page2 is not None:
+                try:
+                    page2.close()
+                except Exception:
+                    pass
+            try:
+                api_context.delete(f"/api/chats/{chat_id}")
+            except Exception:
+                pass
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/e2e/tests/test_cross_module.py
+++ b/e2e/tests/test_cross_module.py
@@ -13,6 +13,7 @@ Run with: pytest tests/test_cross_module.py -v
 from __future__ import annotations
 
 import logging
+import re
 import time
 import pytest
 from playwright.sync_api import Page, expect, TimeoutError
@@ -689,3 +690,80 @@ class TestEnvAndRuntimeConfigFlow:
 
         log_test_result(test_name, True, 0)
         logger.info(f"Test {test_name} passed - environment variable and runtime config linkage verified")
+
+
+# ============================================================================
+# MA-001 P1 — sidebar Agent switcher (Agents API -> Chat sidebar)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.cross_module
+class TestAgentSwitcherInChat:
+    """MA-001: seed an agent via API, switch to it in the sidebar
+    AgentSelector, assert the trigger reflects the selection; restore."""
+
+    @pytest.mark.test_id("MA-001")
+    def test_agent_switcher_in_chat(
+        self,
+        page: Page,
+        api_context,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        from pages.agents_page import AgentsPage
+
+        test_name = request.node.name
+        chat = ChatPage(page)
+        agents_page = AgentsPage(page)
+        agent_name = f"E2E Switcher {int(time.time())}"
+        agent_id = None
+
+        log_test_step("1. Seed a fresh agent via API")
+        created = agents_page.api_create_agent(
+            api_context, agent_name, description="switcher probe"
+        )
+        agent_id = (created or {}).get("id")
+        if not agent_id:
+            pytest.skip(f"agent seed failed: {created!r}")
+
+        try:
+            log_test_step("2. Open /chat — AgentSelector mounts and fetches")
+            chat.open()
+            switcher = page.locator(chat.AGENT_SWITCHER).first
+            expect(switcher).to_be_visible(timeout=chat.timeout)
+
+            log_test_step("3. Open the switcher; seeded agent is listed")
+            switcher.click()
+            option = page.locator(chat.AGENT_SWITCHER_OPTION).filter(
+                has_text=agent_name
+            ).first
+            expect(option).to_be_visible(timeout=chat.timeout)
+
+            log_test_step("4. Select it; trigger label shows the agent name")
+            option.click()
+            page.wait_for_timeout(800)
+            value = page.locator(chat.AGENT_SWITCHER_VALUE).first
+            expect(value).to_contain_text(
+                agent_name, timeout=chat.timeout
+            )
+
+            log_test_step("5. Switch back to the default agent")
+            switcher.click()
+            default_option = page.locator(
+                chat.AGENT_SWITCHER_OPTION
+            ).filter(has_text=re.compile("Default Agent|默认智能体")).first
+            expect(default_option).to_be_visible(timeout=chat.timeout)
+            default_option.click()
+            page.wait_for_timeout(800)
+            expect(
+                page.locator(chat.AGENT_SWITCHER_VALUE).first
+            ).not_to_contain_text(agent_name, timeout=chat.timeout)
+        finally:
+            if agent_id:
+                try:
+                    agents_page.api_delete_agent(api_context, agent_id)
+                except Exception:
+                    pass
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")

--- a/e2e/tests/test_inbox.py
+++ b/e2e/tests/test_inbox.py
@@ -12,6 +12,8 @@ Cases:
 - INBOX-004 P1  test_message_card_renders_and_modal_opens
 - INBOX-005 P1  test_batch_mode_select_and_delete
 - INBOX-006 P1  test_sidebar_unread_dot_appears_with_seeded_event
+- INBOX-007 P1  test_single_card_delete
+- INBOX-008 P2  test_mark_all_read
 - SYNC-003  P2  test_skill_autosync_notification_card
 """
 from __future__ import annotations
@@ -376,6 +378,148 @@ class TestSkillAutoSyncInbox:
                 has_text=re.compile(r"Skill auto-sync|技能自动同步")
             )
             expect(title.first).to_be_visible(timeout=inbox_page.timeout)
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed")
+        finally:
+            inbox_page.clean_inbox()
+
+
+# ============================================================================
+# INBOX-007 P1  Single-card delete via the trash icon (+ Popconfirm)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.inbox
+class TestSingleCardDelete:
+    """INBOX-007: the per-card Trash button deletes exactly one message."""
+
+    @pytest.mark.test_id("INBOX-007")
+    def test_single_card_delete(
+        self,
+        inbox_page: InboxPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        try:
+            log_test_step("1. Seed 2 events and open /inbox")
+            inbox_page.clean_inbox()
+            inbox_page.seed_events([
+                inbox_page.make_event(
+                    event_id="evt-del-1",
+                    title="Cron delete target",
+                    body="to be deleted",
+                    read=True,
+                    created_at=time.time(),
+                ),
+                inbox_page.make_event(
+                    event_id="evt-keep-1",
+                    title="Cron survivor",
+                    body="should remain",
+                    read=True,
+                    created_at=time.time() - 60,
+                ),
+            ])
+            inbox_page.open()
+            cards = inbox_page.page.locator(inbox_page.MESSAGE_CARD)
+            expect(cards.first).to_be_visible(timeout=18000)
+            assert cards.count() == 2, f"expected 2 cards, got {cards.count()}"
+
+            log_test_step("2. Click the trash icon on the first card")
+            target = cards.filter(has_text="Cron delete target").first
+            expect(target).to_be_visible(timeout=inbox_page.timeout)
+            target.locator(inbox_page.CARD_DELETE_BTN).first.click()
+
+            log_test_step("3. Confirm the Popconfirm")
+            ok_btn = inbox_page.page.locator(inbox_page.POPCONFIRM_OK).first
+            expect(ok_btn).to_be_visible(timeout=inbox_page.timeout)
+            ok_btn.click()
+
+            log_test_step("4. Exactly the target card disappears")
+            expect(
+                inbox_page.page.locator(
+                    inbox_page.MESSAGE_CARD
+                ).filter(has_text="Cron delete target")
+            ).to_have_count(0, timeout=18000)
+            expect(
+                inbox_page.page.locator(
+                    inbox_page.MESSAGE_CARD
+                ).filter(has_text="Cron survivor").first
+            ).to_be_visible(timeout=inbox_page.timeout)
+
+            log_test_result(test_name, True, 0)
+            logger.info(f"Test {test_name} passed")
+        finally:
+            inbox_page.clean_inbox()
+
+
+# ============================================================================
+# INBOX-008 P2  "Mark all read" clears every unread dot
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p2
+@pytest.mark.inbox
+class TestMarkAllRead:
+    """INBOX-008: toolbar Mark-all-read flips all cards to read state."""
+
+    @pytest.mark.test_id("INBOX-008")
+    def test_mark_all_read(
+        self,
+        inbox_page: InboxPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        try:
+            log_test_step("1. Seed 2 unread events and open /inbox")
+            inbox_page.clean_inbox()
+            inbox_page.seed_events([
+                inbox_page.make_event(
+                    event_id="evt-unread-1",
+                    title="Cron unread one",
+                    read=False,
+                    created_at=time.time(),
+                ),
+                inbox_page.make_event(
+                    event_id="evt-unread-2",
+                    title="Cron unread two",
+                    read=False,
+                    created_at=time.time() - 60,
+                ),
+            ])
+            inbox_page.open()
+            cards = inbox_page.page.locator(inbox_page.MESSAGE_CARD)
+            expect(cards.first).to_be_visible(timeout=18000)
+
+            log_test_step("2. Unread dots are present on the cards")
+            dots = inbox_page.page.locator(
+                f"{inbox_page.MESSAGE_CARD} {inbox_page.UNREAD_DOT_IN_CARD}"
+            )
+            expect(dots.first).to_be_visible(timeout=inbox_page.timeout)
+            assert dots.count() >= 2, (
+                f"expected >=2 unread dots, got {dots.count()}"
+            )
+
+            log_test_step("3. Click 'Mark all read'")
+            mark_btn = inbox_page.page.locator(
+                inbox_page.MARK_ALL_READ_BTN
+            ).first
+            expect(mark_btn).to_be_enabled(timeout=inbox_page.timeout)
+            mark_btn.click()
+
+            log_test_step("4. All unread dots disappear")
+            expect(
+                inbox_page.page.locator(
+                    f"{inbox_page.MESSAGE_CARD} "
+                    f"{inbox_page.UNREAD_DOT_IN_CARD}"
+                )
+            ).to_have_count(0, timeout=18000)
+
+            log_test_step("5. Button becomes disabled (no unread left)")
+            expect(mark_btn).to_be_disabled(timeout=inbox_page.timeout)
 
             log_test_result(test_name, True, 0)
             logger.info(f"Test {test_name} passed")

--- a/e2e/tests/test_memory.py
+++ b/e2e/tests/test_memory.py
@@ -339,7 +339,9 @@ class TestMemoryBackendSelect:
         log_test_step("1. Open /agent-config on the ReAct Agent tab")
         memory_page.open_agent_config()
         memory_page.click_react_tab()
-        backend_select = page.locator(memory_page.BACKEND_SELECT).first
+        backend_select = page.locator(
+            memory_page.BACKEND_SELECT_TRIGGER
+        ).first
         expect(backend_select).to_be_visible(timeout=memory_page.timeout)
 
         log_test_step("2. Baseline: remelight backend => Long-term Memory tab")

--- a/e2e/tests/test_memory.py
+++ b/e2e/tests/test_memory.py
@@ -6,9 +6,13 @@ UI-driven only. Pure API contract tests for /api/workspace/memory and
 /api/workspace/running-config live in ``tests/integration/``.
 
 Cases:
+- MEM-001 P1  test_auto_memory_interval_persistence
+- MEM-002 P1  test_dream_cron_persistence
 - MEM-003 P1  test_memory_card_ui_renders
 - MEM-004 P1  test_workspace_memory_md_visible
 - MEM-005 P2  test_memory_search_recall_seeded         (xfail, requires_llm)
+- MEM-006 P2  test_memory_backend_select_switches_tabs
+- MEM-007 P2  test_auto_memory_search_toggle_and_max_results
 """
 from __future__ import annotations
 
@@ -180,6 +184,268 @@ class TestMemorySearchRecall:
                 f'.qwenpaw-bubble.qwenpaw-bubble-start:has-text("{keyword}")'
             ).first
         ).to_be_visible(timeout=180000)
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+# ============================================================================
+# MEM-001 P1 — auto_memory_interval edit + save + reload persistence
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.memory
+class TestAutoMemoryIntervalPersistence:
+    """MEM-001: edit Auto Memory Interval, save, reload, value persists."""
+
+    @pytest.mark.test_id("MEM-001")
+    def test_auto_memory_interval_persistence(
+        self,
+        memory_page: MemoryPage,
+        api_context,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        log_test_step("0. Snapshot running config for teardown restore")
+        original_cfg = memory_page.api_get_running_config(api_context)
+
+        try:
+            log_test_step("1. Open /agent-config → Long-term Memory tab")
+            memory_page.open_agent_config()
+            memory_page.click_memory_tab()
+            interval_input = memory_page.page.locator(
+                memory_page.AUTO_MEMORY_INTERVAL_INPUT
+            ).first
+            expect(interval_input).to_be_visible(
+                timeout=memory_page.timeout
+            )
+
+            log_test_step("2. Fill a distinct value and save")
+            old_value = interval_input.input_value()
+            new_value = "7" if old_value != "7" else "9"
+            interval_input.fill(new_value)
+            memory_page.click_save()
+
+            log_test_step("3. Reload page, re-open tab, value persisted")
+            memory_page.page.reload(wait_until="domcontentloaded")
+            memory_page.page.wait_for_timeout(3000)
+            memory_page.click_memory_tab()
+            interval_after = memory_page.page.locator(
+                memory_page.AUTO_MEMORY_INTERVAL_INPUT
+            ).first
+            expect(interval_after).to_be_visible(
+                timeout=memory_page.timeout
+            )
+            assert interval_after.input_value() == new_value, (
+                f"interval not persisted: expected {new_value}, "
+                f"got {interval_after.input_value()!r}"
+            )
+        finally:
+            memory_page.api_put_running_config(api_context, original_cfg)
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+# ============================================================================
+# MEM-002 P1 — dream_cron edit + save + reload persistence
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.memory
+class TestDreamCronPersistence:
+    """MEM-002: edit Dream Schedule cron, save, reload, value persists."""
+
+    @pytest.mark.test_id("MEM-002")
+    def test_dream_cron_persistence(
+        self,
+        memory_page: MemoryPage,
+        api_context,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+
+        log_test_step("0. Snapshot running config for teardown restore")
+        original_cfg = memory_page.api_get_running_config(api_context)
+
+        try:
+            log_test_step("1. Open /agent-config → Long-term Memory tab")
+            memory_page.open_agent_config()
+            memory_page.click_memory_tab()
+            cron_input = memory_page.page.locator(
+                memory_page.DREAM_CRON_INPUT
+            ).first
+            expect(cron_input).to_be_visible(timeout=memory_page.timeout)
+
+            log_test_step("2. Ensure dream cron is enabled (input editable)")
+            if cron_input.is_disabled():
+                memory_page.page.locator(
+                    memory_page.DREAM_CRON_ENABLED_SWITCH
+                ).first.click()
+                memory_page.page.wait_for_timeout(300)
+
+            log_test_step("3. Fill a valid 5-field cron and save")
+            old_value = cron_input.input_value()
+            new_value = "0 3 * * *" if old_value != "0 3 * * *" else "0 4 * * *"
+            cron_input.fill(new_value)
+            memory_page.click_save()
+
+            log_test_step("4. Reload page, re-open tab, cron persisted")
+            memory_page.page.reload(wait_until="domcontentloaded")
+            memory_page.page.wait_for_timeout(3000)
+            memory_page.click_memory_tab()
+            cron_after = memory_page.page.locator(
+                memory_page.DREAM_CRON_INPUT
+            ).first
+            expect(cron_after).to_be_visible(timeout=memory_page.timeout)
+            assert cron_after.input_value() == new_value, (
+                f"dream_cron not persisted: expected {new_value!r}, "
+                f"got {cron_after.input_value()!r}"
+            )
+        finally:
+            memory_page.api_put_running_config(api_context, original_cfg)
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+# ============================================================================
+# MEM-006 P2 — memory backend Select drives dynamic memory tabs (no save)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p2
+@pytest.mark.memory
+class TestMemoryBackendSelect:
+    """MEM-006: backend Select options + dynamic tab swap (client-side).
+
+    Intentionally never clicks Save: switching the backend is
+    restart-gated on the server, so the case only asserts the
+    client-side linkage (Select value -> which memory tab renders).
+    """
+
+    @pytest.mark.test_id("MEM-006")
+    def test_memory_backend_select_switches_tabs(
+        self,
+        memory_page: MemoryPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+        page = memory_page.page
+
+        log_test_step("1. Open /agent-config on the ReAct Agent tab")
+        memory_page.open_agent_config()
+        memory_page.click_react_tab()
+        backend_select = page.locator(memory_page.BACKEND_SELECT).first
+        expect(backend_select).to_be_visible(timeout=memory_page.timeout)
+
+        log_test_step("2. Baseline: remelight backend => Long-term Memory tab")
+        expect(
+            page.locator(memory_page.REME_MEMORY_TAB).first
+        ).to_be_visible(timeout=memory_page.timeout)
+
+        log_test_step("3. Open the Select; options include adbpg + none")
+        backend_select.click()
+        options = page.locator(memory_page.BACKEND_OPTION)
+        options.first.wait_for(state="visible", timeout=memory_page.timeout)
+        option_texts = " | ".join(
+            o.inner_text() for o in options.all()
+        )
+        assert "adbpg" in option_texts, f"options: {option_texts}"
+        assert "none" in option_texts, f"options: {option_texts}"
+
+        log_test_step("4. Pick adbpg => adbpgMemory tab replaces remelight")
+        options.filter(has_text="adbpg").first.click()
+        page.wait_for_timeout(800)
+        expect(
+            page.locator(memory_page.ADBPG_MEMORY_TAB).first
+        ).to_be_visible(timeout=memory_page.timeout)
+        expect(
+            page.locator(memory_page.REME_MEMORY_TAB).first
+        ).not_to_be_visible(timeout=5000)
+
+        log_test_step("5. Pick remelight back => Long-term Memory tab returns")
+        backend_select.click()
+        page.locator(memory_page.BACKEND_OPTION).filter(
+            has_text="remelight"
+        ).first.click()
+        page.wait_for_timeout(800)
+        expect(
+            page.locator(memory_page.REME_MEMORY_TAB).first
+        ).to_be_visible(timeout=memory_page.timeout)
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+# ============================================================================
+# MEM-007 P2 — Auto Memory Search switch + max_results field (no save)
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p2
+@pytest.mark.memory
+class TestAutoMemorySearchControls:
+    """MEM-007: expand the Auto Memory Search collapse, toggle the
+    switch (aria-checked flips), and edit max_results in-form.
+
+    Re-anchored from the original plan: v2.0.1 has no ``min_score``
+    field and no conditional show/hide — the collapse children are
+    forceRender'ed, so the assertions target switch state + editability.
+    Nothing is saved; a reload discards the changes.
+    """
+
+    @pytest.mark.test_id("MEM-007")
+    def test_auto_memory_search_toggle_and_max_results(
+        self,
+        memory_page: MemoryPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+        page = memory_page.page
+
+        log_test_step("1. Open /agent-config → Long-term Memory tab")
+        memory_page.open_agent_config()
+        memory_page.click_memory_tab()
+        expect(
+            page.locator(memory_page.DREAM_CRON_INPUT).first
+        ).to_be_visible(timeout=memory_page.timeout)
+
+        log_test_step("2. Expand the 'Auto Memory Search' collapse panel")
+        header = page.locator(
+            memory_page.AUTO_SEARCH_COLLAPSE_HEADER
+        ).first
+        expect(header).to_be_visible(timeout=memory_page.timeout)
+        switch = page.locator(memory_page.AUTO_SEARCH_SWITCH).first
+        if not switch.is_visible():
+            header.click()
+            page.wait_for_timeout(500)
+        expect(switch).to_be_visible(timeout=memory_page.timeout)
+
+        log_test_step("3. Toggle the switch and assert aria-checked flips")
+        before = switch.get_attribute("aria-checked")
+        switch.click()
+        page.wait_for_timeout(300)
+        after = switch.get_attribute("aria-checked")
+        assert before != after, (
+            f"auto search switch did not flip: {before} -> {after}"
+        )
+
+        log_test_step("4. max_results is editable (fill 5, value sticks)")
+        max_results = page.locator(
+            memory_page.AUTO_SEARCH_MAX_RESULTS_INPUT
+        ).first
+        expect(max_results).to_be_visible(timeout=memory_page.timeout)
+        max_results.fill("5")
+        assert max_results.input_value() == "5"
+
+        log_test_step("5. Restore the switch (in-form only, never saved)")
+        switch.click()
+        page.wait_for_timeout(300)
+        assert switch.get_attribute("aria-checked") == before
 
         log_test_result(test_name, True, 0)
         logger.info(f"Test {test_name} passed")

--- a/e2e/tests/test_plugins.py
+++ b/e2e/tests/test_plugins.py
@@ -7,6 +7,8 @@ endpoints belong in ``tests/integration/`` (which already covers them).
 
 Cases:
 - PLUGIN-001 P0  test_plugin_manager_page_loads
+- COMPAT-001 P1  test_market_compat_tags_render
+- COMPAT-002 P1  test_incompatible_install_warning_modal
 """
 from __future__ import annotations
 
@@ -16,6 +18,7 @@ import pytest
 from playwright.sync_api import expect
 
 from pages.plugin_page import PluginPage
+from mocks import plugin_market
 from utils.helpers import log_test_step, log_test_result
 
 
@@ -55,6 +58,100 @@ class TestPluginManagerPageLoads:
         expect(
             plugin_page.page.locator(plugin_page.TAB_OFFICIAL).first
         ).to_be_visible(timeout=plugin_page.timeout)
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+
+# ============================================================================
+# COMPAT-001/002 P1 — Plugin Market version compatibility (upstream #5661)
+#
+# Market catalog data comes from the network (platform.agentscope.io
+# proxy), so the catalog / version / install endpoints are intercepted
+# with page.route mocks; all UI interactions and assertions stay real.
+# ============================================================================
+
+@pytest.mark.integration
+@pytest.mark.p1
+@pytest.mark.plugins
+class TestPluginCompatibility:
+    """Market tab compat tags + incompatible-install warning modal."""
+
+    def _open_market_tab(self, plugin_page: PluginPage) -> None:
+        """Register mocks, open /plugin-manager and switch to Market."""
+        plugin_market.register(plugin_page.page)
+        plugin_page.open()
+        plugin_page.page.locator(plugin_page.TAB_MARKET).first.click()
+        plugin_page.page.locator(plugin_page.MARKET_ROW).first.wait_for(
+            state="visible", timeout=plugin_page.timeout
+        )
+
+    @pytest.mark.test_id("COMPAT-001")
+    def test_market_compat_tags_render(
+        self,
+        plugin_page: PluginPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+        page = plugin_page.page
+
+        log_test_step("1. Open Market tab with mocked catalog (1 compat + 1 legacy)")
+        self._open_market_tab(plugin_page)
+
+        log_test_step("2. Compatible plugin row shows a green 'QwenPaw 2.x' tag")
+        compat_row = page.locator(plugin_page.MARKET_ROW).filter(
+            has_text=plugin_market.COMPATIBLE_PLUGIN_NAME
+        ).first
+        expect(compat_row).to_be_visible(timeout=plugin_page.timeout)
+        green_tag = compat_row.locator(plugin_page.COMPAT_TAG_GREEN).first
+        expect(green_tag).to_be_visible(timeout=plugin_page.timeout)
+        assert "2.x" in (green_tag.inner_text() or ""), (
+            f"green tag text unexpected: {green_tag.inner_text()!r}"
+        )
+
+        log_test_step("3. Incompatible plugin row shows an orange 'QwenPaw 1.x' tag")
+        legacy_row = page.locator(plugin_page.MARKET_ROW).filter(
+            has_text=plugin_market.INCOMPATIBLE_PLUGIN_NAME
+        ).first
+        expect(legacy_row).to_be_visible(timeout=plugin_page.timeout)
+        orange_tag = legacy_row.locator(plugin_page.COMPAT_TAG_ORANGE).first
+        expect(orange_tag).to_be_visible(timeout=plugin_page.timeout)
+        assert "1.x" in (orange_tag.inner_text() or ""), (
+            f"orange tag text unexpected: {orange_tag.inner_text()!r}"
+        )
+
+        log_test_result(test_name, True, 0)
+        logger.info(f"Test {test_name} passed")
+
+    @pytest.mark.test_id("COMPAT-002")
+    def test_incompatible_install_warning_modal(
+        self,
+        plugin_page: PluginPage,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        test_name = request.node.name
+        page = plugin_page.page
+
+        log_test_step("1. Open Market tab with mocked catalog")
+        self._open_market_tab(plugin_page)
+
+        log_test_step("2. Click Install on the incompatible plugin")
+        legacy_row = page.locator(plugin_page.MARKET_ROW).filter(
+            has_text=plugin_market.INCOMPATIBLE_PLUGIN_NAME
+        ).first
+        expect(legacy_row).to_be_visible(timeout=plugin_page.timeout)
+        legacy_row.locator(plugin_page.MARKET_INSTALL_BTN).first.click()
+
+        log_test_step("3. 'Compatibility Warning' Modal.confirm appears")
+        modal = page.locator(plugin_page.COMPAT_MODAL).first
+        expect(modal).to_be_visible(timeout=plugin_page.timeout)
+        expect(
+            page.locator(plugin_page.COMPAT_MODAL_TITLE).first
+        ).to_be_visible(timeout=plugin_page.timeout)
+
+        log_test_step("4. Confirm 'Install anyway' — modal closes (install mocked)")
+        page.locator(plugin_page.COMPAT_MODAL_OK).first.click()
+        expect(modal).not_to_be_visible(timeout=plugin_page.timeout)
 
         log_test_result(test_name, True, 0)
         logger.info(f"Test {test_name} passed")

--- a/e2e/tests/test_slash_commands.py
+++ b/e2e/tests/test_slash_commands.py
@@ -287,3 +287,99 @@ def test_slash_unknown_does_not_crash(clean_chat_page: ChatPage):
     assert page.locator('text=/Chat|Sessions|Channels/').first.count() > 0, (
         "sidebar disappeared after unknown command — UI crashed"
     )
+
+
+# ============================================================================
+# Sprint 5 additions
+# ============================================================================
+
+@pytest.mark.slash_commands
+@pytest.mark.p1
+@pytest.mark.test_id("SLASH-010")
+def test_slash_suggestion_popup_renders(clean_chat_page: ChatPage):
+    """Typing "/" opens the suggestion popup listing built-in commands.
+
+    Pure client-side (no send, no LLM): the popup is driven by the
+    sender's onChange while the value starts with "/" and contains no
+    whitespace. Built-ins are /new, /clear, /compact, /skills.
+    """
+    chat = clean_chat_page.open()
+    page = chat.page
+    page.wait_for_timeout(2000)
+    _wait_session_ready(page)
+
+    inp = page.locator("textarea").first
+    inp.click()
+    inp.fill("/")
+    page.wait_for_timeout(600)
+
+    popup = page.locator(chat.SUGGESTION_POPUP).first
+    assert popup.is_visible(), "suggestion popup did not open on '/'"
+
+    items_text = page.locator(chat.SUGGESTION_POPUP).inner_text()
+    for cmd in ("/new", "/clear", "/compact", "/skills"):
+        assert cmd in items_text, (
+            f"built-in {cmd} missing from suggestions: {items_text!r}"
+        )
+
+    # Typing a space after the command closes the popup.
+    inp.fill("/new ")
+    page.wait_for_timeout(600)
+    assert not page.locator(
+        chat.SUGGESTION_POPUP
+    ).first.is_visible(), "popup should close once whitespace is typed"
+
+    inp.fill("")
+
+
+def _warm_up_session(chat: ChatPage) -> None:
+    """Send one real message so the follow-up slash command is not the
+    session's first response (works around the known first-response
+    re-render flash on brand-new sessions)."""
+    _send_slash(chat, "Reply with the single word: pong", timeout=90000)
+
+
+@pytest.mark.slash_commands
+@pytest.mark.requires_llm
+@pytest.mark.p1
+@pytest.mark.test_id("CMD-001")
+def test_slash_new_starts_new_conversation(clean_chat_page: ChatPage):
+    """``/new`` responds with the New Conversation confirmation."""
+    chat = clean_chat_page.open()
+    _warm_up_session(chat)
+    text = _send_slash(chat, "/new")
+    _assert_any(
+        text,
+        "New Conversation Started",
+        "New Conversation",
+        "Ready for new conversation",
+    )
+
+
+@pytest.mark.slash_commands
+@pytest.mark.requires_llm
+@pytest.mark.p1
+@pytest.mark.test_id("CMD-003")
+def test_slash_model_list_shows_providers(clean_chat_page: ChatPage):
+    """``/model list`` renders the provider/model inventory."""
+    chat = clean_chat_page.open()
+    _warm_up_session(chat)
+    text = _send_slash(chat, "/model list")
+    _assert_any(text, "Available Models", "Provider", "Total:")
+
+
+@pytest.mark.slash_commands
+@pytest.mark.requires_llm
+@pytest.mark.p2
+@pytest.mark.test_id("CMD-007")
+def test_slash_stop_reports_task_state(clean_chat_page: ChatPage):
+    """``/stop`` with no running task reports the no-task state."""
+    chat = clean_chat_page.open()
+    _warm_up_session(chat)
+    text = _send_slash(chat, "/stop")
+    _assert_any(
+        text,
+        "No Active Task",
+        "Task Not Running",
+        "Task Stopped",
+    )


### PR DESCRIPTION
## Summary

Adds 15 UI-driven e2e cases closing out Sprint 4 and covering Sprint 5. All three CI lanes (p0/p1/p2) are green on the fork (runs 30418461581 / 30418464227 / 30418466628).

## New cases

- **Plugin compatibility** (`test_plugins.py` + `mocks/plugin_market.py`): COMPAT-001/002 — plugin market catalog row rendering and compatibility badges
- **Chat sidebar** (`test_chat_sidebar.py`, new file + `mocks/sidebar_sessions.py`, new marker `chat_sidebar`): SIDEBAR-001 session list rendering; MULTITAB-001 multi-tab ownership banner
- **Memory management** (`test_memory.py`): MEM-001/002/006/007 — edit/save flows (with API snapshot restore) and read-only views
- **Cross-module** (`test_cross_module.py`): MA-001 — in-chat agent switcher
- **Inbox** (`test_inbox.py`): INBOX-007 single-item delete; INBOX-008 mark-all-read
- **Slash commands** (`test_slash_commands.py`): SLASH-010 + CMD-001/003/007 (CMD cases marked `requires_llm`; a warm-up message works around the first-response flicker in fresh sessions)

## Fix iterations included

- Resolve 3 first-CI-pass failures (e4ac159e)
- Stop AGENT-005 toggle from hitting the newly added Copy button (15f4b09b)

## Not covered (Sprint 5 exclusions)

- CHAN-CUSTOM / TOOL-DETAIL / SEC-WEB-AUTH: no corresponding UI in v2.0.1
- INBOX-003: no seed path for approval items
- CMD-002: blocked by a frontend wipe bug in `/clear`
- Mission / Proactive / Plugin clusters: hard dependency on LLM or pre-installed environments

## Test plan

- [x] `pytest tests/ --collect-only` in `e2e/` collects 218 cases
- [x] Fork CI p0/p1/p2 dispatch lanes all green
- [x] Pre-commit and NPM format checks pass