### PR TITLE
fix(mcp): recover stale server sessions

### DIFF
--- a/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
+++ b/src/qwenpaw/drivers/handlers/mcp_stateful_client.py
@@ -55,13 +55,17 @@ _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
     ConnectionResetError,
     BrokenPipeError,
 )
+_STALE_SESSION_ERROR_MARKERS = (
+    "session terminated",
+    "session transport closed",
+)
 
 
-# How long ``list_tools`` waits for an in-flight reconnect before raising.
+# How long a request waits for an in-flight reconnect before raising.
 # Picked to cover typical HTTP MCP reconnect latency (sub-second to ~1s
 # in practice) with headroom, while still failing fast enough that a
 # permanently-broken client doesn't stall every turn for long.
-_LIST_TOOLS_RECONNECT_WAIT: float = 3.0
+_MCP_RECONNECT_WAIT: float = 3.0
 _LIFECYCLE_CLEANUP_TIMEOUT: float = 5.0
 _LIFECYCLE_REAPERS: dict[asyncio.Task, asyncio.Task] = {}
 
@@ -74,6 +78,30 @@ def _is_transport_error(exc: BaseException) -> bool:
     ``_TRANSPORT_ERRORS`` for the full list of recognised exception types.
     """
     return isinstance(exc, _TRANSPORT_ERRORS)
+
+
+def _is_stale_session_error(exc: BaseException) -> bool:
+    """Return True when an exception chain reports an expired MCP session."""
+    pending = [exc]
+    seen: set[int] = set()
+
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+
+        message = str(current).casefold()
+        if any(marker in message for marker in _STALE_SESSION_ERROR_MARKERS):
+            return True
+
+        pending.extend(getattr(current, "exceptions", ()) or ())
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+
+    return False
 
 
 def _is_401_error(exc: BaseException) -> bool:
@@ -324,36 +352,29 @@ class _MCPClientMixin:
         Raises:
             RuntimeError: If not connected and no reconnect is in flight,
                 or if the reconnect does not complete within
-                ``_LIST_TOOLS_RECONNECT_WAIT`` seconds.
+                ``_MCP_RECONNECT_WAIT`` seconds.
         """
         if not self.is_connected:
-            has_task = self._lifecycle_task is not None and not (
-                self._lifecycle_task.done()
-            )
-            if has_task:
+            if self._lifecycle_is_running():
                 logger.info(
                     "MCP client '%s' not connected; waiting up to %.1fs "
                     "for reconnect before list_tools.",
                     self.name,
-                    _LIST_TOOLS_RECONNECT_WAIT,
+                    _MCP_RECONNECT_WAIT,
                 )
-                try:
-                    await asyncio.wait_for(
-                        self._ready_event.wait(),
-                        timeout=_LIST_TOOLS_RECONNECT_WAIT,
-                    )
-                except asyncio.TimeoutError:
-                    pass
+                await self._wait_for_reconnect()
 
         # Reconnect succeeded — go fetch fresh schemas.
         if self.is_connected and self.session is not None:
             try:
-                res = await self.session.list_tools()
+                return await self._fetch_tools()
             except Exception as exc:
-                self._handle_transport_error(exc)
-                raise
-            self._cached_tools = res.tools
-            return res.tools
+                if not _is_stale_session_error(exc):
+                    raise
+                if not await self._wait_for_reconnect():
+                    raise
+
+            return await self._fetch_tools()
 
         # Reconnect didn't land in time.  Fall back to the cache from the
         # last successful list_tools call (preserved across transient
@@ -364,7 +385,7 @@ class _MCPClientMixin:
                 "MCP client '%s' still disconnected after %.1fs; serving "
                 "cached schemas from last successful list_tools.",
                 self.name,
-                _LIST_TOOLS_RECONNECT_WAIT,
+                _MCP_RECONNECT_WAIT,
             )
             return self._cached_tools
 
@@ -388,11 +409,15 @@ class _MCPClientMixin:
             RuntimeError: If not connected
         """
         self._validate_connection()
+        session = self.session
+        assert session is not None
 
         try:
-            return await self.session.call_tool(name, arguments or {})
+            return await session.call_tool(name, arguments or {})
         except Exception as exc:
-            self._handle_transport_error(exc)
+            self._handle_transport_error(exc, failed_session=session)
+            if _is_stale_session_error(exc):
+                await self._wait_for_reconnect()
             raise
 
     async def close(self, ignore_errors: bool = True) -> None:
@@ -500,9 +525,45 @@ class _MCPClientMixin:
         await asyncio.gather(task, return_exceptions=True)
         self._clear_lifecycle_state(task)
 
-    def _handle_transport_error(self, exc: BaseException) -> None:
-        """Mark the client as disconnected and schedule a reconnect when *exc*
-        indicates a transport/stream failure rather than an MCP-level error.
+    def _lifecycle_is_running(self) -> bool:
+        """Return whether the lifecycle task can complete a reconnect."""
+        return self._lifecycle_task is not None and not (
+            self._lifecycle_task.done()
+        )
+
+    async def _wait_for_reconnect(self) -> bool:
+        """Wait for an in-flight lifecycle reload to establish a session."""
+        if self._stop_event.is_set() or not self._lifecycle_is_running():
+            return False
+        try:
+            await asyncio.wait_for(
+                self._ready_event.wait(),
+                timeout=_MCP_RECONNECT_WAIT,
+            )
+        except asyncio.TimeoutError:
+            return False
+        return self.is_connected and self.session is not None
+
+    async def _fetch_tools(self):
+        """Fetch and cache tool schemas from the active MCP session."""
+        self._validate_connection()
+        session = self.session
+        assert session is not None
+        try:
+            res = await session.list_tools()
+        except Exception as exc:
+            self._handle_transport_error(exc, failed_session=session)
+            raise
+        self._cached_tools = res.tools
+        return res.tools
+
+    def _handle_transport_error(
+        self,
+        exc: BaseException,
+        *,
+        failed_session: Any | None = None,
+    ) -> None:
+        """Mark the client disconnected for a transport or stale-session error.
 
         **HTTP / streamable_http scenario**
         ``streamable_http_client``'s ``post_writer`` background task silently
@@ -534,10 +595,16 @@ class _MCPClientMixin:
         replaces it.  Clearing it here would require a lock (the lifecycle
         task also writes ``session``), adding unnecessary complexity.
         """
-        if not _is_transport_error(exc):
+        if not (_is_transport_error(exc) or _is_stale_session_error(exc)):
+            return
+        if failed_session is not None and self.session is not failed_session:
+            logger.debug(
+                "Ignoring connection error from replaced MCP session '%s'",
+                self.name,
+            )
             return
         logger.warning(
-            "Transport error on MCP client '%s' (%s: %s); "
+            "Recoverable connection error on MCP client '%s' (%s: %s); "
             "marking as disconnected and scheduling reconnect.",
             self.name,
             type(exc).__name__,

--- a/tests/unit/drivers/handlers/test_mcp_stateful_client.py
+++ b/tests/unit/drivers/handlers/test_mcp_stateful_client.py
@@ -25,8 +25,12 @@ deterministic unit coverage behind the ``fail_under`` gate.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
+
 import httpx
 import pytest
+from mcp import McpError
+from mcp.types import ErrorData
 
 import qwenpaw.drivers.handlers.mcp_stateful_client as mod
 from qwenpaw.drivers.handlers.mcp_stateful_client import (
@@ -44,6 +48,10 @@ def _client() -> HttpStatefulClient:
     synchronous and lifecycle helper methods directly.
     """
     return HttpStatefulClient("test-client", "streamable_http", "http://x")
+
+
+def _stale_session_error(message: str = "Session terminated") -> McpError:
+    return McpError(ErrorData(code=32600, message=message))
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +92,24 @@ def test_is_401_error_drills_into_exception_group():
 
     clean_group = ExceptionGroup("grpc failures", [ValueError()])
     assert not _is_401_error(clean_group)
+
+
+def test_is_stale_session_error_drills_into_wrapped_exceptions():
+    stale = _stale_session_error()
+    group = ExceptionGroup("request failures", [ValueError(), stale])
+    wrapper = RuntimeError("MCP request failed")
+    wrapper.__cause__ = group
+
+    assert mod._is_stale_session_error(wrapper)
+    context_wrapper = RuntimeError("MCP request failed")
+    context_wrapper.__context__ = stale
+    assert mod._is_stale_session_error(context_wrapper)
+    assert mod._is_stale_session_error(
+        RuntimeError("Session transport closed"),
+    )
+    assert not mod._is_stale_session_error(
+        _stale_session_error("Tool execution failed"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -376,6 +402,168 @@ async def test_list_tools_raises_on_cold_start_without_cache():
         await c.list_tools()
 
 
+async def test_list_tools_reconnects_and_retries_stale_session_once():
+    c = _client()
+    c.is_connected = True
+    c._ready_event.set()
+
+    class StaleSession:
+        calls = 0
+
+        async def list_tools(self):
+            self.calls += 1
+            raise _stale_session_error()
+
+    class FreshSession:
+        calls = 0
+
+        async def list_tools(self):
+            self.calls += 1
+            return SimpleNamespace(tools=["fresh-tool"])
+
+    stale_session = StaleSession()
+    fresh_session = FreshSession()
+    c.session = stale_session  # type: ignore[assignment]
+
+    async def lifecycle_reload() -> None:
+        await c._reload_event.wait()
+        c.session = fresh_session  # type: ignore[assignment]
+        c.is_connected = True
+        c._ready_event.set()
+        await asyncio.Event().wait()
+
+    lifecycle_task = asyncio.create_task(lifecycle_reload())
+    c._lifecycle_task = lifecycle_task
+    try:
+        assert await c.list_tools() == ["fresh-tool"]
+    finally:
+        lifecycle_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await lifecycle_task
+
+    assert stale_session.calls == 1
+    assert fresh_session.calls == 1
+    assert c._cached_tools == ["fresh-tool"]
+
+
+async def test_concurrent_stale_list_calls_share_one_reconnect(monkeypatch):
+    monkeypatch.setattr(mod, "_MCP_RECONNECT_WAIT", 0.5)
+    c = _client()
+    c.is_connected = True
+    c._ready_event.set()
+    both_started = asyncio.Event()
+    session_replaced = asyncio.Event()
+
+    class StaleSession:
+        calls = 0
+
+        async def list_tools(self):
+            self.calls += 1
+            call_number = self.calls
+            if self.calls == 2:
+                both_started.set()
+            await both_started.wait()
+            if call_number == 2:
+                await session_replaced.wait()
+            raise _stale_session_error()
+
+    class FreshSession:
+        calls = 0
+
+        async def list_tools(self):
+            self.calls += 1
+            return SimpleNamespace(tools=["fresh-tool"])
+
+    stale_session = StaleSession()
+    fresh_session = FreshSession()
+    c.session = stale_session  # type: ignore[assignment]
+
+    async def lifecycle_reload() -> None:
+        await c._reload_event.wait()
+        c._reload_event.clear()
+        c.session = fresh_session  # type: ignore[assignment]
+        c.is_connected = True
+        c._ready_event.set()
+        session_replaced.set()
+        await asyncio.Event().wait()
+
+    lifecycle_task = asyncio.create_task(lifecycle_reload())
+    c._lifecycle_task = lifecycle_task
+    try:
+        results = await asyncio.gather(c.list_tools(), c.list_tools())
+    finally:
+        lifecycle_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await lifecycle_task
+
+    assert results == [["fresh-tool"], ["fresh-tool"]]
+    assert stale_session.calls == 2
+    assert fresh_session.calls == 2
+    assert c.is_connected is True
+    assert c.session is fresh_session
+    assert not c._reload_event.is_set()
+
+
+async def test_list_tools_retries_stale_session_only_once():
+    c = _client()
+    c.is_connected = True
+    c._ready_event.set()
+
+    class StaleSession:
+        calls = 0
+
+        async def list_tools(self):
+            self.calls += 1
+            raise _stale_session_error()
+
+    first_session = StaleSession()
+    replacement_session = StaleSession()
+    c.session = first_session  # type: ignore[assignment]
+
+    async def lifecycle_reload() -> None:
+        await c._reload_event.wait()
+        c._reload_event.clear()
+        c.session = replacement_session  # type: ignore[assignment]
+        c.is_connected = True
+        c._ready_event.set()
+        await asyncio.Event().wait()
+
+    lifecycle_task = asyncio.create_task(lifecycle_reload())
+    c._lifecycle_task = lifecycle_task
+    try:
+        with pytest.raises(McpError, match="Session terminated"):
+            await c.list_tools()
+    finally:
+        lifecycle_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await lifecycle_task
+
+    assert first_session.calls == 1
+    assert replacement_session.calls == 1
+
+
+async def test_list_tools_does_not_retry_other_mcp_errors():
+    c = _client()
+    c.is_connected = True
+
+    class FailingSession:
+        calls = 0
+
+        async def list_tools(self):
+            self.calls += 1
+            raise _stale_session_error("Permission denied")
+
+    session = FailingSession()
+    c.session = session  # type: ignore[assignment]
+
+    with pytest.raises(McpError, match="Permission denied"):
+        await c.list_tools()
+
+    assert session.calls == 1
+    assert c.is_connected is True
+    assert not c._reload_event.is_set()
+
+
 async def test_call_tool_raises_when_disconnected():
     c = _client()
     with pytest.raises(RuntimeError, match="not connected"):
@@ -396,6 +584,53 @@ async def test_call_tool_handles_transport_error_and_marks_disconnected():
     # _handle_transport_error marked it for reconnect.
     assert c.is_connected is False
     assert c._reload_event.is_set()
+
+
+async def test_call_tool_reconnects_stale_session_without_replaying_call():
+    c = _client()
+    c.is_connected = True
+    c._ready_event.set()
+
+    class StaleSession:
+        calls = 0
+
+        async def call_tool(self, name: str, args: dict) -> None:
+            del name, args
+            self.calls += 1
+            raise _stale_session_error()
+
+    class FreshSession:
+        calls = 0
+
+        async def call_tool(self, name: str, args: dict) -> None:
+            del name, args
+            self.calls += 1
+
+    stale_session = StaleSession()
+    fresh_session = FreshSession()
+    c.session = stale_session  # type: ignore[assignment]
+
+    async def lifecycle_reload() -> None:
+        await c._reload_event.wait()
+        c.session = fresh_session  # type: ignore[assignment]
+        c.is_connected = True
+        c._ready_event.set()
+        await asyncio.Event().wait()
+
+    lifecycle_task = asyncio.create_task(lifecycle_reload())
+    c._lifecycle_task = lifecycle_task
+    try:
+        with pytest.raises(McpError, match="Session terminated"):
+            await c.call_tool("submit_job", {"value": 1})
+    finally:
+        lifecycle_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await lifecycle_task
+
+    assert stale_session.calls == 1
+    assert fresh_session.calls == 0
+    assert c.is_connected is True
+    assert c.session is fresh_session
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Recover stale MCP sessions after a server restart or session expiry.

The MCP SDK reports an expired streamable HTTP session as an MCP-level
`Session terminated` error. QwenPaw previously reconnected only for transport
exceptions, so the lifecycle remained connected while requests kept reusing
the invalid session.

This change:

- detects stale-session errors through direct, grouped, caused, and contextual
  exceptions;
- reuses the shared MCP lifecycle to establish a fresh session;
- retries read-only `list_tools` exactly once;
- reconnects after a stale-session `call_tool` failure without replaying the
  invocation;
- ignores late failures from a replaced session so concurrent requests share
  one reconnect.

The fix is in the shared `_MCPClientMixin`, covering all MCP drivers that use
the stateful client rather than adding a server-, Skill-, or UI-specific
workaround.

**Related Issue:** Fixes #6524

**Security Considerations:** Existing endpoints, credentials, headers, and
transport setup are reused. Tool calls are never replayed automatically after
an ambiguous failure, preventing duplicate side effects.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing API or configuration change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

Not applicable; this change does not modify channel behavior or contracts.

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

The regression tests cover direct and nested stale-session errors, one-shot
`list_tools` retry, concurrent stale requests, a stale replacement session,
ordinary MCP errors, and no replay of `call_tool`.

Verification matrix:

| Surface | Result |
| --- | --- |
| Streamable HTTP stale session | Covered with real MCP SDK errors |
| `ExceptionGroup` / cause / context | Covered |
| Concurrent stale requests | One lifecycle reconnect |
| `list_tools` | Retried exactly once |
| `call_tool` | Reconnected, never replayed |
| Ordinary MCP and transport errors | Existing behavior preserved |
| Channels / frontend | Not applicable |

## Evidence

Observed locally on the rebased branch: all 112 focused driver tests passed,
and every hook applied to the two changed files passed.

```bash
PYTHONPATH=src pytest \
  tests/unit/drivers/handlers \
  tests/unit/drivers/test_capabilities.py \
  tests/unit/drivers/test_contracts.py \
  tests/unit/drivers/test_policy_types.py -q --no-cov
# 112 passed in 2.03s
```

```bash
pre-commit run --files \
  src/qwenpaw/drivers/handlers/mcp_stateful_client.py \
  tests/unit/drivers/handlers/test_mcp_stateful_client.py
# Passed: AST, docstring-first, encoding, private-key detection,
# whitespace, trailing commas, mypy, black, flake8, and pylint.
```

## Additional Notes

`pre-commit run --all-files` passed every hook through flake8 locally, but the
repository-wide pylint scan was still running after 15 minutes and was
interrupted. Pylint passes for both changed files as shown above.

A full `tests/unit/drivers` run is also blocked locally by a pre-existing
`asyncio.to_thread` shutdown hang in
`tests/unit/drivers/adapters/test_mcp_legacy_upgrade.py`; the handler and
protocol-neutral driver suites listed above complete successfully.
