### PR TITLE
fix(scroll): retain active history sessions intact

### DIFF
--- a/src/qwenpaw/agents/context/__init__.py
+++ b/src/qwenpaw/agents/context/__init__.py
@@ -54,10 +54,11 @@ def scroll_unsandboxed_allowed(scroll_config: Any) -> bool:
     return bool(getattr(scroll_config, "allow_unsandboxed", False))
 
 
-# history.db auto-purges past history_retention_days (default 30), but an
-# operator can disable that (set 0) or a very chatty agent can outpace it, so
-# the store may still grow large. Warn when it crosses this size. Process-level
-# dedupe keeps a long-lived server from re-warning on every agent build.
+# history.db auto-purges sessions inactive past history_retention_days
+# (default 30), but an operator can disable that (set 0) or active agents can
+# outpace it, so the store may still grow large. Warn when it crosses this
+# size. Process-level dedupe keeps a long-lived server from re-warning on every
+# agent build.
 _DB_SIZE_WARN_BYTES = 1 * 1024**3  # 1 GiB
 _DB_SIZE_WARNED: set[str] = set()
 
@@ -110,11 +111,11 @@ def _warn_db_size(db_path: Path) -> None:
         return
     _DB_SIZE_WARNED.add(key)
     logger.warning(
-        "scroll history at %s is %.1f GiB. Rows older than "
-        "history_retention_days (default 30) auto-purge on startup and on "
+        "scroll history at %s is %.1f GiB. Sessions inactive longer than "
+        "history_retention_days (default 30) auto-purge on startup and "
         "teardown; if you set history_retention_days=0 the store keeps "
-        "everything and grows without bound. Lower the retention window to "
-        "trim it.",
+        "everything and grows without bound. Lower the inactivity window "
+        "to trim it.",
         db_path,
         total / 1024**3,
     )

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -529,14 +529,54 @@ class HistoryStore:
         tool output (the bulk of the bloat) while keeping the conversation
         turns. The FTS index is kept in sync (each purged row is removed from
         it first). Rows with a NULL/empty ``created_at`` are never matched, so
-        they are retained. This is the retention/clear path — driven on
-        startup and teardown by ``history_retention_days`` (default 30; set 0
-        to keep history forever, which calls nothing here).
+        they are retained. Automatic retention uses
+        :meth:`purge_inactive_sessions`; this row-scoped method remains
+        available for targeted/manual cleanup.
 
         Note: this DELETEs but does not ``VACUUM``, so freed pages are reused
         but the file does not shrink on disk until a separate vacuum.
         """
         where, params = self._purge_where(before, kinds)
+        return self._purge_matching(
+            where=where,
+            params=params,
+            dry_run=dry_run,
+        )
+
+    def purge_inactive_sessions(
+        self,
+        *,
+        before: str,
+        dry_run: bool = False,
+    ) -> int:
+        """Delete whole sessions whose latest row predates ``before``.
+
+        A session's latest ``created_at`` is its durable last-activity time.
+        Keeping every row of an active session prevents retention from
+        silently truncating long-running conversations. Sessions containing
+        only unstamped rows are retained conservatively.
+        """
+        where = (
+            "session_id IN ("
+            "SELECT session_id FROM conversation_history "
+            "GROUP BY session_id "
+            "HAVING MAX(created_at) IS NOT NULL AND MAX(created_at) < ?"
+            ")"
+        )
+        return self._purge_matching(
+            where=where,
+            params=[before],
+            dry_run=dry_run,
+        )
+
+    def _purge_matching(
+        self,
+        *,
+        where: str,
+        params: list,
+        dry_run: bool,
+    ) -> int:
+        """Delete rows matching a trusted SQL predicate, keeping FTS synced."""
         with self._lock, self._conn:
             doomed = self._conn.execute(
                 "SELECT seq, content FROM conversation_history WHERE " + where,

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -1989,12 +1989,16 @@ class ScrollContextManager:
         )
 
     def purge_old(self, retention_days: int, *, dry_run: bool = False) -> int:
-        """Drop durable history older than ``retention_days`` (0 = keep
-        forever). Returns the number of rows removed (or, with ``dry_run``,
-        that would be removed — nothing is deleted)."""
+        """Drop sessions inactive for ``retention_days`` (0 = keep forever).
+
+        Activity is the newest durable row in each session. Active sessions
+        are kept whole instead of losing their oldest rows incrementally.
+        Returns the number of rows removed (or, with ``dry_run``, that would
+        be removed — nothing is deleted).
+        """
         if retention_days <= 0:
             return 0
-        return self._history.purge(
+        return self._history.purge_inactive_sessions(
             before=self._cutoff(retention_days),
             dry_run=dry_run,
         )

--- a/src/qwenpaw/agents/context/scroll/sync.py
+++ b/src/qwenpaw/agents/context/scroll/sync.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MANIFEST_NAME = ".synced.json"
-_MANIFEST_VERSION = 1
+_MANIFEST_VERSION = 2
 _SESSION_PREFIX = "sync:"
 
 
@@ -57,7 +57,7 @@ class FileResult:
     session_id: str = ""
     messages: int = 0  # messages read from the session state
     unparseable: int = 0  # messages that were not a decodable Msg
-    aged_out: int = 0  # messages skipped as older than the retention window
+    aged_out: int = 0  # messages skipped with an inactive session
     rows_processed: int = 0  # LogEntry rows attempted
     rows_inserted: int = 0  # rows actually new (delta of history.count)
     skipped: bool = False  # short-circuited via manifest (already synced)
@@ -122,7 +122,7 @@ class SyncReport:
             parts.append(f"{self.skipped_files} unchanged")
         if self.aged_out:
             parts.append(
-                f"{self.aged_out} message(s) older than retention",
+                f"{self.aged_out} message(s) from inactive sessions",
             )
         if self.unparseable:
             parts.append(f"{self.unparseable} message(s) unparseable")
@@ -234,10 +234,10 @@ def _sync_file(
     keys on its ``msg.id``; a tool result keys on its ``tool_call_id``, or — if
     it has none — on its position within the owning Msg.
 
-    With a ``cutoff`` (ISO-8601 instant), messages older than it are skipped:
-    they fall outside the retention window, so importing them would only
-    resurrect rows the same-boot purge deletes. Messages with no ``created_at``
-    are kept (purge skips NULL timestamps too, so the two stay consistent).
+    With a ``cutoff`` (ISO-8601 instant), a session is skipped only when its
+    latest stamped message predates the cutoff. Active sessions are imported
+    whole, matching the session-level retention purge. Sessions with no
+    stamped messages are kept conservatively.
     """
     res = FileResult(filename=rel_name)
     try:
@@ -264,15 +264,17 @@ def _sync_file(
     res.messages = len(messages)
     res.unparseable = unparseable
 
+    stamped_times = [
+        created_at
+        for msg in messages
+        if (created_at := getattr(msg, "created_at", None))
+    ]
+    if cutoff and stamped_times and max(stamped_times) < cutoff:
+        res.aged_out = len(messages)
+        return res
+
     pending_entries = []
     for row_index, msg in enumerate(messages):
-        # Skip messages older than the retention window so we don't import rows
-        # the same-boot purge would immediately delete. NULL timestamps are
-        # kept (purge skips them too).
-        created_at = getattr(msg, "created_at", None)
-        if cutoff and created_at and created_at < cutoff:
-            res.aged_out += 1
-            continue
         # Fallback id from row position: a re-run derives the same key (unlike
         # id(msg)), keeping dedup stable.
         mid = getattr(msg, "id", None) or f"{session_id}#row{row_index}"
@@ -319,7 +321,10 @@ def _skip_is_safe(history: "HistoryStore", prior: dict) -> bool:
     in *this* DB. A manifest with no rows is trivially safe; an empty session
     that should have rows means the DB was reset — re-sync (the UNIQUE index
     dedups, so a healthy DB only pays a re-read)."""
-    if int(prior.get("rows_inserted", 0)) <= 0:
+    expected_rows = int(
+        prior.get("rows_processed", prior.get("rows_inserted", 0)),
+    )
+    if expected_rows <= 0:
         return True
     session_id = prior.get("session_id") or ""
     if not session_id:
@@ -358,9 +363,10 @@ def sync_sessions_to_history(
     skipped via the manifest and the DB's UNIQUE index makes re-appends no-ops.
     Never deletes or rewrites the source session files.
 
-    ``retention_days`` (0 = keep forever) skips messages older than the window,
-    so we don't import rows the same-boot purge would delete. A fully aged-out
-    session imports 0 rows, and its manifest entry lets later boots skip it.
+    ``retention_days`` (0 = keep forever) skips a session only when its latest
+    message is older than the window, so active sessions remain complete. A
+    fully aged-out session imports 0 rows, and its manifest entry lets later
+    boots skip it.
     """
     sessions_path = Path(sessions_dir).expanduser()
     report = SyncReport()
@@ -448,7 +454,7 @@ def _purge_old_history(
     retention_days: int,
     agent_id: str | None = None,
 ) -> None:
-    """Drop history rows older than ``retention_days`` (0 = keep forever).
+    """Drop sessions inactive for ``retention_days`` (0 = keep forever).
 
     Runs on every startup so the store still shrinks even if the agent was
     killed before its teardown purge could run. Best-effort: a failure is
@@ -460,7 +466,7 @@ def _purge_old_history(
         datetime.now(timezone.utc) - timedelta(days=retention_days)
     ).isoformat()
     try:
-        removed = history.purge(before=cutoff)
+        removed = history.purge_inactive_sessions(before=cutoff)
     except Exception as exc:  # noqa: BLE001 - retention must never break boot
         logger.warning(
             "session-sync[%s]: retention purge failed: %s",
@@ -470,7 +476,8 @@ def _purge_old_history(
         return
     if removed:
         logger.info(
-            "session-sync[%s]: purged %d row(s) older than %dd",
+            "session-sync[%s]: purged %d row(s) from sessions inactive for "
+            "more than %dd",
             agent_id,
             removed,
             retention_days,

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -893,10 +893,10 @@ class ScrollContextConfig(BaseModel):
         default=30,
         ge=0,
         description=(
-            "Days of durable history to keep; rows older than this are "
-            "purged automatically on startup and on agent teardown. Default "
-            "30 keeps roughly the last month. Set 0 to keep history forever "
-            "(unbounded growth — only the capacity warning fires)."
+            "Days an inactive session's durable history is kept. A session "
+            "whose latest row is older than this is purged as a whole on "
+            "startup and agent teardown. Default 30; set 0 to keep history "
+            "forever (unbounded growth — only the capacity warning fires)."
         ),
     )
 

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -223,6 +223,41 @@ def test_purge_dry_run_reports_count_without_deleting(store: HistoryStore):
     assert store.count("s") == 1
 
 
+def test_purge_inactive_sessions_keeps_active_session_whole(
+    store: HistoryStore,
+):
+    old = "2020-01-01T00:00:00+00:00"
+    recent = "2030-01-01T00:00:00+00:00"
+    store.append(
+        session_id="active",
+        dedup_key="old",
+        entry=_entry("active-old", created_at=old),
+    )
+    store.append(
+        session_id="active",
+        dedup_key="new",
+        entry=_entry("active-new", created_at=recent),
+    )
+    store.append(
+        session_id="inactive",
+        dedup_key="old-1",
+        entry=_entry("inactive-1", created_at=old),
+    )
+    store.append(
+        session_id="inactive",
+        dedup_key="old-2",
+        entry=_entry("inactive-2", created_at=old),
+    )
+
+    removed = store.purge_inactive_sessions(
+        before="2025-01-01T00:00:00+00:00",
+    )
+
+    assert removed == 2
+    assert store.count("active") == 2
+    assert store.count("inactive") == 0
+
+
 def test_estimate_purge_reports_rows_and_bytes(store: HistoryStore):
     store.append(
         session_id="s",

--- a/tests/unit/agents/context/test_sync.py
+++ b/tests/unit/agents/context/test_sync.py
@@ -24,6 +24,7 @@ from qwenpaw.agents.context.scroll.sync import (
     sync_all_scroll_agents,
     sync_sessions_to_history,
 )
+from qwenpaw.agents.context.types import LogEntry
 
 
 def _sample_msgs() -> list[Msg]:
@@ -140,6 +141,51 @@ def test_sync_is_idempotent_via_manifest(store, tmp_path: Path):
     assert store.count("sid") == total
 
 
+def test_v1_manifest_is_invalidated_for_session_retention_backfill(
+    store,
+    tmp_path: Path,
+):
+    sessions = tmp_path / "sessions"
+    path = _write_session_2x(
+        sessions,
+        "conv.json",
+        "sid",
+        _sample_msgs(),
+    )
+    store.append(
+        session_id="sid",
+        dedup_key="existing",
+        entry=LogEntry(kind="model_turn", content="existing"),
+    )
+    manifest_path = sessions / MANIFEST_NAME
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "conv.json": {
+                        "sha256": sync_mod._sha256(path),
+                        "session_id": "sid",
+                        "rows_processed": 1,
+                        "rows_inserted": 1,
+                    },
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    report = sync_sessions_to_history(
+        history=store,
+        sessions_dir=sessions,
+    )
+
+    assert report.rows_inserted > 0
+    assert not any(f.skipped for f in report.files)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["version"] == 2
+
+
 def test_manifest_skip_self_heals_when_db_was_reset(tmp_path: Path):
     """A surviving manifest must NOT skip a session missing from a fresh DB.
 
@@ -169,6 +215,45 @@ def test_manifest_skip_self_heals_when_db_was_reset(tmp_path: Path):
         assert h2.count("sid") == 0
         report = sync_sessions_to_history(history=h2, sessions_dir=sessions)
         # Verified skip detected the empty session and re-synced it.
+        assert report.rows_inserted > 0
+        assert h2.count("sid") > 0
+    finally:
+        h2.close()
+
+
+def test_zero_insert_manifest_self_heals_when_db_was_reset(tmp_path: Path):
+    """A v2 re-scan may insert nothing, but still represents expected rows."""
+    sessions = tmp_path / "sessions"
+    _write_session_2x(sessions, "conv.json", "sid", _sample_msgs())
+
+    db_path = tmp_path / "history.db"
+    h1 = HistoryStore(db_path)
+    try:
+        first = sync_sessions_to_history(
+            history=h1,
+            sessions_dir=sessions,
+            use_manifest=False,
+        )
+        assert first.rows_inserted > 0
+        rescan = sync_sessions_to_history(
+            history=h1,
+            sessions_dir=sessions,
+        )
+        assert rescan.rows_inserted == 0
+    finally:
+        h1.close()
+
+    for suffix in ("", "-wal", "-shm"):
+        path = Path(str(db_path) + suffix)
+        if path.exists():
+            path.unlink()
+
+    h2 = HistoryStore(db_path)
+    try:
+        report = sync_sessions_to_history(
+            history=h2,
+            sessions_dir=sessions,
+        )
         assert report.rows_inserted > 0
         assert h2.count("sid") > 0
     finally:
@@ -308,7 +393,7 @@ def _write_session_dated(
     return path
 
 
-def test_retention_skips_messages_older_than_window(store, tmp_path: Path):
+def test_retention_keeps_old_messages_in_active_session(store, tmp_path: Path):
     sessions = tmp_path / "sessions"
     now = datetime.now(timezone.utc)
     old = (now - timedelta(days=40)).isoformat()
@@ -325,14 +410,14 @@ def test_retention_skips_messages_older_than_window(store, tmp_path: Path):
         sessions_dir=sessions,
         retention_days=30,
     )
-    assert report.aged_out == 1  # the 40-day-old user turn was skipped
-    assert store.count("sid") > 0  # the recent assistant turn landed
-    # The aged-out message's content must NOT be in the DB.
+    assert report.aged_out == 0
+    assert store.count("sid") > 0
+    # A recent message keeps the complete session, including its older turn.
     rows = store._conn.execute(
         "SELECT 1 FROM conversation_history "
         "WHERE content LIKE '%please do X%'",
     ).fetchall()
-    assert rows == []
+    assert len(rows) == 1
 
 
 def test_retention_zero_keeps_everything(store, tmp_path: Path):

--- a/website/public/docs/context.en.md
+++ b/website/public/docs/context.en.md
@@ -253,7 +253,7 @@ Conversations that predate scroll — or any chats already stored as `sessions/*
 - **When**: on app startup, for every agent whose `strategy` is `"scroll"`.
 - **Source**: `{working_dir}/sessions/*.json` (including channel subdirectories). The original session files are never modified or deleted.
 - **One-time per file**: a `sessions/.synced.json` manifest records what was imported, so later startups skip unchanged files. Re-imports are no-ops — a `UNIQUE` index deduplicates rows.
-- **Retention-aware**: messages older than `scroll_config.history_retention_days` (default `30`) are skipped during import, matching the same-boot purge that trims `history.db` to the retention window. Set `history_retention_days` to `0` to keep — and import — everything.
+- **Retention-aware**: import skips only inactive sessions whose latest message is older than `scroll_config.history_retention_days` (default `30`). Active sessions are imported whole, matching the same-boot session-level purge of `history.db`. Set `history_retention_days` to `0` to keep — and import — everything.
 - **Non-blocking**: if the backfill fails, startup continues; that agent simply won't have its old chats imported, while scroll keeps recording new turns normally.
 
 > On the first startup, a one-time notice is logged while session files are imported, since a large backlog can take a moment. Later startups have a manifest and pass straight through.
@@ -297,16 +297,16 @@ The legacy `pruning_recent_n` and `pruning_old_msg_max_bytes` tier settings are 
 
 Important fields:
 
-| Field                                            | Default        | Meaning                                                                                                           |
-| ------------------------------------------------ | -------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `strategy`                                       | `"scroll"`     | Selects Scroll's durable-history protocol. Legacy Native values are accepted only for compatibility and fallback. |
-| `context_compact_config.compact_threshold_ratio` | `0.8`          | Trigger when model input reaches this fraction of context size.                                                   |
-| `context_compact_config.reserve_threshold_ratio` | `0.1`          | Recent tail budget kept after eviction.                                                                           |
-| `scroll_config.db_filename`                      | `"history.db"` | SQLite filename relative to the workspace.                                                                        |
-| `scroll_config.tool_output_token_cap`            | `3000`         | Deprecated and ignored; explicit values log a warning. Use `pruning_recent_msg_max_bytes`.                        |
-| `scroll_config.repl_timeout_s`                   | `300`          | Per-call timeout for `recall_history_python`.                                                                     |
-| `scroll_config.history_retention_days`           | `30`           | Auto-purge rows older than this many days. Set `0` to keep forever.                                               |
-| `scroll_config.offload_dialog`                   | `false`        | Also write legacy `dialog/*.jsonl` archive. `history.db` remains the source of truth.                             |
+| Field                                            | Default        | Meaning                                                                                                             |
+| ------------------------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `strategy`                                       | `"scroll"`     | Selects Scroll's durable-history protocol. Legacy Native values are accepted only for compatibility and fallback.   |
+| `context_compact_config.compact_threshold_ratio` | `0.8`          | Trigger when model input reaches this fraction of context size.                                                     |
+| `context_compact_config.reserve_threshold_ratio` | `0.1`          | Recent tail budget kept after eviction.                                                                             |
+| `scroll_config.db_filename`                      | `"history.db"` | SQLite filename relative to the workspace.                                                                          |
+| `scroll_config.tool_output_token_cap`            | `3000`         | Deprecated and ignored; explicit values log a warning. Use `pruning_recent_msg_max_bytes`.                          |
+| `scroll_config.repl_timeout_s`                   | `300`          | Per-call timeout for `recall_history_python`.                                                                       |
+| `scroll_config.history_retention_days`           | `30`           | Purge whole sessions with no new rows for this many days; active sessions remain complete. Set `0` to keep forever. |
+| `scroll_config.offload_dialog`                   | `false`        | Also write legacy `dialog/*.jsonl` archive. `history.db` remains the source of truth.                               |
 
 ## Manual Compaction
 

--- a/website/public/docs/context.zh.md
+++ b/website/public/docs/context.zh.md
@@ -252,7 +252,7 @@ scroll 不再有独立的 token 工具结果 cap。所有实时 preview 都使�
 - **时机**：应用启动时，对每个 `strategy` 为 `"scroll"` 的 Agent 执行。
 - **来源**：`{working_dir}/sessions/*.json`（含渠道子目录）。原始会话文件不会被修改或删除。
 - **逐文件一次性**：`sessions/.synced.json` 清单记录已导入的内容，之后的启动会跳过未变更的文件。重复导入是空操作——`UNIQUE` 索引会去重。
-- **遵循保留期**：导入时会跳过早于 `scroll_config.history_retention_days`（默认 `30`）的消息，与同次启动把 `history.db` 裁剪到保留期的清理保持一致。把 `history_retention_days` 设为 `0` 可保留并导入全部历史。
+- **遵循保留期**：导入时只跳过最后一条消息也早于 `scroll_config.history_retention_days`（默认 `30`）的非活跃会话；活跃会话会完整导入，与同次启动按会话清理 `history.db` 的行为一致。把 `history_retention_days` 设为 `0` 可保留并导入全部历史。
 - **不阻塞启动**：回填失败也不影响启动，该 Agent 只是没导入旧对话，scroll 仍会正常记录新轮次。
 
 > 首次启动导入会话文件时会打印一次性提示，因为积压较多时可能需要一点时间；之后的启动有清单，会直接跳过。
@@ -304,7 +304,7 @@ scroll 不再有独立的 token 工具结果 cap。所有实时 preview 都使�
 | `scroll_config.db_filename`                      | `"history.db"` | 相对工作区的 SQLite 文件名。                                                      |
 | `scroll_config.tool_output_token_cap`            | `3000`         | 已废弃且会被忽略；显式配置会输出 warning。请改用 `pruning_recent_msg_max_bytes`。 |
 | `scroll_config.repl_timeout_s`                   | `300`          | `recall_history_python` 单次调用超时时间。                                        |
-| `scroll_config.history_retention_days`           | `30`           | 自动清理早于该天数的历史行；设为 `0` 表示永久保留。                               |
+| `scroll_config.history_retention_days`           | `30`           | 整体清理超过该天数没有新记录的会话；活跃会话完整保留，设为 `0` 表示永久保留。     |
 | `scroll_config.offload_dialog`                   | `false`        | 是否额外写旧版 `dialog/*.jsonl` 归档；`history.db` 仍是真相来源。                 |
 
 ## 手动压缩


### PR DESCRIPTION
## Summary

Change Scroll history retention from row-level age pruning to session-level inactivity pruning.

Previously, active long-running sessions could lose older messages as individual rows crossed the retention boundary. This change keeps active sessions intact and removes only sessions that have been inactive beyond the configured retention period.

## Changes

- Use `MAX(created_at)` for each `session_id` as the session's last activity time.
- Purge all rows of a session only when its latest row exceeds `history_retention_days`.
- Keep all history rows belonging to active sessions.
- Preserve `history_retention_days = 0` as “keep forever.”
- Keep FTS indexes synchronized during session-level deletion.
- Align `sessions/*.json` startup imports with session-level retention:
  - inactive sessions are skipped;
  - active sessions are imported in full.
- Bump the session sync manifest from v1 to v2:
  - existing session files are rescanned once;
  - existing rows remain deduplicated;
  - recoverable rows previously removed by row-level retention can be backfilled.
- Use `rows_processed` when validating manifest entries so synchronization can recover after `history.db` is rebuilt.
- Update configuration descriptions, warnings, and English/Chinese documentation.
- No `history.db` schema migration is required.
- Source `sessions/*.json` files are never modified or deleted.

## Behavior

- Latest session row is within 30 days → keep the complete session.
- Latest session row is older than 30 days → delete the complete session.
- `history_retention_days = 0` → retain all sessions indefinitely.

## Tests

- 116 related unit tests passed.
- Commit hooks passed, including:
  - mypy
  - Black
  - flake8
  - pylint