### PR TITLE
fix(memory): flush Auto-Memory before Scroll context eviction

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -15,6 +15,7 @@ from .context.scroll.continuation_summary import (
     ContinuationSummary,
     redact_secrets,
 )
+from .middlewares import manual_compact_memory_by_handler
 from .utils.context_stats import format_history_str
 from ..config.config import load_agent_config, get_model_max_input_length
 from ..constant import DEBUG_HISTORY_FILE, MAX_LOAD_HISTORY_COUNT
@@ -397,10 +398,11 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 finally:
                     scroll_mgr.close()
             else:
-                await agent.compress_context(
-                    forced_cfg,
-                    instructions=instructions,
-                )
+                with manual_compact_memory_by_handler():
+                    await agent.compress_context(
+                        forced_cfg,
+                        instructions=instructions,
+                    )
                 index_text = self._scroll_index_text(agent)
                 continuation_text = self._scroll_summary_text(agent)
                 cm = getattr(agent, "_context_manager", None)
@@ -425,6 +427,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
                 messages=messages,
                 session_id=self._current_session_id(),
             )
+            self._discard_submitted_pending_markers(messages)
 
         summary = self._get_summary()
         folded = int(compress_stats.get("folded", 0) or 0)
@@ -466,6 +469,25 @@ class CommandHandler(ConversationCommandHandlerMixin):
             f"{folded_line}"
             f"{detail}",
         )
+
+    def _discard_submitted_pending_markers(
+        self,
+        messages: list[Msg],
+    ) -> None:
+        """Remove pending turns covered by the manual compact task."""
+        getter = getattr(
+            self.memory_manager,
+            "get_auto_memory_turn_state",
+            None,
+        )
+        if not callable(getter):
+            return
+        state = getter(self._current_session_id())
+        pending = state.get("pending") if isinstance(state, dict) else None
+        if not isinstance(pending, list):
+            return
+        submitted = {msg.id for msg in messages if msg.id}
+        pending[:] = [marker for marker in pending if marker not in submitted]
 
     @staticmethod
     def _scroll_index_text(agent: "Agent") -> str:

--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -321,7 +321,7 @@ class CommandHandler(ConversationCommandHandlerMixin):
             return None
         return HintBlock(hint=safe_hint, source="user")
 
-    async def _process_compact(
+    async def _process_compact(  # pylint: disable=too-many-statements
         self,
         messages: list[Msg],
         args: str = "",
@@ -482,7 +482,9 @@ class CommandHandler(ConversationCommandHandlerMixin):
         )
         if not callable(getter):
             return
-        state = getter(self._current_session_id())
+        state = getter(  # pylint: disable=not-callable
+            self._current_session_id(),
+        )
         pending = state.get("pending") if isinstance(state, dict) else None
         if not isinstance(pending, list):
             return

--- a/src/qwenpaw/agents/context/base.py
+++ b/src/qwenpaw/agents/context/base.py
@@ -6,7 +6,8 @@ management. :class:`~qwenpaw.agents.react_agent.QwenPawAgent` delegates its
 AgentScope hooks and provider-overflow recovery to it:
 
 * ``_save_to_context`` -> :meth:`on_save` (after the base append)
-* ``compress_context`` -> :meth:`compress` (instead of the base compression)
+* ``_compress_context_impl`` -> :meth:`compress`
+  (instead of native compression)
 * overflow retry -> :meth:`recover_from_context_overflow`
 
 When no manager is injected, the agent keeps its native AgentScope behavior —
@@ -36,8 +37,8 @@ class ContextManager(Protocol):
     ) -> None:
         """Compress ``agent.state.context`` when it exceeds the threshold.
 
-        Called from ``QwenPawAgent.compress_context`` in place of the native
-        AgentScope compression. ``instructions`` is optional, one-shot
+        Called from ``QwenPawAgent._compress_context_impl`` after AgentScope's
+        compression middleware chain. ``instructions`` is optional, one-shot
         guidance for a manual compaction and must not be persisted as active
         conversation state.
         """

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -173,14 +173,20 @@ class MemoryMiddleware(MiddlewareBase):
             await next_handler(**input_kwargs)
             return
 
-        cfg = self._memory_config()
-        pending_markers = self._auto_memory_turn_state(agent)["pending"]
-        if (
-            getattr(cfg, "summarize_when_compact", False)
-            and pending_markers
-            and await self._will_compress_context(agent, input_kwargs)
-        ):
-            await self._flush_auto_memory(agent)
+        try:
+            cfg = self._memory_config()
+            pending_markers = self._auto_memory_turn_state(agent)["pending"]
+            if (
+                getattr(cfg, "summarize_when_compact", False)
+                and pending_markers
+                and await self._will_compress_context(agent, input_kwargs)
+            ):
+                await self._flush_auto_memory(agent)
+        except Exception:
+            logger.exception(
+                "MemoryMiddleware pre-compression auto-memory flush failed; "
+                "continuing context compression",
+            )
 
         await next_handler(**input_kwargs)
 

--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -16,7 +16,9 @@ Currently provided:
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Set
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Iterator, Set
 
 from agentscope.middleware import MiddlewareBase
 from agentscope.message import Msg
@@ -38,6 +40,20 @@ logger = logging.getLogger(__name__)
 MAX_AUTO_MEMORY_TURN_MARKERS = 1000
 _AUTOMATION_MEMORY_SKIP_SOURCES = frozenset({"cron", "heartbeat"})
 _TOOL_RESULT_METADATA_KEY = "qwenpaw_tool_result_metadata"
+_MANUAL_COMPACT_MEMORY_BY_HANDLER: ContextVar[bool] = ContextVar(
+    "manual_compact_memory_by_handler",
+    default=False,
+)
+
+
+@contextmanager
+def manual_compact_memory_by_handler() -> Iterator[None]:
+    """Let the command handler exclusively schedule manual compact memory."""
+    token = _MANUAL_COMPACT_MEMORY_BY_HANDLER.set(True)
+    try:
+        yield
+    finally:
+        _MANUAL_COMPACT_MEMORY_BY_HANDLER.reset(token)
 
 
 class MemoryMiddleware(MiddlewareBase):
@@ -149,6 +165,10 @@ class MemoryMiddleware(MiddlewareBase):
         input_kwargs: dict[str, Any],
         next_handler: Callable[..., Any],
     ) -> None:
+        if _MANUAL_COMPACT_MEMORY_BY_HANDLER.get():
+            await next_handler(**input_kwargs)
+            return
+
         if self._is_automation_request(agent):
             await next_handler(**input_kwargs)
             return

--- a/src/qwenpaw/agents/react_agent.py
+++ b/src/qwenpaw/agents/react_agent.py
@@ -175,11 +175,13 @@ class QwenPawAgent(CodingModeMixin, Agent):
         context_config: Any = None,
         instructions: HintBlock | None = None,
     ) -> None:
-        """Delegate to the context manager, else native compression.
+        """Run context compression through AgentScope's middleware chain.
 
-        With a ``context_manager`` injected (e.g. the scroll strategy), it owns
-        compression. Otherwise fall back to AgentScope's native path, gated on
-        ``context_compact_config.enabled``.
+        The actual Scroll/native dispatch lives in
+        :meth:`_compress_context_impl`, which is AgentScope's extension point
+        beneath ``on_compress_context`` middlewares. Keeping the public entry
+        point on the base path ensures memory and plugin middlewares observe
+        both strategies consistently.
         """
         # ── Always sanitize tool messages before any model call ──
         # Orphan tool_result messages (whose tool_call was evicted by a
@@ -200,6 +202,24 @@ class QwenPawAgent(CodingModeMixin, Agent):
         except Exception:
             pass
 
+        if self._context_manager is None:
+            try:
+                lcc = self._agent_config.running.light_context_config
+                if not lcc.context_compact_config.enabled:
+                    return
+            except Exception:
+                pass
+        await super().compress_context(
+            context_config,
+            instructions=instructions,
+        )
+
+    async def _compress_context_impl(
+        self,
+        context_config: Any = None,
+        instructions: HintBlock | None = None,
+    ) -> None:
+        """Dispatch the middleware-wrapped compression implementation."""
         if self._context_manager is not None:
             if instructions is None:
                 # Preserve compatibility with third-party managers that
@@ -212,13 +232,8 @@ class QwenPawAgent(CodingModeMixin, Agent):
                     instructions=instructions,
                 )
             return
-        try:
-            lcc = self._agent_config.running.light_context_config
-            if not lcc.context_compact_config.enabled:
-                return
-        except Exception:
-            pass
-        await super().compress_context(
+
+        await super()._compress_context_impl(
             context_config,
             instructions=instructions,
         )

--- a/tests/unit/agents/test_memory_middleware.py
+++ b/tests/unit/agents/test_memory_middleware.py
@@ -417,6 +417,71 @@ class TestOnCompressContextAutomationSkip:
             mock_wc.assert_awaited_once()
             next_handler.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "failing_step",
+        [
+            "memory_config",
+            "turn_state",
+            "will_compress",
+            "flush",
+        ],
+    )
+    async def test_memory_failure_does_not_block_compression(
+        self,
+        failing_step,
+    ):
+        """Memory failures must not disable the context safety valve."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        next_handler = AsyncMock()
+
+        if failing_step == "memory_config":
+            mm.get_memory_config.side_effect = RuntimeError(
+                "memory config unavailable",
+            )
+        else:
+            _auto_memory_turn_state(mm)["pending"] = ["m1"]
+
+        if failing_step == "turn_state":
+            mm.get_auto_memory_turn_state.side_effect = RuntimeError(
+                "memory state unavailable",
+            )
+
+        will_compress = AsyncMock(return_value=True)
+        flush = AsyncMock()
+        if failing_step == "will_compress":
+            will_compress.side_effect = RuntimeError("token count failed")
+        if failing_step == "flush":
+            flush.side_effect = RuntimeError("memory flush failed")
+
+        with patch.object(
+            MemoryMiddleware,
+            "_will_compress_context",
+            will_compress,
+        ), patch.object(
+            MemoryMiddleware,
+            "_flush_auto_memory",
+            flush,
+        ):
+            await mw.on_compress_context(agent, {}, next_handler)
+
+        next_handler.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_compression_failure_is_not_swallowed(self):
+        """Only memory failures are fail-open; compression still fails loud."""
+        mm = _make_memory_manager()
+        mw = MemoryMiddleware(memory_manager=mm)
+        agent = _make_agent(source="user")
+        next_handler = AsyncMock(
+            side_effect=RuntimeError("scroll compression failed"),
+        )
+
+        with pytest.raises(RuntimeError, match="scroll compression failed"):
+            await mw.on_compress_context(agent, {}, next_handler)
+
 
 class TestWillCompressContextBoundary:
     @staticmethod

--- a/tests/unit/agents/test_react_agent_compression.py
+++ b/tests/unit/agents/test_react_agent_compression.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access
+"""Agent-level tests for compression strategy middleware wiring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from agentscope.agent import Agent, ContextConfig
+from agentscope.message import HintBlock, Msg, TextBlock
+
+from qwenpaw.agents.middlewares import MemoryMiddleware
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.constant import (
+    EXTERNAL_USER_QUERY_MESSAGE_TAG,
+    QWENPAW_MESSAGE_TAG_KEY,
+)
+
+
+class _TokenModel:
+    context_size = 100
+
+    async def count_tokens(self, **_kwargs: Any) -> int:
+        return 90
+
+
+class _MemoryManager:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self._turn_state: dict[str, Any] = {
+            "pending": ["turn-1"],
+            "seen": {"turn-1": None},
+            "touched_at": 0,
+        }
+
+    def get_memory_prompt(self) -> str:
+        return ""
+
+    def get_memory_config(self) -> Any:
+        return SimpleNamespace(summarize_when_compact=True)
+
+    def get_auto_memory_turn_state(self, _session_id: str) -> dict[str, Any]:
+        return self._turn_state
+
+    @property
+    def pending(self) -> list[str]:
+        return self._turn_state["pending"]
+
+    async def auto_memory(self, _messages: list[Msg], **_kwargs: Any) -> None:
+        self._events.append("auto_memory")
+
+
+class _ScrollManager:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.instructions: HintBlock | None = None
+
+    async def compress(
+        self,
+        _agent: Any,
+        _context_config: Any = None,
+        instructions: HintBlock | None = None,
+    ) -> None:
+        self.instructions = instructions
+        self._events.append("scroll")
+
+
+def _scroll_agent(
+    memory_manager: _MemoryManager,
+    scroll_manager: _ScrollManager,
+) -> QwenPawAgent:
+    agent = object.__new__(QwenPawAgent)
+    Agent.__init__(
+        agent,
+        name="QwenPaw",
+        system_prompt="",
+        model=_TokenModel(),
+        middlewares=[MemoryMiddleware(memory_manager=memory_manager)],
+        context_config=ContextConfig(trigger_ratio=0.5, reserve_ratio=0.1),
+    )
+    agent._agent_config = SimpleNamespace(
+        running=SimpleNamespace(
+            light_context_config=SimpleNamespace(
+                context_compact_config=SimpleNamespace(enabled=True),
+            ),
+        ),
+    )
+    agent._request_context = {
+        "source": "user",
+        "session_id": "session-1",
+    }
+    agent._context_manager = scroll_manager
+    agent.state.session_id = "session-1"
+    user = Msg(
+        name="user",
+        role="user",
+        content=[TextBlock(type="text", text="remember this")],
+        metadata={
+            QWENPAW_MESSAGE_TAG_KEY: EXTERNAL_USER_QUERY_MESSAGE_TAG,
+        },
+    )
+    user.id = "turn-1"
+    agent.state.context = [user]
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_scroll_runs_auto_memory_middleware_before_eviction() -> None:
+    """Scroll must not bypass AgentScope's compression middleware chain."""
+    events: list[str] = []
+    memory_manager = _MemoryManager(events)
+    scroll_manager = _ScrollManager(events)
+    agent = _scroll_agent(memory_manager, scroll_manager)
+
+    instructions = HintBlock(hint="preserve decisions", source="user")
+    await agent.compress_context(instructions=instructions)
+
+    assert events == ["auto_memory", "scroll"]
+    assert scroll_manager.instructions is instructions
+    assert not memory_manager.pending

--- a/tests/unit/agents/test_react_agent_compression.py
+++ b/tests/unit/agents/test_react_agent_compression.py
@@ -11,6 +11,7 @@ import pytest
 from agentscope.agent import Agent, ContextConfig
 from agentscope.message import HintBlock, Msg, TextBlock
 
+from qwenpaw.agents.command_handler import CommandHandler
 from qwenpaw.agents.middlewares import MemoryMiddleware
 from qwenpaw.agents.react_agent import QwenPawAgent
 from qwenpaw.constant import (
@@ -29,6 +30,8 @@ class _TokenModel:
 class _MemoryManager:
     def __init__(self, events: list[str]) -> None:
         self._events = events
+        self.enabled = True
+        self.submitted: list[list[str]] = []
         self._turn_state: dict[str, Any] = {
             "pending": ["turn-1"],
             "seen": {"turn-1": None},
@@ -50,6 +53,14 @@ class _MemoryManager:
 
     async def auto_memory(self, _messages: list[Msg], **_kwargs: Any) -> None:
         self._events.append("auto_memory")
+
+    def add_summarize_task(
+        self,
+        messages: list[Msg],
+        **_kwargs: Any,
+    ) -> None:
+        self._events.append("handler_memory")
+        self.submitted.append([msg.get_text_content() for msg in messages])
 
 
 class _ScrollManager:
@@ -119,4 +130,42 @@ async def test_scroll_runs_auto_memory_middleware_before_eviction() -> None:
 
     assert events == ["auto_memory", "scroll"]
     assert scroll_manager.instructions is instructions
+    assert not memory_manager.pending
+
+
+@pytest.mark.asyncio
+async def test_manual_compact_submits_auto_memory_once() -> None:
+    """The command handler, not compression middleware, owns manual memory."""
+    events: list[str] = []
+    memory_manager = _MemoryManager(events)
+    scroll_manager = _ScrollManager(events)
+    agent = _scroll_agent(memory_manager, scroll_manager)
+    agent.state.context.append(
+        Msg(
+            name="QwenPaw",
+            role="assistant",
+            content=[TextBlock(type="text", text="answer-1")],
+        ),
+    )
+    handler = CommandHandler(
+        agent_name="QwenPaw",
+        agent=agent,
+        memory_manager=memory_manager,
+    )
+    handler._get_agent_config = lambda: SimpleNamespace(
+        running=SimpleNamespace(
+            light_context_config=SimpleNamespace(
+                strategy="scroll",
+                context_compact_config=SimpleNamespace(enabled=True),
+            ),
+            reme_light_memory_config=SimpleNamespace(
+                summarize_when_compact=True,
+            ),
+        ),
+    )
+
+    await handler.handle_command("/compact")
+
+    assert events == ["scroll", "handler_memory"]
+    assert memory_manager.submitted == [["remember this", "answer-1"]]
     assert not memory_manager.pending

--- a/tests/unit/agents/test_react_agent_scroll_seen.py
+++ b/tests/unit/agents/test_react_agent_scroll_seen.py
@@ -137,6 +137,7 @@ async def test_compress_context_forwards_one_shot_instructions():
     tracker = CompressionTracker()
     agent = object.__new__(QwenPawAgent)
     agent._context_manager = tracker
+    agent._compress_context_middlewares = []
     agent.state = SimpleNamespace(context=[])
     config = SimpleNamespace(trigger_ratio=0.1)
     instructions = HintBlock(hint="prioritize failures", source="user")


### PR DESCRIPTION
## Description

修复 Scroll 上下文策略在自动压缩时绕过 AgentScope 压缩中间件，导致尚未写入 Auto-Memory 的早期会话被淘汰、最终缺失于每日记忆的问题；同时避免手动 `/compact` 接入该中间件链后重复提交 Auto-Memory summarization task。

Fixes #6555

### 问题背景

Auto-Memory 会按照 `auto_memory_interval` 批量处理用户回合，并将结果写入 `memory/YYYY-MM-DD.md`。尚未达到批处理间隔的回合会暂存在 pending markers 中。

原来的 `QwenPawAgent.compress_context()` 存在两条不同路径：

- Native 策略调用 `super().compress_context()`，会进入 AgentScope 的 `on_compress_context` 中间件链。
- Scroll 策略直接调用 `self._context_manager.compress(...)` 并返回，完全绕过中间件链。

因此，当 Scroll 在 Auto-Memory 批处理触发前淘汰早期消息时，`MemoryMiddleware.on_compress_context()` 没有机会先执行 `_flush_auto_memory()`。之后 Auto-Memory 只能从当前活跃上下文中查找 pending markers 对应的消息，而这些消息已经被 Scroll 移出活跃窗口，导致相关事件无法写入每日记忆，后续 Auto-Dream 也无法从每日记忆中恢复这些内容。

统一压缩入口后，agent-backed 手动 `/compact` 也会进入 `MemoryMiddleware`。如果存在 pending markers，middleware 会先通过 `auto_memory()` 提交一次，而 `CommandHandler` 在压缩完成后还会对压缩前的完整消息调用 `add_summarize_task()`，造成重复 LLM summarization、额外费用及潜在的重复或竞争写入。

### 修改内容

1. 将 `QwenPawAgent.compress_context()` 统一接入 AgentScope 的压缩中间件链。
2. 新增 `_compress_context_impl()` 作为中间件链执行完成后的实际策略分派点：
   - 配置了 context manager 时，调用 Scroll 或其他注入的 context manager；
   - 未配置 context manager 时，调用 AgentScope 原生压缩实现。
3. 保留原生压缩的 `context_compact_config.enabled` 开关行为。
4. 保留第三方 context manager 的兼容性：没有一次性 `instructions` 时仍按原有双参数协议调用。
5. 确保手动 `/compact` 传入的 `instructions` 能继续传递给 Scroll manager。
6. 更新 `ContextManager` 接口说明，明确压缩发生在 AgentScope 中间件链之后。
7. 使用调用级 `ContextVar` 标记由 `CommandHandler` 驱动的手动压缩；此时 `MemoryMiddleware` 继续执行压缩链，但跳过 pending flush，由 handler 唯一提交一次压缩前完整消息批次。
8. handler 成功提交后，仅移除该批次已覆盖的 pending markers，避免后续自动 flush 再次提交，同时不污染或改写持久消息 tag。

修改后的自动压缩调用链为：

```text
QwenPawAgent.compress_context()
  -> AgentScope compression middleware chain
  -> MemoryMiddleware.on_compress_context()
  -> flush pending Auto-Memory turns（满足配置和压缩阈值时）
  -> QwenPawAgent._compress_context_impl()
  -> Scroll manager 或 AgentScope native compression
```

手动压缩调用链为：

```text
CommandHandler /compact（设置调用级标记）
  -> AgentScope compression middleware chain
  -> MemoryMiddleware 跳过 pending flush
  -> Scroll/native compression
  -> CommandHandler 提交一次完整消息批次
  -> 清理该批次已覆盖的 pending markers
```

这样，在 Scroll 真正淘汰活跃上下文之前，待处理的用户回合能够先提交给 Auto-Memory，从而避免 #6555 描述的早期会话记忆缺失窗口；手动 `/compact` 则保持单一 Auto-Memory 调度方。

### 行为范围

本次修改修复常规 Scroll 自动压缩绕过中间件的问题，并使 Scroll 与 Native 策略具有一致的压缩中间件语义。自动压缩仍由 `MemoryMiddleware` flush pending turns；手动 `/compact` 仍由 `CommandHandler` 提交压缩前的完整消息，只是不再重复提交。

本次修改不负责回填升级前已经丢失的每日记忆；历史缺失内容仍需从 `history.db` 或 `dialog/*.jsonl` 中恢复。压缩前是否触发 Auto-Memory 仍遵循现有 `summarize_when_compact` 配置。

**Related Issue:** Fixes #6555

**Security Considerations:** 不涉及认证、权限、密钥、网络边界或配置文件安全行为变更。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactoring

## Component(s) Affected

- [x] Core / Backend (agents and context management)
- [ ] Console (frontend web UI)
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [x] Documentation / docstrings
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Testing

新增 `tests/unit/agents/test_react_agent_compression.py`，构造带有 `MemoryMiddleware` 和 Scroll context manager 的 Agent，并验证：

- 达到压缩阈值时，Auto-Memory 在 Scroll 淘汰之前运行；
- 自动压缩的实际事件顺序严格为 `auto_memory -> scroll`；
- pending marker 在 Auto-Memory 成功处理后被清除；
- 一次性压缩 `instructions` 被完整传递给 Scroll manager；
- 完整执行 `handler.handle_command("/compact")` 时，实际事件顺序为 `scroll -> handler_memory`；
- 压缩前消息只提交一个 summarization task，且已覆盖的 pending marker 被清除。

同时更新既有 Scroll 指令透传测试，使其显式初始化压缩中间件列表。

本地执行相关回归测试：

```bash
uv run pytest -q \
  tests/unit/agents/test_react_agent_compression.py \
  tests/unit/agents/test_react_agent_scroll_seen.py \
  tests/unit/agents/test_memory_middleware.py \
  tests/unit/agents/test_command_handler.py \
  tests/unit/agents/test_command_handler_scroll.py \
  tests/unit/agents/test_context_overflow_recovery.py

73 passed in 0.84s
```

## Evidence

- 自动压缩回归测试覆盖 #6555 的关键顺序要求：`events == ["auto_memory", "scroll"]`。
- 手动 `/compact` 回归测试覆盖完整 CommandHandler 调用链，并断言只提交一次完整消息批次：`events == ["scroll", "handler_memory"]`。
- 本地相关测试共 73 项全部通过，Ruff 检查通过。
- GitHub CodeQL Python/TypeScript、网站及 Console 格式检查、Real behavior proof 已通过。
- 完整跨平台测试矩阵由 GitHub Actions 持续验证。

## Additional Notes

该修复选择统一压缩入口，而不是在 Scroll manager 内部直接依赖 MemoryMiddleware。这样可以让当前和未来的其他压缩中间件同样观察 Native 与 Scroll 两种策略，避免两个压缩路径再次产生行为差异。

手动 `/compact` 的所有权通过调用级状态传递，没有向消息增加 tag，因此不会污染模型输入、Scroll 历史或持久化会话数据。
