### PR TITLE
fix(agent_management): normalize empty batch placeholders (#6588)

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -988,13 +988,19 @@ def _normalize_batch(
 ) -> Optional[list[Dict[str, Any]]]:
     """Normalize ``batch`` to ``list[dict]`` or ``None``.
 
-    Accepts a real list or a JSON array string.  Structural checks
-    (non-empty, per-item ``task``) remain in :func:`_spawn_batch`.
+    Accepts a real list or a JSON array string.  Empty placeholders are
+    treated as "field not supplied" so Responses-compatible models that
+    emit ``""``, ``[]``, or ``"[]"`` can still use single-task mode.
+    This compatibility rule stays batch-specific because empty values
+    have security-relevant meanings for fields such as ``allowed_tools``.
     """
     if value is None:
         return None
+    if isinstance(value, str) and not value.strip():
+        return None
     coerced = _coerce_json_list(value, "batch")
-    assert coerced is not None
+    if not coerced:
+        return None
     return coerced  # type: ignore[return-value]
 
 

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -604,6 +604,8 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
         "0.5",
         "1e-9",
         "abc",
+        "null",
+        "None",
         True,
         False,
         "",
@@ -614,6 +616,80 @@ def test_coerce_timeout_accepts_numeric_and_rejects_non_positive():
             assert "timeout" in str(exc)
         else:
             raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "   ", [], "[]", "  [ ]  "],
+)
+def test_normalize_batch_empty_placeholders_return_none(value):
+    assert agent_management._normalize_batch(value) is None
+
+
+@pytest.mark.parametrize("value", ["null", "None", "not json array", {}])
+def test_normalize_batch_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        agent_management._normalize_batch(value)
+
+
+def test_allowed_tools_empty_string_remains_invalid():
+    with pytest.raises(ValueError, match="allowed_tools"):
+        agent_management._normalize_str_list("", "allowed_tools")
+
+
+@pytest.mark.parametrize("batch", ["", "   ", [], "[]", "  [ ]  "])
+async def test_spawn_subagent_empty_batch_uses_single_task(
+    monkeypatch,
+    batch,
+):
+    collected = []
+
+    def fake_collect(_base, payload, _agent_id, _timeout):
+        collected.append(payload)
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    response = await agent_management.spawn_subagent(
+        task="do work",
+        batch=batch,
+    )
+
+    assert "ERROR" not in response.content[0].text
+    assert "done" in response.content[0].text
+    assert len(collected) == 1
 
 
 def test_spawn_subagent_schema_accepts_batch_string():


### PR DESCRIPTION
## Description

Fixes #6588.

Some Responses-compatible model/provider paths emit empty placeholders for
the optional `batch` argument in an otherwise single-task `spawn_subagent`
call. QwenPaw previously treated `batch=[]` and `batch="[]"` as selecting
batch mode, which then conflicted with the non-empty `task`. An empty string
failed during generic list coercion.

This revision follows the maintainer review on this PR:

- Normalize `None`, empty/whitespace strings, empty lists, and JSON empty
  arrays to `None` only in `_normalize_batch()`.
- Keep generic coercers unchanged, so ambiguous values such as
  `allowed_tools=""` continue to fail rather than becoming the permissive
  `None`/inherit-all state.
- Add an end-to-end regression that invokes `spawn_subagent()` with each
  empty placeholder and verifies the single-task dispatch path is used.

**Related Issue:** Fixes #6588

**Security Considerations:** The compatibility behavior is intentionally
batch-specific. `allowed_tools=[]` still means deny all tools, omitted
`allowed_tools` still means inherit, and `allowed_tools=""` remains invalid.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran the applicable pre-commit hooks locally and they pass
- [x] I ran the relevant tests locally and they pass
- [x] Documentation updated (not needed; no user-facing API change)
- [x] Ready for review

## Testing

The focused suite covers direct normalization, invalid values,
`allowed_tools=""` as a fail-loud control, and actual single-task dispatch
for `batch=""`, whitespace, `[]`, `"[]"`, and `" [ ] "`.

## Evidence

```bash
.venv/bin/pytest tests/unit/agents/tools/test_agent_management.py -q
# 47 passed in 5.06s

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/agents/tools/agent_management.py \
  tests/unit/agents/tools/test_agent_management.py
# check python ast, encoding, private-key detection, whitespace,
# trailing commas, mypy, black, flake8, and pylint: Passed
```

`actionlint` was skipped because the local machine exposes Go 1.17.13 while
the hook dependencies require Go 1.19+. It does not inspect either changed
Python file. All applicable hooks passed cleanly.

## Additional Notes

The implementation was AI-assisted and then reviewed against the reported
raw tool-call arguments, maintainer feedback, the current `main` branch, and
the focused regression suite above.
