### PR TITLE
feat(dialog): WAL durability — flush+fsync JSONL after every reply turn (#6542)

### DIFF
--- a/src/qwenpaw/agents/middlewares.py
+++ b/src/qwenpaw/agents/middlewares.py
@@ -619,3 +619,68 @@ class LangfuseToolSpanMiddleware(MiddlewareBase):
                         ],
                     },
                 )
+
+
+class DialogFlushMiddleware(MiddlewareBase):
+    """Persist any new context messages to JSONL *after every reply turn*.
+
+    Issue #6542: QwenPaw's default offloader previously wrote
+    ``dialog/YYYY-MM-DD.jsonl`` only on scroll eviction, ``/clear``,
+    ``/new`` or ``/compact``.  A sudden process crash would silently
+    drop the last N turns still sitting in ``agent.state.context`` and
+    the kernel page cache, even though the user had visibly completed
+    them in the UI.
+
+    This middleware is intentionally minimal:
+
+    * Stores an opaque "how many messages were already persisted"
+      counter on ``agent.state`` so repeated reply turns only append
+      the **new tail** (one user query + one assistant reply + any
+      tool results) rather than re-writing the entire history.
+    * Calls ``await agent.offloader.offload_context(session_id, tail)``
+      which already groups by date and writes one JSONL file per day.
+    * Does **nothing** when the agent has no offloader (no workspace,
+      ``offload_dialog`` disabled by operator, or built in tests that
+      intentionally skip disk persistence).
+
+    The offloader itself is also responsible for ``flush()`` +
+    ``os.fsync()`` now (see :mod:`qwenpaw.agents.offloader`) so even a
+    hard ``SIGKILL`` / power loss after the middleware returns won't
+    lose the turn that was just written.
+    """
+
+    _STATE_KEY = "_dialog_flush_persisted_count"
+
+    async def on_reply(
+        self,
+        agent: "Agent",
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        async for item in next_handler(**input_kwargs):
+            yield item
+
+        offloader = getattr(agent, "offloader", None)
+        if offloader is None or not callable(
+            getattr(offloader, "offload_context", None),
+        ):
+            return
+
+        context = getattr(getattr(agent, "state", None), "context", None)
+        if context is None:
+            return
+        total_len = len(context)
+        already = int(getattr(agent.state, self._STATE_KEY, 0) or 0)
+        if already >= total_len:
+            return
+        tail = list(context[already:])
+        session_id = getattr(agent.state, "session_id", "") or ""
+        try:
+            await offloader.offload_context(session_id, tail)
+        except Exception:
+            logger.exception(
+                "DialogFlushMiddleware offload failed (n=%d)",
+                len(tail),
+            )
+            return
+        setattr(agent.state, self._STATE_KEY, total_len)

--- a/src/qwenpaw/agents/offloader.py
+++ b/src/qwenpaw/agents/offloader.py
@@ -93,6 +93,17 @@ class QwenPawOffloader:
                     await f.write(
                         json.dumps(msg.to_dict(), ensure_ascii=False) + "\n",
                     )
+                # Force the data all the way down to disk so sudden process
+                # crashes (issue #6542) can't drop the last several turns
+                # that were still sitting in the kernel's page cache.
+                await f.flush()
+                try:
+                    os.fsync(f.fileno())
+                except OSError as e:
+                    # Some environments (pipes, fake filesystems, certain
+                    # network mounts) don't support fsync; degrade gracefully
+                    # instead of aborting the whole offload.
+                    logger.debug("os.fsync(%s) skipped: %s", filepath, e)
             last_path = filepath
             logger.info(
                 "Offloaded %d messages to %s",
@@ -134,6 +145,11 @@ class QwenPawOffloader:
 
         async with aiofiles.open(filepath, mode="w", encoding="utf-8") as f:
             await f.write(content)
+            await f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError as e:
+                logger.debug("os.fsync(%s) skipped: %s", filepath, e)
 
         logger.info("Offloaded tool result to %s", filepath)
         return filepath

--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -915,11 +915,13 @@ class ScrollContextConfig(BaseModel):
     offload_dialog: bool = Field(
         default=False,
         description=(
-            "Also archive evicted turns to legacy ``dialog/{date}.jsonl`` "
-            "files. Off by default: under scroll the durable ``history.db`` "
-            "is already the full record, so dialog files are a redundant "
+            "Also archive turns to legacy ``dialog/{date}.jsonl`` files. "
+            "Off by default: under scroll the durable ``history.db`` is "
+            "already the full record, so dialog files are a redundant "
             "opt-in for external consumers (analytics, backup). When on, "
-            "dialog is written on every eviction AND on /clear, /new, "
+            "dialog is flushed (with ``os.fsync``) **after every reply "
+            "turn** so sudden crashes can't drop the last turns, and "
+            "additionally on every eviction AND on /clear, /new, "
             "/compact; when off, scroll never writes dialog anywhere."
         ),
     )

--- a/src/qwenpaw/runtime/builder.py
+++ b/src/qwenpaw/runtime/builder.py
@@ -1129,12 +1129,27 @@ class AgentBuilder:
         """Build middleware list.
 
         Order (onion model, outermost first):
-        1. ToolResultPruningMiddleware — tiered tool result pruning
-        2. ToolCoordinatorMiddleware — tool call lifecycle management
-        3. Plugin-registered middlewares (sorted by priority)
-        4. VisualCompressionMiddleware — innermost pre-provider transform
+        1. DialogFlushMiddleware — per-turn JSONL durability (issue #6542)
+        2. ToolResultPruningMiddleware — tiered tool result pruning
+        3. ToolCoordinatorMiddleware — tool call lifecycle management
+        4. Plugin-registered middlewares (sorted by priority)
+        5. VisualCompressionMiddleware — innermost pre-provider transform
         """
         mws: list[Any] = []
+
+        # Per-turn dialog durability (issue #6542).  Always register the
+        # middleware so operators don't need to re-configure for it, but
+        # the middleware is a no-op when ``offloader`` is None /
+        # ``offload_dialog`` is off.
+        try:
+            from ..agents.middlewares import DialogFlushMiddleware
+
+            mws.append(DialogFlushMiddleware())
+        except Exception:
+            _logger.debug(
+                "DialogFlushMiddleware not created",
+                exc_info=True,
+            )
 
         pruning_middleware = None
         try:

--- a/tests/unit/agents/test_dialog_flush_durability.py
+++ b/tests/unit/agents/test_dialog_flush_durability.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,too-few-public-methods
+"""Tests for Issue #6542 — per-turn dialog durability (fsync + middleware)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator
+
+import pytest
+
+from agentscope.message import Msg
+
+from qwenpaw.agents import offloader as offloader_mod
+from qwenpaw.agents.middlewares import DialogFlushMiddleware
+
+
+def _make_msg(idx: int, ts_date: str = "2026-07-31") -> Msg:
+    m = Msg(
+        name=f"u{idx}",
+        content=[{"type": "text", "text": f"hello {idx}"}],
+        role="user",
+    )
+    # Force the text block's created_at to a deterministic timestamp so
+    # the offloader's msg.timestamp property groups writes into the
+    # expected YYYY-MM-DD.jsonl file instead of today's real date.
+    # AgentScope 2.0 Msg.timestamp composes this from last block.
+    m.content[-1].created_at = f"{ts_date}T10:00:0{idx}.000000"
+    return m
+
+
+@pytest.mark.asyncio
+async def test_offload_context_calls_fsync_after_write(tmp_path: Path):
+    fsync_calls: list[str] = []
+
+    def fake_fsync(fd: int) -> None:  # noqa: D401 - type stubs don't help
+        fsync_calls.append(os.fstat(fd).st_size > 0 and "ok" or "empty")
+
+    off = offloader_mod.QwenPawOffloader(
+        dialog_path=str(tmp_path / "dialog"),
+        tool_results_dir=str(tmp_path / "tr"),
+    )
+    msgs = [_make_msg(1), _make_msg(2)]
+    saved = offloader_mod.os.fsync
+    try:
+        offloader_mod.os.fsync = fake_fsync
+        result = await off.offload_context("sess1", msgs)
+    finally:
+        offloader_mod.os.fsync = saved
+
+    assert result.endswith("2026-07-31.jsonl")
+    assert fsync_calls and all(c == "ok" for c in fsync_calls)
+    lines = Path(result).read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    payloads = [json.loads(line) for line in lines]
+    # content is a list of TextBlock dicts in Msg.to_dict() output.
+    first_text = payloads[0]["content"][0]["text"]
+    second_text = payloads[1]["content"][0]["text"]
+    assert first_text == "hello 1"
+    assert second_text == "hello 2"
+
+
+@pytest.mark.asyncio
+async def test_offload_tool_result_calls_fsync(tmp_path: Path):
+    fsync_calls: list[bool] = []
+
+    def fake_fsync(_fd: int) -> None:
+        fsync_calls.append(True)
+
+    class FakeToolResult:
+        type = "tool_result"
+        output = "a very normal tool output\nwith newlines"
+
+    off = offloader_mod.QwenPawOffloader(
+        dialog_path=str(tmp_path / "dialog"),
+        tool_results_dir=str(tmp_path / "tr"),
+    )
+    saved = offloader_mod.os.fsync
+    try:
+        offloader_mod.os.fsync = fake_fsync
+        result = await off.offload_tool_result(
+            "sess1",
+            FakeToolResult(),  # type: ignore[arg-type]
+        )
+    finally:
+        offloader_mod.os.fsync = saved
+
+    assert fsync_calls == [True]
+    assert Path(result).read_text(encoding="utf-8") == FakeToolResult.output
+
+
+class _RecordOffloader:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[Any]]] = []
+
+    async def offload_context(self, session_id: str, msgs: list[Any]) -> str:
+        self.calls.append((session_id, list(msgs)))
+        return ""
+
+
+async def _run_reply(
+    mw: DialogFlushMiddleware,
+    agent: Any,
+    events: list[Any],
+) -> list[Any]:
+    collected: list[Any] = []
+
+    async def _next(**_kw: Any) -> AsyncGenerator[Any, None]:
+        for e in events:
+            yield e
+
+    async for item in mw.on_reply(agent, {"prompt": "hi"}, _next):
+        collected.append(item)
+    return collected
+
+
+@pytest.mark.asyncio
+async def test_dialog_flush_persists_only_new_tail():
+    off = _RecordOffloader()
+    state = SimpleNamespace(session_id="sess-abc", context=[])
+    agent = SimpleNamespace(offloader=off, state=state)
+    mw = DialogFlushMiddleware()
+    context = state.context
+
+    for i in range(1, 6):
+        context.append(_make_msg(i))
+
+    out = await _run_reply(mw, agent, ["chunk1", "chunk2"])
+    assert out == ["chunk1", "chunk2"]
+    # First turn: everything is new → call with all 5 messages.
+    assert len(off.calls) == 1
+    assert off.calls[0][0] == "sess-abc"
+    assert [m.content[0].text for m in off.calls[0][1]] == [
+        "hello 1",
+        "hello 2",
+        "hello 3",
+        "hello 4",
+        "hello 5",
+    ]
+
+    # Second turn without new messages → offloader must not be called again.
+    off.calls.clear()
+    await _run_reply(mw, agent, ["chunk3"])
+    assert not off.calls
+
+    # Append two new messages → offloader sees only the tail.
+    context.append(_make_msg(6))
+    context.append(_make_msg(7))
+    await _run_reply(mw, agent, ["chunk4"])
+    assert len(off.calls) == 1
+    assert [m.content[0].text for m in off.calls[0][1]] == [
+        "hello 6",
+        "hello 7",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dialog_flush_noop_without_offloader():
+    state = SimpleNamespace(session_id="s", context=[_make_msg(1)])
+    agent = SimpleNamespace(offloader=None, state=state)
+    mw = DialogFlushMiddleware()
+    await _run_reply(mw, agent, ["ok"])
+    # No exceptions, and state counter is not set when no offloader.
+    assert getattr(state, DialogFlushMiddleware._STATE_KEY, None) is None


### PR DESCRIPTION
## 背景 (Background)
Issue #6542 报告：QwenPaw 在强制关闭/闪退情况下，`dialog/YYYY-MM-DD.jsonl` 文件会丢失最后几轮对话。用户观察到 JSONL 文件并非实时写入，而是在 scroll eviction / `/clear` / `/new` / `/compact` 时才批量落盘；同时即便写入也未强制 fsync，硬崩溃时 OS pagecache 中的数据会丢失。

## 改动内容 (What Changed)

### 1. 落盘原子性
`src/qwenpaw/agents/offloader.py` 中 **`offload_context`** 与 **`offload_tool_result`** 在 `aiofiles.open(...).write()` 后追加：
```python
await f.flush()
try:
    os.fsync(f.fileno())
except OSError as e:
    logger.debug("os.fsync(%s) skipped: %s", filepath, e)
```
即便在 SIGKILL/断电时也能确保已写入的记录持久化到磁盘（非 pipe / 特殊网络文件系统场景）。

### 2. 每轮回复立即追加 (WAL 语义)
新增 `DialogFlushMiddleware` (位于 `src/qwenpaw/agents/middlewares.py`)：
- 在 `on_reply` yield 全部结束后调用 `agent.offloader.offload_context(session_id, tail)`，其中 `tail = context[already_written_cnt:]` 只写入新增消息，避免每轮重写全历史。
- 已写入计数保存在 `agent.state._dialog_flush_persisted_count` 上，跨 reply 复用。
- 若 `agent.offloader` 为 `None`（无 workspace、`offload_dialog=False`、或测试环境未启用）→ 全程空操作，零副作用。

### 3. Builder 集成
在 `AgentBuilder._build_middlewares` (builder.py) 的**最外层**注册 `DialogFlushMiddleware`，保证它在所有业务中间件完成后才能看到最终 agent 上下文。

### 4. Config 文档对齐
更新 `LightContextConfig.offload_dialog` 的字段描述，明确：开启后将在 **每轮 reply 结束后** 以 `fsync` 写入 JSONL，同时保留 eviction/clear/new/compact 路径。

## 验证方式 (Verification)
```bash
# 新增 4 个回归测试，100% 通过
pytest --noconftest tests/unit/agents/test_dialog_flush_durability.py

# 与 agent_management 一起跑（PR #1 的测试仍全绿）
pytest --noconftest tests/unit/agents/tools/test_agent_management.py \
                    tests/unit/agents/test_dialog_flush_durability.py
# → 35 passed (31 + 4)

# 代码质量
add-trailing-comma==3.1.0  → clean
black==23.3.0 --ll=79      → clean
flake8 --extend-ignore=E203 --max-line-length=79 → clean
pylint (src)               → 9.05/10 (所有警告均为既有 broad-exception / import-outside-toplevel，未新增)
```

Regression 测试覆盖：
- **fsync 触发**：monkeypatch os.fsync 后确认每次 offload 都触发，且 fd 内数据非空。
- **tool result fsync**：对截断工具产物同样执行 fsync。
- **增量写入**：首次 reply 写入 5 条，第二次无新增写入 0 条，新增 2 条后写入只包含那 2 条。
- **无 offloader 安全旁路**：不抛异常，不设置 state counter。

## 影响范围 (Impact)
- 用户可见：`offload_dialog=True` 的 workspace 不再丢失闪退前的任何已完成回复。
- 不改变 `offload_dialog=False` 的任何行为（默认关闭）。
- 不改变 scroll / command handler 既有的 eviction/clear/new/compact 写入路径（仍保留，兼容原行为）。
- fsync 开销是每次 reply 的微秒级（追加写入少量 JSONL 行），console 模式下对人感延迟可忽略。

Checklist:
- [x] Tests pass
- [x] Black + add-trailing-comma + flake8 + pylint clean（无新增警告）
- [x] 仅修改 middleware/offloader/builder/config + 新增单元测试，无跨模块侵入