### PR TITLE
Fix/issue 6558 session integrity

### DIFF
--- a/console/src/hooks/useCollapsedSessionGroups.test.ts
+++ b/console/src/hooks/useCollapsedSessionGroups.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Collapsed session-group state shared by SidebarSessionList and
+ * ChatSessionDrawer.
+ *
+ * Previously each list kept the collapsed set in component state with
+ * "month" and "older" collapsed by default. Leaving the page remounted
+ * the list and silently re-collapsed those groups, so a conversation
+ * older than 7 days seemed to vanish from the list (no amount of
+ * scrolling reveals a row inside a collapsed group). The hook fixes
+ * both halves: the set persists across remounts, and the group holding
+ * the active session is expanded automatically.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCollapsedSessionGroups } from "./useCollapsedSessionGroups";
+
+const STORAGE_KEY = "qwenpaw_collapsed_session_groups";
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe("useCollapsedSessionGroups", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('collapses "month" and "older" by default', () => {
+    const { result } = renderHook(() => useCollapsedSessionGroups());
+    expect(result.current.collapsedGroups.has("month")).toBe(true);
+    expect(result.current.collapsedGroups.has("older")).toBe(true);
+    expect(result.current.collapsedGroups.has("today")).toBe(false);
+  });
+
+  it("persists toggles across remounts", () => {
+    const first = renderHook(() => useCollapsedSessionGroups());
+    act(() => first.result.current.toggleGroup("older"));
+    expect(first.result.current.collapsedGroups.has("older")).toBe(false);
+    first.unmount();
+
+    // Remount (e.g. navigating away from the page and back).
+    const second = renderHook(() => useCollapsedSessionGroups());
+    expect(second.result.current.collapsedGroups.has("older")).toBe(false);
+    expect(second.result.current.collapsedGroups.has("month")).toBe(true);
+  });
+
+  it("toggle collapses an expanded group again and persists it", () => {
+    const { result } = renderHook(() => useCollapsedSessionGroups());
+    act(() => result.current.toggleGroup("today"));
+    expect(result.current.collapsedGroups.has("today")).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toContain("today");
+  });
+
+  it("expands the group containing the active session", () => {
+    const { result } = renderHook(() => useCollapsedSessionGroups());
+    act(() =>
+      result.current.expandGroupForSession({
+        pinned: false,
+        updatedAt: daysAgoIso(45),
+      }),
+    );
+    expect(result.current.collapsedGroups.has("older")).toBe(false);
+    // Unrelated groups remain collapsed.
+    expect(result.current.collapsedGroups.has("month")).toBe(true);
+  });
+
+  it("expandGroupForSession is a no-op when the group is already open", () => {
+    const { result } = renderHook(() => useCollapsedSessionGroups());
+    const before = result.current.collapsedGroups;
+    act(() =>
+      result.current.expandGroupForSession({
+        pinned: false,
+        updatedAt: daysAgoIso(0),
+      }),
+    );
+    // Same Set identity — no state churn for already-visible groups.
+    expect(result.current.collapsedGroups).toBe(before);
+  });
+
+  it("ignores corrupted persisted state", () => {
+    localStorage.setItem(STORAGE_KEY, "not json");
+    const { result } = renderHook(() => useCollapsedSessionGroups());
+    expect(result.current.collapsedGroups.has("month")).toBe(true);
+    expect(result.current.collapsedGroups.has("older")).toBe(true);
+  });
+});

--- a/console/src/hooks/useCollapsedSessionGroups.ts
+++ b/console/src/hooks/useCollapsedSessionGroups.ts
@@ -1,0 +1,96 @@
+/**
+ * Persistent collapsed-state for the date groups of the session lists.
+ *
+ * Both SidebarSessionList and ChatSessionDrawer group conversations by
+ * date and collapse the "month" / "older" groups by default. Keeping
+ * that set in component state made it reset on every remount: after
+ * navigating away and back, a conversation older than 7 days was hidden
+ * inside a re-collapsed group and could not be found by scrolling.
+ *
+ * This hook persists the set to localStorage and exposes
+ * `expandGroupForSession` so callers can force the group holding the
+ * active conversation open.
+ */
+import { useCallback, useState } from "react";
+import { getDateGroup, type DateGroup } from "../utils/sessionGrouping";
+
+const STORAGE_KEY = "qwenpaw_collapsed_session_groups";
+
+const DEFAULT_COLLAPSED: readonly DateGroup[] = ["month", "older"];
+
+const VALID_GROUPS: ReadonlySet<string> = new Set([
+  "pinned",
+  "today",
+  "week",
+  "month",
+  "older",
+]);
+
+function loadCollapsed(): Set<DateGroup> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return new Set(
+          parsed.filter((g): g is DateGroup => VALID_GROUPS.has(g)),
+        );
+      }
+    }
+  } catch {
+    // storage unavailable or corrupted — fall through to defaults
+  }
+  return new Set(DEFAULT_COLLAPSED);
+}
+
+function saveCollapsed(groups: Set<DateGroup>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...groups]));
+  } catch {
+    // storage unavailable — collapse state simply won't persist
+  }
+}
+
+/** Minimal session shape needed to resolve its date group. */
+interface GroupableSession {
+  pinned?: boolean;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+
+export interface CollapsedSessionGroups {
+  collapsedGroups: Set<DateGroup>;
+  toggleGroup: (key: DateGroup) => void;
+  /** Ensure the group containing `session` is expanded (visible). */
+  expandGroupForSession: (session: GroupableSession) => void;
+}
+
+export function useCollapsedSessionGroups(): CollapsedSessionGroups {
+  const [collapsedGroups, setCollapsedGroups] =
+    useState<Set<DateGroup>>(loadCollapsed);
+
+  const toggleGroup = useCallback((key: DateGroup) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      saveCollapsed(next);
+      return next;
+    });
+  }, []);
+
+  const expandGroupForSession = useCallback((session: GroupableSession) => {
+    const group: DateGroup = session.pinned
+      ? "pinned"
+      : getDateGroup(session.updatedAt ?? session.createdAt);
+    setCollapsedGroups((prev) => {
+      if (!prev.has(group)) return prev;
+      const next = new Set(prev);
+      next.delete(group);
+      saveCollapsed(next);
+      return next;
+    });
+  }, []);
+
+  return { collapsedGroups, toggleGroup, expandGroupForSession };
+}

--- a/console/src/layouts/SidebarSessionList.tsx
+++ b/console/src/layouts/SidebarSessionList.tsx
@@ -22,6 +22,7 @@ import {
   type ExtendedSession,
 } from "../stores/sessionListStore";
 import { type DateGroup, groupSessions } from "../utils/sessionGrouping";
+import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import SessionItem from "../components/SessionItem";
 import styles from "./sidebarSessionList.module.less";
 
@@ -147,10 +148,9 @@ export default function SidebarSessionList({
 
   const [searchQuery, setSearchQuery] = useState("");
   const [historyCollapsed, setHistoryCollapsed] = useState(false);
-  /** Collapsed date groups — default: "month" and "older" are collapsed */
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<DateGroup>>(
-    () => new Set<DateGroup>(["month", "older"]),
-  );
+  /** Collapsed date groups — persisted so remounts keep the user's state */
+  const { collapsedGroups, toggleGroup, expandGroupForSession } =
+    useCollapsedSessionGroups();
 
   const storeSessionsRaw = useSessionListStore((s) => s.sessions);
   const storeSessions = storeSessionsRaw as ExtendedChatSession[];
@@ -219,14 +219,15 @@ export default function SidebarSessionList({
     [sortedSessions, searchQuery, t],
   );
 
-  const toggleGroup = useCallback((key: DateGroup) => {
-    setCollapsedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
+  // Keep the active conversation reachable: expand the (possibly
+  // collapsed) date group that contains it whenever it changes.
+  useEffect(() => {
+    if (!currentSessionId) return;
+    const active = sortedSessions.find(
+      (s) => s.id === currentSessionId || s.realId === currentSessionId,
+    );
+    if (active) expandGroupForSession(active);
+  }, [currentSessionId, sortedSessions, expandGroupForSession]);
 
   /** Flatten groups into a single array of rows for virtual list */
   const flatRows = useMemo<FlatRow[]>(() => {

--- a/console/src/layouts/SidebarSessionList.tsx
+++ b/console/src/layouts/SidebarSessionList.tsx
@@ -21,7 +21,11 @@ import {
   syncSessionsGlobal,
   type ExtendedSession,
 } from "../stores/sessionListStore";
-import { type DateGroup, groupSessions } from "../utils/sessionGrouping";
+import {
+  type DateGroup,
+  groupSessions,
+  findSessionRowIndex,
+} from "../utils/sessionGrouping";
 import { useCollapsedSessionGroups } from "../hooks/useCollapsedSessionGroups";
 import SessionItem from "../components/SessionItem";
 import styles from "./sidebarSessionList.module.less";
@@ -278,6 +282,19 @@ export default function SidebarSessionList({
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);
   }, [flatRows]);
+
+  // Bring the active conversation into view once its row is visible
+  // (group expanded + list measured). Guarded by the last-scrolled id so
+  // background polling doesn't keep yanking the scroll position.
+  const lastScrolledSessionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!currentSessionId) return;
+    if (lastScrolledSessionRef.current === currentSessionId) return;
+    const index = findSessionRowIndex(flatRows, currentSessionId);
+    if (index < 0) return;
+    lastScrolledSessionRef.current = currentSessionId;
+    listRef.current?.scrollToItem(index, "smart");
+  }, [currentSessionId, flatRows, listHeight]);
 
   /** Callback ref: attach a ResizeObserver to measure list container height */
   const listWrapperRef = useCallback((node: HTMLDivElement | null) => {

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -41,6 +41,7 @@ import { useAgentStore } from "../../../../stores/agentStore";
 import {
   type DateGroup,
   groupSessions,
+  findSessionRowIndex,
 } from "../../../../utils/sessionGrouping";
 import { useAppMessage } from "../../../../hooks/useAppMessage";
 import styles from "./index.module.less";
@@ -697,6 +698,19 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);
   }, [flatRows]);
+
+  // Bring the active conversation into view once its row is visible
+  // (group expanded + list measured). Guarded by the last-scrolled id so
+  // background polling doesn't keep yanking the scroll position.
+  const lastScrolledSessionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!currentSessionId) return;
+    if (lastScrolledSessionRef.current === currentSessionId) return;
+    const index = findSessionRowIndex(flatRows, currentSessionId);
+    if (index < 0) return;
+    lastScrolledSessionRef.current = currentSessionId;
+    listRef.current?.scrollToItem(index, "smart");
+  }, [currentSessionId, flatRows, listHeight]);
 
   /** Callback ref: attach a ResizeObserver to measure list container height */
   const listWrapperRef = useCallback((node: HTMLDivElement | null) => {

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -21,6 +21,7 @@ import {
   type IAgentScopeRuntimeWebUISession,
 } from "@agentscope-ai/chat";
 import { useIsMobile } from "../../../../hooks/useIsMobile";
+import { useCollapsedSessionGroups } from "../../../../hooks/useCollapsedSessionGroups";
 import { useCodingMode } from "../../../../stores/codingModeStore";
 import { useCreateNewSession } from "../../hooks/useCreateNewSession";
 import SessionItem from "../../../../components/SessionItem";
@@ -284,10 +285,9 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
   /** Cache last polled sessions to skip no-op state updates */
   const lastPolledSessionsRef = useRef<IAgentScopeRuntimeWebUISession[]>([]);
 
-  /** Collapsed date groups — default: "month" and "older" are collapsed */
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<DateGroup>>(
-    () => new Set<DateGroup>(["month", "older"]),
-  );
+  /** Collapsed date groups — persisted so remounts keep the user's state */
+  const { collapsedGroups, toggleGroup, expandGroupForSession } =
+    useCollapsedSessionGroups();
 
   /** Immediate search input value (bound to Input, updates on every keystroke) */
   const [searchInput, setSearchInput] = useState("");
@@ -636,15 +636,17 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     [sortedSessions, searchQuery, t],
   );
 
-  /** Toggle a date group's collapsed state */
-  const toggleGroup = useCallback((key: DateGroup) => {
-    setCollapsedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
+  // Keep the active conversation reachable: expand the (possibly
+  // collapsed) date group that contains it whenever it changes.
+  useEffect(() => {
+    if (!currentSessionId) return;
+    const active = sortedSessions.find(
+      (s) =>
+        s.id === currentSessionId ||
+        (s as ExtendedChatSession).realId === currentSessionId,
+    );
+    if (active) expandGroupForSession(active as ExtendedChatSession);
+  }, [currentSessionId, sortedSessions, expandGroupForSession]);
 
   /** Flatten groups into a single array of rows for virtual list */
   const flatRows = useMemo<FlatRow[]>(() => {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -3086,10 +3086,13 @@ export default function ChatPage() {
             return null;
           }
 
-          // Replay boundary marker from the reconnect stream — internal
-          // signal only, never rendered.
+          // Replay boundary marker from the reconnect stream. The
+          // fast-forward wrapper strips it at the byte level; if one
+          // still slips through, map it to the SDK's heartbeat no-op —
+          // returning null here would crash the response builder
+          // mid-stream and drop every subsequent live token.
           if (payload.type === "replay_end") {
-            return null;
+            return { object: "message", type: "heartbeat" } as any;
           }
 
           if (payload.type === "rate_limited") {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -14,6 +14,11 @@ import { useTranslation } from "react-i18next";
 import i18n from "../../i18n";
 import { useLocation, useNavigate } from "react-router-dom";
 import sessionApi from "./sessionApi";
+import {
+  attachClientMessageId,
+  createClientMessageId,
+  QWENPAW_CLIENT_MESSAGE_ID_KEY,
+} from "../../utils/clientMessageId";
 import defaultConfig, { getDefaultConfig } from "./OptionsPanel/defaultConfig";
 import { chatApi } from "../../api/modules/chat";
 import { agentApi } from "../../api/modules/agent";
@@ -296,6 +301,7 @@ async function startBackgroundQueue(
       if (rs === "paused" || rs === "error") break;
 
       const item = current[0];
+      const clientMessageId = item.clientMessageId ?? item.id;
 
       // Wait until the backend finishes the currently running task before
       // sending the next one. This preserves order task1 → task2 → task3
@@ -328,7 +334,12 @@ async function startBackgroundQueue(
           { type: "text", text: item.text },
           ...buildAttachmentContentItems(item.attachments),
         ];
-        sessionApi.setLastUserMessage(chatIdForStatus, item.text, contentItems);
+        sessionApi.setLastUserMessage(
+          chatIdForStatus,
+          item.text,
+          contentItems,
+          clientMessageId,
+        );
       }
 
       let fetchSucceeded = false;
@@ -358,6 +369,9 @@ async function startBackgroundQueue(
             input: [
               {
                 role: "user",
+                metadata: {
+                  [QWENPAW_CLIENT_MESSAGE_ID_KEY]: clientMessageId,
+                },
                 content: [
                   { type: "text", text: item.text },
                   ...buildAttachmentContentItems(item.attachments),
@@ -2417,15 +2431,24 @@ export default function ChatPage() {
       const session: SessionInfo = input[input.length - 1]?.session || {};
       const lastInput = input.slice(-1);
       const lastMsg = lastInput[0];
-      const rewrittenInput =
-        lastMsg?.content && Array.isArray(lastMsg.content)
+      const clientMessageId =
+        lastMsg?.role === "user" ? createClientMessageId() : undefined;
+      const rewrittenLastMsg: Record<string, unknown> | undefined = lastMsg
+        ? clientMessageId
+          ? attachClientMessageId(lastMsg, clientMessageId)
+          : lastMsg
+        : undefined;
+      const rewrittenInput: Array<Record<string, unknown>> =
+        rewrittenLastMsg?.content && Array.isArray(rewrittenLastMsg.content)
           ? [
               {
-                ...lastMsg,
-                content: lastMsg.content.map(normalizeContentUrls),
+                ...rewrittenLastMsg,
+                content: rewrittenLastMsg.content.map(normalizeContentUrls),
               },
             ]
-          : lastInput;
+          : rewrittenLastMsg
+          ? [rewrittenLastMsg]
+          : [];
 
       const identity = sessionApi.getSessionIdentity();
       let requestBody: Record<string, unknown> = {
@@ -2447,6 +2470,21 @@ export default function ChatPage() {
         });
         if (next && typeof next === "object") {
           requestBody = next;
+        }
+      }
+
+      if (clientMessageId && Array.isArray(requestBody.input)) {
+        const requestInput = [...requestBody.input] as Array<
+          Record<string, unknown>
+        >;
+        for (let i = requestInput.length - 1; i >= 0; i--) {
+          if (requestInput[i]?.role !== "user") continue;
+          requestInput[i] = attachClientMessageId(
+            requestInput[i],
+            clientMessageId,
+          );
+          requestBody.input = requestInput;
+          break;
         }
       }
 
@@ -2474,7 +2512,7 @@ export default function ChatPage() {
         String(requestBody.session_id || "");
       if (backendChatId) {
         const userText = rewrittenInput
-          .filter((m: any) => m.role === "user")
+          .filter((m) => m.role === "user")
           .map(extractUserMessageText)
           .join("\n")
           .trim();
@@ -2482,7 +2520,7 @@ export default function ChatPage() {
           // Also pass the full content array so patchLastUserMessage can
           // rebuild user card with images/files when reconnecting.
           const lastUserMsg = rewrittenInput
-            .filter((m: any) => m.role === "user")
+            .filter((m) => m.role === "user")
             .slice(-1)[0];
           const contentArr = Array.isArray(lastUserMsg?.content)
             ? (lastUserMsg.content as Array<{
@@ -2490,7 +2528,12 @@ export default function ChatPage() {
                 [key: string]: unknown;
               }>)
             : undefined;
-          sessionApi.setLastUserMessage(backendChatId, userText, contentArr);
+          sessionApi.setLastUserMessage(
+            backendChatId,
+            userText,
+            contentArr,
+            clientMessageId,
+          );
         }
       }
 

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -385,7 +385,10 @@ async function startBackgroundQueue(
           }),
         });
 
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.ok) {
+          sessionApi.discardLastUserMessage(chatIdForStatus, clientMessageId);
+          throw new Error(`HTTP ${res.status}`);
+        }
         fetchStarted = true;
 
         // Drain the stream; reaching `done` means the backend persisted the
@@ -2545,6 +2548,10 @@ export default function ChatPage() {
         body: JSON.stringify(requestBody),
         signal: data.signal,
       });
+
+      if (!response.ok && backendChatId) {
+        sessionApi.discardLastUserMessage(backendChatId, clientMessageId);
+      }
 
       const localIdToResolve = sessionApi.lastActiveChatId ?? chatIdRef.current;
       if (response.ok && localIdToResolve) {

--- a/console/src/pages/Chat/index.tsx
+++ b/console/src/pages/Chat/index.tsx
@@ -46,6 +46,7 @@ import {
   patchContextMaxInputLength,
   wrapChatResponseUsageStream,
 } from "./turnUsage";
+import { wrapReplayFastForward } from "./replayFastForward";
 import { useTurnUsageStore } from "./turnUsageStore";
 import ChatHeaderTitle from "./components/ChatHeaderTitle";
 import ChatSessionInitializer from "./components/ChatSessionInitializer";
@@ -3085,6 +3086,12 @@ export default function ChatPage() {
             return null;
           }
 
+          // Replay boundary marker from the reconnect stream — internal
+          // signal only, never rendered.
+          if (payload.type === "replay_end") {
+            return null;
+          }
+
           if (payload.type === "rate_limited") {
             const alts =
               (payload.alternatives as typeof rateLimitAlternatives) || [];
@@ -3135,7 +3142,12 @@ export default function ChatPage() {
             signal: data.signal,
           });
 
-          return wrapChatResponseUsageStream(response, chatRef);
+          // Fast-forward the replayed section: render the already
+          // generated part instantly instead of re-animating it.
+          return wrapChatResponseUsageStream(
+            wrapReplayFastForward(response),
+            chatRef,
+          );
         },
       },
       customToolRenderConfig: withGenericFallback(mergedToolRenderers),

--- a/console/src/pages/Chat/replayFastForward.ts
+++ b/console/src/pages/Chat/replayFastForward.ts
@@ -5,34 +5,37 @@
  * turn and then emits a `{"type": "replay_end"}` marker before switching
  * to live events. Feeding the replayed events to the SDK one by one
  * re-animates the whole reply token by token from scratch. This wrapper
- * buffers the response bytes until the marker is seen and hands the
- * replayed section to the SDK as a single chunk, so the already-generated
- * part renders instantly; live events after the marker stream through
- * untouched.
+ * re-frames the stream on SSE event boundaries, buffers everything until
+ * the marker and hands the replayed section to the SDK as a single chunk,
+ * so the already-generated part renders instantly; live events after the
+ * marker stream through untouched.
+ *
+ * The marker itself is stripped here at the byte level and never reaches
+ * the SDK: its response builder dereferences `data.object` on every
+ * parsed event, and an unknown payload throws mid-stream, killing all
+ * subsequent live tokens.
  *
  * Backends without the marker are handled by an idle-timeout fallback:
  * when no new chunk arrives within `idleFlushMs` while still buffering,
- * the buffered bytes are flushed and the stream degrades to passthrough.
+ * the buffered events are flushed and the stream degrades to passthrough
+ * (late markers are still filtered out).
  */
 
-/** Raw SSE payload emitted by the backend at the end of a replay. */
-const REPLAY_END_EVENT = '{"type": "replay_end"}';
+/** Exact SSE event emitted by the backend at the end of a replay. */
+const REPLAY_END_EVENT = 'data: {"type": "replay_end"}';
 
 const DEFAULT_IDLE_FLUSH_MS = 300;
 
 /** Unique sentinel for the idle-timeout race. */
 const IDLE_TIMEOUT = Symbol("idle-timeout");
 
-function concatChunks(chunks: Uint8Array[]): Uint8Array {
-  let total = 0;
-  for (const c of chunks) total += c.byteLength;
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const c of chunks) {
-    merged.set(c, offset);
-    offset += c.byteLength;
-  }
-  return merged;
+const isMarker = (event: string): boolean => event.trim() === REPLAY_END_EVENT;
+
+/** Split buffered text into complete SSE events and the partial tail. */
+function splitEvents(buf: string): { events: string[]; rest: string } {
+  const parts = buf.split("\n\n");
+  const rest = parts.pop() ?? "";
+  return { events: parts.filter((e) => e.length > 0), rest };
 }
 
 export function wrapReplayFastForward(
@@ -44,19 +47,23 @@ export function wrapReplayFastForward(
 
   const reader = body.getReader();
   const decoder = new TextDecoder();
-  let buffered: Uint8Array[] = [];
-  let decoded = "";
+  const encoder = new TextEncoder();
+  /** Decoded text still missing its `\n\n` event terminator. */
+  let textBuf = "";
+  /** Complete replayed events awaiting the single fast-forward flush. */
+  let replayEvents: string[] = [];
   let buffering = true;
+
+  const encodeEvents = (events: string[]): Uint8Array =>
+    encoder.encode(events.map((e) => `${e}\n\n`).join(""));
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
-      const flush = () => {
-        if (!buffering) return;
+      const flushReplay = () => {
         buffering = false;
-        const merged = concatChunks(buffered);
-        buffered = [];
-        decoded = "";
-        if (merged.byteLength > 0) controller.enqueue(merged);
+        const out = replayEvents.filter((e) => !isMarker(e));
+        replayEvents = [];
+        if (out.length > 0) controller.enqueue(encodeEvents(out));
       };
 
       // Held across loop iterations so an idle-timeout never leaves a
@@ -81,7 +88,7 @@ export function wrapReplayFastForward(
             if (winner === IDLE_TIMEOUT) {
               // No marker within the window (old backend or the replay
               // already reached the live edge): degrade to passthrough.
-              flush();
+              flushReplay();
               continue;
             }
             result = winner;
@@ -91,16 +98,34 @@ export function wrapReplayFastForward(
           pendingRead = null;
 
           if (result.done) {
-            flush();
+            // Emit everything still held: buffered replay events, any
+            // complete events in the tail, and the partial tail as-is.
+            textBuf += decoder.decode();
+            const { events, rest } = splitEvents(textBuf);
+            const out = [...replayEvents, ...events].filter(
+              (e) => !isMarker(e),
+            );
+            replayEvents = [];
+            const payload = out.map((e) => `${e}\n\n`).join("") + rest;
+            if (payload) controller.enqueue(encoder.encode(payload));
             break;
           }
-          if (!buffering) {
-            controller.enqueue(result.value);
-            continue;
+
+          textBuf += decoder.decode(result.value, { stream: true });
+          const { events, rest } = splitEvents(textBuf);
+          textBuf = rest;
+
+          if (buffering) {
+            let sawMarker = false;
+            for (const event of events) {
+              if (isMarker(event)) sawMarker = true;
+              else replayEvents.push(event);
+            }
+            if (sawMarker) flushReplay();
+          } else {
+            const out = events.filter((e) => !isMarker(e));
+            if (out.length > 0) controller.enqueue(encodeEvents(out));
           }
-          buffered.push(result.value);
-          decoded += decoder.decode(result.value, { stream: true });
-          if (decoded.includes(REPLAY_END_EVENT)) flush();
         }
         controller.close();
       } catch (err) {

--- a/console/src/pages/Chat/replayFastForward.ts
+++ b/console/src/pages/Chat/replayFastForward.ts
@@ -1,0 +1,120 @@
+/**
+ * Reconnect fast-forward for replayed SSE streams.
+ *
+ * On reconnect the backend replays every buffered event of the running
+ * turn and then emits a `{"type": "replay_end"}` marker before switching
+ * to live events. Feeding the replayed events to the SDK one by one
+ * re-animates the whole reply token by token from scratch. This wrapper
+ * buffers the response bytes until the marker is seen and hands the
+ * replayed section to the SDK as a single chunk, so the already-generated
+ * part renders instantly; live events after the marker stream through
+ * untouched.
+ *
+ * Backends without the marker are handled by an idle-timeout fallback:
+ * when no new chunk arrives within `idleFlushMs` while still buffering,
+ * the buffered bytes are flushed and the stream degrades to passthrough.
+ */
+
+/** Raw SSE payload emitted by the backend at the end of a replay. */
+const REPLAY_END_EVENT = '{"type": "replay_end"}';
+
+const DEFAULT_IDLE_FLUSH_MS = 300;
+
+/** Unique sentinel for the idle-timeout race. */
+const IDLE_TIMEOUT = Symbol("idle-timeout");
+
+function concatChunks(chunks: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const c of chunks) total += c.byteLength;
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    merged.set(c, offset);
+    offset += c.byteLength;
+  }
+  return merged;
+}
+
+export function wrapReplayFastForward(
+  response: Response,
+  idleFlushMs: number = DEFAULT_IDLE_FLUSH_MS,
+): Response {
+  const body = response.body;
+  if (!response.ok || !body) return response;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffered: Uint8Array[] = [];
+  let decoded = "";
+  let buffering = true;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const flush = () => {
+        if (!buffering) return;
+        buffering = false;
+        const merged = concatChunks(buffered);
+        buffered = [];
+        decoded = "";
+        if (merged.byteLength > 0) controller.enqueue(merged);
+      };
+
+      // Held across loop iterations so an idle-timeout never leaves a
+      // dangling read() racing a second concurrent read() call.
+      let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | null =
+        null;
+
+      try {
+        for (;;) {
+          const readPromise: Promise<ReadableStreamReadResult<Uint8Array>> =
+            pendingRead ?? reader.read();
+          pendingRead = readPromise;
+
+          let result: ReadableStreamReadResult<Uint8Array>;
+          if (buffering) {
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            const timeout = new Promise<typeof IDLE_TIMEOUT>((resolve) => {
+              timer = setTimeout(() => resolve(IDLE_TIMEOUT), idleFlushMs);
+            });
+            const winner = await Promise.race([readPromise, timeout]);
+            clearTimeout(timer);
+            if (winner === IDLE_TIMEOUT) {
+              // No marker within the window (old backend or the replay
+              // already reached the live edge): degrade to passthrough.
+              flush();
+              continue;
+            }
+            result = winner;
+          } else {
+            result = await readPromise;
+          }
+          pendingRead = null;
+
+          if (result.done) {
+            flush();
+            break;
+          }
+          if (!buffering) {
+            controller.enqueue(result.value);
+            continue;
+          }
+          buffered.push(result.value);
+          decoded += decoder.decode(result.value, { stream: true });
+          if (decoded.includes(REPLAY_END_EVENT)) flush();
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -820,6 +820,21 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     }
   }
 
+  /** Remove a pending message only when it still belongs to this request. */
+  discardLastUserMessage(sessionId: string, clientMessageId?: string): void {
+    if (!sessionId) return;
+    const cached = loadPendingUserMessage(sessionId);
+    if (!cached) return;
+    if (
+      clientMessageId &&
+      cached.clientMessageId &&
+      cached.clientMessageId !== clientMessageId
+    ) {
+      return;
+    }
+    clearPendingUserMessage(sessionId);
+  }
+
   /**
    * Deduplicates concurrent getSessionList calls so that two parallel
    * invocations share one network request and write sessionList only once,

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -16,6 +16,7 @@ import {
   extractLatestSnapshotFromCards,
 } from "../turnUsage";
 import { useTurnUsageStore } from "../turnUsageStore";
+import { QWENPAW_CLIENT_MESSAGE_ID_KEY } from "../../../utils/clientMessageId";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -163,6 +164,18 @@ const extractTextFromContent = (content: unknown): string => {
     .join("\n");
 };
 
+const extractClientMessageId = (metadata: unknown): string | undefined => {
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const nestedMetadata = (metadata as Record<string, unknown>).metadata;
+  if (!nestedMetadata || typeof nestedMetadata !== "object") {
+    return undefined;
+  }
+  const candidate = (nestedMetadata as Record<string, unknown>)[
+    QWENPAW_CLIENT_MESSAGE_ID_KEY
+  ];
+  return typeof candidate === "string" ? candidate : undefined;
+};
+
 function resolveContentItemUrl(c: ContentItem): ContentItem {
   if (c.type === "image" && c.image_url) {
     return { ...c, image_url: toDisplayUrl(c.image_url as string) };
@@ -246,6 +259,7 @@ function buildUserCard(msg: Message): IAgentScopeRuntimeWebUIMessage {
               role: "user",
               type: "message",
               content: contentParts,
+              metadata: msg.metadata ?? null,
             },
           ],
         },
@@ -420,6 +434,7 @@ const STORAGE_PREFIX = "qwenpaw_pending_user_msg_";
 /** Shape stored in sessionStorage. Backward compat: old format was plain text. */
 interface PendingUserMsg {
   text: string;
+  clientMessageId?: string;
   /** Full content array (stored-name format) for rebuilding the user card
    *  with attachments. When absent, only text is displayed. */
   content?: Array<{ type: string; [key: string]: unknown }>;
@@ -791,12 +806,15 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     sessionId: string,
     text: string,
     content?: Array<{ type: string; [key: string]: unknown }>,
+    clientMessageId?: string,
   ): void {
     if (!sessionId || !text) return;
     // Invalidate LRU cache so switching back fetches fresh messages
     this.invalidateConvertedCache(sessionId);
     if (content && content.length > 0) {
-      savePendingUserMessage(sessionId, { text, content });
+      savePendingUserMessage(sessionId, { text, content, clientMessageId });
+    } else if (clientMessageId) {
+      savePendingUserMessage(sessionId, { text, clientMessageId });
     } else {
       savePendingUserMessage(sessionId, text);
     }
@@ -893,17 +911,18 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     // generation completed but the memory flush not finished.
     if (!generating) {
       let lastUserText = "";
+      let lastUserClientMessageId: string | undefined;
       for (let i = messages.length - 1; i >= 0; i--) {
         if (messages[i].role !== ROLE_USER) continue;
-        lastUserText = extractTextFromContent(
-          messages[i]?.cards?.[0]?.data?.input?.[0]?.content,
-        );
+        const input = messages[i]?.cards?.[0]?.data?.input?.[0];
+        lastUserText = extractTextFromContent(input?.content);
+        lastUserClientMessageId = extractClientMessageId(input?.metadata);
         break;
       }
-      // Normalized full equality: substring matching would treat e.g.
-      // pending "yes" as contained in an older "yesterday …" message
-      // and wrongly drop the cache.
-      if (lastUserText.trim() === cached.text.trim()) {
+      const persistenceConfirmed = cached.clientMessageId
+        ? lastUserClientMessageId === cached.clientMessageId
+        : lastUserText.trim() === cached.text.trim();
+      if (persistenceConfirmed) {
         clearPendingUserMessage(backendSessionId);
         return false;
       }

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -876,13 +876,33 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     generating: boolean,
     backendSessionId: string,
   ): void {
-    if (!generating) {
-      clearPendingUserMessage(backendSessionId);
+    const cached = loadPendingUserMessage(backendSessionId);
+    if (!cached || !cached.text) {
+      if (!generating) clearPendingUserMessage(backendSessionId);
       return;
     }
 
-    const cached = loadPendingUserMessage(backendSessionId);
-    if (!cached || !cached.text) return;
+    // When the chat is idle, clear the cache only after the fetched
+    // history actually contains the pending text. Clearing
+    // unconditionally lost the last message in two windows: POST sent
+    // but the run not registered yet (status still "idle"), and
+    // generation completed but the memory flush not finished.
+    if (!generating) {
+      let lastUserText = "";
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].role !== ROLE_USER) continue;
+        lastUserText = extractTextFromContent(
+          messages[i]?.cards?.[0]?.data?.input?.[0]?.content,
+        );
+        break;
+      }
+      if (lastUserText && lastUserText.includes(cached.text)) {
+        clearPendingUserMessage(backendSessionId);
+        return;
+      }
+      // History is missing the turn — fall through and patch it in,
+      // keeping the cache until a later fetch confirms persistence.
+    }
 
     // Use the full content array (with images/files) when available;
     // fall back to text-only for legacy entries.

--- a/console/src/pages/Chat/sessionApi/index.ts
+++ b/console/src/pages/Chat/sessionApi/index.ts
@@ -869,17 +869,21 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
    * completes). If generating, look up the cached data from sessionStorage
    * and patch it into the message list (including any attachments).
    *
-   * When not generating the conversation is done — clear the cached entry.
+   * When not generating the conversation is done — clear the cached entry
+   * once the fetched history contains the pending text.
+   *
+   * Returns true when an unconfirmed pending message was patched in (the
+   * history is incomplete and must not be treated as canonical).
    */
   private patchLastUserMessage(
     messages: IAgentScopeRuntimeWebUIMessage[],
     generating: boolean,
     backendSessionId: string,
-  ): void {
+  ): boolean {
     const cached = loadPendingUserMessage(backendSessionId);
     if (!cached || !cached.text) {
       if (!generating) clearPendingUserMessage(backendSessionId);
-      return;
+      return false;
     }
 
     // When the chat is idle, clear the cache only after the fetched
@@ -896,9 +900,12 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         );
         break;
       }
-      if (lastUserText && lastUserText.includes(cached.text)) {
+      // Normalized full equality: substring matching would treat e.g.
+      // pending "yes" as contained in an older "yesterday …" message
+      // and wrongly drop the cache.
+      if (lastUserText.trim() === cached.text.trim()) {
         clearPendingUserMessage(backendSessionId);
-        return;
+        return false;
       }
       // History is missing the turn — fall through and patch it in,
       // keeping the cache until a later fetch confirms persistence.
@@ -929,6 +936,7 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
         } as Message),
       );
     }
+    return true;
   }
 
   private createEmptySession(
@@ -1330,7 +1338,11 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
     if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
     const generating = isGenerating(chatHistory);
     const messages = convertMessages(chatHistory.messages || []);
-    this.patchLastUserMessage(messages, generating, backendId);
+    const patchedPending = this.patchLastUserMessage(
+      messages,
+      generating,
+      backendId,
+    );
 
     const session: ExtendedSession = {
       id: displayId,
@@ -1346,7 +1358,10 @@ class SessionApi implements IAgentScopeRuntimeWebUISessionAPI {
 
     // Cache non-generating sessions — only within the epoch that fetched
     // them, so a stale load cannot write into the new agent's cache.
-    if (!generating && this.isActiveOwner(owner)) {
+    // A history patched with an unconfirmed pending message is NOT
+    // canonical (the agent reply may still be missing): caching it would
+    // keep serving the incomplete turn for the whole cache TTL.
+    if (!generating && !patchedPending && this.isActiveOwner(owner)) {
       this.setCachedConvertedSession(
         backendId,
         session,

--- a/console/src/pages/Chat/tests/fixtures/reconnectReplayStream.txt
+++ b/console/src/pages/Chat/tests/fixtures/reconnectReplayStream.txt
@@ -1,0 +1,16 @@
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "\n42\n", "sequence_number": 52}
+
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "43\n4", "sequence_number": 53}
+
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "4\n45", "sequence_number": 54}
+
+data: {"type": "replay_end"}
+
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "\n46\n", "sequence_number": 55}
+
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "47\n4", "sequence_number": 56}
+
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "8\n49", "sequence_number": 57}
+
+data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "196\n", "sequence_number": 192}
+

--- a/console/src/pages/Chat/tests/fixtures/reconnectReplayStream.txt
+++ b/console/src/pages/Chat/tests/fixtures/reconnectReplayStream.txt
@@ -13,4 +13,3 @@ data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "con
 data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "8\n49", "sequence_number": 57}
 
 data: {"type": "text", "delta": true, "index": 0, "status": null, "object": "content", "msg_id": "msg_e0e7dfe2e3be4cc9b481f22dc851ebdb", "text": "196\n", "sequence_number": 192}
-

--- a/console/src/pages/Chat/tests/pendingUserMessage.test.ts
+++ b/console/src/pages/Chat/tests/pendingUserMessage.test.ts
@@ -174,6 +174,23 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     });
   });
 
+  it("discards only the pending message owned by the failed request", () => {
+    sessionApi.setLastUserMessage(
+      "chat-failed",
+      "newer request",
+      undefined,
+      "client-new",
+    );
+
+    sessionApi.discardLastUserMessage("chat-failed", "client-old");
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-failed`)).not.toBe(
+      null,
+    );
+
+    sessionApi.discardLastUserMessage("chat-failed", "client-new");
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-failed`)).toBe(null);
+  });
+
   it("clears the cache on idle when history already contains the text", async () => {
     seedSessionList("chat-done");
     sessionApi.setLastUserMessage("chat-done", "persisted question");

--- a/console/src/pages/Chat/tests/pendingUserMessage.test.ts
+++ b/console/src/pages/Chat/tests/pendingUserMessage.test.ts
@@ -39,15 +39,56 @@ vi.mock("../../../api/modules/chat", async (importOriginal) => {
 
 // Import AFTER mocks are registered.
 import sessionApi from "../sessionApi";
+import {
+  attachClientMessageId,
+  QWENPAW_CLIENT_MESSAGE_ID_KEY,
+} from "../../../utils/clientMessageId";
 
 const STORAGE_PREFIX = "qwenpaw_pending_user_msg_";
 
-function userMsg(id: string, text: string): Message {
+interface SessionApiTestAccess {
+  sessionList: Array<Record<string, unknown>>;
+  convertedSessionCache: Map<unknown, unknown>;
+  sessionResultCache: Map<unknown, unknown>;
+  sessionRequests: Map<unknown, unknown>;
+  lastSelectedIds: Set<unknown>;
+}
+
+interface RuntimeContent {
+  type?: string;
+  text?: string;
+}
+
+interface RuntimeMessage {
+  role?: string;
+  cards?: Array<{
+    data?: {
+      input?: Array<{ content?: RuntimeContent[] }>;
+    };
+  }>;
+}
+
+interface RuntimeSession {
+  messages: RuntimeMessage[];
+}
+
+const testApi = sessionApi as unknown as SessionApiTestAccess;
+
+function userMsg(id: string, text: string, clientMessageId?: string): Message {
   return {
     id,
     role: "user",
     content: [{ type: "text", text }],
-    metadata: { timestamp: "2026-06-01 10:00:00.000" },
+    metadata: {
+      timestamp: "2026-06-01 10:00:00.000",
+      ...(clientMessageId
+        ? {
+            metadata: {
+              [QWENPAW_CLIENT_MESSAGE_ID_KEY]: clientMessageId,
+            },
+          }
+        : {}),
+    },
   } as Message;
 }
 
@@ -61,7 +102,7 @@ function assistantMsg(id: string, text: string): Message {
 }
 
 function seedSessionList(id: string): void {
-  (sessionApi as any).sessionList = [
+  testApi.sessionList = [
     { id, sessionId: id, userId: "u", channel: "c", name: "t" },
   ];
 }
@@ -73,15 +114,15 @@ async function mockGetChat(history: ChatHistory) {
 
 /** Collect texts of user-role cards from a converted session. */
 function userCardTexts(session: unknown): string[] {
-  const msgs = (session as { messages: any[] }).messages;
+  const msgs = (session as RuntimeSession).messages;
   return msgs
     .filter((m) => m.role === "user")
     .map((m) => {
       const content = m.cards?.[0]?.data?.input?.[0]?.content;
       return Array.isArray(content)
         ? content
-            .filter((c: any) => c.type === "text")
-            .map((c: any) => c.text)
+            .filter((c) => c.type === "text")
+            .map((c) => c.text)
             .join("\n")
         : "";
     });
@@ -89,11 +130,11 @@ function userCardTexts(session: unknown): string[] {
 
 describe("patchLastUserMessage — pending cache lifecycle", () => {
   beforeEach(() => {
-    (sessionApi as any).sessionList = [];
-    (sessionApi as any).convertedSessionCache.clear();
-    (sessionApi as any).sessionResultCache.clear();
-    (sessionApi as any).sessionRequests.clear();
-    (sessionApi as any).lastSelectedIds.clear();
+    testApi.sessionList = [];
+    testApi.convertedSessionCache.clear();
+    testApi.sessionResultCache.clear();
+    testApi.sessionRequests.clear();
+    testApi.lastSelectedIds.clear();
     sessionStorage.clear();
   });
 
@@ -116,6 +157,21 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-running`)).not.toBe(
       null,
     );
+  });
+
+  it("attaches the client id without dropping existing metadata", () => {
+    expect(
+      attachClientMessageId(
+        { role: "user", metadata: { source: "sdk" } },
+        "client-new",
+      ),
+    ).toEqual({
+      role: "user",
+      metadata: {
+        source: "sdk",
+        [QWENPAW_CLIENT_MESSAGE_ID_KEY]: "client-new",
+      },
+    });
   });
 
   it("clears the cache on idle when history already contains the text", async () => {
@@ -191,6 +247,52 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     );
   });
 
+  it("keeps an identical pending prompt when its client id is newer", async () => {
+    seedSessionList("chat-repeat");
+    sessionApi.setLastUserMessage(
+      "chat-repeat",
+      "continue",
+      undefined,
+      "client-new",
+    );
+    await mockGetChat({
+      messages: [
+        userMsg("u1", "continue", "client-old"),
+        assistantMsg("a1", "previous answer"),
+      ],
+      status: "idle",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-repeat");
+    expect(userCardTexts(session)).toEqual(["continue", "continue"]);
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-repeat`)).not.toBe(
+      null,
+    );
+  });
+
+  it("clears an identical pending prompt only when its client id matches", async () => {
+    seedSessionList("chat-repeat-confirmed");
+    sessionApi.setLastUserMessage(
+      "chat-repeat-confirmed",
+      "continue",
+      undefined,
+      "client-new",
+    );
+    await mockGetChat({
+      messages: [
+        userMsg("u1", "continue", "client-new"),
+        assistantMsg("a1", "latest answer"),
+      ],
+      status: "idle",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-repeat-confirmed");
+    expect(userCardTexts(session)).toEqual(["continue"]);
+    expect(
+      sessionStorage.getItem(`${STORAGE_PREFIX}chat-repeat-confirmed`),
+    ).toBe(null);
+  });
+
   it("does not serve a patched (incomplete) idle history from the LRU cache", async () => {
     // The patched history is missing the agent reply that has not been
     // flushed yet. Caching it would keep serving the incomplete turn
@@ -204,8 +306,8 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     } as ChatHistory);
 
     await sessionApi.getSession("chat-nocache");
-    (sessionApi as any).sessionResultCache.clear();
-    (sessionApi as any).lastSelectedIds.clear();
+    testApi.sessionResultCache.clear();
+    testApi.lastSelectedIds.clear();
     await sessionApi.getSession("chat-nocache");
     expect(getChat).toHaveBeenCalledTimes(2);
   });
@@ -222,8 +324,8 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     } as ChatHistory);
 
     await sessionApi.getSession("chat-confirmed");
-    (sessionApi as any).sessionResultCache.clear();
-    (sessionApi as any).lastSelectedIds.clear();
+    testApi.sessionResultCache.clear();
+    testApi.lastSelectedIds.clear();
     await sessionApi.getSession("chat-confirmed");
     // Second call is served from the LRU cache — history was complete.
     expect(getChat).toHaveBeenCalledTimes(1);

--- a/console/src/pages/Chat/tests/pendingUserMessage.test.ts
+++ b/console/src/pages/Chat/tests/pendingUserMessage.test.ts
@@ -169,4 +169,63 @@ describe("patchLastUserMessage — pending cache lifecycle", () => {
     expect(userCardTexts(session)).toEqual(["q"]);
     expect(getChat).toHaveBeenCalledTimes(1);
   });
+
+  it("does not clear the cache when the pending text is a substring of an older message", async () => {
+    // "yes" is contained in "yesterday what happened" — substring
+    // matching would wrongly treat the new turn as persisted and drop
+    // the pending instruction. Only a normalized full match may clear.
+    seedSessionList("chat-substr");
+    sessionApi.setLastUserMessage("chat-substr", "yes");
+    await mockGetChat({
+      messages: [
+        userMsg("u1", "yesterday what happened"),
+        assistantMsg("a1", "an answer"),
+      ],
+      status: "idle",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-substr");
+    expect(userCardTexts(session)).toContain("yes");
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-substr`)).not.toBe(
+      null,
+    );
+  });
+
+  it("does not serve a patched (incomplete) idle history from the LRU cache", async () => {
+    // The patched history is missing the agent reply that has not been
+    // flushed yet. Caching it would keep serving the incomplete turn
+    // for up to the cache TTL; every switch-back must refetch until the
+    // backend history confirms the pending text.
+    seedSessionList("chat-nocache");
+    sessionApi.setLastUserMessage("chat-nocache", "unconfirmed turn");
+    const getChat = await mockGetChat({
+      messages: [userMsg("u1", "old q"), assistantMsg("a1", "old a")],
+      status: "idle",
+    } as ChatHistory);
+
+    await sessionApi.getSession("chat-nocache");
+    (sessionApi as any).sessionResultCache.clear();
+    (sessionApi as any).lastSelectedIds.clear();
+    await sessionApi.getSession("chat-nocache");
+    expect(getChat).toHaveBeenCalledTimes(2);
+  });
+
+  it("still caches idle sessions once the pending text is confirmed", async () => {
+    seedSessionList("chat-confirmed");
+    sessionApi.setLastUserMessage("chat-confirmed", "the question");
+    const getChat = await mockGetChat({
+      messages: [
+        userMsg("u1", "the question"),
+        assistantMsg("a1", "the answer"),
+      ],
+      status: "idle",
+    } as ChatHistory);
+
+    await sessionApi.getSession("chat-confirmed");
+    (sessionApi as any).sessionResultCache.clear();
+    (sessionApi as any).lastSelectedIds.clear();
+    await sessionApi.getSession("chat-confirmed");
+    // Second call is served from the LRU cache — history was complete.
+    expect(getChat).toHaveBeenCalledTimes(1);
+  });
 });

--- a/console/src/pages/Chat/tests/pendingUserMessage.test.ts
+++ b/console/src/pages/Chat/tests/pendingUserMessage.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Pending user message must survive the "generation finished but memory
+ * not yet flushed" window.
+ *
+ * customFetch caches the last user message in sessionStorage
+ * (setLastUserMessage) so patchLastUserMessage can re-insert it when the
+ * chat page remounts (mode switch /chat <-> /coding, session switch) while
+ * the backend has not persisted the turn yet.
+ *
+ * The old behavior cleared the cache unconditionally whenever the chat
+ * reported status != "running". Two windows made that lossy:
+ *   - POST sent but the tracker has not registered the run yet
+ *     (status still "idle"),
+ *   - generation completed but the agent memory flush has not finished,
+ *     so the fetched history is missing the final turn.
+ * In both cases the last user message disappeared permanently.
+ *
+ * New semantics: on idle, clear the cache only when the fetched history
+ * already contains the pending text; otherwise patch the message in and
+ * keep the cache for the next confirmation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Message, ChatHistory } from "../../../api/types/chat";
+
+vi.mock("../../../api/modules/chat", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../api/modules/chat")
+  >();
+  return {
+    ...actual,
+    chatApi: {
+      ...actual.chatApi,
+      filePreviewUrl: vi.fn(
+        (p: string) => `http://localhost:8000/files/preview/${p}`,
+      ),
+    },
+  };
+});
+
+// Import AFTER mocks are registered.
+import sessionApi from "../sessionApi";
+
+const STORAGE_PREFIX = "qwenpaw_pending_user_msg_";
+
+function userMsg(id: string, text: string): Message {
+  return {
+    id,
+    role: "user",
+    content: [{ type: "text", text }],
+    metadata: { timestamp: "2026-06-01 10:00:00.000" },
+  } as Message;
+}
+
+function assistantMsg(id: string, text: string): Message {
+  return {
+    id,
+    role: "assistant",
+    content: [{ type: "text", text }],
+    metadata: { timestamp: "2026-06-01 10:00:01.000" },
+  } as Message;
+}
+
+function seedSessionList(id: string): void {
+  (sessionApi as any).sessionList = [
+    { id, sessionId: id, userId: "u", channel: "c", name: "t" },
+  ];
+}
+
+async function mockGetChat(history: ChatHistory) {
+  const apiImport = await import("../../../api");
+  return vi.spyOn(apiImport.api, "getChat").mockResolvedValue(history);
+}
+
+/** Collect texts of user-role cards from a converted session. */
+function userCardTexts(session: unknown): string[] {
+  const msgs = (session as { messages: any[] }).messages;
+  return msgs
+    .filter((m) => m.role === "user")
+    .map((m) => {
+      const content = m.cards?.[0]?.data?.input?.[0]?.content;
+      return Array.isArray(content)
+        ? content
+            .filter((c: any) => c.type === "text")
+            .map((c: any) => c.text)
+            .join("\n")
+        : "";
+    });
+}
+
+describe("patchLastUserMessage — pending cache lifecycle", () => {
+  beforeEach(() => {
+    (sessionApi as any).sessionList = [];
+    (sessionApi as any).convertedSessionCache.clear();
+    (sessionApi as any).sessionResultCache.clear();
+    (sessionApi as any).sessionRequests.clear();
+    (sessionApi as any).lastSelectedIds.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("patches the pending user message while generating (status running)", async () => {
+    seedSessionList("chat-running");
+    sessionApi.setLastUserMessage("chat-running", "hello in flight");
+    await mockGetChat({
+      messages: [userMsg("u1", "earlier"), assistantMsg("a1", "reply")],
+      status: "running",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-running");
+    expect(userCardTexts(session)).toContain("hello in flight");
+    // Cache is kept while the turn is still generating.
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-running`)).not.toBe(
+      null,
+    );
+  });
+
+  it("clears the cache on idle when history already contains the text", async () => {
+    seedSessionList("chat-done");
+    sessionApi.setLastUserMessage("chat-done", "persisted question");
+    await mockGetChat({
+      messages: [
+        userMsg("u1", "persisted question"),
+        assistantMsg("a1", "final answer"),
+      ],
+      status: "idle",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-done");
+    const texts = userCardTexts(session);
+    // No duplicate user card.
+    expect(texts.filter((t) => t.includes("persisted question"))).toHaveLength(
+      1,
+    );
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-done`)).toBe(null);
+  });
+
+  it("keeps the cache and patches the message on idle when history is missing it (flush window)", async () => {
+    seedSessionList("chat-window");
+    sessionApi.setLastUserMessage("chat-window", "lost in the window");
+    await mockGetChat({
+      messages: [
+        userMsg("u1", "old question"),
+        assistantMsg("a1", "old answer"),
+      ],
+      status: "idle",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-window");
+    // The pending message must still be visible after the remount…
+    expect(userCardTexts(session)).toContain("lost in the window");
+    // …and the cache must survive until history confirms persistence.
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}chat-window`)).not.toBe(
+      null,
+    );
+  });
+
+  it("does nothing on idle when no pending message is cached", async () => {
+    seedSessionList("chat-clean");
+    const getChat = await mockGetChat({
+      messages: [userMsg("u1", "q"), assistantMsg("a1", "a")],
+      status: "idle",
+    } as ChatHistory);
+
+    const session = await sessionApi.getSession("chat-clean");
+    expect(userCardTexts(session)).toEqual(["q"]);
+    expect(getChat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/console/src/pages/Chat/tests/replayFastForward.test.ts
+++ b/console/src/pages/Chat/tests/replayFastForward.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Reconnect fast-forward: the backend replays the buffered SSE events on
+ * reconnect and terminates the replayed section with a
+ * `{"type": "replay_end"}` marker event. Everything before the marker
+ * must reach the SDK as a single chunk (instant render, no token-by-token
+ * re-animation); everything after must stream through untouched.
+ *
+ * Backends without the marker fall back to an idle-timeout flush.
+ */
+import { describe, it, expect } from "vitest";
+import { wrapReplayFastForward } from "../replayFastForward";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const MARKER = 'data: {"type": "replay_end"}\n\n';
+
+/** Build an SSE Response whose chunks are pushed via the returned fns. */
+function makeSseResponse(): {
+  response: Response;
+  push: (text: string) => void;
+  close: () => void;
+} {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  const response = new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+  return {
+    response,
+    push: (text: string) => controller.enqueue(encoder.encode(text)),
+    close: () => controller.close(),
+  };
+}
+
+async function readAllChunks(response: Response): Promise<string[]> {
+  const reader = response.body!.getReader();
+  const chunks: string[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(decoder.decode(value));
+  }
+  return chunks;
+}
+
+describe("wrapReplayFastForward", () => {
+  it("flushes all replayed events as one chunk when the marker arrives", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 5000);
+
+    push("data: one\n\n");
+    push("data: two\n\n");
+    push(MARKER);
+    push("data: live\n\n");
+    close();
+
+    const chunks = await readAllChunks(wrapped);
+    // Replayed part (including the marker, swallowed later by the
+    // response parser) arrives as a single chunk; live part separately.
+    expect(chunks[0]).toBe(`data: one\n\ndata: two\n\n${MARKER}`);
+    expect(chunks.slice(1)).toEqual(["data: live\n\n"]);
+  });
+
+  it("detects a marker split across chunk boundaries", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 5000);
+
+    push("data: one\n\n");
+    push(MARKER.slice(0, 10));
+    push(MARKER.slice(10));
+    push("data: live\n\n");
+    close();
+
+    const chunks = await readAllChunks(wrapped);
+    expect(chunks[0]).toBe(`data: one\n\n${MARKER}`);
+    expect(chunks.slice(1)).toEqual(["data: live\n\n"]);
+  });
+
+  it("falls back to an idle-timeout flush when no marker is sent", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 20);
+
+    push("data: one\n\n");
+    push("data: two\n\n");
+
+    const reader = wrapped.body!.getReader();
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toBe("data: one\n\ndata: two\n\n");
+
+    // After the fallback flush the stream is passthrough.
+    push("data: three\n\n");
+    const second = await reader.read();
+    expect(decoder.decode(second.value)).toBe("data: three\n\n");
+
+    close();
+    const end = await reader.read();
+    expect(end.done).toBe(true);
+  });
+
+  it("flushes buffered events when the stream ends without a marker", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 5000);
+
+    push("data: only\n\n");
+    close();
+
+    const chunks = await readAllChunks(wrapped);
+    expect(chunks).toEqual(["data: only\n\n"]);
+  });
+
+  it("returns the response unchanged when there is no body or not ok", () => {
+    const bad = new Response(null, { status: 500 });
+    expect(wrapReplayFastForward(bad, 100)).toBe(bad);
+  });
+});

--- a/console/src/pages/Chat/tests/replayFastForward.test.ts
+++ b/console/src/pages/Chat/tests/replayFastForward.test.ts
@@ -5,6 +5,11 @@
  * must reach the SDK as a single chunk (instant render, no token-by-token
  * re-animation); everything after must stream through untouched.
  *
+ * The marker itself must NEVER appear in the output: the SDK's response
+ * builder dereferences `data.object` on every parsed event, so any
+ * non-response payload reaching it throws mid-stream and kills all
+ * subsequent live tokens. Stripping happens here, at the byte level.
+ *
  * Backends without the marker fall back to an idle-timeout flush.
  */
 import { describe, it, expect } from "vitest";
@@ -50,7 +55,7 @@ async function readAllChunks(response: Response): Promise<string[]> {
 }
 
 describe("wrapReplayFastForward", () => {
-  it("flushes all replayed events as one chunk when the marker arrives", async () => {
+  it("flushes all replayed events as one chunk and strips the marker", async () => {
     const { response, push, close } = makeSseResponse();
     const wrapped = wrapReplayFastForward(response, 5000);
 
@@ -61,13 +66,13 @@ describe("wrapReplayFastForward", () => {
     close();
 
     const chunks = await readAllChunks(wrapped);
-    // Replayed part (including the marker, swallowed later by the
-    // response parser) arrives as a single chunk; live part separately.
-    expect(chunks[0]).toBe(`data: one\n\ndata: two\n\n${MARKER}`);
+    expect(chunks[0]).toBe("data: one\n\ndata: two\n\n");
     expect(chunks.slice(1)).toEqual(["data: live\n\n"]);
+    // The marker never reaches the SDK parser.
+    expect(chunks.join("")).not.toContain("replay_end");
   });
 
-  it("detects a marker split across chunk boundaries", async () => {
+  it("detects and strips a marker split across chunk boundaries", async () => {
     const { response, push, close } = makeSseResponse();
     const wrapped = wrapReplayFastForward(response, 5000);
 
@@ -78,8 +83,9 @@ describe("wrapReplayFastForward", () => {
     close();
 
     const chunks = await readAllChunks(wrapped);
-    expect(chunks[0]).toBe(`data: one\n\n${MARKER}`);
+    expect(chunks[0]).toBe("data: one\n\n");
     expect(chunks.slice(1)).toEqual(["data: live\n\n"]);
+    expect(chunks.join("")).not.toContain("replay_end");
   });
 
   it("falls back to an idle-timeout flush when no marker is sent", async () => {
@@ -103,6 +109,26 @@ describe("wrapReplayFastForward", () => {
     expect(end.done).toBe(true);
   });
 
+  it("strips a marker arriving after the idle-timeout flush", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 20);
+
+    push("data: one\n\n");
+
+    const reader = wrapped.body!.getReader();
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toBe("data: one\n\n");
+
+    // Late replay tail: marker + live event in the same network chunk.
+    push(`${MARKER}data: live\n\n`);
+    const second = await reader.read();
+    expect(decoder.decode(second.value)).toBe("data: live\n\n");
+
+    close();
+    const end = await reader.read();
+    expect(end.done).toBe(true);
+  });
+
   it("flushes buffered events when the stream ends without a marker", async () => {
     const { response, push, close } = makeSseResponse();
     const wrapped = wrapReplayFastForward(response, 5000);
@@ -112,6 +138,19 @@ describe("wrapReplayFastForward", () => {
 
     const chunks = await readAllChunks(wrapped);
     expect(chunks).toEqual(["data: only\n\n"]);
+  });
+
+  it("forwards a trailing partial event at stream end", async () => {
+    const { response, push, close } = makeSseResponse();
+    const wrapped = wrapReplayFastForward(response, 5000);
+
+    push("data: one\n\n");
+    push(MARKER);
+    push("data: partial");
+    close();
+
+    const chunks = await readAllChunks(wrapped);
+    expect(chunks.join("")).toBe("data: one\n\ndata: partial");
   });
 
   it("returns the response unchanged when there is no body or not ok", () => {

--- a/console/src/pages/Chat/tests/replaySdkIntegration.test.ts
+++ b/console/src/pages/Chat/tests/replaySdkIntegration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration guard for the reconnect replay path: the bytes that leave
+ * wrapReplayFastForward are fed to the REAL SDK response builder the same
+ * way useChatRequest does (responseParser -> builder.handle).
+ *
+ * The unit tests for the wrapper only assert chunk framing. They cannot
+ * catch a marker leaking into the SDK, which is fatal: Builder.handle
+ * dereferences `data.object` and routes anything unknown to handleError,
+ * appending an ERROR message and flipping the response to Failed — the
+ * live tokens that follow the replay are then never rendered.
+ */
+import { describe, it, expect } from "vitest";
+// The vitest config aliases the whole `@agentscope-ai/chat` package to a
+// stub (the real 2.3MB bundle OOMs the runner), so reach the compiled
+// builder through a relative path — the alias only matches the bare
+// package specifier. This keeps the assertion against real SDK code.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — compiled JS without bundled types on this deep path
+import AgentScopeRuntimeResponseBuilder from "../../../../node_modules/@agentscope-ai/chat/lib/AgentScopeRuntimeWebUI/core/AgentScopeRuntime/Response/Builder.js";
+import { wrapReplayFastForward } from "../replayFastForward";
+import realReconnectStream from "./fixtures/reconnectReplayStream.txt?raw";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const MARKER = 'data: {"type": "replay_end"}\n\n';
+
+/** Shape of the builder's accumulated response, as far as we assert. */
+interface SdkResponse {
+  status: string;
+  output?: Array<{ type?: string }>;
+}
+
+/** Seed the builder the way useChatRequest does for a fresh turn. */
+const builderSeed = {
+  id: "r1",
+  status: "created",
+  created_at: 0,
+} as unknown as ConstructorParameters<
+  typeof AgentScopeRuntimeResponseBuilder
+>[0];
+
+/** Minimal SSE frames of a replayed-then-live assistant turn. */
+const replayedFrames = [
+  `data: ${JSON.stringify({
+    object: "message",
+    id: "m1",
+    type: "message",
+    role: "assistant",
+    status: "in_progress",
+    content: [{ type: "text", text: "replayed ", index: 0, delta: true }],
+  })}\n\n`,
+  `data: ${JSON.stringify({
+    object: "content",
+    msg_id: "m1",
+    index: 0,
+    type: "text",
+    delta: true,
+    status: "in_progress",
+    text: "part",
+  })}\n\n`,
+];
+
+const liveFrames = [
+  `data: ${JSON.stringify({
+    object: "content",
+    msg_id: "m1",
+    index: 0,
+    type: "text",
+    delta: true,
+    status: "in_progress",
+    text: " + live",
+  })}\n\n`,
+  `data: ${JSON.stringify({
+    object: "response",
+    id: "r1",
+    status: "completed",
+    output: [],
+  })}\n\n`,
+];
+
+function sseResponse(frames: string[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      for (const f of frames) c.enqueue(encoder.encode(f));
+      c.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+/** Split raw bytes into `data:` payloads, mirroring the SDK's SSE reader. */
+async function readSsePayloads(response: Response): Promise<string[]> {
+  const reader = response.body!.getReader();
+  let buf = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+  }
+  return buf
+    .split("\n\n")
+    .map((e) => e.trim())
+    .filter(Boolean)
+    .map((e) => e.replace(/^data:\s*/, ""));
+}
+
+describe("replay fast-forward -> real SDK response builder", () => {
+  it("consumes replayed and live events without a builder error", async () => {
+    const wrapped = wrapReplayFastForward(
+      sseResponse([...replayedFrames, MARKER, ...liveFrames]),
+      5000,
+    );
+    const payloads = await readSsePayloads(wrapped);
+
+    // No marker survives to the parser stage.
+    expect(payloads.some((p) => p.includes("replay_end"))).toBe(false);
+
+    const builder = new AgentScopeRuntimeResponseBuilder(builderSeed);
+    let result: SdkResponse | undefined;
+    for (const payload of payloads) {
+      result = builder.handle(JSON.parse(payload));
+    }
+
+    // The live tail was consumed: completed status, no ERROR output.
+    expect(result?.status).toBe("completed");
+    const errors = (result?.output ?? []).filter((m) => m.type === "error");
+    expect(errors).toEqual([]);
+  });
+
+  it("consumes a real captured reconnect stream without a builder error", async () => {
+    // Fixture captured from a live `POST /console/chat` reconnect against a
+    // running generation, so the marker's exact wire format is pinned by
+    // real backend output rather than a hand-written guess.
+    const wrapped = wrapReplayFastForward(
+      sseResponse([realReconnectStream]),
+      5000,
+    );
+    const payloads = await readSsePayloads(wrapped);
+
+    expect(payloads.length).toBeGreaterThan(3);
+    expect(payloads.some((p) => p.includes("replay_end"))).toBe(false);
+
+    const builder = new AgentScopeRuntimeResponseBuilder(builderSeed);
+    let result: SdkResponse | undefined;
+    for (const payload of payloads) {
+      result = builder.handle(JSON.parse(payload));
+    }
+    const errors = (result?.output ?? []).filter((m) => m.type === "error");
+    expect(errors).toEqual([]);
+    expect(result?.status).not.toBe("failed");
+  });
+
+  it("a leaked marker WOULD break the builder (pins why stripping matters)", () => {
+    const builder = new AgentScopeRuntimeResponseBuilder(builderSeed);
+    const result: SdkResponse = builder.handle({
+      type: "replay_end",
+    } as unknown as Parameters<typeof builder.handle>[0]);
+    // Documents the failure mode the wrapper prevents.
+    expect(result.status).toBe("failed");
+  });
+});

--- a/console/src/stores/messageQueueStore.test.ts
+++ b/console/src/stores/messageQueueStore.test.ts
@@ -107,6 +107,7 @@ describe("messageQueueStore", () => {
     const queue = useMessageQueueStore.getState().getQueue(SESSION_ID);
     expect(queue).toHaveLength(1);
     expect(queue[0].text).toBe("hello");
+    expect(queue[0].clientMessageId).toBeTruthy();
     expect(queue[0].status).toBe("pending");
     expect(queue[0].retryCount).toBe(0);
     expect(queue[0].createdAt).toBeGreaterThan(0);

--- a/console/src/stores/messageQueueStore.ts
+++ b/console/src/stores/messageQueueStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createClientMessageId } from "../utils/clientMessageId";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -37,6 +38,7 @@ export interface QueueQuote {
 /** Full message body for a queued item (Phase 3 ready) */
 export interface QueueItem {
   id: string;
+  clientMessageId?: string;
   text: string;
   attachments?: QueueAttachment[];
   images?: QueueImage[];
@@ -370,6 +372,7 @@ export const useMessageQueueStore = create<MessageQueueStore>((set, get) => ({
       undefined;
     const item: QueueItem = {
       id: nextQueueId(),
+      clientMessageId: createClientMessageId(),
       text: input.text,
       attachments: input.attachments,
       images: input.images,

--- a/console/src/utils/clientMessageId.ts
+++ b/console/src/utils/clientMessageId.ts
@@ -1,0 +1,30 @@
+export const QWENPAW_CLIENT_MESSAGE_ID_KEY = "qwenpaw_client_message_id";
+
+function randomBase36(length: number): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let value = "";
+  for (const byte of bytes) value += (byte % 36).toString(36);
+  return value;
+}
+
+export function createClientMessageId(): string {
+  return crypto.randomUUID?.() ?? `${Date.now()}-${randomBase36(16)}`;
+}
+
+export function attachClientMessageId(
+  message: Record<string, unknown>,
+  clientMessageId: string,
+): Record<string, unknown> {
+  const metadata =
+    typeof message.metadata === "object" && message.metadata !== null
+      ? message.metadata
+      : {};
+  return {
+    ...message,
+    metadata: {
+      ...metadata,
+      [QWENPAW_CLIENT_MESSAGE_ID_KEY]: clientMessageId,
+    },
+  };
+}

--- a/console/src/utils/sessionGrouping.test.ts
+++ b/console/src/utils/sessionGrouping.test.ts
@@ -1,0 +1,37 @@
+/**
+ * findSessionRowIndex locates the active conversation inside the
+ * flattened (group header + session) row list used by the virtualized
+ * session lists, so they can scroll it into view after remount.
+ */
+import { describe, it, expect } from "vitest";
+import { findSessionRowIndex } from "./sessionGrouping";
+
+const rows = [
+  { kind: "groupHeader" as const },
+  { kind: "session" as const, session: { id: "a" } },
+  { kind: "session" as const, session: { id: "local-1", realId: "b" } },
+  { kind: "groupHeader" as const },
+  { kind: "session" as const, session: { id: "c" } },
+];
+
+describe("findSessionRowIndex", () => {
+  it("finds a session row by id", () => {
+    expect(findSessionRowIndex(rows, "c")).toBe(4);
+  });
+
+  it("finds a session row by realId (local timestamp entries)", () => {
+    expect(findSessionRowIndex(rows, "b")).toBe(2);
+  });
+
+  it("returns -1 when the session is not in the visible rows", () => {
+    expect(findSessionRowIndex(rows, "hidden")).toBe(-1);
+  });
+
+  it("returns -1 for an undefined session id", () => {
+    expect(findSessionRowIndex(rows, undefined)).toBe(-1);
+  });
+
+  it("never matches a group header row", () => {
+    expect(findSessionRowIndex([{ kind: "groupHeader" }], "a")).toBe(-1);
+  });
+});

--- a/console/src/utils/sessionGrouping.ts
+++ b/console/src/utils/sessionGrouping.ts
@@ -86,3 +86,23 @@ export function groupSessions<
       sessions: buckets[key],
     }));
 }
+
+/**
+ * Locate a session inside the flattened (group header + session) rows
+ * of the virtualized session lists. Rows inside collapsed groups are
+ * not present, so a -1 result also means "not currently visible".
+ */
+export function findSessionRowIndex(
+  rows: Array<{
+    kind: string;
+    session?: { id?: string; realId?: string };
+  }>,
+  sessionId: string | undefined,
+): number {
+  if (!sessionId) return -1;
+  return rows.findIndex(
+    (row) =>
+      row.kind === "session" &&
+      (row.session?.id === sessionId || row.session?.realId === sessionId),
+  );
+}

--- a/console/src/utils/sessionRoute.test.ts
+++ b/console/src/utils/sessionRoute.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSessionPath, getSessionIdFromPath } from "./sessionRoute";
+
+describe("session mode routes", () => {
+  it("preserves the session id across coding and chat routes", () => {
+    const sessionId = getSessionIdFromPath("/coding/chat-123");
+
+    expect(buildSessionPath("chat", sessionId)).toBe("/chat/chat-123");
+    expect(
+      buildSessionPath("coding", getSessionIdFromPath("/chat/chat-123")),
+    ).toBe("/coding/chat-123");
+  });
+});

--- a/src/qwenpaw/app/channels/base.py
+++ b/src/qwenpaw/app/channels/base.py
@@ -566,6 +566,7 @@ class BaseChannel(ABC):
             chat.id,
             payload,
             self._stream_with_tracker,
+            owner=self._workspace,
         )
 
         if is_new:

--- a/src/qwenpaw/app/channels/console/channel.py
+++ b/src/qwenpaw/app/channels/console/channel.py
@@ -263,6 +263,9 @@ class ConsoleChannel(BaseChannel):
             content_parts=content_parts,
             channel_meta=meta,
         )
+        message_metadata = payload.get("message_metadata")
+        if isinstance(message_metadata, dict) and request.input:
+            request.input[0].metadata = message_metadata
         request.channel_meta = meta
         rc = meta.get("request_context")
         if isinstance(rc, dict) and rc:

--- a/src/qwenpaw/app/chats/utils.py
+++ b/src/qwenpaw/app/chats/utils.py
@@ -30,6 +30,7 @@ from ...config import load_config
 from ...constant import (
     QWENPAW_MESSAGE_TAG_KEY,
     SCROLL_MEMORY_MESSAGE_TAG,
+    SYNTHETIC_USER_MESSAGE_TAGS,
 )
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,35 @@ def _is_scroll_memory_placeholder(msg: Msg) -> bool:
     return (
         text.lstrip().startswith("<system-info>")
         and "[context compressed]" in text
+    )
+
+
+# Visual compression collapses history/context ranges into user-role
+# messages with these names. They are model-only reconstructions.
+_VISUAL_PLACEHOLDER_NAMES = frozenset(
+    {"visual_context", "visual_history"},
+)
+
+
+def _is_synthetic_user_message(msg: Msg) -> bool:
+    """Return whether *msg* is a runtime-injected user-role message.
+
+    Loop gates, stop handlers, and rubric evaluation append tagged
+    ``role="user"`` stubs to keep a turn going; visual compression
+    collapses history into ``visual_history`` / ``visual_context``
+    user messages. None of them is user transcript — rendering them as
+    user cards made the original instruction appear rewritten after a
+    session switch.
+    """
+    if msg.role != "user":
+        return False
+    if msg.name in _VISUAL_PLACEHOLDER_NAMES:
+        return True
+    metadata = getattr(msg, "metadata", None)
+    return (
+        isinstance(metadata, dict)
+        and metadata.get(QWENPAW_MESSAGE_TAG_KEY)
+        in SYNTHETIC_USER_MESSAGE_TAGS
     )
 
 
@@ -492,6 +522,8 @@ def agentscope_msg_to_message(
 
     for msg in msgs:
         if _is_scroll_memory_placeholder(msg):
+            continue
+        if _is_synthetic_user_message(msg):
             continue
         role = msg.role or "assistant"
 

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -27,6 +27,9 @@ from ..utils.startup_display import AgentStartupDisplay
 
 logger = logging.getLogger(__name__)
 
+_OLD_WORKSPACE_TASK_WAIT_SECONDS = 60.0
+_OLD_WORKSPACE_TASK_MAX_WAIT_ROUNDS = 24 * 60
+
 
 class MultiAgentManager:
     """Manages multiple agent workspaces.
@@ -243,6 +246,8 @@ class MultiAgentManager:
         Args:
             old_instance: The old workspace instance to stop
             agent_id: Agent ID for logging
+            active_tasks: Fixed snapshot of tasks owned by the old workspace.
+                When omitted, the method captures the snapshot itself.
         """
         if active_tasks is None:
             active_tasks = (
@@ -263,21 +268,32 @@ class MultiAgentManager:
             async def delayed_cleanup():
                 """Wait for tasks to complete, then stop old instance."""
                 try:
-                    while not (
-                        await old_instance.task_tracker.wait_tasks_done(
-                            list(active_tasks.values()),
-                            timeout=60.0,
+                    completed = False
+                    for _ in range(_OLD_WORKSPACE_TASK_MAX_WAIT_ROUNDS):
+                        completed = (
+                            await old_instance.task_tracker.wait_tasks_done(
+                                list(active_tasks.values()),
+                                timeout=_OLD_WORKSPACE_TASK_WAIT_SECONDS,
+                            )
                         )
-                    ):
+                        if completed:
+                            break
                         logger.warning(
                             f"Tasks are still active for old instance "
                             f"{agent_id}. Keeping it alive until they finish.",
                         )
 
-                    logger.info(
-                        f"All tasks completed for old instance "
-                        f"{agent_id}. Stopping now.",
-                    )
+                    if completed:
+                        logger.info(
+                            f"All tasks completed for old instance "
+                            f"{agent_id}. Stopping now.",
+                        )
+                    else:
+                        logger.error(
+                            f"Tasks did not finish within 24 hours for old "
+                            f"instance {agent_id}. Forcing cleanup to prevent "
+                            f"a resource leak.",
+                        )
                     await old_instance.stop(final=False)
                     logger.info(
                         f"Old workspace instance stopped: {agent_id}. "

--- a/src/qwenpaw/app/multi_agent_manager.py
+++ b/src/qwenpaw/app/multi_agent_manager.py
@@ -233,6 +233,7 @@ class MultiAgentManager:
         self,
         old_instance: Workspace,
         agent_id: str,
+        active_tasks: dict[str, asyncio.Future] | None = None,
     ) -> None:
         """Gracefully stop old instance after checking for active tasks.
 
@@ -243,35 +244,40 @@ class MultiAgentManager:
             old_instance: The old workspace instance to stop
             agent_id: Agent ID for logging
         """
-        has_active = await old_instance.task_tracker.has_active_tasks()
+        if active_tasks is None:
+            active_tasks = (
+                await old_instance.task_tracker.snapshot_active_tasks(
+                    owner=old_instance,
+                )
+            )
 
-        if has_active:
+        if active_tasks:
             # Active tasks - schedule delayed cleanup in background
-            active_tasks = await old_instance.task_tracker.list_active_tasks()
             logger.info(
                 f"Old workspace instance has {len(active_tasks)} active "
-                f"task(s): {active_tasks}. Scheduling delayed cleanup for "
+                f"task(s): {list(active_tasks)}. "
+                f"Scheduling delayed cleanup for "
                 f"{agent_id}.",
             )
 
             async def delayed_cleanup():
                 """Wait for tasks to complete, then stop old instance."""
                 try:
-                    # Wait up to 1 minutes for tasks to complete
-                    completed = await old_instance.task_tracker.wait_all_done(
-                        timeout=60.0,
-                    )
-                    if completed:
-                        logger.info(
-                            f"All tasks completed for old instance "
-                            f"{agent_id}. Stopping now.",
+                    while not (
+                        await old_instance.task_tracker.wait_tasks_done(
+                            list(active_tasks.values()),
+                            timeout=60.0,
                         )
-                    else:
+                    ):
                         logger.warning(
-                            f"Timeout waiting for tasks to complete for "
-                            f"{agent_id}. Forcing stop after 5 minutes.",
+                            f"Tasks are still active for old instance "
+                            f"{agent_id}. Keeping it alive until they finish.",
                         )
 
+                    logger.info(
+                        f"All tasks completed for old instance "
+                        f"{agent_id}. Stopping now.",
+                    )
                     await old_instance.stop(final=False)
                     logger.info(
                         f"Old workspace instance stopped: {agent_id}. "
@@ -427,6 +433,11 @@ class MultiAgentManager:
             old_instance = self.agents.get(agent_id)
 
         if old_instance:
+            # TaskTracker is agent-scoped rather than workspace-scoped. Reuse
+            # it before startup so reconnect/status/stop requests arriving
+            # after the atomic swap can still reach in-flight runs.
+            new_instance.set_task_tracker(old_instance.task_tracker)
+
             # Get all reusable services from old instance's ServiceManager
             # pylint: disable=protected-access
             reusable = old_instance._service_manager.get_reusable_services()
@@ -472,9 +483,21 @@ class MultiAgentManager:
             self.agents[agent_id] = new_instance
             logger.info(f"Workspace instance replaced: {agent_id}")
 
+        # Snapshot only runs owned by the old workspace. Runs started through
+        # the new workspace after the swap must not delay old resource cleanup.
+        old_active_tasks = (
+            await old_instance.task_tracker.snapshot_active_tasks(
+                owner=old_instance,
+            )
+        )
+
         # Step 5: Gracefully stop old instance (outside lock)
         # Delegates to helper method to avoid too-many-statements
-        await self._graceful_stop_old_instance(old_instance, agent_id)
+        await self._graceful_stop_old_instance(
+            old_instance,
+            agent_id,
+            active_tasks=old_active_tasks,
+        )
 
         return True
 

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -159,6 +159,37 @@ def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
     return native_payload
 
 
+def _is_reconnect_request(request_data: Union[AgentRequest, dict]) -> bool:
+    """Return whether the chat request asks to attach to a running stream.
+
+    ``AgentRequest`` uses ``extra="allow"`` and has no required fields,
+    so FastAPI parses ``{"reconnect": true, ...}`` bodies into an
+    ``AgentRequest`` instance — a dict-only check silently classified
+    every reconnect as a fresh send and restarted a run with an empty
+    input. Check both shapes.
+    """
+    if isinstance(request_data, dict):
+        return request_data.get("reconnect") is True
+    return getattr(request_data, "reconnect", None) is True
+
+
+def _empty_sse_response() -> StreamingResponse:
+    """An SSE response that terminates immediately."""
+
+    async def _empty() -> AsyncGenerator[str, None]:
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+    return StreamingResponse(
+        _empty(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+
+
 def _tail_text_file(
     path: Path,
     *,
@@ -239,14 +270,16 @@ async def post_console_chat(
             ),
         )
 
-    is_reconnect = False
-    if isinstance(request_data, dict):
-        is_reconnect = request_data.get("reconnect") is True
+    is_reconnect = _is_reconnect_request(request_data)
 
     if is_reconnect:
         queue = await tracker.attach(chat.id)
         if queue is None:
-            return
+            # The run finished (or never existed): reply with an
+            # immediately-terminated SSE stream so the client's reader
+            # completes normally and falls back to the persisted
+            # history. Returning a JSON null here left the chat blank.
+            return _empty_sse_response()
     else:
         queue, _ = await tracker.attach_or_start(
             chat.id,

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -112,15 +112,24 @@ def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
         content_parts = (
             list(request_data.input[0].content) if request_data.input else []
         )
+        message_metadata = (
+            request_data.input[0].metadata if request_data.input else None
+        )
     else:
         channel_id = request_data.get("channel", "console")
         sender_id = request_data.get("user_id", "default")
         session_id = request_data.get("session_id", "default")
         input_data = request_data.get("input", [])
         content_parts = []
+        message_metadata = None
         for content_part in input_data:
             if hasattr(content_part, "content"):
                 content_parts.extend(list(content_part.content or []))
+                message_metadata = getattr(
+                    content_part,
+                    "metadata",
+                    message_metadata,
+                )
             elif isinstance(content_part, dict) and "content" in content_part:
                 # Coerce raw dicts to typed Content models so downstream
                 # getattr checks (e.g. _content_has_text) see real attrs.
@@ -128,6 +137,8 @@ def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
                     _coerce_content_item(c)
                     for c in (content_part["content"] or [])
                 )
+                if isinstance(content_part.get("metadata"), dict):
+                    message_metadata = content_part["metadata"]
 
     meta: dict = {
         "session_id": session_id,
@@ -146,6 +157,7 @@ def _extract_session_and_payload(request_data: Union[AgentRequest, dict]):
         "channel_id": channel_id,
         "sender_id": sender_id,
         "content_parts": content_parts,
+        "message_metadata": message_metadata,
         "meta": meta,
     }
 

--- a/src/qwenpaw/app/routers/console.py
+++ b/src/qwenpaw/app/routers/console.py
@@ -297,6 +297,7 @@ async def post_console_chat(
             chat.id,
             native_payload,
             console_channel.stream_one,
+            owner=workspace,
         )
 
     async def event_generator() -> AsyncGenerator[str, None]:

--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 
 _SENTINEL = None
 
+# Emitted to reconnect subscribers right after the buffered events, so
+# the client can render the replayed part instantly (no token-by-token
+# re-animation) and switch to live streaming afterwards.
+REPLAY_END_SSE = f"data: {json.dumps({'type': 'replay_end'})}\n\n"
+
 
 @dataclass
 class _RunState:
@@ -139,8 +144,9 @@ class TaskTracker:
     async def attach(self, run_key: str) -> asyncio.Queue | None:
         """Attach to an existing run.
 
-        Returns a new queue pre-filled with the event buffer, or ``None``
-        if no run is active for *run_key*.
+        Returns a new queue pre-filled with the event buffer plus a
+        ``replay_end`` marker, or ``None`` if no run is active for
+        *run_key*.
         """
         async with self._lock:
             state = self._runs.get(run_key)
@@ -149,6 +155,7 @@ class TaskTracker:
             q: asyncio.Queue = asyncio.Queue()
             for sse in state.buffer:
                 q.put_nowait(sse)
+            q.put_nowait(REPLAY_END_SSE)
             state.queues.append(q)
             return q
 

--- a/src/qwenpaw/app/task_tracker.py
+++ b/src/qwenpaw/app/task_tracker.py
@@ -34,14 +34,16 @@ class _RunState:
     buffer: list[str] = field(default_factory=list)
     start_time: Optional[datetime] = None
     finish_time: Optional[datetime] = None
+    owner: object | None = None
 
 
 class TaskTracker:
-    """Per-workspace tracker: run_key -> RunState.
+    """Per-agent tracker: run_key -> RunState.
 
     All mutations to _runs under _lock. Producer broadcasts under lock.
     Subscribers use unbounded per-connection queues; disconnect removes them
-    via :meth:`detach_subscriber`.
+    via :meth:`detach_subscriber`. A workspace reload reuses the same tracker
+    so active runs remain reconnectable.
     """
 
     def __init__(self) -> None:
@@ -120,6 +122,40 @@ class TaskTracker:
                 for run_key, state in self._runs.items()
                 if not state.task.done()
             ]
+
+    async def snapshot_active_tasks(
+        self,
+        owner: object | None = None,
+    ) -> dict[str, asyncio.Future]:
+        """Return the currently active tasks without tracking later runs."""
+        async with self._lock:
+            return {
+                run_key: state.task
+                for run_key, state in self._runs.items()
+                if not state.task.done()
+                and (owner is None or state.owner is owner)
+            }
+
+    async def wait_tasks_done(
+        self,
+        tasks: list[asyncio.Future],
+        timeout: float = 300.0,
+    ) -> bool:
+        """Wait for a fixed task snapshot without cancelling on timeout."""
+        if not tasks:
+            return True
+
+        async def _wait_snapshot() -> None:
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in tasks),
+                return_exceptions=True,
+            )
+
+        try:
+            await asyncio.wait_for(_wait_snapshot(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
 
     async def wait_all_done(self, timeout: float = 300.0) -> bool:
         """Wait for all active tasks to complete.
@@ -212,6 +248,7 @@ class TaskTracker:
         run_key: str,
         payload: Any,
         stream_fn: Callable[..., Coroutine],
+        owner: object | None = None,
     ) -> tuple[asyncio.Queue, bool]:
         """Attach to an existing run or start a new one.
 
@@ -231,6 +268,7 @@ class TaskTracker:
                 task=asyncio.Future(),  # placeholder, replaced below
                 queues=[my_queue],
                 buffer=[],
+                owner=owner,
             )
             self._runs[run_key] = run
 

--- a/src/qwenpaw/app/workspace/workspace.py
+++ b/src/qwenpaw/app/workspace/workspace.py
@@ -126,6 +126,15 @@ class Workspace:
         """Get task tracker for background chat and reconnect."""
         return self._task_tracker
 
+    def set_task_tracker(self, task_tracker: TaskTracker) -> None:
+        """Reuse an agent task tracker before this workspace starts."""
+        if self._started:
+            raise RuntimeError(
+                f"Cannot replace task tracker for started workspace "
+                f"'{self.agent_id}'",
+            )
+        self._task_tracker = task_tracker
+
     @property
     def config(self):
         """Get agent configuration."""

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -128,6 +128,7 @@ PROJECT_NAME = "QwenPaw"
 
 # Message metadata tags shared across agent middleware and memory managers.
 QWENPAW_MESSAGE_TAG_KEY = "qwenpaw_tag"
+QWENPAW_CLIENT_MESSAGE_ID_KEY = "qwenpaw_client_message_id"
 SCROLL_MEMORY_MESSAGE_TAG = "scroll_memory"
 AUTO_MEMORY_SEARCH_BLOCK_IDS_KEY = "auto_memory_search_block_ids"
 EXTERNAL_USER_QUERY_MESSAGE_TAG = "external_user_query"

--- a/src/qwenpaw/runtime/message_convert.py
+++ b/src/qwenpaw/runtime/message_convert.py
@@ -16,12 +16,15 @@ from ..constant import (
 logger = logging.getLogger(__name__)
 
 
-def _request_message_metadata(role: str) -> dict[str, str]:
+def _request_message_metadata(
+    role: str,
+    metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
     if role != "user":
         return {}
-    return {
-        QWENPAW_MESSAGE_TAG_KEY: EXTERNAL_USER_QUERY_MESSAGE_TAG,
-    }
+    result = dict(metadata or {})
+    result[QWENPAW_MESSAGE_TAG_KEY] = EXTERNAL_USER_QUERY_MESSAGE_TAG
+    return result
 
 
 def _media_type_to_block_type(media_type: str | None) -> str:
@@ -179,7 +182,10 @@ def _request_input_to_msgs(
                 name=role,
                 role=role,
                 content=blocks,
-                metadata=_request_message_metadata(role),
+                metadata=_request_message_metadata(
+                    role,
+                    getattr(m, "metadata", None),
+                ),
             ),
         )
     return out

--- a/tests/unit/app/channels/test_console_channel.py
+++ b/tests/unit/app/channels/test_console_channel.py
@@ -142,6 +142,21 @@ class TestBuildAgentRequestFromNative:
         req = console_channel.build_agent_request_from_native(payload)
         assert req.request_context == {"foo": "bar"}
 
+    def test_message_metadata_propagated(self, console_channel):
+        payload = {
+            "sender_id": "u1",
+            "content_parts": [TextContent(text="hi")],
+            "message_metadata": {
+                "qwenpaw_client_message_id": "client-2",
+            },
+            "meta": {},
+        }
+        req = console_channel.build_agent_request_from_native(payload)
+
+        assert req.input[0].metadata == {
+            "qwenpaw_client_message_id": "client-2",
+        }
+
     def test_non_dict_payload_returns_empty_request(
         self,
         console_channel,

--- a/tests/unit/app/chats/test_utils.py
+++ b/tests/unit/app/chats/test_utils.py
@@ -15,6 +15,7 @@ from qwenpaw.app.chats.title_generator import _clean_title
 from qwenpaw.constant import (
     QWENPAW_MESSAGE_TAG_KEY,
     SCROLL_MEMORY_MESSAGE_TAG,
+    SYNTHETIC_USER_MESSAGE_TAGS,
 )
 
 
@@ -214,6 +215,65 @@ def test_msg_to_message_preserves_ordinary_memory_named_message():
     [message] = agentscope_msg_to_message(user_msg)
     rendered = "".join(c.text for c in message.content)
     assert rendered == "remember this preference"
+
+
+def test_msg_to_message_omits_synthetic_user_stubs():
+    """Runtime-injected user-role stubs (auto-continue, loop continuation,
+    rubric evaluation) are model-only context. Rendering them as user cards
+    made the original instruction appear rewritten after a session switch."""
+    for tag in SYNTHETIC_USER_MESSAGE_TAGS:
+        stub = Msg(
+            name="user",
+            role="user",
+            content=[
+                {"type": "text", "text": "Continue working on the task."},
+            ],
+            metadata={QWENPAW_MESSAGE_TAG_KEY: tag},
+        )
+        assert not agentscope_msg_to_message(stub), tag
+
+
+def test_msg_to_message_omits_visual_compression_placeholders():
+    """Visual-compression collapse rewrites history into user-role
+    ``visual_history`` / ``visual_context`` messages. They are model-only
+    reconstructions, never the user's transcript."""
+    for name in ("visual_history", "visual_context"):
+        collapsed = Msg(
+            name=name,
+            role="user",
+            content=[
+                {"type": "text", "text": "[pages 1-3 of prior history]"},
+            ],
+        )
+        assert not agentscope_msg_to_message(collapsed), name
+
+
+def test_msg_to_message_keeps_user_message_with_unknown_tag():
+    user_msg = Msg(
+        name="user",
+        role="user",
+        content=[{"type": "text", "text": "real question"}],
+        metadata={QWENPAW_MESSAGE_TAG_KEY: "some_future_tag"},
+    )
+
+    [message] = agentscope_msg_to_message(user_msg)
+    rendered = "".join(c.text for c in message.content)
+    assert rendered == "real question"
+
+
+def test_msg_to_message_keeps_assistant_message_with_synthetic_tag():
+    """The synthetic-tag filter is scoped to user-role stubs only."""
+    tag = next(iter(SYNTHETIC_USER_MESSAGE_TAGS))
+    assistant_msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[{"type": "text", "text": "still working"}],
+        metadata={QWENPAW_MESSAGE_TAG_KEY: tag},
+    )
+
+    [message] = agentscope_msg_to_message(assistant_msg)
+    rendered = "".join(c.text for c in message.content)
+    assert rendered == "still working"
 
 
 def test_history_batch_hides_scroll_internals_but_keeps_transcript():

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the ``POST /console/chat`` reconnect branch.
+
+When a client reconnects to a chat whose run already finished (the
+tracker cleaned it up between the status poll and the reconnect), the
+endpoint must answer with an immediately-terminated SSE stream so the
+client's stream reader completes normally and falls back to loading the
+persisted history. Returning ``None`` produced a JSON ``null`` body,
+which left the chat UI blank until a manual refresh.
+"""
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from qwenpaw.app.task_tracker import TaskTracker
+
+
+@pytest.fixture
+def console_workspace(workspace_mock):
+    """Workspace with a console channel, chat manager, and empty tracker."""
+    console_channel = MagicMock(name="ConsoleChannel")
+    console_channel.resolve_session_id = MagicMock(
+        return_value="console:default",
+    )
+    # stream_one must never run for a reconnect: sentinel async generator
+    # that records invocation.
+    stream_calls: list = []
+
+    async def _stream_one(payload):
+        stream_calls.append(payload)
+        yield "data: should-not-happen\n\n"
+
+    console_channel.stream_one = _stream_one
+    console_channel.stream_calls = stream_calls
+    workspace_mock.channel_manager.get_channel = AsyncMock(
+        return_value=console_channel,
+    )
+    workspace_mock.console_channel = console_channel
+
+    chat = MagicMock(name="ChatSpec")
+    chat.id = "chat-1"
+    chat.name = "New Chat"
+    workspace_mock.chat_manager = MagicMock(name="ChatManager")
+    workspace_mock.chat_manager.get_or_create_chat = AsyncMock(
+        return_value=chat,
+    )
+
+    # Real tracker with no active run: attach() returns None.
+    workspace_mock.task_tracker = TaskTracker()
+    return workspace_mock
+
+
+@pytest.fixture
+def app(manager_mock, console_workspace) -> FastAPI:
+    """A fresh FastAPI app mounting only the console router under /api."""
+    from qwenpaw.app.routers.console import router as console_router
+
+    application = FastAPI()
+    application.state.multi_agent_manager = manager_mock
+    application.include_router(console_router, prefix="/api")
+    return application
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def test_reconnect_without_active_run_returns_empty_sse(
+    client,
+    console_workspace,
+):
+    response = client.post(
+        "/api/console/chat",
+        json={
+            "reconnect": True,
+            "session_id": "console:default",
+            "user_id": "default",
+            "channel": "console",
+        },
+    )
+
+    assert response.status_code == 200
+    content_type = response.headers.get("content-type", "")
+    assert content_type.startswith("text/event-stream")
+    assert response.text == ""
+    # A reconnect must attach only — never start a fresh run with the
+    # (empty) reconnect payload.
+    assert console_workspace.console_channel.stream_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconnect_with_active_run_replays_buffer_and_marker(
+    app,
+    console_workspace,
+):
+    from starlette.requests import Request
+    from qwenpaw.app.routers.console import post_console_chat
+
+    tracker = console_workspace.task_tracker
+    release = asyncio.Event()
+
+    async def slow_stream(_payload):
+        yield "data: first\n\n"
+        await release.wait()
+
+    await tracker.attach_or_start("chat-1", None, slow_stream)
+    # Let the producer buffer the first event before reconnecting.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/api/console/chat",
+            "headers": [],
+            "app": app,
+        },
+    )
+    response = await post_console_chat(
+        request_data={
+            "reconnect": True,
+            "session_id": "console:default",
+            "user_id": "default",
+            "channel": "console",
+        },
+        request=request,
+    )
+
+    received: list[str] = []
+
+    async def _consume() -> None:
+        async for chunk in response.body_iterator:
+            received.append(chunk)
+            # End the producer once the replay part is over.
+            if "replay_end" in chunk:
+                release.set()
+
+    try:
+        # Bounded wait: without the marker the stream never ends —
+        # fail fast instead of hanging the test session.
+        await asyncio.wait_for(_consume(), timeout=5)
+    finally:
+        release.set()
+
+    assert received[0] == "data: first\n\n"
+    payload = json.loads(received[1][len("data: ") :])
+    assert payload == {"type": "replay_end"}
+    # No fresh run was started by the reconnect.
+    assert console_workspace.console_channel.stream_calls == []

--- a/tests/unit/app/routers/test_console_chat_reconnect.py
+++ b/tests/unit/app/routers/test_console_chat_reconnect.py
@@ -19,7 +19,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from qwenpaw.app.routers.console import _extract_session_and_payload
 from qwenpaw.app.task_tracker import TaskTracker
+from qwenpaw.schemas import AgentRequest, Message, Role, TextContent
 
 
 @pytest.fixture
@@ -94,6 +96,26 @@ def test_reconnect_without_active_run_returns_empty_sse(
     # A reconnect must attach only — never start a fresh run with the
     # (empty) reconnect payload.
     assert console_workspace.console_channel.stream_calls == []
+
+
+def test_extract_payload_preserves_user_message_metadata():
+    payload = _extract_session_and_payload(
+        AgentRequest(
+            input=[
+                Message(
+                    role=Role.USER,
+                    content=[TextContent(text="continue")],
+                    metadata={
+                        "qwenpaw_client_message_id": "client-new",
+                    },
+                ),
+            ],
+        ),
+    )
+
+    assert payload["message_metadata"] == {
+        "qwenpaw_client_message_id": "client-new",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/test_multi_agent_manager_startup.py
+++ b/tests/unit/app/test_multi_agent_manager_startup.py
@@ -152,6 +152,38 @@ async def test_cleanup_keeps_old_workspace_alive_after_wait_timeout() -> None:
     assert old_workspace.stopped is True
 
 
+@pytest.mark.asyncio
+async def test_cleanup_forces_stop_after_maximum_wait_rounds(
+    monkeypatch,
+) -> None:
+    manager = MultiAgentManager()
+    old_workspace = _ReloadWorkspace("agent-1")
+    task = asyncio.Future()
+    old_workspace.task_tracker.wait_tasks_done = AsyncMock(
+        return_value=False,
+    )
+    monkeypatch.setattr(
+        multi_agent_manager_module,
+        "_OLD_WORKSPACE_TASK_MAX_WAIT_ROUNDS",
+        2,
+    )
+
+    await manager._graceful_stop_old_instance(
+        old_workspace,
+        "agent-1",
+        active_tasks={"chat-1": task},
+    )
+    cleanup_tasks = list(manager._cleanup_tasks)
+    assert cleanup_tasks
+    await asyncio.wait_for(
+        asyncio.gather(*cleanup_tasks),
+        timeout=1,
+    )
+
+    assert old_workspace.task_tracker.wait_tasks_done.await_count == 2
+    assert old_workspace.stopped is True
+
+
 def _read_custom_startup_concurrency(
     value: str | None = None,
     legacy_value: str | None = None,

--- a/tests/unit/app/test_multi_agent_manager_startup.py
+++ b/tests/unit/app/test_multi_agent_manager_startup.py
@@ -16,6 +16,7 @@ import qwenpaw.app.multi_agent_manager as multi_agent_manager_module
 import qwenpaw.constant as constants
 from qwenpaw.app.agent_startup import AgentStartupStatus
 from qwenpaw.app.multi_agent_manager import MultiAgentManager
+from qwenpaw.app.task_tracker import REPLAY_END_SSE, TaskTracker
 from qwenpaw.constant import BUILTIN_QA_AGENT_ID
 
 
@@ -31,6 +32,124 @@ def _config(*agent_ids: str):
     return SimpleNamespace(
         agents=SimpleNamespace(profiles=profiles),
     )
+
+
+class _ReloadServiceManager:
+    def __init__(self) -> None:
+        self.services = {}
+
+    def get_reusable_services(self) -> dict:
+        return {}
+
+
+class _ReloadWorkspace:
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.task_tracker = TaskTracker()
+        self._service_manager = _ReloadServiceManager()
+        self.started = False
+        self.stopped = False
+        self.manager = None
+
+    def set_task_tracker(self, task_tracker: TaskTracker) -> None:
+        assert not self.started
+        self.task_tracker = task_tracker
+
+    async def set_reusable_components(self, _components: dict) -> None:
+        return None
+
+    async def start(self) -> None:
+        self.started = True
+
+    def set_manager(self, manager: MultiAgentManager) -> None:
+        self.manager = manager
+
+    async def stop(self, final: bool = True) -> None:
+        del final
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_reload_reuses_tracker_for_active_stream_reconnect(
+    monkeypatch,
+) -> None:
+    manager = MultiAgentManager()
+    config = _config("agent-1")
+    monkeypatch.setattr(
+        "qwenpaw.app.multi_agent_manager.load_config",
+        lambda: config,
+    )
+    old_workspace = _ReloadWorkspace("agent-1")
+    new_workspace = _ReloadWorkspace("agent-1")
+    manager.agents["agent-1"] = old_workspace
+    manager._create_workspace = MagicMock(return_value=new_workspace)
+    release = asyncio.Event()
+    emitted = asyncio.Event()
+
+    async def producer(_payload):
+        yield "data: replayed\n\n"
+        emitted.set()
+        await release.wait()
+        yield "data: live\n\n"
+
+    original_queue, _ = await old_workspace.task_tracker.attach_or_start(
+        "chat-1",
+        None,
+        producer,
+        owner=old_workspace,
+    )
+    await asyncio.wait_for(emitted.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert await manager.reload_agent("agent-1") is True
+    assert manager.agents["agent-1"] is new_workspace
+    assert new_workspace.task_tracker is old_workspace.task_tracker
+
+    reconnect_queue = await new_workspace.task_tracker.attach("chat-1")
+    assert reconnect_queue is not None
+    assert await reconnect_queue.get() == "data: replayed\n\n"
+    assert await reconnect_queue.get() == REPLAY_END_SSE
+
+    cleanup_tasks = list(manager._cleanup_tasks)
+    assert cleanup_tasks
+    release.set()
+    assert await reconnect_queue.get() == "data: live\n\n"
+    assert await reconnect_queue.get() is None
+    async for _ in old_workspace.task_tracker.stream_from_queue(
+        original_queue,
+        "chat-1",
+    ):
+        pass
+    await asyncio.wait_for(
+        asyncio.gather(*cleanup_tasks),
+        timeout=1,
+    )
+    assert old_workspace.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_cleanup_keeps_old_workspace_alive_after_wait_timeout() -> None:
+    manager = MultiAgentManager()
+    old_workspace = _ReloadWorkspace("agent-1")
+    task = asyncio.Future()
+    old_workspace.task_tracker.wait_tasks_done = AsyncMock(
+        side_effect=[False, True],
+    )
+
+    await manager._graceful_stop_old_instance(
+        old_workspace,
+        "agent-1",
+        active_tasks={"chat-1": task},
+    )
+    cleanup_tasks = list(manager._cleanup_tasks)
+    assert cleanup_tasks
+    await asyncio.wait_for(
+        asyncio.gather(*cleanup_tasks),
+        timeout=1,
+    )
+
+    assert old_workspace.task_tracker.wait_tasks_done.await_count == 2
+    assert old_workspace.stopped is True
 
 
 def _read_custom_startup_concurrency(

--- a/tests/unit/app/test_task_tracker.py
+++ b/tests/unit/app/test_task_tracker.py
@@ -344,6 +344,81 @@ async def test_wait_all_done_times_out_when_task_runs():
             pass
 
 
+@pytest.mark.asyncio
+async def test_snapshot_active_tasks_filters_by_owner():
+    tracker = TaskTracker()
+    owner_a = object()
+    owner_b = object()
+    release = asyncio.Event()
+
+    async def producer(_payload):
+        await release.wait()
+        yield "data: done\n\n"
+
+    queue_a, _ = await tracker.attach_or_start(
+        "run-owner-a",
+        None,
+        producer,
+        owner=owner_a,
+    )
+    queue_b, _ = await tracker.attach_or_start(
+        "run-owner-b",
+        None,
+        producer,
+        owner=owner_b,
+    )
+
+    try:
+        snapshot = await tracker.snapshot_active_tasks(owner=owner_a)
+        assert list(snapshot) == ["run-owner-a"]
+    finally:
+        release.set()
+        async for _ in tracker.stream_from_queue(queue_a, "run-owner-a"):
+            pass
+        async for _ in tracker.stream_from_queue(queue_b, "run-owner-b"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_wait_tasks_done_ignores_runs_started_after_snapshot():
+    tracker = TaskTracker()
+    release_old = asyncio.Event()
+    release_new = asyncio.Event()
+
+    async def old_producer(_payload):
+        await release_old.wait()
+        yield "data: old\n\n"
+
+    async def new_producer(_payload):
+        await release_new.wait()
+        yield "data: new\n\n"
+
+    old_queue, _ = await tracker.attach_or_start(
+        "run-old",
+        None,
+        old_producer,
+    )
+    snapshot = await tracker.snapshot_active_tasks()
+    new_queue, _ = await tracker.attach_or_start(
+        "run-new",
+        None,
+        new_producer,
+    )
+
+    release_old.set()
+    assert await tracker.wait_tasks_done(
+        list(snapshot.values()),
+        timeout=1,
+    )
+    assert await tracker.get_status("run-new") == "running"
+
+    release_new.set()
+    async for _ in tracker.stream_from_queue(old_queue, "run-old"):
+        pass
+    async for _ in tracker.stream_from_queue(new_queue, "run-new"):
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Concurrent attach / start safety
 # ---------------------------------------------------------------------------

--- a/tests/unit/app/test_task_tracker.py
+++ b/tests/unit/app/test_task_tracker.py
@@ -378,3 +378,50 @@ async def test_concurrent_attach_or_start_only_one_producer():
             item = await asyncio.wait_for(q.get(), timeout=1)
             if item is None:
                 break
+
+
+# ---------------------------------------------------------------------------
+# attach(): replay-end marker for reconnect fast-forward
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attach_appends_replay_end_marker_after_buffer():
+    """Reconnect subscribers get the buffered events, then a
+    ``replay_end`` marker, then live events. The marker lets the client
+    render the replayed part instantly instead of re-animating it."""
+    tracker = TaskTracker()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_stream(_payload):
+        yield "data: first\n\n"
+        started.set()
+        await release.wait()
+        yield "data: second\n\n"
+
+    queue_a, _ = await tracker.attach_or_start(
+        "run-replay",
+        payload=None,
+        stream_fn=slow_stream,
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    queue_b = await tracker.attach("run-replay")
+    assert queue_b is not None
+
+    first = await asyncio.wait_for(queue_b.get(), timeout=1)
+    marker = await asyncio.wait_for(queue_b.get(), timeout=1)
+    assert first == "data: first\n\n"
+    assert marker.startswith("data: ")
+    assert json.loads(marker[len("data: ") :].strip()) == {
+        "type": "replay_end",
+    }
+
+    release.set()
+    rest_b = await _drain(queue_b, 2)
+    assert rest_b == ["data: second\n\n", None]
+    # The original (non-reconnect) subscriber never sees the marker.
+    rest_a = await _drain(queue_a, 3)
+    assert rest_a == ["data: first\n\n", "data: second\n\n", None]

--- a/tests/unit/runtime/test_message_convert.py
+++ b/tests/unit/runtime/test_message_convert.py
@@ -3,6 +3,7 @@
 
 from qwenpaw.constant import (
     EXTERNAL_USER_QUERY_MESSAGE_TAG,
+    QWENPAW_CLIENT_MESSAGE_ID_KEY,
     QWENPAW_MESSAGE_TAG_KEY,
 )
 from qwenpaw.runtime.message_convert import _request_input_to_msgs
@@ -28,3 +29,20 @@ def test_only_external_user_input_gets_query_tag():
         EXTERNAL_USER_QUERY_MESSAGE_TAG
     )
     assert QWENPAW_MESSAGE_TAG_KEY not in messages[1].metadata
+
+
+def test_user_message_client_id_survives_conversion():
+    messages = _request_input_to_msgs(
+        [
+            Message(
+                role=Role.USER,
+                content=[TextContent(text="repeat")],
+                metadata={QWENPAW_CLIENT_MESSAGE_ID_KEY: "client-2"},
+            ),
+        ],
+    )
+
+    assert messages[0].metadata[QWENPAW_CLIENT_MESSAGE_ID_KEY] == "client-2"
+    assert messages[0].metadata[QWENPAW_MESSAGE_TAG_KEY] == (
+        EXTERNAL_USER_QUERY_MESSAGE_TAG
+    )


### PR DESCRIPTION
## Summary

Fixes #6558 and preserves active responses when switching between Coding and Chat modes.

- Preserve in-flight streams across agent Workspace hot reloads.
- Reconnect to buffered and live events through a shared per-agent TaskTracker.
- Keep old Workspace resources alive until their owned tasks finish, including tasks longer than 60 seconds.
- Preserve pending user messages until backend persistence is confirmed.
- Use client message IDs to distinguish repeated identical prompts.
- Remove pending messages when the backend explicitly rejects a request.
- Fast-forward replayed SSE events instead of rendering responses token by token again.
- Hide runtime-generated synthetic user messages from conversation history.
- Persist and restore collapsed session groups and active-session visibility.
- Preserve the session ID when switching between `/coding` and `/chat`.
<img width="1839" height="1225" alt="image" src="https://github.com/user-attachments/assets/fc06d0fe-4e51-4564-abe6-32c09b509a78" />
<img width="1846" height="1227" alt="image" src="https://github.com/user-attachments/assets/ffc4c2ff-9085-4752-afc4-d3dfc46e531f" />

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
