### PR TITLE
fix(console): scope chat 100dvh override to touch devices

### DIFF
--- a/console/src/styles/layout.css
+++ b/console/src/styles/layout.css
@@ -866,11 +866,15 @@ html.dark-mode
   padding-bottom: env(safe-area-inset-bottom, 0px) !important;
 }
 
-/* When the virtual keyboard is open (supported browsers), shrink viewport */
+/* When the virtual keyboard is open (supported browsers), shrink viewport.
+   Touch devices only: on desktop the chat sits below the header, so
+   forcing 100dvh overflows the container and hides the sender. */
 @supports (height: 100dvh) {
-  .qwenpaw-chat-anywhere-chat,
-  [class*="chat-anywhere-chat"] {
-    height: 100dvh;
+  @media (hover: none) and (pointer: coarse) {
+    .qwenpaw-chat-anywhere-chat,
+    [class*="chat-anywhere-chat"] {
+      height: 100dvh;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #6549

Restrict the rule to touchscreen devices (`@media (hover: none) and (pointer: coarse)`, consistent with existing mobile-specific styling in the same file):
On desktop, revert to the component library's default `height: 100%`, ensuring the input box is fully visible and the message area scrolls independently.
Mobile keyboard adaptation behavior (#4738) remains unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
