### PR TITLE
fix(providers): return typed tagged tool calls

### DIFF
--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Callable
 
+from agentscope.message import ToolCallBlock
 from agentscope.model import OpenAIChatModel
 from agentscope.model._model_response import ChatResponse
 
@@ -733,9 +734,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
         response: Any,
     ) -> AsyncGenerator[ChatResponse, None]:
         sanitized_response = _SanitizedStream(response)
-
-        _think_tool_calls: dict[str, dict] = {}
-        _text_tool_calls: dict[str, dict] = {}
+        next_think_tool_call_id = 0
+        next_text_tool_call_id = 0
 
         async for parsed in super()._parse_stream_response(
             start_datetime=start_datetime,
@@ -807,10 +807,8 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                 for b in parsed.content
             )
 
-            if has_tool_use:
-                _think_tool_calls.clear()
-                _text_tool_calls.clear()
-            else:
+            recovered_tool_calls: list[ToolCallBlock] = []
+            if not has_tool_use:
                 # --- 1. Scan thinking blocks ---
                 for block in parsed.content:
                     btype = _battr(block, "type")
@@ -826,16 +824,15 @@ class OpenAIChatModelCompat(OpenAIChatModel):
 
                     _bset(block, "thinking", think_parsed.text_before.strip())
 
-                    _think_tool_calls = {
-                        f"thinking_{i}": {
-                            "type": "tool_use",
-                            "id": f"think_call_{i}",
-                            "name": ptc.name,
-                            "input": ptc.arguments,
-                            "raw_input": ptc.raw_arguments,
-                        }
-                        for i, ptc in enumerate(think_parsed.tool_calls)
-                    }
+                    for tool_call in think_parsed.tool_calls:
+                        recovered_tool_calls.append(
+                            ToolCallBlock(
+                                id=f"think_call_{next_think_tool_call_id}",
+                                name=tool_call.name,
+                                input=tool_call.raw_arguments,
+                            ),
+                        )
+                        next_think_tool_call_id += 1
 
                 # --- 2. Scan text/content blocks ---
                 new_content: list | None = None
@@ -851,16 +848,15 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                     _bset(block, "text", clean_text)
 
                     if text_parsed.tool_calls:
-                        _text_tool_calls = {
-                            f"text_{j}": {
-                                "type": "tool_use",
-                                "id": f"text_call_{j}",
-                                "name": ptc.name,
-                                "input": ptc.arguments,
-                                "raw_input": ptc.raw_arguments,
-                            }
-                            for j, ptc in enumerate(text_parsed.tool_calls)
-                        }
+                        for tool_call in text_parsed.tool_calls:
+                            recovered_tool_calls.append(
+                                ToolCallBlock(
+                                    id=f"text_call_{next_text_tool_call_id}",
+                                    name=tool_call.name,
+                                    input=tool_call.raw_arguments,
+                                ),
+                            )
+                            next_text_tool_call_id += 1
 
                     # If the text block is now empty, mark it for removal.
                     if not clean_text:
@@ -871,10 +867,9 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                 if new_content is not None:
                     parsed.content = [b for b in new_content if b is not None]
 
-                extra = list(_think_tool_calls.values()) + list(
-                    _text_tool_calls.values(),
-                )
-                if extra:
-                    parsed.content = list(parsed.content) + extra
+                if recovered_tool_calls:
+                    parsed.content = (
+                        list(parsed.content) + recovered_tool_calls
+                    )
 
             yield parsed

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -6,7 +6,10 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from agentscope.credential import OpenAICredential
+from agentscope.message import ToolCallBlock
+from agentscope.model._model_response import ChatResponse
 
 from qwenpaw.providers.openai_chat_model_compat import (
     OpenAIChatModelCompat,
@@ -52,13 +55,18 @@ class FakeAsyncStream:
             raise StopAsyncIteration from exc
 
 
-def _make_chunk(tool_calls: list[Any]) -> Any:
+def _make_chunk(
+    tool_calls: list[Any] | None = None,
+    *,
+    content: str | None = None,
+    reasoning_content: str | None = None,
+) -> Any:
     delta = SimpleNamespace(
-        reasoning_content=None,
-        content=None,
+        reasoning_content=reasoning_content,
+        content=content,
         tool_calls=tool_calls,
     )
-    choice = SimpleNamespace(delta=delta)
+    choice = SimpleNamespace(delta=delta, finish_reason=None)
     return SimpleNamespace(usage=None, choices=[choice])
 
 
@@ -178,3 +186,88 @@ def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:
     assert sanitized_missing_name_and_arguments is not None
     assert sanitized_missing_name_and_arguments.function.name == ""
     assert sanitized_missing_name_and_arguments.function.arguments == ""
+
+
+@pytest.mark.parametrize(
+    ("use_reasoning", "id_prefix"),
+    [
+        (False, "text_call_"),
+        (True, "think_call_"),
+    ],
+)
+async def test_tagged_tool_calls_use_agentscope_blocks_once(
+    use_reasoning: bool,
+    id_prefix: str,
+) -> None:
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+    tagged = '<tool_call>{"name":"ping","arguments":{"x":1}}</tool_call>'
+    if use_reasoning:
+        tagged_chunk = _make_chunk(reasoning_content=tagged)
+        following_chunk = _make_chunk(reasoning_content="done")
+    else:
+        tagged_chunk = _make_chunk(content=tagged)
+        following_chunk = _make_chunk(content="done")
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        FakeAsyncStream([tagged_chunk, following_chunk]),
+    )
+
+    tool_blocks = [
+        block
+        for response in responses
+        for block in response.content
+        if isinstance(block, ToolCallBlock)
+    ]
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0].id.startswith(id_prefix)
+    assert tool_blocks[0].name == "ping"
+    assert json.loads(tool_blocks[0].input) == {"x": 1}
+
+    accumulated = ChatResponse(content=[], is_last=True)
+    for response in responses:
+        accumulated.append_chat_response(response)
+
+    accumulated_tools = [
+        block
+        for block in accumulated.content
+        if isinstance(block, ToolCallBlock)
+    ]
+    assert len(accumulated_tools) == 1
+    assert json.loads(accumulated_tools[0].input) == {"x": 1}
+
+
+async def test_multiple_tagged_tool_calls_have_unique_ids() -> None:
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+    tagged = (
+        '<tool_call>{"name":"first","arguments":{}}</tool_call>'
+        '<tool_call>{"name":"second","arguments":{}}</tool_call>'
+    )
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        FakeAsyncStream([_make_chunk(content=tagged)]),
+    )
+
+    tool_blocks = [
+        block
+        for response in responses
+        for block in response.content
+        if isinstance(block, ToolCallBlock)
+    ]
+    assert [block.name for block in tool_blocks] == ["first", "second"]
+    assert len({block.id for block in tool_blocks}) == 2


### PR DESCRIPTION
## Summary

- rehydrate tool calls extracted from thinking or text tags as AgentScope 2
  `ToolCallBlock` objects
- preserve raw JSON arguments as the block input
- emit each recovered tool call once with a unique stream-local ID
- cover thinking, content, streaming accumulation, and multiple tool calls

## Root cause

The compatibility parser appended legacy dictionary-shaped `tool_use` blocks
to `ChatResponse.content`. AgentScope 2 expects typed content blocks and reads
`block.id` while accumulating streaming responses, which raised:

```text
AttributeError: 'dict' object has no attribute 'id'
```

Converting the recovered calls to `ToolCallBlock` also requires one-shot
emission; otherwise subsequent stream chunks repeat the same block and append
its complete JSON input more than once.

## Validation

- `pytest -q tests/unit/providers`: 341 passed
- parser and tag-parser tests: 31 passed
- pre-commit for changed files: passed
- `git diff --check`: passed
