### PR TITLE
fix(read_file): accept numeric string line ranges

### DIFF
--- a/src/qwenpaw/agents/tools/file_io.py
+++ b/src/qwenpaw/agents/tools/file_io.py
@@ -103,10 +103,12 @@ def _get_encoding_for_file(file_path: str) -> str:
     ui_description="Read file contents",
     ui_icon="📄",
 )
+# Keep numeric strings in the public type: AgentScope validates the generated
+# schema before entering this function, where they are normalized to integers.
 async def read_file(  # pylint: disable=too-many-return-statements
     file_path: str,
-    start_line: Optional[int] = None,
-    end_line: Optional[int] = None,
+    start_line: Optional[int | str] = None,
+    end_line: Optional[int | str] = None,
 ) -> ToolChunk:
     """Read a file. Relative paths resolve from WORKING_DIR.
 
@@ -116,10 +118,12 @@ async def read_file(  # pylint: disable=too-many-return-statements
     Args:
         file_path (`str`):
             Path to the file.
-        start_line (`int`, optional):
-            First line to read (1-based, inclusive).
-        end_line (`int`, optional):
-            Last line to read (1-based, inclusive).
+        start_line (`int | str`, optional):
+            First line to read (1-based, inclusive). Decimal strings are
+            accepted for tool-call compatibility.
+        end_line (`int | str`, optional):
+            Last line to read (1-based, inclusive). Decimal strings are
+            accepted for tool-call compatibility.
     """
 
     # Convert start_line/end_line to int if they are strings

--- a/tests/unit/agents/tools/test_file_io.py
+++ b/tests/unit/agents/tools/test_file_io.py
@@ -159,6 +159,19 @@ class TestReadFile:
         assert text.endswith(info["notice"])
 
     @pytest.mark.asyncio
+    async def test_read_with_string_line_range(self, tmp_path):
+        f = tmp_path / "lines.txt"
+        f.write_text("line1\nline2\nline3\nline4\n", encoding="utf-8")
+
+        result = await read_file(str(f), start_line="2", end_line="3")
+
+        text = result.content[0].text
+        assert "line1" not in text
+        assert "line2" in text
+        assert "line3" in text
+        assert "line4" not in text
+
+    @pytest.mark.asyncio
     async def test_read_start_line_exceeds_file(self, tmp_path):
         f = tmp_path / "short.txt"
         f.write_text("only one line\n", encoding="utf-8")

--- a/tests/unit/providers/test_openai_tool_schema_compat.py
+++ b/tests/unit/providers/test_openai_tool_schema_compat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import jsonschema
 import pytest
 from agentscope.tool import Toolkit
 
@@ -145,8 +146,14 @@ def test_sanitize_tool_schemas_removes_nullable_builtin_tool_branches() -> (
     assert read_file_params["required"] == ["file_path"]
     start_line = read_file_params["properties"]["start_line"]
     assert start_line == {
-        "type": "integer",
-        "description": "First line to read (1-based, inclusive).",
+        "anyOf": [
+            {"type": "integer"},
+            {"type": "string"},
+        ],
+        "description": (
+            "First line to read (1-based, inclusive). Decimal strings are\n"
+            "accepted for tool-call compatibility."
+        ),
         "default": None,
     }
 
@@ -175,6 +182,24 @@ def test_sanitize_tool_schemas_removes_nullable_builtin_tool_branches() -> (
         ),
         "type": "object",
     }
+
+
+def test_read_file_schema_accepts_string_line_numbers() -> None:
+    """Numeric strings must survive AgentScope's pre-call validation."""
+    tool = PolicyGuardedTool(
+        read_file,
+        governor=None,
+        request_context={},
+    )
+
+    jsonschema.validate(
+        {
+            "file_path": "/tmp/tool-result.txt",
+            "start_line": "96",
+            "end_line": "300",
+        },
+        tool.input_schema,
+    )
 
 
 def test_sanitize_tool_schemas_removes_null_from_type_arrays() -> None:


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
