### PR TITLE
feat(desktop): add global-hotkey floating quick-input window

### DIFF
--- a/console/src-tauri/Cargo.lock
+++ b/console/src-tauri/Cargo.lock
@@ -1261,6 +1261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1390,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2830,6 +2858,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
@@ -4092,6 +4121,21 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5788,6 +5832,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5796,6 +5857,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/console/src-tauri/Cargo.toml
+++ b/console/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-global-shortcut = "2"
 tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "5"

--- a/console/src-tauri/capabilities/quick-input.json
+++ b/console/src-tauri/capabilities/quick-input.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "quick-input",
+  "description": "Quick-input floating window: backend-hosted chat route, no chrome.",
+  "windows": ["quick-input"],
+  "remote": {
+    "urls": ["http://127.0.0.1:*", "http://localhost:*"]
+  },
+  "permissions": ["core:default"]
+}

--- a/console/src-tauri/src/backend.rs
+++ b/console/src-tauri/src/backend.rs
@@ -72,7 +72,7 @@ impl BackendState {
         self.generation.load(Ordering::SeqCst) == generation
     }
 
-    fn port(&self) -> Option<u16> {
+    pub(crate) fn port(&self) -> Option<u16> {
         self.with_inner(|inner| inner.port)
     }
 

--- a/console/src-tauri/src/lib.rs
+++ b/console/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod external_link;
 mod runtime_env;
 mod tray;
 mod updates;
+mod quick_input;
 
 use tauri::{Manager, RunEvent, WebviewWindow, WindowEvent};
 
@@ -30,6 +31,17 @@ pub fn run() {
         .plugin(
             tauri_plugin_updater::Builder::new()
                 .default_version_comparator(updates::is_remote_update_newer)
+                .build(),
+        )
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app, _shortcut, event| {
+                    if event.state
+                        == tauri_plugin_global_shortcut::ShortcutState::Pressed
+                    {
+                        quick_input::toggle_quick_input(app);
+                    }
+                })
                 .build(),
         )
         .invoke_handler(tauri::generate_handler![
@@ -56,12 +68,25 @@ pub fn run() {
         .setup(|app| {
             backend::setup(app)?;
             tray::setup(app)?;
+            quick_input::register_hotkey(app.handle());
             Ok(())
         })
-        .on_window_event(|window, event| {
-            if let WindowEvent::CloseRequested { api, .. } = event {
-                api.prevent_close();
-                tray::request_close(window.app_handle());
+        .on_window_event(|window, event| match window.label() {
+            "quick-input" => match event {
+                WindowEvent::CloseRequested { api, .. } => {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+                WindowEvent::Focused(false) => {
+                    let _ = window.hide();
+                }
+                _ => {}
+            },
+            _ => {
+                if let WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
+                    tray::request_close(window.app_handle());
+                }
             }
         })
         .build(tauri::generate_context!());

--- a/console/src-tauri/src/quick_input.rs
+++ b/console/src-tauri/src/quick_input.rs
@@ -1,0 +1,81 @@
+//! Global-hotkey quick-input floating window.
+//!
+//! A borderless, always-on-top window summoned by a global hotkey (default
+//! `alt+space`, i.e. Option+Space on macOS) so the user can ask the agent a
+//! quick question without opening the full console. The window loads the
+//! backend-hosted SPA at `/console/quick-input?desktop=1`. See issue #6568.
+
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+
+use crate::backend::BackendState;
+
+/// Label of the quick-input window (also used for capability scoping).
+pub(crate) const QUICK_INPUT_WINDOW_LABEL: &str = "quick-input";
+
+/// Tauri accelerator. On macOS `Alt` is the Option key, so this matches the
+/// requested Option+Space. Kept as a single const so it is trivially
+/// changeable; a settings UI for re-binding is deferred.
+pub(crate) const QUICK_INPUT_HOTKEY: &str = "alt+space";
+
+/// Show, hide, or first-create the quick-input window.
+pub(crate) fn toggle_quick_input(app: &tauri::AppHandle) {
+    // Window already exists: toggle visibility (re-center on show).
+    if let Some(window) = app.get_webview_window(QUICK_INPUT_WINDOW_LABEL) {
+        if window.is_visible().unwrap_or(false) {
+            let _ = window.hide();
+        } else {
+            let _ = window.show();
+            let _ = window.center();
+            let _ = window.set_focus();
+        }
+        return;
+    }
+
+    // First invocation: create the window. The hotkey only fires while the
+    // app is running, by which point backend::setup has resolved the port.
+    let Some(port) = app.state::<BackendState>().port() else {
+        log::warn!("[quick-input] backend port unknown; ignoring hotkey");
+        return;
+    };
+    let url_string = format!("http://127.0.0.1:{port}/console/quick-input?desktop=1");
+    let url = match reqwest::Url::parse(&url_string) {
+        Ok(url) => url,
+        Err(err) => {
+            log::warn!("[quick-input] invalid url {url_string}: {err}");
+            return;
+        }
+    };
+
+    // Opaque borderless for MVP: transparent(true) has Windows WebView2
+    // quirks (black background / broken hit-testing); transparency, blur and
+    // rounded corners are deferred polish (and .transparent() is omitted —
+    // the default is opaque).
+    let result = WebviewWindowBuilder::new(
+        app,
+        QUICK_INPUT_WINDOW_LABEL,
+        WebviewUrl::External(url),
+    )
+    .title("QwenPaw Quick Input")
+    .inner_size(480.0, 640.0)
+    .resizable(false)
+    .decorations(false)
+    .always_on_top(true)
+    .center()
+    .visible(true)
+    .build();
+
+    if let Err(err) = result {
+        log::warn!("[quick-input] failed to build window: {err}");
+    }
+}
+
+/// Register the global hotkey. Failures (e.g. the key is already claimed by
+/// another app or an IME) are logged and swallowed — never block startup.
+pub(crate) fn register_hotkey(app: &tauri::AppHandle) {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+    if let Err(err) = app.global_shortcut().register(QUICK_INPUT_HOTKEY) {
+        log::warn!(
+            "[quick-input] failed to register hotkey {QUICK_INPUT_HOTKEY:?}: {err}"
+        );
+    }
+}

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -32,6 +32,7 @@ import { Suspense } from "react";
 import { lazyImportWithRetry } from "./utils/lazyWithRetry";
 
 const LoginPage = lazyImportWithRetry("./pages/Login/index");
+const QuickInputPage = lazyImportWithRetry("./pages/QuickInput/index");
 import { authApi } from "./api/modules/auth";
 import { languageApi } from "./api/modules/language";
 import { useUploadLimitStore } from "./stores/uploadLimitStore";
@@ -223,6 +224,14 @@ function AppInner() {
                     element={
                       <Suspense fallback={null}>
                         <LoginPage />
+                      </Suspense>
+                    }
+                  />
+                  <Route
+                    path="/quick-input"
+                    element={
+                      <Suspense fallback={null}>
+                        <QuickInputPage />
                       </Suspense>
                     }
                   />

--- a/console/src/pages/QuickInput/index.tsx
+++ b/console/src/pages/QuickInput/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { getApiUrl } from "../../api/config";
 import { buildAuthHeaders } from "../../api/authHeaders";
@@ -55,7 +55,6 @@ export default function QuickInputPage() {
   const [text, setText] = useState("");
   const [reply, setReply] = useState("");
   const [loading, setLoading] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
 
   const send = useCallback(async () => {
     const query = text.trim();
@@ -63,7 +62,6 @@ export default function QuickInputPage() {
     setLoading(true);
     setReply("");
     const controller = new AbortController();
-    abortRef.current = controller;
 
     const identity = sessionApi.getSessionIdentity();
     const body = {

--- a/console/src/pages/QuickInput/index.tsx
+++ b/console/src/pages/QuickInput/index.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useRef, useState } from "react";
+
+import { getApiUrl } from "../../api/config";
+import { buildAuthHeaders } from "../../api/authHeaders";
+import sessionApi from "../Chat/sessionApi";
+
+/**
+ * Minimal Doubao-style quick-input page: a single text box plus a streamed
+ * reply. Loaded in the floating quick-input window (route /quick-input),
+ * summoned by the global hotkey registered on the Tauri side. See #6568.
+ *
+ * Deliberately slim — does NOT mount the full AgentScopeRuntimeWebUI; it
+ * POSTs the user's text directly to /console/chat (stream:true) and renders
+ * the streamed assistant text. Session identity comes from
+ * sessionApi.getSessionIdentity(), which returns safe defaults in a fresh
+ * window (the backend creates the conversation on the first message).
+ */
+const STYLES = {
+  root: {
+    display: "flex",
+    flexDirection: "column" as const,
+    height: "100vh",
+    background: "#1e1e1e",
+    color: "#e8e8e8",
+    fontFamily: "system-ui, sans-serif",
+  },
+  textarea: {
+    flex: "0 0 auto",
+    minHeight: 56,
+    maxHeight: 160,
+    margin: 12,
+    padding: 12,
+    borderRadius: 10,
+    border: "1px solid #444",
+    background: "#2a2a2a",
+    color: "#e8e8e8",
+    fontSize: 15,
+    resize: "none" as const,
+    outline: "none",
+  },
+  reply: {
+    flex: "1 1 auto",
+    margin: "0 12px 12px",
+    padding: 12,
+    borderRadius: 10,
+    background: "#262626",
+    overflowY: "auto" as const,
+    whiteSpace: "pre-wrap" as const,
+    fontSize: 14,
+    lineHeight: 1.5,
+  },
+};
+
+export default function QuickInputPage() {
+  const [text, setText] = useState("");
+  const [reply, setReply] = useState("");
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const send = useCallback(async () => {
+    const query = text.trim();
+    if (!query || loading) return;
+    setLoading(true);
+    setReply("");
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const identity = sessionApi.getSessionIdentity();
+    const body = {
+      input: [{ role: "user", content: [{ type: "text", text: query }] }],
+      session_id: identity.sessionId,
+      user_id: identity.userId,
+      channel: identity.channel,
+      stream: true,
+    };
+
+    try {
+      const res = await fetch(getApiUrl("/console/chat"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...buildAuthHeaders() },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!res.ok || !res.body) {
+        setReply(`Error: HTTP ${res.status}`);
+        return;
+      }
+
+      // Minimal SSE reader (mirrors parseSseDataLines in Chat/turnUsage.ts).
+      // res.body is a ReadableStream; use the reader API (the TS lib here
+      // doesn't include ReadableStream's async iterator).
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done || !value) break;
+        buffer += decoder.decode(value, { stream: true });
+        for (;;) {
+          const sep = buffer.indexOf("\n\n");
+          if (sep < 0) break;
+          const block = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+          for (const line of block.split("\n")) {
+            if (!line.startsWith("data: ")) continue;
+            let payload: Record<string, unknown>;
+            try {
+              payload = JSON.parse(line.slice(6)) as Record<string, unknown>;
+            } catch {
+              continue;
+            }
+            if (
+              payload.type === "turn_usage" ||
+              payload.type === "rate_limited"
+            ) {
+              continue;
+            }
+            const delta = extractAssistantText(payload);
+            if (delta) setReply(delta); // full-output convention: replace
+          }
+        }
+      }
+    } catch (e) {
+      if ((e as { name?: string })?.name !== "AbortError") {
+        setReply(`Error: ${String(e)}`);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [text, loading]);
+
+  return (
+    <div style={STYLES.root}>
+      <textarea
+        style={STYLES.textarea}
+        placeholder="Ask anything…  (Enter to send, Shift+Enter for newline)"
+        autoFocus
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            void send();
+          }
+        }}
+      />
+      <div style={STYLES.reply}>{reply || (loading ? "…" : "")}</div>
+    </div>
+  );
+}
+
+/** Extract the assistant's text from a streamed payload's `output` array.
+ * Mirrors extractTextFromContent (sessionApi/index.ts) + the payload shape
+ * consumed by responseParser (Chat/index.tsx). */
+function extractAssistantText(payload: Record<string, unknown>): string {
+  const out = Array.isArray(payload.output) ? payload.output : [];
+  return out
+    .filter((m): m is { content: unknown } => {
+      const msg = m as { role?: string };
+      return msg?.role === "assistant";
+    })
+    .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+    .filter((c): c is { type?: string; text?: string } => c?.type === "text")
+    .map((c) => c.text || "")
+    .join("");
+}


### PR DESCRIPTION
## Description

Implements #6568 — a Doubao-style global-hotkey quick-input window for the desktop app.

Press the global hotkey (default `alt+space` = Option+Space on macOS; a single named const, easy to change) and a borderless, always-on-top, centered floating window appears, loading a minimal chat route at `/console/quick-input`. The user types a question, hits Enter, and the streamed reply renders inline — no need to open the full console.

### How (MVP)
- **Rust** (`console/src-tauri/`): add `tauri-plugin-global-shortcut`; register the hotkey in `setup`; on press, `toggle_quick_input` shows/hides (or first-creates via `WebviewWindowBuilder` with `decorations(false)` + `always_on_top(true)` + `center()`) a window whose URL is the backend-hosted SPA at `http://127.0.0.1:<port>/console/quick-input?desktop=1` (port read from `BackendState`, bumped to `pub(crate)`). The window is created dynamically because the backend port is only known at runtime. `on_window_event` branches by label so the quick-input window hides on close/blur instead of triggering the main close-prompt. New least-privilege `capabilities/quick-input.json` scoped to the window.
- **Frontend** (`console/src/`): add `/quick-input` as a standalone top-level route (sibling of `/login`, no `MainLayout`/`AuthGuard`) rendering a minimal `QuickInputPage` — a textarea + streamed-reply area that POSTs to `/console/chat` (`stream:true`) reusing `sessionApi.getSessionIdentity()` (returns safe defaults in a fresh window) + `buildAuthHeaders()` + the SSE stream (mirrors `parseSseDataLines` + the `responseParser` payload shape).

### Scope / what's deferred
- Opaque borderless (no transparency/blur/rounded corners yet — `transparent()` has Windows WebView2 quirks; deferred).
- Slim inline SSE parser; the full `AgentScopeRuntimeWebUI` is NOT mounted (history/attachments/markdown/tool-output deferred).
- Hotkey is a named const, no settings UI yet.
- Configurable hotkey, transparency polish, auth-redirect-when-no-token, and sharing the main window's active chat session are all follow-ups.

**Type of Change:** New feature

**Component(s) Affected:** Core / Backend (app, via Tauri) + Console (frontend)

**Security Considerations:** none — a local hotkey plus a window loading the same backend SPA the main window already loads; no auth/config exposure.

## Evidence

Compile / type / format checks pass:
- `cargo check --manifest-path console/src-tauri/Cargo.toml` — clean (the new `tauri-plugin-global-shortcut` dep, the `quick_input` module, `BackendState::port` visibility, `WebviewWindowBuilder`/`WebviewUrl::External`, the `on_window_event` match, and the `with_handler`/`register`/`ShortcutState::Pressed` global-shortcut API all type-check).
- `tsc -b --noEmit` + `prettier --check` on the two changed frontend files (`src/App.tsx`, `src/pages/QuickInput/index.tsx`) — clean.

```text
$ cargo check --manifest-path console/src-tauri/Cargo.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.14s

$ npx prettier --check console/src/App.tsx console/src/pages/QuickInput/index.tsx
Checking formatting...
All matched files use Prettier code style!
```

### Verification scope (honest)

The agent has no GUI and cannot runtime-verify the floating window behavior. End-to-end verification needs `cd console && npx tauri dev` (first build compiles all Rust crates, ~5-15 min) → press Option/Alt+Space → centered borderless floating window at `/console/quick-input` → type → Enter → streamed reply → hotkey/click-away hides it. The session-default behavior (fresh window → default agent's console channel) and the hotkey-conflict behavior warrant maintainer confirmation (#6568).

## Checklist

- [x] `cargo check` (Rust) + `tsc` + `prettier` on changed files pass
- [x] Documentation: n/a for MVP (a docs note + a settings UI for the hotkey are deferred)
- [x] Ready for review (design pending maintainer sign-off on #6568 — see Scope)
