### PR TITLE
fix: shell command execution hangs and UI freezes

### DIFF
--- a/src/qwenpaw/agents/tools/shell.py
+++ b/src/qwenpaw/agents/tools/shell.py
@@ -777,12 +777,12 @@ async def execute_shell_command(
         except (ValueError, TypeError):
             timeout = 60.0
 
-    # Apply agent-configured default when the caller used the hardcoded
-    # default (60.0).  An explicit LLM-provided value != 60.0 is kept.
-    if timeout == 60.0:
-        configured = get_current_shell_command_timeout()
-        if configured is not None:
-            timeout = configured
+    configured = get_current_shell_command_timeout()
+    if timeout == 60.0 and configured is not None:
+        timeout = configured
+
+    max_t = configured if configured is not None else 600.0
+    timeout = min(timeout, max_t)
 
     # Use current workspace_dir from context, fallback to WORKING_DIR
     if cwd is not None:
@@ -936,6 +936,19 @@ async def execute_shell_command(
                     proc,
                     stderr_suffix,
                 )
+
+        def _limit_lines(text: str, mx: int = 500) -> str:
+            if not text:
+                return text
+            lines = text.splitlines(keepends=True)
+            if len(lines) > mx:
+                return f"... [{len(lines) - mx} lines truncated]\n" + "".join(
+                    lines[-mx:],
+                )
+            return text
+
+        stdout_str = _limit_lines(stdout_str)
+        stderr_str = _limit_lines(stderr_str)
 
         if returncode == 0:
             if stdout_str:


### PR DESCRIPTION
## What Problem This Solves

Fixes #6608 and #6589.

Found a couple of issues with how shell commands run that were causing freezes:
1. Hard limits for timeouts weren't working properly if the command set an arbitrarily large timeout. I capped it against the configured max (default 600s).
2. If a command spits out tens of thousands of lines, it freezes the frontend UI. I added a quick truncation step to only keep the last 500 lines for stdout and stderr to prevent UI locking up.

## Evidence

Ran local unit tests in `tests/unit/agents/tools/test_shell.py` and manually verified output truncation and timeout limits for runaway commands.

`pre-commit run --all-files`
<details>
<summary>View Output</summary>

ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed

</details>

`pytest`
<details>
<summary>View Output</summary>

tests/unit/agents/tools/test_shell.py .................................. [ 38%]
......................................................                   [100%]
============================== 88 passed in 2.50s ==============================

</details>

## Type of Change

- [x] Bug fix
- [ ] New feature

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Ready for review