### PR TITLE
fix(config): handle corrupted agent config and invalid JSON in load_agent_config

### DIFF
--- a/src/qwenpaw/config/config.py
+++ b/src/qwenpaw/config/config.py
@@ -2791,8 +2791,26 @@ def load_agent_config(  # pylint: disable=too-many-branches,too-many-statements
                 return cached_config
 
         # Need to reload config from disk
-        with open(agent_config_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        try:
+            with open(agent_config_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except UnicodeDecodeError as e:
+            raise ConfigurationException(
+                config_key="agent",
+                message=(
+                    f"Agent '{agent_id}' configuration file is corrupted "
+                    f"(invalid UTF-8 encoding). Path: {agent_config_path}. "
+                    f"Please repair or delete it. Error: {e}"
+                ),
+            ) from e
+        except json.JSONDecodeError as e:
+            raise ConfigurationException(
+                config_key="agent",
+                message=(
+                    f"Agent '{agent_id}' configuration file contains "
+                    f"invalid JSON. Path: {agent_config_path}. Error: {e}"
+                ),
+            ) from e
 
         project_dir_migrated = migrate_project_directory_config(data)
 


### PR DESCRIPTION
## What Problem This Solves

If the agent's `agent.json` config file is corrupted — for example due to an interrupted write, invalid UTF-8 bytes, or truncated JSON — `load_agent_config()` previously propagated a raw `UnicodeDecodeError` or `json.JSONDecodeError` from deep inside the file-read path. These low-level exceptions give no actionable context: they don't say which agent or which file is broken.

## What This Fix Does

Wraps the `open(...) / json.load(...)` call inside `load_agent_config()` with two targeted `except` clauses:

- **`UnicodeDecodeError`** → re-raised as `ConfigurationException(config_key="agent")` with a message that includes the agent ID, the full file path, and the original error.
- **`json.JSONDecodeError`** → re-raised as `ConfigurationException(config_key="agent")` with the same actionable context.

In both cases the original exception is preserved via `__cause__` (i.e. `raise ... from e`), so the full traceback is still available.

The corrupted file is **intentionally left untouched** — the caller receives a clear diagnostic exception and can decide how to recover (delete, repair, restore from backup).

## Evidence

Before (on `main`):
```
json  → JSONDecodeError    (no agent ID, no path)
utf8  → UnicodeDecodeError (no agent ID, no path)
```

After (this PR):
```
json  → ConfigurationException  config_key=agent  cause=JSONDecodeError  path=<agent_config_path>
utf8  → ConfigurationException  config_key=agent  cause=UnicodeDecodeError  path=<agent_config_path>
```

## Testing

- Added `tests/unit/config/test_load_agent_config.py` with two dedicated tests: invalid UTF-8 and malformed JSON.
- `pytest tests/unit/config/` — 15 passed.
- `pre-commit run --files src/qwenpaw/config/config.py tests/unit/config/test_load_agent_config.py` — all hooks passed (mypy, black, flake8, pylint).
- `git diff --check origin/main...c6b7ee36` — passed.