### PR TITLE
fix(cli): build a valid user message for the headless task command

### DIFF
--- a/src/qwenpaw/cli/task_cmd.py
+++ b/src/qwenpaw/cli/task_cmd.py
@@ -95,7 +95,7 @@ async def _run_task(
 ) -> dict:
     from types import SimpleNamespace
 
-    from agentscope.message import Msg
+    from agentscope.message import UserMsg
 
     from ..runtime.builder import AgentBuilder
     from ..schemas import AgentRequest
@@ -137,7 +137,7 @@ async def _run_task(
         try:
             response = await asyncio.wait_for(
                 agent.reply(
-                    [Msg(name="user", role="user", content=instruction)],
+                    [UserMsg(name="user", content=instruction)],
                 ),
                 timeout=timeout,
             )

--- a/tests/unit/cli/test_cli_task.py
+++ b/tests/unit/cli/test_cli_task.py
@@ -376,3 +376,54 @@ def test_isolated_workspace_does_not_pollute_real_workspace(tmp_path):
         pass
 
     assert set(real_ws.iterdir()) == original_contents
+
+
+# ── _run_task ────────────────────────────────────────────────────────
+
+
+async def test_run_task_sends_a_valid_user_message(monkeypatch) -> None:
+    """``_run_task`` must build a message AgentScope 2.0 accepts.
+
+    ``Msg.content`` is typed ``list[ContentBlock]``, so a bare string
+    raises a pydantic ``ValidationError`` that the surrounding
+    ``except Exception`` turns into ``status="error"`` — the task never
+    reaches the agent.
+    """
+    from qwenpaw.config.config import AgentProfileConfig
+    from qwenpaw.cli.task_cmd import _run_task
+
+    captured: dict = {}
+
+    class _FakeAgent:
+        model = None
+
+        async def reply(self, msgs):
+            captured["msgs"] = list(msgs)
+            reply = MagicMock()
+            reply.get_text_content.return_value = "done"
+            return reply
+
+    class _FakeBuilder:
+        async def build(self, _ctx):
+            return _FakeAgent()
+
+    monkeypatch.setattr(
+        "qwenpaw.runtime.builder.AgentBuilder",
+        _FakeBuilder,
+    )
+
+    result = await _run_task(
+        instruction="do the thing",
+        agent_config=AgentProfileConfig(id="default", name="Default"),
+        request_context={},
+        max_iters=1,
+        timeout=30,
+        output_dir=None,
+    )
+
+    assert result["status"] == "success"
+    assert result["response"] == "done"
+    msg = captured["msgs"][0]
+    assert msg.role == "user"
+    assert msg.content[0].type == "text"
+    assert msg.content[0].text == "do the thing"


### PR DESCRIPTION
## Description

`qwenpaw task` never runs a task. `_run_task` builds the message it hands to the agent like this:

```python
[Msg(name="user", role="user", content=instruction)]
```

`instruction` is a `str`, but on the pinned `agentscope==2.0.4.post1` `Msg.content` is typed `list[ContentBlock]` and the model has no `mode="before"` validator (the only validator is `mode="after"`, `validate_role_content`). Pydantic v2 does not iterate a `str` for a `list[...]` field, so this raises `ValidationError` on every invocation.

The call sits inside the `try` block, and the broad `except Exception` below it converts the failure into a result payload rather than a traceback, so the command exits 1 with a `status: error` result instead of crashing. That is why this survived: the symptom looks like a task that errored, not like a CLI that cannot construct its own input.

The rest of the codebase already gets this right. Every other `Msg(...)` construction under `src/qwenpaw` passes a block list, for example `app/chats/title_generator.py`, `app/app_services/_builtin_tool_commands.py`, and `agents/context/visual_compression/pipeline/history.py`. `_run_task` itself builds the correct shape 25 lines earlier for `AgentRequest`:

```python
{"role": "user", "content": [{"type": "text", "text": instruction}]}
```

Only the `Msg` was left on the 1.x content shape. This switches it to `UserMsg`, AgentScope's own factory for this case, which wraps a plain string in a `TextBlock`. `UserMsg` is already used in-tree in `agents/context/scroll/manager.py`. `Msg` appeared only on the import line and the call site in this file, so the import swap is complete.

**Related Issue:** none

**Security Considerations:** none

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

On the first box: I ran `pre-commit run --files` against the two changed files rather than `--all-files`. On this Windows checkout the `--all-files` run rewrites line endings across roughly a hundred untouched files, which would bury the diff. The changed-file run is included below and every hook passes.

## Testing

`_run_task` had no test coverage at all. All fifteen existing tests in `tests/unit/cli/test_cli_task.py` monkeypatch `_run_task` itself, which is exactly why the broken message construction was never exercised.

The new `test_run_task_sends_a_valid_user_message` mocks a single seam, `AgentBuilder`, and runs the real `_run_task` body. It captures the message that reaches `agent.reply` and asserts the role, the block type and the text.

## Evidence

Calling `_run_task` on current `main` with a stub agent, so that nothing but the message construction can fail, returns this. This is what a user gets from `qwenpaw task -i "do the thing"` today:

```json
{
  "status": "error",
  "elapsed_seconds": 0.0,
  "error": "1 validation error for Msg\ncontent\n  Input should be a valid list [type=list_type, input_value='do the thing', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.13/v/list_type",
  "response": "",
  "usage": {}
}
```

With the fix, the same call reaches the agent:

```json
{
  "status": "success",
  "elapsed_seconds": 0.0,
  "response": "done",
  "usage": {}
}
```

The new test reproduces that as a regression test. With the source change reverted and only the test applied it fails on the first assertion, because nothing ever reaches the fake agent:

```
$ git stash push src/qwenpaw/cli/task_cmd.py
$ pytest tests/unit/cli/test_cli_task.py -q -k run_task_sends_a_valid_user_message

>       assert result["status"] == "success"
E       AssertionError: assert 'error' == 'success'
E         - success
E         + error

FAILED tests/unit/cli/test_cli_task.py::test_run_task_sends_a_valid_user_message
1 failed, 15 deselected in 1.15s
```

With the fix applied the whole CLI suite passes, and so does the full unit suite on this branch:

```
$ pytest tests/unit/cli/ -q
250 passed in 24.75s

$ pytest tests/unit/ -q
6009 passed, 64 skipped, 58 warnings in 400.44s (0:06:40)
```

Lint on the changed files, through `pre-commit` so the pinned hook versions are used:

```
$ pre-commit run --files src/qwenpaw/cli/task_cmd.py \
    tests/unit/cli/test_cli_task.py

check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

## Additional Notes

The same 1.x content shape appears in `agents/memory/proactive/proactive_responder.py`. I left it out to keep this change to one file and one concern, and I am happy to send it as a separate PR if you would like it fixed too.
