### PR TITLE
fix(console): remove forced UTC timestamp normalization in session list

### DIFF
--- a/console/src/pages/Control/Sessions/components/constants.ts
+++ b/console/src/pages/Control/Sessions/components/constants.ts
@@ -5,23 +5,16 @@ export interface Session extends ChatSpec {
 }
 
 /**
- * Normalize ISO timestamp to ensure UTC timezone is always recognized.
- * Timestamps without timezone suffix (e.g. from datetime.utcnow()) are
- * treated as local time by browsers, causing incorrect display. Appending
- * 'Z' forces UTC interpretation, consistent with timezone-aware timestamps.
+ * Format timestamp for display in user's local timezone.
+ * Backend should send timezone-aware ISO strings (e.g., "2026-08-01T10:36:39+08:00")
+ * after the fix in #6301. This function parses them correctly without forcing UTC.
  */
-const normalizeTimestamp = (timestamp: string): string => {
-  if (/[Z+\-]\d{2}:?\d{2}$/.test(timestamp) || timestamp.endsWith("Z")) {
-    return timestamp;
-  }
-  return timestamp + "Z";
-};
-
 export const formatTime = (timestamp: string | number | null): string => {
   if (timestamp === null || timestamp === undefined) return "N/A";
-  const normalized =
-    typeof timestamp === "string" ? normalizeTimestamp(timestamp) : timestamp;
-  const date = new Date(normalized);
+  const date = new Date(
+    typeof timestamp === "string" ? timestamp : timestamp,
+  );
+  if (isNaN(date.getTime())) return "N/A";
   return date.toLocaleString("zh-CN", {
     year: "numeric",
     month: "2-digit",


### PR DESCRIPTION
The  function was appending 'Z' to naive timestamps, forcing them to be interpreted as UTC. This caused session timestamps to display in UTC instead of the user's local timezone.

After backend fix #6301, timestamps will be timezone-aware (e.g., '2026-08-01T10:36:39+08:00'). This fix removes the forced UTC normalization and lets the browser parse timestamps correctly in the user's local timezone.

Closes: #6301 (frontend part)

## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
