### PR TITLE
fix(providers): relay Gemini thought_signature without mutating strict ToolCallBlock

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -39,6 +39,7 @@ from .utils.message_request_normalizer import (
 from ..exceptions import ProviderError, ModelFormatterError
 from ..providers import ProviderManager
 from ..providers.capping_formatter import MAX_INLINE_MEDIA_BYTES
+from ..providers.openai_chat_model_compat import _drain_tool_call_extra
 from ..providers.retry_chat_model import (
     RetryChatModel,
     RetryConfig,
@@ -1087,9 +1088,14 @@ def _create_file_block_support_formatter(
                 for block in msg.content or []:
                     btype = _battr(block, "type")
                     if btype in ("tool_use", "tool_call"):
+                        bid = _battr(block, "id", "")
                         ec = _battr(block, "extra_content")
+                        if ec is None:
+                            # Streamed Gemini thought_signature is relayed
+                            # via the module-level side-table (the pydantic
+                            # ToolCallBlock has no extra_content field).
+                            ec = _drain_tool_call_extra(bid)
                         if ec is not None:
-                            bid = _battr(block, "id", "")
                             extra_contents[bid] = ec
 
             # Convert file:// URLs to paths for all media blocks,

--- a/src/qwenpaw/agents/utils/message_request_normalizer.py
+++ b/src/qwenpaw/agents/utils/message_request_normalizer.py
@@ -28,7 +28,9 @@ _MEDIA_BLOCK_TYPES = {"image", "audio", "video", "file"}
 _MEDIA_MIME_PREFIXES = ("image/", "audio/", "video/")
 
 # Fields that are provider-specific and should not leak across families.
-# Gemini: extra_content carries thought_signature.
+# Gemini: extra_content carries thought_signature.  It is relayed either
+# as a top-level key on dict blocks or via the module-level side-table in
+# ``openai_chat_model_compat`` for pydantic ToolCallBlock.
 # AgentScope internal: raw_input is a stream-parsing artefact.
 _PROVIDER_ONLY_TOOL_USE_FIELDS = frozenset({"extra_content", "raw_input"})
 
@@ -48,7 +50,9 @@ def _clean_provider_specific_fields(
     Current rules
     ~~~~~~~~~~~~~
     * ``extra_content`` – Gemini-specific (``thought_signature``).
-      Kept only when *target_family* is ``"gemini"``.
+      Kept only when *target_family* is ``"gemini"``.  On dict blocks it
+      is a top-level key; on pydantic blocks it is relayed via the
+      module-level side-table in ``openai_chat_model_compat``.
     * ``raw_input`` – AgentScope stream-parsing artefact.
       Stripped unconditionally; some providers reject unknown fields.
     """

--- a/src/qwenpaw/providers/openai_chat_model_compat.py
+++ b/src/qwenpaw/providers/openai_chat_model_compat.py
@@ -153,6 +153,28 @@ def _sanitize_stream_item(item: Any) -> Any:
     return _sanitize_chunk(item)
 
 
+# Extra content (Gemini ``thought_signature``) relayed from streamed
+# tool-call chunks, keyed by tool-call id.  ``ToolCallBlock`` is a strict
+# pydantic model (agentscope 2.0.4.post1) without an ``extra_content`` or
+# ``metadata`` field, so the value cannot be stored on the block itself.
+# The id -> extra mapping is consumed once by the formatter
+# (``model_factory``) when it rebuilds the Gemini wire request; it is
+# scoped to a single streamed response, which is how the stream parser is
+# always invoked.
+_TOOL_CALL_EXTRA_CONTENTS: dict[str, Any] = {}
+
+
+def _register_tool_call_extra(tool_id: str, extra: Any) -> None:
+    """Remember relayed ``extra_content`` (Gemini thought_signature) for a
+    tool-call id so the formatter can re-attach it to the Gemini request."""
+    _TOOL_CALL_EXTRA_CONTENTS[tool_id] = extra
+
+
+def _drain_tool_call_extra(tool_id: str) -> Any:
+    """Return and remove the relayed extra for *tool_id*."""
+    return _TOOL_CALL_EXTRA_CONTENTS.pop(tool_id, None)
+
+
 class _SanitizedStream:
     """Proxy OpenAI async stream that sanitizes each emitted item and
     captures ``extra_content`` from tool-call chunks (used by Gemini
@@ -792,10 +814,12 @@ class OpenAIChatModelCompat(OpenAIChatModel):
                         continue
                     ec = sanitized_response.extra_contents.get(tool_id)
                     if ec:
-                        if isinstance(block, dict):
-                            block["extra_content"] = ec
-                        else:
-                            block.extra_content = ec
+                        # ToolCallBlock is a strict pydantic model without
+                        # an ``extra_content`` field; register the relayed
+                        # Gemini ``thought_signature`` in the module-level
+                        # side-table instead (see
+                        # ``_TOOL_CALL_EXTRA_CONTENTS``).
+                        _register_tool_call_extra(tool_id, ec)
 
             has_tool_use = any(
                 (

--- a/tests/unit/providers/test_openai_stream_toolcall_compat.py
+++ b/tests/unit/providers/test_openai_stream_toolcall_compat.py
@@ -10,6 +10,7 @@ from agentscope.credential import OpenAICredential
 
 from qwenpaw.providers.openai_chat_model_compat import (
     OpenAIChatModelCompat,
+    _drain_tool_call_extra,
     _sanitize_tool_call,
 )
 
@@ -115,6 +116,54 @@ async def test_stream_parser_skips_tool_call_without_function() -> None:
     if isinstance(block_input, str):
         block_input = json.loads(block_input)
     assert block_input == {"x": 1}
+
+
+async def test_stream_parser_relays_extra_content_via_side_table() -> None:
+    """Gemini thought_signature must not crash the strict ToolCallBlock.
+
+    Regression test for #6619: setting ``extra_content`` directly on the
+    pydantic ``ToolCallBlock`` (agentscope 2.0.4.post1) raises
+    ``ValueError``.  The relay must be stored in the module-level
+    side-table keyed by tool-call id instead.
+    """
+    model = CompatHarnessOpenAIChatModel(
+        credential=OpenAICredential(
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+        ),
+        model="dummy",
+        stream=True,
+    )
+
+    tool_call = SimpleNamespace(
+        index=0,
+        id="call_sig",
+        function=SimpleNamespace(name="ping", arguments='{"x":1}'),
+        extra_content="thought-signature-abc",
+    )
+
+    stream = FakeAsyncStream([_make_chunk([tool_call])])
+
+    responses = await model.parse_stream_for_test(
+        datetime.now(),
+        stream,
+    )
+
+    assert responses
+    tool_blocks = [
+        block
+        for response in responses
+        for block in response.content
+        if getattr(block, "type", None) in ("tool_use", "tool_call")
+    ]
+    assert tool_blocks
+    block = tool_blocks[0]
+    assert getattr(block, "id", None) == "call_sig"
+    # The strict pydantic model must not carry ``extra_content`` directly.
+    assert not hasattr(block, "extra_content")
+    # The relayed signature is available via the side-table and drains once.
+    assert _drain_tool_call_extra("call_sig") == "thought-signature-abc"
+    assert _drain_tool_call_extra("call_sig") is None
 
 
 def test_sanitize_tool_call_normalizes_non_string_arguments() -> None:


### PR DESCRIPTION
## Description

**Bug:** Streaming a response whose tool calls carry Gemini `extra_content` (thought signature relay) crashes every request with `ValueError: "ToolCallBlock" object has no field "extra_content"` at `openai_chat_model_compat.py` — the relay assigned the value directly onto the pydantic `ToolCallBlock`, which is a strict model in `agentscope==2.0.4.post1` (no `extra_content` field, no `extra="allow"`).

**Fix:** Store the relayed `extra_content` (Gemini `thought_signature`) in a module-level side-table keyed by tool-call id instead of mutating the block. The formatter (`model_factory`) drains the side-table when rebuilding the Gemini wire request. This matches how the existing `extra_contents` map already works within `format()`, and how the native Gemini parser encodes the signature into the call id. The pydantic block is never mutated, so the strict model constraint is respected regardless of the pinned agentscope version.

**Related Issue:** Fixes #6619

**Security Considerations:** None — crash fix only, no data exposure, no auth/env changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

- `tests/unit/providers/test_openai_stream_toolcall_compat.py` — 3 passed (includes new regression test).
- `tests/unit/providers/` — 340 passed.
- `tests/unit/agents/` — 393 passed, 2 skipped (one pre-existing ACP teardown timeout also reproduces on unpatched `main`; unrelated to this change).
- Pre-commit (flake8, black, mypy, pylint, trailing-commas, etc.) — all passed on the changed files.

## Evidence

```bash
# New regression test + existing compat tests
$ python -m pytest tests/unit/providers/test_openai_stream_toolcall_compat.py -q
3 passed in 0.22s

# Full providers suite
$ python -m pytest tests/unit/providers/ -q
340 passed in 2.36s

# Pre-commit on changed files
$ pre-commit run --files src/qwenpaw/providers/openai_chat_model_compat.py \
    src/qwenpaw/agents/model_factory.py \
    src/qwenpaw/agents/utils/message_request_normalizer.py \
    tests/unit/providers/test_openai_stream_toolcall_compat.py
check python ast .......... Passed
check docstring is first .. Passed
fix python encoding pragma. Passed
detect private key ........ Passed
trim trailing whitespace .. Passed
Add trailing commas ....... Passed
mypy ...................... Passed
black ..................... Passed
flake8 .................... Passed
pylint .................... Passed
```

Pre-fix the new regression test crashes with the reported `ValueError: "ToolCallBlock" object has no field "extra_content"` (verified by stashing the fix); post-fix it passes and the side-table drains exactly once.

## Additional Notes

The fix is self-contained in qwenpaw and does not depend on the pinned `agentscope==2.0.4.post1`'s pydantic strictness. The module-level side-table is scoped to a single streamed response (the stream parser is always invoked per-response), and the formatter drains entries when consumed, so nothing leaks across requests. Alternative considered and rejected: patching `ToolCallBlock` at import time (adds a dependency on agentscope internals and only papers over the strict model).
