### PR TITLE
fix(skills): preserve plugin-sourced skill tags across reconcile cycles

### DIFF
--- a/src/qwenpaw/agents/skill_system/registry.py
+++ b/src/qwenpaw/agents/skill_system/registry.py
@@ -1037,7 +1037,15 @@ def reconcile_pool_manifest() -> dict[str, Any]:
 
         for skill_name in list(skills):
             if skill_name not in discovered:
-                skills.pop(skill_name, None)
+                existing_entry = skills.get(skill_name, {})
+                # Preserve plugin-sourced skill entries (source: "plugin:<id>")
+                # even when their directory is not found on disk. Plugin skills
+                # are lightweight stubs with no on-disk SKILL.md, so they will
+                # never appear in discovered dirs. Preserve their tags and
+                # config so they survive restarts and plugin update cycles.
+                source = existing_entry.get("source", "")
+                if not source.startswith("plugin:"):
+                    skills.pop(skill_name, None)
 
         return payload
 
@@ -1147,7 +1155,15 @@ def reconcile_workspace_manifest(workspace_dir: Path) -> dict[str, Any]:
 
         for skill_name in list(skills):
             if skill_name not in discovered:
-                skills.pop(skill_name, None)
+                existing_entry = skills.get(skill_name, {})
+                # Preserve plugin-sourced skill entries (source: "plugin:<id>")
+                # even when their directory is not found on disk. Plugin skills
+                # are lightweight stubs with no on-disk SKILL.md, so they will
+                # never appear in discovered dirs. Preserve their tags and
+                # config so they survive restarts and plugin update cycles.
+                source = existing_entry.get("source", "")
+                if not source.startswith("plugin:"):
+                    skills.pop(skill_name, None)
 
         return payload
 


### PR DESCRIPTION
## Description

Fixes #6537: Skill tags set in the Skill Pool UI disappear after restarting QwenPaw.

**Problem:** The `reconcile_pool_manifest()` and `reconcile_workspace_manifest()` functions unconditionally removed manifest entries whose on-disk directory was not found. Plugin-sourced skills (source: 'plugin:...') do not have a SKILL.md in the pool directory — they are lightweight stubs. Tags were stripped on every reconcile cycle.

**Root Cause:** This is a regression of #3270 (item 3): #3362 added tag preservation to the build path (`_build_reconciled_pool_entry` copies `tags` from the previous entry), but the removal pass in `reconcile_pool_manifest` / `reconcile_workspace_manifest` still dropped non-disk entries unconditionally — so plugin stubs (and their tags) are deleted before the build path ever runs.

**Fix:** Added a `source.startswith('plugin:')` check before removal in both `reconcile_pool_manifest()` and `reconcile_workspace_manifest()`. Plugin-sourced entries are now preserved even when their directory is missing, so `tags` and `config` survive restarts and plugin update cycles.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Component(s) Affected

- [x] Core / Backend (agents/skill_system)
- [x] Skills

## Checklist

- [x] Code compiles successfully
- [x] No new dependencies added
- [x] Ready for review

## Testing

- Module imports successfully: `PYTHONPATH=src python3 -c "from qwenpaw.agents.skill_system.registry import reconcile_pool_manifest, reconcile_workspace_manifest; print('Import OK')"` → OK
- The change only modifies the removal pass in `reconcile_pool_manifest()` and `reconcile_workspace_manifest()` — plugin-sourced entries are now preserved instead of being deleted.

## Evidence

```bash
$ PYTHONPATH=src python3 -c "from qwenpaw.agents.skill_system.registry import reconcile_pool_manifest, reconcile_workspace_manifest; print('Import OK')"
Import OK
```

## Local Verification Evidence

The change modifies the removal pass in both `reconcile_pool_manifest()` and `reconcile_workspace_manifest()`:

```diff
 for skill_name in list(skills):
     if skill_name not in discovered:
-        skills.pop(skill_name, None)
+        existing_entry = skills.get(skill_name, {})
+        # Preserve plugin-sourced skill entries (source: "plugin:<id>")
+        # even when their directory is not found on disk.
+        source = existing_entry.get("source", "")
+        if not source.startswith("plugin:"):
+            skills.pop(skill_name, None)
```

## Additional Notes

This fix addresses the removal-pass plugin-drop in both pool and workspace reconcile (the primary reported regression). Genuinely-deleted customized/builtin skills (no disk dir, non-plugin source) are still dropped as before.

## Component(s) Affected

- [x] Core / Backend (agents/skill_system)
- [x] Skills

## Checklist

- [x] Code compiles successfully
- [x] No new dependencies added
- [x] Ready for review

## Testing

- Module imports successfully
- The change only modifies the removal pass in reconcile_pool_manifest() and reconcile_workspace_manifest()

## Evidence

```bash
PYTHONPATH=src python3 -c "from qwenpaw.agents.skill_system.registry import reconcile_pool_manifest, reconcile_workspace_manifest; print('Import OK')"
# Import OK
```

## Local Verification Evidence

The change modifies the removal pass in both reconcile_pool_manifest() and reconcile_workspace_manifest() to preserve plugin-sourced skill entries even when their directory is not found on disk.

## Additional Notes

This fix preserves plugin-sourced skill entries (source: 'plugin:<id>') across reconcile cycles, so their tags and config survive restarts and plugin update cycles.