### PR TITLE
test(integration): align chrome + coding-project cases with product contract

### DIFF
--- a/tests/integration/js/service_worker_harness.mjs
+++ b/tests/integration/js/service_worker_harness.mjs
@@ -205,7 +205,7 @@ const scenarios = {
     return { observedState: response.targetCommandFact.observedState };
   },
 
-  async stale_epoch_no_reexec() {
+  async stale_received_reexecuted() {
     seedTargetReceipt({
       ...commandParams,
       state: "RECEIVED",

--- a/tests/integration/test_chrome_nm_host.py
+++ b/tests/integration/test_chrome_nm_host.py
@@ -53,7 +53,9 @@ def test_two_mib_inbound_message_is_accepted() -> None:
     raw = payload.encode("utf-8")
     reader = io.BytesIO(struct.pack("<I", len(raw)) + raw)
 
-    message = host.read_nm_message(reader)
+    frame = host.read_nm_frame(reader)
+    assert frame is not None
+    message = json.loads(frame)
 
     assert message["result"]["data"].startswith("x")
     assert len(message["result"]["data"]) == 2 * 1024 * 1024
@@ -65,7 +67,7 @@ def test_inbound_above_protocol_limit_is_rejected() -> None:
     reader = io.BytesIO(struct.pack("<I", oversized))
 
     with pytest.raises(ValueError):
-        host.read_nm_message(reader)
+        host.read_nm_frame(reader)
 
 
 def test_oversized_outbound_message_writes_nothing() -> None:
@@ -73,9 +75,9 @@ def test_oversized_outbound_message_writes_nothing() -> None:
     stdout = io.BytesIO()
 
     with pytest.raises(host.NativeMessageTooLargeError):
-        host.write_nm_message(
+        host.write_nm_frame(
             stdout,
-            {"id": 7, "result": "q" * 2_000_000},
+            host._dumps({"id": 7, "result": "q" * 2_000_000}).encode("utf-8"),
         )
 
     assert stdout.getvalue() == b""
@@ -143,7 +145,7 @@ class _ClosedWebSocket:
     async def send(self, _message: str) -> None:
         return None
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         return None
 
     def __aiter__(self) -> "_ClosedWebSocket":
@@ -164,7 +166,7 @@ class _FailingSendWebSocket:
             return None
         raise RuntimeError("send failed")
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         return None
 
     def __aiter__(self) -> "_FailingSendWebSocket":
@@ -257,7 +259,7 @@ class _CoreWebSocket:
             raise self._response
         return self._response
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         self.closed = True
 
 
@@ -334,7 +336,7 @@ class _WebSocket:
     async def send(self, _message: str) -> None:
         return None
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         return None
 
 
@@ -457,7 +459,7 @@ class _FakeWebSocket:
     async def send(self, message: str) -> None:
         self.sent.append(message)
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         self.closed = True
 
     def __aiter__(self):

--- a/tests/integration/test_chrome_service_worker.py
+++ b/tests/integration/test_chrome_service_worker.py
@@ -94,10 +94,12 @@ def test_observed_state_closed_set(case, expected) -> None:
     assert result["observedState"] == expected
 
 
-def test_stale_receipt_is_never_reexecuted() -> None:
-    result = run_scenario("stale_epoch_no_reexec")
-    assert result["executorCalls"] == 0
-    assert result["receiptState"] in {"RECEIVED", "RUNNING"}
+def test_stale_received_receipt_is_reexecuted() -> None:
+    # A stale RECEIVED receipt proves the executor never crossed the
+    # durable RUNNING barrier, so runReceiptCommand safely re-runs it.
+    result = run_scenario("stale_received_reexecuted")
+    assert result["executorCalls"] == 1
+    assert result["receiptState"] == "COMPLETED"
 
 
 # test_chrome_cdp_send_guard.py

--- a/tests/integration/test_coding_project.py
+++ b/tests/integration/test_coding_project.py
@@ -32,6 +32,7 @@ No LLM / external network deps required.
 from __future__ import annotations
 
 import io
+import shutil
 import zipfile
 from pathlib import Path
 
@@ -174,15 +175,17 @@ def test_import_local_copies_source(app_server) -> None:
     """POST /import-local copies a real source dir into the project.
 
     Test flow:
-      1. Seed a source dir (under working_dir) with a marker file.
+      1. Seed a source dir (under home, required by #6487) with a marker.
       2. POST /import-local {path, name} -> 200 {path, name}.
       3. The marker file exists inside the imported project dir.
-      4. finally: reset to default.
+      4. finally: remove the seeded source + reset to default.
 
     API endpoints:
       - POST /api/workspace/coding-project/import-local
     """
-    src = app_server.working_dir / "integ-cp-import-src"
+    # Upstream #6487 requires the import source to live under the user's
+    # home directory, so a pytest tmp working dir cannot be used here.
+    src = Path.home() / ".qwenpaw-integ-cp-import-src"
     src.mkdir(parents=True, exist_ok=True)
     (src / "marker.txt").write_text("imported\n", encoding="utf-8")
     name = "integ-cp-import-C"
@@ -197,6 +200,7 @@ def test_import_local_copies_source(app_server) -> None:
         dest = Path(resp.json()["path"])
         assert (dest / "marker.txt").is_file(), resp.json()
     finally:
+        shutil.rmtree(src, ignore_errors=True)
         _reset_project(app_server)
 
 


### PR DESCRIPTION
## Summary

Four integration cases assert against APIs / behaviors that never matched
the product code they exercise. They have failed on **every OS** in the
nightly full sweep since the moment they landed (confirmed reproduced
locally on `main`). None of these are product logic bugs — the tests are
wrong. This PR aligns each test with the real contract.

### 1. `test_chrome_nm_host.py` — wrong API names + wrong fake signatures
- The product `plugins/bundle/chrome/assets/scripts/nm_host.py` exposes
  `read_nm_frame` / `write_nm_frame` (raw length-prefixed **bytes**), but
  the tests called `read_nm_message` / `write_nm_message`, which do not
  exist → `AttributeError`. Fixed to use the real API and do the
  JSON encode/decode in the test.
- The five fake WebSocket stand-ins declared `async def close(self)`, but
  the host closes the socket with `close(code=..., reason=...)` to match
  the real `websockets` library (`ClientConnection.close(self, code, reason)`,
  verified on websockets 16.0) → `TypeError: unexpected keyword argument
  'code'`. Fixed to accept `**kwargs`.

### 2. `test_coding_project.py::test_import_local_copies_source` — not updated for #6487
- #6487 added `_validate_import_source`, which returns **403** for any
  source outside the user's home directory. The test seeded its source
  under a pytest tmp dir (outside home) → 403 instead of 200. Fixed to
  seed under `Path.home()` and clean up in `finally`.

### 3. `test_chrome_service_worker.py` — assertion is the opposite of the contract
- `runReceiptCommand` deliberately **re-executes** a stale `RECEIVED`
  receipt: a stale RECEIVED state is proof the executor never crossed the
  durable RUNNING barrier, so it is safe to run (see the in-code comment;
  `observed_states` likewise maps `received_stale_epoch -> NOT_STARTED`).
  The test asserted `executorCalls == 0`, the opposite. Fixed to assert
  re-execution (`executorCalls == 1`, receipt `COMPLETED`) and renamed the
  test + harness scenario accordingly.

## Test plan
- [x] `pytest tests/integration/test_chrome_nm_host.py` — 11 passed
- [x] `pytest tests/integration/test_chrome_service_worker.py` — passed
- [x] `pytest tests/integration/test_coding_project.py::test_import_local_copies_source` — passed
- [x] Combined run of all three files — 23 passed
- [x] `pre-commit run --files <changed>` — green (mypy/black/flake8/trailing-comma)

## Not included
`tests/integration/browser/*` (7 cases) fail because the nightly
Integration job has no `playwright install` step — infrastructure, tracked
separately. `test_acp_runner.py::test_acp_close_after_start` (Windows-only,
`os.replace` `WinError 5` on `jobs.json`) is a product-side atomic-write
issue on Windows, also out of scope here.