### PR TITLE
fix(ci): cap playwright below 1.62 so the macOS desktop verify passes

### DIFF
--- a/scripts/verify/desktop_verify.py
+++ b/scripts/verify/desktop_verify.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import abc
 import argparse
+import faulthandler
 import json
 import os
 import sys
@@ -55,6 +56,12 @@ DEFAULT_PROVIDER = "dashscope"
 DEFAULT_TIMEOUT = 120
 SESSION_ID = "release-verify-session"
 USER_ID = "release-verify-user"
+
+# The verify step runs under timeout-minutes: 10 in desktop-build.yml, so
+# self-report at 540s: a hung driver dumps every thread's stack and exits
+# while there is still time, instead of being SIGKILLed at 600s with its
+# buffered stdout discarded and the step showing no diagnostics at all.
+HANG_DUMP_SECONDS = 540
 
 # Selectors come straight from e2e/pages/chat_page.py so they stay in sync
 # with what the real UI tests expect.
@@ -254,6 +261,7 @@ class PlaywrightDriver(UIDriver):
 
     INPUT_VISIBLE_TIMEOUT_MS = 60_000
     NAVIGATE_TIMEOUT_MS = 60_000
+    LAUNCH_TIMEOUT_MS = 60_000
 
     def __init__(
         self,
@@ -306,7 +314,10 @@ class PlaywrightDriver(UIDriver):
                     raise UIDriverInitError(
                         f"playwright has no browser '{browser}'",
                     )
-                self._browser = launcher.launch(headless=headless)
+                self._browser = launcher.launch(
+                    headless=headless,
+                    timeout=self.LAUNCH_TIMEOUT_MS,
+                )
                 self._context = self._browser.new_context()
                 self._page = self._context.new_page()
         except UIDriverInitError:
@@ -946,4 +957,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    faulthandler.dump_traceback_later(HANG_DUMP_SECONDS, exit=True)
     sys.exit(main())

--- a/scripts/verify/requirements-verify.txt
+++ b/scripts/verify/requirements-verify.txt
@@ -6,4 +6,12 @@
 
 # All platforms: Playwright drives Chromium (Legacy + Tauri Win) or
 # WebKit (Tauri macOS) for headed/headless browser automation.
-playwright>=1.40
+#
+# Upper bound: 1.62 ships WebKit 26.5, but build-tauri-macos runs on
+# macos-14, which only receives the frozen WebKit v2251 build. Against
+# that frozen browser the 1.62 driver launches fine and then blocks
+# forever on the first page operation, which timed out the macOS verify
+# step. Measured on macos-14, same script and same WebKit v2251: 1.61.0
+# finishes in 3.3s, 1.62.0 is still hung at a 150s cap. Drop the bound
+# once the runner moves to macos-15, where WebKit is not frozen.
+playwright>=1.40,<1.62


### PR DESCRIPTION
## Problem

`build-desktop / build-tauri-macos` fails on main, blocking the release. The `Verify desktop (Tauri macOS)` step times out after 10 minutes with **zero output** — no traceback, no assertion, nothing to go on.

Failing run: https://github.com/agentscope-ai/QwenPaw/actions/runs/30789096404/job/91608763318

## Root cause

`playwright 1.62` ships WebKit 26.5, but `build-tauri-macos` runs on `macos-14` (`desktop-build.yml:165`), which only receives the **frozen** WebKit v2251 build. Against that frozen browser the 1.62 driver launches fine and then blocks forever on the first page operation.

A/B measured on `macos-14`, same script, same WebKit v2251 binary:

| playwright | driver start | webkit launch | first page op | result |
| --- | --- | --- | --- | --- |
| **1.61.0** | 0.3s | 0.5s | 2.5s | **OK**, 3.3s total, exit 0 |
| **1.62.0** | 0.2s | 0.3s (succeeds) | **blocks** | **hung** past a 150s cap, exit 1 |

Hang stack:

```
playwright/sync_api/_context_manager.py:56  greenlet_main
  asyncio/base_events.py:641  run_until_complete
    asyncio/base_events.py:608  run_forever
      selectors.py:566  select
```

Two things this rules out:

- **Not the WebKit binary.** Both sides download the identical `webkit_mac14_arm64_special-2251`. The `frozen webkit` warning is also present in the runs that **passed** (e.g. the successful 7/24 release), so it was never the trigger.
- **Not `launch()`.** Launch succeeds in 0.3s; the block is in the page operation that follows.

The last green release used `playwright 1.61.0`; verify scripts are unchanged since. The driver version is the only variable.

## Changes

1. **`requirements-verify.txt`: `playwright>=1.40` -> `playwright>=1.40,<1.62`.** An upper bound rather than an exact pin, so 1.61.x patches still flow. Resolves to 1.61.0 today — the version with a green release behind it.

2. **Make a hang diagnosable.** The verifier now arms `faulthandler` at 540s, below the step's `timeout-minutes: 10`, so it dumps every thread's stack and exits instead of being SIGKILLed with its buffered stdout discarded. That silent-10-minute-timeout is why this took an A/B experiment to pin down; next time the stack will be right there in the log. The browser launch also passes an explicit timeout instead of relying on the implicit default.

## Verification

- A/B experiment above run on a real `macos-14` runner (both versions, same script, same WebKit build).
- `pip` resolution of the new constraint confirmed to select `playwright==1.61.0`.
- `faulthandler` dump path exercised in that same experiment — it produced the stack quoted above.
- pre-commit clean (mypy / black / flake8 / pylint).
- The full `build-tauri-macos` job is left to CI here; the change is a revert to a previously green version plus additive diagnostics.

## Follow-up (not in this PR)

Moving the runner from `macos-14` to `macos-15` is the actual fix — macOS 15 gets a maintained WebKit, the frozen-browser problem disappears, and this upper bound can come off. Worth scheduling, otherwise every playwright bump risks a repeat. Left out here to keep the release unblocked with a minimal, low-risk change.