### PR TITLE
fix(agents): normalize empty batch placeholders to None (#6588)

### DIFF
--- a/src/qwenpaw/agents/tools/agent_management.py
+++ b/src/qwenpaw/agents/tools/agent_management.py
@@ -988,13 +988,22 @@ def _normalize_batch(
 ) -> Optional[list[Dict[str, Any]]]:
     """Normalize ``batch`` to ``list[dict]`` or ``None``.
 
-    Accepts a real list or a JSON array string.  Structural checks
-    (non-empty, per-item ``task``) remain in :func:`_spawn_batch`.
+    Accepts a real list or a JSON array string. Empty placeholders
+    (``None``, ``""``, whitespace, ``[]``, ``"[]"``) normalize to ``None``
+    so single-task execution paths remain usable when models emit empty
+    placeholders for optional parameters (Issue #6588).
+
+    Structural checks (per-item ``task``) remain in :func:`_spawn_batch`.
     """
     if value is None:
         return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    if isinstance(value, list) and not value:
+        return None
     coerced = _coerce_json_list(value, "batch")
-    assert coerced is not None
+    if not coerced:
+        return None
     return coerced  # type: ignore[return-value]
 
 

--- a/tests/unit/agents/tools/test_agent_management.py
+++ b/tests/unit/agents/tools/test_agent_management.py
@@ -568,6 +568,27 @@ def test_normalize_batch_accepts_json_array_string():
     assert out[1]["fork"] is True
 
 
+def test_normalize_batch_empty_placeholders_return_none():
+    """Empty batch representations normalize to None (Issue #6588)."""
+    assert agent_management._normalize_batch(None) is None
+    assert agent_management._normalize_batch("") is None
+    assert agent_management._normalize_batch("   ") is None
+    assert agent_management._normalize_batch([]) is None
+    assert agent_management._normalize_batch("[]") is None
+    assert agent_management._normalize_batch("  [  ]  ") is None
+
+
+def test_normalize_batch_rejects_invalid_values():
+    """Ambiguous literals and non-array types raise ValueError."""
+    for bad in ("null", "None", "{}", '{"task": "a"}', "invalid", 123, True):
+        try:
+            agent_management._normalize_batch(bad)
+        except ValueError as exc:
+            assert "batch" in str(exc)
+        else:
+            raise AssertionError(f"expected ValueError for {bad!r}")
+
+
 def test_coerce_bool_string_false_is_false():
     assert agent_management._coerce_bool("false") is False
     assert agent_management._coerce_bool("true") is True
@@ -1051,6 +1072,64 @@ async def test_spawn_subagent_top_level_string_bools(monkeypatch):
     assert bad_timeout.content[0].text.startswith("ERROR:")
     assert "timeout" in bad_timeout.content[0].text.lower()
     assert not collected
+
+
+async def test_spawn_subagent_empty_batch_placeholders_single_task(
+    monkeypatch,
+):
+    """Empty batch placeholders fall through to single-task mode.
+
+    Regression test for Issue #6588.
+    """
+    collected: list[dict] = []
+
+    def fake_collect(_base, payload, _agent_id, _timeout):
+        collected.append(payload)
+        return {
+            "output": [
+                {"content": [{"type": "text", "text": "done"}]},
+            ],
+        }
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    from qwenpaw.app import agent_context
+
+    monkeypatch.setattr(
+        agent_management,
+        "collect_final_agent_chat_response",
+        fake_collect,
+    )
+    monkeypatch.setattr(agent_management.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(agent_context, "get_current_agent_id", lambda: "bot-a")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_approval_route",
+        lambda: None,
+    )
+    monkeypatch.setattr(agent_context, "get_current_session_id", lambda: "s1")
+    monkeypatch.setattr(agent_context, "get_current_user_id", lambda: "u1")
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_channel",
+        lambda: "console",
+    )
+    monkeypatch.setattr(
+        agent_context,
+        "get_current_root_session_id",
+        lambda: "s1",
+    )
+
+    for empty_batch in ([], "", "   ", "[]", " [ ] "):
+        collected.clear()
+        res = await agent_management.spawn_subagent(
+            task="do work",
+            batch=empty_batch,
+        )
+        assert "ERROR" not in res.content[0].text
+        assert "done" in res.content[0].text
+        assert len(collected) == 1
 
 
 async def test_spawn_subagent_batch_item_timeout_errors_before_dispatch(


### PR DESCRIPTION
## Description

Fixes #6588.

When certain LLMs (e.g. via OpenAI Responses-compatible endpoints) call `spawn_subagent` for single-task execution, they may pass empty placeholders for optional parameters such as `batch=[]`, `batch=""`, or `batch="[]"`.

Previously, `_normalize_batch` passed these empty values through or raised a `ValueError`. When `[]` was returned, `spawn_subagent` checked `if batch is not None:`, erroneously entering batch mode and raising a mutual exclusivity error against the non-empty `task`.

This PR hardens `_normalize_batch()` to normalize empty placeholders (`None`, `""`, whitespace, `[]`, `"[]"`, `" [ ] "`) to `None` so single-task calls proceed seamlessly.

### Design Considerations:
- **Scoped specifically to `batch`**: As recommended by maintainers on #6588, this change is strictly localized to `_normalize_batch()` and does not alter `allowed_tools` or other list-of-str arguments, preserving `allowed_tools=[]` ("deny all tools") semantics.
- **Ambiguous literals fail loud**: Ambiguous string literals such as `"null"`, `"None"`, or invalid JSON structures still raise `ValueError`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (agents/tools/agent_management.py)
- [ ] Console
- [ ] Channels
- [ ] Skills
- [ ] CLI
- [ ] Documentation
- [x] Tests
- [ ] CI/CD

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally (`pytest`) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing

Added comprehensive unit and regression tests in `tests/unit/agents/tools/test_agent_management.py`:
1. `test_normalize_batch_empty_placeholders_return_none`: Verifies `None`, `""`, `"   "`, `[]`, `"[]"`, and `"  [  ]  "` all normalize to `None`.
2. `test_normalize_batch_rejects_invalid_values`: Verifies ambiguous literals (`"null"`, `"None"`, etc.) and non-array structures still raise `ValueError`.
3. `test_spawn_subagent_empty_batch_placeholders_single_task`: Verifies that single-task calls with empty batch placeholders smoothly dispatch single tasks without mutual exclusivity errors.

## Local Verification Evidence

```bash
.venv/bin/pre-commit run --files src/qwenpaw/agents/tools/agent_management.py tests/unit/agents/tools/test_agent_management.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed

.venv/bin/pytest tests/unit/agents/tools/test_agent_management.py
============================== 34 passed in 1.03s ==============================
```