### PR TITLE
fix(console): wrap multi-file attachment previews

### DIFF
--- a/console/src/pages/Chat/index.module.less
+++ b/console/src/pages/Chat/index.module.less
@@ -211,6 +211,35 @@
   }
 }
 
+/* Fix #6583: Keep enough attachment cards visible to verify a multi-file
+ * selection, while bounding very large drops to three scrollable rows. */
+.chatMessagesArea :global {
+  .qwenpaw-sender-header .qwenpaw-attachment {
+    width: 100%;
+    overflow: visible;
+  }
+
+  .qwenpaw-sender-header .qwenpaw-attachment-list {
+    flex-wrap: wrap;
+    align-content: flex-start;
+    max-height: 208px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+  }
+}
+
+@media (max-width: 600px) {
+  .chatMessagesArea :global {
+    .qwenpaw-sender-header .qwenpaw-attachment-list {
+      column-gap: 8px;
+      padding-inline: 6px;
+    }
+  }
+}
+/* End #6583 */
+
 /* ---- Rate-limit guidance banner ---- */
 .rateLimitBanner {
   display: flex;

--- a/console/src/pages/Chat/index.module.test.ts
+++ b/console/src/pages/Chat/index.module.test.ts
@@ -25,3 +25,26 @@ describe("Chat message markdown layout styles", () => {
     expect(rule).toMatch(/max-width:\s*100%/);
   });
 });
+
+describe("Chat attachment preview styles", () => {
+  it("wraps attachment cards within a bounded scrollable preview", () => {
+    const marker = "Fix #6583";
+    const markerIndex = stylesSource.indexOf(marker);
+    const rule = stylesSource.slice(
+      markerIndex,
+      stylesSource.indexOf("/* End #6583 */", markerIndex),
+    );
+
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(rule).toContain(".qwenpaw-sender-header");
+    expect(rule).toContain(".qwenpaw-attachment-list");
+    expect(rule).toMatch(/flex-wrap:\s*wrap/);
+    expect(rule).toMatch(/max-height:\s*\d+px/);
+    expect(rule).toMatch(/overflow-y:\s*auto/);
+    expect(rule).toMatch(/overflow-x:\s*hidden/);
+    expect(rule).not.toContain(".qwenpaw-attachment-list-card-type-overview");
+    expect(rule).toMatch(/@media\s*\(max-width:\s*600px\)/);
+    expect(rule).toMatch(/column-gap:\s*8px/);
+    expect(rule).toMatch(/padding-inline:\s*6px/);
+  });
+});


### PR DESCRIPTION
## Description

The shared `ChatAnywhere` sender currently renders pending attachments in a
single non-wrapping flex row. This PR scopes a host-side layout override to the
QwenPaw chat composer so attachment cards wrap across rows, while preserving
the existing upload state and actions.

The preview shows up to three complete rows and scrolls additional rows
vertically, preventing large drops from displacing the conversation. At mobile
widths, the spacing is tightened enough to retain two columns without shrinking
the SDK cards or creating page-level horizontal overflow.

**Related Issue:** Fixes #6583

**Security Considerations:** None. This is a layout-only change; attachment
validation, upload handling, and backend requests are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed for this layout-only fix)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] Not applicable: no channel implementation or channel contract changed

## Testing

- `npm run test:run -- src/pages/Chat/index.module.test.ts`
- `npm run test:run -- --maxWorkers=2`
- `npm exec eslint -- src/pages/Chat/index.module.test.ts`
- `npm run format`
- `npm run build`
- `pre-commit run --all-files`
- Real-browser verification with 18 uploaded files at desktop and mobile widths

## Evidence

With 18 real uploaded files, the desktop composer rendered four total rows,
kept three rows (15 cards) fully visible, and exposed the fourth through vertical
scrolling. The list measured `clientHeight=208`, `scrollHeight=276`, and equal
`clientWidth`/`scrollWidth` values of 850, confirming there was no horizontal
overflow.

At a 390x844 viewport, the same list rendered two cards per row, kept three rows
fully visible, and introduced no page overflow (`body.scrollWidth=390`). Scrolling
to the maximum offset made the final card fully visible. Existing remove actions,
upload states, and the composer controls remained usable.

```text
Test Files  174 passed (174)
Tests       1423 passed (1423)

vite v6.4.1 building for production...
16376 modules transformed.
built in 1m 51s
[verify-monaco-css] OK - Monaco stylesheet present in 31 CSS file(s).

pre-commit run --all-files
All applicable hooks passed, including mypy, black, flake8, pylint, and actionlint.
```

## Additional Notes

The repository-wide `npm run lint` still reports the existing upstream baseline
of 286 errors and 86 warnings in unchanged files. Direct ESLint on the changed
test file passes. `scripts/check-channels.sh --changed` is not applicable to this
diff and also assumes `.git` is a directory, so it exits before change detection
when run from a git worktree.
