### PR TITLE
fix(creator): put PawApp category under meta.pawapp for App Center

### DIFF
--- a/plugins/apps/qwenpaw-creator/plugin.json
+++ b/plugins/apps/qwenpaw-creator/plugin.json
@@ -26,7 +26,8 @@
       "icon": "🎬",
       "icon_url": "/api/frontend_plugin/qwenpaw-creator/files/ui/dist/app/logo-mark.png",
       "entry_page": "/apps/qwenpaw-creator",
-      "launch_scope": "page"
+      "launch_scope": "page",
+      "category": "video-creation"
     },
     "permissions": {
       "chat": false,
@@ -50,7 +51,6 @@
         "fallback": "ffmpeg metadata probing"
       }
     },
-    "category": "video-creation",
     "features": [
       "project-management",
       "script-generation",

--- a/tests/unit/app/routers/test_pawapps_build_info.py
+++ b/tests/unit/app/routers/test_pawapps_build_info.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for PawApp listing metadata contract."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from qwenpaw.app.routers.pawapps import _build_app_info
+
+CREATOR_PLUGIN_JSON = (
+    Path(__file__).resolve().parents[4]
+    / "plugins"
+    / "apps"
+    / "qwenpaw-creator"
+    / "plugin.json"
+)
+
+
+class TestBuildAppInfoCategory:
+    def test_reads_category_from_meta_pawapp(self):
+        info = _build_app_info(
+            {
+                "id": "demo-app",
+                "name": "Demo",
+                "version": "1.0.0",
+                "description": "demo",
+                "author": "test",
+                "meta": {
+                    "pawapp": {
+                        "category": "productivity",
+                        "icon": "📋",
+                        "entry_page": "/apps/demo-app",
+                    },
+                },
+            },
+        )
+        assert info["category"] == "productivity"
+
+    def test_ignores_meta_root_category(self):
+        info = _build_app_info(
+            {
+                "id": "misplaced-app",
+                "name": "Misplaced",
+                "version": "1.0.0",
+                "meta": {
+                    "category": "video-creation",
+                    "pawapp": {
+                        "icon": "🎬",
+                        "entry_page": "/apps/misplaced-app",
+                    },
+                },
+            },
+        )
+        assert info["category"] == ""
+
+    def test_creator_plugin_json_exposes_category_under_pawapp(self):
+        manifest = json.loads(CREATOR_PLUGIN_JSON.read_text(encoding="utf-8"))
+        info = _build_app_info(manifest)
+
+        assert info["id"] == "qwenpaw-creator"
+        assert info["category"] == "video-creation"
+        assert "category" not in (manifest.get("meta") or {})
+        assert (manifest.get("meta") or {}).get("pawapp", {}).get(
+            "category",
+        ) == "video-creation"


### PR DESCRIPTION
## Description

Fix App Center category missing for `qwenpaw-creator` by aligning plugin metadata with the PawApp contract.

`GET /api/pawapps` reads `category` from `meta.pawapp.category` (see `_build_app_info`), but Creator declared `meta.category = "video-creation"`. That mismatch made the API return `category: ""`, so App Center category tags and filters never worked for Creator. This PR moves the field into `meta.pawapp` (same shape as `agent-kanban`) and adds a unit test to lock the contract.

**Security Considerations:** N/A — metadata-only change in plugin manifest; no auth, env, or channel handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Confirm `plugins/apps/qwenpaw-creator/plugin.json` has `meta.pawapp.category = "video-creation"` and no root-level `meta.category`.
2. Run:
   ```bash
   pytest tests/unit/app/routers/test_pawapps_build_info.py -v
   ```
3. Optional runtime check: load Creator manifest into PluginRegistry / call `GET /api/pawapps` and assert the Creator entry has `"category": "video-creation"`.
4. In Console App Center (Installed), Creator card should show the `video-creation` category and appear in that filter.

## Evidence

Unit tests for the category contract:

```bash
$ source .venv/bin/activate && python -m pytest tests/unit/app/routers/test_pawapps_build_info.py -v
============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.0.3
collected 3 items

tests/unit/app/routers/test_pawapps_build_info.py::TestBuildAppInfoCategory::test_reads_category_from_meta_pawapp PASSED [ 33%]
tests/unit/app/routers/test_pawapps_build_info.py::TestBuildAppInfoCategory::test_ignores_meta_root_category PASSED [ 66%]
tests/unit/app/routers/test_pawapps_build_info.py::TestBuildAppInfoCategory::test_creator_plugin_json_exposes_category_under_pawapp PASSED [100%]

============================== 3 passed in 0.92s ===============================
```

TestClient simulation of `GET /api/pawapps` with the fixed Creator manifest:

```text
FIXED: {
  "id": "qwenpaw-creator",
  "category": "video-creation",
  "entry_page": "/apps/qwenpaw-creator",
  "icon": "🎬",
  "version": "1.0.1",
  "status": "installed"
}
BROKEN_SHAPE category: ''   # control: meta.category-only still yields ""
RUNTIME_API_OK
```

pre-commit on the changed files (auto trailing-comma fix re-staged and rechecked):

```bash
$ pre-commit run --files plugins/apps/qwenpaw-creator/plugin.json tests/unit/app/routers/test_pawapps_build_info.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
```

## Additional Notes

- Host `pawapps.py` / App Center UI were left unchanged; the bug was plugin metadata location, not API logic.
- Reference correct shape: `plugins/apps/agent-kanban/plugin.json` (`meta.pawapp.category`).