### PR TITLE
feat(providers): support responses prompt caching

### DIFF
--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -45,7 +45,7 @@ from agentscope.formatter import (
 )
 
 from agentscope.formatter import OpenAIResponseFormatter
-from agentscope.message import Base64Source, URLSource
+from agentscope.message import Base64Source, Msg, URLSource
 from pydantic import Field
 
 # Maximum size (in bytes) of a local media file we are willing to inline as
@@ -270,7 +270,35 @@ class _CappingOpenAIResponseFormatter(
     OpenAIResponseFormatter,
     CappingFormatterMixin,
 ):
-    """OpenAI Responses API formatter that caps oversized local media."""
+    """Responses formatter with media capping and opt-in cache boundaries."""
+
+    enable_prompt_cache_breakpoint: bool = Field(default=False)
+
+    async def format(self, msgs: list[Msg]) -> list[dict[str, Any]]:
+        """Format messages and mark the end of the stable system prefix."""
+        items = await super().format(msgs)
+        if not self.enable_prompt_cache_breakpoint:
+            return items
+
+        breakpoint_block: dict[str, Any] | None = None
+        for item in items:
+            if item.get("role") != "system":
+                break
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "input_text"
+                ):
+                    breakpoint_block = block
+
+        if breakpoint_block is not None:
+            breakpoint_block["prompt_cache_breakpoint"] = {
+                "mode": "explicit",
+            }
+        return items
 
     def _placeholder(self, kind: str, size: int) -> dict[str, Any]:
         # Responses API uses ``input_text`` / ``output_text`` — not the

--- a/src/qwenpaw/providers/openai_response_provider.py
+++ b/src/qwenpaw/providers/openai_response_provider.py
@@ -90,6 +90,20 @@ class OpenAIResponseModelCompat(OpenAIResponseModel):
         ):
             generate_kwargs["max_output_tokens"] = max_tokens
         merged = {**self._extra_generate_kwargs, **generate_kwargs}
+        merged.pop("enable_prompt_cache_breakpoint", None)
+        if "prompt_cache_options" in merged:
+            prompt_cache_options = merged.pop("prompt_cache_options")
+            extra_body = merged.get("extra_body")
+            if extra_body is not None and not isinstance(extra_body, dict):
+                raise TypeError(
+                    "extra_body must be a dictionary when "
+                    "prompt_cache_options is configured",
+                )
+            # openai<=2.33 accepts newer request fields through extra_body.
+            merged["extra_body"] = {
+                **(extra_body or {}),
+                "prompt_cache_options": prompt_cache_options,
+            }
         return await super()._call_api(
             model_name,
             messages,
@@ -340,6 +354,9 @@ class OpenAIResponseProvider(OpenAIProvider):
 
         merged_headers = self._build_default_headers()
         gen_kwargs = self.get_effective_generate_kwargs(model_id)
+        enable_prompt_cache_breakpoint = bool(
+            gen_kwargs.pop("enable_prompt_cache_breakpoint", False),
+        )
         parameters = OpenAIResponseModel.Parameters(
             max_tokens=gen_kwargs.pop("max_tokens", None),
             temperature=gen_kwargs.pop("temperature", None),
@@ -359,5 +376,8 @@ class OpenAIResponseProvider(OpenAIProvider):
             extra_generate_kwargs=gen_kwargs or None,
             formatter=_CappingOpenAIResponseFormatter(
                 max_bytes=self.max_inline_media_bytes,
+                enable_prompt_cache_breakpoint=(
+                    enable_prompt_cache_breakpoint
+                ),
             ),
         )

--- a/tests/unit/providers/test_capping_formatter.py
+++ b/tests/unit/providers/test_capping_formatter.py
@@ -18,7 +18,11 @@ directly; the provider-level wiring (the field reaching
 # pylint: disable=protected-access
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
+from agentscope.formatter import OpenAIResponseFormatter
+from agentscope.message import Msg, TextBlock
 
 from qwenpaw.providers.capping_formatter import (
     MAX_INLINE_MEDIA_BYTES,
@@ -26,6 +30,7 @@ from qwenpaw.providers.capping_formatter import (
     _CappingDashScopeFormatter,
     _CappingGeminiFormatter,
     _CappingOpenAIFormatter,
+    _CappingOpenAIResponseFormatter,
     inline_media_size,
 )
 
@@ -321,3 +326,81 @@ def test_non_http_remote_scheme_passthrough() -> None:
         assert result is source, f"{scheme_url} was not passed through"
         # inline_media_size must return None (not try getsize)
         assert inline_media_size(source) is None
+
+
+# ---------------------------------------------------------------------------
+# Responses API prompt-cache breakpoints
+# ---------------------------------------------------------------------------
+
+
+def _text_msg(
+    role: Literal["user", "assistant", "system"],
+    *texts: str,
+) -> Msg:
+    return Msg(
+        name=role,
+        role=role,
+        content=[TextBlock(type="text", text=text) for text in texts],
+    )
+
+
+async def test_response_cache_breakpoint_marks_stable_system_prefix() -> None:
+    messages = [
+        _text_msg("system", "stable one", "stable two"),
+        _text_msg("user", "volatile user input"),
+    ]
+    original = [msg.model_dump(mode="json") for msg in messages]
+
+    result = await _CappingOpenAIResponseFormatter(
+        enable_prompt_cache_breakpoint=True,
+    ).format(messages)
+
+    assert result == [
+        {
+            "role": "system",
+            "content": [
+                {"type": "input_text", "text": "stable one"},
+                {
+                    "type": "input_text",
+                    "text": "stable two",
+                    "prompt_cache_breakpoint": {"mode": "explicit"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "volatile user input"},
+            ],
+        },
+    ]
+    assert [msg.model_dump(mode="json") for msg in messages] == original
+
+
+async def test_response_cache_breakpoint_is_disabled_by_default() -> None:
+    messages = [
+        _text_msg("system", "stable prompt"),
+        _text_msg("user", "latest input"),
+    ]
+
+    expected = await OpenAIResponseFormatter().format(messages)
+    result = await _CappingOpenAIResponseFormatter().format(messages)
+
+    assert result == expected
+
+
+async def test_response_cache_breakpoint_requires_system_prefix() -> None:
+    messages = [_text_msg("user", "latest input")]
+
+    result = await _CappingOpenAIResponseFormatter(
+        enable_prompt_cache_breakpoint=True,
+    ).format(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "latest input"},
+            ],
+        },
+    ]

--- a/tests/unit/providers/test_openai_response_provider.py
+++ b/tests/unit/providers/test_openai_response_provider.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+from copy import deepcopy
 import time
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ from qwenpaw.providers.openai_response_provider import (
     _extract_reasoning_text,
     _extract_response_text,
 )
+from qwenpaw.providers.provider import ModelInfo
 
 
 def _make_provider() -> OpenAIResponseProvider:
@@ -387,3 +389,60 @@ async def test_summary_limit_is_adapted_for_responses_api(
     assert result == "ok"
     assert captured["max_output_tokens"] == 256
     assert "max_tokens" not in captured
+
+
+async def test_prompt_cache_generate_kwargs_are_adapted(
+    monkeypatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_call_api(self, *args, **kwargs):
+        del self, args
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(
+        OpenAIResponseModel,
+        "_call_api",
+        fake_call_api,
+    )
+    provider = _make_provider()
+    provider.generate_kwargs = {
+        "prompt_cache_key": "provider-key",
+        "prompt_cache_options": {"mode": "implicit"},
+        "extra_body": {"metadata": {"source": "provider"}},
+    }
+    provider.models = [
+        ModelInfo(
+            id="gpt-5.6",
+            name="GPT-5.6",
+            generate_kwargs={
+                "prompt_cache_key": "model-key",
+                "prompt_cache_options": {
+                    "mode": "explicit",
+                    "ttl": "30m",
+                },
+                "enable_prompt_cache_breakpoint": True,
+            },
+        ),
+    ]
+    original_provider_kwargs = deepcopy(provider.generate_kwargs)
+    original_model_kwargs = deepcopy(provider.models[0].generate_kwargs)
+
+    model = provider.get_chat_model_instance("gpt-5.6")
+    result = await model._call_api("gpt-5.6", [])
+
+    assert result == "ok"
+    assert model.formatter.enable_prompt_cache_breakpoint is True
+    assert captured["prompt_cache_key"] == "model-key"
+    assert captured["extra_body"] == {
+        "metadata": {"source": "provider"},
+        "prompt_cache_options": {
+            "mode": "explicit",
+            "ttl": "30m",
+        },
+    }
+    assert "prompt_cache_options" not in captured
+    assert "enable_prompt_cache_breakpoint" not in captured
+    assert provider.generate_kwargs == original_provider_kwargs
+    assert provider.models[0].generate_kwargs == original_model_kwargs

--- a/website/public/docs/models.en.md
+++ b/website/public/docs/models.en.md
@@ -241,3 +241,27 @@ Since different models and tasks may require different generation parameters (su
 After configuring, click **Save**. QwenPaw will automatically include these parameters when generating with models from this provider.
 
 ![Generation Parameters](https://img.alicdn.com/imgextra/i1/O1CN0194Bihd239bxJwoVpi_!!6000000007213-2-tps-1180-1858.png)
+
+#### Responses API Prompt Caching
+
+For GPT-5.6 or later models configured with the OpenAI Responses API provider,
+you can opt in to an explicit, reusable cache boundary through the provider or
+model generation parameters:
+
+```json
+{
+  "prompt_cache_key": "qwenpaw-agent-default-v1",
+  "prompt_cache_options": {
+    "mode": "explicit",
+    "ttl": "30m"
+  },
+  "enable_prompt_cache_breakpoint": true
+}
+```
+
+Keep `prompt_cache_key` stable for requests that share the same prompt prefix.
+When `enable_prompt_cache_breakpoint` is `true`, QwenPaw marks the end of the
+leading system prompt as an explicit cache boundary. Omit these options for
+older models or Responses-compatible services that do not support them. See
+the [OpenAI prompt caching guide](https://platform.openai.com/docs/guides/prompt-caching)
+for model support and current limits.

--- a/website/public/docs/models.en.md
+++ b/website/public/docs/models.en.md
@@ -252,7 +252,7 @@ model generation parameters:
 {
   "prompt_cache_key": "qwenpaw-agent-default-v1",
   "prompt_cache_options": {
-    "mode": "explicit",
+    "mode": "implicit",
     "ttl": "30m"
   },
   "enable_prompt_cache_breakpoint": true
@@ -261,7 +261,11 @@ model generation parameters:
 
 Keep `prompt_cache_key` stable for requests that share the same prompt prefix.
 When `enable_prompt_cache_breakpoint` is `true`, QwenPaw marks the end of the
-leading system prompt as an explicit cache boundary. Omit these options for
-older models or Responses-compatible services that do not support them. See
-the [OpenAI prompt caching guide](https://platform.openai.com/docs/guides/prompt-caching)
+leading system prompt as an explicit cache boundary. The recommended `implicit`
+mode also keeps OpenAI's automatic latest-message boundary, which improves
+reuse as agent history grows. Use `explicit` mode only when you want to disable
+that automatic boundary; QwenPaw currently adds no rolling breakpoints after
+completed turns. Omit these options for older models or Responses-compatible
+services that do not support them. See the
+[OpenAI prompt caching guide](https://platform.openai.com/docs/guides/prompt-caching)
 for model support and current limits.

--- a/website/public/docs/models.zh.md
+++ b/website/public/docs/models.zh.md
@@ -251,7 +251,7 @@ QwenPaw 中所有提供商的配置都会保存在 `$QWENPAW_SECRET_DIR/provider
 {
   "prompt_cache_key": "qwenpaw-agent-default-v1",
   "prompt_cache_options": {
-    "mode": "explicit",
+    "mode": "implicit",
     "ttl": "30m"
   },
   "enable_prompt_cache_breakpoint": true
@@ -260,6 +260,8 @@ QwenPaw 中所有提供商的配置都会保存在 `$QWENPAW_SECRET_DIR/provider
 
 对共享同一提示词前缀的请求，应保持 `prompt_cache_key` 稳定。启用
 `enable_prompt_cache_breakpoint` 后，QwenPaw 会将前置系统提示词的末尾标记为
-显式缓存边界。旧模型或不支持这些参数的 Responses 兼容服务应省略上述配置。
-模型支持范围和当前限制请参考
+显式缓存边界。推荐的 `implicit` 模式还会保留 OpenAI 自动生成的最新消息边界，
+更适合历史持续增长的 Agent 会话。只有需要关闭自动边界时才使用 `explicit`
+模式；QwenPaw 当前不会在已完成的对话轮次后滚动添加显式断点。旧模型或不支持
+这些参数的 Responses 兼容服务应省略上述配置。模型支持范围和当前限制请参考
 [OpenAI 提示词缓存指南](https://platform.openai.com/docs/guides/prompt-caching)。

--- a/website/public/docs/models.zh.md
+++ b/website/public/docs/models.zh.md
@@ -241,3 +241,25 @@ QwenPaw 中所有提供商的配置都会保存在 `$QWENPAW_SECRET_DIR/provider
 配置完成后点击 **保存**，QwenPaw 就会在使用该供应商的模型进行生成时自动带上这些参数配置了。
 
 ![生成参数](https://img.alicdn.com/imgextra/i2/O1CN01XreaTi1VPSj9sMQtp_!!6000000002645-2-tps-1170-1476.png)
+
+#### Responses API 提示词缓存
+
+使用 OpenAI Responses API 提供商配置 GPT-5.6 或更新模型时，可以在提供商
+或模型的生成参数中显式启用可复用的缓存边界：
+
+```json
+{
+  "prompt_cache_key": "qwenpaw-agent-default-v1",
+  "prompt_cache_options": {
+    "mode": "explicit",
+    "ttl": "30m"
+  },
+  "enable_prompt_cache_breakpoint": true
+}
+```
+
+对共享同一提示词前缀的请求，应保持 `prompt_cache_key` 稳定。启用
+`enable_prompt_cache_breakpoint` 后，QwenPaw 会将前置系统提示词的末尾标记为
+显式缓存边界。旧模型或不支持这些参数的 Responses 兼容服务应省略上述配置。
+模型支持范围和当前限制请参考
+[OpenAI 提示词缓存指南](https://platform.openai.com/docs/guides/prompt-caching)。


### PR DESCRIPTION
## Description

Adds opt-in GPT-5.6+ prompt caching support to the OpenAI Responses provider.

- Keeps the existing `prompt_cache_key` passthrough through provider/model `generate_kwargs`.
- Sends `prompt_cache_options` through `extra_body`, which produces the required top-level HTTP field while remaining compatible with the pinned OpenAI SDK (`<=2.33.0`).
- Adds `enable_prompt_cache_breakpoint`; when enabled, the shared Responses formatter marks the last `input_text` block in the leading system prefix with an explicit cache breakpoint.
- Leaves the default path and non-Responses providers unchanged, and does not mutate stored provider/model configuration.
- Documents provider-level and model-level configuration in English and Chinese.

**Related Issue:** Fixes #6649

**Security Considerations:** Cache settings remain explicit user-supplied generation configuration. This change does not log cache keys or alter credential handling.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [x] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

```bash
pytest tests/unit/providers/test_capping_formatter.py \
  tests/unit/providers/test_openai_response_provider.py -q --no-cov
# 43 passed

pytest tests/unit/providers -q --no-cov
# 343 passed

pytest tests/unit/agents/context/test_history_store.py -q --no-cov
# 22 passed

pre-commit run --all-files
# all hooks passed
```

The website TypeScript build, search-index generation, Vite production build, SPA fallback generation, and Prettier checks also pass.

## Evidence

```text
Targeted provider regression tests:
........................................... [100%]
43 passed in 0.25s

Provider unit suite:
343 passed in 2.78s

Full pre-commit:
check python ast................................Passed
mypy............................................Passed
black...........................................Passed
flake8..........................................Passed
pylint..........................................Passed
prettier........................................Passed
Lint GitHub Actions workflow files..............Passed

Pinned OpenAI SDK mock-transport request body:
{"input":[{"role":"system","content":[{"type":"input_text","text":"stable","prompt_cache_breakpoint":{"mode":"explicit"}}]}],"model":"gpt-5.6","prompt_cache_options":{"mode":"explicit","ttl":"30m"}}

Website production build:
5805 modules transformed
built in 15.96s
```

Verification matrix:

| Surface | Result |
| --- | --- |
| Provider/model `generate_kwargs` precedence | Covered |
| Stored configuration mutation | Covered; unchanged |
| Breakpoint enabled/disabled and exact placement | Covered |
| Latest user content | Never marked |
| Existing `prompt_cache_key` passthrough | Covered |
| OpenAI SDK `<=2.33.0` body compatibility | Verified with mock transport |
| Stream/non-stream request formatting | Shared AgentScope request path |
| Non-Responses providers | Unchanged; provider suite passes |

## Additional Notes

`previous_response_id` tracking is intentionally out of scope because it requires per-session response-ID lifecycle and persistence rather than request formatting.

A full `tests/unit` run was attempted locally. It intermittently stalled at the existing `test_append_works_from_a_worker_thread`; that test passes independently and the complete `test_history_store.py` file passes (`22 passed`).