### PR TITLE
fix(console): prevent long tool commands from overflowing chat

### DIFF
--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.test.tsx
@@ -41,6 +41,19 @@ const content: ToolCallContent = {
 };
 
 describe("ToolCardShell lazy body", () => {
+  it("keeps the full tool title available when the label is truncated", () => {
+    const title = `Run ${"long-command-argument ".repeat(40)}`;
+
+    const { container } = render(
+      <ToolCardShell content={content} icon={<span />} title={title} />,
+    );
+    const label = container.querySelector(`[title]`);
+
+    expect(label).not.toBeNull();
+    expect(label).toHaveAttribute("title", title);
+    expect(label).toHaveTextContent(title.trim());
+  });
+
   it("mounts the body only after the first expansion", () => {
     const { container } = render(
       <ToolCardShell content={content} icon={<span />} title="Shell">

--- a/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
+++ b/console/src/components/Chat/ToolCards/shared/ToolCardShell.tsx
@@ -119,7 +119,7 @@ const ToolCardShell: React.FC<ToolCardShellProps> = ({
   }, [control.offloadRemaining, control.killRemaining]);
 
   return (
-    <div>
+    <div className={styles.toolCallContainer}>
       <details
         className={`${styles.toolCallCompact} ${
           isLoading ? styles.toolCallCompactLoading : ""

--- a/console/src/components/Chat/ToolCards/shared/toolCards.module.less
+++ b/console/src/components/Chat/ToolCards/shared/toolCards.module.less
@@ -2,11 +2,19 @@
 // Extracted from ChatV2 MessageList.module.less so plugin cards
 // have zero dependencies on files outside ToolCards/.
 
+.toolCallContainer {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
 // Tool call — compact single-line (click to expand)
 .toolCallCompact {
   margin: 2px 0;
   display: block;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
 
   &.toolCallCompactLoading {
     .toolCallLabel {
@@ -30,7 +38,10 @@
   user-select: none;
   list-style: none;
   padding: 2px 0;
+  width: 100%;
+  min-width: 0;
   max-width: 100%;
+  box-sizing: border-box;
 
   &::-webkit-details-marker {
     display: none;
@@ -78,6 +89,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
 
   &:hover {
     color: var(--ant-color-primary, #1677ff);

--- a/console/src/components/Chat/ToolCards/shared/toolCards.module.test.ts
+++ b/console/src/components/Chat/ToolCards/shared/toolCards.module.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const stylesSource = readFileSync(
+  join(
+    process.cwd(),
+    "src/components/Chat/ToolCards/shared/toolCards.module.less",
+  ),
+  "utf8",
+);
+
+function readRule(selector: string): string {
+  const selectorIndex = stylesSource.indexOf(`\n${selector} {`) + 1;
+  if (selectorIndex === 0) return "";
+  return stylesSource.slice(
+    selectorIndex,
+    stylesSource.indexOf("}", selectorIndex) + 1,
+  );
+}
+
+describe("Tool card layout styles", () => {
+  it.each([
+    ".toolCallContainer",
+    ".toolCallCompact",
+    ".toolCallCompactSummary",
+    ".toolCallLabel",
+  ])("allows %s to shrink inside a chat message", (selector) => {
+    const rule = readRule(selector);
+
+    expect(rule).not.toBe("");
+    expect(rule).toMatch(/min-width:\s*0/);
+    expect(rule).toMatch(/max-width:\s*100%/);
+  });
+
+  it("keeps long tool titles on one ellipsized line", () => {
+    const rule = readRule(".toolCallLabel");
+
+    expect(rule).toMatch(/overflow:\s*hidden/);
+    expect(rule).toMatch(/text-overflow:\s*ellipsis/);
+    expect(rule).toMatch(/white-space:\s*nowrap/);
+  });
+});


### PR DESCRIPTION
Tool card containers, summaries, and titles now shrink correctly; excessively long shell commands no longer cause the session window to widen.
Titles remain single-line with truncation, while the full command can still be viewed on hover.
Added regression tests for layout and long titles.

<img width="2560" height="1228" alt="image" src="https://github.com/user-attachments/assets/70789e92-b830-4626-8282-02e4aeb10316" />

Fixes #6673
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
