### PR TITLE
fix(ci): install Playwright Chromium for the integration suite

### DIFF
--- a/.github/workflows/full-tests-nightly.yml
+++ b/.github/workflows/full-tests-nightly.yml
@@ -248,6 +248,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,test,full]"
 
+      # tests/integration/browser drives a real Chromium through the
+      # Playwright control link, so the browser binary must exist before the
+      # full sweep runs. Same command as the e2e workflows.
+      - name: Install Playwright browser
+        shell: bash
+        run: |
+          playwright install chromium --with-deps
+
       - name: Determine coverage flag
         id: cov_flag
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -277,6 +277,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,test,full]"
 
+      # tests/integration/browser carries the integration marker but no
+      # priority marker, so any expression without a p0/p1 filter (a
+      # workflow_dispatch of "integration", say) selects it and needs a real
+      # Chromium. Same command as the e2e workflows.
+      - name: Install Playwright browser
+        shell: bash
+        run: |
+          playwright install chromium --with-deps
+
       - name: Check if integrated tests exist
         id: check-integrated
         shell: bash


### PR DESCRIPTION
## Problem

The nightly full sweep fails on every platform with 7 cases in `tests/integration/browser/` reporting:

```
Executable doesn't exist at .../chromium_headless_shell-1234
```

Example: https://github.com/agentscope-ai/QwenPaw/actions/runs/30761526176

## Root cause

Neither `tests.yml` nor `full-tests-nightly.yml` has ever installed a browser binary — grepping either file for `playwright` returns nothing. The `1234` in that path is the chromium build number bundled with the playwright package (1228 locally), not a mispinned version.

Neither the tests nor the product code are at fault: installing chromium locally turns all 18 cases in that directory green.

## Changes

Add `playwright install chromium --with-deps` to the `integrated-tests` job in both workflows, reusing the exact command the e2e workflows already run so the repo keeps one convention.

- `full-tests-nightly.yml` — required; it runs the suite unfiltered, which is where the failures show up.
- `tests.yml` — also required. These cases carry the `integration` marker but no priority marker, so any expression without a p0/p1 filter selects them: `-m "integration"` collects 18 items. A `workflow_dispatch` with `integration` hits this today.

## Deliberately no skipif guard

Skipping on a missing browser would turn a broken environment into a green run, which is the failure mode this change exists to remove. A missing browser should be red.

## Verification

Two fork CI rounds:

- `Install Playwright browser` succeeded on all four matrix entries (macOS 14s, ubuntu 22-23s, Windows 208s).
- ubuntu py3.11, ubuntu py3.13 and macOS each ran **18/18 browser cases PASSED, zero FAILED**.

## Scope

This PR contains only the workflow change, so it does not alter test selection on any platform and can land on its own. A separate PR fixes the Windows auto-marking bug that hides 65 integration cases there; it is held back because it surfaces pre-existing failures in `test_chrome_nm_host.py` and is better landed alongside those fixes.