### PR TITLE
test(integration): align import-local with #6487 and widen a flaky poll window

### DIFF
--- a/tests/integration/test_tool_calls_lifecycle.py
+++ b/tests/integration/test_tool_calls_lifecycle.py
@@ -497,8 +497,13 @@ def _submit_shell_sleep_task(  # pylint: disable=redefined-outer-name
     return submit_resp.json()["task_id"], session_id
 
 
-def _poll_for_entry(app_server, session_id, timeout=20.0):
-    """Poll list_calls until at least one entry appears; return it."""
+def _poll_for_entry(app_server, session_id, timeout=60.0):
+    """Poll list_calls until at least one entry appears; return it.
+
+    The 60s window absorbs slow-runner latency (2-core Windows under
+    xdist load intermittently needs >20s from task submit to the entry
+    becoming observable); passing runs return as soon as it appears.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         resp = app_server.api_request(


### PR DESCRIPTION
## 1. import-local cases vs the #6487 source guard

#6487 restricted `/import-local` to sources under `$HOME`. The happy-path case seeded its source directory in the pytest tmp dir, which is outside `$HOME`, so the endpoint now returns 403 and the case fails **deterministically on all three platforms**. Confirmed in the nightly sweeps on 7/29 and 8/02:

```
INFO: "POST /api/workspace/coding-project/import-local HTTP/1.1" 403 Forbidden
tests/integration/test_coding_project.py:196: AssertionError
```

Changes:

- Seed the source under `$HOME` with a uuid suffix so xdist workers stay isolated, cleaned up in `finally`.
- Add two p2 cases so the new security semantics are themselves covered by regression: a source outside `$HOME` and a source inside a sensitive directory (`.aws`) both assert 403.
- Build the "guaranteed outside `$HOME`" path from `Path.home().anchor`, which is valid on every platform including a Windows drive anchor.

## 2. Widen the tool-call entry poll window

`test_offload_while_running` flaked 3 nights in 10 on Windows. Under xdist load on 2-core runners the submit -> mock LLM -> tool start -> entry registered pipeline can exceed the 20s poll window, so `_poll_for_entry` returned None. Widened to 60s; passing runs still return the moment the entry appears, so this does not slow the green path.

## Verification

All 13 cases in `test_coding_project.py` pass locally, including the two new 403 cases. pre-commit clean (mypy / black / flake8 / pylint).