### PR TITLE
fix(console): sync legacy max_iters when saving iteration limit

### DIFF
--- a/console/src/pages/Agent/Config/useAgentConfig.test.tsx
+++ b/console/src/pages/Agent/Config/useAgentConfig.test.tsx
@@ -271,6 +271,37 @@ describe("useAgentConfig", () => {
     expect(saved.approval_level).toBe("STRICT");
   });
 
+  it("handleSave syncs legacy max_iters from loop.iteration.max_iterations", async () => {
+    apiMocks.getAgentRunningConfig.mockResolvedValue(
+      makeConfig({ max_iters: 100 }),
+    );
+    const loaded = makeConfig({ max_iters: 100 });
+    const { max_iters: _staleMaxIters, ...formWithoutMaxIters } = loaded;
+    mockGetFieldsValue.mockReturnValue({
+      ...formWithoutMaxIters,
+      loop: {
+        ...loaded.loop,
+        iteration: {
+          enabled: true,
+          max_iterations: 99,
+        },
+      },
+    });
+    apiMocks.updateAgentRunningConfig.mockResolvedValue(makeConfig());
+    const { result } = renderConfigHook();
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    const saved = apiMocks.updateAgentRunningConfig.mock.calls[0][0] as Config;
+    expect(saved.loop.iteration?.max_iterations).toBe(99);
+    expect(saved.max_iters).toBe(99);
+  });
+
   it("handleSave includes unmounted custom loop template values", async () => {
     const customMode = {
       id: "quality",

--- a/console/src/pages/Agent/Config/useAgentConfig.tsx
+++ b/console/src/pages/Agent/Config/useAgentConfig.tsx
@@ -168,6 +168,9 @@ export function useAgentConfig() {
           formValues.auto_title_config,
         ) as typeof original.auto_title_config,
         approval_level: approvalLevel,
+        // Keep legacy max_iters aligned with the UI-bound iteration limit.
+        max_iters:
+          formValues.loop?.iteration?.max_iterations ?? original.max_iters,
       };
 
       await api.updateAgentRunningConfig(configToSave);


### PR DESCRIPTION
## Description

Fix Console Agent running-config save so the legacy `max_iters` field stays in sync with the UI-bound `loop.iteration.max_iterations`.

After the Loop Engineering migration, the iteration limit input writes `loop.iteration.max_iterations`, but `handleSave` kept the original `max_iters` (commonly `100`) in the PUT payload. Runtime already prefers the new field via `resolve_max_iterations`, so agent behavior could be correct while Network inspection and config consistency looked broken.

This PR syncs `max_iters` from `loop.iteration.max_iterations` on save and adds a regression test.

**Security Considerations:** N/A — no auth, channel, or env/config secret handling changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --files console/src/pages/Agent/Config/useAgentConfig.tsx console/src/pages/Agent/Config/useAgentConfig.test.tsx` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`npm test -- --run src/pages/Agent/Config/useAgentConfig.test.tsx` in `console/`) and they pass
- [ ] Documentation updated (if needed)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

1. Open Console → Workspace → Running Config → Agent Loop Settings → Default → Iteration limit.
2. Change **Maximum Iterations** from `100` to `99`.
3. Click **Save**.
4. In DevTools → Network, inspect `PUT /api/workspace/running-config`.
5. Expect payload:
   - `max_iters: 99`
   - `loop.iteration.max_iterations: 99`
6. Reload the page and confirm the input still shows `99`.

Unit coverage:
```bash
cd console && npm test -- --run src/pages/Agent/Config/useAgentConfig.test.tsx
```

## Evidence

Unit test run:

```bash
cd console && npm test -- --run src/pages/Agent/Config/useAgentConfig.test.tsx

 RUN  v4.1.6 /.../console
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

pre-commit on changed files:

```bash
.venv/bin/pre-commit run --files \
  console/src/pages/Agent/Config/useAgentConfig.tsx \
  console/src/pages/Agent/Config/useAgentConfig.test.tsx

detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
# other hooks skipped (no matching files / console excluded from prettier)
```

Manual Console verification (local `qwenpaw app` on `:8088` + Vite on `:5173`):

- UI input set to `99`, then Save.
- Intercepted request body:
  - `PUT /api/workspace/running-config` → `200`
  - `max_iters: 99`
  - `loop.iteration.max_iterations: 99`
- Follow-up `GET /api/workspace/running-config` confirmed both fields persisted as `99`.

## Additional Notes

- Runtime was already reading `loop.iteration.max_iterations` first via `resolve_max_iterations`; this fix addresses payload/config consistency and the Console save path.
- `max_iters` is intentionally kept as a legacy fallback (CLI / older configs / overrides); this PR only keeps it aligned on Console save, and does not remove the field.