### PR TITLE
test(integration): fix chrome contract mismatches and add missing p-tier markers

### DIFF
--- a/tests/integration/js/service_worker_harness.mjs
+++ b/tests/integration/js/service_worker_harness.mjs
@@ -205,7 +205,7 @@ const scenarios = {
     return { observedState: response.targetCommandFact.observedState };
   },
 
-  async stale_epoch_no_reexec() {
+  async stale_received_reexecuted() {
     seedTargetReceipt({
       ...commandParams,
       state: "RECEIVED",

--- a/tests/integration/test_chrome_extension_setup.py
+++ b/tests/integration/test_chrome_extension_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -31,6 +32,8 @@ SERVICE_WORKER = Path(
 # test_chrome_routes_asgi.py
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_install_status_reports_plugin_owned_installation_state() -> None:
     app = FastAPI()
     app.include_router(api_router)
@@ -49,6 +52,8 @@ TESTS_DIR = Path("tests/integration")
 # test_chrome_setup_hygiene.py
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_uninstall_removes_config_and_extension_dir(
     tmp_path: Path,
     isolated_home: Path,

--- a/tests/integration/test_chrome_native_host_install.py
+++ b/tests/integration/test_chrome_native_host_install.py
@@ -24,6 +24,8 @@ SETUP_SOURCE = Path("plugins/bundle/chrome/extension_setup.py")
 # pylint: disable=protected-access,unused-argument
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_probe_round_trips_through_the_real_launcher(
     isolated_home: Path,
     monkeypatch,
@@ -39,6 +41,8 @@ def test_probe_round_trips_through_the_real_launcher(
     assert outcome["ok"] is True
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_broken_launcher_reports_failure_without_raising(
     tmp_path: Path,
     isolated_home: Path,
@@ -53,6 +57,8 @@ def test_broken_launcher_reports_failure_without_raising(
     assert outcome["stage"]
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_recorded_probe_failure_blocks_installed(
     isolated_home: Path,
     monkeypatch,
@@ -75,6 +81,8 @@ def test_recorded_probe_failure_blocks_installed(
     assert status["native_host_repair_instruction"]
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_successful_install_records_a_passing_probe(
     isolated_home: Path,
     monkeypatch,

--- a/tests/integration/test_chrome_nm_host.py
+++ b/tests/integration/test_chrome_nm_host.py
@@ -45,6 +45,8 @@ def _load_host() -> ModuleType:
         sys.path.pop(0)
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_two_mib_inbound_message_is_accepted() -> None:
     host = _load_host()
     payload = json.dumps(
@@ -61,6 +63,8 @@ def test_two_mib_inbound_message_is_accepted() -> None:
     assert len(message["result"]["data"]) == 2 * 1024 * 1024
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_inbound_above_protocol_limit_is_rejected() -> None:
     host = _load_host()
     oversized = host.NM_MAX_INBOUND_BYTES + 1
@@ -70,6 +74,8 @@ def test_inbound_above_protocol_limit_is_rejected() -> None:
         host.read_nm_frame(reader)
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_oversized_outbound_message_writes_nothing() -> None:
     host = _load_host()
     stdout = io.BytesIO()
@@ -83,6 +89,8 @@ def test_oversized_outbound_message_writes_nothing() -> None:
     assert stdout.getvalue() == b""
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_pump_reports_oversized_outbound_and_keeps_running() -> None:
     host = _load_host()
 
@@ -177,6 +185,8 @@ class _FailingSendWebSocket:
         raise StopAsyncIteration
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_terminate_fires_while_stdin_read_is_still_blocked(
     tmp_path: Path,
     monkeypatch,
@@ -210,6 +220,8 @@ def test_terminate_fires_while_stdin_read_is_still_blocked(
     assert calls == [(0, False)]
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_terminate_receives_1_when_a_pump_raises(
     tmp_path: Path,
     monkeypatch,
@@ -263,6 +275,8 @@ class _CoreWebSocket:
         self.closed = True
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_version_mismatch_stops_with_upgrade_advice(tmp_path: Path) -> None:
     websocket = _CoreWebSocket(
         json.dumps(
@@ -294,6 +308,8 @@ def test_version_mismatch_stops_with_upgrade_advice(tmp_path: Path) -> None:
     assert websocket.hello_messages[0]["type"] == "hello"
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_timeout_then_hello_ack_reaches_the_pipe_loop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -340,6 +356,8 @@ class _WebSocket:
         return None
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_transient_hello_failure_reconnects_and_reenters_the_pump(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -396,6 +414,8 @@ def _frame(payload: dict) -> bytes:
     return struct.pack("<I", len(raw)) + raw
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_probe_echoes_one_frame_and_exits_zero() -> None:
     completed = subprocess.run(
         [sys.executable, str(HOST), "--probe"],
@@ -476,6 +496,8 @@ def _native_message(payload: dict[str, str]) -> bytes:
     return struct.pack("<I", len(encoded)) + encoded
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_single_backend_bridge_pumps_both_directions() -> None:
     loaded_nm_host = _load_nm_host()
     stdin = _BlockingInput(_native_message({"direction": "extension-to-core"}))

--- a/tests/integration/test_chrome_nm_host.py
+++ b/tests/integration/test_chrome_nm_host.py
@@ -77,7 +77,7 @@ def test_oversized_outbound_message_writes_nothing() -> None:
     with pytest.raises(host.NativeMessageTooLargeError):
         host.write_nm_frame(
             stdout,
-            host._dumps({"id": 7, "result": "q" * 2_000_000}).encode("utf-8"),
+            json.dumps({"id": 7, "result": "q" * 2_000_000}).encode("utf-8"),
         )
 
     assert stdout.getvalue() == b""

--- a/tests/integration/test_chrome_nm_host.py
+++ b/tests/integration/test_chrome_nm_host.py
@@ -53,7 +53,9 @@ def test_two_mib_inbound_message_is_accepted() -> None:
     raw = payload.encode("utf-8")
     reader = io.BytesIO(struct.pack("<I", len(raw)) + raw)
 
-    message = host.read_nm_message(reader)
+    frame = host.read_nm_frame(reader)
+    assert frame is not None
+    message = json.loads(frame)
 
     assert message["result"]["data"].startswith("x")
     assert len(message["result"]["data"]) == 2 * 1024 * 1024
@@ -65,7 +67,7 @@ def test_inbound_above_protocol_limit_is_rejected() -> None:
     reader = io.BytesIO(struct.pack("<I", oversized))
 
     with pytest.raises(ValueError):
-        host.read_nm_message(reader)
+        host.read_nm_frame(reader)
 
 
 def test_oversized_outbound_message_writes_nothing() -> None:
@@ -73,9 +75,9 @@ def test_oversized_outbound_message_writes_nothing() -> None:
     stdout = io.BytesIO()
 
     with pytest.raises(host.NativeMessageTooLargeError):
-        host.write_nm_message(
+        host.write_nm_frame(
             stdout,
-            {"id": 7, "result": "q" * 2_000_000},
+            host._dumps({"id": 7, "result": "q" * 2_000_000}).encode("utf-8"),
         )
 
     assert stdout.getvalue() == b""
@@ -143,7 +145,7 @@ class _ClosedWebSocket:
     async def send(self, _message: str) -> None:
         return None
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         return None
 
     def __aiter__(self) -> "_ClosedWebSocket":
@@ -164,7 +166,7 @@ class _FailingSendWebSocket:
             return None
         raise RuntimeError("send failed")
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         return None
 
     def __aiter__(self) -> "_FailingSendWebSocket":
@@ -257,7 +259,7 @@ class _CoreWebSocket:
             raise self._response
         return self._response
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         self.closed = True
 
 
@@ -334,7 +336,7 @@ class _WebSocket:
     async def send(self, _message: str) -> None:
         return None
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         return None
 
 
@@ -457,7 +459,7 @@ class _FakeWebSocket:
     async def send(self, message: str) -> None:
         self.sent.append(message)
 
-    async def close(self) -> None:
+    async def close(self, **_kwargs: object) -> None:
         self.closed = True
 
     def __aiter__(self):

--- a/tests/integration/test_chrome_plugin_bundle.py
+++ b/tests/integration/test_chrome_plugin_bundle.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 # test_chrome_selfcontained_plugin.py
 
 PLUGIN = Path("plugins/bundle/chrome")
@@ -19,6 +21,8 @@ def _python_files() -> list[Path]:
     ]
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_chrome_plugin_bundle_is_self_contained() -> None:
     required = (
         "assets/extensions/chrome/manifest.json",
@@ -40,6 +44,8 @@ def test_chrome_plugin_bundle_is_self_contained() -> None:
     assert not (PLUGIN / "engine_impl.py").exists()
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_chrome_plugin_manifest_uses_standard_plugin_entries() -> None:
     manifest = json.loads((PLUGIN / "plugin.json").read_text(encoding="utf-8"))
     extension_manifest = json.loads(

--- a/tests/integration/test_chrome_service_worker.py
+++ b/tests/integration/test_chrome_service_worker.py
@@ -94,10 +94,12 @@ def test_observed_state_closed_set(case, expected) -> None:
     assert result["observedState"] == expected
 
 
-def test_stale_receipt_is_never_reexecuted() -> None:
-    result = run_scenario("stale_epoch_no_reexec")
-    assert result["executorCalls"] == 0
-    assert result["receiptState"] in {"RECEIVED", "RUNNING"}
+def test_stale_received_receipt_is_reexecuted() -> None:
+    # A stale RECEIVED receipt proves the executor never crossed the
+    # durable RUNNING barrier, so runReceiptCommand safely re-runs it.
+    result = run_scenario("stale_received_reexecuted")
+    assert result["executorCalls"] == 1
+    assert result["receiptState"] == "COMPLETED"
 
 
 # test_chrome_cdp_send_guard.py

--- a/tests/integration/test_chrome_service_worker.py
+++ b/tests/integration/test_chrome_service_worker.py
@@ -55,12 +55,16 @@ def run_scenario(name: str, **payload: object) -> dict:
     return json.loads(completed.stdout)
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_running_is_durable_before_the_executor_runs() -> None:
     result = run_scenario("execute_order")
     assert result["stateWhenExecutorRan"] == "RUNNING"
     assert result["states"] == ["RECEIVED", "RUNNING", "COMPLETED"]
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_receipts_carry_the_executor_epoch() -> None:
     first = run_scenario("epoch_present")
     second = run_scenario("epoch_present")
@@ -70,6 +74,8 @@ def test_receipts_carry_the_executor_epoch() -> None:
     )
 
 
+@pytest.mark.integration
+@pytest.mark.p2
 def test_status_query_writes_nothing_and_keeps_the_target() -> None:
     result = run_scenario("status_pure_read", queries=300)
     assert result["storageSetCalls"] == 0
@@ -89,11 +95,15 @@ def test_status_query_writes_nothing_and_keeps_the_target() -> None:
         ("absent", "UNKNOWN"),
     ],
 )
+@pytest.mark.integration
+@pytest.mark.p1
 def test_observed_state_closed_set(case, expected) -> None:
     result = run_scenario("observed_states", case=case)
     assert result["observedState"] == expected
 
 
+@pytest.mark.integration
+@pytest.mark.p1
 def test_stale_received_receipt_is_reexecuted() -> None:
     # A stale RECEIVED receipt proves the executor never crossed the
     # durable RUNNING barrier, so runReceiptCommand safely re-runs it.

--- a/tests/integration/test_coding_project.py
+++ b/tests/integration/test_coding_project.py
@@ -32,6 +32,7 @@ No LLM / external network deps required.
 from __future__ import annotations
 
 import io
+import shutil
 import zipfile
 from pathlib import Path
 
@@ -174,15 +175,17 @@ def test_import_local_copies_source(app_server) -> None:
     """POST /import-local copies a real source dir into the project.
 
     Test flow:
-      1. Seed a source dir (under working_dir) with a marker file.
+      1. Seed a source dir (under home, required by #6487) with a marker.
       2. POST /import-local {path, name} -> 200 {path, name}.
       3. The marker file exists inside the imported project dir.
-      4. finally: reset to default.
+      4. finally: remove the seeded source + reset to default.
 
     API endpoints:
       - POST /api/workspace/coding-project/import-local
     """
-    src = app_server.working_dir / "integ-cp-import-src"
+    # Upstream #6487 requires the import source to live under the user's
+    # home directory, so a pytest tmp working dir cannot be used here.
+    src = Path.home() / ".qwenpaw-integ-cp-import-src"
     src.mkdir(parents=True, exist_ok=True)
     (src / "marker.txt").write_text("imported\n", encoding="utf-8")
     name = "integ-cp-import-C"
@@ -197,6 +200,7 @@ def test_import_local_copies_source(app_server) -> None:
         dest = Path(resp.json()["path"])
         assert (dest / "marker.txt").is_file(), resp.json()
     finally:
+        shutil.rmtree(src, ignore_errors=True)
         _reset_project(app_server)
 
 

--- a/tests/integration/test_driver_mcp_approval_level_policy.py
+++ b/tests/integration/test_driver_mcp_approval_level_policy.py
@@ -74,6 +74,8 @@ async def _next_pending_request(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_driver_mcp_policy_deny_blocks_client_call(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -101,6 +103,8 @@ async def test_driver_mcp_policy_deny_blocks_client_call(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_mcp_policy_update_applies_without_transport_reload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -182,6 +186,8 @@ async def test_mcp_policy_update_applies_without_transport_reload(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_mcp_policy_updates_serialize_persistence_and_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -256,6 +262,8 @@ async def test_mcp_policy_updates_serialize_persistence_and_runtime(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_manual_policy_edit_applies_without_transport_reload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -313,6 +321,8 @@ async def test_manual_policy_edit_applies_without_transport_reload(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_manual_endpoint_edit_reloads_transport(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -351,6 +361,8 @@ async def test_manual_endpoint_edit_reloads_transport(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_driver_mcp_policy_ask_approve_resumes_client_call(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -400,6 +412,8 @@ async def test_driver_mcp_policy_ask_approve_resumes_client_call(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_driver_mcp_policy_ask_session_off_auto_allows_no_persist(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -450,6 +464,8 @@ async def test_driver_mcp_policy_ask_session_off_auto_allows_no_persist(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_driver_mcp_policy_ask_agent_off_auto_allows_no_persist(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -513,6 +529,8 @@ async def test_driver_mcp_policy_ask_agent_off_auto_allows_no_persist(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_driver_mcp_policy_ask_agent_auto_requires_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -561,6 +579,8 @@ async def test_driver_mcp_policy_ask_agent_auto_requires_approval(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_driver_mcp_policy_ask_active_agent_off_auto_allows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -623,6 +643,8 @@ async def test_driver_mcp_policy_ask_active_agent_off_auto_allows(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_driver_mcp_policy_deny_still_blocks_when_session_off(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -651,6 +673,8 @@ async def test_driver_mcp_policy_deny_still_blocks_when_session_off(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_driver_mcp_policy_allow_session_strict_requires_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_driver_mcp_env_ref_flow.py
+++ b/tests/integration/test_driver_mcp_env_ref_flow.py
@@ -13,6 +13,8 @@ from tests.integration.driver_mcp_fakes import patch_mcp_runtime_clients
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_env_ref_header_resolves_from_environment_at_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_driver_mcp_http_flow.py
+++ b/tests/integration/test_driver_mcp_http_flow.py
@@ -17,6 +17,8 @@ from tests.integration.driver_mcp_fakes import (
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_driver_mcp_http_header_secret_flow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_driver_mcp_oauth_flow.py
+++ b/tests/integration/test_driver_mcp_oauth_flow.py
@@ -17,6 +17,8 @@ from tests.integration.driver_mcp_fakes import (
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_driver_mcp_oauth_access_token_flow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -70,6 +72,8 @@ async def test_driver_mcp_oauth_access_token_flow(
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p2
 async def test_driver_mcp_http_combines_oauth_and_static_credentials(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_driver_mcp_stdio_flow.py
+++ b/tests/integration/test_driver_mcp_stdio_flow.py
@@ -17,6 +17,8 @@ from tests.integration.driver_mcp_fakes import (
 
 
 @pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.p1
 async def test_driver_mcp_stdio_env_secret_flow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_driver_workspace_lifecycle.py
+++ b/tests/integration/test_driver_workspace_lifecycle.py
@@ -31,6 +31,7 @@ async def _active_driver_names(manager) -> list[str]:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.p1
 async def test_driver_manager_uses_per_workspace_storage(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem 1 — the PR gate has a coverage hole (root cause)

`tests/conftest.py` auto-marks everything under `tests/integration/` as
`integration`, but **never assigns a p-tier**. The gates are:

| Trigger | Marker expression |
|---|---|
| pull_request | `-m "integration and p0"` |
| push / pre-merge | `-m "integration and (p0 or p1)"` |
| nightly | `-m integration` |

**42 cases across 11 files carry no p-tier marker**, so both the PR gate and
the pre-merge gate silently deselect all of them. Only the nightly full sweep
ever executes them.

Reproduced:

```console
$ pytest tests/integration/test_chrome_nm_host.py -m "integration and p0" --collect-only
no tests collected (11 deselected)
```

**This is how the contract mismatches below shipped through a fully green PR
gate — those cases were never collected.**

## Problem 2 — four groups assert against APIs/behavior that never matched

All are test-side defects; the product code is correct in each case.

### `test_chrome_nm_host.py`
- `nm_host.py` exposes `read_nm_frame` / `write_nm_frame` (raw length-prefixed
  bytes) at L128/L144. The tests called `read_nm_message` / `write_nm_message`,
  which have never existed in the product's history →
  `AttributeError: ... Did you mean: 'read_nm_frame'?`
- Five fake WebSocket stand-ins declared `async def close(self)`, but the host
  closes with `close(code=..., reason=...)` at L372, matching the real library
  (`websockets` 16.0: `close(self, code=1000, reason='')`) →
  `TypeError: unexpected keyword argument 'code'`. The exit-code assertion in
  `test_terminate_fires_while_stdin_read_is_still_blocked` was collateral from
  this and recovers once the stubs accept the kwargs.

### `test_coding_project.py::test_import_local_copies_source`
- #6487 added `_validate_import_source`, which returns **403** for any source
  outside the user's home directory. The test seeded its source under a pytest
  tmp dir, so it got 403 instead of 200. Now seeded under `Path.home()` and
  removed in `finally`.

### `test_chrome_service_worker.py`
- `test_stale_receipt_is_never_reexecuted` required `executorCalls == 0`, but
  `runReceiptCommand` (service_worker.js L789-796) deliberately **re-executes**
  a stale `RECEIVED` receipt: that state is proof the executor never crossed
  the durable RUNNING barrier, so it is safe to run. RUNNING is the
  non-retriable one.
- The same file already agreed with the product elsewhere:
  `test_observed_state_closed_set` maps `received_stale_epoch -> NOT_STARTED`
  and passes. If it is NOT_STARTED, re-running is correct.
- Renamed the test and the harness scenario to state the real contract.

## Changes

1. Use the real `read_nm_frame` / `write_nm_frame`; JSON encode/decode in the
   test. Fakes accept `code` / `reason`.
2. Seed the import-local source under `Path.home()`.
3. Assert stale-RECEIVED re-execution; rename test + harness scenario.
4. Add `p1` / `p2` markers to all 42 unmarked cases (P1 = secondary flows and
   key guards, P2 = boundary conditions). None sit on the core chat path, so no
   new P0. Two chrome modules also needed a `pytest` import for the decorators.

Gate coverage for these files under `p0 or p1`: **0 -> 30 of 48**.

## Test plan
- [x] chrome suite (5 files): 30 passed
- [x] driver + coding-project (7 files): 29 passed
- [x] `pylint` with the repo's CI disable list: 10.00/10
- [x] `pre-commit` on changed files: green
- [x] Fork CI: pre-commit, Unit x4, Contract x4, Integrated x4, Coverage — all pass
- [x] Fork nightly: these cases pass on all platforms; the only remaining
      failures are the 7 `browser/*` cases (see below)

## Out of scope
- `tests/integration/browser/*` (7 cases) fail with
  `BrowserType.launch: Executable doesn't exist ... Please run playwright install`
  — the nightly Integration job has no `playwright install` step. Infrastructure
  fix, tracked separately.
- `test_acp_runner.py::test_acp_close_after_start` fails intermittently on
  Windows only: `os.replace` raises `PermissionError [WinError 5]` on
  `jobs.json` in `write_text_atomic`, racing the config watcher. Product-side
  atomic-write issue on Windows.