### PR TITLE
fix(plugins): isolate bare absolute imports per plugin namespace (fixes #6683)

### DIFF
--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -23,6 +23,11 @@ from packaging.requirements import Requirement
 
 from .architecture import PluginManifest, PluginRecord
 from .api import PluginApi
+from .module_isolation import (
+    build_plugin_builtins,
+    get_namespace_finder,
+    unregister_namespace,
+)
 from .registry import PluginRegistry
 
 logger = logging.getLogger(__name__)
@@ -509,11 +514,18 @@ class PluginLoader:
         """
         module_name = f"plugin_{plugin_id.replace('-', '_')}"
         plugin_dir_str = str(source_path)
+        # Plugins with a nested entry (e.g. ``backend/main.py``) resolve
+        # their bare imports against the entry file's directory, so it
+        # must be searchable alongside the plugin root.
+        entry_dir_str = str(backend_entry_file.parent)
+        search_paths = [plugin_dir_str]
+        if _norm_realpath(entry_dir_str) != _norm_realpath(plugin_dir_str):
+            search_paths.append(entry_dir_str)
 
         spec = importlib.util.spec_from_file_location(
             module_name,
             backend_entry_file,
-            submodule_search_locations=[plugin_dir_str],
+            submodule_search_locations=search_paths,
         )
         if spec is None or spec.loader is None:
             raise ImportError(
@@ -522,10 +534,17 @@ class PluginLoader:
 
         module = importlib.util.module_from_spec(spec)
 
+        # Redirect the plugin's bare absolute imports (``import utils``)
+        # into its private ``plugin_<id>`` namespace so plugins cannot
+        # collide with each other's top-level module names (#6683).
+        plugin_builtins = build_plugin_builtins(module_name, search_paths)
+        module.__dict__["__builtins__"] = plugin_builtins
+        get_namespace_finder().register(module_name, plugin_builtins)
+
         try:
             sys.modules[module_name] = module
             module.__package__ = module_name
-            module.__path__ = [plugin_dir_str]
+            module.__path__ = search_paths
             spec.loader.exec_module(module)
 
             plugin_def = getattr(module, "plugin", None)
@@ -601,6 +620,9 @@ class PluginLoader:
             "Cleaning up failed plugin load for '%s'",
             plugin_id,
         )
+
+        # 0. Import redirection for the plugin's private namespace
+        unregister_namespace(module_name)
 
         # 1. Registry (manifest, providers, hooks, middleware, routes, …)
         self.registry.unregister_plugin(plugin_id)
@@ -1264,6 +1286,7 @@ class PluginLoader:
         # Remove Python module and all sub-modules so the next import
         # gets a fresh copy (e.g. plugin_foo.utils must not be reused).
         module_name = f"plugin_{plugin_id.replace('-', '_')}"
+        unregister_namespace(module_name)
         prefix = module_name + "."
         stale = [
             k for k in sys.modules if k == module_name or k.startswith(prefix)

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -27,6 +27,7 @@ from .module_isolation import (
     build_plugin_builtins,
     get_namespace_finder,
     strip_plugin_sys_path,
+    sweep_bare_tree_modules,
     unregister_namespace,
 )
 from .registry import PluginRegistry
@@ -614,6 +615,11 @@ class PluginLoader:
             # Shared dependency locations (plugin site dir) are
             # untouched — only paths under the plugin's own tree go.
             strip_plugin_sys_path(source_path)
+            # sys.modules is the other residue channel: a bypass import
+            # or a data-directory fallthrough during load can cache a
+            # bare name rooted in this plugin's tree, which would keep
+            # serving later plugins even with sys.path clean.
+            sweep_bare_tree_modules(source_path)
 
         return plugin_def
 
@@ -652,27 +658,17 @@ class PluginLoader:
         for k in stale:
             sys.modules.pop(k, None)
 
-        # 3. sys.modules — by __file__ path (catches bare imports that
-        #    bypassed the plugin_<id> namespace, e.g. ``import utils``
-        #    after the plugin inserted its dir into sys.path).
-        source_resolved = _norm_realpath(source_path)
-        if not source_resolved.endswith(os.sep):
-            source_resolved = source_resolved + os.sep
-        stale_by_file = [
-            k
-            for k, mod in list(sys.modules.items())
-            if (mod_file := getattr(mod, "__file__", None)) is not None
-            and _norm_realpath(mod_file).startswith(source_resolved)
-        ]
-        for k in stale_by_file:
-            sys.modules.pop(k, None)
-
-        # 4. Import redirection — after the sys.modules sweeps, so a
+        # 3. Import redirection — after the sys.modules sweep, so a
         #    concurrent lazy import cannot resolve a plugin submodule
         #    without the plugin builtins in the window between the two.
+        #    Bare (non-namespaced) residue is swept by the caller's
+        #    finally, AFTER strip_plugin_sys_path — sweeping while the
+        #    plugin's sys.path entries are still present could merge
+        #    plugin-tree portions into a shared namespace package's
+        #    __path__ recalculation and evict a host package.
         unregister_namespace(module_name)
 
-        # 5. sys.path — remove the plugin directory and its subdirs
+        # 4. sys.path — remove the plugin directory and its subdirs
         strip_plugin_sys_path(source_path)
 
     async def load_plugin(
@@ -1312,35 +1308,25 @@ class PluginLoader:
         for k in stale:
             sys.modules.pop(k, None)
 
-        # Plugins that manipulate ``sys.path`` (e.g. inserting their own
-        # directory) and use bare ``from sibling import …`` load sibling
-        # modules as top-level entries in ``sys.modules`` — the prefix
-        # cleanup above misses them.  Sweep any module whose ``__file__``
-        # lives inside the plugin directory so a reinstall always gets
-        # fresh code.  Use normcase so Windows drive/dir letter case
-        # differences do not leave stale modules behind.
-        source_resolved = _norm_realpath(record.source_path)
-        if not source_resolved.endswith(os.sep):
-            source_resolved = source_resolved + os.sep
-        stale_by_file = [
-            k
-            for k, mod in list(sys.modules.items())
-            if (mod_file := getattr(mod, "__file__", None)) is not None
-            and _norm_realpath(mod_file).startswith(source_resolved)
-        ]
-        for k in stale_by_file:
-            sys.modules.pop(k, None)
+        # Remove the plugin directory and its subdirectories from
+        # sys.path BEFORE the location-based sweep below: a namespace
+        # package's __path__ recalculation reads the live sys.path, and
+        # sweeping while the plugin's entries are still present could
+        # merge plugin-tree portions into a shared host package's
+        # portions and evict it.
+        strip_plugin_sys_path(record.source_path)
+
+        # Bypass imports (e.g. importlib.import_module after the plugin
+        # inserted its dir into sys.path) land as top-level entries in
+        # ``sys.modules`` — the prefix cleanup above misses them.
+        # Sweep by module location (including __file__-less namespace
+        # packages) so a reinstall always gets fresh code.
+        sweep_bare_tree_modules(record.source_path)
 
         # Drop the import redirection after the sys.modules sweeps, so
         # a concurrent lazy import cannot resolve a plugin submodule
         # without the plugin builtins in the window between the two.
         unregister_namespace(module_name)
-
-        # Remove the plugin directory and its subdirectories from
-        # sys.path (plugins add these at import time for sibling
-        # imports; leaving them leaks into later imports and prevents
-        # clean hot-reload).
-        strip_plugin_sys_path(record.source_path)
 
         # Remove tools from agents.tools + runtime registries while
         # ownership records still exist, then drop plugin registry state.

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -26,6 +26,7 @@ from .api import PluginApi
 from .module_isolation import (
     build_plugin_builtins,
     get_namespace_finder,
+    strip_plugin_sys_path,
     unregister_namespace,
 )
 from .registry import PluginRegistry
@@ -659,16 +660,8 @@ class PluginLoader:
         #    without the plugin builtins in the window between the two.
         unregister_namespace(module_name)
 
-        # 5. sys.path — remove the plugin directory and any of its
-        #    subdirectories (nested-entry plugins insert e.g. backend/)
-        plugin_dir_real = _norm_realpath(source_path)
-        plugin_dir_prefix = plugin_dir_real + os.sep
-        sys.path[:] = [
-            p
-            for p in sys.path
-            if _norm_realpath(p) != plugin_dir_real
-            and not _norm_realpath(p).startswith(plugin_dir_prefix)
-        ]
+        # 5. sys.path — remove the plugin directory and its subdirs
+        strip_plugin_sys_path(source_path)
 
     async def load_plugin(
         self,
@@ -1331,19 +1324,11 @@ class PluginLoader:
         # without the plugin builtins in the window between the two.
         unregister_namespace(module_name)
 
-        # Remove the plugin directory — and any of its subdirectories,
-        # e.g. the backend/ dir nested-entry plugins insert — from
+        # Remove the plugin directory and its subdirectories from
         # sys.path (plugins add these at import time for sibling
         # imports; leaving them leaks into later imports and prevents
         # clean hot-reload).
-        plugin_dir_real = _norm_realpath(record.source_path)
-        plugin_dir_prefix = plugin_dir_real + os.sep
-        sys.path[:] = [
-            p
-            for p in sys.path
-            if _norm_realpath(p) != plugin_dir_real
-            and not _norm_realpath(p).startswith(plugin_dir_prefix)
-        ]
+        strip_plugin_sys_path(record.source_path)
 
         # Remove tools from agents.tools + runtime registries while
         # ownership records still exist, then drop plugin registry state.

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -516,11 +516,14 @@ class PluginLoader:
         plugin_dir_str = str(source_path)
         # Plugins with a nested entry (e.g. ``backend/main.py``) resolve
         # their bare imports against the entry file's directory, so it
-        # must be searchable alongside the plugin root.
+        # must be searchable alongside the plugin root.  The entry
+        # directory comes first: nested-entry plugins put it at
+        # ``sys.path[0]``, so it must win over a same-named module in
+        # the plugin root.
         entry_dir_str = str(backend_entry_file.parent)
-        search_paths = [plugin_dir_str]
+        search_paths = [entry_dir_str]
         if _norm_realpath(entry_dir_str) != _norm_realpath(plugin_dir_str):
-            search_paths.append(entry_dir_str)
+            search_paths.append(plugin_dir_str)
 
         spec = importlib.util.spec_from_file_location(
             module_name,

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -540,7 +540,11 @@ class PluginLoader:
         # Redirect the plugin's bare absolute imports (``import utils``)
         # into its private ``plugin_<id>`` namespace so plugins cannot
         # collide with each other's top-level module names (#6683).
-        plugin_builtins = build_plugin_builtins(module_name, search_paths)
+        plugin_builtins = build_plugin_builtins(
+            module_name,
+            search_paths,
+            entry_file=backend_entry_file,
+        )
         module.__dict__["__builtins__"] = plugin_builtins
         get_namespace_finder().register(module_name, plugin_builtins)
 
@@ -624,9 +628,6 @@ class PluginLoader:
             plugin_id,
         )
 
-        # 0. Import redirection for the plugin's private namespace
-        unregister_namespace(module_name)
-
         # 1. Registry (manifest, providers, hooks, middleware, routes, …)
         self.registry.unregister_plugin(plugin_id)
 
@@ -653,10 +654,20 @@ class PluginLoader:
         for k in stale_by_file:
             sys.modules.pop(k, None)
 
-        # 4. sys.path — remove the plugin directory if it was added
+        # 4. Import redirection — after the sys.modules sweeps, so a
+        #    concurrent lazy import cannot resolve a plugin submodule
+        #    without the plugin builtins in the window between the two.
+        unregister_namespace(module_name)
+
+        # 5. sys.path — remove the plugin directory and any of its
+        #    subdirectories (nested-entry plugins insert e.g. backend/)
         plugin_dir_real = _norm_realpath(source_path)
+        plugin_dir_prefix = plugin_dir_real + os.sep
         sys.path[:] = [
-            p for p in sys.path if _norm_realpath(p) != plugin_dir_real
+            p
+            for p in sys.path
+            if _norm_realpath(p) != plugin_dir_real
+            and not _norm_realpath(p).startswith(plugin_dir_prefix)
         ]
 
     async def load_plugin(
@@ -1289,7 +1300,6 @@ class PluginLoader:
         # Remove Python module and all sub-modules so the next import
         # gets a fresh copy (e.g. plugin_foo.utils must not be reused).
         module_name = f"plugin_{plugin_id.replace('-', '_')}"
-        unregister_namespace(module_name)
         prefix = module_name + "."
         stale = [
             k for k in sys.modules if k == module_name or k.startswith(prefix)
@@ -1316,12 +1326,23 @@ class PluginLoader:
         for k in stale_by_file:
             sys.modules.pop(k, None)
 
-        # Remove the plugin directory from sys.path (plugins add it at
-        # import time for sibling imports; leaving it leaks into later
-        # imports and prevents clean hot-reload).
+        # Drop the import redirection after the sys.modules sweeps, so
+        # a concurrent lazy import cannot resolve a plugin submodule
+        # without the plugin builtins in the window between the two.
+        unregister_namespace(module_name)
+
+        # Remove the plugin directory — and any of its subdirectories,
+        # e.g. the backend/ dir nested-entry plugins insert — from
+        # sys.path (plugins add these at import time for sibling
+        # imports; leaving them leaks into later imports and prevents
+        # clean hot-reload).
         plugin_dir_real = _norm_realpath(record.source_path)
+        plugin_dir_prefix = plugin_dir_real + os.sep
         sys.path[:] = [
-            p for p in sys.path if _norm_realpath(p) != plugin_dir_real
+            p
+            for p in sys.path
+            if _norm_realpath(p) != plugin_dir_real
+            and not _norm_realpath(p).startswith(plugin_dir_prefix)
         ]
 
         # Remove tools from agents.tools + runtime registries while

--- a/src/qwenpaw/plugins/loader.py
+++ b/src/qwenpaw/plugins/loader.py
@@ -602,6 +602,18 @@ class PluginLoader:
                 source_path,
             )
             raise
+        finally:
+            # A loaded plugin no longer needs the sys.path entries it
+            # inserted: its bare imports resolve through the private
+            # namespace (search_paths), not sys.path.  Sweeping here —
+            # on success, failure, AND BaseException (a cancelled
+            # startup) — keeps other plugins' non-local fallthrough
+            # imports from ever resolving into this plugin's source
+            # tree (data-dir fallthrough, uncached stdlib names, or
+            # plain bare imports would otherwise pick up the residue).
+            # Shared dependency locations (plugin site dir) are
+            # untouched — only paths under the plugin's own tree go.
+            strip_plugin_sys_path(source_path)
 
         return plugin_def
 

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -148,6 +148,22 @@ def _norm(path: Any) -> str:
     return os.path.normcase(os.path.realpath(str(path)))
 
 
+_CODE_SUFFIXES = tuple(importlib.machinery.all_suffixes())
+
+
+def _has_importable_code(portions: List[str]) -> bool:
+    """True if any directory portion contains importable code.
+
+    Walks recursively (short-circuiting on the first hit) so a PEP 420
+    package whose code lives only in nested subpackages still counts.
+    """
+    for portion in portions:
+        for _dirpath, _dirnames, filenames in os.walk(portion):
+            if any(f.endswith(_CODE_SUFFIXES) for f in filenames):
+                return True
+    return False
+
+
 def build_plugin_builtins(
     module_name: str,
     search_paths: List[str],
@@ -174,15 +190,17 @@ def build_plugin_builtins(
                 search_paths,
             )
             # A namespace-package portion (loader is None) needs a
-            # tie-break mirroring the real machinery: a plain data
-            # directory (``locale/`` assets) loses to a concrete module
-            # elsewhere on sys.path (the stdlib ``locale`` must win),
-            # but a genuine PEP 420 namespace package the plugin ships
-            # stays plugin-local — sending it to the global namespace
-            # would reopen the cross-plugin collision (#6683).
+            # tie-break: a genuine PEP 420 package the plugin ships
+            # stays plugin-local, but a plain data directory
+            # (``locale/`` assets) must fall through so a concrete
+            # stdlib/third-party module can win.  Decide purely from
+            # the plugin's own files — probing sys.path here would
+            # couple the decision to sys.path entries left behind by
+            # earlier plugins, reopening the cross-plugin collision
+            # this module exists to fix (#6683).
             if spec is not None and spec.loader is None:
-                resolved = importlib.machinery.PathFinder.find_spec(top)
-                if resolved is None or resolved.loader is not None:
+                portions = list(spec.submodule_search_locations or [])
+                if not _has_importable_code(portions):
                     spec = None
             spec_cache[top] = spec
         return spec_cache[top]

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -38,6 +38,11 @@ Known limitations (documented, not silently broken):
   not visible inside plugin modules.
 - Objects pickled with a ``plugin_<id>.…`` ``__module__`` are only
   unpicklable in a process where that plugin is loaded.
+- The local/non-local decision per bare top-level name is cached for
+  the plugin's lifetime; code generated into the plugin directory at
+  runtime after a name was first probed resolves globally.  Extension
+  modules only count as plugin code when importable by the current
+  interpreter (a vendored wrong-ABI ``.so`` reads as data).
 """
 
 import builtins
@@ -75,7 +80,13 @@ class _NamespaceLoader:
         self._wrapped.exec_module(module)
 
     def __getattr__(self, name: str) -> Any:
-        return getattr(self._wrapped, name)
+        # Read via __dict__: on an instance created without __init__
+        # (e.g. cls.__new__ during copy) a plain self._wrapped access
+        # would re-enter __getattr__ and recurse forever.
+        wrapped = self.__dict__.get("_wrapped")
+        if wrapped is None:
+            raise AttributeError(name)
+        return getattr(wrapped, name)
 
 
 class PluginNamespaceFinder(importlib.abc.MetaPathFinder):
@@ -148,6 +159,27 @@ def _norm(path: Any) -> str:
     return os.path.normcase(os.path.realpath(str(path)))
 
 
+def strip_plugin_sys_path(source_path: Any) -> None:
+    """Remove *source_path* and its subdirectories from ``sys.path``.
+
+    Nested-entry plugins insert e.g. their ``backend/`` dir, so subpaths
+    must go too.  Relative entries (``''`` — the CWD — and any other
+    non-absolute path) are never touched: resolving them depends on the
+    CWD at sweep time, so stripping them could remove entries that
+    belong to the process, not the plugin.
+    """
+    root = _norm(source_path)
+    prefix = root + os.sep
+
+    def _keep(entry: str) -> bool:
+        if not os.path.isabs(entry):
+            return True
+        resolved = _norm(entry)
+        return resolved != root and not resolved.startswith(prefix)
+
+    sys.path[:] = [p for p in sys.path if _keep(p)]
+
+
 _CODE_SUFFIXES = tuple(importlib.machinery.all_suffixes())
 
 
@@ -156,11 +188,21 @@ def _has_importable_code(portions: List[str]) -> bool:
 
     Walks recursively (short-circuiting on the first hit) so a PEP 420
     package whose code lives only in nested subpackages still counts.
+    Only paths reachable through valid-identifier components count — a
+    file like ``locale/en_US.UTF-8/tool.py`` cannot be imported as a
+    module, so it must not make a data directory look like a package.
+    The pruning also keeps the walk cheap on large asset trees.
     """
     for portion in portions:
-        for _dirpath, _dirnames, filenames in os.walk(portion):
-            if any(f.endswith(_CODE_SUFFIXES) for f in filenames):
-                return True
+        for _dirpath, dirnames, filenames in os.walk(portion):
+            dirnames[:] = [d for d in dirnames if d.isidentifier()]
+            for filename in filenames:
+                for suffix in _CODE_SUFFIXES:
+                    if (
+                        filename.endswith(suffix)
+                        and filename[: -len(suffix)].isidentifier()
+                    ):
+                        return True
     return False
 
 
@@ -227,6 +269,16 @@ def build_plugin_builtins(
                     # alias the running entry module instead of
                     # executing the file a second time (which would
                     # duplicate module-level state and side effects).
+                    # With a fromlist, delegate so submodules named in
+                    # it are imported, mirroring _handle_fromlist.
+                    if fromlist:
+                        return builtins.__import__(
+                            module_name,
+                            globals,
+                            locals,
+                            fromlist,
+                            0,
+                        )
                     return sys.modules[module_name]
                 full = f"{module_name}.{name}"
                 if fromlist:

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""Per-plugin import isolation for bare absolute imports.
+
+Each plugin backend executes under a private top-level namespace
+(``plugin_<id>``).  Relative imports already stay inside it, but many
+plugins use *bare absolute* imports for their own files (``import
+utils`` / ``from utils.env import x``), which the default machinery
+resolves into the process-wide top-level namespace: the first plugin to
+claim a common name (``utils``, ``models``, ``router``, …) wins, and
+every plugin loaded afterwards silently receives that module instead of
+its own (#6683).
+
+This module redirects such imports back into the plugin's namespace:
+
+- :func:`build_plugin_builtins` returns a ``__builtins__`` mapping whose
+  ``__import__`` resolves a bare top-level name against the plugin's own
+  directories first and, when found there, imports it as
+  ``plugin_<id>.<name>``.
+- :class:`PluginNamespaceFinder` (a ``sys.meta_path`` hook) makes every
+  module imported under ``plugin_<id>.`` execute with that same
+  ``__builtins__``, so nested and lazy (function-level) bare imports
+  stay namespaced too.
+
+Names not present in the plugin's directories fall through to the
+regular import machinery, so stdlib and third-party imports behave
+exactly as before.
+"""
+
+import builtins
+import importlib
+import importlib.abc
+import importlib.machinery
+import sys
+import threading
+from typing import Any, Dict, List, Optional
+
+
+class _NamespaceLoader(importlib.abc.Loader):
+    """Wrap a real loader so the module executes with plugin builtins."""
+
+    def __init__(
+        self,
+        wrapped: importlib.abc.Loader,
+        plugin_builtins: Dict[str, Any],
+    ) -> None:
+        self._wrapped = wrapped
+        self._builtins = plugin_builtins
+
+    def create_module(self, spec: Any) -> Any:
+        return self._wrapped.create_module(spec)
+
+    def exec_module(self, module: Any) -> None:
+        module.__dict__["__builtins__"] = self._builtins
+        self._wrapped.exec_module(module)
+
+
+class PluginNamespaceFinder(importlib.abc.MetaPathFinder):
+    """Meta-path finder active only for registered ``plugin_<id>.*`` names.
+
+    Returns ``None`` for every other import, so it is inert for the rest
+    of the process.
+    """
+
+    def __init__(self) -> None:
+        self._namespaces: Dict[str, Dict[str, Any]] = {}
+
+    def register(
+        self,
+        module_name: str,
+        plugin_builtins: Dict[str, Any],
+    ) -> None:
+        self._namespaces[module_name] = plugin_builtins
+
+    def unregister(self, module_name: str) -> None:
+        self._namespaces.pop(module_name, None)
+
+    def is_registered(self, module_name: str) -> bool:
+        return module_name in self._namespaces
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Any = None,
+        target: Any = None,  # pylint: disable=unused-argument
+    ) -> Optional[importlib.machinery.ModuleSpec]:
+        root, sep, _ = fullname.partition(".")
+        if not sep:
+            # The entry module itself is loaded explicitly by the caller.
+            return None
+        plugin_builtins = self._namespaces.get(root)
+        if plugin_builtins is None:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if spec is None:
+            return None
+        if spec.loader is not None:
+            spec.loader = _NamespaceLoader(spec.loader, plugin_builtins)
+        return spec
+
+
+_finder_lock = threading.Lock()
+_finder: Optional[PluginNamespaceFinder] = None
+
+
+def get_namespace_finder() -> PluginNamespaceFinder:
+    """Return the process-wide finder, installing it on first use."""
+    global _finder
+    with _finder_lock:
+        if _finder is None:
+            _finder = PluginNamespaceFinder()
+            sys.meta_path.insert(0, _finder)
+        return _finder
+
+
+def unregister_namespace(module_name: str) -> None:
+    """Remove *module_name* from the finder (no-op if never installed)."""
+    if _finder is not None:
+        _finder.unregister(module_name)
+
+
+def build_plugin_builtins(
+    module_name: str,
+    search_paths: List[str],
+) -> Dict[str, Any]:
+    """Builtins mapping with a plugin-aware ``__import__``.
+
+    Bare top-level imports whose name exists under *search_paths* (the
+    plugin's own directories) are imported as ``<module_name>.<name>``;
+    everything else falls through to the regular machinery.
+    """
+    local_cache: Dict[str, bool] = {}
+
+    def _is_local(top: str) -> bool:
+        found = local_cache.get(top)
+        if found is None:
+            found = (
+                importlib.machinery.PathFinder.find_spec(top, search_paths)
+                is not None
+            )
+            local_cache[top] = found
+        return found
+
+    def _plugin_import(
+        name: str,
+        globals: Any = None,  # pylint: disable=redefined-builtin
+        locals: Any = None,  # pylint: disable=redefined-builtin
+        fromlist: Any = (),
+        level: int = 0,
+    ) -> Any:
+        if level == 0 and name:
+            top = name.partition(".")[0]
+            if top != module_name and _is_local(top):
+                full = f"{module_name}.{name}"
+                if fromlist:
+                    return builtins.__import__(
+                        full,
+                        globals,
+                        locals,
+                        fromlist,
+                        0,
+                    )
+                builtins.__import__(full, globals, locals, (), 0)
+                # ``import utils.env`` binds the name ``utils`` — return
+                # the namespaced top package, mirroring the default
+                # machinery's contract.
+                return sys.modules[f"{module_name}.{top}"]
+        return builtins.__import__(name, globals, locals, fromlist, level)
+
+    plugin_builtins = dict(vars(builtins))
+    plugin_builtins["__import__"] = _plugin_import
+    return plugin_builtins

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -28,11 +28,14 @@ exactly as before.
 Known limitations (documented, not silently broken):
 
 - Only the ``import`` statement is redirected.  Dynamic imports via
-  ``importlib.import_module("utils")`` bypass ``__import__`` and still
-  resolve in the global top-level namespace.
+  ``importlib.import_module("utils")`` bypass ``__import__``; since a
+  plugin's inserted ``sys.path`` entries are swept once its load
+  finishes, such calls raise ``ModuleNotFoundError`` after load
+  instead of resolving globally.
 - Directories a plugin adds to ``sys.path`` itself (e.g. a vendored
-  ``lib/``) are not part of the plugin's search paths; bare imports
-  from them remain global.
+  ``lib/``) are not part of the plugin's search paths.  Module-level
+  bare imports from them work during load; lazy (function-level) ones
+  fail after load, because the inserted entries are swept.
 - The plugin's ``__builtins__`` is a snapshot dict: later monkeypatches
   of the ``builtins`` module (e.g. ``mock.patch("builtins.open")``) are
   not visible inside plugin modules.

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -46,6 +46,11 @@ Known limitations (documented, not silently broken):
   runtime after a name was first probed resolves globally.  Extension
   modules only count as plugin code when importable by the current
   interpreter (a vendored wrong-ABI ``.so`` reads as data).
+- Plugin modules that landed under bare names via a bypass import are
+  removed from ``sys.modules`` when the load finishes.  Held object
+  references keep working, but name-keyed lookups against them
+  (re-import, ``sys.modules[obj.__module__]`` introspection such as
+  string-annotation resolution or pickling) fail afterwards.
 """
 
 import builtins
@@ -181,6 +186,51 @@ def strip_plugin_sys_path(source_path: Any) -> None:
         return resolved != root and not resolved.startswith(prefix)
 
     sys.path[:] = [p for p in sys.path if _keep(p)]
+
+
+def sweep_bare_tree_modules(source_path: Any) -> None:
+    """Pop non-namespaced ``sys.modules`` entries rooted in *source_path*.
+
+    Redirected plugin imports live under ``plugin_<id>`` and are exempt
+    (their root is registered on the finder).  Anything else whose
+    ``__file__`` — or, for namespace packages, any ``__path__`` portion
+    — falls inside the plugin tree is residue from a bypass import or a
+    data-directory fallthrough; left in place, the ``sys.modules``
+    cache would keep serving it to later imports even after the
+    plugin's ``sys.path`` entries are swept.
+    """
+    root = _norm(source_path)
+    prefix = root + os.sep
+
+    def _under(path: Any) -> bool:
+        resolved = _norm(path)
+        return resolved == root or resolved.startswith(prefix)
+
+    for name, mod in list(sys.modules.items()):
+        top = name.partition(".")[0]
+        if _finder is not None and _finder.is_registered(top):
+            continue
+        try:
+            mod_file = getattr(mod, "__file__", None)
+            if mod_file is not None:
+                if _under(mod_file):
+                    sys.modules.pop(name, None)
+                continue
+            # Namespace packages have no __file__; match by __path__.
+            # Accessing __path__ recomputes _NamespacePath, which can
+            # raise KeyError if a parent was popped earlier in this
+            # loop — such an orphan is residue by definition.
+            try:
+                portions = list(getattr(mod, "__path__", None) or [])
+            except KeyError:
+                sys.modules.pop(name, None)
+                continue
+            if portions and any(_under(p) for p in portions):
+                sys.modules.pop(name, None)
+        except Exception:  # pylint: disable=broad-except
+            # Best-effort cleanup: lazy-module proxies or broken path
+            # hooks must not turn a sweep into a load failure.
+            continue
 
 
 # Source and extension modules only: stale bytecode (__pycache__/*.pyc

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -173,14 +173,17 @@ def build_plugin_builtins(
                 top,
                 search_paths,
             )
-            # A bare data directory (no __init__.py) resolves as a
-            # namespace-package portion (loader is None).  The real
-            # machinery would keep searching sys.path and let e.g. the
-            # stdlib win, so treat it as non-local instead of shadowing
-            # the name with an empty package (a plugin's ``locale/``
-            # assets dir must not hijack the stdlib ``locale``).
+            # A namespace-package portion (loader is None) needs a
+            # tie-break mirroring the real machinery: a plain data
+            # directory (``locale/`` assets) loses to a concrete module
+            # elsewhere on sys.path (the stdlib ``locale`` must win),
+            # but a genuine PEP 420 namespace package the plugin ships
+            # stays plugin-local — sending it to the global namespace
+            # would reopen the cross-plugin collision (#6683).
             if spec is not None and spec.loader is None:
-                spec = None
+                resolved = importlib.machinery.PathFinder.find_spec(top)
+                if resolved is None or resolved.loader is not None:
+                    spec = None
             spec_cache[top] = spec
         return spec_cache[top]
 

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -180,7 +180,15 @@ def strip_plugin_sys_path(source_path: Any) -> None:
     sys.path[:] = [p for p in sys.path if _keep(p)]
 
 
-_CODE_SUFFIXES = tuple(importlib.machinery.all_suffixes())
+# Source and extension modules only: stale bytecode (__pycache__/*.pyc
+# or a stray legacy .pyc) is not evidence that a directory is a real
+# package, and must not let a data directory shadow a concrete module.
+# Deliberate trade-off: a PEP 420 portion shipping ONLY sourceless
+# bytecode no longer counts as plugin code either.
+_CODE_SUFFIXES = tuple(
+    importlib.machinery.SOURCE_SUFFIXES
+    + importlib.machinery.EXTENSION_SUFFIXES,
+)
 
 
 def _has_importable_code(portions: List[str]) -> bool:
@@ -192,10 +200,14 @@ def _has_importable_code(portions: List[str]) -> bool:
     file like ``locale/en_US.UTF-8/tool.py`` cannot be imported as a
     module, so it must not make a data directory look like a package.
     The pruning also keeps the walk cheap on large asset trees.
+    Bytecode caches are skipped entirely: they are derived artifacts,
+    not code the plugin ships.
     """
     for portion in portions:
         for _dirpath, dirnames, filenames in os.walk(portion):
-            dirnames[:] = [d for d in dirnames if d.isidentifier()]
+            dirnames[:] = [
+                d for d in dirnames if d.isidentifier() and d != "__pycache__"
+            ]
             for filename in filenames:
                 for suffix in _CODE_SUFFIXES:
                     if (

--- a/src/qwenpaw/plugins/module_isolation.py
+++ b/src/qwenpaw/plugins/module_isolation.py
@@ -24,19 +24,43 @@ This module redirects such imports back into the plugin's namespace:
 Names not present in the plugin's directories fall through to the
 regular import machinery, so stdlib and third-party imports behave
 exactly as before.
+
+Known limitations (documented, not silently broken):
+
+- Only the ``import`` statement is redirected.  Dynamic imports via
+  ``importlib.import_module("utils")`` bypass ``__import__`` and still
+  resolve in the global top-level namespace.
+- Directories a plugin adds to ``sys.path`` itself (e.g. a vendored
+  ``lib/``) are not part of the plugin's search paths; bare imports
+  from them remain global.
+- The plugin's ``__builtins__`` is a snapshot dict: later monkeypatches
+  of the ``builtins`` module (e.g. ``mock.patch("builtins.open")``) are
+  not visible inside plugin modules.
+- Objects pickled with a ``plugin_<id>.…`` ``__module__`` are only
+  unpicklable in a process where that plugin is loaded.
 """
 
 import builtins
 import importlib
 import importlib.abc
 import importlib.machinery
+import os
 import sys
 import threading
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-class _NamespaceLoader(importlib.abc.Loader):
-    """Wrap a real loader so the module executes with plugin builtins."""
+class _NamespaceLoader:
+    """Wrap a real loader so the module executes with plugin builtins.
+
+    Deliberately not an ``importlib.abc.Loader`` subclass: everything
+    except ``exec_module`` is forwarded to the wrapped loader via
+    ``__getattr__`` (``create_module``, ``get_data``, ``get_source``,
+    ``get_filename``, ``get_resource_reader``, …) so that
+    ``importlib.resources`` and ``pkgutil`` keep working on plugin
+    packages.
+    """
 
     def __init__(
         self,
@@ -46,12 +70,12 @@ class _NamespaceLoader(importlib.abc.Loader):
         self._wrapped = wrapped
         self._builtins = plugin_builtins
 
-    def create_module(self, spec: Any) -> Any:
-        return self._wrapped.create_module(spec)
-
     def exec_module(self, module: Any) -> None:
         module.__dict__["__builtins__"] = self._builtins
         self._wrapped.exec_module(module)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
 
 
 class PluginNamespaceFinder(importlib.abc.MetaPathFinder):
@@ -84,8 +108,10 @@ class PluginNamespaceFinder(importlib.abc.MetaPathFinder):
         target: Any = None,  # pylint: disable=unused-argument
     ) -> Optional[importlib.machinery.ModuleSpec]:
         root, sep, _ = fullname.partition(".")
-        if not sep:
-            # The entry module itself is loaded explicitly by the caller.
+        if not sep or path is None:
+            # The entry module itself is loaded explicitly by the
+            # caller; and without a parent ``__path__`` PathFinder would
+            # fall back to sys.path and could mis-resolve the tail name.
             return None
         plugin_builtins = self._namespaces.get(root)
         if plugin_builtins is None:
@@ -118,27 +144,45 @@ def unregister_namespace(module_name: str) -> None:
         _finder.unregister(module_name)
 
 
+def _norm(path: Any) -> str:
+    return os.path.normcase(os.path.realpath(str(path)))
+
+
 def build_plugin_builtins(
     module_name: str,
     search_paths: List[str],
+    entry_file: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Builtins mapping with a plugin-aware ``__import__``.
 
     Bare top-level imports whose name exists under *search_paths* (the
     plugin's own directories) are imported as ``<module_name>.<name>``;
-    everything else falls through to the regular machinery.
+    everything else falls through to the regular machinery.  A bare
+    import that resolves to *entry_file* itself is aliased to the
+    already-loaded entry module instead of executing the file a second
+    time.
     """
-    local_cache: Dict[str, bool] = {}
+    entry_origin = _norm(entry_file) if entry_file is not None else None
+    spec_cache: Dict[str, Optional[importlib.machinery.ModuleSpec]] = {}
 
-    def _is_local(top: str) -> bool:
-        found = local_cache.get(top)
-        if found is None:
-            found = (
-                importlib.machinery.PathFinder.find_spec(top, search_paths)
-                is not None
+    def _find_local(
+        top: str,
+    ) -> Optional[importlib.machinery.ModuleSpec]:
+        if top not in spec_cache:
+            spec = importlib.machinery.PathFinder.find_spec(
+                top,
+                search_paths,
             )
-            local_cache[top] = found
-        return found
+            # A bare data directory (no __init__.py) resolves as a
+            # namespace-package portion (loader is None).  The real
+            # machinery would keep searching sys.path and let e.g. the
+            # stdlib win, so treat it as non-local instead of shadowing
+            # the name with an empty package (a plugin's ``locale/``
+            # assets dir must not hijack the stdlib ``locale``).
+            if spec is not None and spec.loader is None:
+                spec = None
+            spec_cache[top] = spec
+        return spec_cache[top]
 
     def _plugin_import(
         name: str,
@@ -149,7 +193,20 @@ def build_plugin_builtins(
     ) -> Any:
         if level == 0 and name:
             top = name.partition(".")[0]
-            if top != module_name and _is_local(top):
+            spec = _find_local(top) if top != module_name else None
+            if spec is not None:
+                if (
+                    name == top
+                    and entry_origin is not None
+                    and spec.origin is not None
+                    and _norm(spec.origin) == entry_origin
+                    and module_name in sys.modules
+                ):
+                    # ``import main`` where main.py IS the entry file:
+                    # alias the running entry module instead of
+                    # executing the file a second time (which would
+                    # duplicate module-level state and side effects).
+                    return sys.modules[module_name]
                 full = f"{module_name}.{name}"
                 if fromlist:
                     return builtins.__import__(

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -79,7 +79,11 @@ def validate_plugin_module(
     module.__path__ = search_paths
     # Same bare-import redirection as PluginLoader (#6683) so the plugin
     # is validated under the exact conditions it will run in.
-    plugin_builtins = build_plugin_builtins(module_name, search_paths)
+    plugin_builtins = build_plugin_builtins(
+        module_name,
+        search_paths,
+        entry_file=backend_path,
+    )
     module.__dict__["__builtins__"] = plugin_builtins
     get_namespace_finder().register(module_name, plugin_builtins)
     try:

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -52,13 +52,14 @@ def validate_plugin_module(
     module_name = f"_plugin_validation_{safe_id}"
     plugin_dir_str = str(plugin_path)
     # Nested entry files (e.g. ``backend/main.py``) resolve their bare
-    # imports against the entry directory — mirror PluginLoader.
+    # imports against the entry directory — mirror PluginLoader,
+    # including entry-directory-first precedence.
     entry_dir_str = str(backend_path.parent)
-    search_paths = [plugin_dir_str]
+    search_paths = [entry_dir_str]
     if os.path.normcase(os.path.realpath(entry_dir_str)) != os.path.normcase(
         os.path.realpath(plugin_dir_str),
     ):
-        search_paths.append(entry_dir_str)
+        search_paths.append(plugin_dir_str)
 
     spec = importlib.util.spec_from_file_location(
         module_name,

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from .module_isolation import (
     build_plugin_builtins,
     get_namespace_finder,
+    strip_plugin_sys_path,
     unregister_namespace,
 )
 
@@ -95,9 +96,16 @@ def validate_plugin_module(
             )
     finally:
         # Clean up ephemeral validation modules to avoid
-        # leaking into the process on repeated installs.
-        unregister_namespace(module_name)
+        # leaking into the process on repeated installs.  Sweep
+        # sys.modules BEFORE unregistering the namespace — same
+        # ordering invariant as PluginLoader cleanup, so a lazy
+        # import cannot resolve a submodule without the plugin
+        # builtins in the window between the two.
         prefix = module_name + "."
         for key in list(sys.modules):
             if key == module_name or key.startswith(prefix):
                 sys.modules.pop(key, None)
+        unregister_namespace(module_name)
+        # Drop any sys.path entries the plugin inserted at import
+        # time, so validation leaves no residue in the CLI process.
+        strip_plugin_sys_path(plugin_path)

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -8,8 +8,15 @@ plugins are validated under the same conditions they will run in.
 """
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
+
+from .module_isolation import (
+    build_plugin_builtins,
+    get_namespace_finder,
+    unregister_namespace,
+)
 
 
 def validate_plugin_module(
@@ -44,11 +51,19 @@ def validate_plugin_module(
     safe_id = plugin_id.replace("-", "_")
     module_name = f"_plugin_validation_{safe_id}"
     plugin_dir_str = str(plugin_path)
+    # Nested entry files (e.g. ``backend/main.py``) resolve their bare
+    # imports against the entry directory — mirror PluginLoader.
+    entry_dir_str = str(backend_path.parent)
+    search_paths = [plugin_dir_str]
+    if os.path.normcase(os.path.realpath(entry_dir_str)) != os.path.normcase(
+        os.path.realpath(plugin_dir_str),
+    ):
+        search_paths.append(entry_dir_str)
 
     spec = importlib.util.spec_from_file_location(
         module_name,
         backend_path,
-        submodule_search_locations=[plugin_dir_str],
+        submodule_search_locations=search_paths,
     )
     if not (spec and spec.loader):
         raise ImportError(
@@ -60,7 +75,12 @@ def validate_plugin_module(
     # relative imports can resolve the parent package.
     sys.modules[module_name] = module
     module.__package__ = module_name
-    module.__path__ = [plugin_dir_str]
+    module.__path__ = search_paths
+    # Same bare-import redirection as PluginLoader (#6683) so the plugin
+    # is validated under the exact conditions it will run in.
+    plugin_builtins = build_plugin_builtins(module_name, search_paths)
+    module.__dict__["__builtins__"] = plugin_builtins
+    get_namespace_finder().register(module_name, plugin_builtins)
     try:
         spec.loader.exec_module(module)
 
@@ -71,6 +91,7 @@ def validate_plugin_module(
     finally:
         # Clean up ephemeral validation modules to avoid
         # leaking into the process on repeated installs.
+        unregister_namespace(module_name)
         prefix = module_name + "."
         for key in list(sys.modules):
             if key == module_name or key.startswith(prefix):

--- a/src/qwenpaw/plugins/validation.py
+++ b/src/qwenpaw/plugins/validation.py
@@ -16,6 +16,7 @@ from .module_isolation import (
     build_plugin_builtins,
     get_namespace_finder,
     strip_plugin_sys_path,
+    sweep_bare_tree_modules,
     unregister_namespace,
 )
 
@@ -107,5 +108,7 @@ def validate_plugin_module(
                 sys.modules.pop(key, None)
         unregister_namespace(module_name)
         # Drop any sys.path entries the plugin inserted at import
-        # time, so validation leaves no residue in the CLI process.
+        # time, and any bare sys.modules entries rooted in its tree,
+        # so validation leaves no residue in the CLI process.
         strip_plugin_sys_path(plugin_path)
+        sweep_bare_tree_modules(plugin_path)

--- a/tests/unit/plugins/test_plugin_load_isolation.py
+++ b/tests/unit/plugins/test_plugin_load_isolation.py
@@ -202,8 +202,9 @@ class TestSysModulesCleanup:
         loader,
         tmp_path,
     ):
-        """Modules imported via bare ``import`` (after sys.path manipulation)
-        are cleaned via __file__ path scanning."""
+        """Modules that land in the global top-level namespace (e.g. via
+        ``importlib.import_module``, which bypasses the plugin-namespace
+        ``__import__`` redirection) are cleaned via __file__ scanning."""
         plugin_dir = tmp_path / "bare-imp"
         (plugin_dir).mkdir()
         # A helper that the plugin will import via bare name
@@ -213,9 +214,12 @@ class TestSysModulesCleanup:
         )
         _write_plugin(
             plugin_dir,
-            "import sys, os\n"
+            "import sys, os, importlib\n"
             "sys.path.insert(0, os.path.dirname(__file__))\n"
-            "import bare_helper_xyzzy\n"
+            "bare_helper_xyzzy = importlib.import_module(\n"
+            "    'bare_helper_xyzzy',\n"
+            ")\n"
+            "assert 'bare_helper_xyzzy' in sys.modules\n"
             "\n"
             "class P:\n"
             "    def register(self, api):\n"

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -531,6 +531,107 @@ class TestBareImportNamespaceIsolation:
         assert sys.modules["plugin_dotted_as"].VAL == 7
 
     @pytest.mark.asyncio
+    async def test_cleanup_keeps_relative_sys_path_entries(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Failed-load cleanup must not strip relative sys.path entries
+        ('' — the CWD) even when the CWD is inside the plugin dir."""
+        import os as os_mod
+
+        plugin_dir = tmp_path / "cwd-plug"
+        (plugin_dir / "sub").mkdir(parents=True)
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "raise RuntimeError('boom')\n",
+            encoding="utf-8",
+        )
+
+        old_cwd = os_mod.getcwd()
+        had_empty = "" in sys.path
+        if not had_empty:
+            sys.path.insert(0, "")
+        os_mod.chdir(plugin_dir / "sub")
+        try:
+            with pytest.raises(RuntimeError, match="boom"):
+                await _load(loader, plugin_dir)
+            # The plugin's own absolute entry is swept …
+            plugin_real = os_mod.path.realpath(str(plugin_dir))
+            assert plugin_real not in [
+                os_mod.path.realpath(p) for p in sys.path if p
+            ]
+            # … but the relative CWD entry survives.
+            assert "" in sys.path
+        finally:
+            os_mod.chdir(old_cwd)
+            if not had_empty and "" in sys.path:
+                sys.path.remove("")
+
+    @pytest.mark.asyncio
+    async def test_entry_alias_with_fromlist_imports_sibling(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """``from <entry> import <sibling_module>`` imports the sibling
+        as a namespaced submodule without re-executing the entry."""
+        plugin_dir = tmp_path / "fromlist-plug"
+        plugin_dir.mkdir()
+        (plugin_dir / "sib.py").write_text("S = 'sib'\n", encoding="utf-8")
+        (plugin_dir / "helper.py").write_text(
+            "from plugin import sib\nS = sib.S\n",
+            encoding="utf-8",
+        )
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "RUNS = globals().get('RUNS', 0) + 1\n"
+            "import helper\n"
+            "S = helper.S\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        mod = sys.modules["plugin_fromlist_plug"]
+        assert mod.S == "sib"
+        assert mod.RUNS == 1
+        assert "plugin_fromlist_plug.sib" in sys.modules
+        assert "plugin_fromlist_plug.plugin" not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_non_importable_nested_code_stays_data(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Code reachable only through non-identifier path components
+        (e.g. ``wave/en-US/tool.py``) does not make a data directory
+        shadow the stdlib."""
+        plugin_dir = tmp_path / "l10n-plug"
+        (plugin_dir / "wave" / "en-US").mkdir(parents=True)
+        (plugin_dir / "wave" / "en-US" / "tool.py").write_text(
+            "X = 1\n",
+            encoding="utf-8",
+        )
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import wave\n" "WAVE = wave\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        import wave as real_wave
+
+        assert sys.modules["plugin_l10n_plug"].WAVE is real_wave
+        assert "plugin_l10n_plug.wave" not in sys.modules
+
+    @pytest.mark.asyncio
     async def test_failed_load_unregisters_namespace(
         self,
         loader,

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -359,6 +359,72 @@ class TestBareImportNamespaceIsolation:
         assert sys.modules["plugin_pep_b"].VALUE == "B"
 
     @pytest.mark.asyncio
+    async def test_pep420_package_without_sys_path_insert(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """A PEP 420 package imports fine (and stays isolated) even when
+        the plugin never touches sys.path — same as a regular package."""
+        for name, val in (("noins-a", "A"), ("noins-b", "B")):
+            plugin_dir = tmp_path / name
+            (plugin_dir / "helpers").mkdir(parents=True)
+            (plugin_dir / "helpers" / "value.py").write_text(
+                f"VALUE = '{val}'\n",
+                encoding="utf-8",
+            )
+            _write_manifest(plugin_dir)
+            (plugin_dir / "plugin.py").write_text(
+                "from helpers.value import VALUE\n" + _REGISTER_OK,
+                encoding="utf-8",
+            )
+            await _load(loader, plugin_dir)
+
+        assert sys.modules["plugin_noins_a"].VALUE == "A"
+        assert sys.modules["plugin_noins_b"].VALUE == "B"
+
+    @pytest.mark.asyncio
+    async def test_regular_package_then_pep420_package(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """A regular package left on sys.path by an earlier plugin must
+        not pull a later plugin's same-named PEP 420 package out of its
+        namespace."""
+        code = (
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "from helpers.value import VALUE\n" + _REGISTER_OK
+        )
+        dir_a = tmp_path / "reg-a"
+        (dir_a / "helpers").mkdir(parents=True)
+        (dir_a / "helpers" / "__init__.py").write_text("", encoding="utf-8")
+        (dir_a / "helpers" / "value.py").write_text(
+            "VALUE = 'A'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(code, encoding="utf-8")
+
+        dir_b = tmp_path / "pep-late-b"
+        (dir_b / "helpers").mkdir(parents=True)
+        # No __init__.py on purpose — a PEP 420 namespace package.
+        (dir_b / "helpers" / "value.py").write_text(
+            "VALUE = 'B'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(code, encoding="utf-8")
+
+        await _load(loader, dir_a)
+        await _load(loader, dir_b)
+
+        assert sys.modules["plugin_reg_a"].VALUE == "A"
+        assert sys.modules["plugin_pep_late_b"].VALUE == "B"
+        assert "plugin_pep_late_b.helpers.value" in sys.modules
+
+    @pytest.mark.asyncio
     async def test_data_directory_does_not_shadow_stdlib(
         self,
         loader,

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -632,6 +632,46 @@ class TestBareImportNamespaceIsolation:
         assert "plugin_l10n_plug.wave" not in sys.modules
 
     @pytest.mark.asyncio
+    async def test_stale_bytecode_does_not_make_data_dir_a_package(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Leftover bytecode (``__pycache__`` contents or a stray legacy
+        ``.pyc``) is not importable source — a data directory holding
+        only bytecode must still fall through to the stdlib.  The
+        ``__pycache__/x.py`` file locks the cache-dir pruning: nothing
+        under ``__pycache__`` counts, whatever its suffix."""
+        plugin_dir = tmp_path / "pyc-plug"
+        (plugin_dir / "wave" / "__pycache__").mkdir(parents=True)
+        (plugin_dir / "wave" / "sample.bin").write_bytes(b"\x00")
+        (plugin_dir / "wave" / "__pycache__" / "x.py").write_text(
+            "X = 1\n",
+            encoding="utf-8",
+        )
+        (
+            plugin_dir / "wave" / "__pycache__" / "x.cpython-312.pyc"
+        ).write_bytes(
+            b"\x00",
+        )
+        (plugin_dir / "wave" / "legacy.pyc").write_bytes(b"\x00")
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import wave\n"
+            "WAVE = wave\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        import wave as real_wave
+
+        assert sys.modules["plugin_pyc_plug"].WAVE is real_wave
+        assert "plugin_pyc_plug.wave" not in sys.modules
+
+    @pytest.mark.asyncio
     async def test_failed_load_unregisters_namespace(
         self,
         loader,

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name,protected-access
+"""Tests for per-plugin bare-import namespace isolation (#6683).
+
+Two plugins shipping the same top-level module name (``utils``) must not
+collide: bare absolute imports (``import utils`` / ``from utils.env
+import x``) are redirected into each plugin's private ``plugin_<id>``
+namespace, including nested and lazy (function-level) imports, while
+stdlib / third-party imports fall through untouched.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub missing agentscope 2.0 modules (same pattern as sibling test file)
+# ---------------------------------------------------------------------------
+_AGENTSCOPE_STUBS = [
+    "agentscope.state",
+]
+for _mod_name in _AGENTSCOPE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        _stub.AgentState = type(
+            "AgentState",
+            (),
+            {},
+        )  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fresh_registry():
+    """Create a fresh PluginRegistry (bypass singleton)."""
+    from qwenpaw.plugins.registry import PluginRegistry
+
+    old_instance = PluginRegistry._instance
+    PluginRegistry._instance = None
+    registry = PluginRegistry()
+    yield registry
+    PluginRegistry._instance = old_instance
+
+
+@pytest.fixture()
+def loader(fresh_registry, tmp_path):
+    """Create a PluginLoader wired to the fresh registry."""
+    from qwenpaw.plugins.loader import PluginLoader
+
+    ldr = PluginLoader(plugin_dirs=[tmp_path])
+    ldr.registry = fresh_registry
+    return ldr
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_test_modules(tmp_path):
+    """Remove modules loaded from tmp_path and its sys.path entries."""
+    yield
+    tmp_str = str(tmp_path)
+    for key, mod in list(sys.modules.items()):
+        mod_file = getattr(mod, "__file__", None)
+        if mod_file is not None and mod_file.startswith(tmp_str):
+            sys.modules.pop(key, None)
+    sys.path[:] = [p for p in sys.path if not str(p).startswith(tmp_str)]
+
+
+def _write_manifest(
+    plugin_dir: Path,
+    backend_entry: str = "plugin.py",
+) -> Dict:
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "id": plugin_dir.name,
+        "name": plugin_dir.name,
+        "version": "1.0.0",
+        "entry": {"backend": backend_entry},
+        "qwenpaw_version": {"min": "0.1.0", "max": "99.0.0"},
+    }
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps(manifest),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+async def _load(loader, plugin_dir: Path, backend_entry: str = "plugin.py"):
+    from qwenpaw.plugins.architecture import PluginManifest
+
+    manifest = PluginManifest.from_dict(
+        json.loads((plugin_dir / "plugin.json").read_text(encoding="utf-8")),
+    )
+    return await loader._load_backend_module(
+        manifest.id,
+        plugin_dir / backend_entry,
+        plugin_dir,
+        None,
+        manifest,
+    )
+
+
+_REGISTER_OK = (
+    "\n"
+    "class P:\n"
+    "    def register(self, api):\n"
+    "        pass\n"
+    "\n"
+    "plugin = P()\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBareImportNamespaceIsolation:
+    @pytest.mark.asyncio
+    async def test_conflicting_utils_module_and_package(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """The #6683 repro: plugin A ships ``utils.py`` (a plain module),
+        plugin B ships ``utils/`` (a package).  Both must load and see
+        their own ``utils`` regardless of load order."""
+        dir_a = tmp_path / "plug-a"
+        dir_a.mkdir()
+        (dir_a / "utils.py").write_text("WHO = 'A'\n", encoding="utf-8")
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import utils\n"
+            "WHO = utils.WHO\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "plug-b"
+        (dir_b / "utils").mkdir(parents=True)
+        (dir_b / "utils" / "__init__.py").write_text("", encoding="utf-8")
+        (dir_b / "utils" / "env.py").write_text(
+            "WHO = 'B'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "from utils.env import WHO\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        # Before the fix this raised: No module named 'utils.env';
+        # 'utils' is not a package.
+        await _load(loader, dir_b)
+
+        assert sys.modules["plugin_plug_a"].WHO == "A"
+        assert sys.modules["plugin_plug_b"].WHO == "B"
+        assert "plugin_plug_a.utils" in sys.modules
+        assert "plugin_plug_b.utils" in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_nested_bare_import_stays_namespaced(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Bare imports *inside* plugin submodules resolve to the plugin's
+        own files, not to another plugin's same-named module."""
+        dir_a = tmp_path / "aaa-first"
+        dir_a.mkdir()
+        (dir_a / "helper.py").write_text("TAG = 'first'\n", encoding="utf-8")
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import helper\n"
+            "TAG = helper.TAG\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "bbb-second"
+        (dir_b / "pkg").mkdir(parents=True)
+        (dir_b / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+        # pkg.core reaches a sibling top-level module via a bare import.
+        (dir_b / "pkg" / "core.py").write_text(
+            "from helper import TAG\n",
+            encoding="utf-8",
+        )
+        (dir_b / "helper.py").write_text("TAG = 'second'\n", encoding="utf-8")
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "from pkg.core import TAG\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        await _load(loader, dir_b)
+
+        assert sys.modules["plugin_aaa_first"].TAG == "first"
+        assert sys.modules["plugin_bbb_second"].TAG == "second"
+
+    @pytest.mark.asyncio
+    async def test_lazy_function_level_import(self, loader, tmp_path):
+        """A bare import executed at call time (after other plugins have
+        loaded) still resolves inside the calling plugin."""
+        dir_a = tmp_path / "lazy-a"
+        dir_a.mkdir()
+        (dir_a / "shared_name.py").write_text(
+            "OWNER = 'lazy-a'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "def whoami():\n"
+            "    from shared_name import OWNER\n"
+            "    return OWNER\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "lazy-b"
+        dir_b.mkdir()
+        (dir_b / "shared_name.py").write_text(
+            "OWNER = 'lazy-b'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import shared_name\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        await _load(loader, dir_b)
+
+        # Called only now — after lazy-b claimed ``shared_name`` too.
+        assert sys.modules["plugin_lazy_a"].whoami() == "lazy-a"
+
+    @pytest.mark.asyncio
+    async def test_stdlib_imports_fall_through(self, loader, tmp_path):
+        """Names not shipped by the plugin resolve via the regular
+        machinery and are not captured into the plugin namespace."""
+        plugin_dir = tmp_path / "std-plug"
+        plugin_dir.mkdir()
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import json\n"
+            "JSON_MOD = json\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        assert sys.modules["plugin_std_plug"].JSON_MOD is sys.modules["json"]
+        assert "plugin_std_plug.json" not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_nested_entry_dir_imports(self, loader, tmp_path):
+        """The qwenpaw-creator layout: entry at ``backend/main.py`` with
+        bare imports resolving against ``backend/``."""
+        plugin_dir = tmp_path / "nested-entry"
+        backend = plugin_dir / "backend"
+        (backend / "utils").mkdir(parents=True)
+        (backend / "utils" / "__init__.py").write_text("", encoding="utf-8")
+        (backend / "utils" / "env.py").write_text(
+            "VALUE = 'nested'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(plugin_dir, backend_entry="backend/main.py")
+        (backend / "main.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "from utils.env import VALUE\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir, backend_entry="backend/main.py")
+
+        assert sys.modules["plugin_nested_entry"].VALUE == "nested"
+
+    @pytest.mark.asyncio
+    async def test_failed_load_unregisters_namespace(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """A failed load must remove the plugin's import redirection."""
+        from qwenpaw.plugins.module_isolation import get_namespace_finder
+
+        plugin_dir = tmp_path / "fail-ns"
+        plugin_dir.mkdir()
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "raise RuntimeError('boom')\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await _load(loader, plugin_dir)
+
+        assert not get_namespace_finder().is_registered("plugin_fail_ns")

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -297,6 +297,39 @@ class TestBareImportNamespaceIsolation:
         assert sys.modules["plugin_nested_entry"].VALUE == "nested"
 
     @pytest.mark.asyncio
+    async def test_nested_entry_dir_precedes_plugin_root(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """When the plugin root and the entry directory both ship the same
+        bare module name, the entry directory wins — matching the
+        ``sys.path.insert(0, dirname(__file__))`` semantics nested-entry
+        plugins rely on."""
+        plugin_dir = tmp_path / "nested-priority"
+        backend = plugin_dir / "backend"
+        backend.mkdir(parents=True)
+        (plugin_dir / "helper.py").write_text(
+            "VALUE = 'plugin-root'\n",
+            encoding="utf-8",
+        )
+        (backend / "helper.py").write_text(
+            "VALUE = 'entry-dir'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(plugin_dir, backend_entry="backend/main.py")
+        (backend / "main.py").write_text(
+            "import os, sys\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "from helper import VALUE\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir, backend_entry="backend/main.py")
+
+        assert sys.modules["plugin_nested_priority"].VALUE == "entry-dir"
+
+    @pytest.mark.asyncio
     async def test_failed_load_unregisters_namespace(
         self,
         loader,

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -330,6 +330,112 @@ class TestBareImportNamespaceIsolation:
         assert sys.modules["plugin_nested_priority"].VALUE == "entry-dir"
 
     @pytest.mark.asyncio
+    async def test_data_directory_does_not_shadow_stdlib(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """A bare data directory (no __init__.py, no code) must not be
+        treated as a plugin-local module: ``import wave`` with a
+        ``wave/`` assets dir present still resolves to the stdlib."""
+        plugin_dir = tmp_path / "data-dir"
+        (plugin_dir / "wave").mkdir(parents=True)
+        (plugin_dir / "wave" / "sample.bin").write_bytes(b"\x00")
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import wave\n"
+            "WAVE = wave\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        import wave as real_wave
+
+        assert sys.modules["plugin_data_dir"].WAVE is real_wave
+        assert "plugin_data_dir.wave" not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_loader_forwards_resource_access(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """importlib.resources works on namespaced plugin packages: the
+        wrapping loader must forward get_resource_reader etc."""
+        import importlib.resources
+
+        plugin_dir = tmp_path / "res-plug"
+        pkg = plugin_dir / "assets_pkg"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "data.txt").write_text("hello-resource", encoding="utf-8")
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import assets_pkg\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        mod = sys.modules["plugin_res_plug.assets_pkg"]
+        text = importlib.resources.files(mod).joinpath("data.txt").read_text()
+        assert text == "hello-resource"
+
+    @pytest.mark.asyncio
+    async def test_bare_import_of_entry_aliases_running_module(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """A submodule bare-importing the entry file gets the running
+        entry module, not a second freshly-executed copy."""
+        plugin_dir = tmp_path / "self-imp"
+        plugin_dir.mkdir()
+        (plugin_dir / "helper.py").write_text(
+            "import plugin\nplugin.X.append(1)\n",
+            encoding="utf-8",
+        )
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "X = []\n"
+            "import helper\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        assert sys.modules["plugin_self_imp"].X == [1]
+        assert "plugin_self_imp.plugin" not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_dotted_import_as_binding(self, loader, tmp_path):
+        """``import a.b as c`` binds the submodule under the alias."""
+        plugin_dir = tmp_path / "dotted-as"
+        pkg = plugin_dir / "a"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "b.py").write_text("V = 7\n", encoding="utf-8")
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import a.b as c\n"
+            "VAL = c.V\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, plugin_dir)
+
+        assert sys.modules["plugin_dotted_as"].VAL == 7
+
+    @pytest.mark.asyncio
     async def test_failed_load_unregisters_namespace(
         self,
         loader,

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -330,6 +330,35 @@ class TestBareImportNamespaceIsolation:
         assert sys.modules["plugin_nested_priority"].VALUE == "entry-dir"
 
     @pytest.mark.asyncio
+    async def test_pep420_namespace_packages_stay_isolated(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Packages without __init__.py (PEP 420 namespace packages) are
+        still plugin-local: two plugins shipping the same namespace
+        package name must not share modules."""
+        code = (
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "from helpers.value import VALUE\n" + _REGISTER_OK
+        )
+        for name, val in (("pep-a", "A"), ("pep-b", "B")):
+            plugin_dir = tmp_path / name
+            (plugin_dir / "helpers").mkdir(parents=True)
+            # No __init__.py on purpose — a PEP 420 namespace package.
+            (plugin_dir / "helpers" / "value.py").write_text(
+                f"VALUE = '{val}'\n",
+                encoding="utf-8",
+            )
+            _write_manifest(plugin_dir)
+            (plugin_dir / "plugin.py").write_text(code, encoding="utf-8")
+            await _load(loader, plugin_dir)
+
+        assert sys.modules["plugin_pep_a"].VALUE == "A"
+        assert sys.modules["plugin_pep_b"].VALUE == "B"
+
+    @pytest.mark.asyncio
     async def test_data_directory_does_not_shadow_stdlib(
         self,
         loader,

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -70,6 +70,18 @@ def _cleanup_test_modules(tmp_path):
         mod_file = getattr(mod, "__file__", None)
         if mod_file is not None and mod_file.startswith(tmp_str):
             sys.modules.pop(key, None)
+        elif mod_file is None:
+            # Namespace packages have no __file__; match by __path__.
+            # Accessing __path__ recomputes _NamespacePath, which looks
+            # up the parent in sys.modules — if we already popped the
+            # parent above, the child is an orphan: pop it too.
+            try:
+                paths = list(getattr(mod, "__path__", None) or [])
+            except KeyError:
+                sys.modules.pop(key, None)
+                continue
+            if any(str(p).startswith(tmp_str) for p in paths):
+                sys.modules.pop(key, None)
     sys.path[:] = [p for p in sys.path if not str(p).startswith(tmp_str)]
 
 
@@ -692,3 +704,132 @@ class TestBareImportNamespaceIsolation:
             await _load(loader, plugin_dir)
 
         assert not get_namespace_finder().is_registered("plugin_fail_ns")
+
+
+class TestFallthroughIsolation:
+    """Non-local fallthrough imports must not resolve into other loaded
+    plugins' source trees left on sys.path (PR #6688 review)."""
+
+    @pytest.mark.asyncio
+    async def test_data_dir_fallthrough_skips_other_plugin(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Blocking-1: a data-directory fallthrough must not resolve into
+        an earlier plugin's source tree left on sys.path."""
+        dir_a = tmp_path / "res-a"
+        (dir_a / "helpers_qq").mkdir(parents=True)
+        (dir_a / "helpers_qq" / "__init__.py").write_text(
+            "WHO = 'A'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import helpers_qq\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "res-b"
+        (dir_b / "helpers_qq").mkdir(parents=True)
+        (dir_b / "helpers_qq" / "readme.bin").write_bytes(b"\x00")
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import helpers_qq\n"
+            "H = helpers_qq\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        await _load(loader, dir_b)
+
+        # B must not receive A's module; at most its own (empty)
+        # namespace portion — never a path from A's tree.
+        imported = sys.modules["plugin_res_b"].H
+        assert not hasattr(imported, "WHO")
+        assert list(imported.__path__) == [str(dir_b / "helpers_qq")]
+
+    @pytest.mark.asyncio
+    async def test_uncached_stdlib_name_not_polluted_by_plugin(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Blocking-2: with the stdlib name not pre-cached, a later
+        data-dir fallthrough must load the real stdlib module — not an
+        earlier plugin's same-named file — and must not leave a wrong
+        binding in sys.modules for the host."""
+        dir_a = tmp_path / "fake-a"
+        dir_a.mkdir()
+        (dir_a / "wave.py").write_text("FAKE = True\n", encoding="utf-8")
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import wave\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "data-b"
+        (dir_b / "wave").mkdir(parents=True)
+        (dir_b / "wave" / "sample.bin").write_bytes(b"\x00")
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import wave\n"
+            "WAVE = wave\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        # A's own import was namespaced, so the global name is normally
+        # absent already; pop defensively in case an earlier test (or
+        # the host) imported the real module and cached it.
+        sys.modules.pop("wave", None)
+
+        await _load(loader, dir_b)
+
+        assert not hasattr(sys.modules["plugin_data_b"].WAVE, "FAKE")
+        assert hasattr(sys.modules["plugin_data_b"].WAVE, "open")
+        host_wave = sys.modules["wave"]
+        assert not str(host_wave.__file__).startswith(str(tmp_path))
+
+    @pytest.mark.asyncio
+    async def test_no_local_name_fallthrough_skips_other_plugin(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Blocking-3: a bare import with no plugin-local candidate at
+        all must not resolve into another plugin's source tree."""
+        dir_a = tmp_path / "owner-a"
+        dir_a.mkdir()
+        (dir_a / "only_a_owns_this.py").write_text(
+            "WHO = 'A'\n",
+            encoding="utf-8",
+        )
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import only_a_owns_this\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "bare-b"
+        dir_b.mkdir()
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import only_a_owns_this\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        with pytest.raises(ModuleNotFoundError):
+            await _load(loader, dir_b)
+        assert "only_a_owns_this" not in sys.modules

--- a/tests/unit/plugins/test_plugin_namespace_isolation.py
+++ b/tests/unit/plugins/test_plugin_namespace_isolation.py
@@ -833,3 +833,64 @@ class TestFallthroughIsolation:
         with pytest.raises(ModuleNotFoundError):
             await _load(loader, dir_b)
         assert "only_a_owns_this" not in sys.modules
+
+    @pytest.mark.asyncio
+    async def test_bare_namespace_residue_swept_at_load_end(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """A bare namespace package cached from a plugin's own data dir
+        during load must not outlive the load: sys.modules is the other
+        residue channel besides sys.path."""
+        dir_a = tmp_path / "nsres-a"
+        (dir_a / "resq_pkg").mkdir(parents=True)
+        (dir_a / "resq_pkg" / "x.bin").write_bytes(b"\x00")
+        _write_manifest(dir_a)
+        (dir_a / "plugin.py").write_text(
+            "import sys, os\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "import resq_pkg\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        dir_b = tmp_path / "nsres-b"
+        dir_b.mkdir()
+        _write_manifest(dir_b)
+        (dir_b / "plugin.py").write_text(
+            "import resq_pkg\n" + _REGISTER_OK,
+            encoding="utf-8",
+        )
+
+        await _load(loader, dir_a)
+        assert "resq_pkg" not in sys.modules
+        with pytest.raises(ModuleNotFoundError):
+            await _load(loader, dir_b)
+
+    @pytest.mark.asyncio
+    async def test_failed_load_sweeps_namespace_residue(
+        self,
+        loader,
+        tmp_path,
+    ):
+        """Bare namespace-package residue from a FAILED load is swept
+        too (by the load-end sweep, which runs on every exit path) —
+        such packages have no __file__, so a file-based sweep alone
+        would miss them."""
+        plugin_dir = tmp_path / "nsfail"
+        (plugin_dir / "nsp_dir").mkdir(parents=True)
+        (plugin_dir / "nsp_dir" / "d.bin").write_bytes(b"\x00")
+        _write_manifest(plugin_dir)
+        (plugin_dir / "plugin.py").write_text(
+            "import sys, os, importlib\n"
+            "sys.path.insert(0, os.path.dirname(__file__))\n"
+            "nsp_dir = importlib.import_module('nsp_dir')\n"
+            "assert 'nsp_dir' in sys.modules\n"
+            "raise RuntimeError('post-import boom')\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError, match="post-import boom"):
+            await _load(loader, plugin_dir)
+
+        assert "nsp_dir" not in sys.modules


### PR DESCRIPTION
## Description

Fixes #6683 — installing `qwenpaw-creator` from App Center fails with `No module named 'utils.env'; 'utils' is not a package`.

**Root cause**: `_load_backend_module` gives each plugin's entry file a private namespace (`plugin_<id>`), but that isolation only covers relative imports. Many plugins insert their own directory into `sys.path` and use **bare absolute imports** for their own files (`import utils` / `from utils.env import x`). Those resolve through the standard machinery into the **process-wide top-level namespace**, so all plugins share it — the first plugin to claim a common name (`utils`, `models`, `router`, …) wins, and every plugin loaded afterwards silently receives that module instead of its own. Concrete repro: `html-2-md` ships `utils.py` (a plain module) and loads first; `qwenpaw-creator` ships `utils/` (a package) — creator's `from utils.env import ...` hits the cached plain module → `'utils' is not a package`.

The loader already sweeps bare modules by `__file__` path, but only on failed load / unload — a successful load leaves the pollution in place permanently. Extending that sweep to the success path is not safe either: plugins with lazy function-level imports (creator has ~20) would re-import fresh copies later and duplicate module-level singletons.

**Fix** (no plugin code changes needed):

- `module_isolation.py` (new): `build_plugin_builtins` — a per-plugin `__builtins__` whose `__import__` resolves bare top-level names against the plugin's own directories first, importing them as `plugin_<id>.<name>`; `PluginNamespaceFinder` — a `sys.meta_path` finder (inert for non-plugin imports) that makes every module imported under `plugin_<id>.` execute with that same `__builtins__`, so nested and lazy (function-level) bare imports stay namespaced too. Names the plugin does not ship fall through to the regular machinery — stdlib/third-party imports are untouched.
- `loader.py`: wires the redirection into `_load_backend_module`, searches the entry file's directory for nested entries (creator's `backend/main.py`), unregisters the namespace on failed load / unload. Existing `__file__`-based sweeps stay as a second line of defense.
- `validation.py`: same wiring, so CLI `plugin install/validate` checks plugins under the exact conditions they run in.

Plugins using relative imports are unaffected. Plugins using bare imports (`qwenpaw-creator`, `qwenpaw-pet`, `cloudpaw`, `computer-use`) now resolve them deterministically to their own files regardless of load order.

**Related Issue:** Fixes #6683

**Security Considerations:** None — the redirection only touches names physically present in the plugin's own directory; everything else falls through to the standard import machinery.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (if needed) — not needed, behavior-transparent fix
- [x] Ready for review

## Testing

1. Reproduce: install two plugins that both ship a top-level `utils` — one as `utils.py` (e.g. `html-2-md`), one as a `utils/` package (e.g. `qwenpaw-creator`). Before this fix the second install fails with `'utils' is not a package`; after it, both load and each sees its own `utils`.
2. Or run the new regression suite, which covers: the #6683 repro (module vs package collision), nested bare imports inside plugin submodules, lazy function-level imports after another plugin claims the same name, stdlib fall-through (`json` stays the real `sys.modules['json']`), creator's nested-entry layout (`backend/main.py`), and namespace cleanup on failed load:

```bash
pytest tests/unit/plugins/ -q
```

## Evidence

```bash
$ pre-commit run --all-files
check python ast.........................................................Passed
sort simple yaml files...................................................Passed
check yaml...............................................................Passed
check xml................................................................Passed
check toml...............................................................Passed
check docstring is first.................................................Passed
check json...............................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
mypy.....................................................................Passed
  Success: no issues found in 1209 source files
black....................................................................Passed
flake8...................................................................Passed
pylint...................................................................Passed
prettier.................................................................Passed
Lint GitHub Actions workflow files.......................................Passed

$ pytest tests/unit/plugins/ -q
........................................................................ [ 42%]
.........sssssss........................................................ [ 84%]
..........................                                               [100%]
163 passed, 7 skipped in 2.07s
```

## Additional Notes

Hardening pass in 4e49c802 after an adversarial self-review (edge cases + full-repo interaction audit; all 8 in-repo plugins verified unaffected):

- A bare **data directory** (`locale/`, `config/`, …) no longer shadows a same-named stdlib/third-party package — namespace-package specs are rejected when probing plugin-local names.
- The wrapping loader now forwards the full loader protocol (`get_data`, `get_resource_reader`, …), so `importlib.resources` / `pkgutil` work on namespaced plugin packages.
- A bare import of the entry file itself (`import main`) aliases the running entry module instead of executing it a second time.
- Namespace unregistration moved after the `sys.modules` sweeps (closes a hot-reload race), and `sys.path` cleanup now also removes plugin **sub**directories (nested-entry plugins insert `backend/`).

Known limitations, documented in the module docstring: only the `import` statement is redirected — `importlib.import_module("utils")` bypasses `__import__` and stays global (the existing `__file__`-based sweeps still clean those up on unload, and the cleanup test now exercises exactly that path); directories a plugin adds to `sys.path` itself (vendored `lib/`) are not covered; the plugin `__builtins__` is a snapshot dict; `plugin_<id>.…` pickles require the plugin loaded in the unpickling process.

The new meta-path finder is registered lazily (first plugin load) and matches only registered `plugin_<id>.` prefixes, so it adds zero overhead to non-plugin imports. Module `__name__` for bare-imported plugin files changes from e.g. `utils.env` to `plugin_qwenpaw_creator.utils.env`; in-repo plugins do not depend on the bare form.

