### PR TITLE
feat(channels): retry transient startup failures

### DIFF
--- a/src/qwenpaw/app/channels/manager.py
+++ b/src/qwenpaw/app/channels/manager.py
@@ -24,6 +24,7 @@ from .command_registry import CommandRegistry
 from .registry import get_channel_registry
 from .unified_queue_manager import UnifiedQueueManager
 from ...config import get_available_channels
+from ...exceptions import ChannelStartupError
 
 if TYPE_CHECKING:
     from ...config.config import Config
@@ -35,6 +36,10 @@ OnLastDispatch = Optional[Callable[[str, str, str], None]]
 
 # Default max size per channel queue
 _CHANNEL_QUEUE_MAXSIZE = 1000
+
+# Retry only failures explicitly classified as temporary by the channel.
+_CHANNEL_START_RETRY_INITIAL_DELAY = 5.0
+_CHANNEL_START_RETRY_MAX_DELAY = 60.0
 
 
 async def _process_batch(ch: BaseChannel, batch: List[Any]) -> None:
@@ -449,6 +454,55 @@ class ChannelManager:
                     f"priority={priority_level}",
                 )
 
+    async def _cleanup_failed_start(self, ch: BaseChannel) -> None:
+        """Release resources left by an incomplete start attempt."""
+        try:
+            await ch.stop()
+        except Exception:
+            logger.exception(
+                "failed to clean up channel=%s after startup failure",
+                ch.channel,
+            )
+
+    async def _start_channel(self, ch: BaseChannel) -> None:
+        """Start one channel, retrying explicitly transient failures."""
+        attempt = 1
+        retry_delay = _CHANNEL_START_RETRY_INITIAL_DELAY
+
+        while True:
+            try:
+                await ch.start()
+                if attempt > 1:
+                    logger.info(
+                        "channel=%s started after %d attempts",
+                        ch.channel,
+                        attempt,
+                    )
+                return
+            except ChannelStartupError as exc:
+                await self._cleanup_failed_start(ch)
+                logger.warning(
+                    "channel=%s startup attempt=%d failed; "
+                    "retrying in %.1fs: %s",
+                    ch.channel,
+                    attempt,
+                    retry_delay,
+                    exc,
+                )
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(
+                    retry_delay * 2,
+                    _CHANNEL_START_RETRY_MAX_DELAY,
+                )
+                attempt += 1
+            except Exception:
+                logger.exception(
+                    "failed to start channel=%s; not retrying",
+                    ch.channel,
+                )
+                await self._cleanup_failed_start(ch)
+                return
+
     async def start_all(self) -> None:
         """Start all channels and queue manager."""
         self._loop = asyncio.get_running_loop()
@@ -476,16 +530,8 @@ class ChannelManager:
 
         # Fire-and-forget: channels connect in background so startup
         # is not blocked by slow network handshakes (e.g. WebSocket).
-        async def _start_channel(g):
-            try:
-                await g.start()
-            except Exception:
-                logger.exception(
-                    f"failed to start channel={g.channel}",
-                )
-
         for g in snapshot:
-            task = asyncio.create_task(_start_channel(g))
+            task = asyncio.create_task(self._start_channel(g))
             self._start_tasks.add(task)
             task.add_done_callback(self._start_tasks.discard)
 

--- a/src/qwenpaw/app/channels/matrix/channel.py
+++ b/src/qwenpaw/app/channels/matrix/channel.py
@@ -73,6 +73,7 @@ from ....app.channels.renderer import ChannelDisplayConfig
 from ....app.channels.base import BaseChannel
 from ....app.channels.utils import file_url_to_local_path
 from ....constant import WORKING_DIR
+from ....exceptions import ChannelError, ChannelStartupError
 
 logger = logging.getLogger("qwenpaw.channels.matrix")
 
@@ -89,6 +90,15 @@ DM_ROOM_CACHE_MAX_ENTRIES = 1_000
 ROOM_HISTORY_MAX_ROOMS = 256
 VERIFICATION_STATE_MAX_ENTRIES = 1_024
 VERIFICATION_STATE_TTL_S = 60 * 60
+
+_NON_RETRYABLE_AUTH_CODES = frozenset(
+    {
+        "M_FORBIDDEN",
+        "M_MISSING_TOKEN",
+        "M_UNKNOWN_TOKEN",
+        "M_USER_DEACTIVATED",
+    },
+)
 
 # Known QwenPaw slash commands — used to decide whether to strip
 # @mention prefix
@@ -573,6 +583,22 @@ class MatrixChannel(BaseChannel):
                     "device_id; E2EE store may not be reusable",
                 )
 
+    def _raise_if_non_retryable_auth_error(
+        self,
+        response: Any,
+        auth_step: str,
+    ) -> None:
+        """Reject credential errors that cannot recover through retries."""
+        error_code = getattr(response, "status_code", None)
+        if error_code in _NON_RETRYABLE_AUTH_CODES:
+            raise ChannelError(
+                channel_name=self.channel,
+                message=(
+                    f"Matrix {auth_step} rejected credentials "
+                    f"({error_code}): {response}"
+                ),
+            )
+
     async def _login_with_password(
         self,
         login_user: str,
@@ -593,6 +619,7 @@ class MatrixChannel(BaseChannel):
         if isinstance(resp, LoginResponse):
             self._handle_password_login_success(resp)
             return True
+        self._raise_if_non_retryable_auth_error(resp, "password login")
         logger.error("MatrixChannel: password login failed: %s", resp)
         return False
 
@@ -607,7 +634,13 @@ class MatrixChannel(BaseChannel):
                     self.matrix_user_id,
                     whoami.user_id,
                 )
-                return False
+                raise ChannelError(
+                    channel_name=self.channel,
+                    message=(
+                        "Configured Matrix user_id does not match the "
+                        "access-token owner"
+                    ),
+                )
             self._user_id = whoami.user_id
             self._client.user_id = whoami.user_id
             self._client.user = whoami.user_id
@@ -637,6 +670,7 @@ class MatrixChannel(BaseChannel):
                     )
                     self.encryption = False
             return True
+        self._raise_if_non_retryable_auth_error(whoami, "token login")
         logger.error("MatrixChannel: token login failed: %s", whoami)
         return False
 
@@ -661,6 +695,10 @@ class MatrixChannel(BaseChannel):
         if self._client.should_upload_keys:
             resp = await self._client.keys_upload()
             if not isinstance(resp, KeysUploadResponse):
+                self._raise_if_non_retryable_auth_error(
+                    resp,
+                    "E2EE key upload",
+                )
                 logger.error(
                     "MatrixChannel: E2E keys upload failed after login: %s",
                     resp,
@@ -731,17 +769,26 @@ class MatrixChannel(BaseChannel):
                 login_user,
                 resolved_device_id,
             ):
-                return
+                raise ChannelStartupError(
+                    channel_name=self.channel,
+                    message="Matrix password login failed temporarily",
+                )
         elif self.access_token:
             if not await self._login_with_access_token():
-                return
+                raise ChannelStartupError(
+                    channel_name=self.channel,
+                    message="Matrix token login failed temporarily",
+                )
         else:
             logger.error("MatrixChannel: no credentials configured")
             return
 
         self._register_plain_room_callbacks()
         if not await self._setup_e2ee_after_login():
-            return
+            raise ChannelStartupError(
+                channel_name=self.channel,
+                message="Matrix post-login setup failed temporarily",
+            )
 
         self._http_client = httpx.AsyncClient(
             follow_redirects=True,
@@ -752,17 +799,23 @@ class MatrixChannel(BaseChannel):
         logger.info("MatrixChannel: sync loop started")
 
     async def stop(self) -> None:
-        if self._sync_task:
-            self._sync_task.cancel()
+        sync_task = self._sync_task
+        self._sync_task = None
+        if sync_task:
+            sync_task.cancel()
             try:
-                await self._sync_task
+                await sync_task
             except asyncio.CancelledError:
                 logger.debug("MatrixChannel: sync task cancelled during stop")
-        if self._http_client:
-            await self._http_client.aclose()
-            self._http_client = None
-        if self._client:
-            await self._client.close()
+        http_client = self._http_client
+        self._http_client = None
+        if http_client:
+            await http_client.aclose()
+        client = self._client
+        self._client = None
+        if client:
+            await client.close()
+        self._user_id = None
         self._room_histories.clear()
         self._dm_room_cache.clear()
         self._handled_verification_requests.clear()

--- a/src/qwenpaw/exceptions.py
+++ b/src/qwenpaw/exceptions.py
@@ -292,6 +292,10 @@ class ChannelError(ExternalServiceException):
         )
 
 
+class ChannelStartupError(ChannelError):
+    """Retryable failure while starting an enabled channel."""
+
+
 class AgentStateError(AgentRuntimeErrorException):
     """Exception raised for agent state and session errors."""
 

--- a/tests/unit/app/channels/test_manager.py
+++ b/tests/unit/app/channels/test_manager.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""Tests for channel startup lifecycle management."""
+
+# pylint: disable=protected-access
+
+import asyncio
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+from qwenpaw.app.channels import manager as manager_module
+from qwenpaw.app.channels.manager import ChannelManager
+from qwenpaw.exceptions import ChannelError, ChannelStartupError
+
+
+class _FakeChannel:
+    """Minimal channel double with deterministic startup outcomes."""
+
+    channel = "test"
+    uses_manager_queue = True
+
+    def __init__(self, outcomes: list[Exception | None]) -> None:
+        self._outcomes = list(outcomes)
+        self.start_attempts = 0
+        self.stop_attempts = 0
+        self.first_attempt = asyncio.Event()
+        self.started = asyncio.Event()
+        self.enqueue_callback = None
+
+    def set_enqueue(self, callback) -> None:
+        self.enqueue_callback = callback
+
+    async def start(self) -> None:
+        self.start_attempts += 1
+        self.first_attempt.set()
+        outcome = self._outcomes.pop(0) if self._outcomes else None
+        if outcome is not None:
+            raise outcome
+        self.started.set()
+
+    async def stop(self) -> None:
+        self.stop_attempts += 1
+
+
+def _retryable_error() -> ChannelStartupError:
+    return ChannelStartupError(
+        channel_name="test",
+        message="dependency is temporarily unavailable",
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_all_retries_retryable_failure_until_recovered(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_START_RETRY_INITIAL_DELAY",
+        0.0,
+    )
+    channel = _FakeChannel([_retryable_error(), None])
+    manager = ChannelManager([channel])
+
+    await manager.start_all()
+    await asyncio.wait_for(channel.started.wait(), timeout=1.0)
+
+    assert channel.start_attempts == 2
+    assert channel.stop_attempts == 1
+    await manager.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_startup_retry_backoff_is_capped(monkeypatch) -> None:
+    sleep = AsyncMock()
+    monkeypatch.setattr(manager_module.asyncio, "sleep", sleep)
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_START_RETRY_INITIAL_DELAY",
+        2.0,
+    )
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_START_RETRY_MAX_DELAY",
+        5.0,
+    )
+    channel = _FakeChannel(
+        [
+            _retryable_error(),
+            _retryable_error(),
+            _retryable_error(),
+            _retryable_error(),
+            None,
+        ],
+    )
+    manager = ChannelManager([channel])
+
+    await manager._start_channel(channel)
+
+    assert sleep.await_args_list == [
+        call(2.0),
+        call(4.0),
+        call(5.0),
+        call(5.0),
+    ]
+    assert channel.start_attempts == 5
+    assert channel.stop_attempts == 4
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_startup_failure_is_not_retried() -> None:
+    channel = _FakeChannel(
+        [ChannelError(channel_name="test", message="invalid credentials")],
+    )
+    manager = ChannelManager([channel])
+
+    await manager._start_channel(channel)
+
+    assert channel.start_attempts == 1
+    assert channel.stop_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_all_cancels_pending_startup_retry(monkeypatch) -> None:
+    monkeypatch.setattr(
+        manager_module,
+        "_CHANNEL_START_RETRY_INITIAL_DELAY",
+        60.0,
+    )
+    channel = _FakeChannel([_retryable_error(), None])
+    manager = ChannelManager([channel])
+
+    await manager.start_all()
+    await asyncio.wait_for(channel.first_attempt.wait(), timeout=1.0)
+    await manager.stop_all()
+
+    assert channel.start_attempts == 1
+    assert not manager._start_tasks

--- a/tests/unit/channels/test_matrix.py
+++ b/tests/unit/channels/test_matrix.py
@@ -17,7 +17,7 @@ from nio import (
     UploadError,
     UploadResponse,
 )
-from nio.responses import WhoamiResponse
+from nio.responses import LoginError, WhoamiError, WhoamiResponse
 
 from qwenpaw.schemas import (
     AgentRequest,
@@ -28,6 +28,7 @@ from qwenpaw.schemas import (
 from qwenpaw.app.channels.matrix.channel import MatrixChannel
 from qwenpaw.app.channels.renderer import ChannelDisplayConfig
 from qwenpaw.config.config import MatrixConfig
+from qwenpaw.exceptions import ChannelError, ChannelStartupError
 
 
 @pytest.fixture
@@ -817,6 +818,81 @@ class TestMatrixChannelStartStop:
             assert matrix_channel._sync_task is not None
             assert not matrix_channel._sync_task.done()
 
+    async def test_start_signals_retryable_token_login_failure(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Temporary homeserver failures are retried by the manager."""
+        mock_async_client.whoami.return_value = WhoamiError(
+            message="Bad gateway",
+        )
+
+        with patch(
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
+            return_value=mock_async_client,
+        ):
+            with pytest.raises(ChannelStartupError, match="token login"):
+                await matrix_channel.start()
+
+        assert matrix_channel._sync_task is None
+
+    async def test_start_signals_retryable_password_login_failure(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Password login uses the same transient startup contract."""
+        matrix_channel.access_token = ""
+        matrix_channel.password = "test_password"
+        mock_async_client.login = AsyncMock(
+            return_value=LoginError(message="Bad gateway"),
+        )
+
+        with patch(
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
+            return_value=mock_async_client,
+        ):
+            with pytest.raises(ChannelStartupError, match="password login"):
+                await matrix_channel.start()
+
+    async def test_start_does_not_retry_invalid_access_token(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Invalid credentials require configuration, not retries."""
+        mock_async_client.whoami.return_value = WhoamiError(
+            message="Unknown token",
+            status_code="M_UNKNOWN_TOKEN",
+        )
+
+        with patch(
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
+            return_value=mock_async_client,
+        ):
+            with pytest.raises(ChannelError) as exc_info:
+                await matrix_channel.start()
+
+        assert type(exc_info.value) is ChannelError
+
+    async def test_start_signals_retryable_post_login_failure(
+        self,
+        matrix_channel,
+        mock_async_client,
+    ):
+        """Temporary post-login setup failures are safe to retry."""
+        matrix_channel._setup_e2ee_after_login = AsyncMock(
+            return_value=False,
+        )
+
+        with patch(
+            "qwenpaw.app.channels.matrix.channel.AsyncClient",
+            return_value=mock_async_client,
+        ):
+            with pytest.raises(ChannelStartupError, match="post-login"):
+                await matrix_channel.start()
+
     async def test_stop_cancels_sync_task(
         self,
         matrix_channel,
@@ -845,6 +921,8 @@ class TestMatrixChannelStartStop:
             await matrix_channel.stop()
 
             mock_async_client.close.assert_called_once()
+            assert matrix_channel._client is None
+            assert matrix_channel._sync_task is None
 
     async def test_stop_when_not_started(self, matrix_channel):
         """Test stop when channel was never started."""


### PR DESCRIPTION
## Description

Add a shared, opt-in startup retry contract for channels and use it for Matrix homeserver startup failures.

- `ChannelManager` retries only `ChannelStartupError` with cancellable exponential backoff from 5 seconds to a 60-second cap.
- Failed attempts are stopped before retrying, while ordinary configuration and programming errors remain one-shot failures.
- Matrix classifies temporary login and post-login setup responses as retryable, but keeps invalid tokens, forbidden credentials, deactivated users, and token-owner mismatches non-retryable.
- Matrix clears client and task references during shutdown so each retry starts from clean state.

The retry policy belongs to the shared lifecycle layer; Matrix only identifies transport-specific failures. Existing channel-owned runtime reconnect loops, including Matrix `_sync_loop()`, are unchanged. No configuration switch is added because only channels that explicitly raise the retryable signal opt in.

**Related Issue:** Fixes #6684

**Security Considerations:** Credentials are not included in retry logs. Invalid or mismatched credentials do not enter an infinite retry loop.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [x] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] If pre-commit auto-fixed files, I committed those changes and reran checks
- [x] I ran tests locally (`pytest` or as relevant) and they pass
- [x] Documentation updated (not needed; no user-facing configuration or API change)
- [x] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [x] Ran the channel contract gate directly; `check-channels.sh` requires `.git` to be a directory and does not support Git worktrees
- [x] Contract test exists in `tests/contract/channels/test_matrix_contract.py`
- [x] Contract test implements `create_instance()` with proper channel initialization
- [x] All channel contract verification points pass
- [x] Added focused unit tests for manager retry lifecycle and Matrix failure classification

## Testing

```bash
pre-commit run --all-files

PYTHONPATH=src QWENPAW_WORKING_DIR=/tmp/qwenpaw-test-6684-unit \
  pytest tests/unit/app/channels/test_manager.py \
  tests/unit/channels/test_matrix.py -q

PYTHONPATH=src QWENPAW_WORKING_DIR=/tmp/qwenpaw-test-6684-contract \
  pytest tests/contract/channels -q
```

Verification matrix:

| Surface | Result |
| --- | --- |
| Shared manager retry/backoff/cleanup | Covered |
| Non-retryable startup failures | One attempt, covered |
| Shutdown during retry delay | Cancellation covered |
| Matrix token and password startup failures | Covered |
| Matrix invalid credentials | Non-retryable, covered |
| Matrix runtime sync reconnect | Unchanged |
| Other channels | Unchanged unless they opt into `ChannelStartupError` |

## Evidence

```text
pre-commit run --all-files
# All hooks passed, including mypy, black, flake8, pylint, prettier,
# and GitHub Actions workflow lint.

pytest tests/unit/app/channels/test_manager.py tests/unit/channels/test_matrix.py -q
# 70 passed, 5 pre-existing pytest warnings

pytest tests/contract/channels -q
# 243 passed, 2 skipped, 1 dependency deprecation warning
```

## Additional Notes

The backoff is intentionally manager-owned and limited to synchronous startup. A global periodic health monitor would duplicate or race the reconnect loops already owned by several channel implementations.
