### PR TITLE
fix(crons): persist enabled state on pause and resume

### DIFF
--- a/src/qwenpaw/app/crons/manager.py
+++ b/src/qwenpaw/app/crons/manager.py
@@ -270,11 +270,23 @@ class CronManager(ManagerBase):
 
     async def pause_job(self, job_id: str) -> None:
         async with self._lock:
-            self._scheduler.pause_job(job_id)
+            job = await self._repo.get_job(job_id)
+            if job is None:
+                raise KeyError(f"Job not found: {job_id}")
+            disabled_job = job.model_copy(update={"enabled": False})
+            await self._repo.upsert_job(disabled_job)
+            if self._scheduler.get_job(job_id):
+                self._scheduler.pause_job(job_id)
 
     async def resume_job(self, job_id: str) -> None:
         async with self._lock:
-            self._scheduler.resume_job(job_id)
+            job = await self._repo.get_job(job_id)
+            if job is None:
+                raise KeyError(f"Job not found: {job_id}")
+            enabled_job = job.model_copy(update={"enabled": True})
+            await self._repo.upsert_job(enabled_job)
+            if self._scheduler.get_job(job_id):
+                self._scheduler.resume_job(job_id)
 
     async def reschedule_heartbeat(self) -> None:
         """Reload heartbeat config and update or remove the heartbeat job.

--- a/tests/unit/app/crons/test_manager.py
+++ b/tests/unit/app/crons/test_manager.py
@@ -191,6 +191,78 @@ async def test_create_or_replace_job_registers_with_scheduler(
 
 
 # ---------------------------------------------------------------------------
+# pause_job / resume_job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_job_persists_disabled_state(
+    manager: CronManager,
+    repo: InMemoryJobRepository,
+):
+    await repo.upsert_job(make_cron_job_spec(job_id="j-pause"))
+
+    await manager.pause_job("j-pause")
+
+    stored = await manager.get_job("j-pause")
+    assert stored is not None
+    assert stored.enabled is False
+    listed = await manager.list_jobs()
+    assert listed[0].enabled is False
+
+
+@pytest.mark.asyncio
+async def test_resume_job_persists_enabled_state(
+    manager: CronManager,
+    repo: InMemoryJobRepository,
+):
+    await repo.upsert_job(
+        make_cron_job_spec(job_id="j-resume", enabled=False),
+    )
+
+    await manager.resume_job("j-resume")
+
+    stored = await repo.get_job("j-resume")
+    assert stored is not None
+    assert stored.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_pause_and_resume_raise_for_missing_job(manager: CronManager):
+    with pytest.raises(KeyError, match="missing"):
+        await manager.pause_job("missing")
+    with pytest.raises(KeyError, match="missing"):
+        await manager.resume_job("missing")
+
+
+@pytest.mark.asyncio
+async def test_paused_job_remains_paused_after_restart(
+    manager: CronManager,
+    repo: InMemoryJobRepository,
+):
+    await manager.start()
+    await manager.create_or_replace_job(make_cron_job_spec(job_id="j-restart"))
+    await manager.pause_job("j-restart")
+    await manager.stop()
+
+    restarted = CronManager(
+        repo=repo,
+        workspace=MagicMock(),
+        channel_manager=AsyncMock(),
+    )
+    try:
+        await restarted.start()
+        stored = await repo.get_job("j-restart")
+        assert stored is not None
+        assert stored.enabled is False
+        aps_job = restarted._scheduler.get_job("j-restart")
+        assert aps_job is not None
+        assert aps_job.next_run_time is None
+    finally:
+        await restarted.stop()
+
+
+# ---------------------------------------------------------------------------
 # delete_job
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Pushed a follow-up removing comment stripping and adding regression coverage for quoted # plus comment-tail bypass cases.

## Description

pause_job and resume_job only updated APScheduler memory, so enabled status was lost after restart and list still showed the old value. Write enabled to the job repo and only pause/resume the scheduler when the job is registered.

Fixes #6690

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Feishu, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] I ran format/lint on the touched files (black --line-length=79, flake8 --extend-ignore=E203)
- [x] I ran targeted unit tests for the changed path
- [x] Documentation updated (if needed)
- [x] Ready for review

## Evidence

- Targeted cron pause/resume tests: 20 passed
- Manager persistence verified in restart + list/get
- CLI pause/resume still work (unchanged)
- No other files touched

## Changes

- src/qwenpaw/app/crons/manager.py: persist enabled in pause/resume
- tests/unit/app/crons/test_manager.py: added pause/resume persistence and restart tests