### PR TITLE
fix: avoid logging conversation command arguments

### DIFF
--- a/src/qwenpaw/agents/command_handler.py
+++ b/src/qwenpaw/agents/command_handler.py
@@ -1262,7 +1262,11 @@ class CommandHandler(ConversationCommandHandlerMixin):
         parts = query.strip().lstrip("/").split(" ", maxsplit=1)
         command = parts[0]
         args = parts[1] if len(parts) > 1 else ""
-        logger.info(f"Processing command: {command}, args: {args}")
+        # Command arguments are user-controlled and may contain credentials
+        # (for example, a /compact hint containing an API key).  Do not log
+        # them: downstream handlers sanitize values for their own use, but
+        # logging happens before that handler-specific processing.
+        logger.info("Processing command: %s", command)
 
         handler = getattr(self, f"_process_{command}", None)
         if handler is None:

--- a/tests/unit/agents/test_command_handler.py
+++ b/tests/unit/agents/test_command_handler.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -577,12 +578,14 @@ async def test_compact_under_native_keeps_configured_reserve() -> None:
 
 
 @pytest.mark.asyncio
-async def test_compact_forwards_one_shot_redacted_instruction() -> None:
-    captured = {}
+async def test_compact_forwards_one_shot_redacted_instruction(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured_instructions = []
 
     async def _compress_context(context_config=None, instructions=None):
-        captured["context_config"] = context_config
-        captured["instructions"] = instructions
+        del context_config
+        captured_instructions.append(instructions)
         agent.state.summary = "summary"
 
     agent = _make_agent()
@@ -598,13 +601,22 @@ async def test_compact_forwards_one_shot_redacted_instruction() -> None:
         strategy="native",
     )
 
-    await handler.handle_command(
-        "/compact prioritize failures token=hint-secret-123",
-    )
+    with caplog.at_level(
+        logging.INFO,
+        logger="qwenpaw.agents.command_handler",
+    ):
+        await handler.handle_command(
+            "/compact prioritize failures sk-ctx15fake9876543210ab",
+        )
+        await handler.handle_command("/compact")
 
-    instructions = captured["instructions"]
+    instructions = captured_instructions[0]
     assert isinstance(instructions, HintBlock)
     assert instructions.source == "user"
     assert "prioritize failures" in instructions.hint
-    assert "hint-secret-123" not in instructions.hint
+    assert "sk-ctx15fake9876543210ab" not in instructions.hint
     assert "[secret redacted]" in instructions.hint
+    assert captured_instructions[1] is None
+    assert "Processing command: compact" in caplog.text
+    assert "prioritize failures" not in caplog.text
+    assert "sk-ctx15fake9876543210ab" not in caplog.text


### PR DESCRIPTION
## Summary

- Stop logging raw conversation command arguments at INFO level.
- Keep the command name in logs for operational visibility.
- Add regression coverage for `/compact` hint redaction and one-shot behavior.

## Root Cause

The conversation command dispatcher logged the raw `args` value before command-specific processing. As a result, credentials included in a `/compact` hint could be written to `qwenpaw.log` in plaintext even though the hint was redacted before compaction and persistence.

## Changes

- Log only the conversation command name, excluding user-controlled arguments.
- Verify that a fake `sk-...` credential does not appear in captured logs.
- Verify that the hint passed to the compactor is redacted.
- Verify that a subsequent `/compact` without a hint does not reuse the previous hint.

## Test Plan

- [x] `tests/unit/agents/test_command_handler.py` — 22 passed
- [x] Pre-commit hooks passed, including mypy, Black, Flake8, and Pylint
- [x] `git diff --check` passed

## Related Test Case

`TC-CTX-15` — `/compact` hint one-shot behavior and secret redaction