### PR TITLE
feat(chat): session fork — snapshot conversation context to new session

### DIFF
--- a/console/src/api/modules/chat.ts
+++ b/console/src/api/modules/chat.ts
@@ -7,6 +7,7 @@ import type {
   ChatDeleteResponse,
   ChatUpdateRequest,
   BatchArchiveResult,
+  ForkChatResponse,
   Session,
 } from "../types";
 
@@ -126,6 +127,15 @@ export const chatApi = {
     request<void>(`/console/chat/stop?chat_id=${encodeURIComponent(chatId)}`, {
       method: "POST",
     }),
+
+  forkChat: (chatId: string, name?: string) =>
+    request<ForkChatResponse>(
+      `/chats/${encodeURIComponent(chatId)}/fork`,
+      {
+        method: "POST",
+        body: name ? JSON.stringify({ name }) : undefined,
+      },
+    ),
 };
 
 export const sessionApi = {

--- a/console/src/api/request.ts
+++ b/console/src/api/request.ts
@@ -2,6 +2,16 @@ import { getApiUrl, clearAuthToken } from "./config";
 import { buildAuthHeaders } from "./authHeaders";
 import { getLoginHref, isLoginPath } from "../utils/navigationMode";
 
+/** HTTP error with status code, so callers can distinguish 409 vs 500 etc. */
+export class HttpError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
 function getErrorMessageFromBody(
   text: string,
   contentType: string,
@@ -138,7 +148,7 @@ export async function request<T = unknown>(
           ? `${errorMessage} - ${text}`
           : `Request failed: ${response.status} ${response.statusText}`;
 
-        throw new Error(finalMessage);
+        throw new HttpError(response.status, finalMessage);
       }
 
       if (response.status === 204) {

--- a/console/src/api/types/chat.ts
+++ b/console/src/api/types/chat.ts
@@ -45,5 +45,13 @@ export interface BatchArchiveResult {
   }>;
 }
 
+export interface ForkChatResponse {
+  chat_id: string;
+  session_id: string;
+  name: string;
+  created_at: string;
+  source_state: "ok" | "empty";
+}
+
 // Legacy Session type alias for backward compatibility
 export type Session = ChatSpec;

--- a/console/src/components/SessionItem/index.tsx
+++ b/console/src/components/SessionItem/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { Dropdown, Input } from "antd";
 import type { InputRef } from "antd";
 import { useTranslation } from "react-i18next";
+import { GitFork } from "lucide-react";
 import {
   SparkMoreLine,
   SparkDeleteLine,
@@ -41,6 +42,8 @@ export interface SessionItemProps {
   onDelete?: (sessionId: string) => void;
   onPin?: (sessionId: string) => void;
   onArchive?: (sessionId: string) => void;
+  onFork?: (sessionId: string) => void;
+  forkDisabled?: boolean;
   onEditChange?: (value: string) => void;
   onEditSubmit?: () => void;
   onEditCancel?: () => void;
@@ -66,6 +69,8 @@ const SessionItem: React.FC<SessionItemProps> = ({
   onDelete,
   onPin,
   onArchive,
+  onFork,
+  forkDisabled,
   onEditChange,
   onEditSubmit,
   onEditCancel,
@@ -128,6 +133,13 @@ const SessionItem: React.FC<SessionItemProps> = ({
           : t("sessions.archive.action", "Archive"),
         onClick: () => onArchive?.(sessionId),
       },
+      {
+        key: "fork",
+        icon: <GitFork size={14} />,
+        label: t("chat.contextMenu.fork", "Fork"),
+        disabled: forkDisabled,
+        onClick: () => onFork?.(sessionId),
+      },
       { type: "divider" as const },
       {
         key: "delete",
@@ -144,6 +156,8 @@ const SessionItem: React.FC<SessionItemProps> = ({
       t,
       onPin,
       onArchive,
+      onFork,
+      forkDisabled,
       onDelete,
       handleStartEdit,
     ],

--- a/console/src/layouts/SidebarSessionList.tsx
+++ b/console/src/layouts/SidebarSessionList.tsx
@@ -13,6 +13,7 @@ import { SparkPlusLine, SparkDownArrowLine } from "@agentscope-ai/icons";
 import { getChannelLabel } from "../pages/Control/Channels/components";
 import {
   useSessionListData,
+  getBackendId,
   type ExtendedChatSession,
 } from "../pages/Chat/components/ChatSessionDrawer/useSessionListData";
 import { getSessionIdFromPath } from "../utils/sessionRoute";
@@ -60,6 +61,7 @@ interface VirtualRowData {
   handleDelete: (sessionId: string) => void;
   handlePinToggle: (sessionId: string) => void;
   handleArchiveToggle: (sessionId: string) => void;
+  handleFork: (sessionId: string) => void;
   handleEditChange: (value: string) => void;
   handleEditSubmit: () => void;
   handleEditCancel: () => void;
@@ -127,6 +129,8 @@ const VirtualRow = React.memo(function VirtualRow({
         onDelete={data.handleDelete}
         onPin={data.handlePinToggle}
         onArchive={data.handleArchiveToggle}
+        onFork={data.handleFork}
+        forkDisabled={!getBackendId(session)}
         onEditChange={data.handleEditChange}
         onEditSubmit={data.handleEditSubmit}
         onEditCancel={data.handleEditCancel}
@@ -192,6 +196,7 @@ export default function SidebarSessionList({
     handleDelete,
     handlePinToggle,
     handleArchiveToggle,
+    handleFork,
     handleEditChange,
     handleEditSubmit,
     handleEditCancel,
@@ -328,6 +333,7 @@ export default function SidebarSessionList({
       handleDelete,
       handlePinToggle,
       handleArchiveToggle,
+      handleFork,
       handleEditChange,
       handleEditSubmit,
       handleEditCancel,
@@ -344,6 +350,7 @@ export default function SidebarSessionList({
       handleDelete,
       handlePinToggle,
       handleArchiveToggle,
+      handleFork,
       handleEditChange,
       handleEditSubmit,
       handleEditCancel,

--- a/console/src/locales/en.json
+++ b/console/src/locales/en.json
@@ -2947,8 +2947,14 @@
       "rename": "Rename",
       "pin": "Pin",
       "unpin": "Unpin",
+      "fork": "Fork",
       "delete": "Delete"
     },
+    "forkSuccess": "Session forked",
+    "forkEmptySource": "Source context unavailable; created an empty session.",
+    "forkRunning": "Session is still generating. Wait for it to finish.",
+    "forkFailed": "Fork failed",
+    "forkUnavailable": "Send a message first",
     "queue": {
       "title": "Message Queue",
       "paused": "Paused",

--- a/console/src/locales/zh.json
+++ b/console/src/locales/zh.json
@@ -2804,8 +2804,14 @@
       "rename": "重命名",
       "pin": "置顶",
       "unpin": "取消置顶",
+      "fork": "分叉",
       "delete": "删除"
     },
+    "forkSuccess": "会话已分叉",
+    "forkEmptySource": "原上下文不可用，已创建空会话",
+    "forkRunning": "会话正在生成中，请等待完成后再试",
+    "forkFailed": "分叉失败",
+    "forkUnavailable": "请先发送一条消息",
     "queue": {
       "title": "消息队列",
       "paused": "已暂停",

--- a/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/index.tsx
@@ -26,6 +26,7 @@ import { useCreateNewSession } from "../../hooks/useCreateNewSession";
 import SessionItem from "../../../../components/SessionItem";
 import { getChannelLabel } from "../../../Control/Channels/components";
 import { chatApi } from "../../../../api/modules/chat";
+import { HttpError } from "../../../../api/request";
 import sessionApi from "../../sessionApi";
 import { useMessageQueueStore } from "../../../../stores/messageQueueStore";
 import {
@@ -75,6 +76,7 @@ interface VirtualRowData {
   handleDelete: (sessionId: string) => void;
   handlePinToggle: (sessionId: string) => void;
   handleArchiveToggle: (sessionId: string) => void;
+  handleFork: (sessionId: string) => void;
   handleEditChange: (value: string) => void;
   handleEditSubmit: () => void;
   handleEditCancel: () => void;
@@ -148,6 +150,8 @@ const VirtualRow = React.memo(function VirtualRow({
         onDelete={data.handleDelete}
         onPin={data.handlePinToggle}
         onArchive={data.handleArchiveToggle}
+        onFork={data.handleFork}
+        forkDisabled={!getBackendId(session)}
         onEditChange={data.handleEditChange}
         onEditSubmit={data.handleEditSubmit}
         onEditCancel={data.handleEditCancel}
@@ -613,6 +617,67 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
     [sessions, refreshSessions, location.pathname, message, t],
   );
 
+  const forkingRef = useRef(new Set<string>());
+
+  /** Fork the session: create a snapshot in a new independent chat */
+  const handleFork = useCallback(
+    async (sessionId: string) => {
+      // Prevent duplicate requests
+      if (forkingRef.current.has(sessionId)) return;
+
+      const session = sessions.find((s) => s.id === sessionId) as
+        | ExtendedChatSession
+        | undefined;
+      const backendId = session ? getBackendId(session) : null;
+      if (!backendId) {
+        message.warning(
+          t("chat.forkUnavailable", "Send a message first"),
+        );
+        return;
+      }
+
+      forkingRef.current.add(sessionId);
+
+      let result: Awaited<ReturnType<typeof chatApi.forkChat>>;
+      try {
+        result = await chatApi.forkChat(backendId);
+      } catch (err) {
+        forkingRef.current.delete(sessionId);
+        if (err instanceof HttpError && err.status === 409) {
+          message.warning(
+            t(
+              "chat.forkRunning",
+              "Session is still generating. Wait for it to finish.",
+            ),
+          );
+        } else {
+          message.error(t("chat.forkFailed", "Fork failed"));
+        }
+        return;
+      }
+
+      if (result.source_state === "empty") {
+        message.warning(
+          t(
+            "chat.forkEmptySource",
+            "Source context unavailable; created an empty session.",
+          ),
+        );
+      } else {
+        message.success(t("chat.forkSuccess", "Session forked"));
+      }
+
+      try {
+        await refreshSessions();
+      } catch {
+        console.warn("Fork succeeded but session refresh failed");
+      }
+      handleSessionClick(result.chat_id);
+      forkingRef.current.delete(sessionId);
+    },
+    [sessions, handleSessionClick, refreshSessions, t, message],
+  );
+
   /** Filter sessions by search query */
   const filteredSessions = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -741,6 +806,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       handleDelete,
       handlePinToggle,
       handleArchiveToggle,
+      handleFork,
       handleEditChange,
       handleEditSubmit,
       handleEditCancel,
@@ -758,6 +824,7 @@ const ChatSessionDrawer: React.FC<ChatSessionDrawerProps> = (props) => {
       handleDelete,
       handlePinToggle,
       handleArchiveToggle,
+      handleFork,
       handleEditChange,
       handleEditSubmit,
       handleEditCancel,

--- a/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
+++ b/console/src/pages/Chat/components/ChatSessionDrawer/useSessionListData.ts
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import type { IAgentScopeRuntimeWebUISession } from "@agentscope-ai/chat";
 import type { ChatStatus } from "../../../../api/types/chat";
 import { chatApi } from "../../../../api/modules/chat";
+import { HttpError } from "../../../../api/request";
+import type { ForkChatResponse } from "../../../../api/types/chat";
 import sessionApi from "../../sessionApi";
 import { useMessageQueueStore } from "../../../../stores/messageQueueStore";
 import {
@@ -106,6 +108,7 @@ export interface SessionListData {
   handleDelete: (sessionId: string) => void;
   handlePinToggle: (sessionId: string) => void;
   handleArchiveToggle: (sessionId: string) => void;
+  handleFork: (sessionId: string) => void;
   handleEditChange: (value: string) => void;
   handleEditSubmit: () => void;
   handleEditCancel: () => void;
@@ -399,6 +402,65 @@ export function useSessionListData(
     [sessions, currentSessionId, refreshSessions, message, t],
   );
 
+  const forkingRef = useRef(new Set<string>());
+
+  const handleFork = useCallback(
+    async (sessionId: string) => {
+      // Prevent duplicate requests
+      if (forkingRef.current.has(sessionId)) return;
+
+      const session = sessions.find((s) => s.id === sessionId);
+      const backendId = session ? getBackendId(session) : null;
+      if (!backendId) {
+        message.warning(
+          t("chat.forkUnavailable", "Send a message first"),
+        );
+        return;
+      }
+
+      forkingRef.current.add(sessionId);
+
+      let result: ForkChatResponse;
+      try {
+        result = await chatApi.forkChat(backendId);
+      } catch (err) {
+        forkingRef.current.delete(sessionId);
+        if (err instanceof HttpError && err.status === 409) {
+          message.warning(
+            t(
+              "chat.forkRunning",
+              "Session is still generating. Wait for it to finish.",
+            ),
+          );
+        } else {
+          message.error(t("chat.forkFailed", "Fork failed"));
+        }
+        return;
+      }
+
+      // Warn if source was empty (session file manually deleted)
+      if (result.source_state === "empty") {
+        message.warning(
+          t(
+            "chat.forkEmptySource",
+            "Source context unavailable; created an empty session.",
+          ),
+        );
+      } else {
+        message.success(t("chat.forkSuccess", "Session forked"));
+      }
+
+      try {
+        await refreshSessions();
+      } catch {
+        console.warn("Fork succeeded but session refresh failed");
+      }
+      onSessionClick(result.chat_id);
+      forkingRef.current.delete(sessionId);
+    },
+    [sessions, onSessionClick, refreshSessions, t, message],
+  );
+
   const handleItemContextMenu = useCallback(
     (sessionId: string, event: React.MouseEvent) => {
       setContextMenuSessionId(sessionId);
@@ -467,6 +529,7 @@ export function useSessionListData(
     handleDelete,
     handlePinToggle,
     handleArchiveToggle,
+    handleFork,
     handleEditChange,
     handleEditSubmit,
     handleEditCancel,

--- a/src/qwenpaw/agents/context/scroll/continuation_summary.py
+++ b/src/qwenpaw/agents/context/scroll/continuation_summary.py
@@ -10,7 +10,7 @@ replace the last valid summary with an empty value.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 
 SUMMARY_PREFIX = """[archived task state]
@@ -516,6 +516,56 @@ class ContinuationSummary:
             "decisions": [item.to_dict() for item in self.decisions],
             "open_work": [item.to_dict() for item in self.open_work],
         }
+
+    def remap_sequences(
+        self,
+        seq_map: dict[int, int],
+    ) -> "ContinuationSummary | None":
+        """Return this summary rebased onto cloned durable rows.
+
+        Every sequence source is code-managed provenance. If any referenced
+        endpoint is absent from the cloned history, the whole summary is
+        discarded rather than retaining a cross-session or invalid pointer.
+        """
+        try:
+            covered_seq = (
+                seq_map[self.covered_seq[0]],
+                seq_map[self.covered_seq[1]],
+            )
+
+            def remap_item(item: SummaryItem) -> SummaryItem:
+                sources = tuple(
+                    replace(
+                        source,
+                        lo=seq_map[int(source.lo)],
+                        hi=seq_map[
+                            int(
+                                source.hi
+                                if source.hi is not None
+                                else source.lo,
+                            )
+                        ],
+                    )
+                    if source.type == "seq" and source.lo is not None
+                    else source
+                    for source in item.sources
+                )
+                return replace(item, sources=sources)
+
+            return replace(
+                self,
+                covered_seq=covered_seq,
+                current_state=tuple(
+                    remap_item(item) for item in self.current_state
+                ),
+                constraints=tuple(
+                    remap_item(item) for item in self.constraints
+                ),
+                decisions=tuple(remap_item(item) for item in self.decisions),
+                open_work=tuple(remap_item(item) for item in self.open_work),
+            )
+        except KeyError:
+            return None
 
     @classmethod
     def from_dict(  # pylint: disable=too-many-return-statements

--- a/src/qwenpaw/agents/context/scroll/eviction_index.py
+++ b/src/qwenpaw/agents/context/scroll/eviction_index.py
@@ -230,6 +230,46 @@ class EvictionIndex:
             ],
         }
 
+    def remap_sequences(
+        self,
+        *,
+        session_id: str,
+        seq_map: dict[int, int],
+    ) -> "EvictionIndex":
+        """Return an equivalent index pointing at cloned history rows.
+
+        A block is retained only when all of its sequence endpoints can be
+        mapped. Missing endpoints indicate stale/corrupt checkpoint data; in
+        that case dropping the directory entry is safer than rendering a
+        pointer into another session.
+        """
+        rebased = EvictionIndex(session_id, self._agent_id)
+        for tier in self._tiers:
+            rebased_tier: list[Block] = []
+            for block in tier:
+                try:
+                    rebased_tier.append(
+                        Block(
+                            seq_lo=seq_map[block.seq_lo],
+                            seq_hi=seq_map[block.seq_hi],
+                            lines=[
+                                Line(
+                                    seq_map[line.seq_lo],
+                                    seq_map[line.seq_hi],
+                                    line.head,
+                                    line.tail,
+                                )
+                                for line in block.lines
+                            ],
+                        ),
+                    )
+                except KeyError:
+                    continue
+            rebased._tiers.append(  # pylint: disable=protected-access
+                rebased_tier,
+            )
+        return rebased
+
     @classmethod
     def from_dict(cls, data: dict) -> "EvictionIndex":
         idx = cls(

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -263,6 +263,27 @@ class HistoryStore:
             dedup_key,
         )
 
+    def _delete_fts_rows(self, rows: Sequence[sqlite3.Row]) -> None:
+        """Remove indexed rows from FTS without touching recall-only rows.
+
+        Recall tool rows are deliberately excluded from FTS on append. FTS5's
+        external-content delete command must therefore never be issued for
+        them; attempting to delete an entry that was never indexed can raise
+        ``database disk image is malformed`` and roll back the owning
+        transaction.
+        """
+        if not self._fts:
+            return
+        for row in rows:
+            if row["name"] in _RECALL_TOOL_NAMES:
+                continue
+            self._conn.execute(
+                "INSERT INTO conversation_history_fts"
+                "(conversation_history_fts, rowid, content) "
+                "VALUES('delete', ?, ?)",
+                (row["seq"], row["content"] or ""),
+            )
+
     def append(
         self,
         *,
@@ -426,20 +447,13 @@ class HistoryStore:
         """
         with self._lock, self._conn:
             doomed = self._conn.execute(
-                "SELECT seq, content FROM conversation_history "
+                "SELECT seq, content, name FROM conversation_history "
                 "WHERE session_id = ?",
                 (session_id,),
             ).fetchall()
             if not doomed:
                 return 0
-            if self._fts:
-                for row in doomed:
-                    self._conn.execute(
-                        "INSERT INTO conversation_history_fts"
-                        "(conversation_history_fts, rowid, content) "
-                        "VALUES('delete', ?, ?)",
-                        (row["seq"], row["content"] or ""),
-                    )
+            self._delete_fts_rows(doomed)
             self._conn.execute(
                 "DELETE FROM conversation_history WHERE session_id = ?",
                 (session_id,),
@@ -592,7 +606,7 @@ class HistoryStore:
                         ownership = " AND (agent_id = ? OR agent_id IS NULL)"
                         params.append(agent_id)
                     rows = self._conn.execute(
-                        "SELECT seq, dedup_key, content "
+                        "SELECT seq, dedup_key, content, name "
                         "FROM conversation_history "
                         "WHERE session_id = ? AND dedup_key IN ("
                         + placeholders
@@ -624,14 +638,7 @@ class HistoryStore:
                         if str(row["dedup_key"]) not in existing_keys
                     ]
 
-                    if self._fts:
-                        for row in duplicates:
-                            self._conn.execute(
-                                "INSERT INTO conversation_history_fts"
-                                "(conversation_history_fts, rowid, content) "
-                                "VALUES('delete', ?, ?)",
-                                (row["seq"], row["content"] or ""),
-                            )
+                    self._delete_fts_rows(duplicates)
                     if duplicates:
                         self._conn.executemany(
                             "DELETE FROM conversation_history WHERE seq = ?",
@@ -778,21 +785,15 @@ class HistoryStore:
         where, params = self._purge_where(before, kinds)
         with self._lock, self._conn:
             doomed = self._conn.execute(
-                "SELECT seq, content FROM conversation_history WHERE " + where,
+                "SELECT seq, content, name FROM conversation_history WHERE "
+                + where,
                 params,
             ).fetchall()
             if not doomed:
                 return 0
             if dry_run:
                 return len(doomed)
-            if self._fts:
-                for row in doomed:
-                    self._conn.execute(
-                        "INSERT INTO conversation_history_fts"
-                        "(conversation_history_fts, rowid, content) "
-                        "VALUES('delete', ?, ?)",
-                        (row["seq"], row["content"] or ""),
-                    )
+            self._delete_fts_rows(doomed)
             self._conn.execute(
                 "DELETE FROM conversation_history WHERE " + where,
                 params,

--- a/src/qwenpaw/agents/context/scroll/history.py
+++ b/src/qwenpaw/agents/context/scroll/history.py
@@ -353,6 +353,99 @@ class HistoryStore:
                     )
         return inserted
 
+    def clone_session_rows(
+        self,
+        *,
+        source_session_id: str,
+        destination_session_id: str,
+    ) -> dict[int, int]:
+        """Copy one session's durable rows into an independent session.
+
+        The destination rows receive new globally unique ``seq`` values. The
+        returned mapping lets callers rebase every checkpoint pointer that
+        referenced a source row. ``dedup_key`` values are preserved because
+        they are scoped by ``session_id`` and identify the same logical live
+        messages in the copied AgentState.
+
+        The destination must be empty. All row and FTS writes happen in one
+        SQLite transaction, so a partial history clone is never observable.
+        """
+        if source_session_id == destination_session_id:
+            raise ValueError("source and destination sessions must differ")
+
+        placeholders = ", ".join("?" for _ in _INSERT_COLUMNS)
+        insert_sql = (
+            f"INSERT INTO conversation_history "
+            f"({', '.join(_INSERT_COLUMNS)}) VALUES ({placeholders})"
+        )
+        seq_map: dict[int, int] = {}
+
+        with self._lock, self._conn:
+            existing = self._conn.execute(
+                "SELECT 1 FROM conversation_history "
+                "WHERE session_id = ? LIMIT 1",
+                (destination_session_id,),
+            ).fetchone()
+            if existing is not None:
+                raise ValueError(
+                    "destination session already has durable history: "
+                    f"{destination_session_id}",
+                )
+
+            rows = self._conn.execute(
+                "SELECT * FROM conversation_history "
+                "WHERE session_id = ? ORDER BY seq",
+                (source_session_id,),
+            ).fetchall()
+            for row in rows:
+                values = tuple(
+                    destination_session_id
+                    if column == "session_id"
+                    else row[column]
+                    for column in _INSERT_COLUMNS
+                )
+                cur = self._conn.execute(insert_sql, values)
+                destination_seq = int(cur.lastrowid or 0)
+                source_seq = int(row["seq"])
+                seq_map[source_seq] = destination_seq
+                if self._fts and row["name"] not in _RECALL_TOOL_NAMES:
+                    self._conn.execute(
+                        "INSERT INTO conversation_history_fts(rowid, content) "
+                        "VALUES (?, ?)",
+                        (destination_seq, row["content"] or ""),
+                    )
+
+        return seq_map
+
+    def delete_session_rows(self, session_id: str) -> int:
+        """Delete every durable row owned by ``session_id``.
+
+        Used to roll back a fork whose later session-file or ChatSpec write
+        failed. The FTS external-content index is updated in the same
+        transaction. Returns the number of removed rows.
+        """
+        with self._lock, self._conn:
+            doomed = self._conn.execute(
+                "SELECT seq, content FROM conversation_history "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+            if not doomed:
+                return 0
+            if self._fts:
+                for row in doomed:
+                    self._conn.execute(
+                        "INSERT INTO conversation_history_fts"
+                        "(conversation_history_fts, rowid, content) "
+                        "VALUES('delete', ?, ?)",
+                        (row["seq"], row["content"] or ""),
+                    )
+            self._conn.execute(
+                "DELETE FROM conversation_history WHERE session_id = ?",
+                (session_id,),
+            )
+            return len(doomed)
+
     def update_entry(
         self,
         seq: int,

--- a/src/qwenpaw/agents/context/scroll/manager.py
+++ b/src/qwenpaw/agents/context/scroll/manager.py
@@ -17,6 +17,7 @@ two delegated hooks.
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -1923,6 +1924,117 @@ class ScrollContextManager:
         return self._continuation_summary.render()
 
     # -- checkpoint ----------------------------------------------------------
+
+    @staticmethod
+    def rebase_checkpoint(
+        data: Any,
+        *,
+        session_id: str,
+        seq_map: dict[int, int],
+    ) -> dict:
+        """Rebase a persisted Scroll checkpoint onto cloned history rows.
+
+        Scroll checkpoints contain globally addressed SQLite sequence values.
+        A raw JSON copy would leave those values pointing into the source
+        session. This method remaps every such pointer and drops stale entries
+        whose source row was not present when the durable history was cloned.
+        """
+        if not isinstance(data, dict):
+            return {}
+        rebased = copy.deepcopy(data)
+
+        def remap_scalar_map(raw: Any) -> dict[str, int]:
+            if not isinstance(raw, dict):
+                return {}
+            mapped: dict[str, int] = {}
+            for key, value in raw.items():
+                try:
+                    mapped[str(key)] = seq_map[int(value)]
+                except (KeyError, TypeError, ValueError):
+                    continue
+            return mapped
+
+        seq_by_tcid = remap_scalar_map(rebased.get("seq_by_tcid"))
+        model_turn_seq = remap_scalar_map(rebased.get("model_turn_seq"))
+
+        seq_by_id: dict[str, list[int]] = {}
+        raw_seq_by_id = rebased.get("seq_by_id")
+        if isinstance(raw_seq_by_id, dict):
+            for key, value in raw_seq_by_id.items():
+                try:
+                    lo, hi = value
+                    seq_by_id[str(key)] = [
+                        seq_map[int(lo)],
+                        seq_map[int(hi)],
+                    ]
+                except (KeyError, TypeError, ValueError):
+                    continue
+
+        leaf_by_id: dict[str, list[Any]] = {}
+        raw_leaf_by_id = rebased.get("leaf_by_id")
+        if isinstance(raw_leaf_by_id, dict):
+            for key, value in raw_leaf_by_id.items():
+                try:
+                    seq, headline = value
+                    leaf_by_id[str(key)] = [seq_map[int(seq)], headline]
+                except (KeyError, TypeError, ValueError):
+                    continue
+
+        persisted_ids = {
+            str(item) for item in rebased.get("persisted_ids", ())
+        }
+        persisted_tcids = {
+            str(item) for item in rebased.get("persisted_tcids", ())
+        }
+        persisted_ids.intersection_update(model_turn_seq)
+        persisted_tcids.intersection_update(seq_by_tcid)
+
+        rebased["persisted_ids"] = sorted(persisted_ids)
+        rebased["persisted_tcids"] = sorted(persisted_tcids)
+        rebased["seen_tool_result_ids"] = sorted(
+            {
+                str(item) for item in rebased.get("seen_tool_result_ids", ())
+            }.intersection(persisted_tcids),
+        )
+        rebased["seq_by_tcid"] = seq_by_tcid
+        rebased["seq_by_id"] = seq_by_id
+        rebased["model_turn_seq"] = model_turn_seq
+        rebased["model_turn_nblk"] = {
+            str(key): value
+            for key, value in (
+                rebased.get("model_turn_nblk", {}).items()
+                if isinstance(rebased.get("model_turn_nblk"), dict)
+                else ()
+            )
+            if str(key) in model_turn_seq
+        }
+        rebased["leaf_by_id"] = leaf_by_id
+
+        raw_index = rebased.get("index")
+        if isinstance(raw_index, dict):
+            rebased["index"] = (
+                EvictionIndex.from_dict(raw_index)
+                .remap_sequences(session_id=session_id, seq_map=seq_map)
+                .to_dict()
+            )
+        else:
+            rebased["index"] = EvictionIndex(session_id).to_dict()
+
+        raw_summary = rebased.get("continuation_summary")
+        if isinstance(raw_summary, dict):
+            summary = ContinuationSummary.from_dict(raw_summary)
+            rebased_summary = (
+                summary.remap_sequences(seq_map)
+                if summary is not None
+                else None
+            )
+            rebased["continuation_summary"] = (
+                rebased_summary.to_dict()
+                if rebased_summary is not None
+                else None
+            )
+
+        return rebased
 
     def to_dict(self) -> dict:
         """Snapshot the dedup bookkeeping + eviction index for the agent

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -21,6 +21,8 @@ from .models import (
     ChatSpec,
     ChatUpdate,
     ChatHistory,
+    ForkChatRequest,
+    ForkChatResponse,
 )
 from .utils import agentscope_msg_to_message, parse_legacy_memory_state
 from ...services.project_directory import (
@@ -325,6 +327,115 @@ async def clear_chat_project_dir(
     if chat is None:
         raise HTTPException(status_code=404, detail="Chat not found")
     return await _project_directory_response(chat, workspace)
+
+
+# ----- Fork endpoint -----
+
+
+@router.post(
+    "/{chat_id}/fork",
+    response_model=ForkChatResponse,
+    status_code=201,
+)
+async def fork_chat(
+    chat_id: str,
+    body: ForkChatRequest = ForkChatRequest(),
+    mgr: ChatManager = Depends(get_chat_manager),
+    session: SafeJSONSession = Depends(get_session),
+    workspace=Depends(get_workspace),
+):
+    """Fork a chat: create a full snapshot in a new independent session.
+
+    201 on success.
+    404 if the source chat does not exist.
+    409 if the source chat is currently running (best-effort guard;
+         a TOCTOU window exists — see the design doc).
+    500 on I/O or persistence failures.
+    """
+    # 1. Validate source exists
+    source = await mgr.get_chat(chat_id)
+    if source is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Chat not found: {chat_id}",
+        )
+
+    # 2. Best-effort guard: reject if currently running
+    tracker = workspace.task_tracker
+    status = await tracker.get_status(chat_id)
+    if status == "running":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Source chat is still generating. "
+                "Wait for it to finish before forking."
+            ),
+        )
+
+    # 3. Generate new session_id
+    fork_uuid = str(uuid4())[:8]
+    new_session_id = f"{source.session_id}:fork-{fork_uuid}"
+
+    # 4. Clone session state file (BEFORE creating ChatSpec).
+    #    allow_missing_source=True: if source file was manually deleted,
+    #    write {} to preserve the invariant that the session file exists
+    #    before any ChatSpec references it.
+    source_missing = False
+    try:
+        source_missing = await session.clone_session_state(
+            src_session_id=source.session_id,
+            dst_session_id=new_session_id,
+            user_id=source.user_id,
+            channel=source.channel,
+            allow_missing_source=True,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to clone session state for chat %s",
+            chat_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to copy session state.",
+        ) from exc
+
+    # 5. Create ChatSpec (best-effort cleanup on failure)
+    fork_name = body.name or f"Fork of {source.name}"
+    try:
+        new_spec = await mgr.fork_chat(
+            source_chat_id=chat_id,
+            new_session_id=new_session_id,
+            name=fork_name,
+        )
+    except Exception as exc:
+        # Best-effort cleanup of now-orphan session file
+        deleted = await session.delete_session_state(
+            session_id=new_session_id,
+            user_id=source.user_id,
+            channel=source.channel,
+        )
+        if not deleted:
+            logger.warning(
+                "ChatSpec creation failed; orphan session file could "
+                "not be deleted: %s",
+                new_session_id,
+            )
+        logger.exception(
+            "Failed to create forked chat for source %s",
+            chat_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to create forked chat.",
+        ) from exc
+
+    return ForkChatResponse(
+        chat_id=new_spec.id,
+        session_id=new_spec.session_id,
+        name=new_spec.name,
+        created_at=new_spec.created_at,
+        source_state="empty" if source_missing else "ok",
+    )
 
 
 # ----- Existing CRUD endpoints -----

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -452,8 +452,8 @@ async def fork_chat(
 
     # 5. Clone session state file (BEFORE creating ChatSpec).
     #    allow_missing_source=True: if source file was manually deleted,
-    #    write {} to preserve the invariant that the session file exists
-    #    before any ChatSpec references it.
+    #    write a valid empty AgentState with the fork identity before any
+    #    ChatSpec references it.
     source_missing = False
     try:
         source_missing = await session.clone_session_state(

--- a/src/qwenpaw/app/chats/api.py
+++ b/src/qwenpaw/app/chats/api.py
@@ -30,11 +30,65 @@ from ...services.project_directory import (
     session_project_dir,
 )
 from ...checkpoints.runtime import RUNTIME as CHECKPOINT_RUNTIME
+from ...utils.io_utils import run_sync_io
 
 logger = logging.getLogger(__name__)
 
 
 router = APIRouter(prefix="/chats", tags=["chats"])
+
+
+def _scroll_history_path(workspace) -> Path | None:
+    """Return the configured Scroll history path without creating a DB.
+
+    Existing rows are cloned even when the agent currently runs in native
+    mode: the source may have been compressed before the strategy changed,
+    and those evicted turns exist only in this store.
+    """
+    try:
+        light_context = workspace.config.running.light_context_config
+        path = Path(workspace.workspace_dir) / (
+            light_context.scroll_config.db_filename
+        )
+    except (AttributeError, TypeError):
+        return None
+    return path if path.exists() else None
+
+
+def _clone_scroll_history(
+    workspace,
+    *,
+    source_session_id: str,
+    destination_session_id: str,
+) -> dict[int, int]:
+    """Clone durable Scroll rows and return source-to-fork seq mapping."""
+    path = _scroll_history_path(workspace)
+    if path is None:
+        return {}
+    from ...agents.context.scroll.history import HistoryStore
+
+    history = HistoryStore(path)
+    try:
+        return history.clone_session_rows(
+            source_session_id=source_session_id,
+            destination_session_id=destination_session_id,
+        )
+    finally:
+        history.close()
+
+
+def _delete_scroll_history(workspace, session_id: str) -> int:
+    """Best-effort rollback for durable rows created during a failed fork."""
+    path = _scroll_history_path(workspace)
+    if path is None:
+        return 0
+    from ...agents.context.scroll.history import HistoryStore
+
+    history = HistoryStore(path)
+    try:
+        return history.delete_session_rows(session_id)
+    finally:
+        history.close()
 
 
 async def get_workspace(request: Request):
@@ -376,7 +430,27 @@ async def fork_chat(
     fork_uuid = str(uuid4())[:8]
     new_session_id = f"{source.session_id}:fork-{fork_uuid}"
 
-    # 4. Clone session state file (BEFORE creating ChatSpec).
+    # 4. Clone durable Scroll rows first. New globally addressed seq values
+    #    are returned so the JSON checkpoint can be rebased onto fork-owned
+    #    history instead of retaining source pointers.
+    try:
+        scroll_seq_map = await run_sync_io(
+            _clone_scroll_history,
+            workspace,
+            source_session_id=source.session_id,
+            destination_session_id=new_session_id,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Failed to clone Scroll history for chat %s",
+            chat_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to copy durable session history.",
+        ) from exc
+
+    # 5. Clone session state file (BEFORE creating ChatSpec).
     #    allow_missing_source=True: if source file was manually deleted,
     #    write {} to preserve the invariant that the session file exists
     #    before any ChatSpec references it.
@@ -388,8 +462,21 @@ async def fork_chat(
             user_id=source.user_id,
             channel=source.channel,
             allow_missing_source=True,
+            scroll_seq_map=scroll_seq_map,
         )
     except Exception as exc:
+        try:
+            await run_sync_io(
+                _delete_scroll_history,
+                workspace,
+                new_session_id,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to clean up fork Scroll history: %s",
+                new_session_id,
+                exc_info=True,
+            )
         logger.exception(
             "Failed to clone session state for chat %s",
             chat_id,
@@ -399,7 +486,7 @@ async def fork_chat(
             detail="Failed to copy session state.",
         ) from exc
 
-    # 5. Create ChatSpec (best-effort cleanup on failure)
+    # 6. Create ChatSpec (best-effort cleanup on failure)
     fork_name = body.name or f"Fork of {source.name}"
     try:
         new_spec = await mgr.fork_chat(
@@ -419,6 +506,19 @@ async def fork_chat(
                 "ChatSpec creation failed; orphan session file could "
                 "not be deleted: %s",
                 new_session_id,
+            )
+        try:
+            await run_sync_io(
+                _delete_scroll_history,
+                workspace,
+                new_session_id,
+            )
+        except Exception:
+            logger.warning(
+                "ChatSpec creation failed; fork Scroll history could not "
+                "be deleted: %s",
+                new_session_id,
+                exc_info=True,
             )
         logger.exception(
             "Failed to create forked chat for source %s",

--- a/src/qwenpaw/app/chats/manager.py
+++ b/src/qwenpaw/app/chats/manager.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 from datetime import datetime, timezone
 from collections.abc import Awaitable, Callable
 from typing import Optional
+from uuid import uuid4
 
 from .models import (
     BatchArchiveResult,
@@ -452,6 +454,62 @@ class ChatManager:
             f"{len(result.failed)} failed",
         )
         return result
+
+    # ----- Fork Operations -----
+
+    async def fork_chat(
+        self,
+        *,
+        source_chat_id: str,
+        new_session_id: str,
+        name: str,
+    ) -> ChatSpec:
+        """Create a new ChatSpec by forking the source spec.
+
+        Copies user_id, channel, and meta from source. Adds trace fields
+        (forked_from_chat_id, forked_from_session_id, forked_at) into a
+        deep-copied meta dict.
+
+        The caller is responsible for:
+        1. Verifying source existence and status before calling.
+        2. Writing the new session state file before calling this method.
+        3. Cleaning up the session file if this method raises.
+        """
+        async with self._lock:
+            source = await self._repo.get_chat(source_chat_id)
+            if source is None:
+                raise ValueError(
+                    f"Source chat not found: {source_chat_id}",
+                )
+
+            # deep copy meta + fork trace
+            forked_meta = copy.deepcopy(source.meta)
+            forked_meta.update(
+                {
+                    "forked_from_chat_id": source.id,
+                    "forked_from_session_id": source.session_id,
+                    "forked_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+
+            new_spec = ChatSpec(
+                id=str(uuid4()),
+                session_id=new_session_id,
+                user_id=source.user_id,
+                channel=source.channel,
+                name=name,
+                source=SessionSource.chat,
+                meta=forked_meta,
+            )
+            await self._repo.upsert_chat(new_spec)
+            logger.info(
+                "Forked chat %s -> %s (session %s -> %s)",
+                source.id,
+                new_spec.id,
+                source.session_id,
+                new_session_id,
+            )
+            return new_spec
 
     # ----- Misc Operations -----
 

--- a/src/qwenpaw/app/chats/models.py
+++ b/src/qwenpaw/app/chats/models.py
@@ -126,3 +126,36 @@ class ChatsFile(BaseModel):
 
     version: int = 1
     chats: list[ChatSpec] = Field(default_factory=list)
+
+
+class ForkChatRequest(BaseModel):
+    """Request body for POST /chats/{chat_id}/fork.
+
+    P0: *name* is the only user-controlled field.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(
+        default=None,
+        description=(
+            "Name for the forked chat. " "Defaults to 'Fork of {source.name}'."
+        ),
+    )
+
+
+class ForkChatResponse(BaseModel):
+    """Response body for POST /chats/{chat_id}/fork."""
+
+    chat_id: str
+    session_id: str
+    name: str
+    created_at: datetime
+    source_state: str = Field(
+        default="ok",
+        description=(
+            '"ok" when the source session was fully copied; '
+            '"empty" when the source file was missing and the '
+            "fork starts with no messages."
+        ),
+    )

--- a/src/qwenpaw/app/chats/session.py
+++ b/src/qwenpaw/app/chats/session.py
@@ -490,9 +490,9 @@ class SafeJSONSession:
         destination path lock. Other persisted state modules are preserved.
 
         When *allow_missing_source* is True and the source file does not
-        exist, writes an empty dict ``{}`` to the destination instead of
-        raising. This preserves the invariant that the destination file
-        exists before any ChatSpec references it.
+        exist, writes a valid empty AgentState with the destination identity
+        instead of raising. This preserves the invariant that the destination
+        file exists before any ChatSpec references it.
 
         Returns True if the source was missing and ``allow_missing_source``
         was True (caller can warn the user). Returns False otherwise.
@@ -528,22 +528,41 @@ class SafeJSONSession:
         # checkpoint also addresses global history.db sequence values, which
         # must be replaced with the destination rows created by the caller.
         agent_state = src_state.get("agent")
-        if isinstance(agent_state, dict):
-            raw_state = agent_state.get("state")
-            if isinstance(raw_state, dict):
-                raw_state["session_id"] = dst_session_id
+        if not isinstance(agent_state, dict):
+            agent_state = {}
+            src_state["agent"] = agent_state
 
-            raw_scroll = agent_state.get("scroll")
-            if isinstance(raw_scroll, dict):
-                from ...agents.context.scroll.manager import (
-                    ScrollContextManager,
-                )
+        raw_state = agent_state.get("state")
+        if isinstance(raw_state, dict):
+            raw_state["session_id"] = dst_session_id
+        elif raw_state is None:
+            # Missing snapshots and 1.x ``agent.memory`` snapshots otherwise
+            # receive AgentState's random default identity on first build.
+            # Normalize both forms now so every fork has the destination
+            # identity before MemoryMiddleware performs any routing.
+            from agentscope.state import AgentState
 
-                agent_state["scroll"] = ScrollContextManager.rebase_checkpoint(
-                    raw_scroll,
-                    session_id=dst_session_id,
-                    seq_map=scroll_seq_map or {},
-                )
+            migrated_state = AgentState(session_id=dst_session_id)
+            legacy_memory = agent_state.get("memory")
+            if isinstance(legacy_memory, dict):
+                from .utils import parse_legacy_memory_state
+
+                messages, summary = parse_legacy_memory_state(legacy_memory)
+                migrated_state.context.extend(messages)
+                migrated_state.summary = summary
+            agent_state["state"] = migrated_state.model_dump(mode="json")
+        else:
+            raise ValueError("agent.state must be a JSON object")
+
+        raw_scroll = agent_state.get("scroll")
+        if isinstance(raw_scroll, dict):
+            from ...agents.context.scroll.manager import ScrollContextManager
+
+            agent_state["scroll"] = ScrollContextManager.rebase_checkpoint(
+                raw_scroll,
+                session_id=dst_session_id,
+                seq_map=scroll_seq_map or {},
+            )
 
         # 2. Write to destination file (path lock + atomic write)
         dst_path = await run_sync_io(

--- a/src/qwenpaw/app/chats/session.py
+++ b/src/qwenpaw/app/chats/session.py
@@ -480,11 +480,14 @@ class SafeJSONSession:
         user_id: str = "",
         channel: str = "",
         allow_missing_source: bool = False,
+        scroll_seq_map: dict[int, int] | None = None,
     ) -> bool:
-        """Copy session state from src to dst at the raw JSON level.
+        """Copy and rebase session state from ``src`` to ``dst``.
 
-        Reads the full source session dict under path lock, then writes it
-        atomically to a new destination file under path lock.
+        Reads the full source session dict under path lock, changes the
+        AgentScope session identity to the destination, rebases Scroll's
+        durable sequence pointers, then writes the result atomically under the
+        destination path lock. Other persisted state modules are preserved.
 
         When *allow_missing_source* is True and the source file does not
         exist, writes an empty dict ``{}`` to the destination instead of
@@ -520,6 +523,27 @@ class SafeJSONSession:
                     source_missing = True
                 else:
                     raise
+
+        # A fork must own a distinct AgentScope/memory identity. Scroll's
+        # checkpoint also addresses global history.db sequence values, which
+        # must be replaced with the destination rows created by the caller.
+        agent_state = src_state.get("agent")
+        if isinstance(agent_state, dict):
+            raw_state = agent_state.get("state")
+            if isinstance(raw_state, dict):
+                raw_state["session_id"] = dst_session_id
+
+            raw_scroll = agent_state.get("scroll")
+            if isinstance(raw_scroll, dict):
+                from ...agents.context.scroll.manager import (
+                    ScrollContextManager,
+                )
+
+                agent_state["scroll"] = ScrollContextManager.rebase_checkpoint(
+                    raw_scroll,
+                    session_id=dst_session_id,
+                    seq_map=scroll_seq_map or {},
+                )
 
         # 2. Write to destination file (path lock + atomic write)
         dst_path = await run_sync_io(

--- a/src/qwenpaw/app/chats/session.py
+++ b/src/qwenpaw/app/chats/session.py
@@ -471,3 +471,107 @@ class SafeJSONSession:
                 f"because it does not exist"
             ),
         )
+
+    async def clone_session_state(
+        self,
+        *,
+        src_session_id: str,
+        dst_session_id: str,
+        user_id: str = "",
+        channel: str = "",
+        allow_missing_source: bool = False,
+    ) -> bool:
+        """Copy session state from src to dst at the raw JSON level.
+
+        Reads the full source session dict under path lock, then writes it
+        atomically to a new destination file under path lock.
+
+        When *allow_missing_source* is True and the source file does not
+        exist, writes an empty dict ``{}`` to the destination instead of
+        raising. This preserves the invariant that the destination file
+        exists before any ChatSpec references it.
+
+        Returns True if the source was missing and ``allow_missing_source``
+        was True (caller can warn the user). Returns False otherwise.
+
+        Raises FileNotFoundError when *allow_missing_source* is False
+        (the default) and the source file is missing.
+        """
+        source_missing = False
+        # 1. Read source file under path lock
+        src_path = await run_sync_io(
+            self._get_save_path,
+            src_session_id,
+            user_id,
+            channel,
+        )
+        async with get_path_lock(src_path):
+            try:
+                src_state = await run_sync_io(_read_session_json, src_path)
+            except FileNotFoundError:
+                if allow_missing_source:
+                    logger.warning(
+                        "Source session file missing for %s, "
+                        "cloning empty state to %s.",
+                        src_session_id,
+                        dst_session_id,
+                    )
+                    src_state = {}
+                    source_missing = True
+                else:
+                    raise
+
+        # 2. Write to destination file (path lock + atomic write)
+        dst_path = await run_sync_io(
+            self._get_save_path,
+            dst_session_id,
+            user_id,
+            channel,
+        )
+        async with get_path_lock(dst_path):
+            await write_json_atomic_async(
+                dst_path,
+                src_state,
+                indent=None,
+            )
+
+        logger.info(
+            "Cloned session state %s -> %s (%d top-level keys)",
+            src_session_id,
+            dst_session_id,
+            len(src_state),
+        )
+        return source_missing
+
+    async def delete_session_state(
+        self,
+        *,
+        session_id: str,
+        user_id: str = "",
+        channel: str = "",
+    ) -> bool:
+        """Delete a session state file. Best-effort; never raises.
+
+        Returns True if the file was deleted, False if it didn't exist.
+        Uses run_sync_io to avoid blocking the async event loop.
+        """
+        path = await run_sync_io(
+            self._get_save_path,
+            session_id,
+            user_id,
+            channel,
+        )
+        async with get_path_lock(path):
+            try:
+                await run_sync_io(os.remove, path)
+                logger.info("Deleted orphan session file: %s", path)
+                return True
+            except FileNotFoundError:
+                return False
+            except OSError as exc:
+                logger.warning(
+                    "Failed to delete orphan session file %s: %s",
+                    path,
+                    exc,
+                )
+                return False

--- a/tests/unit/agents/context/test_history_store.py
+++ b/tests/unit/agents/context/test_history_store.py
@@ -209,6 +209,56 @@ def test_reconcile_rows_deduplicates_source_and_fts(store: HistoryStore):
     assert hits == []
 
 
+def test_reconcile_rows_deduplicates_recall_rows_not_indexed_in_fts(
+    store: HistoryStore,
+):
+    """Deleting a duplicate recall row must not issue an FTS delete for it."""
+    if not store._fts:
+        pytest.skip("SQLite build lacks FTS5")
+    recall = _entry("recall output", name="recall_history")
+    store.append(
+        session_id="canonical",
+        dedup_key="shared-recall",
+        entry=recall,
+    )
+    store.append(
+        session_id="sync:file",
+        dedup_key="shared-recall",
+        entry=recall,
+    )
+
+    result = store.reconcile_session_rows(
+        {"sync:file"},
+        "canonical",
+        {"shared-recall"},
+    )
+
+    assert result == (0, 1, 0)
+    assert store.count("sync:file") == 0
+    assert store.count("canonical") == 1
+
+
+def test_delete_session_rows_skips_fts_delete_for_recall_rows(
+    store: HistoryStore,
+):
+    if not store._fts:
+        pytest.skip("SQLite build lacks FTS5")
+    store.append(
+        session_id="fork",
+        dedup_key="recall",
+        entry=_entry("recall output", name="recall_history"),
+    )
+    store.append(
+        session_id="fork",
+        dedup_key="normal",
+        entry=_entry("ordinary indexed output"),
+    )
+
+    assert store.delete_session_rows("fork") == 2
+    assert store.count("fork") == 0
+    assert store._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+
+
 def test_null_dedup_key_is_never_deduped(store: HistoryStore):
     store.append(session_id="s", dedup_key=None, entry=_entry("x"))
     store.append(session_id="s", dedup_key=None, entry=_entry("x"))
@@ -314,6 +364,24 @@ def test_purge_drops_old_rows_and_keeps_recent(store: HistoryStore):
     removed = store.purge(before="2025-01-01T00:00:00+00:00")
     assert removed == 1
     assert store.count("s") == 1
+
+
+def test_purge_skips_fts_delete_for_recall_rows(store: HistoryStore):
+    if not store._fts:
+        pytest.skip("SQLite build lacks FTS5")
+    store.append(
+        session_id="s",
+        dedup_key="old-recall",
+        entry=_entry(
+            "old recall output",
+            name="recall_history_python",
+            created_at="2020-01-01T00:00:00+00:00",
+        ),
+    )
+
+    assert store.purge(before="2025-01-01T00:00:00+00:00") == 1
+    assert store.count("s") == 0
+    assert store._conn.execute("PRAGMA quick_check").fetchone()[0] == "ok"
 
 
 def test_purge_dry_run_reports_count_without_deleting(store: HistoryStore):

--- a/tests/unit/app/chats/test_fork.py
+++ b/tests/unit/app/chats/test_fork.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for chat forking: ChatManager.fork_chat + SafeJSONSession
+clone_session_state / delete_session_state.
+
+Uses the real :class:`JsonChatRepository` and :class:`SafeJSONSession`
+backed by ``tmp_path``.
+"""
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qwenpaw.app.chats.manager import ChatManager
+from qwenpaw.app.chats.models import ChatSpec, SessionSource
+from qwenpaw.app.chats.repo import JsonChatRepository
+from qwenpaw.app.chats.session import SafeJSONSession
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyModule:
+    """Minimal state module for testing SafeJSONSession."""
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def state_dict(self) -> dict:
+        return self._state
+
+    def load_state_dict(self, data: dict) -> None:
+        self._state = data
+
+
+def _make_spec(
+    *,
+    chat_id: str | None = None,
+    session_id: str = "console:u1",
+    user_id: str = "u1",
+    name: str = "Test Chat",
+    source: SessionSource = SessionSource.chat,
+    meta: dict | None = None,
+) -> ChatSpec:
+    kwargs: dict = {
+        "session_id": session_id,
+        "user_id": user_id,
+        "name": name,
+        "source": source,
+    }
+    if chat_id is not None:
+        kwargs["id"] = chat_id
+    if meta is not None:
+        kwargs["meta"] = meta
+    return ChatSpec(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def repo_path(tmp_path: Path) -> Path:
+    return tmp_path / "chats.json"
+
+
+@pytest.fixture
+def sessions_dir(tmp_path: Path) -> Path:
+    p = tmp_path / "sessions"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def manager(repo_path: Path) -> ChatManager:
+    return ChatManager(repo=JsonChatRepository(repo_path))
+
+
+@pytest.fixture
+def session(sessions_dir: Path) -> SafeJSONSession:
+    return SafeJSONSession(save_dir=str(sessions_dir))
+
+
+# ---------------------------------------------------------------------------
+# ChatManager.fork_chat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fork_creates_independent_spec(manager: ChatManager):
+    """Fork creates a new ChatSpec with lineage metadata."""
+    source = await manager.create_chat(
+        _make_spec(
+            session_id="console:u1",
+            user_id="u1",
+            name="Source",
+            meta={"custom": "value"},
+        ),
+    )
+
+    forked = await manager.fork_chat(
+        source_chat_id=source.id,
+        new_session_id="console:u1:fork-abc12345",
+        name="Fork of Source",
+    )
+
+    assert forked.id != source.id
+    assert forked.name == "Fork of Source"
+    assert forked.session_id == "console:u1:fork-abc12345"
+    assert forked.user_id == source.user_id
+    assert forked.channel == source.channel
+    assert forked.source == SessionSource.chat
+    # lineage
+    assert forked.meta["forked_from_chat_id"] == source.id
+    assert forked.meta["forked_from_session_id"] == source.session_id
+    assert "forked_at" in forked.meta
+    # deep copy — original meta preserved
+    assert forked.meta["custom"] == "value"
+    # original source meta unchanged
+    assert source.meta == {"custom": "value"}
+
+
+@pytest.mark.asyncio
+async def test_fork_raises_on_unknown_source(manager: ChatManager):
+    with pytest.raises(ValueError, match="Source chat not found"):
+        await manager.fork_chat(
+            source_chat_id="nonexistent-id",
+            new_session_id="console:u1:fork-00000000",
+            name="Ghost",
+        )
+
+
+@pytest.mark.asyncio
+async def test_fork_meta_deep_copy_independence(manager: ChatManager):
+    """Mutating source.meta after fork doesn't affect forked meta."""
+    source = await manager.create_chat(
+        _make_spec(
+            session_id="console:u1",
+            user_id="u1",
+            name="Source",
+            meta={"a": 1},
+        ),
+    )
+
+    forked = await manager.fork_chat(
+        source_chat_id=source.id,
+        new_session_id="console:u1:fork-xyz",
+        name="Fork",
+    )
+
+    source.meta["a"] = 999
+    source.meta["b"] = 2
+
+    assert forked.meta["a"] == 1
+    assert "b" not in forked.meta
+
+
+# ---------------------------------------------------------------------------
+# SafeJSONSession.clone_session_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clone_session_state_copies_full_state(
+    session: SafeJSONSession,
+):
+    """Full state dict is copied to the new session file."""
+    await session.save_session_state(
+        session_id="src-session",
+        user_id="u1",
+        dummy=_DummyModule({"key": "value", "nested": {"x": 1}}),
+    )
+
+    await session.clone_session_state(
+        src_session_id="src-session",
+        dst_session_id="dst-session",
+        user_id="u1",
+    )
+
+    dst_state = await session.get_session_state_dict(
+        "dst-session",
+        user_id="u1",
+    )
+    assert dst_state == {"dummy": {"key": "value", "nested": {"x": 1}}}
+
+
+@pytest.mark.asyncio
+async def test_clone_raises_when_source_missing(
+    session: SafeJSONSession,
+):
+    with pytest.raises(FileNotFoundError):
+        await session.clone_session_state(
+            src_session_id="nonexistent",
+            dst_session_id="dst",
+            user_id="u1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_clone_allow_missing_writes_empty_dict(
+    session: SafeJSONSession,
+):
+    """allow_missing_source=True writes {} to the destination."""
+    await session.clone_session_state(
+        src_session_id="nonexistent",
+        dst_session_id="dst",
+        user_id="u1",
+        allow_missing_source=True,
+    )
+
+    dst_state = await session.get_session_state_dict("dst", user_id="u1")
+    assert dst_state == {}
+
+
+@pytest.mark.asyncio
+async def test_clone_session_independent(
+    session: SafeJSONSession,
+):
+    """Cloned session is independent — modifications don't cross."""
+    await session.save_session_state(
+        session_id="src",
+        user_id="u1",
+        dummy=_DummyModule({"v": 1}),
+    )
+
+    await session.clone_session_state(
+        src_session_id="src",
+        dst_session_id="dst",
+        user_id="u1",
+    )
+
+    # modify original via update
+    await session.update_session_state(
+        session_id="src",
+        key="dummy.v",
+        value=99,
+        user_id="u1",
+    )
+
+    src = await session.get_session_state_dict("src", user_id="u1")
+    dst = await session.get_session_state_dict("dst", user_id="u1")
+    assert src["dummy"]["v"] == 99
+    assert dst["dummy"]["v"] == 1
+
+
+# ---------------------------------------------------------------------------
+# SafeJSONSession.delete_session_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_session_state_removes_file(
+    session: SafeJSONSession,
+):
+    await session.save_session_state(
+        session_id="orphan",
+        user_id="u1",
+        dummy=_DummyModule({"x": 1}),
+    )
+    deleted = await session.delete_session_state(
+        session_id="orphan",
+        user_id="u1",
+    )
+    assert deleted is True
+    state = await session.get_session_state_dict("orphan", user_id="u1")
+    assert state == {}
+
+
+@pytest.mark.asyncio
+async def test_delete_session_state_returns_false_when_missing(
+    session: SafeJSONSession,
+):
+    deleted = await session.delete_session_state(
+        session_id="nonexistent",
+        user_id="u1",
+    )
+    assert deleted is False
+
+
+@pytest.mark.asyncio
+async def test_delete_session_state_never_raises_on_double_delete(
+    session: SafeJSONSession,
+):
+    """Deleting an already-deleted file returns False, never raises."""
+    await session.save_session_state(
+        session_id="temp",
+        user_id="u1",
+        dummy=_DummyModule({"x": 1}),
+    )
+    # first delete succeeds
+    assert await session.delete_session_state(
+        session_id="temp",
+        user_id="u1",
+    )
+    # second delete is a no-op
+    result = await session.delete_session_state(
+        session_id="temp",
+        user_id="u1",
+    )
+    assert result is False

--- a/tests/unit/app/chats/test_fork.py
+++ b/tests/unit/app/chats/test_fork.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from agentscope.message import Msg, TextBlock
+from agentscope.state import AgentState
 
 from qwenpaw.app.chats.manager import ChatManager
 from qwenpaw.app.chats.models import ChatSpec, SessionSource
@@ -185,7 +187,10 @@ async def test_clone_session_state_copies_full_state(
         "dst-session",
         user_id="u1",
     )
-    assert dst_state == {"dummy": {"key": "value", "nested": {"x": 1}}}
+    assert dst_state["dummy"] == {"key": "value", "nested": {"x": 1}}
+    cloned_agent = AgentState.model_validate(dst_state["agent"]["state"])
+    assert cloned_agent.session_id == "dst-session"
+    assert cloned_agent.context == []
 
 
 @pytest.mark.asyncio
@@ -201,19 +206,61 @@ async def test_clone_raises_when_source_missing(
 
 
 @pytest.mark.asyncio
-async def test_clone_allow_missing_writes_empty_dict(
+async def test_clone_allow_missing_writes_empty_agent_state(
     session: SafeJSONSession,
 ):
-    """allow_missing_source=True writes {} to the destination."""
-    await session.clone_session_state(
+    """A missing source still produces a valid destination identity."""
+    source_missing = await session.clone_session_state(
         src_session_id="nonexistent",
         dst_session_id="dst",
         user_id="u1",
         allow_missing_source=True,
     )
 
+    assert source_missing is True
     dst_state = await session.get_session_state_dict("dst", user_id="u1")
-    assert dst_state == {}
+    cloned_agent = AgentState.model_validate(dst_state["agent"]["state"])
+    assert cloned_agent.session_id == "dst"
+    assert cloned_agent.context == []
+
+
+@pytest.mark.asyncio
+async def test_clone_migrates_legacy_memory_with_destination_identity(
+    session: SafeJSONSession,
+):
+    legacy_message = Msg(
+        name="user",
+        role="user",
+        content=[TextBlock(type="text", text="legacy context")],
+    )
+    legacy_memory = {
+        "content": [[legacy_message.to_dict(), []]],
+        "_compressed_summary": "legacy summary",
+    }
+    await session.save_session_state(
+        session_id="legacy-src",
+        user_id="u1",
+        agent=_DummyModule({"memory": legacy_memory}),
+    )
+
+    source_missing = await session.clone_session_state(
+        src_session_id="legacy-src",
+        dst_session_id="legacy-fork",
+        user_id="u1",
+    )
+
+    assert source_missing is False
+    dst_state = await session.get_session_state_dict(
+        "legacy-fork",
+        user_id="u1",
+    )
+    cloned_agent = AgentState.model_validate(dst_state["agent"]["state"])
+    assert cloned_agent.session_id == "legacy-fork"
+    assert cloned_agent.summary == "legacy summary"
+    assert [msg.get_text_content() for msg in cloned_agent.context] == [
+        "legacy context",
+    ]
+    assert dst_state["agent"]["memory"] == legacy_memory
 
 
 @pytest.mark.asyncio

--- a/tests/unit/app/chats/test_session_fork_scroll.py
+++ b/tests/unit/app/chats/test_session_fork_scroll.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,too-many-statements
+"""Production-path regression coverage for Scroll-aware session forks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agentscope.message import Msg, TextBlock
+from agentscope.state import AgentState
+
+from qwenpaw.agents.context.scroll.continuation_summary import (
+    ContinuationSummary,
+    SummaryItem,
+    SummarySource,
+)
+from qwenpaw.agents.context.scroll.history import HistoryStore
+from qwenpaw.agents.context.scroll.manager import ScrollContextManager
+from qwenpaw.agents.context.scroll.memoryspace import MemorySpace
+from qwenpaw.agents.middlewares import MemoryMiddleware
+from qwenpaw.agents.react_agent import QwenPawAgent
+from qwenpaw.app.chats.session import SafeJSONSession
+
+
+class _AgentShim:
+    """Run the production Agent state serialization without model wiring."""
+
+    def __init__(self, manager: ScrollContextManager, state=None) -> None:
+        self._context_manager = manager
+        self.state = state if state is not None else AgentState()
+
+    def state_dict(self) -> dict:
+        return QwenPawAgent.state_dict(self)
+
+    def load_state_dict(self, data: dict, strict: bool = True) -> None:
+        QwenPawAgent.load_state_dict(self, data, strict=strict)
+
+    def _sanitize_loaded_context(self) -> None:
+        QwenPawAgent._sanitize_loaded_context(self)
+
+
+def _message(role: str, text: str) -> Msg:
+    return Msg(
+        name="user" if role == "user" else "assistant",
+        role=role,
+        content=[TextBlock(type="text", text=text)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_fork_rebases_identity_and_owns_full_scroll_history(
+    tmp_path: Path,
+):
+    """Evicted and live rows survive under an independent fork identity."""
+    source_session_id = "console:user"
+    fork_session_id = "console:user:fork-12345678"
+    history_path = tmp_path / "history.db"
+    history = HistoryStore(history_path)
+    sessions = SafeJSONSession(save_dir=str(tmp_path / "sessions"))
+
+    old = _message("assistant", "old context already evicted")
+    recent = _message("user", "recent context still live")
+    source_state = AgentState(
+        session_id=source_session_id,
+        context=[old, recent],
+    )
+    source_manager = ScrollContextManager(
+        history=history,
+        session_id=source_session_id,
+        agent_id="agent-1",
+    )
+    source_agent = _AgentShim(source_manager, source_state)
+    source_manager._persist_new(source_agent)
+    old_source_seq = source_manager._seq_by_id[old.id][0]
+    recent_source_seq = source_manager._seq_by_id[recent.id][0]
+
+    # Model a real compression boundary: the old turn is durable and indexed,
+    # but no longer present in AgentState.context.
+    source_manager._index_evicted([old])
+    source_agent.state.context = [recent]
+    source_manager._prune_bookkeeping_to_live_context(source_agent)
+    source_manager._continuation_summary = ContinuationSummary(
+        covered_seq=(old_source_seq, old_source_seq),
+        active_task="Continue the forked task",
+        status="in_progress",
+        current_state=(
+            SummaryItem(
+                text="The old turn established the task.",
+                sources=(
+                    SummarySource(
+                        type="seq",
+                        lo=old_source_seq,
+                        hi=old_source_seq,
+                    ),
+                ),
+            ),
+        ),
+    )
+    await sessions.save_session_state(
+        session_id=source_session_id,
+        agent=source_agent,
+    )
+
+    seq_map = history.clone_session_rows(
+        source_session_id=source_session_id,
+        destination_session_id=fork_session_id,
+    )
+    await sessions.clone_session_state(
+        src_session_id=source_session_id,
+        dst_session_id=fork_session_id,
+        scroll_seq_map=seq_map,
+    )
+
+    fork_manager = ScrollContextManager(
+        history=history,
+        session_id=fork_session_id,
+        agent_id="agent-1",
+    )
+    fork_agent = _AgentShim(fork_manager)
+    await sessions.load_session_state(
+        session_id=fork_session_id,
+        agent=fork_agent,
+    )
+
+    # AgentScope/ReMe routing uses the fork identity, never the source.
+    assert fork_agent.state.session_id == fork_session_id
+    assert MemoryMiddleware._agent_session_id(fork_agent) == fork_session_id
+
+    # Both the evicted turn and the restored live turn have fork-owned rows.
+    old_fork_seq = seq_map[old_source_seq]
+    recent_fork_seq = seq_map[recent_source_seq]
+    memory = MemorySpace(
+        history_db_path=history_path,
+        session_id=fork_session_id,
+        agent_id="agent-1",
+    )
+    try:
+        assert memory.expand(old_fork_seq, old_fork_seq)[0]["content"] == (
+            "old context already evicted"
+        )
+        assert (
+            memory.expand(recent_fork_seq, recent_fork_seq)[0]["content"]
+            == "recent context still live"
+        )
+        hits = memory.search(
+            "already evicted",
+            session_id=fork_session_id,
+        )
+        assert [(hit["session_id"], hit["content"]) for hit in hits] == [
+            (fork_session_id, "old context already evicted"),
+        ]
+    finally:
+        memory.close()
+
+    index = fork_manager._index.to_dict()
+    assert index["session_id"] == fork_session_id
+    assert index["tiers"][0][0]["seq_lo"] == old_fork_seq
+    assert index["tiers"][0][0]["seq_hi"] == old_fork_seq
+    assert fork_manager._model_turn_seq[recent.id] == recent_fork_seq
+    assert fork_manager._seq_by_id[recent.id] == (
+        recent_fork_seq,
+        recent_fork_seq,
+    )
+    assert fork_manager._continuation_summary is not None
+    assert fork_manager._continuation_summary.covered_seq == (
+        old_fork_seq,
+        old_fork_seq,
+    )
+    assert fork_manager._continuation_summary.seq_spans() == (
+        (old_fork_seq, old_fork_seq),
+    )
+
+    # First resume write-through recognizes the copied live row. A new fork
+    # turn then changes only the fork's durable scope.
+    fork_manager.on_save(fork_agent, None)
+    assert history.count(source_session_id) == 2
+    assert history.count(fork_session_id) == 2
+
+    fork_agent.state.context.append(_message("user", "fork-only follow-up"))
+    fork_manager.on_save(fork_agent, None)
+    assert history.count(source_session_id) == 2
+    assert history.count(fork_session_id) == 3
+
+    history.close()

--- a/tests/unit/app/routers/test_chats_fork_router.py
+++ b/tests/unit/app/routers/test_chats_fork_router.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""API-layer tests for POST /chats/{chat_id}/fork."""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+
+from qwenpaw.app.agent_context import get_current_session_id
+from qwenpaw.app.chats.api import router
+from qwenpaw.app.chats.manager import ChatManager
+from qwenpaw.app.chats.models import ChatSpec, SessionSource
+from qwenpaw.app.chats.session import SafeJSONSession
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_workspace(
+    *,
+    mgr: ChatManager,
+    session: SafeJSONSession,
+    status: str = "idle",
+):
+    """Build a workspace mock wired with the given manager/session/tracker."""
+    tracker = MagicMock()
+    tracker.get_status = AsyncMock(return_value=status)
+
+    ws = MagicMock()
+    ws.chat_manager = mgr
+    ws.session = session
+    ws.task_tracker = tracker
+    return ws
+
+
+def _make_chat_spec(
+    *,
+    chat_id: str = "abc-123",
+    session_id: str = "console:u1",
+    user_id: str = "u1",
+    name: str = "Test Chat",
+) -> ChatSpec:
+    return ChatSpec(
+        id=chat_id,
+        session_id=session_id,
+        user_id=user_id,
+        channel="console",
+        name=name,
+        source=SessionSource.chat,
+        meta={"existing": "data"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_mock():
+    return AsyncMock(spec=ChatManager)
+
+
+@pytest.fixture
+def session_mock():
+    s = AsyncMock(spec=SafeJSONSession)
+    s.clone_session_state = AsyncMock()
+    s.delete_session_state = AsyncMock(return_value=True)
+    return s
+
+
+@pytest.fixture
+def app(manager_mock, session_mock):
+    """FastAPI app with overridden dependencies for the fork endpoint."""
+    app = FastAPI()
+    app.include_router(router)
+
+    ws = _mock_workspace(mgr=manager_mock, session=session_mock)
+
+    async def override_workspace():
+        return ws
+
+    app.dependency_overrides[get_current_session_id] = lambda: None
+    # Wire the Depends(get_workspace) / Depends(get_chat_manager) /
+    # Depends(get_session) used inside the endpoint
+    from qwenpaw.app.chats.api import get_workspace
+    from qwenpaw.app.chats.api import get_chat_manager as _gcm
+    from qwenpaw.app.chats.api import get_session as _gs
+
+    app.dependency_overrides[get_workspace] = override_workspace
+    app.dependency_overrides[_gcm] = lambda: manager_mock
+    app.dependency_overrides[_gs] = lambda: session_mock
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# 201 — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_fork_returns_201_and_new_chat(
+    client,
+    manager_mock,
+    session_mock,
+):
+    """Happy path: fork returns 201 with lineage in meta."""
+    source = _make_chat_spec()
+    manager_mock.get_chat = AsyncMock(return_value=source)
+    manager_mock.fork_chat = AsyncMock(
+        return_value=ChatSpec(
+            id="fork-999",
+            session_id="console:u1:fork-abcdef01",
+            user_id=source.user_id,
+            channel=source.channel,
+            name="Fork of Test Chat",
+            source=SessionSource.chat,
+            meta={
+                "forked_from_chat_id": source.id,
+                "forked_from_session_id": source.session_id,
+                "forked_at": "2026-08-05T00:00:00Z",
+            },
+        ),
+    )
+
+    resp = client.post("/chats/abc-123/fork")
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["chat_id"] == "fork-999"
+    assert data["session_id"] == "console:u1:fork-abcdef01"
+    assert data["name"] == "Fork of Test Chat"
+
+    # verify clone was called with allow_missing_source=True
+    session_mock.clone_session_state.assert_awaited_once()
+    _, kwargs = session_mock.clone_session_state.call_args
+    assert kwargs["src_session_id"] == "console:u1"
+    assert kwargs["allow_missing_source"] is True
+
+    # verify manager fork was called
+    manager_mock.fork_chat.assert_awaited_once()
+    _, kwargs = manager_mock.fork_chat.call_args
+    assert kwargs["source_chat_id"] == "abc-123"
+    assert kwargs["name"] == "Fork of Test Chat"
+
+
+def test_fork_custom_name(client, manager_mock):
+    """Custom name from request body is forwarded."""
+    source = _make_chat_spec(name="Debug")
+    manager_mock.get_chat = AsyncMock(return_value=source)
+    manager_mock.fork_chat = AsyncMock(
+        return_value=ChatSpec(
+            id="f-1",
+            session_id="console:u1:fork-xx",
+            user_id="u1",
+            channel="console",
+            name="My Custom Fork",
+            source=SessionSource.chat,
+        ),
+    )
+
+    resp = client.post(
+        "/chats/abc-123/fork",
+        json={"name": "My Custom Fork"},
+    )
+
+    assert resp.status_code == 201
+    manager_mock.fork_chat.assert_awaited_once()
+    _, kwargs = manager_mock.fork_chat.call_args
+    assert kwargs["name"] == "My Custom Fork"
+
+
+# ---------------------------------------------------------------------------
+# 404
+# ---------------------------------------------------------------------------
+
+
+def test_fork_404_when_chat_not_found(client, manager_mock):
+    """404 when source chat does not exist."""
+    manager_mock.get_chat = AsyncMock(return_value=None)
+
+    resp = client.post("/chats/nonexistent/fork")
+
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 409
+# ---------------------------------------------------------------------------
+
+
+def test_fork_409_when_running(manager_mock):
+    """409 when source chat is still generating."""
+    source = _make_chat_spec()
+    manager_mock.get_chat = AsyncMock(return_value=source)
+
+    # Build a fresh app with running status
+    session_mock_409 = AsyncMock(spec=SafeJSONSession)
+    session_mock_409.clone_session_state = AsyncMock()
+
+    app_409 = FastAPI()
+    app_409.include_router(router)
+    ws = _mock_workspace(
+        mgr=manager_mock,
+        session=session_mock_409,
+        status="running",
+    )
+
+    async def override_ws():
+        return ws
+
+    from qwenpaw.app.chats.api import get_workspace
+    from qwenpaw.app.chats.api import get_chat_manager as _gcm
+    from qwenpaw.app.chats.api import get_session as _gs
+
+    app_409.dependency_overrides[get_workspace] = override_ws
+    app_409.dependency_overrides[_gcm] = lambda: manager_mock
+    app_409.dependency_overrides[_gs] = lambda: session_mock_409
+
+    from fastapi.testclient import TestClient
+
+    client_409 = TestClient(app_409)
+
+    resp = client_409.post("/chats/abc-123/fork")
+
+    assert resp.status_code == 409
+    assert "generating" in resp.json()["detail"].lower()
+    # clone must NOT have been called
+    session_mock_409.clone_session_state.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 500 — clone failure (no orphan to clean up)
+# ---------------------------------------------------------------------------
+
+
+def test_fork_500_when_clone_fails(client, manager_mock, session_mock):
+    """500 when clone_session_state raises; ChatSpec not created."""
+    source = _make_chat_spec()
+    manager_mock.get_chat = AsyncMock(return_value=source)
+    session_mock.clone_session_state = AsyncMock(
+        side_effect=OSError("disk full"),
+    )
+
+    resp = client.post("/chats/abc-123/fork")
+
+    assert resp.status_code == 500
+    assert "copy" in resp.json()["detail"].lower()
+    # fork_chat must NOT have been called — no orphan to clean up
+    manager_mock.fork_chat.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 500 — ChatSpec write failure (orphan cleanup invoked)
+# ---------------------------------------------------------------------------
+
+
+def test_fork_500_when_chat_spec_fails_with_cleanup(
+    client,
+    manager_mock,
+    session_mock,
+):
+    """500 when fork_chat raises; delete_session_state called to clean up."""
+    source = _make_chat_spec()
+    manager_mock.get_chat = AsyncMock(return_value=source)
+    manager_mock.fork_chat = AsyncMock(
+        side_effect=ValueError("repo write failed"),
+    )
+
+    resp = client.post("/chats/abc-123/fork")
+
+    assert resp.status_code == 500
+    assert "create" in resp.json()["detail"].lower()
+    # cleanup should have been called
+    session_mock.delete_session_state.assert_awaited_once()
+
+
+def test_fork_500_cleanup_failure_still_returns_500(
+    client,
+    manager_mock,
+    session_mock,
+):
+    """500 when both fork_chat and cleanup fail."""
+    source = _make_chat_spec()
+    manager_mock.get_chat = AsyncMock(return_value=source)
+    manager_mock.fork_chat = AsyncMock(
+        side_effect=ValueError("repo write failed"),
+    )
+    session_mock.delete_session_state = AsyncMock(return_value=False)
+
+    resp = client.post("/chats/abc-123/fork")
+
+    assert resp.status_code == 500
+    session_mock.delete_session_state.assert_awaited_once()


### PR DESCRIPTION
## Description

**Related Issue:** Relates to https://github.com/agentscope-ai/QwenPaw/issues/6560

Add session fork feature: users can right-click a session and fork it into a new independent session with the full conversation context copied. This is a checkpoint-style snapshot — the forked session starts with all history intact and evolves independently.

**Backend:**
- `POST /chats/{chat_id}/fork` (201)
- `SafeJSONSession.clone_session_state()` — copies the raw session JSON to a new file under path lock. If the source file was manually deleted, writes `{}` so the fork still succeeds with an empty session.
- `SafeJSONSession.delete_session_state()` — removes the session JSON file when ChatSpec creation fails, skips without error if already deleted.
- `ChatManager.fork_chat()` — creates a new `ChatSpec` with user/channel copied from the source, plus `forked_from_chat_id`, `forked_from_session_id`, and `forked_at` in meta so the lineage is traceable.
- Returns 409 if the source is still generating, since the persisted state may be incomplete.

**Frontend:**
- Added `HttpError` to `request.ts` so callers can check `err.status === 409`.
- `SessionItem` dropdown now has a Fork item (`GitFork` icon from lucide). Disabled for sessions that haven't sent a message yet (no backend UUID).
- Flow: call fork API → refresh the session list in the sidebar → navigate to the new chat. Refresh and navigation are independent — a failed refresh still lands you in the new chat.
- `useRef(Set)` tracks in-flight fork requests so double-clicking doesn't create duplicates.
- If `source_state` comes back `"empty"`, a warning toast lets the user know the original context wasn't available.

**Security Considerations:** Fork endpoint inherits existing chat API auth. No new secrets or permissions.

## Type of Change

- [x] New feature

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [x] Console (frontend web UI)
- [x] Tests

## Checklist

- [x] I ran `pre-commit run --all-files` locally and it passes
- [x] I ran tests locally and they pass
- [x] Ready for review

## Testing

**Backend (17 tests):**

| Scope | Tests | What they verify |
|-------|-------|-----------------|
| `test_fork.py` | 10 | `ChatManager.fork_chat`: creates independent spec with lineage meta, raises on unknown source, deep-copies meta. `clone_session_state`: full state copy, raises on missing source, `allow_missing_source=True` writes `{}`, cloned session is independent. `delete_session_state`: removes file, returns false on missing, handles double-delete. |
| `test_chats_fork_router.py` | 7 | API layer: 201 with Fork name and `source_state`, custom name forwarding, 404 on unknown chat, 409 when running, 500 on clone failure (no orphan), 500 on ChatSpec failure (cleanup called), 500 on cleanup failure (still returns 500). |

**Frontend:**
- `npx tsc --noEmit` — 0 errors, all props/types aligned across SessionItem/Drawer/Sidebar.

## Evidence

All local checks and tests passed — see details below.

### Pre-commit

All hooks passed (check ast, mypy, black, flake8, pylint).

### Tests — 17 passed

What the 17 tests prove:
- Fork API returns 201 with correct lineage metadata on success
- 404 / 409 / 500 error paths all respond correctly
- Cloned session file is fully independent — mutations don't cross
- Missing source session file gracefully writes `{}` instead of crashing
- Orphan session file is cleaned up when ChatSpec creation fails
- Cleanup failure does not block the error response

### Console UI

<img width="3024" height="1964" alt="04ef6491c989dacbafec4557371ba0b0" src="https://github.com/user-attachments/assets/5249eb91-2f8f-4f1c-8e0b-648974c82c35" />

