### PR TITLE
fix(desktop): handle port socket construction errors

### DIFF
--- a/src/qwenpaw/utils/port.py
+++ b/src/qwenpaw/utils/port.py
@@ -76,6 +76,7 @@ def try_bind_port(host: str, port: int) -> socket.socket | None:
     port is unavailable.  The caller is responsible for closing the
     socket (or passing it to a server that will).
     """
+    sock: socket.socket | None = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if sys.platform == "win32":
@@ -86,10 +87,11 @@ def try_bind_port(host: str, port: int) -> socket.socket | None:
         sock.listen(1)
         return sock
     except OSError:
-        try:
-            sock.close()
-        except OSError:
-            pass
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
         return None
 
 

--- a/tests/unit/utils/test_port.py
+++ b/tests/unit/utils/test_port.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""Tests for desktop backend port allocation."""
+
+from unittest.mock import patch
+
+from qwenpaw.utils.port import try_bind_port
+
+
+def test_try_bind_port_handles_socket_construction_error() -> None:
+    with patch(
+        "qwenpaw.utils.port.socket.socket",
+        side_effect=OSError("file descriptor limit reached"),
+    ):
+        assert try_bind_port("127.0.0.1", 8088) is None


### PR DESCRIPTION
## Description

`try_bind_port()` promises to return `None` when a desktop backend port
cannot be probed. If `socket.socket()` itself raises `OSError` (for example,
because the process has exhausted file descriptors), the exception handler
currently calls `sock.close()` before `sock` has been assigned. This masks
the resource error with `UnboundLocalError` and aborts desktop startup.

This PR initializes the socket reference before construction and closes it
only when construction succeeded.

**Related Issue:** None; regression found on current `main`.

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Applicable pre-commit hooks pass
- [x] Relevant tests pass
- [x] Documentation updated (not needed; contract-preserving fix)
- [x] Ready for review

## Testing

## Evidence

Before the fix:

```bash
.venv/bin/pytest tests/unit/utils/test_port.py -q
# FAILED: UnboundLocalError: cannot access local variable 'sock'
```

After the fix:

```bash
.venv/bin/pytest \
  tests/unit/utils/test_port.py \
  tests/unit/cli/test_desktop_cmd.py \
  tests/unit/tauri/test_entry.py -q
# 13 passed in 0.48s

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/utils/port.py tests/unit/utils/test_port.py
# Python AST, encoding, secret detection, trailing commas,
# mypy, black, flake8, pylint: Passed
```

`actionlint` is not applicable to these Python files and cannot initialize
locally because the host Go version is 1.17.13 while its dependencies require
Go 1.19+.

## Additional Notes

The implementation was AI-assisted and verified with a deterministic
socket-construction failure, the desktop/Tauri test surface, and semantic
duplicate searches across this repository's issues and PRs.
