### PR TITLE
fix(config): honor UTC and POSIX TZ environment values

### DIFF
--- a/src/qwenpaw/config/timezone.py
+++ b/src/qwenpaw/config/timezone.py
@@ -125,8 +125,10 @@ def _probe_python() -> Optional[str]:
 
 def _probe_env() -> Optional[str]:
     """Check the ``$TZ`` environment variable."""
-    tz = os.environ.get("TZ", "")
-    return tz if _is_iana(tz) else None
+    tz = os.environ.get("TZ", "").strip()
+    if tz.startswith(":"):
+        tz = tz[1:]
+    return tz or None
 
 
 _WIN_TO_IANA = {

--- a/tests/unit/config/test_timezone.py
+++ b/tests/unit/config/test_timezone.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Tests for system timezone detection."""
+# pylint: disable=protected-access
+
+from qwenpaw.config import timezone as timezone_config
+
+
+def test_probe_env_accepts_utc(monkeypatch) -> None:
+    monkeypatch.setenv("TZ", "UTC")
+
+    assert timezone_config._probe_env() == "UTC"
+
+
+def test_probe_env_normalizes_posix_colon_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("TZ", ":America/New_York")
+
+    assert timezone_config._probe_env() == "America/New_York"


### PR DESCRIPTION
## Description

The system timezone detector checks `TZ` before filesystem and systemd
probes, but `_probe_env()` currently accepts only values containing `/`.
This rejects valid `TZ=UTC`. In a container whose `/etc/timezone` differs
from its explicit environment, QwenPaw can therefore select the wrong
timezone.

POSIX also permits a leading colon for implementation-defined timezone
files, so the common `TZ=:America/New_York` form currently reaches
`ZoneInfo` with an invalid leading `:`.

This PR makes the environment probe:

- trim surrounding whitespace;
- remove one POSIX leading colon;
- return any remaining value to the existing `normalize_tz()` validator.

Invalid values still fall through to later probes exactly as before.

**Related Issue:** None; regression found on current `main`.

**Security Considerations:** None.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [x] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [x] CLI
- [ ] Documentation (website)
- [x] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [x] Applicable pre-commit hooks pass
- [x] Relevant tests pass
- [x] Documentation updated (not needed; standards-compatible correction)
- [x] Ready for review

## Testing

## Evidence

Before the fix:

```bash
.venv/bin/pytest tests/unit/config/test_timezone.py -q
# 2 failed:
# TZ=UTC returned None
# TZ=:America/New_York retained the invalid leading colon
```

After the fix:

```bash
.venv/bin/pytest \
  tests/unit/config/test_timezone.py \
  tests/unit/cli/test_cron_cmd.py \
  tests/unit/app/crons/test_manager.py -q
# 34 passed in 1.02s

SKIP=actionlint .venv/bin/pre-commit run --files \
  src/qwenpaw/config/timezone.py tests/unit/config/test_timezone.py
# Python AST, encoding, secret detection, trailing commas,
# mypy, black, flake8, pylint: Passed
```

`actionlint` is not applicable to these Python files and cannot initialize
locally because the host Go version is 1.17.13 while its dependencies require
Go 1.19+.

## Additional Notes

The implementation was AI-assisted and verified against `ZoneInfo`
validation, POSIX `TZ` syntax, cron timezone tests, and semantic duplicate
searches across this repository's issues and PRs.
