### PR TITLE
fix(router): add audit visibility for sensitive directory exclusion

### DIFF
--- a/src/qwenpaw/app/routers/coding_project.py
+++ b/src/qwenpaw/app/routers/coding_project.py
@@ -477,6 +477,8 @@ async def import_local(body: ImportLocalRequest, request: Request) -> dict:
     base = _projects_base(workspace.workspace_dir)
     dest = safe_project_dest(base, dest_name)
 
+    excluded_sensitive: list[str] = []
+
     def _copy() -> Path:
         import shutil
         import stat
@@ -533,12 +535,13 @@ async def import_local(body: ImportLocalRequest, request: Request) -> dict:
             # Skip symlinks and Windows junctions.
             ignored |= {c for c in contents if _is_link_or_junction(d / c)}
             # Skip sensitive directory and file names.
-            ignored |= {
+            sensitive_hits = {
                 c
                 for c in contents
                 if c.lower() in _SENSITIVE_DIR_NAMES
                 or c.lower() in _SENSITIVE_FILE_NAMES
             }
+            ignored |= sensitive_hits
             # Skip entries that complete a sensitive
             # multi-component directory sequence.
             dir_low = _dir_parts_lower(directory)
@@ -549,7 +552,15 @@ async def import_local(body: ImportLocalRequest, request: Request) -> dict:
                 for seq in _SENSITIVE_DIR_SEQUENCES:
                     if _match_dir_sequence(full, seq):
                         ignored.add(c)
+                        sensitive_hits.add(c)
                         break
+            # Record excluded sensitive entries with relative path.
+            if sensitive_hits:
+                rel_dir = Path(directory).relative_to(source)
+                for name in sorted(sensitive_hits):
+                    excluded_sensitive.append(
+                        str(rel_dir / name) if str(rel_dir) != "." else name,
+                    )
             return ignored
 
         base.mkdir(parents=True, exist_ok=True)
@@ -566,16 +577,25 @@ async def import_local(body: ImportLocalRequest, request: Request) -> dict:
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+    if excluded_sensitive:
+        logger.info(
+            "import-local excluded sensitive entries: %s",
+            ", ".join(excluded_sensitive),
+        )
+
     await asyncio.to_thread(
         _save_project_dir,
         workspace.agent_id,
         str(project_path),
     )
 
-    return {
+    result: dict = {
         "path": str(project_path),
         "name": project_path.name,
     }
+    if excluded_sensitive:
+        result["excluded"] = excluded_sensitive
+    return result
 
 
 @router.post(

--- a/src/qwenpaw/app/routers/coding_project.py
+++ b/src/qwenpaw/app/routers/coding_project.py
@@ -578,6 +578,7 @@ async def import_local(body: ImportLocalRequest, request: Request) -> dict:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     if excluded_sensitive:
+        excluded_sensitive = sorted(set(excluded_sensitive))
         logger.info(
             "import-local excluded sensitive entries: %s",
             ", ".join(excluded_sensitive),

--- a/tests/unit/tauri/test_entry.py
+++ b/tests/unit/tauri/test_entry.py
@@ -15,6 +15,7 @@ from qwenpaw.tauri.env import DESKTOP_CORS_ORIGINS_ENV, DESKTOP_READY_PREFIX
 
 
 def test_install_desktop_runtime_preserves_existing_cors_values(monkeypatch):
+    monkeypatch.delitem(sys.modules, "qwenpaw.app._app", raising=False)
     monkeypatch.setenv(
         DESKTOP_CORS_ORIGINS_ENV,
         "https://example.test,tauri://localhost",


### PR DESCRIPTION
## Description

[Describe what this PR does and why]

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
