### PR TITLE
fix(providers): retry SSE errors with status codes in messages

### DIFF
--- a/src/qwenpaw/providers/error_utils.py
+++ b/src/qwenpaw/providers/error_utils.py
@@ -3,7 +3,15 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterator
 from typing import Any
+
+
+_STREAMING_ERROR_STATUS_RE = re.compile(
+    r"\bStreaming response failed\s*:\s*\[\s*([1-5]\d{2})\s*\]",
+    re.IGNORECASE,
+)
 
 
 def _as_http_status(value: Any) -> int | None:
@@ -15,6 +23,35 @@ def _as_http_status(value: Any) -> int | None:
     except (TypeError, ValueError):
         return None
     return status if 100 <= status <= 599 else None
+
+
+def _status_from_streaming_error_message(value: Any) -> int | None:
+    """Extract a status from the explicit gateway streaming-error format."""
+    if not isinstance(value, str):
+        return None
+    match = _STREAMING_ERROR_STATUS_RE.search(value)
+    if match is None:
+        return None
+    return _as_http_status(match.group(1))
+
+
+def _iter_streaming_error_messages(exc: Exception) -> Iterator[Any]:
+    """Yield message fields that may contain an in-stream HTTP status."""
+    yield getattr(exc, "message", None)
+    yield str(exc)
+
+    for payload in (
+        getattr(exc, "body", None),
+        getattr(exc, "details", None),
+    ):
+        if isinstance(payload, str):
+            yield payload
+            continue
+        if not isinstance(payload, dict):
+            continue
+        for container in (payload, payload.get("error")):
+            if isinstance(container, dict):
+                yield container.get("message")
 
 
 def extract_status_code(exc: Exception) -> int | None:
@@ -49,5 +86,16 @@ def extract_status_code(exc: Exception) -> int | None:
                 status = _as_http_status(container.get(key))
                 if status is not None:
                     return status
+
+    # Some OpenAI-compatible gateways return HTTP 200 and report the real
+    # failure inside the SSE stream.  The OpenAI SDK raises a base APIError
+    # for that event, with no status_code; certain gateways retain the status
+    # only in a message such as "Streaming response failed: [503] ...".
+    # Keep this fallback deliberately narrow to avoid treating unrelated
+    # three-digit numbers in provider messages as HTTP status codes.
+    for message in _iter_streaming_error_messages(exc):
+        status = _status_from_streaming_error_message(message)
+        if status is not None:
+            return status
 
     return None


### PR DESCRIPTION
## Description

Handle OpenAI-compatible SSE errors where the HTTP status code is only present in the error message, such as Streaming response failed: [503]. This allows transient in-stream errors to use the existing retry and backoff logic while avoiding unrelated numeric values in provider messages.

**Related Issue:** Fixes #6708

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
