### PR TITLE
fix: retry reasoning-content errors for AgentScope messages

### DIFF
--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1449,6 +1449,13 @@ def create_model_and_formatter(
     # ``__init__``), so we just wrap that one with file-block support
     # instead of class-resolving via a brittle map.
     formatter = _create_formatter_instance(model)
+    # Keep the provider model and the separately returned formatter on the
+    # same instance.  AgentScope formats ``Msg`` objects through
+    # ``model.formatter`` inside every API call, while QwenPaw's retry layer
+    # toggles request-time fallback flags on that same formatter.  Binding it
+    # here makes the contract hold for every factory caller, including those
+    # that intentionally ignore the second return value.
+    model.formatter = formatter
 
     # agentscope 2.0 ChatModelBase has its own retry loop
     # (model/_base.py:162: ``for attempt in range(self.max_retries + 1)``)

--- a/src/qwenpaw/agents/model_factory.py
+++ b/src/qwenpaw/agents/model_factory.py
@@ -1142,15 +1142,25 @@ def _create_file_block_support_formatter(
                         if ec:
                             tc["extra_content"] = ec
 
+            relay_reasoning = getattr(
+                self,
+                "relay_reasoning_content",
+                True,
+            )
+            require_reasoning = getattr(
+                self,
+                "_qwenpaw_require_reasoning_content",
+                False,
+            )
+            should_inject_reasoning = has_reasoning or require_reasoning
+            formatter_supports_reasoning = (
+                not is_anthropic_formatter and not _is_response_formatter
+            )
+            should_relay_reasoning = relay_reasoning or require_reasoning
             if (
-                has_reasoning
-                and not is_anthropic_formatter
-                and not _is_response_formatter
-                and getattr(
-                    self,
-                    "relay_reasoning_content",
-                    True,
-                )
+                should_inject_reasoning
+                and formatter_supports_reasoning
+                and should_relay_reasoning
             ):
                 aligned_reasoning = []
                 for m in (
@@ -1171,13 +1181,18 @@ def _create_file_block_support_formatter(
                     logger.warning(
                         "Assistant message count mismatch after formatting "
                         "(%d expected survivors, %d actual). "
-                        "Skipping reasoning_content injection for this turn. "
+                        "%s reasoning_content injection for this turn. "
                         "A block type may be dropped by the base formatter "
                         "without being handled by "
                         "_is_block_dropped_by_formatter, "
                         "or a new split pattern needs to be predicted.",
                         len(aligned_reasoning),
                         len(out_assistant),
+                        (
+                            "Falling back to placeholder"
+                            if require_reasoning
+                            else "Skipping"
+                        ),
                     )
                     if logger.isEnabledFor(logging.DEBUG):
                         for _i, m in enumerate(
@@ -1195,10 +1210,19 @@ def _create_file_block_support_formatter(
                                 _i,
                                 types,
                             )
+                    if require_reasoning:
+                        # Positional reasoning is unsafe when source and wire
+                        # counts differ.  A provider that already rejected the
+                        # request still needs the field, so use placeholders
+                        # without mutating the original AgentScope messages.
+                        for out_msg in out_assistant:
+                            out_msg.setdefault("reasoning_content", " ")
                 else:
                     for i, out_msg in enumerate(out_assistant):
-                        if aligned_reasoning[i]:
+                        if relay_reasoning and aligned_reasoning[i]:
                             out_msg["reasoning_content"] = aligned_reasoning[i]
+                        elif require_reasoning:
+                            out_msg.setdefault("reasoning_content", " ")
 
             return _strip_top_level_message_name(messages)
 

--- a/src/qwenpaw/providers/capping_formatter.py
+++ b/src/qwenpaw/providers/capping_formatter.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import base64
 import os
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -182,6 +182,8 @@ class CappingFormatterMixin:  # pylint: disable=too-few-public-methods
 class _CappingOpenAIFormatter(OpenAIChatFormatter, CappingFormatterMixin):
     """OpenAI formatter that caps oversized local image/audio media."""
 
+    _qwenpaw_supports_reasoning_content_fallback: ClassVar[bool] = True
+
     def _format_image_source(self, source: Any) -> dict[str, Any]:
         capped = self._maybe_cap(source, "image")
         if capped is not None:
@@ -240,6 +242,8 @@ class _CappingDashScopeFormatter(
     CappingFormatterMixin,
 ):
     """DashScope formatter capping oversized local image/video/audio media."""
+
+    _qwenpaw_supports_reasoning_content_fallback: ClassVar[bool] = True
 
     def _format_video_source(self, source: Any) -> dict[str, Any]:
         capped = self._maybe_cap(source, "video")

--- a/src/qwenpaw/providers/retry_chat_model.py
+++ b/src/qwenpaw/providers/retry_chat_model.py
@@ -220,6 +220,74 @@ def _inject_reasoning_content(
     return modified
 
 
+def _enable_reasoning_content_fallback(
+    model: Any,
+    args: tuple,
+    kwargs: dict[str, Any],
+) -> bool:
+    """Enable the missing-reasoning fallback at the correct call layer.
+
+    Some callers pass already-formatted wire dictionaries, where the legacy
+    in-place injector is sufficient.  AgentScope 2.0 passes ``Msg`` objects
+    instead; those are formatted only inside the wrapped provider model, so
+    adding a dictionary key here cannot work.  For that path, enable the
+    formatter's request-time placeholder mode and let it preserve real
+    reasoning while filling only missing assistant segments.
+
+    Returns ``True`` when the fallback is available for this call.  An
+    already-enabled formatter also returns ``True``: another concurrent call
+    may have enabled it after this request was formatted but before its 400
+    was handled, and that in-flight request still needs one retry.
+    """
+    if _inject_reasoning_content(args, kwargs):
+        return True
+
+    messages = kwargs.get("messages")
+    if messages is None and args:
+        messages = args[0] if isinstance(args[0], list) else None
+    if not isinstance(messages, list) or not any(
+        getattr(msg, "role", None) == "assistant" for msg in messages
+    ):
+        return False
+
+    # RetryChatModel wraps TokenRecordingModelWrapper, which in turn wraps
+    # the provider model.  Walk both conventional wrapper links without
+    # depending on those concrete classes.
+    pending = [model]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+
+        formatter = getattr(current, "formatter", None)
+        if formatter is not None and getattr(
+            formatter,
+            "_qwenpaw_supports_reasoning_content_fallback",
+            False,
+        ):
+            if getattr(
+                formatter,
+                "_qwenpaw_require_reasoning_content",
+                False,
+            ):
+                return True
+            setattr(
+                formatter,
+                "_qwenpaw_require_reasoning_content",
+                True,
+            )
+            return True
+
+        for attr in ("_inner", "_model"):
+            wrapped = getattr(current, attr, None)
+            if wrapped is not None:
+                pending.append(wrapped)
+
+    return False
+
+
 def _extract_retry_after(exc: Exception) -> float | None:
     """Parse the Retry-After header value (in seconds) from an exception.
 
@@ -414,7 +482,7 @@ class RetryChatModel(ChatModelBase):
         key = self.model_key
 
         if cache.get(key, "needs_reasoning_content", False):
-            _inject_reasoning_content(args, kwargs)
+            _enable_reasoning_content_fallback(self, args, kwargs)
 
         # Each model gets its own rate limiter keyed by
         # "provider_id:model_name" so that a 429 on one model (e.g. from a
@@ -467,7 +535,11 @@ class RetryChatModel(ChatModelBase):
                 except Exception as inner_exc:
                     if not (
                         _is_missing_reasoning_content_error(inner_exc)
-                        and _inject_reasoning_content(args, kwargs)
+                        and _enable_reasoning_content_fallback(
+                            self,
+                            args,
+                            kwargs,
+                        )
                     ):
                         raise
                     cache.learn(key, "needs_reasoning_content", True)
@@ -601,7 +673,11 @@ class RetryChatModel(ChatModelBase):
                 if (
                     not reasoning_injected
                     and _is_missing_reasoning_content_error(retry_exc)
-                    and _inject_reasoning_content(call_args, call_kwargs)
+                    and _enable_reasoning_content_fallback(
+                        self,
+                        call_args,
+                        call_kwargs,
+                    )
                 ):
                     reasoning_injected = True
                     get_capability_cache().learn(

--- a/tests/unit/agents/test_create_model_and_formatter_override.py
+++ b/tests/unit/agents/test_create_model_and_formatter_override.py
@@ -12,6 +12,15 @@ from qwenpaw.config import config as config_module
 from qwenpaw.config.config import ModelSlotConfig
 
 
+class _FakeChatModel:
+    """Minimal provider model used by the factory tests."""
+
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+        self.formatter = SimpleNamespace()
+        self.max_retries = 3
+
+
 def _patched_load_agent_config(_agent_id):  # noqa: ARG001
     """Return fake agent config with an overridable active model."""
     return SimpleNamespace(
@@ -52,7 +61,9 @@ def _patch_dependencies(monkeypatch):
                 get_provider=lambda provider_id: SimpleNamespace(
                     provider_id=provider_id,
                     get_chat_model_instance=(
-                        lambda model_name: f"{provider_id}/{model_name}"
+                        lambda model_name: _FakeChatModel(
+                            f"{provider_id}/{model_name}",
+                        )
                     ),
                 ),
                 get_active_chat_model=lambda: None,
@@ -88,8 +99,19 @@ def test_override_with_model_slot_config():
             model_slot_override=override,
         )
 
-    assert model == "p/m"
+    assert model.identifier == "p/m"
     assert fmt == "formatter"
+
+
+def test_factory_binds_returned_formatter_to_provider_model():
+    """Callers that ignore the formatter return still use the enhanced one."""
+    with patch.object(model_factory, "RetryConfig") as retry_cls:
+        retry_cls.return_value = "rc"
+        model, fmt = model_factory.create_model_and_formatter(
+            agent_id="agent-1",
+        )
+
+    assert model.formatter is fmt
 
 
 def test_override_with_dict():
@@ -101,7 +123,7 @@ def test_override_with_dict():
             model_slot_override={"provider_id": "p", "model": "m"},
         )
 
-    assert model == "p/m"
+    assert model.identifier == "p/m"
 
 
 def test_override_with_string():
@@ -113,7 +135,7 @@ def test_override_with_string():
             model_slot_override="p:m",
         )
 
-    assert model == "p/m"
+    assert model.identifier == "p/m"
 
 
 def test_override_with_string_preserves_colon_in_model_name():
@@ -125,7 +147,7 @@ def test_override_with_string_preserves_colon_in_model_name():
             model_slot_override="openai:gpt-4o:2024-08-06",
         )
 
-    assert model == "openai/gpt-4o:2024-08-06"
+    assert model.identifier == "openai/gpt-4o:2024-08-06"
 
 
 def test_override_with_invalid_string_falls_back_to_active_model():
@@ -137,7 +159,7 @@ def test_override_with_invalid_string_falls_back_to_active_model():
             model_slot_override="no-colon-here",
         )
 
-    assert model == "default-provider/default-model"
+    assert model.identifier == "default-provider/default-model"
 
 
 def test_override_with_unsupported_type_falls_back_to_active_model():
@@ -149,7 +171,7 @@ def test_override_with_unsupported_type_falls_back_to_active_model():
             model_slot_override=12345,
         )
 
-    assert model == "default-provider/default-model"
+    assert model.identifier == "default-provider/default-model"
 
 
 def test_no_override_uses_active_model():
@@ -160,4 +182,4 @@ def test_no_override_uses_active_model():
             agent_id="agent-1",
         )
 
-    assert model == "default-provider/default-model"
+    assert model.identifier == "default-provider/default-model"

--- a/tests/unit/agents/test_model_factory_message_normalization.py
+++ b/tests/unit/agents/test_model_factory_message_normalization.py
@@ -385,6 +385,101 @@ async def test_openai_formatter_does_not_carry_reasoning_forward() -> None:
 
 
 @pytest.mark.asyncio
+async def test_required_reasoning_preserves_real_and_fills_missing() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(
+        relay_reasoning_content=True,
+    )
+    formatter._qwenpaw_require_reasoning_content = True
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="tool reasoning"),
+            ToolCallBlock(id="call_1", name="tool", input="{}"),
+            ToolResultBlock(
+                id="call_1",
+                name="tool",
+                output=[TextBlock(text="result")],
+                state=ToolResultState.SUCCESS,
+            ),
+            TextBlock(text="done"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert [item.get("reasoning_content") for item in assistant_messages] == [
+        "tool reasoning",
+        " ",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_required_reasoning_respects_disabled_relay_privacy() -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(
+        relay_reasoning_content=False,
+    )
+    formatter._qwenpaw_require_reasoning_content = True
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="private reasoning"),
+            TextBlock(text="answer"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert assistant_messages[0]["reasoning_content"] == " "
+
+
+@pytest.mark.asyncio
+async def test_required_reasoning_falls_back_when_alignment_mismatches(
+    monkeypatch,
+) -> None:
+    formatter_class = model_factory._create_file_block_support_formatter(
+        _CappingOpenAIFormatter,
+    )
+    formatter = formatter_class(
+        relay_reasoning_content=True,
+    )
+    formatter._qwenpaw_require_reasoning_content = True
+    monkeypatch.setattr(
+        model_factory,
+        "_reasoning_by_assistant_segment",
+        lambda _blocks, _formatter: ["real reasoning", "extra segment"],
+    )
+    msg = Msg(
+        name="assistant",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="real reasoning"),
+            TextBlock(text="answer"),
+        ],
+    )
+
+    formatted = await formatter.format([msg])
+
+    assistant_messages = [
+        item for item in formatted if item.get("role") == "assistant"
+    ]
+    assert assistant_messages[0]["reasoning_content"] == " "
+
+
+@pytest.mark.asyncio
 async def test_openai_formatter_respects_disabled_reasoning_relay() -> None:
     formatter_class = model_factory._create_file_block_support_formatter(
         _CappingOpenAIFormatter,

--- a/tests/unit/providers/test_retry_chat_model.py
+++ b/tests/unit/providers/test_retry_chat_model.py
@@ -6,7 +6,17 @@ from types import SimpleNamespace
 from typing import Any, AsyncGenerator, cast
 
 import pytest
+from agentscope.message import (
+    Msg,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+    ToolResultState,
+)
 
+from qwenpaw.agents import model_factory
+from qwenpaw.providers.capping_formatter import _CappingOpenAIFormatter
 from qwenpaw.providers.model_capability_cache import get_capability_cache
 from qwenpaw.providers.rate_limiter import _limiters
 from qwenpaw.providers.retry_chat_model import (
@@ -15,6 +25,7 @@ from qwenpaw.providers.retry_chat_model import (
     RetryConfig,
     RateLimitConfig,
     _compute_backoff,
+    _enable_reasoning_content_fallback,
     _extract_retry_after,
     _extract_status_code,
     _inject_reasoning_content,
@@ -55,6 +66,39 @@ class _ReasoningRetryStreamModel:
     ) -> AsyncGenerator[Any, None]:
         self.calls += 1
         if self.calls == 1:
+            return _failing_reasoning_stream()
+        return _successful_stream()
+
+
+class _ReasoningRetryMsgStreamModel:
+    model = "reasoning-msg-stream-test"
+    stream = True
+    context_size = 32768
+    parameters = None
+    _provider_id = "unit"
+
+    def __init__(self) -> None:
+        formatter_class = model_factory._create_file_block_support_formatter(
+            _CappingOpenAIFormatter,
+        )
+        self.formatter = formatter_class(relay_reasoning_content=True)
+        self.calls = 0
+        self.formatted_calls: list[list[dict[str, Any]]] = []
+
+    async def __call__(
+        self,
+        messages: list[Msg],
+        **_kwargs: Any,
+    ) -> AsyncGenerator[Any, None]:
+        self.calls += 1
+        formatted = await self.formatter.format(messages)
+        self.formatted_calls.append(formatted)
+        assistants = [
+            message
+            for message in formatted
+            if message.get("role") == "assistant"
+        ]
+        if any("reasoning_content" not in message for message in assistants):
             return _failing_reasoning_stream()
         return _successful_stream()
 
@@ -319,6 +363,77 @@ def test_inject_reasoning_content_empty_list() -> None:
     assert _inject_reasoning_content((), {"messages": []}) is False
 
 
+def test_enable_reasoning_fallback_for_agentscope_messages() -> None:
+    formatter = SimpleNamespace(
+        _qwenpaw_supports_reasoning_content_fallback=True,
+        _qwenpaw_require_reasoning_content=False,
+    )
+    provider_model = SimpleNamespace(formatter=formatter)
+    token_wrapper = SimpleNamespace(_model=provider_model)
+    retry_wrapper = SimpleNamespace(_inner=token_wrapper)
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[TextBlock(text="previous reply")],
+        ),
+    ]
+
+    result = _enable_reasoning_content_fallback(
+        retry_wrapper,
+        (),
+        {"messages": messages},
+    )
+
+    assert result is True
+    assert formatter._qwenpaw_require_reasoning_content is True
+    assert len(messages[0].content) == 1
+    assert isinstance(messages[0].content[0], TextBlock)
+    assert messages[0].content[0].text == "previous reply"
+
+
+def test_enabled_reasoning_fallback_allows_concurrent_retry() -> None:
+    formatter = SimpleNamespace(
+        _qwenpaw_supports_reasoning_content_fallback=True,
+        _qwenpaw_require_reasoning_content=True,
+    )
+    model = SimpleNamespace(formatter=formatter)
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[TextBlock(text="previous reply")],
+        ),
+    ]
+
+    # Another request may have enabled the shared formatter after this one
+    # was formatted.  This request must still be allowed to retry once.
+    assert _enable_reasoning_content_fallback(
+        model,
+        (),
+        {"messages": messages},
+    )
+    assert formatter._qwenpaw_require_reasoning_content is True
+
+
+def test_reasoning_fallback_rejects_unsupported_formatter() -> None:
+    formatter = SimpleNamespace()
+    model = SimpleNamespace(formatter=formatter)
+    messages = [
+        Msg(
+            name="assistant",
+            role="assistant",
+            content=[TextBlock(text="previous reply")],
+        ),
+    ]
+
+    assert not _enable_reasoning_content_fallback(
+        model,
+        (),
+        {"messages": messages},
+    )
+
+
 # ---------------------------------------------------------------------------
 # _extract_retry_after
 # ---------------------------------------------------------------------------
@@ -478,5 +593,76 @@ async def test_stream_recovers_missing_reasoning_content_error() -> None:
         assert inner.calls == 2
         assert messages[0]["reasoning_content"] == " "
         assert cache.get(model_key, "needs_reasoning_content") is True
+    finally:
+        cache.clear(model_key)
+
+
+@pytest.mark.asyncio
+async def test_stream_recovers_agentscope_msg_via_formatter_fallback() -> None:
+    cache = get_capability_cache()
+    model_key = "unit:reasoning-msg-stream-test"
+    cache.clear(model_key)
+
+    try:
+        inner = _ReasoningRetryMsgStreamModel()
+        model = RetryChatModel(
+            inner,  # type: ignore[arg-type]
+            retry_config=RetryConfig(enabled=False),
+            rate_limit_config=RateLimitConfig(
+                max_concurrent=1,
+                max_qpm=0,
+                pause_seconds=1.0,
+                jitter_range=0.0,
+                acquire_timeout=10.0,
+            ),
+        )
+        messages = [
+            Msg(
+                name="assistant",
+                role="assistant",
+                content=[
+                    ThinkingBlock(thinking="real tool reasoning"),
+                    ToolCallBlock(id="call_1", name="tool", input="{}"),
+                    ToolResultBlock(
+                        id="call_1",
+                        name="tool",
+                        output=[TextBlock(text="result")],
+                        state=ToolResultState.SUCCESS,
+                    ),
+                    TextBlock(text="done"),
+                ],
+            ),
+        ]
+
+        result = await model(messages=messages)
+        stream = cast(AsyncGenerator[Any, None], result)
+        chunks = [chunk async for chunk in stream]
+
+        assert [chunk.content for chunk in chunks] == ["ok"]
+        assert inner.calls == 2
+        first_assistants = [
+            message
+            for message in inner.formatted_calls[0]
+            if message.get("role") == "assistant"
+        ]
+        second_assistants = [
+            message
+            for message in inner.formatted_calls[1]
+            if message.get("role") == "assistant"
+        ]
+        assert [
+            message.get("reasoning_content") for message in first_assistants
+        ] == ["real tool reasoning", None]
+        assert [
+            message.get("reasoning_content") for message in second_assistants
+        ] == ["real tool reasoning", " "]
+        assert inner.formatter._qwenpaw_require_reasoning_content is True
+        assert cache.get(model_key, "needs_reasoning_content") is True
+        assert [block.type for block in messages[0].content] == [
+            "thinking",
+            "tool_call",
+            "tool_result",
+            "text",
+        ]
     finally:
         cache.clear(model_key)


### PR DESCRIPTION
## Description

Handle reasoning-content validation errors when requests contain AgentScope Msg objects. On retry, enable formatter-level reasoning-content normalization, preserving existing reasoning and filling only missing values with a blank string. This also supports formatter count mismatches and concurrent retries without changing the default request behavior.

Fixes #6707
Fixes #6667

**Related Issue:** Fixes #(issue_number) or Relates to #(issue_number)

**Security Considerations:** [If applicable, e.g. channel auth, env/config handling]

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring

## Component(s) Affected

- [ ] Core / Backend (app, agents, config, providers, utils, local_models)
- [ ] Console (frontend web UI)
- [ ] Channels (DingTalk, Lark, QQ, Discord, iMessage, etc.)
- [ ] Skills
- [ ] CLI
- [ ] Documentation (website)
- [ ] Tests
- [ ] CI/CD
- [ ] Scripts / Deploy

## Checklist

- [ ] I ran `pre-commit run --all-files` locally and it passes
- [ ] If pre-commit auto-fixed files, I committed those changes and reran checks
- [ ] I ran tests locally (`pytest` or as relevant) and they pass
- [ ] Documentation updated (if needed)
- [ ] Ready for review

### For Channel Changes (DingTalk, Lark, QQ, Console, etc.)

- [ ] I ran `./scripts/check-channels.sh` (or `./scripts/check-channels.sh --changed`) and it passes
- [ ] **Contract test** exists in `tests/contract/channels/test_<channel>_contract.py` (REQUIRED)
- [ ] Contract test implements `create_instance()` with proper channel initialization
- [ ] All 19 contract verification points pass (see `tests/contract/channels/__init__.py`)
- [ ] **Optional**: Unit tests in `tests/unit/channels/test_<channel>.py` for complex internal logic

## Testing

[How to test these changes]

## Evidence

<!-- Required for external contributors. The CI "Real behavior proof" check
     will block your PR if this section is missing or empty. Template
     comments (like this one) do NOT count as evidence.

     Keep the section headings "## Description" and "## Evidence" verbatim
     — the CI check matches these headings by name. If you rename them,
     your PR will be flagged as missing context even if you filled in the
     content. -->

Examples of valid evidence:
- Terminal transcript of the test run (e.g. `pytest tests/unit/app/chats/ -q` output)
- Screenshot of the Console UI showing the fix
- CI artifact link
- `pre-commit run --all-files` summary

```bash
pre-commit run --all-files
# paste summary result

pytest
# paste summary result
```

## Additional Notes

[Optional: any other context]
