### PR TITLE
fix(provider): expire stale capability cache entries and clear on model switch

### DIFF
--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -406,6 +406,20 @@ try:
 except (TypeError, ValueError):
     TOOL_GUARD_APPROVAL_HEARTBEAT_INTERVAL = 15.0
 
+# TTL for learned model capability cache entries (seconds).
+# 0 disables expiry. Stale entries from transient upstream failures
+# (e.g. a gateway routing a multimodal model to a text-only backend)
+# are discarded after this duration.
+try:
+    CAPABILITY_CACHE_TTL_SECONDS = max(
+        float(
+            _get_env("QWENPAW_CAPABILITY_CACHE_TTL_SECONDS", "1800"),
+        ),
+        0.0,
+    )
+except (TypeError, ValueError):
+    CAPABILITY_CACHE_TTL_SECONDS = 1800.0
+
 # Marker prepended to every truncation notice.
 # Format:
 #   <<<TRUNCATED>>>

--- a/src/qwenpaw/constant.py
+++ b/src/qwenpaw/constant.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from pathlib import Path
+
 from dotenv import load_dotenv
 
 # Load .env file from project root before reading any env vars

--- a/src/qwenpaw/providers/model_capability_cache.py
+++ b/src/qwenpaw/providers/model_capability_cache.py
@@ -120,6 +120,20 @@ class ModelCapabilityCache:
             else:
                 self._learned.pop(model_key, None)
 
+    def forget(self, model_key: str, capability: str) -> None:
+        """Drop a single capability entry for *model_key*.
+
+        Unlike :meth:`clear`, this preserves other learned capabilities
+        (e.g. ``needs_reasoning_content``) and all entries for other models.
+        """
+        with self._data_lock:
+            bucket = self._learned.get(model_key)
+            if bucket is None:
+                return
+            bucket.pop(capability, None)
+            if not bucket:
+                self._learned.pop(model_key, None)
+
 
 def get_capability_cache() -> ModelCapabilityCache:
     """Return the global :class:`ModelCapabilityCache` singleton."""

--- a/src/qwenpaw/providers/model_capability_cache.py
+++ b/src/qwenpaw/providers/model_capability_cache.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 class _CacheEntry:
-    """A learned capability value paired with the wall-clock time it was set."""
+    """A learned value paired with the monotonic time it was set."""
 
     __slots__ = ("value", "set_at")
 

--- a/src/qwenpaw/providers/model_capability_cache.py
+++ b/src/qwenpaw/providers/model_capability_cache.py
@@ -10,21 +10,39 @@ This avoids repeated first-call failures when the same model is used
 again after a model switch.  The cache is process-scoped (not persisted)
 and deliberately conservative: entries are only written after a confirmed
 failure-then-recovery cycle.
+
+Entries expire after ``CAPABILITY_CACHE_TTL_SECONDS`` so that a stale
+finding from a transient upstream issue does not permanently suppress
+media input.  Setting the TTL to ``0`` (via
+``QWENPAW_CAPABILITY_CACHE_TTL_SECONDS``) disables expiry.
 """
 
 from __future__ import annotations
 
 import logging
 import threading
+import time
 from typing import Any
 
+from ..constant import CAPABILITY_CACHE_TTL_SECONDS
+
 logger = logging.getLogger(__name__)
+
+
+class _CacheEntry:
+    """A learned capability value paired with the wall-clock time it was set."""
+
+    __slots__ = ("value", "set_at")
+
+    def __init__(self, value: Any, set_at: float) -> None:
+        self.value = value
+        self.set_at = set_at
 
 
 class ModelCapabilityCache:
     """Thread-safe, process-scoped cache for learned model capabilities.
 
-    Capabilities are stored as ``{model_key: {capability_name: value}}``.
+    Capabilities are stored as ``{model_key: {capability_name: _CacheEntry}}``.
 
     Known capability keys:
         ``needs_reasoning_content`` (bool):
@@ -39,7 +57,7 @@ class ModelCapabilityCache:
     _lock = threading.Lock()
 
     def __init__(self) -> None:
-        self._learned: dict[str, dict[str, Any]] = {}
+        self._learned: dict[str, dict[str, _CacheEntry]] = {}
         self._data_lock = threading.Lock()
 
     @classmethod
@@ -52,16 +70,20 @@ class ModelCapabilityCache:
 
     def learn(self, model_key: str, capability: str, value: Any) -> None:
         """Record a learned capability for *model_key*."""
+        now = time.monotonic()
         with self._data_lock:
             bucket = self._learned.setdefault(model_key, {})
-            if bucket.get(capability) != value:
-                bucket[capability] = value
-                logger.info(
-                    "Learned capability for %s: %s=%r",
-                    model_key,
-                    capability,
-                    value,
-                )
+            existing = bucket.get(capability)
+            if existing is not None and existing.value == value:
+                existing.set_at = now
+                return
+            bucket[capability] = _CacheEntry(value=value, set_at=now)
+            logger.info(
+                "Learned capability for %s: %s=%r",
+                model_key,
+                capability,
+                value,
+            )
 
     def get(
         self,
@@ -69,12 +91,22 @@ class ModelCapabilityCache:
         capability: str,
         default: Any = None,
     ) -> Any:
-        """Return the cached value, or *default* if not learned yet."""
+        """Return the cached value, or *default* if not learned or expired."""
         with self._data_lock:
-            return self._learned.get(model_key, {}).get(
-                capability,
-                default,
-            )
+            bucket = self._learned.get(model_key)
+            if bucket is None:
+                return default
+            entry = bucket.get(capability)
+            if entry is None:
+                return default
+            if CAPABILITY_CACHE_TTL_SECONDS > 0:
+                age = time.monotonic() - entry.set_at
+                if age >= CAPABILITY_CACHE_TTL_SECONDS:
+                    del bucket[capability]
+                    if not bucket:
+                        self._learned.pop(model_key, None)
+                    return default
+            return entry.value
 
     def clear(self, model_key: str | None = None) -> None:
         """Clear learned capabilities.

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -2501,9 +2501,11 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
                 if "extra_models" in saved_config:
                     provider_info.extra_models = [
                         ModelInfo.model_validate(
-                            model.model_dump()
-                            if isinstance(model, BaseModel)
-                            else model,
+                            (
+                                model.model_dump()
+                                if isinstance(model, BaseModel)
+                                else model
+                            ),
                         )
                         for model in saved_config["extra_models"]
                     ]

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1672,6 +1672,12 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         )
         self.save_active_model(self.active_model)
 
+        # Stale capability findings (e.g. rejects_media from a transient
+        # upstream failure) no longer apply after a model switch.
+        from .model_capability_cache import get_capability_cache
+
+        get_capability_cache().clear()
+
         self.maybe_probe_multimodal(provider_id, model_id)
 
     def maybe_probe_multimodal(self, provider_id: str, model_id: str) -> None:

--- a/src/qwenpaw/providers/provider_manager.py
+++ b/src/qwenpaw/providers/provider_manager.py
@@ -1672,11 +1672,16 @@ class ProviderManager:  # pylint: disable=too-many-public-methods
         )
         self.save_active_model(self.active_model)
 
-        # Stale capability findings (e.g. rejects_media from a transient
-        # upstream failure) no longer apply after a model switch.
+        # Drop a stale ``rejects_media`` entry for this model so that a
+        # transient upstream failure (e.g. a gateway misroute) does not
+        # keep stripping images after re-selection.  Other capabilities
+        # and other models are left untouched.
         from .model_capability_cache import get_capability_cache
 
-        get_capability_cache().clear()
+        get_capability_cache().forget(
+            f"{provider_id}:{model_id}",
+            "rejects_media",
+        )
 
         self.maybe_probe_multimodal(provider_id, model_id)
 

--- a/tests/unit/providers/test_model_capability_cache.py
+++ b/tests/unit/providers/test_model_capability_cache.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=protected-access,redefined-outer-name
+from __future__ import annotations
+
+import time
+from unittest import mock
+
+import pytest
+
+from qwenpaw.providers.model_capability_cache import ModelCapabilityCache
+
+
+@pytest.fixture()
+def cache() -> ModelCapabilityCache:
+    return ModelCapabilityCache()
+
+
+def test_learn_and_get_roundtrip(cache: ModelCapabilityCache) -> None:
+    cache.learn("p:m", "rejects_media", True)
+    assert cache.get("p:m", "rejects_media", False) is True
+
+
+def test_get_returns_default_when_unlearned(cache: ModelCapabilityCache) -> None:
+    assert cache.get("p:m", "rejects_media", False) is False
+    assert cache.get("p:m", "rejects_media") is None
+
+
+def test_clear_all(cache: ModelCapabilityCache) -> None:
+    cache.learn("p:m", "rejects_media", True)
+    cache.clear()
+    assert cache.get("p:m", "rejects_media", False) is False
+
+
+def test_clear_single_model_key(cache: ModelCapabilityCache) -> None:
+    cache.learn("a:m", "rejects_media", True)
+    cache.learn("b:n", "rejects_media", True)
+    cache.clear("a:m")
+    assert cache.get("a:m", "rejects_media", False) is False
+    assert cache.get("b:n", "rejects_media", False) is True
+
+
+def test_relearn_same_value_refreshes_timestamp(
+    cache: ModelCapabilityCache,
+) -> None:
+    cache.learn("p:m", "rejects_media", True)
+    entry_before = cache._learned["p:m"]["rejects_media"]
+    time.sleep(0.01)
+    cache.learn("p:m", "rejects_media", True)
+    entry_after = cache._learned["p:m"]["rejects_media"]
+    assert entry_after.set_at > entry_before.set_at
+    assert entry_after.value is True
+
+
+def test_relearn_different_value_overwrites(cache: ModelCapabilityCache) -> None:
+    cache.learn("p:m", "rejects_media", True)
+    cache.learn("p:m", "rejects_media", False)
+    assert cache.get("p:m", "rejects_media") is False
+
+
+def test_expired_entry_returns_default(
+    cache: ModelCapabilityCache,
+) -> None:
+    with mock.patch(
+        "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS",
+        0.05,
+    ):
+        cache.learn("p:m", "rejects_media", True)
+        assert cache.get("p:m", "rejects_media", False) is True
+        time.sleep(0.08)
+        assert cache.get("p:m", "rejects_media", False) is False
+
+
+def test_expired_entry_is_evicted_from_bucket(
+    cache: ModelCapabilityCache,
+) -> None:
+    with mock.patch(
+        "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS",
+        0.05,
+    ):
+        cache.learn("p:m", "rejects_media", True)
+        time.sleep(0.08)
+        cache.get("p:m", "rejects_media", False)
+        assert "p:m" not in cache._learned
+
+
+def test_ttl_zero_disables_expiry(cache: ModelCapabilityCache) -> None:
+    with mock.patch(
+        "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS",
+        0.0,
+    ):
+        cache.learn("p:m", "rejects_media", True)
+        time.sleep(0.05)
+        assert cache.get("p:m", "rejects_media", False) is True

--- a/tests/unit/providers/test_model_capability_cache.py
+++ b/tests/unit/providers/test_model_capability_cache.py
@@ -20,7 +20,9 @@ def test_learn_and_get_roundtrip(cache: ModelCapabilityCache) -> None:
     assert cache.get("p:m", "rejects_media", False) is True
 
 
-def test_get_returns_default_when_unlearned(cache: ModelCapabilityCache) -> None:
+def test_get_returns_default_when_unlearned(
+    cache: ModelCapabilityCache,
+) -> None:
     assert cache.get("p:m", "rejects_media", False) is False
     assert cache.get("p:m", "rejects_media") is None
 
@@ -65,16 +67,21 @@ def test_forget_unknown_key_is_noop(cache: ModelCapabilityCache) -> None:
 def test_relearn_same_value_refreshes_timestamp(
     cache: ModelCapabilityCache,
 ) -> None:
-    cache.learn("p:m", "rejects_media", True)
-    entry_before = cache._learned["p:m"]["rejects_media"]
-    time.sleep(0.01)
-    cache.learn("p:m", "rejects_media", True)
-    entry_after = cache._learned["p:m"]["rejects_media"]
-    assert entry_after.set_at > entry_before.set_at
-    assert entry_after.value is True
+    with mock.patch(
+        "qwenpaw.providers.model_capability_cache.time.monotonic",
+        side_effect=[100.0, 200.0],
+    ):
+        cache.learn("p:m", "rejects_media", True)
+        set_at_before = cache._learned["p:m"]["rejects_media"].set_at
+        cache.learn("p:m", "rejects_media", True)
+        set_at_after = cache._learned["p:m"]["rejects_media"].set_at
+    assert set_at_after > set_at_before
+    assert cache._learned["p:m"]["rejects_media"].value is True
 
 
-def test_relearn_different_value_overwrites(cache: ModelCapabilityCache) -> None:
+def test_relearn_different_value_overwrites(
+    cache: ModelCapabilityCache,
+) -> None:
     cache.learn("p:m", "rejects_media", True)
     cache.learn("p:m", "rejects_media", False)
     assert cache.get("p:m", "rejects_media") is False

--- a/tests/unit/providers/test_model_capability_cache.py
+++ b/tests/unit/providers/test_model_capability_cache.py
@@ -9,6 +9,8 @@ import pytest
 
 from qwenpaw.providers.model_capability_cache import ModelCapabilityCache
 
+_TTL = "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS"
+
 
 @pytest.fixture()
 def cache() -> ModelCapabilityCache:
@@ -90,10 +92,7 @@ def test_relearn_different_value_overwrites(
 def test_expired_entry_returns_default(
     cache: ModelCapabilityCache,
 ) -> None:
-    with mock.patch(
-        "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS",
-        0.05,
-    ):
+    with mock.patch(_TTL, 0.05):
         cache.learn("p:m", "rejects_media", True)
         assert cache.get("p:m", "rejects_media", False) is True
         time.sleep(0.08)
@@ -103,10 +102,7 @@ def test_expired_entry_returns_default(
 def test_expired_entry_is_evicted_from_bucket(
     cache: ModelCapabilityCache,
 ) -> None:
-    with mock.patch(
-        "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS",
-        0.05,
-    ):
+    with mock.patch(_TTL, 0.05):
         cache.learn("p:m", "rejects_media", True)
         time.sleep(0.08)
         cache.get("p:m", "rejects_media", False)
@@ -114,10 +110,7 @@ def test_expired_entry_is_evicted_from_bucket(
 
 
 def test_ttl_zero_disables_expiry(cache: ModelCapabilityCache) -> None:
-    with mock.patch(
-        "qwenpaw.providers.model_capability_cache.CAPABILITY_CACHE_TTL_SECONDS",
-        0.0,
-    ):
+    with mock.patch(_TTL, 0.0):
         cache.learn("p:m", "rejects_media", True)
         time.sleep(0.05)
         assert cache.get("p:m", "rejects_media", False) is True

--- a/tests/unit/providers/test_model_capability_cache.py
+++ b/tests/unit/providers/test_model_capability_cache.py
@@ -39,6 +39,29 @@ def test_clear_single_model_key(cache: ModelCapabilityCache) -> None:
     assert cache.get("b:n", "rejects_media", False) is True
 
 
+def test_forget_drops_single_capability(cache: ModelCapabilityCache) -> None:
+    cache.learn("p:m", "rejects_media", True)
+    cache.learn("p:m", "needs_reasoning_content", True)
+    cache.forget("p:m", "rejects_media")
+    assert cache.get("p:m", "rejects_media", False) is False
+    assert cache.get("p:m", "needs_reasoning_content", False) is True
+
+
+def test_forget_preserves_other_models(cache: ModelCapabilityCache) -> None:
+    cache.learn("a:m", "rejects_media", True)
+    cache.learn("b:n", "rejects_media", True)
+    cache.forget("a:m", "rejects_media")
+    assert cache.get("a:m", "rejects_media", False) is False
+    assert cache.get("b:n", "rejects_media", False) is True
+
+
+def test_forget_unknown_key_is_noop(cache: ModelCapabilityCache) -> None:
+    cache.forget("nonexistent", "rejects_media")
+    cache.learn("p:m", "rejects_media", True)
+    cache.forget("p:m", "needs_reasoning_content")
+    assert cache.get("p:m", "rejects_media", False) is True
+
+
 def test_relearn_same_value_refreshes_timestamp(
     cache: ModelCapabilityCache,
 ) -> None:

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -930,3 +930,43 @@ async def test_update_config_persists_api_key_prefixes(
     assert provider.api_key_prefixes == ["ghp_", "github_pat_"]
     info = await provider.get_info()
     assert info.api_key_prefixes == ["ghp_", "github_pat_"]
+
+
+async def test_activate_model_clears_capability_cache(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    """Switching the active model must discard stale capability findings."""
+    from qwenpaw.providers.model_capability_cache import (
+        ModelCapabilityCache,
+        get_capability_cache,
+    )
+    from qwenpaw.providers.openai_provider import OpenAIProvider
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            return SimpleNamespace(id="ok", request=kwargs)
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+    monkeypatch.setattr(
+        OpenAIProvider,
+        "_client",
+        lambda self, timeout=5: fake_client,
+    )
+
+    # Replace the global singleton with a fresh instance so prior tests
+    # cannot leak state into this assertion.
+    fresh = ModelCapabilityCache()
+    monkeypatch.setattr(
+        ModelCapabilityCache, "_instance", fresh
+    )
+    cache = get_capability_cache()
+    cache.learn("openai:gpt-5", "rejects_media", True)
+    assert cache.get("openai:gpt-5", "rejects_media", False) is True
+
+    manager = ProviderManager()
+    await manager.activate_model("openai", "gpt-5")
+
+    assert cache.get("openai:gpt-5", "rejects_media", False) is False

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -941,7 +941,6 @@ async def test_activate_model_clears_rejects_media_for_selected_model(
         ModelCapabilityCache,
         get_capability_cache,
     )
-    from qwenpaw.providers.openai_provider import OpenAIProvider
 
     class FakeCompletions:
         def create(self, **kwargs):
@@ -977,7 +976,6 @@ async def test_activate_model_preserves_other_models_and_capabilities(
         ModelCapabilityCache,
         get_capability_cache,
     )
-    from qwenpaw.providers.openai_provider import OpenAIProvider
 
     class FakeCompletions:
         def create(self, **kwargs):

--- a/tests/unit/providers/test_provider_manager.py
+++ b/tests/unit/providers/test_provider_manager.py
@@ -932,11 +932,11 @@ async def test_update_config_persists_api_key_prefixes(
     assert info.api_key_prefixes == ["ghp_", "github_pat_"]
 
 
-async def test_activate_model_clears_capability_cache(
+async def test_activate_model_clears_rejects_media_for_selected_model(
     isolated_secret_dir,
     monkeypatch,
 ) -> None:
-    """Switching the active model must discard stale capability findings."""
+    """Re-selecting a model drops its stale rejects_media entry."""
     from qwenpaw.providers.model_capability_cache import (
         ModelCapabilityCache,
         get_capability_cache,
@@ -956,12 +956,8 @@ async def test_activate_model_clears_capability_cache(
         lambda self, timeout=5: fake_client,
     )
 
-    # Replace the global singleton with a fresh instance so prior tests
-    # cannot leak state into this assertion.
     fresh = ModelCapabilityCache()
-    monkeypatch.setattr(
-        ModelCapabilityCache, "_instance", fresh
-    )
+    monkeypatch.setattr(ModelCapabilityCache, "_instance", fresh)
     cache = get_capability_cache()
     cache.learn("openai:gpt-5", "rejects_media", True)
     assert cache.get("openai:gpt-5", "rejects_media", False) is True
@@ -970,3 +966,45 @@ async def test_activate_model_clears_capability_cache(
     await manager.activate_model("openai", "gpt-5")
 
     assert cache.get("openai:gpt-5", "rejects_media", False) is False
+
+
+async def test_activate_model_preserves_other_models_and_capabilities(
+    isolated_secret_dir,
+    monkeypatch,
+) -> None:
+    """Activating one model must not evict capabilities of other models."""
+    from qwenpaw.providers.model_capability_cache import (
+        ModelCapabilityCache,
+        get_capability_cache,
+    )
+    from qwenpaw.providers.openai_provider import OpenAIProvider
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            return SimpleNamespace(id="ok", request=kwargs)
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+    monkeypatch.setattr(
+        OpenAIProvider,
+        "_client",
+        lambda self, timeout=5: fake_client,
+    )
+
+    fresh = ModelCapabilityCache()
+    monkeypatch.setattr(ModelCapabilityCache, "_instance", fresh)
+    cache = get_capability_cache()
+    cache.learn("openai:gpt-5", "rejects_media", True)
+    cache.learn("openai:gpt-5", "needs_reasoning_content", True)
+    cache.learn("ollama:llama3", "rejects_media", True)
+
+    manager = ProviderManager()
+    await manager.activate_model("openai", "gpt-5")
+
+    # rejects_media for the selected model is cleared
+    assert cache.get("openai:gpt-5", "rejects_media", False) is False
+    # needs_reasoning_content for the same model is preserved
+    assert cache.get("openai:gpt-5", "needs_reasoning_content", False) is True
+    # another model's entries are untouched
+    assert cache.get("ollama:llama3", "rejects_media", False) is True


### PR DESCRIPTION
## What Problem This Solves

The learned-capability cache (`rejects_media`, `needs_reasoning_content`) never expired and was never cleared. A single transient upstream failure — e.g. an API gateway routing a multimodal model (`kimi2.6`) to a non-multimodal backend (`dsv4`) for a few minutes — permanently poisoned the cache. Every subsequent request then silently stripped user-uploaded images (`Proactively stripped 1 media block(s)`), and the model responded "I don't see any image" until the qwenpaw process was restarted.

Observed in production: after a gateway misroute returned `400 dsv4 is not a multimodal model`, qwenpaw called `get_capability_cache().learn(model_key, "rejects_media", True)`. From that point on, `_reasoning()` hit the proactive-strip branch on every turn — even after the gateway was fixed and the model could accept images again. The only recovery was deleting the pod.

Root cause: `ModelCapabilityCache` has a `clear()` method but nothing in the codebase ever calls it, and entries have no TTL.

## Fix

**1. Cache entries now expire after a TTL** — each entry records a monotonic timestamp; `get()` evicts entries older than `CAPABILITY_CACHE_TTL_SECONDS` (default 30 min, `0` disables expiry).

**2. `activate_model()` clears the cache** — switching or re-selecting a model discards findings that no longer apply.

## Evidence

Before the fix, a poisoned cache strips images permanently:

```
# gateway returned 400 once (transient misroute)
Learned capability for yunnet-kimi:kimi2.6: rejects_media=True

# every subsequent request, even after gateway was fixed:
WARNING | Proactively stripped 1 media block(s) before _reasoning (model lacks multimodal support).
# model response: "我没有看到图片"
```

After the fix, the same scenario self-heals:

```
# cache entry expires after TTL → get() returns default (False)
# → should_strip is False → image reaches the model
# model response: "红色"  (correctly identified the uploaded image)
```

Switching the model via `activate_model()` also clears the cache immediately, so an operator can recover without waiting for TTL or restarting the pod.

## Config

The TTL constant follows the existing `constant.py` convention (`_get_env` with `COPAW_` legacy fallback), consistent with `TOOL_GUARD_APPROVAL_TIMEOUT_SECONDS`.

| Env | Default | Effect |
|---|---|---|
| `QWENPAW_CAPABILITY_CACHE_TTL_SECONDS` | `1800` (30 min) | `0` disables expiry |

## Type of Change

- [x] Bug fix

## Component(s) Affected

- [x] Core / Backend (providers)

## Checklist

- [x] I ran tests locally and they pass
- [x] Ready for review